### PR TITLE
fix(agents): ignore ACP-only streamTo on subagent sessions_spawn

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -284,7 +284,7 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamTo when runtime is not "acp"', async () => {
+  it('silently drops streamTo when runtime is "subagent"', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -296,12 +296,14 @@ describe("sessions_spawn tool", () => {
     });
 
     expect(result.details).toMatchObject({
-      status: "error",
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
     });
-    const details = result.details as { error?: string };
-    expect(details.error).toContain("streamTo is only supported for runtime=acp");
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ streamTo: "parent" }),
+      expect.any(Object),
+    );
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -175,7 +175,10 @@ export function createSessionsSpawnTool(
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const expectsCompletionMessage = params.expectsCompletionMessage !== false;
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const requestedStreamTo = params.streamTo === "parent" ? "parent" : undefined;
+      // Some callers retain ACP-only fields when they fall back to subagent runtime.
+      // Treat streamTo as ACP-only and drop it silently for subagent requests.
+      const streamTo = runtime === "acp" ? requestedStreamTo : undefined;
       const lightContext = params.lightContext === true;
       if (runtime === "acp" && lightContext) {
         throw new Error("lightContext is only supported for runtime='subagent'.");
@@ -200,13 +203,6 @@ export function createSessionsSpawnTool(
             mimeType?: string;
           }>)
         : undefined;
-
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
 
       if (resumeSessionId && runtime !== "acp") {
         return jsonResult({
@@ -346,3 +342,4 @@ export function createSessionsSpawnTool(
     },
   };
 }
+


### PR DESCRIPTION
## Problem

When an agent falls back from ACP runtime to subagent runtime, it may still pass `streamTo: "parent"` from the original ACP request parameters. This caused `sessions_spawn` to return an error:

```
streamTo is only supported for runtime=acp; got runtime=subagent
```

## Fix

Treat `streamTo` as ACP-only: silently drop it when runtime is not ACP, instead of returning an error. The parameter is documented as ACP-only in the schema, so dropping it is correct behavior.

```ts
// Before
const streamTo = params.streamTo === "parent" ? "parent" : undefined;
// ...
if (streamTo && runtime !== "acp") return jsonResult({ status: "error", error: `streamTo is only supported for runtime=acp` });

// After
const requestedStreamTo = params.streamTo === "parent" ? "parent" : undefined;
// Some callers retain ACP-only fields when they fall back to subagent runtime.
// Treat streamTo as ACP-only and drop it silently for subagent requests.
const streamTo = runtime === "acp" ? requestedStreamTo : undefined;
```

## Validation

Validated end-to-end on v4.11: spawned a real research subagent that ran `web_search` + `web_fetch`, completed in 67.6s with `outcome.status = "ok"` and valid `frozenResultText` JSON output.

## References

- Closes #43556
- PR #55483 contained the correct fix but was closed due to 100-file scope creep (AI-generated). This PR contains only the 2-line change needed.