### PR TITLE
tests(contracts): use contract-api for Slack and Discord directories

### DIFF
--- a/extensions/discord/contract-api.ts
+++ b/extensions/discord/contract-api.ts
@@ -1,4 +1,8 @@
 export { createThreadBindingManager } from "./src/monitor/thread-bindings.manager.js";
+export {
+  listDiscordDirectoryGroupsFromConfig,
+  listDiscordDirectoryPeersFromConfig,
+} from "./src/directory-config.js";
 export { normalizeCompatibilityConfig, legacyConfigRules } from "./src/doctor-contract.js";
 export {
   collectRuntimeConfigAssignments,

--- a/extensions/slack/contract-api.ts
+++ b/extensions/slack/contract-api.ts
@@ -1,5 +1,9 @@
 export { normalizeCompatibilityConfig, legacyConfigRules } from "./src/doctor-contract.js";
 export {
+  listSlackDirectoryGroupsFromConfig,
+  listSlackDirectoryPeersFromConfig,
+} from "./src/directory-config.js";
+export {
   collectRuntimeConfigAssignments,
   secretTargetRegistryEntries,
 } from "./src/secret-contract.js";

--- a/test/helpers/channels/plugins-core-extension-contract.ts
+++ b/test/helpers/channels/plugins-core-extension-contract.ts
@@ -6,34 +6,43 @@ import type {
 } from "../../../src/channels/plugins/types.js";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import type { LineProbeResult } from "../../../src/plugin-sdk/line.js";
-import { loadBundledPluginApiSync } from "../../../src/test-utils/bundled-plugin-public-surface.js";
+import {
+  loadBundledPluginApiSync,
+  loadBundledPluginContractApiSync,
+} from "../../../src/test-utils/bundled-plugin-public-surface.js";
 import { withEnvAsync } from "../../../src/test-utils/env.js";
 
-type DiscordApiSurface = typeof import("@openclaw/discord/api.js");
+type DiscordContractApiSurface = Pick<
+  typeof import("@openclaw/discord/contract-api.js"),
+  "listDiscordDirectoryPeersFromConfig" | "listDiscordDirectoryGroupsFromConfig"
+>;
 type DiscordProbe = import("@openclaw/discord/api.js").DiscordProbe;
 type DiscordTokenResolution = import("@openclaw/discord/api.js").DiscordTokenResolution;
 type IMessageProbe = import("@openclaw/imessage/runtime-api.js").IMessageProbe;
 type SignalProbe = import("@openclaw/signal/api.js").SignalProbe;
-type SlackApiSurface = typeof import("@openclaw/slack/api.js");
+type SlackContractApiSurface = Pick<
+  typeof import("@openclaw/slack/contract-api.js"),
+  "listSlackDirectoryPeersFromConfig" | "listSlackDirectoryGroupsFromConfig"
+>;
 type SlackProbe = import("@openclaw/slack/api.js").SlackProbe;
 type TelegramApiSurface = typeof import("@openclaw/telegram/api.js");
 type TelegramProbe = import("@openclaw/telegram/api.js").TelegramProbe;
 type TelegramTokenResolution = import("@openclaw/telegram/api.js").TelegramTokenResolution;
 type WhatsAppApiSurface = typeof import("@openclaw/whatsapp/api.js");
 
-let discordApi: DiscordApiSurface | undefined;
-let slackApi: SlackApiSurface | undefined;
+let discordContractApi: DiscordContractApiSurface | undefined;
+let slackContractApi: SlackContractApiSurface | undefined;
 let telegramApi: TelegramApiSurface | undefined;
 let whatsappApi: WhatsAppApiSurface | undefined;
 
-function getDiscordApi(): DiscordApiSurface {
-  discordApi ??= loadBundledPluginApiSync<DiscordApiSurface>("discord");
-  return discordApi;
+function getDiscordContractApi(): DiscordContractApiSurface {
+  discordContractApi ??= loadBundledPluginContractApiSync<DiscordContractApiSurface>("discord");
+  return discordContractApi;
 }
 
-function getSlackApi(): SlackApiSurface {
-  slackApi ??= loadBundledPluginApiSync<SlackApiSurface>("slack");
-  return slackApi;
+function getSlackContractApi(): SlackContractApiSurface {
+  slackContractApi ??= loadBundledPluginContractApiSync<SlackContractApiSurface>("slack");
+  return slackContractApi;
 }
 
 function getTelegramApi(): TelegramApiSurface {
@@ -75,8 +84,8 @@ async function expectDirectoryIds(
 
 export function describeDiscordPluginsCoreExtensionContract() {
   describe("discord plugins-core extension contract", () => {
-    const listPeers = () => getDiscordApi().listDiscordDirectoryPeersFromConfig;
-    const listGroups = () => getDiscordApi().listDiscordDirectoryGroupsFromConfig;
+    const listPeers = () => getDiscordContractApi().listDiscordDirectoryPeersFromConfig;
+    const listGroups = () => getDiscordContractApi().listDiscordDirectoryGroupsFromConfig;
 
     it("DiscordProbe satisfies BaseProbeResult", () => {
       expectTypeOf<DiscordProbe>().toMatchTypeOf<BaseProbeResult>();
@@ -176,8 +185,8 @@ export function describeDiscordPluginsCoreExtensionContract() {
 
 export function describeSlackPluginsCoreExtensionContract() {
   describe("slack plugins-core extension contract", () => {
-    const listPeers = () => getSlackApi().listSlackDirectoryPeersFromConfig;
-    const listGroups = () => getSlackApi().listSlackDirectoryGroupsFromConfig;
+    const listPeers = () => getSlackContractApi().listSlackDirectoryPeersFromConfig;
+    const listGroups = () => getSlackContractApi().listSlackDirectoryGroupsFromConfig;
 
     it("SlackProbe satisfies BaseProbeResult", () => {
       expectTypeOf<SlackProbe>().toMatchTypeOf<BaseProbeResult>();


### PR DESCRIPTION
## Summary

- CI pipeline: `checks-fast-contracts-protocol`
- Failing problem: `src/channels/plugins/contracts/plugins-core-extension.slack.contract.test.ts` -> `lists peers/groups from config`
- Failing problem: `src/channels/plugins/contracts/plugins-core-extension.discord.contract.test.ts` -> `lists peers/groups from config (numeric ids only)`
- Problem: the shared plugins-core extension contract helper synchronously loaded the full Slack and Discord `api.ts` surfaces just to reach config-backed directory listing helpers
- Why it matters: those broader imports made the Slack and Discord directory contract tests slow enough to time out in the contracts lane
- What changed: export the config-backed directory listing helpers from each plugin's `contract-api.ts`, then have the shared contract helper load those narrower contract surfaces instead of the full plugin APIs
- What did NOT change (scope boundary): runtime directory behavior, account-merging logic, and the public `api.ts` surfaces used by real runtime callers

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #64154
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the shared channel contract helper used `loadBundledPluginApiSync(...)` for Slack and Discord directory assertions, even though the tests only needed config-backed directory functions
- Missing detection / guardrail: those directory functions were not exported on the narrower `contract-api.ts` surface, so the helper had to pull in the full plugin API surface
- Contributing context (if known): the contracts lane runs these directory suites alongside many other contract tests, so excess import cost turned into job-level timeouts

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/channels/plugins/contracts/plugins-core-extension.slack.contract.test.ts`, `src/channels/plugins/contracts/plugins-core-extension.discord.contract.test.ts`
- Scenario the test should lock in: config-backed directory contract coverage can load Slack and Discord through a narrow public contract seam without timing out
- Why this is the smallest reliable guardrail: the regression lived at the public-surface loading boundary shared by both contract suites
- Existing test that already covers this (if any): these two contract files are the direct regression coverage
- If no new test is added, why not: existing contract tests already capture the failure once they load the right public seam

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
contract helper -> loadBundledPluginApiSync("slack"/"discord") -> full api.ts graph
=> directory contract tests spend too long importing and time out in contracts CI

After:
contract helper -> loadBundledPluginContractApiSync("slack"/"discord") -> contract-api.ts
contract-api.ts -> directory-config helpers
=> same directory assertions run through a narrower public seam
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Slack, Discord
- Relevant config (redacted): config-only directory fixtures in contract tests

### Steps

1. Run `pnpm exec vitest run -c test/vitest/vitest.contracts.config.ts src/channels/plugins/contracts/plugins-core-extension.slack.contract.test.ts src/channels/plugins/contracts/plugins-core-extension.discord.contract.test.ts`
2. Observe the shared directory contract helper loading Slack and Discord public surfaces
3. Confirm both contract files finish successfully in the contracts lane

### Expected

- Slack and Discord config-backed directory contract tests complete without timing out.

### Actual

- Before this change, both suites timed out in the contracts pipeline because the helper imported the heavier `api.ts` surfaces.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Slack and Discord directory contract suites both pass through `test/vitest/vitest.contracts.config.ts` after switching to `contract-api`
- Edge cases checked: the helper still keeps API-surface type assertions for `SlackProbe`, `DiscordProbe`, and token-resolution types while loading directory functions from the narrower contract seam
- What you did **not** verify: the full contracts suite end-to-end

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: other contract helpers could still load broader plugin surfaces than they need
  - Mitigation: this PR moves Slack and Discord directory coverage onto explicit contract-api exports, which is the narrow seam reviewers can apply elsewhere if needed
