### PR TITLE
fix(slack): resolve DM thread delivery failure (channel_not_found)

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -350,6 +350,18 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
           return false;
         }
       },
+      resolveDeliveryTarget: ({ conversationId, parentConversationId }) => {
+        if (parentConversationId && parentConversationId !== conversationId) {
+          return { to: `channel:${parentConversationId}`, threadId: conversationId };
+        }
+        if (conversationId && /^U[A-Z0-9]+$/i.test(conversationId)) {
+          return { to: `user:${conversationId}` };
+        }
+        if (conversationId && /^[DGC][A-Z0-9]+$/i.test(conversationId)) {
+          return { to: `channel:${conversationId}` };
+        }
+        return conversationId ? { to: `channel:${conversationId}` } : {};
+      },
       targetResolver: {
         looksLikeId: looksLikeSlackTargetId,
         hint: "<channelId|user:ID|channel:ID>",

--- a/src/infra/outbound/conversation-id.ts
+++ b/src/infra/outbound/conversation-id.ts
@@ -4,7 +4,7 @@ import {
 } from "../../shared/string-coerce.js";
 
 function resolveExplicitConversationTargetId(target: string): string | undefined {
-  for (const prefix of ["channel:", "conversation:", "group:", "room:", "dm:"]) {
+  for (const prefix of ["channel:", "conversation:", "group:", "room:", "dm:", "user:"]) {
     if (normalizeLowercaseStringOrEmpty(target).startsWith(prefix)) {
       return normalizeOptionalString(target.slice(prefix.length));
     }


### PR DESCRIPTION
## Summary

Fixes async message delivery failure in Slack DM threads. Subagent/exec completion messages and background task announcements fail with `channel_not_found` or land at top-level DM instead of the correct thread.

### Root cause

1. Slack DM inbound sets `OriginatingTo = "user:UXXXX"` (user ID)
2. `resolveExplicitConversationTargetId()` only recognizes `channel:`, `conversation:`, `group:`, `room:`, `dm:` — **not `user:`**
3. So `parentConversationId` is never set in conversation bindings
4. When `resolveConversationDeliveryTarget()` runs for async delivery, without `parentConversationId` it falls through to `channel:${conversationId}` — a message **timestamp**, not a channel ID
5. Slack rejects with `channel_not_found`

### Downstream effects

- **Subagent completion messages**: lost entirely (`channel_not_found`)
- **Background task announcements** ("Background task done: ..."): delivered to top-level DM instead of thread, because ACP session `deliveryContext` inherits incomplete binding data (missing `to` and `threadId`)
- **Synchronous replies**: unaffected (use `replyTarget = "channel:${message.channel}"` directly)

### Why Telegram isn't affected

The Telegram plugin implements `bindings.resolveCommandConversation` and sets `selfParentConversationByDefault: true`. The Slack plugin has neither.

### Changes

- **`src/infra/outbound/conversation-id.ts`**: Add `"user:"` to the canonical prefix list in `resolveExplicitConversationTargetId`. Slack's `chat.postMessage` accepts user IDs as the `channel` parameter.
- **`extensions/slack/src/channel.ts`**: Add `resolveDeliveryTarget` to the Slack plugin `messaging` config. Provides Slack-aware delivery target resolution that correctly handles DM threads (`parentConversationId` + `conversationId`), user ID targets, and channel ID targets.

### Evidence

- All 14 active Slack DM conversation bindings were missing `parentConversationId`
- 29 failed delivery queue entries, all with `to: "channel:TIMESTAMP"` and `channel_not_found`
- 17 ACP sessions had `deliveryContext: {"channel": "slack"}` with no `to` or `threadId`
- Session store confirmed correct `to: "user:U0ALWV542TX"` + `threadId` exists on main sessions but wasn't propagated to ACP child sessions via bindings

### Note

The Slack plugin could also benefit from implementing `bindings.resolveCommandConversation` (like Telegram does) to use `NativeChannelId` as the DM parent identifier. This PR takes the minimal fix approach; that enhancement could follow.

## Test plan

- [ ] Send a DM to the bot, trigger a background task (subagent/exec), verify:
  - [ ] Completion content arrives **in the DM thread** (not lost)
  - [ ] "Background task done" announcement arrives **in the DM thread** (not top-level)
- [ ] Verify channel thread replies still work correctly
- [ ] Verify Telegram delivery is unaffected by the `user:` prefix addition
- [ ] Verify existing sessions with stale `deliveryContext` recover after the first new inbound message

🤖 Generated with [Claude Code](https://claude.com/claude-code)