### PR TITLE
feat: Add PLaMo provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -363,6 +363,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/phone-control/**"
+"extensions: plamo":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/plamo/**"
 "extensions: qianfan":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Docs: https://docs.openclaw.ai
 - Diagnostics/OTEL: emit bounded exec-process diagnostics and export them as `openclaw.exec` spans without exposing command text, working directories, or container identifiers. (#71451) Thanks @vincentkoc and @jlapenna.
 - Diagnostics/OTEL: support `OPENCLAW_OTEL_PRELOADED=1` so the plugin can reuse an already-registered OpenTelemetry SDK while keeping OpenClaw diagnostic listeners wired. (#71450) Thanks @vincentkoc and @jlapenna.
 - Providers/Xiaomi: add MiMo TTS as a bundled speech provider with MP3/WAV output and voice-note Opus transcoding. Fixes #52376. (#55614) Thanks @zoujiejun.
-- Providers/PLaMo: add PLaMo as a bundled model provider with API-key auth, catalog setup, request-authenticated proxy support, and native tool-call stream handling. Thanks @mitmul.
+- Providers/Preferred Networks: add Preferred Networks as a bundled model provider for PLaMo with API-key auth, catalog setup, request-authenticated proxy support, and native tool-call stream handling. Thanks @mitmul.
 - Providers/ElevenLabs: include `eleven_v3` in the bundled TTS model catalog so model selection surfaces can offer ElevenLabs v3. (#68321) Thanks @itsuzef.
 - Providers/Local CLI TTS: add a bundled local command speech provider with file/stdout input, voice-note Opus conversion, and telephony PCM output. (#56239) Thanks @solar2ain.
 - Providers/Inworld: add Inworld as a bundled speech provider with streaming TTS synthesis, voice listing, voice-note output, and PCM telephony output. (#55972) Thanks @cshape.
@@ -84,6 +84,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Preferred Networks: show Preferred Networks as the provider name in onboarding and auth surfaces while keeping PLaMo for model names and refs. Thanks @mitmul.
 - UI/Windows: quote resolved pnpm `.cmd` launcher paths before spawning UI install/build/test commands so Node installs under `C:\Program Files` no longer fail as `C:\Program`. Fixes #45275. Thanks @Kobevictor, @stoppieboy, and @iubns.
 - Codex/agent: translate `--thinking minimal` to `low` for modern Codex models (gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.2) at request build time so the first turn is accepted instead of paying a wasted call + retry-with-low fallback. Older Codex models still receive `minimal` directly. Fixes #71946. Thanks @hclsys.
 - Plugins/uninstall: remove tracked plugin files from their recorded managed extensions root even when the current state directory points somewhere else, so `openclaw plugins uninstall --force` does not leave the plugin discoverable. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 - Diagnostics/OTEL: emit bounded exec-process diagnostics and export them as `openclaw.exec` spans without exposing command text, working directories, or container identifiers. (#71451) Thanks @vincentkoc and @jlapenna.
 - Diagnostics/OTEL: support `OPENCLAW_OTEL_PRELOADED=1` so the plugin can reuse an already-registered OpenTelemetry SDK while keeping OpenClaw diagnostic listeners wired. (#71450) Thanks @vincentkoc and @jlapenna.
 - Providers/Xiaomi: add MiMo TTS as a bundled speech provider with MP3/WAV output and voice-note Opus transcoding. Fixes #52376. (#55614) Thanks @zoujiejun.
+- Providers/PLaMo: add PLaMo as a bundled model provider with API-key auth, catalog setup, request-authenticated proxy support, and native tool-call stream handling. Thanks @mitmul.
 - Providers/ElevenLabs: include `eleven_v3` in the bundled TTS model catalog so model selection surfaces can offer ElevenLabs v3. (#68321) Thanks @itsuzef.
 - Providers/Local CLI TTS: add a bundled local command speech provider with file/stdout input, voice-note Opus conversion, and telephony PCM output. (#56239) Thanks @solar2ain.
 - Providers/Inworld: add Inworld as a bundled speech provider with streaming TTS synthesis, voice listing, voice-note output, and PCM telephony output. (#55972) Thanks @cshape.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-947221d62a0eb0b66250fba2b011ca28a11cb1058bc542b9c155d55479f15935  plugin-sdk-api-baseline.json
-0d750f785adbe4d90f209842ed9297476669dd62f7be81fa41e06b6736cc2aaf  plugin-sdk-api-baseline.jsonl
+4f58dfbbbbd74a920568dcc8987c82efc6f1cff46fe29d8111e42400972e6a50  plugin-sdk-api-baseline.json
+21936ab6ca6eddea76f03ff6b4c8bde8029cb95f792665acb00836842a41916a  plugin-sdk-api-baseline.jsonl

--- a/docs/.i18n/glossary.ja-JP.json
+++ b/docs/.i18n/glossary.ja-JP.json
@@ -60,6 +60,18 @@
     "target": "Pi"
   },
   {
+    "source": "PLaMo",
+    "target": "PLaMo"
+  },
+  {
+    "source": "Preferred Networks",
+    "target": "Preferred Networks"
+  },
+  {
+    "source": "Preferred Networks (PLaMo)",
+    "target": "Preferred Networks（PLaMo）"
+  },
+  {
     "source": "Plugin",
     "target": "Plugin"
   },

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -188,6 +188,10 @@
     "target": "功能"
   },
   {
+    "source": "Image & media support",
+    "target": "图像与媒体支持"
+  },
+  {
     "source": "DMs",
     "target": "私信"
   },
@@ -250,6 +254,10 @@
   {
     "source": "Network model",
     "target": "网络模型"
+  },
+  {
+    "source": "Remote access",
+    "target": "远程访问"
   },
   {
     "source": "Bridge protocol (legacy nodes, historical)",

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -12,6 +12,18 @@
     "target": "OpenAI provider"
   },
   {
+    "source": "Preferred Networks",
+    "target": "Preferred Networks"
+  },
+  {
+    "source": "Preferred Networks (PLaMo)",
+    "target": "Preferred Networks（PLaMo）"
+  },
+  {
+    "source": "PLaMo",
+    "target": "PLaMo"
+  },
+  {
     "source": "Azure Speech",
     "target": "Azure Speech"
   },

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -291,6 +291,7 @@ See [/providers/kilocode](/providers/kilocode) for setup details.
 | Moonshot                | `moonshot`                       | `MOONSHOT_API_KEY`                                           | `moonshot/kimi-k2.6`                            |
 | NVIDIA                  | `nvidia`                         | `NVIDIA_API_KEY`                                             | `nvidia/nvidia/llama-3.1-nemotron-70b-instruct` |
 | OpenRouter              | `openrouter`                     | `OPENROUTER_API_KEY`                                         | `openrouter/auto`                               |
+| Preferred Networks      | `plamo`                          | `PLAMO_API_KEY`                                              | `plamo/plamo-3.0-prime-beta`                    |
 | Qianfan                 | `qianfan`                        | `QIANFAN_API_KEY`                                            | `qianfan/deepseek-v3.2`                         |
 | Qwen Cloud              | `qwen`                           | `QWEN_API_KEY` / `MODELSTUDIO_API_KEY` / `DASHSCOPE_API_KEY` | `qwen/qwen3.5-plus`                             |
 | StepFun                 | `stepfun` / `stepfun-plan`       | `STEPFUN_API_KEY`                                            | `stepfun/step-3.5-flash`                        |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -201,6 +201,14 @@
       "destination": "/providers/opencode-go"
     },
     {
+      "source": "/preferred-networks",
+      "destination": "/providers/preferred-networks"
+    },
+    {
+      "source": "/plamo",
+      "destination": "/providers/preferred-networks"
+    },
+    {
       "source": "/qianfan",
       "destination": "/providers/qianfan"
     },
@@ -1333,6 +1341,7 @@
                   "providers/opencode-go",
                   "providers/openrouter",
                   "providers/perplexity-provider",
+                  "providers/preferred-networks",
                   "providers/qianfan",
                   "providers/qwen",
                   "providers/runway",

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -337,6 +337,7 @@ releases.
   | `plugin-sdk/provider-catalog-shared` | Shared provider catalog helpers | `findCatalogTemplate`, `buildSingleProviderApiKeyCatalog`, `supportsNativeStreamingUsageCompat`, `applyProviderNativeStreamingUsageCompat` |
   | `plugin-sdk/provider-onboard` | Provider onboarding patches | Onboarding config helpers |
   | `plugin-sdk/provider-http` | Provider HTTP helpers | Generic provider HTTP/endpoint capability helpers, including audio transcription multipart form helpers |
+  | `plugin-sdk/provider-http-runtime` | Provider HTTP transport runtime helpers | Runtime-heavy LLM transport helpers such as `buildGuardedModelFetch` |
   | `plugin-sdk/provider-web-fetch` | Provider web-fetch helpers | Web-fetch provider registration/cache helpers |
   | `plugin-sdk/provider-web-search-config-contract` | Provider web-search config helpers | Narrow web-search config/credential helpers for providers that do not need plugin-enable wiring |
   | `plugin-sdk/provider-web-search-contract` | Provider web-search contract helpers | Narrow web-search config/credential contract helpers such as `createWebSearchProviderContractFields`, `enablePluginInConfig`, `resolveProviderWebSearchPluginConfig`, and scoped credential setters/getters |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -96,6 +96,7 @@ For the plugin authoring guide, see [Plugin SDK overview](/plugins/sdk-overview)
     | `plugin-sdk/provider-model-shared` | `ProviderReplayFamily`, `buildProviderReplayFamilyHooks`, `normalizeModelCompat`, shared replay-policy builders, provider-endpoint helpers, and model-id normalization helpers such as `normalizeNativeXaiModelId` |
     | `plugin-sdk/provider-catalog-shared` | `findCatalogTemplate`, `buildSingleProviderApiKeyCatalog`, `supportsNativeStreamingUsageCompat`, `applyProviderNativeStreamingUsageCompat` |
     | `plugin-sdk/provider-http` | Generic provider HTTP/endpoint capability helpers, provider HTTP errors, and audio transcription multipart form helpers |
+    | `plugin-sdk/provider-http-runtime` | Runtime-heavy LLM transport helpers such as `buildGuardedModelFetch` |
     | `plugin-sdk/provider-web-fetch-contract` | Narrow web-fetch config/selection contract helpers such as `enablePluginInConfig` and `WebFetchProviderPlugin` |
     | `plugin-sdk/provider-web-fetch` | Web-fetch provider registration/cache helpers |
     | `plugin-sdk/provider-web-search-config-contract` | Narrow web-search config/credential helpers for providers that do not need plugin-enable wiring |

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -60,6 +60,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [OpenCode Go](/providers/opencode-go)
 - [OpenRouter](/providers/openrouter)
 - [Perplexity (web search)](/providers/perplexity-provider)
+- [Preferred Networks (PLaMo)](/providers/preferred-networks)
 - [Qianfan](/providers/qianfan)
 - [Qwen Cloud](/providers/qwen)
 - [Runway](/providers/runway)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -40,6 +40,7 @@ model as `provider/model`.
 - [OpenAI (API + Codex)](/providers/openai)
 - [OpenCode (Zen + Go)](/providers/opencode)
 - [OpenRouter](/providers/openrouter)
+- [Preferred Networks (PLaMo)](/providers/preferred-networks)
 - [Qianfan](/providers/qianfan)
 - [Qwen](/providers/qwen)
 - [Runway](/providers/runway)

--- a/docs/providers/preferred-networks.md
+++ b/docs/providers/preferred-networks.md
@@ -1,0 +1,103 @@
+---
+summary: "Use Preferred Networks PLaMo models in OpenClaw"
+read_when:
+  - You want to use PLaMo models with OpenClaw
+  - You need Preferred Networks API key onboarding and model refs
+title: "Preferred Networks"
+---
+
+# Preferred Networks
+
+Preferred Networks provides the PLaMo model family through the PreferredAI
+platform API. OpenClaw shows **Preferred Networks** as the provider name in
+onboarding and auth surfaces, while model refs keep the `plamo/...` prefix.
+
+- Provider: `plamo`
+- Auth: `PLAMO_API_KEY`
+- API: OpenAI-compatible Chat Completions (`https://api.platform.preferredai.jp/v1`)
+- Default model: `plamo/plamo-3.0-prime-beta` (`PLaMo 3.0 Prime Beta`)
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Create or copy an API key from the PreferredAI platform.
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice plamo-api-key
+    ```
+
+    Or pass the key directly:
+
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice plamo-api-key \
+      --plamo-api-key "$PLAMO_API_KEY"
+    ```
+
+  </Step>
+  <Step title="Set a default model">
+    ```json5
+    {
+      agents: {
+        defaults: {
+          model: { primary: "plamo/plamo-3.0-prime-beta" },
+        },
+      },
+    }
+    ```
+  </Step>
+  <Step title="Verify the model is available">
+    ```bash
+    openclaw models list --provider plamo
+    ```
+  </Step>
+</Steps>
+
+## Naming
+
+- **Preferred Networks** is the provider/company name shown in onboarding,
+  `models auth`, and plugin metadata.
+- **PLaMo** is the model family name. Keep using `plamo/...` model refs, such
+  as `plamo/plamo-3.0-prime-beta`.
+
+## Built-in catalog
+
+| Model ref                    | Input | Context | Max output | Notes         |
+| ---------------------------- | ----- | ------- | ---------- | ------------- |
+| `plamo/plamo-3.0-prime-beta` | text  | 65,536  | 20,000     | Default model |
+
+## Advanced configuration
+
+OpenClaw writes the provider under `models.providers.plamo`:
+
+```json5
+{
+  models: {
+    providers: {
+      plamo: {
+        baseUrl: "https://api.platform.preferredai.jp/v1",
+        api: "openai-completions",
+        models: [{ id: "plamo-3.0-prime-beta", name: "PLaMo 3.0 Prime Beta" }],
+      },
+    },
+  },
+}
+```
+
+The provider also supports request-authenticated proxy setups through
+`models.providers.plamo.request` or auth headers, matching the shared
+OpenAI-compatible provider configuration surface.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Models CLI" href="/cli/models" icon="terminal">
+    List, set, and inspect configured models.
+  </Card>
+</CardGroup>

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -39,6 +39,8 @@ For a high-level overview, see [Onboarding (CLI)](/start/wizard).
       - Sets `agents.defaults.model` to `openai/gpt-5.5` when model is unset, `openai/*`, or `openai-codex/*`.
     - **xAI (Grok) API key**: prompts for `XAI_API_KEY` and configures xAI as a model provider.
     - **OpenCode**: prompts for `OPENCODE_API_KEY` (or `OPENCODE_ZEN_API_KEY`, get it at https://opencode.ai/auth) and lets you pick the Zen or Go catalog.
+    - **Preferred Networks**: prompts for `PLAMO_API_KEY` and configures Preferred Networks as the provider for PLaMo models.
+    - More detail: [Preferred Networks](/providers/preferred-networks)
     - **Ollama**: offers **Cloud + Local**, **Cloud only**, or **Local only** first. `Cloud only` prompts for `OLLAMA_API_KEY` and uses `https://ollama.com`; the host-backed modes prompt for the Ollama base URL, discover available models, and auto-pull the selected local model when needed; `Cloud + Local` also checks whether that Ollama host is signed in for cloud access.
     - More detail: [Ollama](/providers/ollama)
     - **API key**: stores the key for you.

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -14,7 +14,7 @@ For the short guide, see [Onboarding (CLI)](/start/wizard).
 
 Local mode (default) walks you through:
 
-- Model and auth setup (OpenAI Code subscription OAuth, Anthropic Claude CLI or API key, plus MiniMax, GLM, Ollama, Moonshot, StepFun, and AI Gateway options)
+- Model and auth setup (OpenAI Code subscription OAuth, Anthropic Claude CLI or API key, plus Preferred Networks, MiniMax, GLM, Ollama, Moonshot, StepFun, and AI Gateway options)
 - Workspace location and bootstrap files
 - Gateway settings (port, bind, auth, tailscale)
 - Channels and providers (Telegram, WhatsApp, Discord, Google Chat, Mattermost, Signal, BlueBubbles, and other bundled channel plugins)
@@ -151,6 +151,11 @@ What you set:
   <Accordion title="OpenCode">
     Prompts for `OPENCODE_API_KEY` (or `OPENCODE_ZEN_API_KEY`) and lets you choose the Zen or Go catalog.
     Setup URL: [opencode.ai/auth](https://opencode.ai/auth).
+  </Accordion>
+  <Accordion title="Preferred Networks">
+    Prompts for `PLAMO_API_KEY` and configures Preferred Networks as the provider for PLaMo models.
+    Default model: `plamo/plamo-3.0-prime-beta`.
+    More detail: [Preferred Networks](/providers/preferred-networks).
   </Accordion>
   <Accordion title="API key (generic)">
     Stores the key for you.

--- a/extensions/plamo/index.test.ts
+++ b/extensions/plamo/index.test.ts
@@ -1,0 +1,3737 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import type {
+  ProviderResolveDynamicModelContext,
+  ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { attachModelProviderRequestTransport } from "../../src/agents/provider-request-config.js";
+import { resolveProviderPluginChoice } from "../../src/plugins/provider-wizard.js";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import plamoPlugin from "./index.js";
+import { PLAMO_REQUEST_AUTH_MARKER } from "./provider-catalog.js";
+import { createPlamoToolCallWrapper, normalizePlamoToolMarkupInMessage } from "./stream.js";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/provider-http-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/provider-http-runtime")>(
+    "openclaw/plugin-sdk/provider-http-runtime",
+  );
+  return {
+    ...actual,
+    buildGuardedModelFetch:
+      (_model: unknown, options?: { auditContext?: string }) =>
+      async (input: Request | URL | string, init?: RequestInit) => {
+        const request = input instanceof Request ? new Request(input, init) : undefined;
+        const url =
+          request?.url ??
+          (input instanceof URL
+            ? input.toString()
+            : typeof input === "string"
+              ? input
+              : (() => {
+                  throw new Error("unsupported fetch input for PLaMo transport test");
+                })());
+        const requestInit =
+          request &&
+          ({
+            method: request.method,
+            headers: request.headers,
+            body: request.body ?? undefined,
+            redirect: request.redirect,
+            signal: request.signal,
+            ...(request.body ? ({ duplex: "half" } as const) : {}),
+          } satisfies RequestInit & { duplex?: "half" });
+        const result = await fetchWithSsrFGuardMock({
+          url,
+          init: requestInit ?? init,
+          ...(options?.auditContext ? { auditContext: options.auditContext } : {}),
+        });
+        return result.response as Response;
+      },
+  };
+});
+
+type FakeWrappedStream = {
+  result: () => Promise<unknown>;
+  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+};
+
+function createFakeStream(params: {
+  events: unknown[];
+  resultMessage: unknown;
+}): FakeWrappedStream {
+  return {
+    async result() {
+      return params.resultMessage;
+    },
+    [Symbol.asyncIterator]() {
+      return (async function* () {
+        for (const event of params.events) {
+          yield event;
+        }
+      })();
+    },
+  };
+}
+
+async function loadPlamoCatalog() {
+  const provider = await registerSingleProviderPlugin(plamoPlugin);
+  const catalog = await provider.catalog!.run({
+    config: {},
+    env: {},
+    resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+    resolveProviderAuth: () => ({
+      apiKey: "test-key",
+      mode: "api_key",
+      source: "env",
+    }),
+  } as never);
+
+  if (!catalog || !("provider" in catalog)) {
+    throw new Error("expected single-provider catalog");
+  }
+
+  return { provider, catalog };
+}
+
+function createWrappedPlamoStream(
+  provider: Awaited<ReturnType<typeof registerSingleProviderPlugin>>,
+  options?: {
+    modelId?: string;
+  },
+) {
+  const modelId = options?.modelId ?? "plamo-3.0-prime-beta";
+  const wrapped = provider.createStreamFn?.({
+    config: {},
+    provider: "plamo",
+    modelId,
+    model: {
+      api: "openai-completions",
+      provider: "plamo",
+      id: modelId,
+    } as never,
+  } as never);
+  if (!wrapped) {
+    throw new Error("expected wrapped stream function");
+  }
+  return wrapped;
+}
+
+function createDynamicContext(params: {
+  provider: string;
+  modelId: string;
+  models: ProviderRuntimeModel[];
+  providerConfig?: ProviderResolveDynamicModelContext["providerConfig"];
+}): ProviderResolveDynamicModelContext {
+  return {
+    provider: params.provider,
+    modelId: params.modelId,
+    providerConfig: params.providerConfig,
+    modelRegistry: {
+      find(providerId: string, modelId: string) {
+        return (
+          params.models.find(
+            (model) =>
+              model.provider === providerId && model.id.toLowerCase() === modelId.toLowerCase(),
+          ) ?? null
+        );
+      },
+    } as ModelRegistry,
+  };
+}
+
+beforeEach(() => {
+  fetchWithSsrFGuardMock.mockReset();
+  fetchWithSsrFGuardMock.mockImplementation(async (paramsUnknown: unknown) => {
+    const params = paramsUnknown as {
+      url: string;
+      init?: RequestInit;
+    };
+    return {
+      response: await fetch(params.url, params.init),
+      release: async () => {},
+    };
+  });
+});
+
+describe("plamo provider plugin", () => {
+  it("registers PLaMo with api-key auth wizard metadata", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "plamo-api-key",
+    });
+
+    expect(provider.id).toBe("plamo");
+    expect(provider.label).toBe("PLaMo");
+    expect(provider.envVars).toEqual(["PLAMO_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+    expect(provider.buildReplayPolicy).toBeTypeOf("function");
+    expect(provider.sanitizeReplayHistory).toBeTypeOf("function");
+    expect(provider.createStreamFn).toBeTypeOf("function");
+    expect(provider.wrapStreamFn).toBeUndefined();
+    expect(resolved).not.toBeNull();
+    expect(resolved?.provider.id).toBe("plamo");
+    expect(resolved?.method.id).toBe("api-key");
+  });
+
+  it("advertises PLaMo refs as modern models", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+
+    expect(
+      provider.isModernModelRef?.({
+        provider: "plamo",
+        modelId: "plamo-3.0-prime-beta",
+      } as never),
+    ).toBe(true);
+    expect(
+      provider.isModernModelRef?.({
+        provider: "plamo",
+        modelId: " PLaMo-next-preview ",
+      } as never),
+    ).toBe(true);
+    expect(
+      provider.isModernModelRef?.({
+        provider: "plamo",
+        modelId: "gpt-5.4",
+      } as never),
+    ).toBe(false);
+  });
+
+  it("exposes synthetic auth for request-authenticated PLaMo configs", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "plamo",
+        providerConfig: {
+          api: "openai-completions",
+          baseUrl: "https://proxy.example.test/v1",
+          request: {
+            auth: {
+              mode: "header",
+              headerName: "X-Proxy-Token",
+              value: {
+                source: "env",
+                provider: "default",
+                id: "PLAMO_PROXY_TOKEN",
+              },
+            },
+          },
+          models: [],
+        },
+      } as never),
+    ).toEqual({
+      apiKey: PLAMO_REQUEST_AUTH_MARKER,
+      source: "models.providers.plamo.request (synthetic request auth)",
+      mode: "api-key",
+    });
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "plamo",
+        providerConfig: {
+          api: "openai-completions",
+          baseUrl: "https://proxy.example.test/v1",
+          headers: {
+            Authorization: {
+              source: "env",
+              provider: "default",
+              id: "PLAMO_PROXY_TOKEN",
+            },
+          },
+          models: [],
+        },
+      } as never),
+    ).toEqual({
+      apiKey: PLAMO_REQUEST_AUTH_MARKER,
+      source: "models.providers.plamo.request (synthetic request auth)",
+      mode: "api-key",
+    });
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "plamo",
+        providerConfig: {
+          api: "openai-completions",
+          baseUrl: "https://proxy.example.test/v1",
+          request: {
+            headers: {
+              "X-Proxy-Token": {
+                source: "env",
+                provider: "default",
+                id: "PLAMO_PROXY_TOKEN",
+              },
+            },
+          },
+          models: [],
+        },
+      } as never),
+    ).toEqual({
+      apiKey: PLAMO_REQUEST_AUTH_MARKER,
+      source: "models.providers.plamo.request (synthetic request auth)",
+      mode: "api-key",
+    });
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "plamo",
+        providerConfig: {
+          api: "openai-completions",
+          baseUrl: "https://proxy.example.test/v1",
+          request: {
+            headers: {
+              "X-Tenant": {
+                source: "env",
+                provider: "default",
+                id: "PLAMO_TENANT",
+              },
+            },
+          },
+          models: [],
+        },
+      } as never),
+    ).toBeUndefined();
+  });
+
+  it("builds the static PLaMo model catalog", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+    expect(provider.catalog).toBeDefined();
+
+    expect(catalog.provider.api).toBe("openai-completions");
+    expect(catalog.provider.baseUrl).toBe("https://api.platform.preferredai.jp/v1");
+    expect(catalog.provider.models).toEqual([
+      {
+        id: "plamo-3.0-prime-beta",
+        name: "PLaMo 3.0 Prime Beta",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0.375, output: 1.5625, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 65_536,
+        maxTokens: 20_000,
+        compat: {
+          maxTokensField: "max_tokens",
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          supportsStore: false,
+          supportsStrictMode: false,
+        },
+      },
+    ]);
+  });
+
+  it("keeps the PLaMo catalog available for header-authenticated setups without an api key", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+    const catalog = await provider.catalog!.run({
+      config: {
+        models: {
+          providers: {
+            plamo: {
+              baseUrl: "https://proxy.example.test/v1",
+              request: {
+                auth: {
+                  mode: "header",
+                  headerName: "X-Proxy-Token",
+                  value: {
+                    source: "env",
+                    provider: "default",
+                    id: "PLAMO_PROXY_TOKEN",
+                  },
+                },
+              },
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({
+        apiKey: undefined,
+        mode: "none",
+        source: "none",
+      }),
+    } as never);
+
+    expect(catalog).toMatchObject({
+      provider: {
+        api: "openai-completions",
+        baseUrl: "https://proxy.example.test/v1",
+      },
+    });
+  });
+
+  it("keeps the PLaMo catalog available when proxy auth is supplied via request headers", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+    const catalog = await provider.catalog!.run({
+      config: {
+        models: {
+          providers: {
+            plamo: {
+              baseUrl: "https://proxy.example.test/v1",
+              request: {
+                headers: {
+                  "X-Proxy-Token": {
+                    source: "env",
+                    provider: "default",
+                    id: "PLAMO_PROXY_TOKEN",
+                  },
+                },
+              },
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({
+        apiKey: undefined,
+        mode: "none",
+        source: "none",
+      }),
+    } as never);
+
+    expect(catalog).toMatchObject({
+      provider: {
+        api: "openai-completions",
+        baseUrl: "https://proxy.example.test/v1",
+      },
+    });
+  });
+
+  it("keeps the PLaMo catalog available when auth is supplied via top-level provider headers", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+    const catalog = await provider.catalog!.run({
+      config: {
+        models: {
+          providers: {
+            plamo: {
+              baseUrl: "https://proxy.example.test/v1",
+              headers: {
+                Authorization: {
+                  source: "env",
+                  provider: "default",
+                  id: "PLAMO_PROXY_TOKEN",
+                },
+              },
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({
+        apiKey: undefined,
+        mode: "none",
+        source: "none",
+      }),
+    } as never);
+
+    expect(catalog).toMatchObject({
+      provider: {
+        api: "openai-completions",
+        baseUrl: "https://proxy.example.test/v1",
+      },
+    });
+  });
+
+  it("does not keep the PLaMo catalog available for non-auth request headers alone", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+    const catalog = await provider.catalog!.run({
+      config: {
+        models: {
+          providers: {
+            plamo: {
+              baseUrl: "https://proxy.example.test/v1",
+              request: {
+                headers: {
+                  "X-Tenant": {
+                    source: "env",
+                    provider: "default",
+                    id: "PLAMO_TENANT",
+                  },
+                },
+              },
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({
+        apiKey: undefined,
+        mode: "none",
+        source: "none",
+      }),
+    } as never);
+
+    expect(catalog).toBeNull();
+  });
+
+  it("resolves forward-compat PLaMo model ids even when the local catalog has no template row", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+    const resolved = provider.resolveDynamicModel?.(
+      createDynamicContext({
+        provider: "plamo",
+        modelId: "plamo-next-preview",
+        models: [],
+      }),
+    );
+
+    expect(resolved).toMatchObject({
+      provider: "plamo",
+      id: "plamo-next-preview",
+      api: "openai-completions",
+      baseUrl: "https://api.platform.preferredai.jp/v1",
+      reasoning: false,
+      input: ["text"],
+      contextWindow: 65_536,
+      maxTokens: 20_000,
+      compat: {
+        maxTokensField: "max_tokens",
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+        supportsStore: false,
+        supportsStrictMode: false,
+      },
+    });
+  });
+
+  it("inherits the resolved template baseUrl for forward-compat PLaMo models", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+    const resolved = provider.resolveDynamicModel?.(
+      createDynamicContext({
+        provider: "plamo",
+        modelId: "plamo-next-preview",
+        models: [
+          {
+            provider: "plamo",
+            api: "openai-completions",
+            id: "plamo-3.0-prime-beta",
+            name: "PLaMo 3.0 Prime Beta",
+            baseUrl: "https://proxy.example.test/v1",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0.375, output: 1.5625, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 65_536,
+            maxTokens: 20_000,
+            compat: {
+              maxTokensField: "max_tokens",
+              supportsDeveloperRole: false,
+              supportsReasoningEffort: false,
+              supportsStore: false,
+              supportsStrictMode: false,
+            },
+          } as ProviderRuntimeModel,
+        ],
+      }),
+    );
+
+    expect(resolved).toMatchObject({
+      provider: "plamo",
+      id: "plamo-next-preview",
+      api: "openai-completions",
+      baseUrl: "https://proxy.example.test/v1",
+      reasoning: false,
+    });
+  });
+
+  it("inherits configured provider baseUrl when forward-compat fallback has no template row", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+    const resolved = provider.resolveDynamicModel?.(
+      createDynamicContext({
+        provider: "plamo",
+        modelId: "plamo-next-preview",
+        models: [],
+        providerConfig: {
+          baseUrl: "https://proxy.example.test/v1",
+        },
+      }),
+    );
+
+    expect(resolved).toMatchObject({
+      provider: "plamo",
+      id: "plamo-next-preview",
+      api: "openai-completions",
+      baseUrl: "https://proxy.example.test/v1",
+      reasoning: false,
+    });
+  });
+
+  it("drops replayed assistant thinking blocks before sending follow-up turns", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    let resolveRequest: ((value: { body: Record<string, unknown> }) => void) | null = null;
+    const requestSeen = new Promise<{
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal reasoning that must not be replayed",
+                thinkingSignature: "reasoning_content",
+              },
+              {
+                type: "redacted_thinking",
+                data: "encrypted reasoning that must not be replayed",
+              },
+              { type: "text", text: "前回の回答です。" },
+            ],
+          },
+          { role: "user", content: "続けて" },
+        ],
+      } as never,
+      {
+        apiKey: "test-key",
+        reasoningEffort: "low",
+      } as never,
+    );
+
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      await stream.result();
+    } finally {
+      server.close();
+    }
+
+    const request = await requestSeen;
+    expect(request.body.max_tokens).toBe(20_000);
+    expect(request.body.messages).toEqual([
+      { role: "system", content: "system prompt" },
+      { role: "assistant", content: "前回の回答です。" },
+      { role: "user", content: "続けて" },
+    ]);
+    expect((request.body.messages as Array<Record<string, unknown>>)[1]).not.toHaveProperty(
+      "reasoning_content",
+    );
+  });
+
+  it("owns replay cleanup through provider replay hooks", async () => {
+    const provider = await registerSingleProviderPlugin(plamoPlugin);
+
+    expect(
+      provider.buildReplayPolicy?.({
+        provider: "plamo",
+        modelId: "plamo-3.0-prime-beta",
+        modelApi: "openai-completions",
+      } as never),
+    ).toMatchObject({
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+      applyAssistantFirstOrderingFix: true,
+      validateGeminiTurns: true,
+      validateAnthropicTurns: true,
+    });
+
+    const sanitized = await provider.sanitizeReplayHistory?.({
+      provider: "plamo",
+      modelId: "plamo-3.0-prime-beta",
+      modelApi: "openai-completions",
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "reasoning that should not be replayed",
+              thinkingSignature: "reasoning_content",
+            },
+            {
+              type: "redacted_thinking",
+              data: "encrypted reasoning that should not be replayed",
+            },
+            { type: "toolUse", id: "call_1", name: "read", input: { path: "README.md" } },
+            { type: "functionCall", id: "call_2", name: "exec", arguments: { cmd: "pwd" } },
+            { type: "text", text: "Answer" },
+          ],
+        },
+      ],
+      sessionId: "session-1",
+    } as never);
+
+    expect(sanitized).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_1", name: "read", arguments: { path: "README.md" } },
+          { type: "toolCall", id: "call_2", name: "exec", arguments: { cmd: "pwd" } },
+          { type: "text", text: "Answer" },
+        ],
+      },
+    ]);
+  });
+
+  it("sends the documented streaming payload and auth headers on the wire", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    let resolveRequest:
+      | ((value: {
+          method: string | undefined;
+          url: string | undefined;
+          headers: Record<string, string | string[] | undefined>;
+          body: Record<string, unknown>;
+        }) => void)
+      | null = null;
+    const requestSeen = new Promise<{
+      method: string | undefined;
+      url: string | undefined;
+      headers: Record<string, string | string[] | undefined>;
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          method: req.method,
+          url: req.url,
+          headers: req.headers,
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+        tools: [
+          {
+            name: "read",
+            description: "Read a file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      {
+        apiKey: "test-key",
+        maxTokens: 512,
+        reasoningEffort: "low",
+        onPayload: async (payload: unknown) => ({
+          ...(payload as Record<string, unknown>),
+          stream_options: { include_usage: true },
+          store: false,
+          reasoning_effort: "low",
+        }),
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    const request = await requestSeen;
+    expect(request.method).toBe("POST");
+    expect(request.url).toBe("/v1/chat/completions");
+    expect(request.headers.authorization).toBe("Bearer test-key");
+    expect(String(request.headers["content-type"] ?? "")).toContain("application/json");
+    expect(request.body).toMatchObject({
+      model: "plamo-3.0-prime-beta",
+      max_tokens: 512,
+      messages: [
+        { role: "system", content: "system prompt" },
+        { role: "user", content: "こんにちは" },
+      ],
+      stream: true,
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "read",
+            description: "Read a file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        },
+      ],
+    });
+    expect(request.body).not.toHaveProperty("stream_options");
+    expect(request.body).not.toHaveProperty("store");
+    expect(request.body).not.toHaveProperty("reasoning_effort");
+    expect(
+      (request.body.tools as Array<{ function?: { strict?: unknown } }> | undefined)?.[0]?.function,
+    ).not.toHaveProperty("strict");
+  });
+
+  it("allows header-authenticated native transport requests without an explicit api key", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    let resolveRequest:
+      | ((value: {
+          headers: Record<string, string | string[] | undefined>;
+          body: Record<string, unknown>;
+        }) => void)
+      | null = null;
+    const requestSeen = new Promise<{
+      headers: Record<string, string | string[] | undefined>;
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          headers: req.headers,
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-proxy-auth",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-proxy-auth",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        headers: {
+          "X-Proxy-Token": "proxy-token",
+        },
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {} as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    const request = await requestSeen;
+    expect(request.headers["x-proxy-token"]).toBe("proxy-token");
+    expect(request.headers.authorization).toBeUndefined();
+    expect(request.body).toMatchObject({
+      model: "plamo-3.0-prime-beta",
+      stream: true,
+    });
+  });
+
+  it("keeps top-level auth headers while still injecting bearer auth when api key is available", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    let resolveRequest:
+      | ((value: {
+          headers: Record<string, string | string[] | undefined>;
+          body: Record<string, unknown>;
+        }) => void)
+      | null = null;
+    const requestSeen = new Promise<{
+      headers: Record<string, string | string[] | undefined>;
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          headers: req.headers,
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-top-level-proxy-auth",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-top-level-proxy-auth",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        headers: {
+          "X-Proxy-Token": "proxy-token",
+        },
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    const request = await requestSeen;
+    expect(request.headers["x-proxy-token"]).toBe("proxy-token");
+    expect(request.headers.authorization).toBe("Bearer test-key");
+  });
+
+  it("uses PLAMO_API_KEY for native transport requests when options.apiKey is absent", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+    const previousApiKey = process.env.PLAMO_API_KEY;
+    process.env.PLAMO_API_KEY = "env-test-key";
+
+    let resolveRequest:
+      | ((value: {
+          headers: Record<string, string | string[] | undefined>;
+          body: Record<string, unknown>;
+        }) => void)
+      | null = null;
+    const requestSeen = new Promise<{
+      headers: Record<string, string | string[] | undefined>;
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          headers: req.headers,
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-env-auth",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-env-auth",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {} as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+      if (previousApiKey === undefined) {
+        delete process.env.PLAMO_API_KEY;
+      } else {
+        process.env.PLAMO_API_KEY = previousApiKey;
+      }
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    const request = await requestSeen;
+    expect(request.headers.authorization).toBe("Bearer env-test-key");
+    expect(request.body).toMatchObject({
+      model: "plamo-3.0-prime-beta",
+      stream: true,
+    });
+  });
+
+  it("replaces blank authorization headers with bearer auth when an api key is available", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    let resolveRequest:
+      | ((value: {
+          headers: Record<string, string | string[] | undefined>;
+          body: Record<string, unknown>;
+        }) => void)
+      | null = null;
+    const requestSeen = new Promise<{
+      headers: Record<string, string | string[] | undefined>;
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          headers: req.headers,
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-blank-auth-header",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-blank-auth-header",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        headers: {
+          Authorization: "   ",
+        },
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    const request = await requestSeen;
+    expect(request.headers.authorization).toBe("Bearer test-key");
+    expect(request.body).toMatchObject({
+      model: "plamo-3.0-prime-beta",
+      stream: true,
+    });
+  });
+
+  it("does not inject bearer auth when request auth overrides use a custom header", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    let resolveRequest:
+      | ((value: {
+          headers: Record<string, string | string[] | undefined>;
+          body: Record<string, unknown>;
+        }) => void)
+      | null = null;
+    const requestSeen = new Promise<{
+      headers: Record<string, string | string[] | undefined>;
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          headers: req.headers,
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-proxy-auth-override",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-proxy-auth-override",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      attachModelProviderRequestTransport(
+        {
+          ...model,
+          provider: "plamo",
+          api: "openai-completions",
+          baseUrl: `http://127.0.0.1:${address.port}/v1`,
+          headers: {
+            "X-Proxy-Token": "proxy-token",
+          },
+        },
+        {
+          auth: {
+            mode: "header",
+            headerName: "X-Proxy-Token",
+            value: "proxy-token",
+          },
+        },
+      ) as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    const request = await requestSeen;
+    expect(request.headers["x-proxy-token"]).toBe("proxy-token");
+    expect(request.headers.authorization).toBeUndefined();
+    expect(request.body).toMatchObject({
+      model: "plamo-3.0-prime-beta",
+      stream: true,
+    });
+  });
+
+  it("does not inject bearer auth for synthetic request-auth markers", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+    const previousApiKey = process.env.PLAMO_API_KEY;
+    process.env.PLAMO_API_KEY = "env-test-key";
+
+    let resolveRequest:
+      | ((value: {
+          headers: Record<string, string | string[] | undefined>;
+          body: Record<string, unknown>;
+        }) => void)
+      | null = null;
+    const requestSeen = new Promise<{
+      headers: Record<string, string | string[] | undefined>;
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          headers: req.headers,
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-synthetic-request-auth",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-synthetic-request-auth",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        headers: {
+          "X-Proxy-Token": "proxy-token",
+        },
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: PLAMO_REQUEST_AUTH_MARKER,
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+      if (previousApiKey === undefined) {
+        delete process.env.PLAMO_API_KEY;
+      } else {
+        process.env.PLAMO_API_KEY = previousApiKey;
+      }
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    const request = await requestSeen;
+    expect(request.headers["x-proxy-token"]).toBe("proxy-token");
+    expect(request.headers.authorization).toBeUndefined();
+  });
+
+  it("normalizes zero-argument tool schemas on the native transport path", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    let resolveRequest: ((value: { body: Record<string, unknown> }) => void) | null = null;
+    const requestSeen = new Promise<{
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+        tools: [
+          {
+            name: "ping",
+            description: "No-arg tool",
+            parameters: {},
+          },
+        ],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      await stream.result();
+    } finally {
+      server.close();
+    }
+
+    const request = await requestSeen;
+    expect(request.body.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "ping",
+          description: "No-arg tool",
+          parameters: {
+            type: "object",
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("uses PLaMo-safe compat defaults for uncataloged models without explicit compat", async () => {
+    const { provider } = await loadPlamoCatalog();
+
+    let resolveRequest: ((value: { body: Record<string, unknown> }) => void) | null = null;
+    const requestSeen = new Promise<{
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const wrapped = createWrappedPlamoStream(provider, {
+      modelId: "plamo-next-preview",
+    });
+    const stream = await wrapped(
+      {
+        provider: "plamo",
+        api: "openai-completions",
+        id: "plamo-next-preview",
+        name: "PLaMo Next Preview",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 65_536,
+        maxTokens: 1_024,
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+        tools: [
+          {
+            name: "read",
+            description: "Read a file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      {
+        apiKey: "test-key",
+        reasoningEffort: "high",
+        onPayload: async (payload: unknown) => ({
+          ...(payload as Record<string, unknown>),
+          store: true,
+          reasoning_effort: "high",
+          stream_options: { include_usage: true },
+        }),
+      } as never,
+    );
+
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      await stream.result();
+    } finally {
+      server.close();
+    }
+
+    const request = await requestSeen;
+    expect(request.body).toMatchObject({
+      model: "plamo-next-preview",
+      max_tokens: 1_024,
+      messages: [
+        { role: "system", content: "system prompt" },
+        { role: "user", content: "こんにちは" },
+      ],
+      stream: true,
+    });
+    expect(request.body).not.toHaveProperty("max_completion_tokens");
+    expect(request.body).not.toHaveProperty("store");
+    expect(request.body).not.toHaveProperty("reasoning_effort");
+    expect(request.body).not.toHaveProperty("stream_options");
+    expect(
+      (request.body.tools as Array<{ function?: { strict?: unknown } }> | undefined)?.[0]?.function,
+    ).not.toHaveProperty("strict");
+  });
+
+  it("re-normalizes payload after mutation-style onPayload hooks that return undefined", async () => {
+    const { provider } = await loadPlamoCatalog();
+
+    let resolveRequest: ((value: { body: Record<string, unknown> }) => void) | null = null;
+    const requestSeen = new Promise<{
+      body: Record<string, unknown>;
+    }>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const server = createServer((req, res) => {
+      const chunks: string[] = [];
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        resolveRequest?.({
+          body: JSON.parse(chunks.join("")) as Record<string, unknown>,
+        });
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: { content: "ok" } }],
+          })}\n\n`,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-stream-test",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const wrapped = createWrappedPlamoStream(provider, {
+      modelId: "plamo-next-preview",
+    });
+    const stream = await wrapped(
+      {
+        provider: "plamo",
+        api: "openai-completions",
+        id: "plamo-next-preview",
+        name: "PLaMo Next Preview",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 65_536,
+        maxTokens: 1_024,
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+        tools: [
+          {
+            name: "read",
+            description: "Read a file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      } as never,
+      {
+        apiKey: "test-key",
+        reasoningEffort: "high",
+        onPayload: async (payload: unknown) => {
+          const payloadRecord = payload as Record<string, unknown>;
+          payloadRecord.store = true;
+          payloadRecord.reasoning_effort = "high";
+          payloadRecord.stream_options = { include_usage: true };
+          const tools = payloadRecord.tools as
+            | Array<{ function?: Record<string, unknown> }>
+            | undefined;
+          if (tools?.[0]?.function) {
+            tools[0].function.strict = true;
+          }
+          return undefined;
+        },
+      } as never,
+    );
+
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the request completes.
+      }
+      await stream.result();
+    } finally {
+      server.close();
+    }
+
+    const request = await requestSeen;
+    expect(request.body).toMatchObject({
+      model: "plamo-next-preview",
+      max_tokens: 1_024,
+      stream: true,
+    });
+    expect(request.body).not.toHaveProperty("max_completion_tokens");
+    expect(request.body).not.toHaveProperty("store");
+    expect(request.body).not.toHaveProperty("reasoning_effort");
+    expect(request.body).not.toHaveProperty("stream_options");
+    expect(
+      (request.body.tools as Array<{ function?: { strict?: unknown } }> | undefined)?.[0]?.function,
+    ).not.toHaveProperty("strict");
+  });
+
+  it("reassembles fragmented native SSE chunks without truncating the final text", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+
+      const writeFragmented = (text: string) => {
+        for (let index = 0; index < text.length; index += 7) {
+          res.write(text.slice(index, index + 7));
+        }
+      };
+      const writeEvent = (event: Record<string, unknown>) => {
+        writeFragmented(`data: ${JSON.stringify(event)}\n\n`);
+      };
+
+      writeEvent({
+        id: "chatcmpl-stream-fragmented",
+        choices: [{ index: 0, delta: { reasoning_content: "thinking " } }],
+      });
+      writeEvent({
+        id: "chatcmpl-stream-fragmented",
+        choices: [{ index: 0, delta: { content: "明日" } }],
+      });
+      writeEvent({
+        id: "chatcmpl-stream-fragmented",
+        choices: [{ index: 0, delta: { content: "は晴れ" } }],
+      });
+      writeEvent({
+        id: "chatcmpl-stream-fragmented",
+        choices: [{ index: 0, delta: { content: "です。" }, finish_reason: "stop" }],
+      });
+      writeEvent({
+        id: "chatcmpl-stream-fragmented",
+        usage: { prompt_tokens: 11, completion_tokens: 5, total_tokens: 16 },
+        choices: [],
+      });
+      writeFragmented("data: [DONE]\n\n");
+      res.end();
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    const deltas: string[] = [];
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const event of stream) {
+        if (event.type === "text_delta") {
+          deltas.push(event.delta);
+        }
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(deltas.join("")).toBe("明日は晴れです。");
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      usage: { input: 11, output: 5, totalTokens: 16 },
+      content: [
+        { type: "thinking", thinking: "thinking " },
+        { type: "text", text: "明日は晴れです。" },
+      ],
+    });
+  });
+
+  it("clamps uncached prompt usage to zero when cached_tokens exceeds prompt_tokens", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-stream-usage-clamp",
+          choices: [{ index: 0, delta: { content: "ok" } }],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-stream-usage-clamp",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: {
+            prompt_tokens: 2,
+            completion_tokens: 5,
+            total_tokens: 7,
+            prompt_tokens_details: { cached_tokens: 4 },
+          },
+        })}\n\n`,
+      );
+      res.end("data: [DONE]\n\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the final usage is available.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      usage: {
+        input: 0,
+        output: 5,
+        cacheRead: 4,
+        totalTokens: 9,
+      },
+      content: [{ type: "text", text: "ok" }],
+    });
+  });
+
+  it("does not double-count reasoning tokens in streamed usage", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-stream-usage-reasoning",
+          choices: [{ index: 0, delta: { content: "ok" } }],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-stream-usage-reasoning",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            total_tokens: 30,
+            prompt_tokens_details: { cached_tokens: 3 },
+            completion_tokens_details: { reasoning_tokens: 7 },
+          },
+        })}\n\n`,
+      );
+      res.end("data: [DONE]\n\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the final usage is available.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      usage: {
+        input: 7,
+        output: 20,
+        cacheRead: 3,
+        totalTokens: 30,
+      },
+      content: [{ type: "text", text: "ok" }],
+    });
+  });
+
+  it("treats native SSE EOF without finish_reason as an error", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-stream-truncated",
+          choices: [{ index: 0, delta: { content: "partial" } }],
+        })}\n\n`,
+      );
+      res.end("data: [DONE]\n\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    const events: unknown[] = [];
+    try {
+      for await (const event of stream) {
+        events.push(event);
+      }
+    } finally {
+      server.close();
+    }
+
+    expect(events.some((event) => (event as { type?: unknown }).type === "done")).toBe(false);
+    expect(events.at(-1)).toMatchObject({
+      type: "error",
+      reason: "error",
+      error: expect.objectContaining({
+        stopReason: "error",
+        errorMessage: expect.stringContaining("finish_reason"),
+      }),
+    });
+  });
+
+  it("normalizes inline PLaMo tool markup in native stream results without synthetic toolcall events", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+    const toolMarkup =
+      "<|plamo:begin_tool_requests:plamo|>" +
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>read<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"README.md"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>" +
+      "<|plamo:end_tool_requests:plamo|>";
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-tool",
+          choices: [{ index: 0, delta: { content: `I will inspect the file.\n${toolMarkup}` } }],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-tool",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+        })}\n\n`,
+      );
+      res.end("data: [DONE]\n\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    const eventTypes: string[] = [];
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(eventTypes).not.toContain("toolcall_start");
+    expect(eventTypes).not.toContain("toolcall_delta");
+    expect(eventTypes).not.toContain("toolcall_end");
+    expect(result).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text: "I will inspect the file.",
+        },
+        {
+          type: "toolCall",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+      ],
+    });
+  });
+
+  it("preserves later native text deltas after inline tool markup closes mid-stream", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+    const toolMarkup =
+      "<|plamo:begin_tool_requests:plamo|>" +
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>read<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"README.md"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>" +
+      "<|plamo:end_tool_requests:plamo|>";
+    const splitToolMarkupIndex = 5;
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-tool-midstream",
+          choices: [
+            {
+              index: 0,
+              delta: { content: `Checking...${toolMarkup.slice(0, splitToolMarkupIndex)}` },
+            },
+          ],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-tool-midstream",
+          choices: [
+            {
+              index: 0,
+              delta: { content: toolMarkup.slice(splitToolMarkupIndex) },
+            },
+          ],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-tool-midstream",
+          choices: [{ index: 0, delta: { content: " Done." } }],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-tool-midstream",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 1, completion_tokens: 3, total_tokens: 4 },
+        })}\n\n`,
+      );
+      res.end("data: [DONE]\n\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    const textDeltas: string[] = [];
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const event of stream) {
+        if (event.type === "text_delta") {
+          textDeltas.push(event.delta);
+        }
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(textDeltas.join("")).toBe("Checking... Done.");
+    expect(textDeltas.some((delta) => delta.includes("<|plamo:"))).toBe(false);
+    expect(result).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text: "Checking...",
+        },
+        {
+          type: "toolCall",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+        {
+          type: "text",
+          text: "Done.",
+        },
+      ],
+    });
+  });
+
+  it("preserves trailing plain-text markup prefixes on the final native stream flush", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-trailing-prefix",
+          choices: [{ index: 0, delta: { content: "Ends with <|" } }],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-trailing-prefix",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        })}\n\n`,
+      );
+      res.end("data: [DONE]\n\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "Return a literal suffix." }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the final message is assembled.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "Ends with <|" }],
+    });
+  });
+
+  it("strips parser-only fields from native partial stream snapshots", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-native-partials",
+          choices: [{ index: 0, delta: { content: "Checking..." } }],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-native-partials",
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: { name: "read", arguments: '{"path":"README' },
+                  },
+                ],
+              },
+            },
+          ],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-native-partials",
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: { arguments: '.md"}' },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+        })}\n\n`,
+      );
+      res.end("data: [DONE]\n\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    const events: Array<Record<string, unknown>> = [];
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const event of stream) {
+        events.push(event as Record<string, unknown>);
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    const textStartEvent = events.find((event) => event.type === "text_start");
+    expect(textStartEvent).toMatchObject({
+      partial: {
+        content: expect.arrayContaining([{ type: "text", text: "Checking..." }]),
+      },
+    });
+    expect(
+      (
+        textStartEvent as {
+          partial?: {
+            content?: Array<Record<string, unknown>>;
+          };
+        }
+      ).partial?.content?.[0],
+    ).not.toHaveProperty("rawText");
+    expect(
+      (
+        textStartEvent as {
+          partial?: {
+            content?: Array<Record<string, unknown>>;
+          };
+        }
+      ).partial?.content?.[0],
+    ).not.toHaveProperty("streamStarted");
+
+    const toolCallDeltaEvent = events.find((event) => event.type === "toolcall_delta");
+    expect(toolCallDeltaEvent).toMatchObject({
+      partial: {
+        content: expect.arrayContaining([
+          expect.objectContaining({
+            type: "toolCall",
+            name: "read",
+            arguments: {},
+          }),
+        ]),
+      },
+    });
+    const streamedToolCallBlock = (
+      (
+        toolCallDeltaEvent as {
+          partial?: {
+            content?: Array<Record<string, unknown>>;
+          };
+        }
+      ).partial?.content ?? []
+    ).find((block) => block.type === "toolCall");
+    expect(streamedToolCallBlock).not.toHaveProperty("partialArgs");
+
+    expect(result).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        { type: "text", text: "Checking..." },
+        { type: "toolCall", name: "read", arguments: { path: "README.md" } },
+      ],
+    });
+  });
+
+  it("splits interleaved tool-call deltas by index when ids are omitted", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-tool-indexed",
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: { name: "read", arguments: '{"path":"README' },
+                  },
+                  {
+                    index: 1,
+                    function: { name: "write", arguments: '{"path":"notes.txt","content":"he' },
+                  },
+                ],
+              },
+            },
+          ],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-tool-indexed",
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: { arguments: '.md"}' },
+                  },
+                  {
+                    index: 1,
+                    function: { arguments: 'llo"}' },
+                  },
+                ],
+                content: "",
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+        })}\n\n`,
+      );
+      res.end("data: [DONE]\n\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the final message is assembled.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "toolCall",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "notes.txt", content: "hello" },
+        },
+      ],
+    });
+  });
+
+  it("normalizes inline PLaMo tool markup into cloned wrapped-stream snapshots", async () => {
+    const toolMarkup =
+      "<|plamo:begin_tool_requests:plamo|>" +
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>read<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"README.md"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>" +
+      "<|plamo:end_tool_requests:plamo|>";
+    const partialMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: `Checking...${toolMarkup}` }],
+    };
+    const streamedMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: `Reading now.${toolMarkup}` }],
+    };
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: `I will inspect the file.\n${toolMarkup}` }],
+    };
+
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [{ partial: partialMessage, message: streamedMessage }],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const wrapped = createPlamoToolCallWrapper(baseFn as never);
+
+    const stream = await wrapped(
+      {
+        api: "openai-completions",
+        provider: "plamo",
+        id: "plamo-3.0-prime-beta",
+      } as never,
+      { messages: [] } as never,
+      {} as never,
+    );
+
+    const events: unknown[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    const result = await stream.result();
+    const wrappedToolCallId = (
+      (
+        events[0] as {
+          partial?: { content?: Array<{ type?: string; id?: string }> };
+          message?: { content?: Array<{ type?: string; id?: string }> };
+        }
+      ).message?.content ?? []
+    ).find((block) => block.type === "toolCall")?.id;
+    const partialToolCallId = (
+      (
+        events[0] as {
+          partial?: { content?: Array<{ type?: string; id?: string }> };
+        }
+      ).partial?.content ?? []
+    ).find((block) => block.type === "toolCall")?.id;
+    const resultToolCallId = (
+      (result as { content?: Array<{ type?: string; id?: string }> }).content ?? []
+    ).find((block) => block.type === "toolCall")?.id;
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        partial: expect.objectContaining({
+          content: [
+            { type: "text", text: "Checking..." },
+            expect.objectContaining({
+              type: "toolCall",
+              name: "read",
+              arguments: { path: "README.md" },
+            }),
+          ],
+          stopReason: "toolUse",
+        }),
+        message: expect.objectContaining({
+          content: [
+            { type: "text", text: "Reading now." },
+            expect.objectContaining({
+              type: "toolCall",
+              name: "read",
+              arguments: { path: "README.md" },
+            }),
+          ],
+          stopReason: "toolUse",
+        }),
+      }),
+    );
+    expect(partialMessage.content).toEqual([{ type: "text", text: `Checking...${toolMarkup}` }]);
+    expect(streamedMessage.content).toEqual([{ type: "text", text: `Reading now.${toolMarkup}` }]);
+    expect(finalMessage.content).toEqual([
+      { type: "text", text: `I will inspect the file.\n${toolMarkup}` },
+    ]);
+    expect(finalMessage).toMatchObject({ role: "assistant" });
+    expect(result).toEqual({
+      role: "assistant",
+      stopReason: "toolUse",
+      content: [
+        { type: "text", text: "I will inspect the file." },
+        expect.objectContaining({
+          type: "toolCall",
+          name: "read",
+          arguments: { path: "README.md" },
+        }),
+      ],
+    });
+    expect(partialToolCallId).toBeTypeOf("string");
+    expect(wrappedToolCallId).toBe(partialToolCallId);
+    expect(resultToolCallId).toBe(partialToolCallId);
+    expect(result).not.toBe(finalMessage);
+  });
+
+  it("keeps done reason synchronized with normalized tool-use stopReason on wrapped streams", async () => {
+    const toolMarkup =
+      "<|plamo:begin_tool_requests:plamo|>" +
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>read<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"README.md"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>" +
+      "<|plamo:end_tool_requests:plamo|>";
+    const doneMessage = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: `I will inspect the file.\n${toolMarkup}` }],
+    };
+
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [{ type: "done", reason: "stop", message: doneMessage }],
+        resultMessage: doneMessage,
+      }),
+    );
+
+    const wrapped = createPlamoToolCallWrapper(baseFn as never);
+
+    const stream = await wrapped(
+      {
+        api: "openai-completions",
+        provider: "plamo",
+        id: "plamo-3.0-prime-beta",
+      } as never,
+      { messages: [] } as never,
+      {} as never,
+    );
+
+    const events: unknown[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    const result = await stream.result();
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "done",
+        reason: "toolUse",
+        message: expect.objectContaining({
+          stopReason: "toolUse",
+          content: [
+            { type: "text", text: "I will inspect the file." },
+            expect.objectContaining({
+              type: "toolCall",
+              name: "read",
+              arguments: { path: "README.md" },
+            }),
+          ],
+        }),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        stopReason: "toolUse",
+        content: [
+          { type: "text", text: "I will inspect the file." },
+          expect.objectContaining({
+            type: "toolCall",
+            name: "read",
+            arguments: { path: "README.md" },
+          }),
+        ],
+      }),
+    );
+    expect(result).not.toBe(doneMessage);
+    expect(doneMessage).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: `I will inspect the file.\n${toolMarkup}` }],
+    });
+  });
+
+  it("preserves later text deltas after wrapped-stream inline tool normalization", async () => {
+    const toolMarkup =
+      "<|plamo:begin_tool_requests:plamo|>" +
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>read<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"README.md"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>" +
+      "<|plamo:end_tool_requests:plamo|>";
+    const liveMessage = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: `Checking...${toolMarkup}` }],
+    };
+
+    const baseFn = vi.fn(() => ({
+      async result() {
+        return liveMessage;
+      },
+      [Symbol.asyncIterator]() {
+        let step = 0;
+        return {
+          async next() {
+            if (step === 0) {
+              step += 1;
+              return { done: false as const, value: { partial: liveMessage } };
+            }
+            if (step === 1) {
+              const firstBlock = liveMessage.content[0];
+              if (!firstBlock || typeof firstBlock !== "object" || firstBlock.type !== "text") {
+                throw new Error("expected live wrapped stream to keep a text block");
+              }
+              firstBlock.text += " Done.";
+              step += 1;
+              return {
+                done: false as const,
+                value: { type: "done", reason: "stop", message: liveMessage },
+              };
+            }
+            return { done: true as const, value: undefined };
+          },
+          async return(value?: unknown) {
+            return { done: true as const, value };
+          },
+          async throw(error?: unknown) {
+            throw error;
+          },
+        };
+      },
+    }));
+
+    const wrapped = createPlamoToolCallWrapper(baseFn as never);
+    const stream = await wrapped(
+      {
+        api: "openai-completions",
+        provider: "plamo",
+        id: "plamo-3.0-prime-beta",
+      } as never,
+      { messages: [] } as never,
+      {} as never,
+    );
+
+    const events: unknown[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    const result = await stream.result();
+
+    expect(baseFn).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      expect.objectContaining({
+        partial: expect.objectContaining({
+          stopReason: "toolUse",
+          content: [
+            { type: "text", text: "Checking..." },
+            expect.objectContaining({
+              type: "toolCall",
+              name: "read",
+              arguments: { path: "README.md" },
+            }),
+          ],
+        }),
+      }),
+      expect.objectContaining({
+        type: "done",
+        reason: "toolUse",
+        message: expect.objectContaining({
+          stopReason: "toolUse",
+          content: [
+            { type: "text", text: "Checking..." },
+            expect.objectContaining({
+              type: "toolCall",
+              name: "read",
+              arguments: { path: "README.md" },
+            }),
+            { type: "text", text: "Done." },
+          ],
+        }),
+      }),
+    ]);
+    expect(result).toEqual(
+      expect.objectContaining({
+        stopReason: "toolUse",
+        content: [
+          { type: "text", text: "Checking..." },
+          expect.objectContaining({
+            type: "toolCall",
+            name: "read",
+            arguments: { path: "README.md" },
+          }),
+          { type: "text", text: "Done." },
+        ],
+      }),
+    );
+    expect(liveMessage).toEqual({
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: `Checking...${toolMarkup} Done.` }],
+    });
+  });
+
+  it("treats toolUse and functionCall blocks as prior tool history on the native transport path", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+    let capturedPayload: Record<string, unknown> | undefined;
+    fetchWithSsrFGuardMock.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        init?: RequestInit;
+      };
+      const requestBody = params.init?.body;
+      if (typeof requestBody !== "string") {
+        throw new Error("expected native PLaMo transport to send a string request body");
+      }
+      capturedPayload = JSON.parse(requestBody) as Record<string, unknown>;
+      return {
+        response: new Response(
+          [
+            `data: ${JSON.stringify({
+              id: "chatcmpl-tool-history",
+              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+              usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+            })}`,
+            "",
+            "data: [DONE]",
+            "",
+          ].join("\n"),
+          {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        ),
+        release: async () => {},
+      };
+    });
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: "https://api.platform.preferredai.jp/v1",
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "toolUse", id: "call_1", name: "read", input: { path: "README.md" } },
+              { type: "functionCall", id: "call_2", name: "exec", arguments: { cmd: "pwd" } },
+            ],
+          },
+        ],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    for await (const _event of stream) {
+      // Drain the stream so the request completes.
+    }
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      model: "plamo-3.0-prime-beta",
+      stream: true,
+      max_tokens: 20_000,
+      tools: [],
+      messages: [
+        { role: "system", content: "system prompt" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: "read",
+                arguments: '{"path":"README.md"}',
+              },
+            },
+            {
+              id: "call_2",
+              type: "function",
+              function: {
+                name: "exec",
+                arguments: '{"cmd":"pwd"}',
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_1",
+          content: "No result provided",
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_2",
+          content: "No result provided",
+        },
+      ],
+    });
+  });
+
+  it("keeps replayed assistant tool calls ahead of tool results on the native transport path", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+    let capturedPayload: Record<string, unknown> | undefined;
+    fetchWithSsrFGuardMock.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        init?: RequestInit;
+      };
+      const requestBody = params.init?.body;
+      if (typeof requestBody !== "string") {
+        throw new Error("expected native PLaMo transport to send a string request body");
+      }
+      capturedPayload = JSON.parse(requestBody) as Record<string, unknown>;
+      return {
+        response: new Response(
+          [
+            `data: ${JSON.stringify({
+              id: "chatcmpl-tool-result-history",
+              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+              usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+            })}`,
+            "",
+            "data: [DONE]",
+            "",
+          ].join("\n"),
+          {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        ),
+        release: async () => {},
+      };
+    });
+
+    const [model] = catalog.provider.models;
+    const wrapped = createWrappedPlamoStream(provider);
+    const stream = await wrapped(
+      {
+        ...model,
+        provider: "plamo",
+        api: "openai-completions",
+        baseUrl: "https://api.platform.preferredai.jp/v1",
+      } as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "toolUse", id: "call_1", name: "read", input: { path: "README.md" } },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "read",
+            content: [{ type: "text", text: "README contents here" }],
+          },
+          { role: "user", content: "Continue from the tool result in one sentence." },
+        ],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    for await (const _event of stream) {
+      // Drain the stream so the request completes.
+    }
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      messages: [
+        { role: "system", content: "system prompt" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: "read",
+                arguments: '{"path":"README.md"}',
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_1",
+          content: "README contents here",
+        },
+        {
+          role: "user",
+          content: "Continue from the tool result in one sentence.",
+        },
+      ],
+      tools: [],
+    });
+  });
+
+  it("parses tool calls from every tool_requests wrapper in assistant text", () => {
+    const firstToolMarkup =
+      "<|plamo:begin_tool_requests:plamo|>" +
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>read<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"README.md"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>" +
+      "<|plamo:end_tool_requests:plamo|>";
+    const secondToolMarkup =
+      "<|plamo:begin_tool_requests:plamo|>" +
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>" +
+      "<|plamo:end_tool_requests:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: `${firstToolMarkup}${secondToolMarkup}` }],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        { type: "toolCall", name: "read", arguments: { path: "README.md" } },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    });
+  });
+
+  it("parses standalone tool_request blocks even when wrapped tool_requests blocks are present", () => {
+    const wrappedToolMarkup =
+      "<|plamo:begin_tool_requests:plamo|>" +
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>read<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"README.md"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>" +
+      "<|plamo:end_tool_requests:plamo|>";
+    const standaloneToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: `${wrappedToolMarkup}${standaloneToolMarkup}` }],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        { type: "toolCall", name: "read", arguments: { path: "README.md" } },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    });
+  });
+
+  it("keeps existing toolCall blocks and adds extra inline-only tool calls", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        { type: "text", text: `Checking...${inlineToolMarkup}` },
+        {
+          type: "toolCall",
+          id: "existing_call",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+      ],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        { type: "text", text: "Checking..." },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+        {
+          type: "toolCall",
+          id: "existing_call",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+      ],
+    });
+  });
+
+  it("deduplicates inline tool calls even when argument key order differs", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"content":"ok","path":"notes.txt"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        { type: "text", text: `Checking...${inlineToolMarkup}` },
+        {
+          type: "toolCall",
+          id: "existing_call",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "stop",
+      content: [
+        { type: "text", text: "Checking..." },
+        {
+          type: "toolCall",
+          id: "existing_call",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    });
+  });
+
+  it("deduplicates inline tool markup against existing toolUse and functionCall blocks", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const toolUseMessage = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        { type: "text", text: `Checking...${inlineToolMarkup}` },
+        {
+          type: "toolUse",
+          id: "existing_tool_use",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    };
+    normalizePlamoToolMarkupInMessage(toolUseMessage);
+    expect(toolUseMessage).toMatchObject({
+      stopReason: "stop",
+      content: [
+        { type: "text", text: "Checking..." },
+        {
+          type: "toolUse",
+          id: "existing_tool_use",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    });
+
+    const functionCallMessage = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        { type: "text", text: `Checking...${inlineToolMarkup}` },
+        {
+          type: "functionCall",
+          id: "existing_function_call",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    };
+    normalizePlamoToolMarkupInMessage(functionCallMessage);
+    expect(functionCallMessage).toMatchObject({
+      stopReason: "stop",
+      content: [
+        { type: "text", text: "Checking..." },
+        {
+          type: "functionCall",
+          id: "existing_function_call",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    });
+
+    const toolUseInputMessage = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        { type: "text", text: `Checking...${inlineToolMarkup}` },
+        {
+          type: "toolUse",
+          id: "existing_tool_use_input",
+          name: "write",
+          input: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    };
+    normalizePlamoToolMarkupInMessage(toolUseInputMessage);
+    expect(toolUseInputMessage).toMatchObject({
+      stopReason: "stop",
+      content: [
+        { type: "text", text: "Checking..." },
+        {
+          type: "toolUse",
+          id: "existing_tool_use_input",
+          name: "write",
+          input: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    });
+  });
+
+  it("preserves later inline tool markup when the same structured tool call already appeared", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        {
+          type: "toolCall",
+          id: "existing_call",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+        { type: "text", text: `Checking again...${inlineToolMarkup}` },
+      ],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "toolCall",
+          id: "existing_call",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+        { type: "text", text: "Checking again..." },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    });
+    expect((message.content[2] as { id?: unknown }).id).toBeTypeOf("string");
+    expect((message.content[2] as { id?: unknown }).id).not.toBe("existing_call");
+  });
+
+  it("preserves multiple text blocks around non-text blocks when normalizing inline tool markup", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        { type: "text", text: "Before" },
+        {
+          type: "toolCall",
+          id: "existing_call",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+        { type: "text", text: `After${inlineToolMarkup}` },
+      ],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        { type: "text", text: "Before" },
+        {
+          type: "toolCall",
+          id: "existing_call",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+        { type: "text", text: "After" },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    });
+  });
+
+  it("preserves surrounding whitespace in text blocks when removing inline tool markup", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        { type: "text", text: "Before " },
+        { type: "text", text: inlineToolMarkup },
+        { type: "text", text: " after" },
+      ],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        { type: "text", text: "Before" },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+        { type: "text", text: "after" },
+      ],
+    });
+  });
+
+  it("removes split inline tool markup from continuation text blocks", () => {
+    const splitInlineToolMarkup = [
+      "<|plamo:begin_tool_request:plamo|>" +
+        "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+        '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt"',
+      ',"content":"ok"}<|plamo:end_tool_arguments:plamo|><|plamo:end_tool_request:plamo|>',
+    ] as const;
+
+    const message = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [
+        { type: "text", text: `Before ${splitInlineToolMarkup[0]}` },
+        { type: "text", text: `${splitInlineToolMarkup[1]} after` },
+      ],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        { type: "text", text: "Before" },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+        { type: "text", text: "after" },
+      ],
+    });
+  });
+
+  it("preserves non-stop terminal reasons when inline tool markup is normalized", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "length",
+      content: [{ type: "text", text: `Checking...${inlineToolMarkup}` }],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "length",
+      content: [
+        { type: "text", text: "Checking..." },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "notes.txt", content: "ok" },
+        },
+      ],
+    });
+  });
+
+  it("preserves malformed inline tool requests while normalizing valid ones", () => {
+    const validToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>read<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"README.md"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+    const invalidToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      "<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>not-json" +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text: `before ${validToolMarkup} middle ${invalidToolMarkup} after`,
+        },
+      ],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text: "before",
+        },
+        {
+          type: "toolCall",
+          name: "read",
+          arguments: { path: "README.md" },
+        },
+        {
+          type: "text",
+          text: `middle ${invalidToolMarkup} after`,
+        },
+      ],
+    });
+  });
+
+  it("parses inline tool arguments when PLAMO_MSG appears inside a JSON string", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|>{"path":"notes.txt","content":"literal <|plamo:msg|> token"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const message = {
+      role: "assistant",
+      stopReason: "toolUse",
+      content: [{ type: "text", text: `before ${inlineToolMarkup} after` }],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        { type: "text", text: "before" },
+        {
+          type: "toolCall",
+          name: "write",
+          arguments: {
+            path: "notes.txt",
+            content: "literal <|plamo:msg|> token",
+          },
+        },
+        { type: "text", text: "after" },
+      ],
+    });
+  });
+
+  it("keeps synthesized inline tool-call ids stable across cloned normalization passes", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const firstMessage = {
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: `Checking...${inlineToolMarkup}` }],
+    };
+    const secondMessage = structuredClone(firstMessage);
+
+    normalizePlamoToolMarkupInMessage(firstMessage);
+    normalizePlamoToolMarkupInMessage(secondMessage);
+
+    const firstToolCallId = (firstMessage.content as Array<{ type?: string; id?: string }>).find(
+      (block) => block.type === "toolCall",
+    )?.id;
+    const secondToolCallId = (secondMessage.content as Array<{ type?: string; id?: string }>).find(
+      (block) => block.type === "toolCall",
+    )?.id;
+
+    expect(firstToolCallId).toBeTypeOf("string");
+    expect(secondToolCallId).toBe(firstToolCallId);
+  });
+
+  it("generates different synthetic tool-call ids for identical inline calls in later assistant turns", () => {
+    const inlineToolMarkup =
+      "<|plamo:begin_tool_request:plamo|>" +
+      "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+      '<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>{"path":"notes.txt","content":"ok"}' +
+      "<|plamo:end_tool_arguments:plamo|>" +
+      "<|plamo:end_tool_request:plamo|>";
+
+    const firstMessage = {
+      role: "assistant",
+      stopReason: "stop",
+      timestamp: 1_700_000_000_000,
+      content: [{ type: "text", text: `Checking...${inlineToolMarkup}` }],
+    };
+    const secondMessage = {
+      role: "assistant",
+      stopReason: "stop",
+      timestamp: 1_700_000_000_001,
+      content: [{ type: "text", text: `Checking...${inlineToolMarkup}` }],
+    };
+
+    normalizePlamoToolMarkupInMessage(firstMessage);
+    normalizePlamoToolMarkupInMessage(secondMessage);
+
+    const firstToolCallId = (firstMessage.content as Array<{ type?: string; id?: string }>).find(
+      (block) => block.type === "toolCall",
+    )?.id;
+    const secondToolCallId = (secondMessage.content as Array<{ type?: string; id?: string }>).find(
+      (block) => block.type === "toolCall",
+    )?.id;
+
+    expect(firstToolCallId).toBeTypeOf("string");
+    expect(secondToolCallId).toBeTypeOf("string");
+    expect(secondToolCallId).not.toBe(firstToolCallId);
+  });
+
+  it("preserves raw inline tool markup when no valid tool-call blocks are produced", () => {
+    const message = {
+      role: "assistant",
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text:
+            "<|plamo:begin_tool_request:plamo|>" +
+            "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+            "<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>not-json" +
+            "<|plamo:end_tool_arguments:plamo|>" +
+            "<|plamo:end_tool_request:plamo|>",
+        },
+      ],
+    };
+
+    normalizePlamoToolMarkupInMessage(message);
+
+    expect(message).toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "text",
+          text:
+            "<|plamo:begin_tool_request:plamo|>" +
+            "<|plamo:begin_tool_name:plamo|>write<|plamo:end_tool_name:plamo|>" +
+            "<|plamo:begin_tool_arguments:plamo|><|plamo:msg|>not-json" +
+            "<|plamo:end_tool_arguments:plamo|>" +
+            "<|plamo:end_tool_request:plamo|>",
+        },
+      ],
+    });
+  });
+});

--- a/extensions/plamo/index.test.ts
+++ b/extensions/plamo/index.test.ts
@@ -1,4 +1,5 @@
 import { once } from "node:events";
+import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type {
@@ -158,17 +159,29 @@ beforeEach(() => {
 });
 
 describe("plamo provider plugin", () => {
-  it("registers PLaMo with api-key auth wizard metadata", async () => {
+  it("registers Preferred Networks with api-key auth wizard metadata", async () => {
     const provider = await registerSingleProviderPlugin(plamoPlugin);
     const resolved = resolveProviderPluginChoice({
       providers: [provider],
       choice: "plamo-api-key",
     });
+    const manifest = JSON.parse(
+      readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf8"),
+    ) as { providerAuthChoices?: Array<Record<string, unknown>> };
 
     expect(provider.id).toBe("plamo");
-    expect(provider.label).toBe("PLaMo");
+    expect(provider.label).toBe("Preferred Networks");
+    expect(provider.docsPath).toBe("/providers/preferred-networks");
     expect(provider.envVars).toEqual(["PLAMO_API_KEY"]);
     expect(provider.auth).toHaveLength(1);
+    expect(provider.auth[0]).toMatchObject({
+      label: "Preferred Networks API key",
+      wizard: {
+        choiceLabel: "Preferred Networks API key",
+        groupLabel: "Preferred Networks",
+        groupHint: "PLaMo API",
+      },
+    });
     expect(provider.buildReplayPolicy).toBeTypeOf("function");
     expect(provider.sanitizeReplayHistory).toBeTypeOf("function");
     expect(provider.createStreamFn).toBeTypeOf("function");
@@ -176,6 +189,12 @@ describe("plamo provider plugin", () => {
     expect(resolved).not.toBeNull();
     expect(resolved?.provider.id).toBe("plamo");
     expect(resolved?.method.id).toBe("api-key");
+    expect(manifest.providerAuthChoices?.[0]).toMatchObject({
+      choiceLabel: "Preferred Networks API key",
+      groupLabel: "Preferred Networks",
+      groupHint: "PLaMo API",
+      cliDescription: "Preferred Networks API key",
+    });
   });
 
   it("advertises PLaMo refs as modern models", async () => {

--- a/extensions/plamo/index.ts
+++ b/extensions/plamo/index.ts
@@ -1,0 +1,119 @@
+import type { ProviderResolveDynamicModelContext } from "openclaw/plugin-sdk/plugin-entry";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import {
+  buildProviderReplayFamilyHooks,
+  cloneFirstTemplateModel,
+  normalizeModelCompat,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { normalizeOpenAICompatibleToolParameters } from "openclaw/plugin-sdk/provider-tools";
+import {
+  PLAMO_BASE_URL,
+  PLAMO_DEFAULT_CONTEXT_WINDOW,
+  PLAMO_DEFAULT_MAX_TOKENS,
+  PLAMO_DEFAULT_MODEL_ID,
+  PLAMO_MODEL_INPUT,
+  PLAMO_OPENAI_COMPAT,
+} from "./model-definitions.js";
+import { applyPlamoConfig, PLAMO_DEFAULT_MODEL_REF } from "./onboard.js";
+import {
+  buildPlamoCatalog,
+  hasConfiguredPlamoProviderAuth,
+  PLAMO_REQUEST_AUTH_MARKER,
+} from "./provider-catalog.js";
+import { createPlamoToolCallWrapper, sanitizePlamoReplayHistory } from "./stream.js";
+
+const PROVIDER_ID = "plamo";
+const OPENAI_COMPATIBLE_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
+  family: "openai-compatible",
+});
+
+function isPlamoModelId(modelId: string): boolean {
+  return modelId.trim().toLowerCase().startsWith("plamo-");
+}
+
+function resolvePlamoDynamicModel(ctx: ProviderResolveDynamicModelContext) {
+  const modelId = ctx.modelId.trim();
+  if (!modelId || !isPlamoModelId(modelId)) {
+    return undefined;
+  }
+
+  return (
+    cloneFirstTemplateModel({
+      providerId: PROVIDER_ID,
+      modelId,
+      templateIds: [PLAMO_DEFAULT_MODEL_ID],
+      ctx,
+      patch: {
+        provider: PROVIDER_ID,
+        api: "openai-completions",
+        reasoning: false,
+      },
+    }) ??
+    normalizeModelCompat({
+      id: modelId,
+      name: modelId,
+      provider: PROVIDER_ID,
+      api: "openai-completions",
+      baseUrl: ctx.providerConfig?.baseUrl ?? PLAMO_BASE_URL,
+      reasoning: false,
+      input: [...PLAMO_MODEL_INPUT],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: PLAMO_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: PLAMO_DEFAULT_MAX_TOKENS,
+      compat: { ...PLAMO_OPENAI_COMPAT },
+    })
+  );
+}
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "PLaMo Provider",
+  description: "Bundled PLaMo provider plugin",
+  provider: {
+    label: "PLaMo",
+    docsPath: "/providers/models",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "PLaMo API key",
+        hint: "API key",
+        optionKey: "plamoApiKey",
+        flagName: "--plamo-api-key",
+        envVar: "PLAMO_API_KEY",
+        promptMessage: "Enter PLaMo API key",
+        defaultModel: PLAMO_DEFAULT_MODEL_REF,
+        applyConfig: applyPlamoConfig,
+        wizard: {
+          choiceId: "plamo-api-key",
+          choiceLabel: "PLaMo API key",
+          groupId: "plamo",
+          groupLabel: "PLaMo",
+          groupHint: "API key",
+        },
+      },
+    ],
+    catalog: {
+      run: buildPlamoCatalog,
+    },
+    resolveSyntheticAuth: ({ providerConfig }) =>
+      hasConfiguredPlamoProviderAuth(providerConfig)
+        ? {
+            apiKey: PLAMO_REQUEST_AUTH_MARKER,
+            source: "models.providers.plamo.request (synthetic request auth)",
+            mode: "api-key" as const,
+          }
+        : undefined,
+    ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
+    sanitizeReplayHistory: ({ messages }) => sanitizePlamoReplayHistory(messages),
+    normalizeToolSchemas: ({ tools }) =>
+      tools.map((tool) => ({
+        ...tool,
+        parameters: normalizeOpenAICompatibleToolParameters(
+          tool.parameters,
+        ) as typeof tool.parameters,
+      })),
+    resolveDynamicModel: (ctx) => resolvePlamoDynamicModel(ctx),
+    isModernModelRef: ({ modelId }) => isPlamoModelId(modelId),
+    createStreamFn: () => createPlamoToolCallWrapper(undefined),
+  },
+});

--- a/extensions/plamo/index.ts
+++ b/extensions/plamo/index.ts
@@ -67,28 +67,28 @@ function resolvePlamoDynamicModel(ctx: ProviderResolveDynamicModelContext) {
 
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
-  name: "PLaMo Provider",
-  description: "Bundled PLaMo provider plugin",
+  name: "Preferred Networks Provider",
+  description: "Bundled Preferred Networks model provider plugin for PLaMo",
   provider: {
-    label: "PLaMo",
-    docsPath: "/providers/models",
+    label: "Preferred Networks",
+    docsPath: "/providers/preferred-networks",
     auth: [
       {
         methodId: "api-key",
-        label: "PLaMo API key",
+        label: "Preferred Networks API key",
         hint: "API key",
         optionKey: "plamoApiKey",
         flagName: "--plamo-api-key",
         envVar: "PLAMO_API_KEY",
-        promptMessage: "Enter PLaMo API key",
+        promptMessage: "Enter Preferred Networks API key",
         defaultModel: PLAMO_DEFAULT_MODEL_REF,
         applyConfig: applyPlamoConfig,
         wizard: {
           choiceId: "plamo-api-key",
-          choiceLabel: "PLaMo API key",
+          choiceLabel: "Preferred Networks API key",
           groupId: "plamo",
-          groupLabel: "PLaMo",
-          groupHint: "API key",
+          groupLabel: "Preferred Networks",
+          groupHint: "PLaMo API",
         },
       },
     ],

--- a/extensions/plamo/model-definitions.ts
+++ b/extensions/plamo/model-definitions.ts
@@ -1,0 +1,48 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const PLAMO_BASE_URL = "https://api.platform.preferredai.jp/v1";
+export const PLAMO_DEFAULT_MODEL_ID = "plamo-3.0-prime-beta";
+export const PLAMO_DEFAULT_MODEL_REF = `plamo/${PLAMO_DEFAULT_MODEL_ID}`;
+export const PLAMO_DEFAULT_CONTEXT_WINDOW = 65_536;
+export const PLAMO_DEFAULT_MAX_TOKENS = 20_000;
+export const PLAMO_PRICE_USD_PER_1M_INPUT = 0.375;
+export const PLAMO_PRICE_USD_PER_1M_OUTPUT = 1.5625;
+export const PLAMO_MODEL_INPUT = ["text"] as const;
+
+export const PLAMO_OPENAI_COMPAT = {
+  // PLaMo's Chat Completions reference documents only `system`/`user`/`assistant`
+  // roles, `max_tokens`, and the legacy tool schema without `strict`/`store`.
+  maxTokensField: "max_tokens",
+  supportsDeveloperRole: false,
+  supportsReasoningEffort: false,
+  supportsStore: false,
+  supportsStrictMode: false,
+} as const satisfies NonNullable<ModelDefinitionConfig["compat"]>;
+
+const PLAMO_MODEL_CATALOG = [
+  {
+    id: PLAMO_DEFAULT_MODEL_ID,
+    name: "PLaMo 3.0 Prime Beta",
+    // PLaMo returns `reasoning_content`, but the public API does not expose a
+    // request-side reasoning toggle. In OpenClaw, `reasoning: true` means "the
+    // caller can opt into provider-controlled reasoning mode", so keep this
+    // false and treat the streamed reasoning payload as an always-on side
+    // channel instead.
+    reasoning: false,
+    input: [...PLAMO_MODEL_INPUT],
+    // Converted from JPY pricing using a fixed 1 USD = 160 JPY assumption.
+    cost: {
+      input: PLAMO_PRICE_USD_PER_1M_INPUT,
+      output: PLAMO_PRICE_USD_PER_1M_OUTPUT,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: PLAMO_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: PLAMO_DEFAULT_MAX_TOKENS,
+    compat: PLAMO_OPENAI_COMPAT,
+  },
+] as const satisfies readonly ModelDefinitionConfig[];
+
+export function buildPlamoCatalogModels(): ModelDefinitionConfig[] {
+  return PLAMO_MODEL_CATALOG.map((model) => Object.assign({}, model, { input: [...model.input] }));
+}

--- a/extensions/plamo/native-transport-request-policy.test.ts
+++ b/extensions/plamo/native-transport-request-policy.test.ts
@@ -1,0 +1,109 @@
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { describe, expect, it } from "vitest";
+import { attachModelProviderRequestTransport } from "../../src/agents/provider-request-config.js";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import plamoPlugin from "./index.js";
+
+async function loadPlamoCatalog() {
+  const provider = await registerSingleProviderPlugin(plamoPlugin);
+  const catalog = await provider.catalog!.run({
+    config: {},
+    env: {},
+    resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+    resolveProviderAuth: () => ({
+      apiKey: "test-key",
+      mode: "api_key",
+      source: "env",
+    }),
+  } as never);
+
+  if (!catalog || !("provider" in catalog)) {
+    throw new Error("expected single-provider catalog");
+  }
+
+  return { provider, catalog };
+}
+
+describe("plamo native transport request policy", () => {
+  it("honors model allowPrivateNetwork overrides on the native stream path", async () => {
+    const { provider, catalog } = await loadPlamoCatalog();
+
+    const server = createServer((req, res) => {
+      req.resume();
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-allow-private-network",
+          choices: [{ index: 0, delta: { content: "ok" } }],
+        })}\n\n`,
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          id: "chatcmpl-allow-private-network",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        })}\n\n`,
+      );
+      res.end("data: [DONE]\n\n");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("expected tcp server address");
+    }
+
+    const [model] = catalog.provider.models;
+    const wrapped = provider.createStreamFn?.({
+      config: {},
+      provider: "plamo",
+      modelId: model.id,
+      model: {
+        api: "openai-completions",
+        provider: "plamo",
+        id: model.id,
+      } as never,
+    } as never);
+    if (!wrapped) {
+      server.close();
+      throw new Error("expected wrapped stream function");
+    }
+
+    const stream = await wrapped(
+      attachModelProviderRequestTransport(
+        {
+          ...model,
+          provider: "plamo",
+          api: "openai-completions",
+          baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        },
+        { allowPrivateNetwork: true },
+      ) as never,
+      {
+        systemPrompt: "system prompt",
+        messages: [{ role: "user", content: "こんにちは" }],
+      } as never,
+      {
+        apiKey: "test-key",
+      } as never,
+    );
+
+    let result: Awaited<ReturnType<typeof stream.result>> | undefined;
+    try {
+      for await (const _event of stream) {
+        // Drain the stream so the final message is assembled.
+      }
+      result = await stream.result();
+    } finally {
+      server.close();
+    }
+
+    expect(result).toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "ok" }],
+    });
+  });
+});

--- a/extensions/plamo/onboard.test.ts
+++ b/extensions/plamo/onboard.test.ts
@@ -1,0 +1,44 @@
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { describe, expect, it } from "vitest";
+import {
+  createConfigWithFallbacks,
+  EXPECTED_FALLBACKS,
+} from "../../test/helpers/plugins/onboard-config.js";
+import { applyPlamoConfig, applyPlamoProviderConfig, PLAMO_DEFAULT_MODEL_REF } from "./onboard.js";
+
+describe("plamo onboard", () => {
+  it("adds the PLaMo provider in provider-only mode without changing the primary model", () => {
+    const cfg = applyPlamoProviderConfig({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+        },
+      },
+    });
+
+    expect(cfg.models?.providers?.plamo).toMatchObject({
+      baseUrl: "https://api.platform.preferredai.jp/v1",
+      api: "openai-completions",
+    });
+    expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe("openai/gpt-5.4");
+  });
+
+  it("sets the default PLaMo model without changing ACP backend config", () => {
+    const cfg = applyPlamoConfig({});
+
+    expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe(
+      PLAMO_DEFAULT_MODEL_REF,
+    );
+    expect(cfg.acp?.backend).toBeUndefined();
+  });
+
+  it("preserves existing model fallbacks", () => {
+    const cfg = applyPlamoConfig(createConfigWithFallbacks());
+    expect(resolveAgentModelFallbackValues(cfg.agents?.defaults?.model)).toEqual([
+      ...EXPECTED_FALLBACKS,
+    ]);
+  });
+});

--- a/extensions/plamo/onboard.test.ts
+++ b/extensions/plamo/onboard.test.ts
@@ -10,7 +10,7 @@ import {
 import { applyPlamoConfig, applyPlamoProviderConfig, PLAMO_DEFAULT_MODEL_REF } from "./onboard.js";
 
 describe("plamo onboard", () => {
-  it("adds the PLaMo provider in provider-only mode without changing the primary model", () => {
+  it("adds the Preferred Networks provider in provider-only mode without changing the primary model", () => {
     const cfg = applyPlamoProviderConfig({
       agents: {
         defaults: {

--- a/extensions/plamo/onboard.ts
+++ b/extensions/plamo/onboard.ts
@@ -1,0 +1,30 @@
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildPlamoCatalogModels,
+  PLAMO_BASE_URL,
+  PLAMO_DEFAULT_MODEL_REF,
+} from "./model-definitions.js";
+
+export { PLAMO_DEFAULT_MODEL_REF };
+
+const plamoPresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: PLAMO_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "plamo",
+    api: "openai-completions",
+    baseUrl: PLAMO_BASE_URL,
+    catalogModels: buildPlamoCatalogModels(),
+    aliases: [{ modelRef: PLAMO_DEFAULT_MODEL_REF, alias: "PLaMo" }],
+  }),
+});
+
+export function applyPlamoProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return plamoPresetAppliers.applyProviderConfig(cfg);
+}
+
+export function applyPlamoConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return plamoPresetAppliers.applyConfig(cfg);
+}

--- a/extensions/plamo/openclaw.plugin.json
+++ b/extensions/plamo/openclaw.plugin.json
@@ -1,0 +1,32 @@
+{
+  "id": "plamo",
+  "enabledByDefault": true,
+  "providers": ["plamo"],
+  "nonSecretAuthMarkers": ["plamo-request-auth"],
+  "modelSupport": {
+    "modelPrefixes": ["plamo-"]
+  },
+  "providerAuthEnvVars": {
+    "plamo": ["PLAMO_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "plamo",
+      "method": "api-key",
+      "choiceId": "plamo-api-key",
+      "choiceLabel": "PLaMo API key",
+      "groupId": "plamo",
+      "groupLabel": "PLaMo",
+      "groupHint": "API key",
+      "optionKey": "plamoApiKey",
+      "cliFlag": "--plamo-api-key",
+      "cliOption": "--plamo-api-key <key>",
+      "cliDescription": "PLaMo API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/plamo/openclaw.plugin.json
+++ b/extensions/plamo/openclaw.plugin.json
@@ -14,14 +14,14 @@
       "provider": "plamo",
       "method": "api-key",
       "choiceId": "plamo-api-key",
-      "choiceLabel": "PLaMo API key",
+      "choiceLabel": "Preferred Networks API key",
       "groupId": "plamo",
-      "groupLabel": "PLaMo",
-      "groupHint": "API key",
+      "groupLabel": "Preferred Networks",
+      "groupHint": "PLaMo API",
       "optionKey": "plamoApiKey",
       "cliFlag": "--plamo-api-key",
       "cliOption": "--plamo-api-key <key>",
-      "cliDescription": "PLaMo API key"
+      "cliDescription": "Preferred Networks API key"
     }
   ],
   "configSchema": {

--- a/extensions/plamo/package.json
+++ b/extensions/plamo/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openclaw/plamo-provider",
+  "version": "2026.4.25",
+  "private": true,
+  "description": "OpenClaw PLaMo provider plugin",
+  "type": "module",
+  "dependencies": {
+    "@mariozechner/pi-agent-core": "0.70.2",
+    "@mariozechner/pi-ai": "0.70.2"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/plamo/package.json
+++ b/extensions/plamo/package.json
@@ -2,7 +2,7 @@
   "name": "@openclaw/plamo-provider",
   "version": "2026.4.25",
   "private": true,
-  "description": "OpenClaw PLaMo provider plugin",
+  "description": "OpenClaw Preferred Networks model provider plugin for PLaMo",
   "type": "module",
   "dependencies": {
     "@mariozechner/pi-agent-core": "0.70.2",

--- a/extensions/plamo/provider-catalog.ts
+++ b/extensions/plamo/provider-catalog.ts
@@ -1,0 +1,104 @@
+import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/provider-auth";
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildPlamoCatalogModels, PLAMO_BASE_URL } from "./model-definitions.js";
+
+const PROVIDER_ID = "plamo";
+export const PLAMO_REQUEST_AUTH_MARKER = "plamo-request-auth";
+const PLAMO_AUTH_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authorization",
+  "x-proxy-token",
+  "x-auth-token",
+  "x-api-key",
+  "api-key",
+]);
+
+export function buildPlamoProvider(): ModelProviderConfig {
+  return {
+    baseUrl: PLAMO_BASE_URL,
+    api: "openai-completions",
+    models: buildPlamoCatalogModels(),
+  };
+}
+
+function resolveExplicitPlamoProviderConfig(ctx: ProviderCatalogContext) {
+  const providers = ctx.config.models?.providers;
+  if (!providers || typeof providers !== "object") {
+    return undefined;
+  }
+  return Object.entries(providers).find(
+    ([configuredProviderId]) => configuredProviderId.trim().toLowerCase() === PROVIDER_ID,
+  )?.[1];
+}
+
+export function hasConfiguredPlamoAuthHeaders(headers: unknown): boolean {
+  if (headers && typeof headers === "object" && !Array.isArray(headers)) {
+    for (const [headerName, headerValue] of Object.entries(headers)) {
+      if (
+        PLAMO_AUTH_HEADER_NAMES.has(headerName.trim().toLowerCase()) &&
+        hasConfiguredSecretInput(headerValue)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function hasConfiguredPlamoRequestAuth(request: unknown): boolean {
+  if (!request || typeof request !== "object") {
+    return false;
+  }
+  const headers = (request as { headers?: unknown }).headers;
+  if (hasConfiguredPlamoAuthHeaders(headers)) {
+    return true;
+  }
+  const auth = (request as { auth?: unknown }).auth;
+  if (!auth || typeof auth !== "object") {
+    return false;
+  }
+  const mode = (auth as { mode?: unknown }).mode;
+  if (mode === "authorization-bearer") {
+    return hasConfiguredSecretInput((auth as { token?: unknown }).token);
+  }
+  if (mode === "header") {
+    const headerName = (auth as { headerName?: unknown }).headerName;
+    return (
+      typeof headerName === "string" &&
+      headerName.trim().length > 0 &&
+      hasConfiguredSecretInput((auth as { value?: unknown }).value)
+    );
+  }
+  return false;
+}
+
+export function hasConfiguredPlamoProviderAuth(providerConfig: unknown): boolean {
+  if (!providerConfig || typeof providerConfig !== "object") {
+    return false;
+  }
+  return (
+    hasConfiguredPlamoAuthHeaders((providerConfig as { headers?: unknown }).headers) ||
+    hasConfiguredPlamoRequestAuth((providerConfig as { request?: unknown }).request)
+  );
+}
+
+export async function buildPlamoCatalog(ctx: ProviderCatalogContext) {
+  const apiKey =
+    ctx.resolveProviderAuth(PROVIDER_ID).apiKey ?? ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+  const explicitProvider = resolveExplicitPlamoProviderConfig(ctx);
+  const explicitBaseUrl =
+    typeof explicitProvider?.baseUrl === "string" ? explicitProvider.baseUrl.trim() : "";
+
+  if (!apiKey && !hasConfiguredPlamoProviderAuth(explicitProvider)) {
+    return null;
+  }
+
+  return {
+    provider: {
+      ...buildPlamoProvider(),
+      ...(explicitBaseUrl ? { baseUrl: explicitBaseUrl } : {}),
+      ...(apiKey ? { apiKey } : {}),
+    },
+  };
+}

--- a/extensions/plamo/stream.ts
+++ b/extensions/plamo/stream.ts
@@ -1,0 +1,1824 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
+import {
+  calculateCost,
+  createAssistantMessageEventStream,
+  streamSimple,
+  type AssistantMessage,
+  type AssistantMessageEventStream,
+  type OpenAICompletionsCompat,
+  type StopReason,
+  type Tool,
+  type ToolCall,
+  type Usage,
+} from "@mariozechner/pi-ai";
+import { convertMessages } from "@mariozechner/pi-ai/openai-completions";
+import {
+  isNonSecretApiKeyMarker,
+  resolveEnvApiKey,
+} from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  buildGuardedModelFetch,
+  resolveModelRequestAuthMode,
+} from "openclaw/plugin-sdk/provider-http-runtime";
+import { normalizeOpenAICompatibleToolParameters } from "openclaw/plugin-sdk/provider-tools";
+
+const PLAMO_BEGIN_TOOL_REQUEST = "<|plamo:begin_tool_request:plamo|>";
+const PLAMO_END_TOOL_REQUEST = "<|plamo:end_tool_request:plamo|>";
+const PLAMO_BEGIN_TOOL_REQUESTS = "<|plamo:begin_tool_requests:plamo|>";
+const PLAMO_END_TOOL_REQUESTS = "<|plamo:end_tool_requests:plamo|>";
+const PLAMO_BEGIN_TOOL_NAME = "<|plamo:begin_tool_name:plamo|>";
+const PLAMO_END_TOOL_NAME = "<|plamo:end_tool_name:plamo|>";
+const PLAMO_BEGIN_TOOL_ARGUMENTS = "<|plamo:begin_tool_arguments:plamo|>";
+const PLAMO_END_TOOL_ARGUMENTS = "<|plamo:end_tool_arguments:plamo|>";
+const PLAMO_MSG = "<|plamo:msg|>";
+const PLAMO_TAG_TOKENS = [
+  PLAMO_BEGIN_TOOL_REQUEST,
+  PLAMO_END_TOOL_REQUEST,
+  PLAMO_BEGIN_TOOL_REQUESTS,
+  PLAMO_END_TOOL_REQUESTS,
+  PLAMO_BEGIN_TOOL_NAME,
+  PLAMO_END_TOOL_NAME,
+  PLAMO_BEGIN_TOOL_ARGUMENTS,
+  PLAMO_END_TOOL_ARGUMENTS,
+  PLAMO_MSG,
+] as const;
+const PLAMO_SYNTHETIC_TURN_SEED_SYMBOL = Symbol("openclaw.plamoSyntheticTurnSeed");
+
+const PLAMO_TOOL_REQUEST_BLOCK_RE = new RegExp(
+  `${escapeRegExp(PLAMO_BEGIN_TOOL_REQUEST)}(.*?)${escapeRegExp(PLAMO_END_TOOL_REQUEST)}`,
+  "gs",
+);
+const PLAMO_TOOL_REQUESTS_BLOCK_RE = new RegExp(
+  `${escapeRegExp(PLAMO_BEGIN_TOOL_REQUESTS)}(.*?)${escapeRegExp(PLAMO_END_TOOL_REQUESTS)}`,
+  "gs",
+);
+
+type ParsedPlamoToolCall = {
+  name: string;
+  arguments: Record<string, unknown>;
+  range: TextRange;
+};
+
+type NormalizedParsedPlamoToolCall = ParsedPlamoToolCall & {
+  syntheticId?: string;
+};
+
+type IndexedParsedPlamoToolCall = ParsedPlamoToolCall & {
+  parsedIndex: number;
+  contentIndex: number;
+};
+
+type MessageContentBlock = {
+  type?: unknown;
+  text?: unknown;
+};
+
+type AssistantContentBlock = Extract<AgentMessage, { role: "assistant" }>["content"][number];
+type RuntimeModel = Parameters<StreamFn>[0];
+type RuntimeContext = Parameters<StreamFn>[1];
+type RuntimeOptions = Parameters<StreamFn>[2];
+type ResolvedPlamoCompat = Required<Omit<OpenAICompletionsCompat, "cacheControlFormat">> &
+  Pick<OpenAICompletionsCompat, "cacheControlFormat">;
+type TextRange = readonly [start: number, end: number];
+type ReplayToolCallBlock = {
+  type?: unknown;
+  id?: unknown;
+  name?: unknown;
+  input?: unknown;
+  arguments?: unknown;
+  thoughtSignature?: unknown;
+};
+type StreamingTextBlock = {
+  type: "text";
+  text: string;
+  rawText?: string;
+  streamStarted?: boolean;
+};
+
+const PLAMO_PAYLOAD_DUMP_PATH = process.env.OPENCLAW_PLAMO_PAYLOAD_DUMP_PATH?.trim() || "";
+
+type OpenAIStyleToolCall = {
+  index?: unknown;
+  id?: unknown;
+  type?: unknown;
+  function?: {
+    name?: unknown;
+    arguments?: unknown;
+  } | null;
+};
+
+type OpenAIStyleChunkDelta = {
+  content?: unknown;
+  reasoning?: unknown;
+  reasoning_content?: unknown;
+  reasoning_text?: unknown;
+  tool_calls?: unknown;
+  reasoning_details?: unknown;
+};
+
+type OpenAIStyleChunkChoice = {
+  finish_reason?: unknown;
+  delta?: OpenAIStyleChunkDelta | null;
+  usage?: OpenAIStyleUsage | null;
+};
+
+type OpenAIStyleUsage = {
+  prompt_tokens?: unknown;
+  completion_tokens?: unknown;
+  prompt_tokens_details?: {
+    cached_tokens?: unknown;
+  } | null;
+  completion_tokens_details?: {
+    reasoning_tokens?: unknown;
+  } | null;
+};
+
+type OpenAIStyleChunk = {
+  id?: unknown;
+  usage?: OpenAIStyleUsage | null;
+  choices?: OpenAIStyleChunkChoice[] | null;
+};
+
+const DEFAULT_PLAMO_COMPAT: ResolvedPlamoCompat = {
+  supportsStore: false,
+  supportsDeveloperRole: false,
+  supportsReasoningEffort: false,
+  reasoningEffortMap: {},
+  supportsUsageInStreaming: false,
+  maxTokensField: "max_tokens",
+  requiresToolResultName: false,
+  requiresAssistantAfterToolResult: false,
+  requiresThinkingAsText: false,
+  requiresReasoningContentOnAssistantMessages: false,
+  thinkingFormat: "openai",
+  openRouterRouting: {},
+  vercelGatewayRouting: {},
+  zaiToolStream: false,
+  supportsStrictMode: false,
+  sendSessionAffinityHeaders: false,
+  supportsLongCacheRetention: false,
+};
+
+function isAssistantMessageWithContent(
+  message: AgentMessage,
+): message is Extract<AgentMessage, { role: "assistant" }> {
+  return (
+    !!message &&
+    typeof message === "object" &&
+    message.role === "assistant" &&
+    Array.isArray(message.content)
+  );
+}
+
+function dropPlamoThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const message of messages) {
+    if (!isAssistantMessageWithContent(message)) {
+      out.push(message);
+      continue;
+    }
+
+    const nextContent: AssistantContentBlock[] = [];
+    let changed = false;
+    for (const block of message.content) {
+      if (
+        block &&
+        typeof block === "object" &&
+        ((block as { type?: unknown }).type === "thinking" ||
+          (block as { type?: unknown }).type === "redacted_thinking")
+      ) {
+        touched = true;
+        changed = true;
+        continue;
+      }
+      nextContent.push(block);
+    }
+
+    if (!changed) {
+      out.push(message);
+      continue;
+    }
+
+    out.push({
+      ...message,
+      content:
+        nextContent.length > 0
+          ? nextContent
+          : ([{ type: "text", text: "" }] as AssistantContentBlock[]),
+    });
+  }
+  return touched ? out : messages;
+}
+
+function isReplayToolCallBlock(block: unknown): block is ReplayToolCallBlock {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return type === "toolCall" || type === "toolUse" || type === "functionCall";
+}
+
+function resolveReplayToolCallArguments(
+  block: ReplayToolCallBlock,
+): Record<string, unknown> | null {
+  const args = block.arguments ?? block.input;
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return null;
+  }
+  return args as Record<string, unknown>;
+}
+
+function normalizePlamoReplayToolHistory(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const normalizedMessages: AgentMessage[] = [];
+  for (const message of messages) {
+    if (!isAssistantMessageWithContent(message)) {
+      normalizedMessages.push(message);
+      continue;
+    }
+
+    let changed = false;
+    const nextContent = message.content.map((block) => {
+      if (!isReplayToolCallBlock(block) || block.type === "toolCall") {
+        return block;
+      }
+      const toolBlock = block as ReplayToolCallBlock;
+      if (typeof toolBlock.id !== "string" || typeof toolBlock.name !== "string") {
+        return block;
+      }
+      const argumentsObject = resolveReplayToolCallArguments(toolBlock);
+      if (!argumentsObject) {
+        return block;
+      }
+      changed = true;
+      touched = true;
+      return {
+        type: "toolCall",
+        id: toolBlock.id,
+        name: toolBlock.name,
+        arguments: argumentsObject,
+        ...(typeof toolBlock.thoughtSignature === "string"
+          ? { thoughtSignature: toolBlock.thoughtSignature }
+          : {}),
+      } as AssistantContentBlock;
+    });
+
+    if (!changed) {
+      normalizedMessages.push(message);
+      continue;
+    }
+    normalizedMessages.push({
+      ...message,
+      content: nextContent,
+    });
+  }
+  return touched ? normalizedMessages : messages;
+}
+
+export function sanitizePlamoReplayHistory(messages: AgentMessage[]): AgentMessage[] {
+  return normalizePlamoReplayToolHistory(dropPlamoThinkingBlocks(messages));
+}
+
+function sanitizePlamoReplayMessages(context: RuntimeContext): RuntimeContext {
+  const messages = (context as { messages?: unknown } | null | undefined)?.messages;
+  if (!Array.isArray(messages)) {
+    return context;
+  }
+
+  // PLaMo always emits `reasoning_content`, but replaying prior reasoning into
+  // follow-up turns can cause the API to stop the visible answer mid-sentence.
+  const sanitized = sanitizePlamoReplayHistory(messages as AgentMessage[]);
+  if (sanitized === messages) {
+    return context;
+  }
+
+  return {
+    ...context,
+    messages: sanitized,
+  } as RuntimeContext;
+}
+
+function injectPlamoMaxTokens(
+  payload: Record<string, unknown>,
+  model: RuntimeModel,
+  compat: ResolvedPlamoCompat,
+): void {
+  const field = compat.maxTokensField;
+  const otherField = field === "max_tokens" ? "max_completion_tokens" : "max_tokens";
+  delete payload[otherField];
+  if (Object.hasOwn(payload, field)) {
+    return;
+  }
+  const maxTokens = (model as { maxTokens?: unknown }).maxTokens;
+  if (typeof maxTokens !== "number" || !Number.isFinite(maxTokens) || maxTokens <= 0) {
+    return;
+  }
+  payload[field] = Math.trunc(maxTokens);
+}
+
+function dumpPlamoPayload(kind: "streaming", payload: Record<string, unknown>): void {
+  if (!PLAMO_PAYLOAD_DUMP_PATH) {
+    return;
+  }
+  try {
+    fs.mkdirSync(path.dirname(PLAMO_PAYLOAD_DUMP_PATH), { recursive: true });
+  } catch {
+    // ignore dump directory failures
+  }
+  try {
+    fs.appendFileSync(
+      PLAMO_PAYLOAD_DUMP_PATH,
+      `${JSON.stringify({ ts: Date.now(), kind, payload })}\n`,
+      "utf8",
+    );
+  } catch {
+    // ignore dump write failures
+  }
+}
+
+function escapeRegExp(text: string): string {
+  return text.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractTaggedText(text: string, beginTag: string, endTag: string): string | null {
+  const startIndex = text.indexOf(beginTag);
+  if (startIndex === -1) {
+    return null;
+  }
+  const contentStart = startIndex + beginTag.length;
+  const endIndex = text.indexOf(endTag, contentStart);
+  if (endIndex === -1) {
+    return null;
+  }
+  return text.slice(contentStart, endIndex);
+}
+
+function extractToolArguments(block: string): string | null {
+  const raw = extractTaggedText(block, PLAMO_BEGIN_TOOL_ARGUMENTS, PLAMO_END_TOOL_ARGUMENTS);
+  if (raw === null) {
+    return null;
+  }
+  const trimmedStart = raw.trimStart();
+  const normalized = trimmedStart.startsWith(PLAMO_MSG)
+    ? trimmedStart.slice(PLAMO_MSG.length)
+    : raw;
+  return normalized.trim();
+}
+
+function parseToolArguments(raw: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function resolveStreamingTextBlockRawText(block: StreamingTextBlock): string {
+  return typeof block.rawText === "string" ? block.rawText : block.text;
+}
+
+function isTextBlock(
+  block: unknown,
+): block is MessageContentBlock & { type: "text"; text: string } {
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
+}
+
+function isIndexWithinRanges(index: number, ranges: readonly TextRange[]): boolean {
+  return ranges.some(([start, end]) => index >= start && index < end);
+}
+
+function resolveTrailingPlamoTagPrefixLength(text: string): number {
+  let longestPrefix = 0;
+  for (const token of PLAMO_TAG_TOKENS) {
+    const maxPrefixLength = Math.min(text.length, token.length - 1);
+    for (let prefixLength = maxPrefixLength; prefixLength > longestPrefix; prefixLength -= 1) {
+      if (token.startsWith(text.slice(-prefixLength))) {
+        longestPrefix = prefixLength;
+        break;
+      }
+    }
+  }
+  return longestPrefix;
+}
+
+function findFirstIncompletePlamoMarkupStart(
+  text: string,
+  completeRanges: readonly TextRange[],
+  options?: { includeTrailingPrefix?: boolean },
+): number | null {
+  let earliestStart: number | null = null;
+  for (const token of [PLAMO_BEGIN_TOOL_REQUESTS, PLAMO_BEGIN_TOOL_REQUEST] as const) {
+    let searchStart = 0;
+    while (searchStart < text.length) {
+      const index = text.indexOf(token, searchStart);
+      if (index === -1) {
+        break;
+      }
+      if (!isIndexWithinRanges(index, completeRanges)) {
+        earliestStart = earliestStart === null ? index : Math.min(earliestStart, index);
+        break;
+      }
+      searchStart = index + token.length;
+    }
+  }
+
+  if (options?.includeTrailingPrefix !== false) {
+    const trailingPrefixLength = resolveTrailingPlamoTagPrefixLength(text);
+    if (trailingPrefixLength > 0) {
+      const trailingPrefixStart = text.length - trailingPrefixLength;
+      earliestStart =
+        earliestStart === null ? trailingPrefixStart : Math.min(earliestStart, trailingPrefixStart);
+    }
+  }
+
+  return earliestStart;
+}
+
+function resolveStreamingVisiblePlamoText(
+  rawText: string,
+  options?: { includeTrailingPrefix?: boolean },
+): string {
+  if (!rawText) {
+    return "";
+  }
+
+  const parsedToolCalls = parsePlamoToolCalls(rawText);
+  const markupRanges = collectSafePlamoToolMarkupRanges(rawText, parsedToolCalls);
+  const incompleteMarkupStart = findFirstIncompletePlamoMarkupStart(rawText, markupRanges, options);
+  const visibleCutoff = incompleteMarkupStart ?? rawText.length;
+  const visibleMarkupRanges = markupRanges
+    .filter(([start]) => start < visibleCutoff)
+    .map(([start, end]) => [start, Math.min(end, visibleCutoff)] as const);
+  return removePlamoToolMarkupRanges(rawText.slice(0, visibleCutoff), 0, visibleMarkupRanges);
+}
+
+function hasToolCallBlock(content: unknown[]): boolean {
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return type === "toolCall" || type === "toolUse" || type === "functionCall";
+  });
+}
+
+function normalizeToolCallSignatureValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeToolCallSignatureValue(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const normalized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>).toSorted(([a], [b]) =>
+    a.localeCompare(b),
+  )) {
+    normalized[key] = normalizeToolCallSignatureValue(entry);
+  }
+  return normalized;
+}
+
+function createToolCallSignature(name: string, args: Record<string, unknown>): string {
+  return JSON.stringify(
+    normalizeToolCallSignatureValue({
+      name,
+      arguments: args,
+    }),
+  );
+}
+
+function createStablePlamoSyntheticToolCallId(
+  toolCall: ParsedPlamoToolCall,
+  toolCallIndex: number,
+  turnSeed: string,
+): string {
+  const hash = createHash("sha256")
+    .update(turnSeed)
+    .update("\0")
+    .update(String(toolCallIndex))
+    .update("\0")
+    .update(createToolCallSignature(toolCall.name, toolCall.arguments))
+    .digest("hex")
+    .slice(0, 24);
+  return `plamo_call_${hash}`;
+}
+
+function resolveToolCallBlockSignature(block: unknown): string | null {
+  if (!block || typeof block !== "object") {
+    return null;
+  }
+  const type = (block as { type?: unknown }).type;
+  if (type !== "toolCall" && type !== "toolUse" && type !== "functionCall") {
+    return null;
+  }
+  const name = (block as { name?: unknown }).name;
+  const args = (block as { arguments?: unknown }).arguments ?? (block as { input?: unknown }).input;
+  if (typeof name !== "string" || !args || typeof args !== "object" || Array.isArray(args)) {
+    return null;
+  }
+  return createToolCallSignature(name, args as Record<string, unknown>);
+}
+
+function resolvePlamoSyntheticToolCallTurnSeed(message: unknown, combinedText: string): string {
+  if (message && typeof message === "object") {
+    const attachedSeed = (message as { [PLAMO_SYNTHETIC_TURN_SEED_SYMBOL]?: unknown })[
+      PLAMO_SYNTHETIC_TURN_SEED_SYMBOL
+    ];
+    if (typeof attachedSeed === "string" && attachedSeed.length > 0) {
+      return attachedSeed;
+    }
+    const responseId = (message as { responseId?: unknown }).responseId;
+    if (typeof responseId === "string" && responseId.trim().length > 0) {
+      return `response:${responseId.trim()}`;
+    }
+    const timestamp = (message as { timestamp?: unknown }).timestamp;
+    if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+      return `timestamp:${Math.trunc(timestamp)}`;
+    }
+  }
+  return `content:${createHash("sha256").update(combinedText).digest("hex").slice(0, 24)}`;
+}
+
+function attachPlamoSyntheticToolCallTurnSeed(value: unknown, turnSeed: string): void {
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  Object.defineProperty(value, PLAMO_SYNTHETIC_TURN_SEED_SYMBOL, {
+    value: turnSeed,
+    configurable: true,
+  });
+}
+
+function indexParsedPlamoToolCalls(
+  parsedToolCalls: readonly ParsedPlamoToolCall[],
+  content: unknown[],
+): IndexedParsedPlamoToolCall[] {
+  const indexedToolCalls: IndexedParsedPlamoToolCall[] = [];
+  let textOffset = 0;
+  let nextToolCallIndex = 0;
+
+  for (const [contentIndex, block] of content.entries()) {
+    if (!isTextBlock(block)) {
+      continue;
+    }
+    const rawText = resolveStreamingTextBlockRawText(
+      block as MessageContentBlock & StreamingTextBlock,
+    );
+    const blockStart = textOffset;
+    const blockEnd = blockStart + rawText.length;
+    while (
+      nextToolCallIndex < parsedToolCalls.length &&
+      parsedToolCalls[nextToolCallIndex].range[0] < blockEnd
+    ) {
+      indexedToolCalls.push({
+        ...parsedToolCalls[nextToolCallIndex],
+        parsedIndex: nextToolCallIndex,
+        contentIndex,
+      });
+      nextToolCallIndex += 1;
+    }
+    textOffset = blockEnd;
+  }
+
+  return indexedToolCalls;
+}
+
+function buildNormalizedParsedPlamoToolCalls(
+  parsedToolCalls: readonly ParsedPlamoToolCall[],
+  content: unknown[],
+  turnSeed: string,
+): NormalizedParsedPlamoToolCall[] {
+  const indexedToolCalls = indexParsedPlamoToolCalls(parsedToolCalls, content);
+  const matchedInlineToolCallIndices = new Set<number>();
+
+  if (hasToolCallBlock(content)) {
+    for (const [contentIndex, block] of content.entries()) {
+      const signature = resolveToolCallBlockSignature(block);
+      if (!signature) {
+        continue;
+      }
+
+      for (let index = indexedToolCalls.length - 1; index >= 0; index -= 1) {
+        const parsedToolCall = indexedToolCalls[index];
+        if (
+          parsedToolCall.contentIndex >= contentIndex ||
+          matchedInlineToolCallIndices.has(parsedToolCall.parsedIndex)
+        ) {
+          continue;
+        }
+        if (createToolCallSignature(parsedToolCall.name, parsedToolCall.arguments) !== signature) {
+          continue;
+        }
+        matchedInlineToolCallIndices.add(parsedToolCall.parsedIndex);
+        break;
+      }
+    }
+  }
+
+  return parsedToolCalls.map((toolCall, toolCallIndex) => {
+    if (!matchedInlineToolCallIndices.has(toolCallIndex)) {
+      return {
+        ...toolCall,
+        syntheticId: createStablePlamoSyntheticToolCallId(toolCall, toolCallIndex, turnSeed),
+      };
+    }
+    return { ...toolCall };
+  });
+}
+
+function resolvePlamoCompat(model: RuntimeModel): ResolvedPlamoCompat {
+  const compat = (model as { compat?: OpenAICompletionsCompat }).compat;
+  return {
+    ...DEFAULT_PLAMO_COMPAT,
+    ...compat,
+    reasoningEffortMap: compat?.reasoningEffortMap ?? DEFAULT_PLAMO_COMPAT.reasoningEffortMap,
+    openRouterRouting: compat?.openRouterRouting ?? DEFAULT_PLAMO_COMPAT.openRouterRouting,
+    vercelGatewayRouting: compat?.vercelGatewayRouting ?? DEFAULT_PLAMO_COMPAT.vercelGatewayRouting,
+  };
+}
+
+function hasToolHistory(messages: AgentMessage[]): boolean {
+  for (const message of messages) {
+    if (message.role === "toolResult") {
+      return true;
+    }
+    if (message.role === "assistant" && hasToolCallBlock(message.content)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function convertTools(tools: Tool[], compat: ResolvedPlamoCompat): Array<Record<string, unknown>> {
+  return tools.map((tool) => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: normalizeOpenAICompatibleToolParameters(tool.parameters),
+      ...(compat.supportsStrictMode ? { strict: false } : {}),
+    },
+  }));
+}
+
+function buildPlamoStreamingPayload(
+  model: RuntimeModel,
+  context: RuntimeContext,
+  options: RuntimeOptions,
+): Record<string, unknown> {
+  const compat = resolvePlamoCompat(model);
+  const params: Record<string, unknown> = {
+    model: model.id,
+    messages: convertMessages(model as never, context as never, compat),
+    stream: true,
+  };
+
+  if (compat.supportsStore) {
+    params.store = false;
+  }
+  if (options?.maxTokens) {
+    params[compat.maxTokensField] = options.maxTokens;
+  } else {
+    injectPlamoMaxTokens(params, model, compat);
+  }
+  if (options?.temperature !== undefined) {
+    params.temperature = options.temperature;
+  }
+  if (context.tools) {
+    params.tools = convertTools(context.tools, compat);
+  } else if (hasToolHistory(context.messages)) {
+    params.tools = [];
+  }
+  if ((options as { toolChoice?: unknown } | undefined)?.toolChoice) {
+    params.tool_choice = (options as { toolChoice?: unknown }).toolChoice;
+  }
+  return params;
+}
+
+function normalizePlamoStreamingPayload(
+  payload: Record<string, unknown>,
+  model: RuntimeModel,
+): Record<string, unknown> {
+  const compat = resolvePlamoCompat(model);
+  payload.stream = true;
+  delete payload.stream_options;
+  if (!compat.supportsStore) {
+    delete payload.store;
+  }
+  if (!compat.supportsReasoningEffort) {
+    delete payload.reasoning_effort;
+  }
+  injectPlamoMaxTokens(payload, model, compat);
+
+  const tools = payload.tools;
+  if (!compat.supportsStrictMode && Array.isArray(tools)) {
+    for (const tool of tools) {
+      if (!tool || typeof tool !== "object") {
+        continue;
+      }
+      const fn = (tool as { function?: unknown }).function;
+      if (fn && typeof fn === "object") {
+        delete (fn as { strict?: unknown }).strict;
+      }
+    }
+  }
+  return payload;
+}
+
+function finalizePlamoStreamingPayload(
+  payload: Record<string, unknown>,
+  model: RuntimeModel,
+): Record<string, unknown> {
+  return normalizePlamoStreamingPayload(payload, model);
+}
+
+async function resolvePlamoStreamingPayload(
+  model: RuntimeModel,
+  context: RuntimeContext,
+  options: RuntimeOptions,
+): Promise<Record<string, unknown>> {
+  let payload = finalizePlamoStreamingPayload(
+    buildPlamoStreamingPayload(model, context, options),
+    model,
+  );
+  const nextPayload = await options?.onPayload?.(payload, model);
+  if (nextPayload !== undefined) {
+    if (!nextPayload || typeof nextPayload !== "object" || Array.isArray(nextPayload)) {
+      throw new Error("PLaMo payload override must return an object");
+    }
+    payload = nextPayload as Record<string, unknown>;
+  }
+  return finalizePlamoStreamingPayload(payload, model);
+}
+
+function buildChatCompletionsUrl(baseUrl: string): string {
+  const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return new URL("chat/completions", normalizedBaseUrl).toString();
+}
+
+function resolvePlamoApiKey(model: RuntimeModel, options: RuntimeOptions): string | undefined {
+  const requestAuthMode = resolveModelRequestAuthMode(model);
+  if (requestAuthMode === "authorization-bearer" || requestAuthMode === "header") {
+    return undefined;
+  }
+  const explicitApiKey = options?.apiKey?.trim();
+  if (explicitApiKey) {
+    return isNonSecretApiKeyMarker(explicitApiKey) ? undefined : explicitApiKey;
+  }
+  return resolveEnvApiKey(model.provider)?.apiKey || undefined;
+}
+
+function hasAuthorizationHeader(headers: Record<string, string>): boolean {
+  return Object.entries(headers).some(
+    ([key, value]) => key.trim().toLowerCase() === "authorization" && value.trim().length > 0,
+  );
+}
+
+function stripAuthorizationHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([key]) => key.trim().toLowerCase() !== "authorization"),
+  );
+}
+
+function buildRequestHeaders(
+  model: RuntimeModel,
+  apiKey: string | undefined,
+  options: RuntimeOptions,
+): Record<string, string> {
+  const headers = {
+    Accept: "text/event-stream",
+    "Content-Type": "application/json",
+    ...(model as { headers?: Record<string, string> }).headers,
+    ...options?.headers,
+  };
+  if (!apiKey || hasAuthorizationHeader(headers)) {
+    return headers;
+  }
+  return {
+    ...stripAuthorizationHeaders(headers),
+    Authorization: `Bearer ${apiKey}`,
+  };
+}
+
+function formatHttpErrorMessage(status: number, statusText: string, bodyText: string): string {
+  const trimmed = bodyText.trim();
+  if (!trimmed) {
+    return `PLaMo request failed: ${status} ${statusText}`;
+  }
+  return `PLaMo request failed: ${status} ${statusText}\n${trimmed}`;
+}
+
+function toFiniteNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function buildZeroUsage(model: RuntimeModel): Usage {
+  const usage: Usage = {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+  calculateCost(model as never, usage as never);
+  return usage;
+}
+
+function parseUsage(rawUsage: OpenAIStyleUsage | null | undefined, model: RuntimeModel): Usage {
+  if (!rawUsage || typeof rawUsage !== "object") {
+    return buildZeroUsage(model);
+  }
+  const cachedTokens = toFiniteNumber(rawUsage.prompt_tokens_details?.cached_tokens);
+  const input = Math.max(0, toFiniteNumber(rawUsage.prompt_tokens) - cachedTokens);
+  const output = toFiniteNumber(rawUsage.completion_tokens);
+  const usage: Usage = {
+    input,
+    output,
+    cacheRead: cachedTokens,
+    cacheWrite: 0,
+    totalTokens: input + output + cachedTokens,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+  calculateCost(model as never, usage as never);
+  return usage;
+}
+
+function formatFinishReason(reason: unknown): string {
+  if (
+    typeof reason === "string" ||
+    typeof reason === "number" ||
+    typeof reason === "boolean" ||
+    typeof reason === "bigint"
+  ) {
+    return String(reason);
+  }
+  if (typeof reason === "symbol") {
+    return reason.toString();
+  }
+  if (reason === null) {
+    return "null";
+  }
+  if (reason === undefined) {
+    return "undefined";
+  }
+  try {
+    return JSON.stringify(reason) ?? Object.prototype.toString.call(reason);
+  } catch {
+    return Object.prototype.toString.call(reason);
+  }
+}
+
+function mapStopReason(reason: unknown): { stopReason: StopReason; errorMessage?: string } {
+  if (reason === null || reason === undefined) {
+    return { stopReason: "stop" };
+  }
+  switch (reason) {
+    case "stop":
+    case "end":
+      return { stopReason: "stop" };
+    case "length":
+      return { stopReason: "length" };
+    case "function_call":
+    case "tool_calls":
+      return { stopReason: "toolUse" };
+    case "content_filter":
+      return { stopReason: "error", errorMessage: "Provider finish_reason: content_filter" };
+    case "network_error":
+      return { stopReason: "error", errorMessage: "Provider finish_reason: network_error" };
+    default:
+      return {
+        stopReason: "error",
+        errorMessage: `Provider finish_reason: ${formatFinishReason(reason)}`,
+      };
+  }
+}
+
+function isOpenAIStyleChunkDelta(value: unknown): value is OpenAIStyleChunkDelta {
+  return !!value && typeof value === "object";
+}
+
+function buildErrorAssistantMessage(
+  model: RuntimeModel,
+  error: unknown,
+  aborted: boolean,
+): AssistantMessage & { stopReason: Extract<StopReason, "aborted" | "error"> } {
+  return {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: buildZeroUsage(model),
+    stopReason: aborted ? "aborted" : "error",
+    errorMessage: error instanceof Error ? error.message : String(error),
+    timestamp: Date.now(),
+  };
+}
+
+type StreamingToolCallBlock = ToolCall & {
+  partialArgs: string;
+};
+
+type ActiveToolCallState = {
+  block: StreamingToolCallBlock;
+  contentIndex: number;
+};
+
+function parseSsePayloads(reader: ReadableStreamDefaultReader<Uint8Array>): AsyncIterable<string> {
+  const decoder = new TextDecoder();
+  return {
+    async *[Symbol.asyncIterator]() {
+      let buffer = "";
+      let currentData = "";
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let lineEnd = buffer.indexOf("\n");
+        while (lineEnd !== -1) {
+          let line = buffer.slice(0, lineEnd);
+          buffer = buffer.slice(lineEnd + 1);
+          if (line.endsWith("\r")) {
+            line = line.slice(0, -1);
+          }
+          if (line === "") {
+            if (currentData) {
+              yield currentData;
+              currentData = "";
+            }
+            lineEnd = buffer.indexOf("\n");
+            continue;
+          }
+          if (line.startsWith(":")) {
+            lineEnd = buffer.indexOf("\n");
+            continue;
+          }
+          const [rawField, ...rest] = line.split(":");
+          const field = rawField.trim();
+          const rawValue = rest.join(":");
+          const data = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue;
+          if (field === "data") {
+            currentData = currentData ? `${currentData}\n${data}` : data;
+          }
+          lineEnd = buffer.indexOf("\n");
+        }
+      }
+      buffer += decoder.decode();
+      if (buffer.length > 0) {
+        const lines = buffer.split(/\n/);
+        for (let line of lines) {
+          if (line.endsWith("\r")) {
+            line = line.slice(0, -1);
+          }
+          if (!line || line.startsWith(":")) {
+            continue;
+          }
+          const [rawField, ...rest] = line.split(":");
+          const field = rawField.trim();
+          const rawValue = rest.join(":");
+          const data = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue;
+          if (field === "data") {
+            currentData = currentData ? `${currentData}\n${data}` : data;
+          }
+        }
+      }
+      if (currentData) {
+        yield currentData;
+      }
+    },
+  };
+}
+
+function parseStreamingChunk(raw: string): OpenAIStyleChunk | null {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === "[DONE]") {
+    return null;
+  }
+  try {
+    return JSON.parse(trimmed) as OpenAIStyleChunk;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid PLaMo stream chunk: ${message}`, { cause: error });
+  }
+}
+
+function resolveToolCallChunkIndex(toolCall: OpenAIStyleToolCall): number | null {
+  return typeof toolCall.index === "number" && Number.isInteger(toolCall.index)
+    ? toolCall.index
+    : null;
+}
+
+function extractStreamingReasoning(delta: OpenAIStyleChunkDelta): string {
+  for (const field of ["reasoning_content", "reasoning", "reasoning_text"] as const) {
+    const value = delta[field];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return "";
+}
+
+function createNativePlamoStream(
+  model: RuntimeModel,
+  context: RuntimeContext,
+  options: RuntimeOptions,
+): AssistantMessageEventStream {
+  const stream = createAssistantMessageEventStream();
+  const output: AssistantMessage = {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: buildZeroUsage(model),
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+
+  void (async () => {
+    let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+    let sawFinishReason = false;
+    try {
+      const payload = await resolvePlamoStreamingPayload(model, context, options);
+      dumpPlamoPayload("streaming", payload);
+      const apiKey = resolvePlamoApiKey(model, options);
+      const fetchWithModelTransport = buildGuardedModelFetch(model as never, {
+        auditContext: "plamo-stream",
+      });
+      const response = await fetchWithModelTransport(buildChatCompletionsUrl(model.baseUrl), {
+        method: "POST",
+        headers: buildRequestHeaders(model, apiKey, options),
+        body: JSON.stringify(payload),
+        signal: options?.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          formatHttpErrorMessage(response.status, response.statusText, await response.text()),
+        );
+      }
+      if (!response.body) {
+        throw new Error("PLaMo streaming response did not include a body");
+      }
+
+      reader = response.body.getReader();
+      stream.push({ type: "start", partial: output });
+
+      let currentBlock:
+        | StreamingTextBlock
+        | { type: "thinking"; thinking: string; thinkingSignature?: string }
+        | StreamingToolCallBlock
+        | null = null;
+      const activeToolCallStates = new Map<string, ActiveToolCallState>();
+      const blocks = output.content;
+      const blockIndex = () => blocks.length - 1;
+      const finishOpenToolCallBlocks = () => {
+        const states = [...new Set(activeToolCallStates.values())];
+        activeToolCallStates.clear();
+        for (const state of states) {
+          const finalArgs = parseToolArguments(state.block.partialArgs) ?? {};
+          delete (state.block as { partialArgs?: string }).partialArgs;
+          state.block.arguments = finalArgs;
+          stream.push({
+            type: "toolcall_end",
+            contentIndex: state.contentIndex,
+            toolCall: state.block,
+            partial: output,
+          });
+        }
+      };
+      const finishCurrentBlock = () => {
+        if (!currentBlock) {
+          return;
+        }
+        if (currentBlock.type === "text") {
+          currentBlock.text = resolveStreamingVisiblePlamoText(
+            resolveStreamingTextBlockRawText(currentBlock),
+            {
+              includeTrailingPrefix: false,
+            },
+          );
+          if (currentBlock.streamStarted) {
+            stream.push({
+              type: "text_end",
+              contentIndex: blockIndex(),
+              content: currentBlock.text,
+              partial: output,
+            });
+          }
+        } else if (currentBlock.type === "thinking") {
+          stream.push({
+            type: "thinking_end",
+            contentIndex: blockIndex(),
+            content: currentBlock.thinking,
+            partial: output,
+          });
+        } else {
+          const finalArgs = parseToolArguments(currentBlock.partialArgs) ?? {};
+          delete (currentBlock as { partialArgs?: string }).partialArgs;
+          currentBlock.arguments = finalArgs;
+          stream.push({
+            type: "toolcall_end",
+            contentIndex: blockIndex(),
+            toolCall: currentBlock,
+            partial: output,
+          });
+        }
+        currentBlock = null;
+      };
+
+      for await (const rawChunk of parseSsePayloads(reader)) {
+        const chunk = parseStreamingChunk(rawChunk);
+        if (!chunk) {
+          continue;
+        }
+
+        if (typeof chunk.id === "string" && chunk.id.length > 0) {
+          output.responseId ||= chunk.id;
+        }
+        if (chunk.usage) {
+          output.usage = parseUsage(chunk.usage, model);
+        }
+
+        const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
+        if (!choice) {
+          continue;
+        }
+        if (!chunk.usage && choice.usage) {
+          output.usage = parseUsage(choice.usage, model);
+        }
+        if (choice.finish_reason !== undefined && choice.finish_reason !== null) {
+          sawFinishReason = true;
+          const finishReasonResult = mapStopReason(choice.finish_reason);
+          output.stopReason = finishReasonResult.stopReason;
+          if (finishReasonResult.errorMessage) {
+            output.errorMessage = finishReasonResult.errorMessage;
+          }
+        }
+
+        const delta = choice.delta;
+        if (!isOpenAIStyleChunkDelta(delta)) {
+          continue;
+        }
+
+        const textDelta = typeof delta.content === "string" ? delta.content : "";
+        if (textDelta) {
+          finishOpenToolCallBlocks();
+          if (!currentBlock || currentBlock.type !== "text") {
+            finishCurrentBlock();
+            currentBlock = { type: "text", text: "", rawText: "", streamStarted: false };
+            output.content.push(currentBlock);
+          }
+          const previousVisibleText = currentBlock.text;
+          currentBlock.rawText = `${resolveStreamingTextBlockRawText(currentBlock)}${textDelta}`;
+          const nextVisibleText = resolveStreamingVisiblePlamoText(currentBlock.rawText);
+          const stableVisibleText =
+            nextVisibleText.length >= previousVisibleText.length
+              ? nextVisibleText
+              : previousVisibleText;
+          currentBlock.text = stableVisibleText;
+          if (!currentBlock.streamStarted && stableVisibleText.length > 0) {
+            currentBlock.streamStarted = true;
+            stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+          }
+          const visibleDelta = stableVisibleText.slice(previousVisibleText.length);
+          if (visibleDelta) {
+            stream.push({
+              type: "text_delta",
+              contentIndex: blockIndex(),
+              delta: visibleDelta,
+              partial: output,
+            });
+          }
+        }
+
+        const reasoningDelta = extractStreamingReasoning(delta);
+        if (reasoningDelta) {
+          finishOpenToolCallBlocks();
+          if (!currentBlock || currentBlock.type !== "thinking") {
+            finishCurrentBlock();
+            currentBlock = {
+              type: "thinking",
+              thinking: "",
+              thinkingSignature: "reasoning_content",
+            };
+            output.content.push(currentBlock);
+            stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+          }
+          currentBlock.thinking += reasoningDelta;
+          stream.push({
+            type: "thinking_delta",
+            contentIndex: blockIndex(),
+            delta: reasoningDelta,
+            partial: output,
+          });
+        }
+
+        if (Array.isArray(delta.tool_calls)) {
+          finishCurrentBlock();
+          for (const toolCall of delta.tool_calls as OpenAIStyleToolCall[]) {
+            const nextIndex = resolveToolCallChunkIndex(toolCall);
+            const nextId = typeof toolCall.id === "string" ? toolCall.id : "";
+            const indexKey = nextIndex !== null ? `index:${nextIndex}` : null;
+            const idKey = nextId ? `id:${nextId}` : null;
+            let state =
+              (indexKey ? activeToolCallStates.get(indexKey) : undefined) ??
+              (idKey ? activeToolCallStates.get(idKey) : undefined);
+            if (!state) {
+              const block: StreamingToolCallBlock = {
+                type: "toolCall",
+                id: nextId,
+                name:
+                  toolCall.function && typeof toolCall.function === "object"
+                    ? typeof toolCall.function.name === "string"
+                      ? toolCall.function.name
+                      : ""
+                    : "",
+                arguments: {},
+                partialArgs: "",
+              };
+              output.content.push(block);
+              state = {
+                block,
+                contentIndex: blockIndex(),
+              };
+              stream.push({
+                type: "toolcall_start",
+                contentIndex: state.contentIndex,
+                partial: output,
+              });
+            }
+            if (indexKey) {
+              activeToolCallStates.set(indexKey, state);
+            }
+            if (idKey) {
+              activeToolCallStates.set(idKey, state);
+            }
+            const currentToolCall = state.block;
+            if (nextId) {
+              currentToolCall.id = nextId;
+            }
+            if (toolCall.function && typeof toolCall.function === "object") {
+              if (typeof toolCall.function.name === "string") {
+                currentToolCall.name = toolCall.function.name;
+              }
+              const argsDelta =
+                typeof toolCall.function.arguments === "string" ? toolCall.function.arguments : "";
+              if (argsDelta) {
+                currentToolCall.partialArgs += argsDelta;
+                stream.push({
+                  type: "toolcall_delta",
+                  contentIndex: state.contentIndex,
+                  delta: argsDelta,
+                  partial: output,
+                });
+              }
+            }
+          }
+        }
+
+        if (Array.isArray(delta.reasoning_details)) {
+          for (const detail of delta.reasoning_details as Array<Record<string, unknown>>) {
+            if (
+              detail?.type === "reasoning.encrypted" &&
+              typeof detail.id === "string" &&
+              detail.data !== undefined
+            ) {
+              const matchingToolCall = output.content.find(
+                (block) => block.type === "toolCall" && block.id === detail.id,
+              );
+              if (matchingToolCall && matchingToolCall.type === "toolCall") {
+                matchingToolCall.thoughtSignature = JSON.stringify(detail);
+              }
+            }
+          }
+        }
+      }
+
+      finishOpenToolCallBlocks();
+      finishCurrentBlock();
+      normalizePlamoToolMarkupInMessage(output);
+      stripPlamoStreamingInternalsInMessage(output);
+
+      if (options?.signal?.aborted) {
+        throw new Error("Request was aborted");
+      }
+      if (output.stopReason === "aborted") {
+        throw new Error("Request was aborted");
+      }
+      if (output.stopReason === "error") {
+        throw new Error(output.errorMessage || "Provider returned an error stop reason");
+      }
+      if (!sawFinishReason) {
+        throw new Error("PLaMo stream ended before a finish_reason was received");
+      }
+
+      stream.push({ type: "done", reason: output.stopReason, message: output });
+      stream.end();
+    } catch (error) {
+      const aborted =
+        options?.signal?.aborted || (error instanceof Error && error.name === "AbortError");
+      const errorMessage = buildErrorAssistantMessage(model, error, aborted);
+      stream.push({
+        type: "error",
+        reason: errorMessage.stopReason,
+        error: errorMessage,
+      });
+      stream.end();
+    } finally {
+      try {
+        await reader?.cancel();
+      } catch {
+        // ignore reader cleanup failures
+      }
+    }
+  })();
+
+  return stream;
+}
+
+export function stripPlamoToolMarkup(text: string): string {
+  const parsedToolCalls = parsePlamoToolCalls(text);
+  return removePlamoToolMarkupRanges(
+    text,
+    0,
+    collectSafePlamoToolMarkupRanges(text, parsedToolCalls),
+  ).trim();
+}
+
+function mergeTextRanges(ranges: readonly TextRange[]): TextRange[] {
+  if (ranges.length === 0) {
+    return [];
+  }
+
+  const sortedRanges = [...ranges].toSorted(
+    (left, right) => left[0] - right[0] || left[1] - right[1],
+  );
+  const mergedRanges: Array<[number, number]> = [];
+  for (const [start, end] of sortedRanges) {
+    const previousRange = mergedRanges.at(-1);
+    if (!previousRange || start > previousRange[1]) {
+      mergedRanges.push([start, end]);
+      continue;
+    }
+    previousRange[1] = Math.max(previousRange[1], end);
+  }
+
+  return mergedRanges;
+}
+
+function collectSafePlamoToolMarkupRanges(
+  text: string,
+  parsedToolCalls: readonly ParsedPlamoToolCall[],
+): TextRange[] {
+  if (parsedToolCalls.length === 0) {
+    return [];
+  }
+
+  const requestRanges = mergeTextRanges(parsedToolCalls.map((toolCall) => toolCall.range));
+  const wrapperRanges: TextRange[] = [];
+
+  for (const match of text.matchAll(PLAMO_TOOL_REQUESTS_BLOCK_RE)) {
+    if (match.index === undefined) {
+      continue;
+    }
+    const wrapperStart = match.index;
+    const wrapperEnd = wrapperStart + match[0].length;
+    const contentStart = wrapperStart + PLAMO_BEGIN_TOOL_REQUESTS.length;
+    const contentEnd = wrapperEnd - PLAMO_END_TOOL_REQUESTS.length;
+    const remainingContent = removePlamoToolMarkupRanges(
+      text.slice(contentStart, contentEnd),
+      contentStart,
+      requestRanges,
+    );
+    if (remainingContent.trim().length === 0) {
+      wrapperRanges.push([wrapperStart, wrapperEnd] as const);
+    }
+  }
+
+  return mergeTextRanges([...requestRanges, ...wrapperRanges]);
+}
+
+function removePlamoToolMarkupRanges(
+  text: string,
+  blockStart: number,
+  ranges: TextRange[],
+): string {
+  if (text.length === 0 || ranges.length === 0) {
+    return text;
+  }
+
+  const blockEnd = blockStart + text.length;
+  const segments: string[] = [];
+  let cursor = blockStart;
+
+  for (const [start, end] of ranges) {
+    if (end <= cursor) {
+      continue;
+    }
+    if (start >= blockEnd) {
+      break;
+    }
+
+    const overlapStart = Math.max(start, cursor);
+    const overlapEnd = Math.min(end, blockEnd);
+
+    if (overlapStart > cursor) {
+      segments.push(text.slice(cursor - blockStart, overlapStart - blockStart));
+    }
+    cursor = Math.max(cursor, overlapEnd);
+    if (cursor >= blockEnd) {
+      break;
+    }
+  }
+
+  if (cursor < blockEnd) {
+    segments.push(text.slice(cursor - blockStart));
+  }
+
+  return segments.join("");
+}
+
+function isPlamoMarkupAdjacentOnLeft(offset: number, ranges: readonly TextRange[]): boolean {
+  return ranges.some(([start, end]) => end === offset || (start < offset && end > offset));
+}
+
+function isPlamoMarkupAdjacentOnRight(offset: number, ranges: readonly TextRange[]): boolean {
+  return ranges.some(([start, end]) => start === offset || (start < offset && end > offset));
+}
+
+function appendNormalizedPlamoTextSegment(params: {
+  nextContent: unknown[];
+  stableBlock: Omit<StreamingTextBlock, "rawText" | "streamStarted">;
+  rawText: string;
+  blockStart: number;
+  segmentStart: number;
+  segmentEnd: number;
+  markupRanges: TextRange[];
+}): void {
+  if (params.segmentStart >= params.segmentEnd) {
+    return;
+  }
+
+  let cleanedText = removePlamoToolMarkupRanges(
+    params.rawText.slice(
+      params.segmentStart - params.blockStart,
+      params.segmentEnd - params.blockStart,
+    ),
+    params.segmentStart,
+    params.markupRanges,
+  );
+  if (!cleanedText) {
+    return;
+  }
+
+  if (isPlamoMarkupAdjacentOnLeft(params.segmentStart, params.markupRanges)) {
+    cleanedText = cleanedText.trimStart();
+  }
+  if (isPlamoMarkupAdjacentOnRight(params.segmentEnd, params.markupRanges)) {
+    cleanedText = cleanedText.trimEnd();
+  }
+  if (!cleanedText) {
+    return;
+  }
+
+  params.nextContent.push({
+    ...params.stableBlock,
+    text: cleanedText,
+  });
+}
+
+export function parsePlamoToolCalls(text: string): ParsedPlamoToolCall[] {
+  if (!text) {
+    return [];
+  }
+
+  const toolCalls: ParsedPlamoToolCall[] = [];
+
+  for (const match of text.matchAll(PLAMO_TOOL_REQUEST_BLOCK_RE)) {
+    if (match.index === undefined) {
+      continue;
+    }
+    const block = match[1] ?? "";
+    const name = extractTaggedText(block, PLAMO_BEGIN_TOOL_NAME, PLAMO_END_TOOL_NAME)?.trim();
+    const rawArguments = extractToolArguments(block);
+    if (!name || rawArguments === null) {
+      continue;
+    }
+    const argumentsObject = parseToolArguments(rawArguments);
+    if (!argumentsObject) {
+      continue;
+    }
+    toolCalls.push({
+      name,
+      arguments: argumentsObject,
+      range: [match.index, match.index + match[0].length] as const,
+    });
+  }
+
+  return toolCalls;
+}
+
+export function normalizePlamoToolMarkupInMessage(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return;
+  }
+
+  const textBlocks = content.filter(isTextBlock);
+  if (textBlocks.length === 0) {
+    return;
+  }
+
+  const combinedText = textBlocks
+    .map((block) =>
+      resolveStreamingTextBlockRawText(block as MessageContentBlock & StreamingTextBlock),
+    )
+    .join("");
+  if (
+    !combinedText.includes(PLAMO_BEGIN_TOOL_REQUEST) &&
+    !combinedText.includes(PLAMO_BEGIN_TOOL_REQUESTS)
+  ) {
+    return;
+  }
+  const parsedToolCalls = parsePlamoToolCalls(combinedText);
+  const markupRanges = collectSafePlamoToolMarkupRanges(combinedText, parsedToolCalls);
+  if (markupRanges.length === 0) {
+    return;
+  }
+
+  const normalizedToolCalls = buildNormalizedParsedPlamoToolCalls(
+    parsedToolCalls,
+    content,
+    resolvePlamoSyntheticToolCallTurnSeed(message, combinedText),
+  );
+
+  const nextContent: unknown[] = [];
+  let textOffset = 0;
+  let nextToolCallIndex = 0;
+  for (const block of content) {
+    if (!isTextBlock(block)) {
+      nextContent.push(block);
+      continue;
+    }
+    const rawText = resolveStreamingTextBlockRawText(
+      block as MessageContentBlock & StreamingTextBlock,
+    );
+    const blockStart = textOffset;
+    const blockEnd = blockStart + rawText.length;
+    const {
+      rawText: _rawText,
+      streamStarted: _streamStarted,
+      ...stableBlock
+    } = block as MessageContentBlock & StreamingTextBlock;
+    let cursor = blockStart;
+    while (
+      nextToolCallIndex < normalizedToolCalls.length &&
+      normalizedToolCalls[nextToolCallIndex].range[0] < blockEnd
+    ) {
+      const toolCall = normalizedToolCalls[nextToolCallIndex];
+      const segmentEnd = Math.max(cursor, Math.min(blockEnd, toolCall.range[0]));
+      appendNormalizedPlamoTextSegment({
+        nextContent,
+        stableBlock,
+        rawText,
+        blockStart,
+        segmentStart: cursor,
+        segmentEnd,
+        markupRanges,
+      });
+      if (toolCall.syntheticId && toolCall.range[0] >= blockStart) {
+        nextContent.push({
+          type: "toolCall",
+          id: toolCall.syntheticId,
+          name: toolCall.name,
+          arguments: toolCall.arguments,
+        });
+      }
+      cursor = Math.max(cursor, Math.min(blockEnd, toolCall.range[1]));
+      nextToolCallIndex += 1;
+    }
+
+    appendNormalizedPlamoTextSegment({
+      nextContent,
+      stableBlock,
+      rawText,
+      blockStart,
+      segmentStart: cursor,
+      segmentEnd: blockEnd,
+      markupRanges,
+    });
+    textOffset = blockEnd;
+  }
+
+  (message as { content: unknown[] }).content = nextContent;
+  if (normalizedToolCalls.some((toolCall) => toolCall.syntheticId)) {
+    const stopReason = (message as { stopReason?: unknown }).stopReason;
+    if (stopReason === undefined || stopReason === "stop") {
+      (message as { stopReason?: unknown }).stopReason = "toolUse";
+    }
+  } else if (
+    (message as { stopReason?: unknown }).stopReason === "toolUse" &&
+    !hasToolCallBlock(nextContent)
+  ) {
+    (message as { stopReason?: unknown }).stopReason = "stop";
+  }
+}
+
+function stripPlamoStreamingInternalsInMessage(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return;
+  }
+
+  for (const block of content) {
+    if (isTextBlock(block)) {
+      delete (block as { rawText?: unknown }).rawText;
+      delete (block as { streamStarted?: unknown }).streamStarted;
+      continue;
+    }
+    if (block && typeof block === "object" && (block as { type?: unknown }).type === "toolCall") {
+      delete (block as { partialArgs?: unknown }).partialArgs;
+    }
+  }
+}
+
+function syncDoneEventReasonWithMessageStopReason(event: unknown): void {
+  if (!event || typeof event !== "object") {
+    return;
+  }
+  const doneEvent = event as {
+    type?: unknown;
+    reason?: unknown;
+    message?: unknown;
+  };
+  if (doneEvent.type !== "done" || !doneEvent.message || typeof doneEvent.message !== "object") {
+    return;
+  }
+  const stopReason = (doneEvent.message as { stopReason?: unknown }).stopReason;
+  if (typeof stopReason === "string" && stopReason.length > 0) {
+    doneEvent.reason = stopReason;
+  }
+}
+
+function clonePlamoNormalizationSnapshot<T>(value: T): T {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  try {
+    return structuredClone(value);
+  } catch {
+    return value;
+  }
+}
+
+function wrapStreamNormalizePlamoToolMarkup(
+  stream: ReturnType<typeof streamSimple>,
+  options?: { normalizePartial?: boolean },
+): ReturnType<typeof streamSimple> {
+  const normalizationTurnSeed = createHash("sha256")
+    .update(String(Date.now()))
+    .update("\0")
+    .update(String(Math.random()))
+    .digest("hex")
+    .slice(0, 24);
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = clonePlamoNormalizationSnapshot(await originalResult());
+    attachPlamoSyntheticToolCallTurnSeed(message, normalizationTurnSeed);
+    normalizePlamoToolMarkupInMessage(message);
+    stripPlamoStreamingInternalsInMessage(message);
+    return message;
+  };
+
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
+    function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          const result = await iterator.next();
+          if (!result.done && result.value && typeof result.value === "object") {
+            // Normalize cloned snapshots so later deltas still land on the
+            // underlying live message objects owned by the base stream.
+            const event = clonePlamoNormalizationSnapshot(result.value) as {
+              partial?: unknown;
+              message?: unknown;
+            };
+            if (options?.normalizePartial !== false) {
+              attachPlamoSyntheticToolCallTurnSeed(event.partial, normalizationTurnSeed);
+              normalizePlamoToolMarkupInMessage(event.partial);
+            }
+            stripPlamoStreamingInternalsInMessage(event.partial);
+            attachPlamoSyntheticToolCallTurnSeed(event.message, normalizationTurnSeed);
+            normalizePlamoToolMarkupInMessage(event.message);
+            stripPlamoStreamingInternalsInMessage(event.message);
+            syncDoneEventReasonWithMessageStopReason(event);
+            return {
+              ...result,
+              value: event,
+            } as typeof result;
+          }
+          return result;
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+        },
+      };
+    };
+
+  return stream;
+}
+
+export function createPlamoToolCallWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const sanitizedContext = sanitizePlamoReplayMessages(context);
+
+    if (underlying === streamSimple) {
+      return wrapStreamNormalizePlamoToolMarkup(
+        createNativePlamoStream(model, sanitizedContext, options),
+        { normalizePartial: false },
+      );
+    }
+
+    const originalOnPayload = options?.onPayload;
+    const maybeStream = underlying(model, sanitizedContext, {
+      ...options,
+      onPayload: async (payload, payloadModel) => {
+        const effectiveModel = payloadModel ?? model;
+        let nextPayload = payload;
+        if (nextPayload && typeof nextPayload === "object" && !Array.isArray(nextPayload)) {
+          nextPayload = finalizePlamoStreamingPayload(
+            nextPayload as Record<string, unknown>,
+            effectiveModel,
+          );
+        }
+        const overridden = await originalOnPayload?.(nextPayload, effectiveModel);
+        if (overridden !== undefined) {
+          if (!overridden || typeof overridden !== "object" || Array.isArray(overridden)) {
+            throw new Error("PLaMo payload override must return an object");
+          }
+          const normalized = finalizePlamoStreamingPayload(
+            overridden as Record<string, unknown>,
+            effectiveModel,
+          );
+          dumpPlamoPayload("streaming", normalized);
+          return normalized;
+        }
+        if (nextPayload && typeof nextPayload === "object" && !Array.isArray(nextPayload)) {
+          const normalized = finalizePlamoStreamingPayload(
+            nextPayload as Record<string, unknown>,
+            effectiveModel,
+          );
+          dumpPlamoPayload("streaming", normalized);
+          return normalized;
+        }
+        return nextPayload;
+      },
+    });
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) =>
+        wrapStreamNormalizePlamoToolMarkup(stream),
+      );
+    }
+    return wrapStreamNormalizePlamoToolMarkup(maybeStream);
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1091,6 +1091,10 @@
       "types": "./dist/plugin-sdk/provider-http.d.ts",
       "default": "./dist/plugin-sdk/provider-http.js"
     },
+    "./plugin-sdk/provider-http-runtime": {
+      "types": "./dist/plugin-sdk/provider-http-runtime.d.ts",
+      "default": "./dist/plugin-sdk/provider-http-runtime.js"
+    },
     "./plugin-sdk/provider-model-types": {
       "types": "./dist/plugin-sdk/provider-model-types.d.ts",
       "default": "./dist/plugin-sdk/provider-model-types.js"

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -84,6 +84,10 @@
       "types": "./dist/src/plugin-sdk/provider-http.d.ts",
       "default": "./src/provider-http.ts"
     },
+    "./provider-http-runtime": {
+      "types": "./dist/src/plugin-sdk/provider-http-runtime.d.ts",
+      "default": "./src/provider-http-runtime.ts"
+    },
     "./provider-model-types": {
       "types": "./dist/src/plugin-sdk/provider-model-types.d.ts",
       "default": "./src/provider-model-types.ts"

--- a/packages/plugin-sdk/src/provider-http-runtime.ts
+++ b/packages/plugin-sdk/src/provider-http-runtime.ts
@@ -1,0 +1,1 @@
+export * from "../../../src/plugin-sdk/provider-http-runtime.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,6 +1041,19 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/plamo:
+    dependencies:
+      '@mariozechner/pi-agent-core':
+        specifier: 0.70.2
+        version: 0.70.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai':
+        specifier: 0.70.2
+        version: 0.70.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/qa-channel:
     dependencies:
       typebox:

--- a/scripts/lib/plugin-sdk-doc-metadata.ts
+++ b/scripts/lib/plugin-sdk-doc-metadata.ts
@@ -80,6 +80,9 @@ export const pluginSdkDocMetadata = {
   "provider-selection-runtime": {
     category: "provider",
   },
+  "provider-http-runtime": {
+    category: "provider",
+  },
   opencode: {
     category: "provider",
   },

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -258,6 +258,7 @@
   "provider-entry",
   "provider-env-vars",
   "provider-http",
+  "provider-http-runtime",
   "provider-model-types",
   "provider-model-shared",
   "opencode",

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -605,6 +605,7 @@ export type ModelAuthMode = "api-key" | "oauth" | "token" | "mixed" | "aws-sdk" 
 
 export { resolveEnvApiKey } from "./model-auth-env.js";
 export type { EnvApiKeyResult } from "./model-auth-env.js";
+export { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 
 export function resolveModelAuthMode(
   provider?: string,

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -118,6 +118,30 @@ describe("buildGuardedModelFetch", () => {
     });
   });
 
+  it("forwards optional auditContext into the shared guarded fetch seam", async () => {
+    const { buildGuardedModelFetch } = await import("./provider-transport-fetch.js");
+    const model = {
+      id: "plamo-3.0-prime-beta",
+      provider: "plamo",
+      api: "openai-completions",
+      baseUrl: "https://api.platform.preferredai.jp/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const fetcher = buildGuardedModelFetch(model, { auditContext: "plamo-stream" });
+    await fetcher("https://api.platform.preferredai.jp/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"messages":[]}',
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api.platform.preferredai.jp/v1/chat/completions",
+        auditContext: "plamo-stream",
+      }),
+    );
+  });
+
   describe("long retry-after handling", () => {
     const anthropicModel = {
       id: "sonnet-4.6",
@@ -329,5 +353,187 @@ describe("buildGuardedModelFetch", () => {
 
       expect(response.headers.get("x-should-retry")).toBeNull();
     });
+  });
+
+  it("applies resolved transport auth and extra headers before dispatch", async () => {
+    resolveProviderRequestPolicyConfigMock.mockReturnValue({
+      allowPrivateNetwork: false,
+      headers: {
+        "X-Tenant": "acme",
+        "X-Proxy-Token": "proxy-token",
+        "X-Provider": "provider",
+      },
+      policy: {
+        attributionHeaders: {
+          "X-Provider": "provider",
+        },
+      },
+      auth: {
+        configured: true,
+        mode: "header",
+        headerName: "X-Proxy-Token",
+        value: "proxy-token",
+        injectAuthorizationHeader: false,
+      },
+    } as never);
+
+    const { buildGuardedModelFetch } = await import("./provider-transport-fetch.js");
+    const model = {
+      id: "plamo-3.0-prime-beta",
+      provider: "plamo",
+      api: "openai-completions",
+      baseUrl: "https://api.platform.preferredai.jp/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const fetcher = buildGuardedModelFetch(model);
+    await fetcher("https://api.platform.preferredai.jp/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer caller",
+        "X-Call": "1",
+        "X-Provider": "caller",
+      },
+      body: '{"messages":[]}',
+    });
+
+    const request = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as {
+      init?: RequestInit;
+    };
+    const headers = new Headers(request.init?.headers);
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("x-call")).toBe("1");
+    expect(headers.get("x-provider")).toBe("provider");
+    expect(headers.get("x-proxy-token")).toBe("proxy-token");
+    expect(headers.get("x-tenant")).toBe("acme");
+  });
+
+  it("keeps configured bearer auth overrides ahead of caller authorization headers", async () => {
+    resolveProviderRequestPolicyConfigMock.mockReturnValue({
+      allowPrivateNetwork: false,
+      headers: {
+        Authorization: "Bearer override-token",
+      },
+      policy: {
+        attributionHeaders: {},
+      },
+      auth: {
+        configured: true,
+        mode: "authorization-bearer",
+        headerName: "Authorization",
+        value: "override-token",
+        injectAuthorizationHeader: true,
+      },
+    } as never);
+
+    const { buildGuardedModelFetch } = await import("./provider-transport-fetch.js");
+    const model = {
+      id: "plamo-3.0-prime-beta",
+      provider: "plamo",
+      api: "openai-completions",
+      baseUrl: "https://api.platform.preferredai.jp/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const fetcher = buildGuardedModelFetch(model);
+    await fetcher("https://api.platform.preferredai.jp/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer caller",
+      },
+      body: '{"messages":[]}',
+    });
+
+    const request = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as {
+      init?: RequestInit;
+    };
+    const headers = new Headers(request.init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer override-token");
+  });
+
+  it("lets request-time headers override non-protected configured defaults", async () => {
+    resolveProviderRequestPolicyConfigMock.mockReturnValue({
+      allowPrivateNetwork: false,
+      headers: {
+        Authorization: "Bearer configured-token",
+        "X-Tenant": "configured-tenant",
+        "X-Trace": "configured-trace",
+      },
+      policy: {
+        attributionHeaders: {},
+      },
+      auth: {
+        configured: false,
+        mode: "provider-default",
+        injectAuthorizationHeader: false,
+      },
+    } as never);
+
+    const { buildGuardedModelFetch } = await import("./provider-transport-fetch.js");
+    const model = {
+      id: "plamo-3.0-prime-beta",
+      provider: "plamo",
+      api: "openai-completions",
+      baseUrl: "https://api.platform.preferredai.jp/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const fetcher = buildGuardedModelFetch(model);
+    await fetcher("https://api.platform.preferredai.jp/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer caller-token",
+        "X-Tenant": "caller-tenant",
+        "X-Trace": "caller-trace",
+        "X-Call": "1",
+      },
+      body: '{"messages":[]}',
+    });
+
+    const request = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as {
+      init?: RequestInit;
+    };
+    const headers = new Headers(request.init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer caller-token");
+    expect(headers.get("x-tenant")).toBe("caller-tenant");
+    expect(headers.get("x-trace")).toBe("caller-trace");
+    expect(headers.get("x-call")).toBe("1");
+  });
+
+  it("lets request-time beta headers override configured request header defaults", async () => {
+    resolveProviderRequestPolicyConfigMock.mockReturnValue({
+      allowPrivateNetwork: false,
+      headers: {
+        "anthropic-beta": "configured-beta",
+      },
+      policy: {
+        attributionHeaders: {},
+      },
+      auth: {
+        configured: false,
+        mode: "provider-default",
+        injectAuthorizationHeader: false,
+      },
+    } as never);
+
+    const { buildGuardedModelFetch } = await import("./provider-transport-fetch.js");
+    const model = {
+      id: "claude-sonnet-4-6",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com/v1",
+    } as unknown as Model<"anthropic-messages">;
+
+    const fetcher = buildGuardedModelFetch(model);
+    await fetcher("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "anthropic-beta": "runtime-beta",
+      },
+      body: '{"messages":[]}',
+    });
+
+    const request = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as {
+      init?: RequestInit;
+    };
+    const headers = new Headers(request.init?.headers);
+    expect(headers.get("anthropic-beta")).toBe("runtime-beta");
   });
 });

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -154,7 +154,60 @@ function resolveModelRequestPolicy(model: Model<Api>) {
   });
 }
 
-export function buildGuardedModelFetch(model: Model<Api>, timeoutMs?: number): typeof fetch {
+type BuildGuardedModelFetchOptions = {
+  auditContext?: string;
+  timeoutMs?: number;
+};
+
+function normalizeHeaderKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+function resolveProtectedModelRequestHeaderKeys(
+  requestConfig: ReturnType<typeof resolveModelRequestPolicy>,
+): Set<string> {
+  const protectedKeys = new Set<string>(
+    Object.keys(requestConfig.policy?.attributionHeaders ?? {}).map((key) =>
+      normalizeHeaderKey(key),
+    ),
+  );
+  const auth = requestConfig.auth;
+  if (!auth?.configured || typeof auth.headerName !== "string") {
+    return protectedKeys;
+  }
+  protectedKeys.add(normalizeHeaderKey(auth.headerName));
+  if (auth.mode === "header") {
+    protectedKeys.add("authorization");
+  }
+  return protectedKeys;
+}
+
+function mergeResolvedModelRequestHeaders(
+  requestInit: RequestInit | undefined,
+  requestConfig: ReturnType<typeof resolveModelRequestPolicy>,
+): RequestInit | undefined {
+  if (!requestConfig.headers && !requestInit?.headers) {
+    return requestInit;
+  }
+  const headers = new Headers(requestConfig.headers);
+  const protectedKeys = resolveProtectedModelRequestHeaderKeys(requestConfig);
+  for (const [key, value] of new Headers(requestInit?.headers).entries()) {
+    if (protectedKeys.has(normalizeHeaderKey(key))) {
+      continue;
+    }
+    headers.set(key, value);
+  }
+  return {
+    ...requestInit,
+    headers,
+  };
+}
+
+export function buildGuardedModelFetch(
+  model: Model<Api>,
+  options?: number | BuildGuardedModelFetchOptions,
+): typeof fetch {
+  const resolvedOptions = typeof options === "number" ? { timeoutMs: options } : options;
   const requestConfig = resolveModelRequestPolicy(model);
   const dispatcherPolicy = buildProviderRequestDispatcherPolicy(requestConfig);
   return async (input, init) => {
@@ -178,9 +231,10 @@ export function buildGuardedModelFetch(model: Model<Api>, timeoutMs?: number): t
         signal: request.signal,
         ...(request.body ? ({ duplex: "half" } as const) : {}),
       } satisfies RequestInit & { duplex?: "half" });
+    const mergedRequestInit = mergeResolvedModelRequestHeaders(requestInit ?? init, requestConfig);
     const result = await fetchWithSsrFGuard({
       url,
-      init: requestInit ?? init,
+      init: mergedRequestInit,
       capture: {
         meta: {
           provider: model.provider,
@@ -188,8 +242,9 @@ export function buildGuardedModelFetch(model: Model<Api>, timeoutMs?: number): t
           model: model.id,
         },
       },
+      ...(resolvedOptions?.auditContext ? { auditContext: resolvedOptions.auditContext } : {}),
       dispatcherPolicy,
-      timeoutMs,
+      timeoutMs: resolvedOptions?.timeoutMs,
       // Provider transport intentionally keeps the secure default and never
       // replays unsafe request bodies across cross-origin redirects.
       allowCrossOriginUnsafeRedirectReplay: false,

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -1,12 +1,18 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
+  completeMock: vi.fn(),
   resolveModelMock: vi.fn(),
   getApiKeyForModelMock: vi.fn(),
   applyLocalNoAuthHeaderOverrideMock: vi.fn(),
   setRuntimeApiKeyMock: vi.fn(),
   resolveCopilotApiTokenMock: vi.fn(),
   prepareProviderRuntimeAuthMock: vi.fn(),
+  registerProviderStreamForModelMock: vi.fn(),
+}));
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  complete: hoisted.completeMock,
 }));
 
 vi.mock("./pi-embedded-runner/model.js", () => ({
@@ -16,6 +22,8 @@ vi.mock("./pi-embedded-runner/model.js", () => ({
 vi.mock("./model-auth.js", () => ({
   getApiKeyForModel: hoisted.getApiKeyForModelMock,
   applyLocalNoAuthHeaderOverride: hoisted.applyLocalNoAuthHeaderOverrideMock,
+  isNonSecretApiKeyMarker: (value: string) =>
+    value === "custom-local" || value === "plamo-request-auth",
 }));
 
 vi.mock("./github-copilot-token.js", () => ({
@@ -26,19 +34,27 @@ vi.mock("../plugins/provider-runtime.runtime.js", () => ({
   prepareProviderRuntimeAuth: hoisted.prepareProviderRuntimeAuthMock,
 }));
 
+vi.mock("./provider-stream.js", () => ({
+  registerProviderStreamForModel: hoisted.registerProviderStreamForModelMock,
+}));
+
 let prepareSimpleCompletionModel: typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModel;
+let completeWithPreparedSimpleCompletionModel: typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel;
 
 beforeAll(async () => {
-  ({ prepareSimpleCompletionModel } = await import("./simple-completion-runtime.js"));
+  ({ prepareSimpleCompletionModel, completeWithPreparedSimpleCompletionModel } =
+    await import("./simple-completion-runtime.js"));
 });
 
 beforeEach(() => {
+  hoisted.completeMock.mockReset();
   hoisted.resolveModelMock.mockReset();
   hoisted.getApiKeyForModelMock.mockReset();
   hoisted.applyLocalNoAuthHeaderOverrideMock.mockReset();
   hoisted.setRuntimeApiKeyMock.mockReset();
   hoisted.resolveCopilotApiTokenMock.mockReset();
   hoisted.prepareProviderRuntimeAuthMock.mockReset();
+  hoisted.registerProviderStreamForModelMock.mockReset();
 
   hoisted.applyLocalNoAuthHeaderOverrideMock.mockImplementation((model: unknown) => model);
 
@@ -64,6 +80,8 @@ beforeEach(() => {
     baseUrl: "https://api.individual.githubcopilot.com",
   });
   hoisted.prepareProviderRuntimeAuthMock.mockResolvedValue(undefined);
+  hoisted.completeMock.mockResolvedValue("ok");
+  hoisted.registerProviderStreamForModelMock.mockReturnValue(undefined);
 });
 
 describe("prepareSimpleCompletionModel", () => {
@@ -404,5 +422,366 @@ describe("prepareSimpleCompletionModel", () => {
         }),
       }),
     );
+  });
+
+  it("omits synthetic request-auth markers from simple completion auth", async () => {
+    const requestTransportSymbol = Symbol.for("openclaw.modelProviderRequestTransport");
+    hoisted.resolveModelMock.mockReturnValueOnce({
+      model: {
+        provider: "plamo",
+        id: "plamo-3.0-prime-beta",
+        api: "openai-completions",
+        baseUrl: "https://proxy.example.test/v1",
+        headers: {
+          "X-Proxy-Token": "proxy-token",
+        },
+        [requestTransportSymbol]: {
+          headers: {
+            "X-Proxy-Token": "proxy-token",
+          },
+        },
+      },
+      authStorage: {
+        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+      },
+      modelRegistry: {},
+    });
+    hoisted.getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "plamo-request-auth",
+      source: "models.providers.plamo.request (synthetic request auth)",
+      mode: "api-key",
+    });
+
+    const result = await prepareSimpleCompletionModel({
+      cfg: undefined,
+      provider: "plamo",
+      modelId: "plamo-3.0-prime-beta",
+    });
+
+    expect(hoisted.setRuntimeApiKeyMock).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          apiKey: undefined,
+          source: "models.providers.plamo.request (synthetic request auth)",
+          mode: "api-key",
+        }),
+      }),
+    );
+  });
+
+  it("keeps real api keys when auth-like request headers are additive", async () => {
+    const requestTransportSymbol = Symbol.for("openclaw.modelProviderRequestTransport");
+    hoisted.resolveModelMock.mockReturnValueOnce({
+      model: {
+        provider: "plamo",
+        id: "plamo-3.0-prime-beta",
+        api: "openai-completions",
+        baseUrl: "https://proxy.example.test/v1",
+        headers: {
+          "X-Proxy-Token": "proxy-token",
+        },
+        [requestTransportSymbol]: {
+          headers: {
+            "X-Proxy-Token": "proxy-token",
+          },
+        },
+      },
+      authStorage: {
+        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+      },
+      modelRegistry: {},
+    });
+    hoisted.getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "sk-real-key",
+      source: "env:PLAMO_API_KEY",
+      mode: "api-key",
+    });
+
+    const result = await prepareSimpleCompletionModel({
+      cfg: undefined,
+      provider: "plamo",
+      modelId: "plamo-3.0-prime-beta",
+    });
+
+    expect(hoisted.setRuntimeApiKeyMock).toHaveBeenCalledWith("plamo", "sk-real-key");
+    expect(result).toEqual(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          apiKey: "sk-real-key",
+          source: "env:PLAMO_API_KEY",
+          mode: "api-key",
+        }),
+      }),
+    );
+  });
+
+  it("keeps real api keys when request transport headers are non-auth metadata", async () => {
+    const requestTransportSymbol = Symbol.for("openclaw.modelProviderRequestTransport");
+    hoisted.resolveModelMock.mockReturnValueOnce({
+      model: {
+        provider: "plamo",
+        id: "plamo-3.0-prime-beta",
+        api: "openai-completions",
+        baseUrl: "https://proxy.example.test/v1",
+        headers: {
+          "X-Tenant": "tenant-a",
+        },
+        [requestTransportSymbol]: {
+          headers: {
+            "X-Tenant": "tenant-a",
+          },
+        },
+      },
+      authStorage: {
+        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+      },
+      modelRegistry: {},
+    });
+    hoisted.getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "sk-real-key",
+      source: "env:PLAMO_API_KEY",
+      mode: "api-key",
+    });
+
+    const result = await prepareSimpleCompletionModel({
+      cfg: undefined,
+      provider: "plamo",
+      modelId: "plamo-3.0-prime-beta",
+    });
+
+    expect(hoisted.setRuntimeApiKeyMock).toHaveBeenCalledWith("plamo", "sk-real-key");
+    expect(result).toEqual(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          apiKey: "sk-real-key",
+          source: "env:PLAMO_API_KEY",
+          mode: "api-key",
+        }),
+      }),
+    );
+  });
+
+  it("omits synthetic request-auth markers when auth is carried by model headers alone", async () => {
+    hoisted.resolveModelMock.mockReturnValueOnce({
+      model: {
+        provider: "plamo",
+        id: "plamo-3.0-prime-beta",
+        api: "openai-completions",
+        baseUrl: "https://proxy.example.test/v1",
+        headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      },
+      authStorage: {
+        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+      },
+      modelRegistry: {},
+    });
+    hoisted.getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "plamo-request-auth",
+      source: "models.providers.plamo.request (synthetic request auth)",
+      mode: "api-key",
+    });
+
+    const result = await prepareSimpleCompletionModel({
+      cfg: undefined,
+      provider: "plamo",
+      modelId: "plamo-3.0-prime-beta",
+    });
+
+    expect(hoisted.setRuntimeApiKeyMock).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          apiKey: undefined,
+          source: "models.providers.plamo.request (synthetic request auth)",
+          mode: "api-key",
+        }),
+      }),
+    );
+  });
+
+  it("keeps real api keys when auth-like model headers are additive", async () => {
+    hoisted.resolveModelMock.mockReturnValueOnce({
+      model: {
+        provider: "plamo",
+        id: "plamo-3.0-prime-beta",
+        api: "openai-completions",
+        baseUrl: "https://proxy.example.test/v1",
+        headers: {
+          Authorization: "Bearer proxy-token",
+        },
+      },
+      authStorage: {
+        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+      },
+      modelRegistry: {},
+    });
+    hoisted.getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "sk-real-key",
+      source: "env:PLAMO_API_KEY",
+      mode: "api-key",
+    });
+
+    const result = await prepareSimpleCompletionModel({
+      cfg: undefined,
+      provider: "plamo",
+      modelId: "plamo-3.0-prime-beta",
+    });
+
+    expect(hoisted.setRuntimeApiKeyMock).toHaveBeenCalledWith("plamo", "sk-real-key");
+    expect(result).toEqual(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          apiKey: "sk-real-key",
+          source: "env:PLAMO_API_KEY",
+          mode: "api-key",
+        }),
+      }),
+    );
+  });
+
+  it("omits real api keys when request auth explicitly replaces provider auth", async () => {
+    const requestTransportSymbol = Symbol.for("openclaw.modelProviderRequestTransport");
+    hoisted.resolveModelMock.mockReturnValueOnce({
+      model: {
+        provider: "plamo",
+        id: "plamo-3.0-prime-beta",
+        api: "openai-completions",
+        baseUrl: "https://proxy.example.test/v1",
+        [requestTransportSymbol]: {
+          auth: {
+            mode: "header",
+            headerName: "X-Proxy-Token",
+            value: "proxy-token",
+          },
+        },
+      },
+      authStorage: {
+        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+      },
+      modelRegistry: {},
+    });
+    hoisted.getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "sk-real-key",
+      source: "env:PLAMO_API_KEY",
+      mode: "api-key",
+    });
+
+    const result = await prepareSimpleCompletionModel({
+      cfg: undefined,
+      provider: "plamo",
+      modelId: "plamo-3.0-prime-beta",
+    });
+
+    expect(hoisted.setRuntimeApiKeyMock).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          apiKey: undefined,
+          source: "env:PLAMO_API_KEY",
+          mode: "api-key",
+        }),
+      }),
+    );
+  });
+});
+
+describe("completeWithPreparedSimpleCompletionModel", () => {
+  it("routes request-authenticated models through the provider-owned stream", async () => {
+    const requestTransportSymbol = Symbol.for("openclaw.modelProviderRequestTransport");
+    const model = {
+      provider: "plamo",
+      id: "plamo-3.0-prime-beta",
+      api: "openai-completions",
+      baseUrl: "https://proxy.example.test/v1",
+      headers: {
+        "X-Proxy-Token": "proxy-token",
+      },
+      [requestTransportSymbol]: {
+        headers: {
+          "X-Proxy-Token": "proxy-token",
+        },
+      },
+    };
+    const context = {
+      messages: [{ role: "user", content: "title", timestamp: 1 }],
+    };
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "ok" }],
+      api: "openai-completions",
+      provider: "plamo",
+      model: "plamo-3.0-prime-beta",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 1,
+    };
+    const stream = {
+      result: vi.fn(async () => message),
+      [Symbol.asyncIterator]: async function* () {},
+    };
+    const streamFn = vi.fn(() => stream);
+    hoisted.registerProviderStreamForModelMock.mockReturnValueOnce(streamFn);
+
+    const result = await completeWithPreparedSimpleCompletionModel({
+      model: model as never,
+      auth: {
+        apiKey: undefined,
+        source: "models.providers.plamo.request (synthetic request auth)",
+        mode: "api-key",
+      },
+      context: context as never,
+      options: { maxTokens: 12 },
+    });
+
+    expect(result).toBe(message);
+    expect(hoisted.registerProviderStreamForModelMock).toHaveBeenCalledWith({
+      model,
+    });
+    expect(streamFn).toHaveBeenCalledWith(model, context, {
+      maxTokens: 12,
+      apiKey: undefined,
+    });
+    expect(stream.result).toHaveBeenCalledTimes(1);
+    expect(hoisted.completeMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps normal api-key completions on the built-in completion path", async () => {
+    const model = {
+      provider: "plamo",
+      id: "plamo-3.0-prime-beta",
+      api: "openai-completions",
+      baseUrl: "https://api.platform.preferredai.jp/v1",
+    };
+    const context = {
+      messages: [{ role: "user", content: "title", timestamp: 1 }],
+    };
+
+    const result = await completeWithPreparedSimpleCompletionModel({
+      model: model as never,
+      auth: {
+        apiKey: "sk-real-key",
+        source: "env:PLAMO_API_KEY",
+        mode: "api-key",
+      },
+      context: context as never,
+      options: { maxTokens: 12 },
+    });
+
+    expect(result).toBe("ok");
+    expect(hoisted.registerProviderStreamForModelMock).not.toHaveBeenCalled();
+    expect(hoisted.completeMock).toHaveBeenCalledWith(model, context, {
+      maxTokens: 12,
+      apiKey: "sk-real-key",
+    });
   });
 });

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -7,6 +7,7 @@ import { DEFAULT_PROVIDER } from "./defaults.js";
 import {
   applyLocalNoAuthHeaderOverride,
   getApiKeyForModel,
+  isNonSecretApiKeyMarker,
   type ResolvedProviderAuth,
 } from "./model-auth.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
@@ -16,6 +17,8 @@ import {
   resolveModelRefFromString,
 } from "./model-selection.js";
 import { resolveModel } from "./pi-embedded-runner/model.js";
+import { getModelProviderRequestTransport } from "./provider-request-config.js";
+import { registerProviderStreamForModel } from "./provider-stream.js";
 
 type SimpleCompletionAuthStorage = {
   setRuntimeApiKey: (provider: string, apiKey: string) => void;
@@ -27,6 +30,14 @@ type CompletionRuntimeCredential = {
 };
 
 type AllowedMissingApiKeyMode = ResolvedProviderAuth["mode"];
+const SIMPLE_COMPLETION_AUTH_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authorization",
+  "x-proxy-token",
+  "x-auth-token",
+  "x-api-key",
+  "api-key",
+]);
 
 export type SimpleCompletionModelOptions = {
   maxTokens?: number;
@@ -150,6 +161,41 @@ function hasMissingApiKeyAllowance(params: {
   return Boolean(params.allowMissingApiKeyModes?.includes(params.mode));
 }
 
+function shouldUseRequestAuthenticatedSimpleCompletion(params: {
+  model: Model<Api>;
+  auth: ResolvedProviderAuth;
+}): boolean {
+  const requestTransport = getModelProviderRequestTransport(params.model);
+  return (
+    Boolean(requestTransport?.auth && requestTransport.auth.mode !== "provider-default") ||
+    (Boolean(params.auth.apiKey?.trim()) &&
+      isNonSecretApiKeyMarker(params.auth.apiKey!.trim()) &&
+      (hasAuthLikeModelHeaders(requestTransport?.headers) ||
+        hasAuthLikeModelHeaders((params.model as { headers?: unknown }).headers)))
+  );
+}
+
+function hasRequestAuthenticatedSimpleCompletionModel(model: Model<Api>): boolean {
+  const requestTransport = getModelProviderRequestTransport(model);
+  return (
+    Boolean(requestTransport?.auth && requestTransport.auth.mode !== "provider-default") ||
+    hasAuthLikeModelHeaders(requestTransport?.headers) ||
+    hasAuthLikeModelHeaders((model as { headers?: unknown }).headers)
+  );
+}
+
+function hasAuthLikeModelHeaders(headers: unknown): boolean {
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return false;
+  }
+  return Object.entries(headers).some(
+    ([headerName, headerValue]) =>
+      SIMPLE_COMPLETION_AUTH_HEADER_NAMES.has(headerName.trim().toLowerCase()) &&
+      typeof headerValue === "string" &&
+      headerValue.trim().length > 0,
+  );
+}
+
 export async function prepareSimpleCompletionModel(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -196,7 +242,11 @@ export async function prepareSimpleCompletionModel(params: {
 
   let resolvedApiKey = rawApiKey;
   let resolvedModel = resolved.model;
-  if (rawApiKey) {
+  const requestAuthenticatedSimpleCompletion = shouldUseRequestAuthenticatedSimpleCompletion({
+    model: resolved.model,
+    auth,
+  });
+  if (rawApiKey && !requestAuthenticatedSimpleCompletion) {
     const runtimeCredential = await setRuntimeApiKeyForCompletion({
       authStorage: resolved.authStorage,
       model: resolved.model,
@@ -214,6 +264,8 @@ export async function prepareSimpleCompletionModel(params: {
         baseUrl: runtimeBaseUrl,
       };
     }
+  } else if (requestAuthenticatedSimpleCompletion) {
+    resolvedApiKey = undefined;
   }
 
   const resolvedAuth: ResolvedProviderAuth = {
@@ -272,8 +324,16 @@ export async function completeWithPreparedSimpleCompletionModel(params: {
   context: Parameters<typeof complete>[1];
   options?: SimpleCompletionModelOptions;
 }) {
-  return await complete(params.model, params.context, {
+  const options = {
     ...params.options,
     apiKey: params.auth.apiKey,
-  });
+  };
+  if (!params.auth.apiKey?.trim() && hasRequestAuthenticatedSimpleCompletionModel(params.model)) {
+    const providerStreamFn = registerProviderStreamForModel({ model: params.model });
+    if (providerStreamFn) {
+      const stream = await providerStreamFn(params.model, params.context, options);
+      return await stream.result();
+    }
+  }
+  return await complete(params.model, params.context, options);
 }

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -8,6 +8,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveApiKeyForProvider as resolveModelApiKeyForProvider } from "../agents/model-auth.js";
 
 export { resolveEnvApiKey } from "../agents/model-auth-env.js";
+export { isNonSecretApiKeyMarker } from "../agents/model-auth-markers.js";
 export {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,

--- a/src/plugin-sdk/provider-http-runtime.ts
+++ b/src/plugin-sdk/provider-http-runtime.ts
@@ -1,0 +1,15 @@
+// Shared provider-facing LLM transport helpers. Keep runtime-heavy request
+// policy and SSRF-guard wiring off the broad `provider-http` SDK barrel.
+
+export { buildGuardedModelFetch } from "../agents/provider-transport-fetch.js";
+import { getModelProviderRequestTransport } from "../agents/provider-request-config.js";
+
+/**
+ * Returns the configured request-auth mode attached to a resolved runtime
+ * model, if the provider config overrode transport auth behavior.
+ */
+export function resolveModelRequestAuthMode(
+  model: object,
+): "provider-default" | "authorization-bearer" | "header" | undefined {
+  return getModelProviderRequestTransport(model)?.auth?.mode;
+}

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -5,6 +5,7 @@ import {
   findOpenAIStrictSchemaViolations,
   inspectGeminiToolSchemas,
   inspectOpenAIToolSchemas,
+  normalizeOpenAICompatibleToolParameters,
   normalizeGeminiToolSchemas,
   normalizeOpenAIToolSchemas,
   resolveXaiModelCompatPatch,
@@ -113,6 +114,25 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     });
 
     expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    });
+  });
+
+  it("normalizes parameter-free schemas for openai-compatible transports", () => {
+    expect(normalizeOpenAICompatibleToolParameters({})).toEqual({
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    });
+    expect(
+      normalizeOpenAICompatibleToolParameters({
+        type: "object",
+      }),
+    ).toEqual({
       type: "object",
       properties: {},
       required: [],

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -1,4 +1,3 @@
-import type { TSchema } from "typebox";
 import {
   cleanSchemaForGemini,
   GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS,
@@ -139,7 +138,7 @@ export function normalizeGeminiToolSchemas(
     }
     return {
       ...tool,
-      parameters: cleanSchemaForGemini(tool.parameters),
+      parameters: cleanSchemaForGemini(tool.parameters as Record<string, unknown>),
     };
   });
 }
@@ -170,7 +169,7 @@ export function normalizeOpenAIToolSchemas(
     if (tool.parameters == null) {
       return {
         ...tool,
-        parameters: normalizeOpenAIStrictCompatSchema({}),
+        parameters: normalizeOpenAIToolParametersForAgentTool({}),
       };
     }
     if (typeof tool.parameters !== "object") {
@@ -178,15 +177,26 @@ export function normalizeOpenAIToolSchemas(
     }
     return {
       ...tool,
-      parameters: normalizeOpenAIStrictCompatSchema(tool.parameters),
+      parameters: normalizeOpenAIToolParametersForAgentTool(tool.parameters),
     };
   });
 }
 
-function normalizeOpenAIStrictCompatSchema(schema: unknown): TSchema {
-  return normalizeOpenAIStrictCompatSchemaRecursive(schema, {
-    promoteEmptyObject: true,
-  }) as TSchema;
+/**
+ * Normalizes a single tool parameter schema for OpenAI-compatible transports
+ * that require an object-root schema but do not use the native OpenAI strict
+ * tool-routing hooks.
+ */
+export function normalizeOpenAICompatibleToolParameters(schema: unknown): unknown {
+  return normalizeOpenAIStrictCompatSchema(schema ?? {});
+}
+
+function normalizeOpenAIToolParametersForAgentTool(schema: unknown): AnyAgentTool["parameters"] {
+  return normalizeOpenAIStrictCompatSchema(schema) as AnyAgentTool["parameters"];
+}
+
+function normalizeOpenAIStrictCompatSchema(schema: unknown): unknown {
+  return normalizeOpenAIStrictCompatSchemaRecursive(schema, { promoteEmptyObject: true });
 }
 
 function shouldApplyOpenAIToolCompat(ctx: ProviderNormalizeToolSchemasContext): boolean {

--- a/src/plugins/contracts/extension-package-project-boundaries.test.ts
+++ b/src/plugins/contracts/extension-package-project-boundaries.test.ts
@@ -148,6 +148,12 @@ describe("opt-in extension package boundaries", () => {
     expect(packageJson.exports?.["./provider-http"]?.types).toBe(
       "./dist/src/plugin-sdk/provider-http.d.ts",
     );
+    expect(packageJson.exports?.["./provider-http-runtime"]?.types).toBe(
+      "./dist/src/plugin-sdk/provider-http-runtime.d.ts",
+    );
+    expect(packageJson.exports?.["./provider-http-runtime"]?.default).toBe(
+      "./src/provider-http-runtime.ts",
+    );
     expect(packageJson.exports?.["./provider-usage"]?.types).toBe(
       "./dist/src/plugin-sdk/provider-usage.d.ts",
     );

--- a/src/plugins/contracts/provider-family-plugin-tests.test.ts
+++ b/src/plugins/contracts/provider-family-plugin-tests.test.ts
@@ -43,6 +43,9 @@ const EXPECTED_SENTINEL_SHARED_FAMILY_ASSIGNMENTS: Record<string, ExpectedShared
   openai: {
     toolCompatFamilies: ["openai"],
   },
+  plamo: {
+    replayFamilies: ["openai-compatible"],
+  },
 };
 
 function toRepoRelative(path: string): string {

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -115,6 +115,13 @@ function setOwningProviderManifestPluginsWithWorkspace() {
       },
     }),
     createManifestProviderPlugin({
+      id: "plamo",
+      providerIds: ["plamo"],
+      modelSupport: {
+        modelPrefixes: ["plamo-"],
+      },
+    }),
+    createManifestProviderPlugin({
       id: "workspace-provider",
       providerIds: ["workspace-provider"],
       origin: "workspace",
@@ -1241,6 +1248,10 @@ describe("resolvePluginProviders", () => {
     {
       model: "claude-sonnet-4-6",
       expectedPluginIds: ["anthropic"],
+    },
+    {
+      model: "plamo-3.0-prime-beta",
+      expectedPluginIds: ["plamo"],
     },
     {
       model: "openai/gpt-5.4",


### PR DESCRIPTION
## What changed

This updates the bundled PLaMo provider so uncataloged `plamo-*` model ids resolve to safe runtime metadata, and so parameter-free tool schemas are normalized before they are sent over PLaMo's OpenAI-compatible transport.

It also adds focused coverage for the new dynamic-model and tool-schema paths, plus the expected generated Plugin SDK baseline and A2UI hash updates.

## Why it changed

PLaMo requests could fail in two cases: when users selected a forward-compat `plamo-*` model id that was not yet present in the local catalog, and when a tool exposed a zero-argument schema like `{}` that PLaMo rejected without an object-root normalization pass.

## Impact

Users can keep using newer PLaMo model ids before the local catalog is refreshed, and parameter-free tools now serialize in the provider-compatible schema shape on both the plugin normalization path and the native stream transport path.

## Validation

- `pnpm test extensions/plamo/index.test.ts`
- `pnpm test src/plugin-sdk/provider-tools.test.ts`
- `pnpm plugin-sdk:api:check`
- `pnpm build`
- `pnpm test src/gateway/method-scopes.test.ts -t "classifies every exposed core gateway handler method"` *(fails on this branch in unrelated gateway method classification: `doctor.memory.repairDreamingArtifacts` / `doctor.memory.dedupeDreamDiary` are unclassified)*
- `pnpm test src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts -t "fires compaction hooks during timeout recovery for ownsCompaction engines"` *(fails on this branch in unrelated timeout-compaction coverage: `mockedRunPostCompactionSideEffects` was not called)*
