### PR TITLE
compaction + caches: add Anthropic native compaction and mixed cache TTLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Docs: https://docs.openclaw.ai
 - Memory/active-memory: default QMD recall to search and surface better search-path telemetry so memory-backed recall works more predictably out of the box. (#65068) Thanks @Takhoffman.
 - Docs/providers: expand bundled provider docs with richer capability, env-var, and setup guidance across provider pages.
 - Docs/memory-wiki: add the recommended QMD + bridge-mode hybrid recipe plus zero-artifact troubleshooting guidance for `memory-wiki` bridge setups. (#63165) Thanks @sercada and @vincentkoc.
-
+- Agents/Anthropic: add native compaction support plus mixed cache retention so stable prefixes can keep a 1h cache while trailing conversation turns stay short-lived, and preserve compaction blocks across Anthropic transport replay. (#65288) Thanks @100yenadmin.
 ### Fixes
 
 - fix(security): remove busybox/toybox from interpreter-like safe bins [AI-assisted]. (#65713) Thanks @pgondhi987.

--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyAnthropicServerCompactionToParams,
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
+  resolveAnthropicRequiredBetaFeatures,
 } from "./anthropic-payload-policy.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./system-prompt-cache-boundary.js";
 
@@ -68,7 +70,7 @@ describe("anthropic payload policy", () => {
           type: "tool_result",
           tool_use_id: "tool_1",
           content: "done",
-          cache_control: { type: "ephemeral", ttl: "1h" },
+          cache_control: { type: "ephemeral" },
         },
       ],
     });
@@ -169,7 +171,7 @@ describe("anthropic payload policy", () => {
     ]);
     expect(payload.messages[0]).toEqual({
       role: "user",
-      content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral", ttl: "1h" } }],
+      content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral" } }],
     });
   });
 
@@ -223,5 +225,46 @@ describe("anthropic payload policy", () => {
         text: "Stable prefix\nDynamic lab suffix",
       },
     ]);
+  });
+
+  it("injects Anthropic server compaction edits without replacing existing edits", () => {
+    const payload: Record<string, unknown> = {
+      context_management: {
+        edits: [{ type: "clear_tool_uses_20250919" }],
+      },
+    };
+
+    applyAnthropicServerCompactionToParams(payload, {
+      compactThreshold: 123_456,
+      pauseAfterCompaction: true,
+      instructions: "Preserve code decisions.",
+    });
+
+    expect(payload.context_management).toEqual({
+      edits: [
+        { type: "clear_tool_uses_20250919" },
+        {
+          type: "compact_20260112",
+          trigger: { type: "input_tokens", value: 123_456 },
+          pause_after_compaction: true,
+          instructions: "Preserve code decisions.",
+        },
+      ],
+    });
+  });
+
+  it("adds Anthropic compaction beta features when compaction is enabled or blocks are present", () => {
+    expect(
+      resolveAnthropicRequiredBetaFeatures({
+        enableServerCompaction: true,
+        hasCompactionBlocks: false,
+      }),
+    ).toEqual(["context-management-2025-06-27", "compact-2026-01-12"]);
+    expect(
+      resolveAnthropicRequiredBetaFeatures({
+        enableServerCompaction: false,
+        hasCompactionBlocks: true,
+      }),
+    ).toEqual(["context-management-2025-06-27", "compact-2026-01-12"]);
   });
 });

--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -4,6 +4,7 @@ import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
   resolveAnthropicRequiredBetaFeatures,
+  shouldEnableAnthropicServerCompaction,
 } from "./anthropic-payload-policy.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./system-prompt-cache-boundary.js";
 
@@ -197,6 +198,18 @@ describe("anthropic payload policy", () => {
         cache_control: { type: "ephemeral" },
       },
     ]);
+  });
+
+  it("requires explicit opt-in before enabling Anthropic server compaction", () => {
+    expect(
+      shouldEnableAnthropicServerCompaction("anthropic", "https://api.anthropic.com/v1", undefined),
+    ).toBe(false);
+    expect(
+      shouldEnableAnthropicServerCompaction("anthropic", "https://api.anthropic.com/v1", false),
+    ).toBe(false);
+    expect(
+      shouldEnableAnthropicServerCompaction("anthropic", "https://api.anthropic.com/v1", true),
+    ).toBe(true);
   });
 
   it("strips the boundary even when cache retention is disabled", () => {

--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -212,6 +212,27 @@ describe("anthropic payload policy", () => {
     ).toBe(true);
   });
 
+  it("clamps Anthropic compaction triggers to the documented minimum", () => {
+    const payload: Record<string, unknown> = {
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    applyAnthropicServerCompactionToParams(payload, {
+      compactThreshold: 25_000,
+      pauseAfterCompaction: true,
+    });
+
+    expect(payload.context_management).toEqual({
+      edits: [
+        {
+          type: "compact_20260112",
+          trigger: { type: "input_tokens", value: 50_000 },
+          pause_after_compaction: true,
+        },
+      ],
+    });
+  });
+
   it("strips the boundary even when cache retention is disabled", () => {
     const policy = resolveAnthropicPayloadPolicy({
       provider: "anthropic",

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -11,6 +11,12 @@ export type AnthropicEphemeralCacheControl = {
   ttl?: "1h";
 };
 
+export type AnthropicServerCompactionConfig = {
+  compactThreshold?: number;
+  instructions?: string;
+  pauseAfterCompaction?: boolean;
+};
+
 type AnthropicPayloadPolicyInput = {
   api?: string;
   baseUrl?: string;
@@ -22,7 +28,8 @@ type AnthropicPayloadPolicyInput = {
 
 export type AnthropicPayloadPolicy = {
   allowsServiceTier: boolean;
-  cacheControl: AnthropicEphemeralCacheControl | undefined;
+  systemCacheControl: AnthropicEphemeralCacheControl | undefined;
+  messageCacheControl: AnthropicEphemeralCacheControl | undefined;
   serviceTier: AnthropicServiceTier | undefined;
 };
 
@@ -60,6 +67,17 @@ function resolveAnthropicEphemeralCacheControl(
   }
   const ttl = retention === "long" && isLongTtlEligibleEndpoint(baseUrl) ? "1h" : undefined;
   return { type: "ephemeral", ...(ttl ? { ttl } : {}) };
+}
+
+function resolveAnthropicMessageCacheControl(
+  cacheRetention: AnthropicPayloadPolicyInput["cacheRetention"],
+): AnthropicEphemeralCacheControl | undefined {
+  const retention =
+    cacheRetention ?? (process.env.PI_CACHE_RETENTION === "long" ? "long" : "short");
+  if (retention === "none") {
+    return undefined;
+  }
+  return { type: "ephemeral" };
 }
 
 function applyAnthropicCacheControlToSystem(
@@ -184,9 +202,13 @@ export function resolveAnthropicPayloadPolicy(
 
   return {
     allowsServiceTier: capabilities.allowsAnthropicServiceTier,
-    cacheControl:
+    systemCacheControl:
       input.enableCacheControl === true
         ? resolveAnthropicEphemeralCacheControl(input.baseUrl, input.cacheRetention)
+        : undefined,
+    messageCacheControl:
+      input.enableCacheControl === true
+        ? resolveAnthropicMessageCacheControl(input.cacheRetention)
         : undefined,
     serviceTier: input.serviceTier,
   };
@@ -204,18 +226,101 @@ export function applyAnthropicPayloadPolicyToParams(
     payloadObj.service_tier = policy.serviceTier;
   }
 
-  if (policy.cacheControl) {
-    applyAnthropicCacheControlToSystem(payloadObj.system, policy.cacheControl);
+  if (policy.systemCacheControl) {
+    applyAnthropicCacheControlToSystem(payloadObj.system, policy.systemCacheControl);
   } else {
     stripAnthropicSystemPromptBoundary(payloadObj.system);
   }
 
-  if (!policy.cacheControl) {
+  if (!policy.messageCacheControl) {
     return;
   }
 
   // Preserve Anthropic cache-write scope by only tagging the trailing user turn.
-  applyAnthropicCacheControlToMessages(payloadObj.messages, policy.cacheControl);
+  applyAnthropicCacheControlToMessages(payloadObj.messages, policy.messageCacheControl);
+}
+
+function hasCompactionEdit(edits: unknown): boolean {
+  return Array.isArray(edits)
+    ? edits.some(
+        (edit) =>
+          edit &&
+          typeof edit === "object" &&
+          (edit as Record<string, unknown>).type === "compact_20260112",
+      )
+    : false;
+}
+
+export function applyAnthropicServerCompactionToParams(
+  payloadObj: Record<string, unknown>,
+  config: AnthropicServerCompactionConfig | undefined,
+): void {
+  if (!config) {
+    return;
+  }
+
+  const edit: Record<string, unknown> = {
+    type: "compact_20260112",
+  };
+  if (typeof config.compactThreshold === "number" && Number.isFinite(config.compactThreshold)) {
+    edit.trigger = {
+      type: "input_tokens",
+      value: Math.max(1, Math.floor(config.compactThreshold)),
+    };
+  }
+  if (typeof config.pauseAfterCompaction === "boolean") {
+    edit.pause_after_compaction = config.pauseAfterCompaction;
+  }
+  if (typeof config.instructions === "string" && config.instructions.trim().length > 0) {
+    edit.instructions = config.instructions.trim();
+  }
+
+  const current = payloadObj.context_management;
+  if (current === undefined) {
+    payloadObj.context_management = { edits: [edit] };
+    return;
+  }
+  if (!current || typeof current !== "object" || Array.isArray(current)) {
+    return;
+  }
+
+  const record = current as Record<string, unknown>;
+  if (hasCompactionEdit(record.edits)) {
+    return;
+  }
+
+  if (record.edits === undefined) {
+    record.edits = [edit];
+    return;
+  }
+  if (Array.isArray(record.edits)) {
+    record.edits = [...record.edits, edit];
+  }
+}
+
+export function shouldEnableAnthropicServerCompaction(
+  provider: string | undefined,
+  baseUrl: string | undefined,
+  explicit: boolean | undefined,
+): boolean {
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  if (provider !== "anthropic") {
+    return false;
+  }
+  return isLongTtlEligibleEndpoint(baseUrl);
+}
+
+export function resolveAnthropicRequiredBetaFeatures(params: {
+  enableServerCompaction?: boolean;
+  hasCompactionBlocks?: boolean;
+}): string[] {
+  const features: string[] = [];
+  if (params.enableServerCompaction || params.hasCompactionBlocks) {
+    features.push("context-management-2025-06-27", "compact-2026-01-12");
+  }
+  return features;
 }
 
 export function applyAnthropicEphemeralCacheControlMarkers(

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -303,13 +303,10 @@ export function shouldEnableAnthropicServerCompaction(
   baseUrl: string | undefined,
   explicit: boolean | undefined,
 ): boolean {
-  if (explicit !== undefined) {
-    return explicit;
-  }
-  if (provider !== "anthropic") {
+  if (explicit !== true) {
     return false;
   }
-  return isLongTtlEligibleEndpoint(baseUrl);
+  return provider === "anthropic" && isLongTtlEligibleEndpoint(baseUrl);
 }
 
 export function resolveAnthropicRequiredBetaFeatures(params: {

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -308,6 +308,13 @@ export function shouldEnableAnthropicServerCompaction(
   if (explicit !== true) {
     return false;
   }
+  return supportsAnthropicContextManagementTransport(provider, baseUrl);
+}
+
+export function supportsAnthropicContextManagementTransport(
+  provider: string | undefined,
+  baseUrl: string | undefined,
+): boolean {
   return provider === "anthropic" && isLongTtlEligibleEndpoint(baseUrl);
 }
 

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -17,6 +17,8 @@ export type AnthropicServerCompactionConfig = {
   pauseAfterCompaction?: boolean;
 };
 
+export const ANTHROPIC_MIN_COMPACTION_TRIGGER_TOKENS = 50_000;
+
 type AnthropicPayloadPolicyInput = {
   api?: string;
   baseUrl?: string;
@@ -265,7 +267,7 @@ export function applyAnthropicServerCompactionToParams(
   if (typeof config.compactThreshold === "number" && Number.isFinite(config.compactThreshold)) {
     edit.trigger = {
       type: "input_tokens",
-      value: Math.max(1, Math.floor(config.compactThreshold)),
+      value: Math.max(ANTHROPIC_MIN_COMPACTION_TRIGGER_TOKENS, Math.floor(config.compactThreshold)),
     };
   }
   if (typeof config.pauseAfterCompaction === "boolean") {

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -486,7 +486,15 @@ describe("anthropic transport stream", () => {
         } as Parameters<typeof streamFn>[2],
       ),
     );
+    const eventsPromise = (async () => {
+      const events: Array<{ type?: string }> = [];
+      for await (const event of stream) {
+        events.push(event as { type?: string });
+      }
+      return events;
+    })();
     const result = await stream.result();
+    const events = await eventsPromise;
 
     expect(anthropicCtorMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -513,6 +521,9 @@ describe("anthropic transport stream", () => {
       ]),
     );
     expect(result.stopReason).toBe("stop");
+    expect(events.some((event) => event.type === "text_start" || event.type === "text_delta")).toBe(
+      false,
+    );
     expect(result.content).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -521,5 +532,66 @@ describe("anthropic transport stream", () => {
         }),
       ]),
     );
+  });
+
+  it("drops compaction history blocks before sending GitHub Copilot Anthropic requests", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        api: "anthropic-messages",
+        provider: "github-copilot",
+        baseUrl: "https://api.githubcopilot.com/anthropic",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [
+            {
+              role: "assistant",
+              provider: "anthropic",
+              api: "anthropic-messages",
+              model: "claude-sonnet-4-6",
+              stopReason: "stop",
+              timestamp: 0,
+              content: [{ type: "compaction", content: "Earlier compacted summary." }],
+            },
+            { role: "user", content: "Continue." },
+          ],
+        } as never,
+        {
+          apiKey: "gho_test",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    const firstCallParams = anthropicMessagesStreamMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(firstCallParams.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Continue.", cache_control: { type: "ephemeral" } }],
+      },
+    ]);
+    expect(
+      anthropicCtorMock.mock.calls[0]?.[0]?.defaultHeaders?.["anthropic-beta"] ?? "",
+    ).not.toContain("compact-2026-01-12");
   });
 });

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -595,6 +595,70 @@ describe("anthropic transport stream", () => {
     ).not.toContain("compact-2026-01-12");
   });
 
+  it("drops compaction history blocks and replay betas for non-Anthropic transports", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "minimax-m1",
+        name: "MiniMax M1",
+        api: "anthropic-messages",
+        provider: "minimax",
+        baseUrl: "https://api.minimax.chat/compatible-mode/anthropic",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [
+            {
+              role: "assistant",
+              provider: "anthropic",
+              api: "anthropic-messages",
+              model: "claude-sonnet-4-6",
+              stopReason: "stop",
+              timestamp: 0,
+              content: [{ type: "compaction", content: "Earlier compacted summary." }],
+            },
+            { role: "user", content: "Continue." },
+          ],
+        } as never,
+        {
+          apiKey: "sk-minimax-test",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    const firstCallParams = anthropicMessagesStreamMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(firstCallParams.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Continue.", cache_control: { type: "ephemeral" } }],
+      },
+    ]);
+    expect(
+      anthropicCtorMock.mock.calls[0]?.[0]?.defaultHeaders?.["anthropic-beta"] ?? "",
+    ).not.toContain("compact-2026-01-12");
+    expect(
+      anthropicCtorMock.mock.calls[0]?.[0]?.defaultHeaders?.["anthropic-beta"] ?? "",
+    ).not.toContain("context-management-2025-06-27");
+  });
+
   it("preserves string assistant content when stripping compaction blocks for Copilot transport", async () => {
     const model = attachModelProviderRequestTransport(
       {

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -520,7 +520,7 @@ describe("anthropic transport stream", () => {
         }),
       ]),
     );
-    expect(result.stopReason).toBe("stop");
+    expect(result.stopReason).toBe("compaction");
     expect(events.some((event) => event.type === "text_start" || event.type === "text_delta")).toBe(
       false,
     );
@@ -593,5 +593,67 @@ describe("anthropic transport stream", () => {
     expect(
       anthropicCtorMock.mock.calls[0]?.[0]?.defaultHeaders?.["anthropic-beta"] ?? "",
     ).not.toContain("compact-2026-01-12");
+  });
+
+  it("preserves string assistant content when stripping compaction blocks for Copilot transport", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        api: "anthropic-messages",
+        provider: "github-copilot",
+        baseUrl: "https://api.githubcopilot.com/anthropic",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [
+            {
+              role: "assistant",
+              provider: "anthropic",
+              api: "anthropic-messages",
+              model: "claude-sonnet-4-6",
+              stopReason: "stop",
+              timestamp: 0,
+              content: "Earlier plain assistant text.",
+            },
+            { role: "user", content: "Continue." },
+          ],
+        } as never,
+        {
+          apiKey: "gho_test",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    const firstCallParams = anthropicMessagesStreamMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(firstCallParams.messages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Earlier plain assistant text." }],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Continue.", cache_control: { type: "ephemeral" } }],
+      },
+    ]);
   });
 });

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -336,4 +336,190 @@ describe("anthropic transport stream", () => {
       undefined,
     );
   });
+
+  it("uses mixed Anthropic cache TTLs and injects native compaction edits when enabled", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          systemPrompt: "Follow policy.",
+          messages: [{ role: "user", content: "Keep coding." }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+          cacheRetention: "long",
+          anthropicServerCompaction: true,
+          anthropicCompactThreshold: 123_456,
+          anthropicCompactPauseAfter: true,
+          anthropicCompactInstructions: "Preserve important code decisions.",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(anthropicCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultHeaders: expect.objectContaining({
+          "anthropic-beta": expect.stringContaining("context-management-2025-06-27"),
+        }),
+      }),
+    );
+    const firstCallParams = anthropicMessagesStreamMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(firstCallParams.system).toEqual([
+      {
+        type: "text",
+        text: "Follow policy.",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ]);
+    expect(firstCallParams.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Keep coding.", cache_control: { type: "ephemeral" } }],
+      },
+    ]);
+    expect(firstCallParams.context_management).toEqual({
+      edits: [
+        {
+          type: "compact_20260112",
+          trigger: { type: "input_tokens", value: 123_456 },
+          pause_after_compaction: true,
+          instructions: "Preserve important code decisions.",
+        },
+      ],
+    });
+  });
+
+  it("round-trips Anthropic compaction blocks in requests and streamed responses", async () => {
+    anthropicMessagesStreamMock.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: "message_start",
+          message: { id: "msg_compact", usage: { input_tokens: 25, output_tokens: 0 } },
+        };
+        yield {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "compaction", content: "" },
+        };
+        yield {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "compaction_delta", content: "Summarized old context." },
+        };
+        yield {
+          type: "content_block_stop",
+          index: 0,
+        };
+        yield {
+          type: "message_delta",
+          delta: { stop_reason: "compaction" },
+          usage: { input_tokens: 25, output_tokens: 10 },
+        };
+      })(),
+    );
+
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [
+            {
+              role: "assistant",
+              provider: "anthropic",
+              api: "anthropic-messages",
+              model: "claude-sonnet-4-6",
+              stopReason: "stop",
+              timestamp: 0,
+              content: [{ type: "compaction", content: "Earlier compacted summary." }],
+            },
+            { role: "user", content: "Continue." },
+          ],
+        } as never,
+        {
+          apiKey: "sk-ant-api",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(anthropicCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultHeaders: expect.objectContaining({
+          "anthropic-beta": expect.stringContaining("compact-2026-01-12"),
+        }),
+      }),
+    );
+    const firstCallParams = anthropicMessagesStreamMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(firstCallParams.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "assistant",
+          content: expect.arrayContaining([
+            expect.objectContaining({
+              type: "compaction",
+              content: "Earlier compacted summary.",
+            }),
+          ]),
+        }),
+      ]),
+    );
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "compaction",
+          content: "Summarized old context.",
+        }),
+      ]),
+    );
+  });
 });

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -414,6 +414,52 @@ describe("anthropic transport stream", () => {
     });
   });
 
+  it("merges wrapper-provided Anthropic betas with required compaction betas", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Keep coding." }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+          anthropicServerCompaction: true,
+          headers: {
+            "anthropic-beta": "context-1m-2025-08-07",
+          },
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    const betaHeader =
+      anthropicCtorMock.mock.calls[0]?.[0]?.defaultHeaders?.["anthropic-beta"] ?? "";
+    expect(betaHeader).toContain("context-1m-2025-08-07");
+    expect(betaHeader).toContain("context-management-2025-06-27");
+    expect(betaHeader).toContain("compact-2026-01-12");
+  });
+
   it("round-trips Anthropic compaction blocks in requests and streamed responses", async () => {
     anthropicMessagesStreamMock.mockReturnValueOnce(
       (async function* () {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -12,8 +12,12 @@ import {
 } from "@mariozechner/pi-ai";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
+  applyAnthropicServerCompactionToParams,
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
+  resolveAnthropicRequiredBetaFeatures,
+  shouldEnableAnthropicServerCompaction,
+  type AnthropicServerCompactionConfig,
 } from "./anthropic-payload-policy.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
@@ -58,7 +62,12 @@ type AnthropicTransportModel = Model<"anthropic-messages"> & {
 };
 
 type AnthropicTransportOptions = AnthropicOptions &
-  Pick<SimpleStreamOptions, "reasoning" | "thinkingBudgets">;
+  Pick<SimpleStreamOptions, "reasoning" | "thinkingBudgets"> & {
+    anthropicServerCompaction?: boolean;
+    anthropicCompactThreshold?: number;
+    anthropicCompactPauseAfter?: boolean;
+    anthropicCompactInstructions?: string;
+  };
 
 type TransportContentBlock =
   | { type: "text"; text: string; index?: number }
@@ -76,7 +85,8 @@ type TransportContentBlock =
       arguments: unknown;
       partialJson?: string;
       index?: number;
-    };
+    }
+  | { type: "compaction"; content: string | null; index?: number };
 
 type MutableAssistantOutput = {
   role: "assistant";
@@ -311,6 +321,17 @@ function convertAnthropicMessages(
             name: isOAuthToken ? toClaudeCodeName(block.name) : block.name,
             input: coerceTransportToolCallArguments(block.arguments),
           });
+          continue;
+        }
+        const maybeCompactionBlock = block as { type?: string; content?: string | null };
+        if (maybeCompactionBlock.type === "compaction") {
+          blocks.push({
+            type: "compaction",
+            content:
+              typeof maybeCompactionBlock.content === "string"
+                ? sanitizeTransportPayloadText(maybeCompactionBlock.content)
+                : null,
+          });
         }
       }
       if (blocks.length > 0) {
@@ -373,6 +394,7 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
 function mapStopReason(reason: string | undefined): string {
   switch (reason) {
     case "end_turn":
+    case "compaction":
       return "stop";
     case "max_tokens":
       return "length";
@@ -390,6 +412,80 @@ function mapStopReason(reason: string | undefined): string {
   }
 }
 
+function hasCompactionBlocks(messages: Context["messages"]): boolean {
+  return messages.some(
+    (message) =>
+      message.role === "assistant" &&
+      Array.isArray(message.content) &&
+      message.content.some(
+        (block) =>
+          block && typeof block === "object" && (block as { type?: string }).type === "compaction",
+      ),
+  );
+}
+
+function resolveAnthropicCompactionThreshold(
+  model: Pick<AnthropicTransportModel, "contextWindow">,
+  requested: number | undefined,
+): number | undefined {
+  if (typeof requested === "number" && Number.isFinite(requested) && requested > 0) {
+    return Math.floor(requested);
+  }
+  const contextWindow =
+    typeof model.contextWindow === "number" && Number.isFinite(model.contextWindow)
+      ? model.contextWindow
+      : undefined;
+  if (!contextWindow || contextWindow <= 0) {
+    return 150_000;
+  }
+  return Math.max(1, Math.min(150_000, Math.floor(contextWindow * 0.75)));
+}
+
+function resolveAnthropicServerCompactionConfig(params: {
+  model: AnthropicTransportModel;
+  options: AnthropicTransportOptions | undefined;
+}): AnthropicServerCompactionConfig | undefined {
+  const enabled = shouldEnableAnthropicServerCompaction(
+    params.model.provider,
+    params.model.baseUrl,
+    params.options?.anthropicServerCompaction,
+  );
+  if (!enabled) {
+    return undefined;
+  }
+  return {
+    compactThreshold: resolveAnthropicCompactionThreshold(
+      params.model,
+      params.options?.anthropicCompactThreshold,
+    ),
+    pauseAfterCompaction: params.options?.anthropicCompactPauseAfter,
+    instructions: params.options?.anthropicCompactInstructions,
+  };
+}
+
+function applyAnthropicUsageSnapshot(
+  usageTarget: MutableAssistantOutput["usage"],
+  usage: Record<string, unknown> | undefined,
+): void {
+  if (!usage) {
+    return;
+  }
+  if (typeof usage.input_tokens === "number") {
+    usageTarget.input = usage.input_tokens;
+  }
+  if (typeof usage.output_tokens === "number") {
+    usageTarget.output = usage.output_tokens;
+  }
+  if (typeof usage.cache_read_input_tokens === "number") {
+    usageTarget.cacheRead = usage.cache_read_input_tokens;
+  }
+  if (typeof usage.cache_creation_input_tokens === "number") {
+    usageTarget.cacheWrite = usage.cache_creation_input_tokens;
+  }
+  usageTarget.totalTokens =
+    usageTarget.input + usageTarget.output + usageTarget.cacheRead + usageTarget.cacheWrite;
+}
+
 function createAnthropicTransportClient(params: {
   model: AnthropicTransportModel;
   context: Context;
@@ -399,9 +495,24 @@ function createAnthropicTransportClient(params: {
   const { model, context, apiKey, options } = params;
   const needsInterleavedBeta =
     (options?.interleavedThinking ?? true) && !supportsAdaptiveThinking(model.id);
+  const anthropicCompactionEnabled = shouldEnableAnthropicServerCompaction(
+    model.provider,
+    model.baseUrl,
+    options?.anthropicServerCompaction,
+  );
+  const betaFeatures = [
+    "fine-grained-tool-streaming-2025-05-14",
+    ...resolveAnthropicRequiredBetaFeatures({
+      enableServerCompaction: anthropicCompactionEnabled,
+      hasCompactionBlocks: hasCompactionBlocks(context.messages),
+    }),
+  ];
+  if (needsInterleavedBeta) {
+    betaFeatures.push("interleaved-thinking-2025-05-14");
+  }
   const fetch = buildGuardedModelFetch(model);
   if (model.provider === "github-copilot") {
-    const betaFeatures = needsInterleavedBeta ? ["interleaved-thinking-2025-05-14"] : [];
+    const copilotBetas = needsInterleavedBeta ? ["interleaved-thinking-2025-05-14"] : [];
     return {
       client: new Anthropic({
         apiKey: null,
@@ -412,7 +523,7 @@ function createAnthropicTransportClient(params: {
           {
             accept: "application/json",
             "anthropic-dangerous-direct-browser-access": "true",
-            ...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
+            ...(copilotBetas.length > 0 ? { "anthropic-beta": copilotBetas.join(",") } : {}),
           },
           model.headers,
           buildCopilotDynamicHeaders({
@@ -425,10 +536,6 @@ function createAnthropicTransportClient(params: {
       }),
       isOAuthToken: false,
     };
-  }
-  const betaFeatures = ["fine-grained-tool-streaming-2025-05-14"];
-  if (needsInterleavedBeta) {
-    betaFeatures.push("interleaved-thinking-2025-05-14");
   }
   if (isAnthropicOAuthToken(apiKey)) {
     return {
@@ -479,6 +586,7 @@ function buildAnthropicParams(
   isOAuthToken: boolean,
   options: AnthropicTransportOptions | undefined,
 ) {
+  const serverCompaction = resolveAnthropicServerCompactionConfig({ model, options });
   const payloadPolicy = resolveAnthropicPayloadPolicy({
     provider: model.provider,
     api: model.api,
@@ -547,6 +655,7 @@ function buildAnthropicParams(
       typeof options.toolChoice === "string" ? { type: options.toolChoice } : options.toolChoice;
   }
   applyAnthropicPayloadPolicyToParams(params, payloadPolicy);
+  applyAnthropicServerCompactionToParams(params, serverCompaction);
   return params;
 }
 
@@ -571,6 +680,10 @@ function resolveAnthropicTransportOptions(
     toolChoice: options?.toolChoice,
     thinkingBudgets: options?.thinkingBudgets,
     reasoning: options?.reasoning,
+    anthropicServerCompaction: options?.anthropicServerCompaction,
+    anthropicCompactThreshold: options?.anthropicCompactThreshold,
+    anthropicCompactPauseAfter: options?.anthropicCompactPauseAfter,
+    anthropicCompactInstructions: options?.anthropicCompactInstructions,
   };
   if (!options?.reasoning) {
     resolved.thinkingEnabled = false;
@@ -637,21 +750,8 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             const message = event.message as
               | { id?: string; usage?: Record<string, unknown> }
               | undefined;
-            const usage = message?.usage ?? {};
             output.responseId = typeof message?.id === "string" ? message.id : undefined;
-            output.usage.input = typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
-            output.usage.output = typeof usage.output_tokens === "number" ? usage.output_tokens : 0;
-            output.usage.cacheRead =
-              typeof usage.cache_read_input_tokens === "number" ? usage.cache_read_input_tokens : 0;
-            output.usage.cacheWrite =
-              typeof usage.cache_creation_input_tokens === "number"
-                ? usage.cache_creation_input_tokens
-                : 0;
-            output.usage.totalTokens =
-              output.usage.input +
-              output.usage.output +
-              output.usage.cacheRead +
-              output.usage.cacheWrite;
+            applyAnthropicUsageSnapshot(output.usage, message?.usage);
             calculateCost(model, output.usage);
             continue;
           }
@@ -694,6 +794,20 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               output.content.push(block);
               stream.push({
                 type: "thinking_start",
+                contentIndex: output.content.length - 1,
+                partial: output as never,
+              });
+              continue;
+            }
+            if (contentBlock?.type === "compaction") {
+              const block: TransportContentBlock = {
+                type: "compaction",
+                content: typeof contentBlock.content === "string" ? contentBlock.content : "",
+                index,
+              };
+              output.content.push(block);
+              stream.push({
+                type: "text_start",
                 contentIndex: output.content.length - 1,
                 partial: output as never,
               });
@@ -778,6 +892,22 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               typeof delta.signature === "string"
             ) {
               block.thinkingSignature = `${block.thinkingSignature ?? ""}${delta.signature}`;
+              continue;
+            }
+            if (block?.type === "compaction" && delta?.type === "compaction_delta") {
+              if (delta.content === null) {
+                block.content = null;
+                continue;
+              }
+              if (typeof delta.content === "string") {
+                block.content = `${block.content ?? ""}${delta.content}`;
+                stream.push({
+                  type: "text_delta",
+                  contentIndex: index,
+                  delta: delta.content,
+                  partial: output as never,
+                });
+              }
             }
             continue;
           }
@@ -817,6 +947,15 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
                 toolCall: block as never,
                 partial: output as never,
               });
+              continue;
+            }
+            if (block.type === "compaction") {
+              stream.push({
+                type: "text_end",
+                contentIndex: index,
+                content: block.content ?? "",
+                partial: output as never,
+              });
             }
             continue;
           }
@@ -826,23 +965,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             if (delta?.stop_reason) {
               output.stopReason = mapStopReason(delta.stop_reason);
             }
-            if (typeof usage?.input_tokens === "number") {
-              output.usage.input = usage.input_tokens;
-            }
-            if (typeof usage?.output_tokens === "number") {
-              output.usage.output = usage.output_tokens;
-            }
-            if (typeof usage?.cache_read_input_tokens === "number") {
-              output.usage.cacheRead = usage.cache_read_input_tokens;
-            }
-            if (typeof usage?.cache_creation_input_tokens === "number") {
-              output.usage.cacheWrite = usage.cache_creation_input_tokens;
-            }
-            output.usage.totalTokens =
-              output.usage.input +
-              output.usage.output +
-              output.usage.cacheRead +
-              output.usage.cacheWrite;
+            applyAnthropicUsageSnapshot(output.usage, usage);
             calculateCost(model, output.usage);
           }
         }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -424,10 +424,29 @@ function hasCompactionBlocks(messages: Context["messages"]): boolean {
   );
 }
 
+function stripCompactionBlocksForTransport(messages: Context["messages"]): Context["messages"] {
+  const filteredMessages: Context["messages"] = [];
+  for (const message of messages) {
+    if (message.role !== "assistant") {
+      filteredMessages.push(message);
+      continue;
+    }
+    const filteredContent = message.content.filter((block) => block.type !== "compaction");
+    if (filteredContent.length === 0) {
+      continue;
+    }
+    filteredMessages.push({
+      ...message,
+      content: filteredContent,
+    });
+  }
+  return filteredMessages;
+}
+
 function resolveAnthropicCompactionThreshold(
   model: Pick<AnthropicTransportModel, "contextWindow">,
   requested: number | undefined,
-): number | undefined {
+): number {
   if (typeof requested === "number" && Number.isFinite(requested) && requested > 0) {
     return Math.floor(requested);
   }
@@ -493,6 +512,10 @@ function createAnthropicTransportClient(params: {
   options: AnthropicTransportOptions | undefined;
 }) {
   const { model, context, apiKey, options } = params;
+  const transportMessages =
+    model.provider === "github-copilot"
+      ? stripCompactionBlocksForTransport(context.messages)
+      : context.messages;
   const needsInterleavedBeta =
     (options?.interleavedThinking ?? true) && !supportsAdaptiveThinking(model.id);
   const anthropicCompactionEnabled = shouldEnableAnthropicServerCompaction(
@@ -504,7 +527,7 @@ function createAnthropicTransportClient(params: {
     "fine-grained-tool-streaming-2025-05-14",
     ...resolveAnthropicRequiredBetaFeatures({
       enableServerCompaction: anthropicCompactionEnabled,
-      hasCompactionBlocks: hasCompactionBlocks(context.messages),
+      hasCompactionBlocks: hasCompactionBlocks(transportMessages),
     }),
   ];
   if (needsInterleavedBeta) {
@@ -527,8 +550,8 @@ function createAnthropicTransportClient(params: {
           },
           model.headers,
           buildCopilotDynamicHeaders({
-            messages: context.messages,
-            hasImages: hasCopilotVisionInput(context.messages),
+            messages: transportMessages,
+            hasImages: hasCopilotVisionInput(transportMessages),
           }),
           options?.headers,
         ),
@@ -595,9 +618,13 @@ function buildAnthropicParams(
     enableCacheControl: true,
   });
   const defaultMaxTokens = Math.min(model.maxTokens, 32_000);
+  const transportMessages =
+    model.provider === "github-copilot"
+      ? stripCompactionBlocksForTransport(context.messages)
+      : context.messages;
   const params: Record<string, unknown> = {
     model: model.id,
-    messages: convertAnthropicMessages(context.messages, model, isOAuthToken),
+    messages: convertAnthropicMessages(transportMessages, model, isOAuthToken),
     max_tokens: options?.maxTokens || defaultMaxTokens,
     stream: true,
   };
@@ -806,11 +833,6 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
                 index,
               };
               output.content.push(block);
-              stream.push({
-                type: "text_start",
-                contentIndex: output.content.length - 1,
-                partial: output as never,
-              });
               continue;
             }
             if (contentBlock?.type === "tool_use") {
@@ -901,12 +923,6 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               }
               if (typeof delta.content === "string") {
                 block.content = `${block.content ?? ""}${delta.content}`;
-                stream.push({
-                  type: "text_delta",
-                  contentIndex: index,
-                  delta: delta.content,
-                  partial: output as never,
-                });
               }
             }
             continue;
@@ -950,12 +966,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               continue;
             }
             if (block.type === "compaction") {
-              stream.push({
-                type: "text_end",
-                contentIndex: index,
-                content: block.content ?? "",
-                partial: output as never,
-              });
+              continue;
             }
             continue;
           }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -528,6 +528,34 @@ function applyAnthropicUsageSnapshot(
     usageTarget.input + usageTarget.output + usageTarget.cacheRead + usageTarget.cacheWrite;
 }
 
+function parseAnthropicBetaHeader(value: string | undefined): string[] {
+  if (typeof value !== "string") {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function mergeAnthropicBetaHeaders(params: {
+  headerSources: Array<Record<string, string> | undefined>;
+  betaFeatures: string[];
+}): Record<string, string> | undefined {
+  const merged = mergeTransportHeaders(...params.headerSources);
+  if (params.betaFeatures.length === 0) {
+    return merged;
+  }
+  const record = { ...merged };
+  const existingKey = Object.keys(record).find(
+    (key) => normalizeLowercaseStringOrEmpty(key) === "anthropic-beta",
+  );
+  const existingValues = existingKey ? parseAnthropicBetaHeader(record[existingKey]) : [];
+  const key = existingKey ?? "anthropic-beta";
+  record[key] = [...new Set([...existingValues, ...params.betaFeatures])].join(",");
+  return record;
+}
+
 function createAnthropicTransportClient(params: {
   model: AnthropicTransportModel;
   context: Context;
@@ -539,10 +567,9 @@ function createAnthropicTransportClient(params: {
     model.provider,
     model.baseUrl,
   );
-  const transportMessages =
-    supportsCompactionTransport
-      ? context.messages
-      : stripCompactionBlocksForTransport(context.messages);
+  const transportMessages = supportsCompactionTransport
+    ? context.messages
+    : stripCompactionBlocksForTransport(context.messages);
   const needsInterleavedBeta =
     (options?.interleavedThinking ?? true) && !supportsAdaptiveThinking(model.id);
   const anthropicCompactionEnabled = shouldEnableAnthropicServerCompaction(
@@ -569,19 +596,21 @@ function createAnthropicTransportClient(params: {
         authToken: apiKey,
         baseURL: model.baseUrl,
         dangerouslyAllowBrowser: true,
-        defaultHeaders: mergeTransportHeaders(
-          {
-            accept: "application/json",
-            "anthropic-dangerous-direct-browser-access": "true",
-            ...(copilotBetas.length > 0 ? { "anthropic-beta": copilotBetas.join(",") } : {}),
-          },
-          model.headers,
-          buildCopilotDynamicHeaders({
-            messages: transportMessages,
-            hasImages: hasCopilotVisionInput(transportMessages),
-          }),
-          options?.headers,
-        ),
+        defaultHeaders: mergeAnthropicBetaHeaders({
+          betaFeatures: copilotBetas,
+          headerSources: [
+            {
+              accept: "application/json",
+              "anthropic-dangerous-direct-browser-access": "true",
+            },
+            model.headers,
+            buildCopilotDynamicHeaders({
+              messages: transportMessages,
+              hasImages: hasCopilotVisionInput(transportMessages),
+            }),
+            options?.headers,
+          ],
+        }),
         fetch,
       }),
       isOAuthToken: false,
@@ -594,17 +623,19 @@ function createAnthropicTransportClient(params: {
         authToken: apiKey,
         baseURL: model.baseUrl,
         dangerouslyAllowBrowser: true,
-        defaultHeaders: mergeTransportHeaders(
-          {
-            accept: "application/json",
-            "anthropic-dangerous-direct-browser-access": "true",
-            "anthropic-beta": `claude-code-20250219,oauth-2025-04-20,${betaFeatures.join(",")}`,
-            "user-agent": `claude-cli/${CLAUDE_CODE_VERSION}`,
-            "x-app": "cli",
-          },
-          model.headers,
-          options?.headers,
-        ),
+        defaultHeaders: mergeAnthropicBetaHeaders({
+          betaFeatures: ["claude-code-20250219", "oauth-2025-04-20", ...betaFeatures],
+          headerSources: [
+            {
+              accept: "application/json",
+              "anthropic-dangerous-direct-browser-access": "true",
+              "user-agent": `claude-cli/${CLAUDE_CODE_VERSION}`,
+              "x-app": "cli",
+            },
+            model.headers,
+            options?.headers,
+          ],
+        }),
         fetch,
       }),
       isOAuthToken: true,
@@ -615,15 +646,17 @@ function createAnthropicTransportClient(params: {
       apiKey,
       baseURL: model.baseUrl,
       dangerouslyAllowBrowser: true,
-      defaultHeaders: mergeTransportHeaders(
-        {
-          accept: "application/json",
-          "anthropic-dangerous-direct-browser-access": "true",
-          "anthropic-beta": betaFeatures.join(","),
-        },
-        model.headers,
-        options?.headers,
-      ),
+      defaultHeaders: mergeAnthropicBetaHeaders({
+        betaFeatures,
+        headerSources: [
+          {
+            accept: "application/json",
+            "anthropic-dangerous-direct-browser-access": "true",
+          },
+          model.headers,
+          options?.headers,
+        ],
+      }),
       fetch,
     }),
     isOAuthToken: false,
@@ -649,10 +682,9 @@ function buildAnthropicParams(
     model.provider,
     model.baseUrl,
   );
-  const transportMessages =
-    supportsCompactionTransport
-      ? context.messages
-      : stripCompactionBlocksForTransport(context.messages);
+  const transportMessages = supportsCompactionTransport
+    ? context.messages
+    : stripCompactionBlocksForTransport(context.messages);
   const params: Record<string, unknown> = {
     model: model.id,
     messages: convertAnthropicMessages(transportMessages, model, isOAuthToken),

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -17,6 +17,7 @@ import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
   resolveAnthropicRequiredBetaFeatures,
+  supportsAnthropicContextManagementTransport,
   shouldEnableAnthropicServerCompaction,
   type AnthropicServerCompactionConfig,
 } from "./anthropic-payload-policy.js";
@@ -534,10 +535,14 @@ function createAnthropicTransportClient(params: {
   options: AnthropicTransportOptions | undefined;
 }) {
   const { model, context, apiKey, options } = params;
+  const supportsCompactionTransport = supportsAnthropicContextManagementTransport(
+    model.provider,
+    model.baseUrl,
+  );
   const transportMessages =
-    model.provider === "github-copilot"
-      ? stripCompactionBlocksForTransport(context.messages)
-      : context.messages;
+    supportsCompactionTransport
+      ? context.messages
+      : stripCompactionBlocksForTransport(context.messages);
   const needsInterleavedBeta =
     (options?.interleavedThinking ?? true) && !supportsAdaptiveThinking(model.id);
   const anthropicCompactionEnabled = shouldEnableAnthropicServerCompaction(
@@ -549,7 +554,7 @@ function createAnthropicTransportClient(params: {
     "fine-grained-tool-streaming-2025-05-14",
     ...resolveAnthropicRequiredBetaFeatures({
       enableServerCompaction: anthropicCompactionEnabled,
-      hasCompactionBlocks: hasCompactionBlocks(transportMessages),
+      hasCompactionBlocks: supportsCompactionTransport && hasCompactionBlocks(transportMessages),
     }),
   ];
   if (needsInterleavedBeta) {
@@ -640,10 +645,14 @@ function buildAnthropicParams(
     enableCacheControl: true,
   });
   const defaultMaxTokens = Math.min(model.maxTokens, 32_000);
+  const supportsCompactionTransport = supportsAnthropicContextManagementTransport(
+    model.provider,
+    model.baseUrl,
+  );
   const transportMessages =
-    model.provider === "github-copilot"
-      ? stripCompactionBlocksForTransport(context.messages)
-      : context.messages;
+    supportsCompactionTransport
+      ? context.messages
+      : stripCompactionBlocksForTransport(context.messages);
   const params: Record<string, unknown> = {
     model: model.id,
     messages: convertAnthropicMessages(transportMessages, model, isOAuthToken),

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -12,6 +12,7 @@ import {
 } from "@mariozechner/pi-ai";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
+  ANTHROPIC_MIN_COMPACTION_TRIGGER_TOKENS,
   applyAnthropicServerCompactionToParams,
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
@@ -279,7 +280,17 @@ function convertAnthropicMessages(
     }
     if (msg.role === "assistant") {
       const blocks: Array<Record<string, unknown>> = [];
-      for (const block of msg.content) {
+      const assistantContent = (
+        typeof msg.content === "string"
+          ? [{ type: "text" as const, text: msg.content }]
+          : msg.content
+      ) as Array<
+        | { type: "text"; text: string }
+        | { type: "thinking"; thinking: string; thinkingSignature?: string; redacted?: boolean }
+        | { type: "toolCall"; id: string; name: string; arguments: unknown }
+        | { type: "compaction"; content: string | null }
+      >;
+      for (const block of assistantContent) {
         if (block.type === "text") {
           if (block.text.trim().length > 0) {
             blocks.push({
@@ -394,8 +405,9 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
 function mapStopReason(reason: string | undefined): string {
   switch (reason) {
     case "end_turn":
-    case "compaction":
       return "stop";
+    case "compaction":
+      return "compaction";
     case "max_tokens":
       return "length";
     case "tool_use":
@@ -431,7 +443,14 @@ function stripCompactionBlocksForTransport(messages: Context["messages"]): Conte
       filteredMessages.push(message);
       continue;
     }
-    const filteredContent = message.content.filter((block) => block.type !== "compaction");
+    if (!Array.isArray(message.content)) {
+      filteredMessages.push(message);
+      continue;
+    }
+    const filteredContent = message.content.filter(
+      (block) =>
+        !(block && typeof block === "object" && (block as { type?: string }).type === "compaction"),
+    );
     if (filteredContent.length === 0) {
       continue;
     }
@@ -448,7 +467,7 @@ function resolveAnthropicCompactionThreshold(
   requested: number | undefined,
 ): number {
   if (typeof requested === "number" && Number.isFinite(requested) && requested > 0) {
-    return Math.floor(requested);
+    return Math.max(ANTHROPIC_MIN_COMPACTION_TRIGGER_TOKENS, Math.floor(requested));
   }
   const contextWindow =
     typeof model.contextWindow === "number" && Number.isFinite(model.contextWindow)
@@ -457,7 +476,10 @@ function resolveAnthropicCompactionThreshold(
   if (!contextWindow || contextWindow <= 0) {
     return 150_000;
   }
-  return Math.max(1, Math.min(150_000, Math.floor(contextWindow * 0.75)));
+  return Math.max(
+    ANTHROPIC_MIN_COMPACTION_TRIGGER_TOKENS,
+    Math.min(150_000, Math.floor(contextWindow * 0.75)),
+  );
 }
 
 function resolveAnthropicServerCompactionConfig(params: {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1800,6 +1800,38 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.cacheRetention).toBe("long");
   });
 
+  it("passes through Anthropic native compaction options for direct Anthropic models", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = buildAnthropicModelConfig("anthropic/claude-sonnet-4-6", {
+      anthropicServerCompaction: true,
+      anthropicCompactThreshold: 111_000,
+      anthropicCompactPauseAfter: true,
+      anthropicCompactInstructions: "Keep code decisions.",
+      cacheRetention: "long",
+    });
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-sonnet-4-6");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      baseUrl: "https://api.anthropic.com/v1",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBe("long");
+    expect(calls[0]).toMatchObject({
+      anthropicServerCompaction: true,
+      anthropicCompactThreshold: 111_000,
+      anthropicCompactPauseAfter: true,
+      anthropicCompactInstructions: "Keep code decisions.",
+    });
+  });
+
   it("adds Anthropic 1M beta header when context1m is enabled for Opus/Sonnet", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = buildAnthropicModelConfig("anthropic/claude-opus-4-6", { context1m: true });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -110,6 +110,10 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
   cacheRetention?: "none" | "short" | "long";
   cachedContent?: string;
   openaiWsWarmup?: boolean;
+  anthropicServerCompaction?: boolean;
+  anthropicCompactThreshold?: number;
+  anthropicCompactPauseAfter?: boolean;
+  anthropicCompactInstructions?: string;
 };
 type SupportedTransport = Exclude<CacheRetentionStreamOptions["transport"], undefined>;
 
@@ -259,6 +263,24 @@ function createStreamFnWithExtraParams(
   }
   if (typeof extraParams.openaiWsWarmup === "boolean") {
     streamParams.openaiWsWarmup = extraParams.openaiWsWarmup;
+  }
+  if (typeof extraParams.anthropicServerCompaction === "boolean") {
+    streamParams.anthropicServerCompaction = extraParams.anthropicServerCompaction;
+  }
+  if (
+    typeof extraParams.anthropicCompactThreshold === "number" &&
+    Number.isFinite(extraParams.anthropicCompactThreshold)
+  ) {
+    streamParams.anthropicCompactThreshold = extraParams.anthropicCompactThreshold;
+  }
+  if (typeof extraParams.anthropicCompactPauseAfter === "boolean") {
+    streamParams.anthropicCompactPauseAfter = extraParams.anthropicCompactPauseAfter;
+  }
+  if (
+    typeof extraParams.anthropicCompactInstructions === "string" &&
+    extraParams.anthropicCompactInstructions.trim()
+  ) {
+    streamParams.anthropicCompactInstructions = extraParams.anthropicCompactInstructions.trim();
   }
   const cachedContent =
     typeof extraParams.cachedContent === "string"

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -15,6 +15,7 @@ import {
   isLikelyExecutionAckPrompt,
   PLANNING_ONLY_RETRY_INSTRUCTION,
   resolveAckExecutionFastPathInstruction,
+  resolveIncompleteTurnPayloadText,
   resolvePlanningOnlyRetryLimit,
   resolvePlanningOnlyRetryInstruction,
   STRICT_AGENTIC_BLOCKED_TEXT,
@@ -464,6 +465,28 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
         incompleteTurnText,
       }),
     ).toBe("paused");
+  });
+
+  it("preserves the side-effect warning for compaction-only incomplete turns", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: [],
+      didSendViaMessagingTool: true,
+      lastAssistant: {
+        stopReason: "compaction",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+
+    expect(
+      resolveIncompleteTurnPayloadText({
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toContain("may have already been executed");
   });
 
   it("retries once after an Anthropic compaction-only stop", async () => {

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -440,6 +440,68 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
       }),
     ).toBe("paused");
   });
+
+  it("marks compaction-only incomplete turns as paused and replay-invalid", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: [],
+      lastAssistant: {
+        stopReason: "compaction",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+    const incompleteTurnText =
+      "⚠️ Agent compacted the conversation before finishing the reply. Please try again if the response does not continue automatically.";
+
+    expect(resolveReplayInvalidFlag({ attempt, incompleteTurnText })).toBe(true);
+    expect(
+      resolveRunLivenessState({
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+        incompleteTurnText,
+      }),
+    ).toBe("paused");
+  });
+
+  it("retries once after an Anthropic compaction-only stop", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [],
+        lastAssistant: {
+          stopReason: "compaction",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          content: [{ type: "compaction", content: "Summarized old context." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Continued response after compaction."],
+        lastAssistant: {
+          stopReason: "stop",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          content: [{ type: "text", text: "Continued response after compaction." }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      runId: "run-server-compaction-continue",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.isError).not.toBe(true);
+  });
 });
 
 describe("resolvePlanningOnlyRetryInstruction single-action loophole", () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1636,7 +1636,12 @@ export async function runEmbeddedPiAgent(
             !attempt.clientToolCall &&
             !attempt.yieldDetected &&
             !attempt.didSendDeterministicApprovalPrompt &&
+            !attempt.didSendViaMessagingTool &&
             !attempt.lastToolError &&
+            // Don't auto-retry compaction after side-effecting tool work —
+            // the retry would re-execute the turn and could duplicate
+            // mutations or message sends.
+            !attempt.replayMetadata.hadPotentialSideEffects &&
             (payloadsWithToolMedia?.length ?? 0) === 0;
           if (
             compactionOnlyStop &&

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -123,6 +123,10 @@ type ApiKeyInfo = ResolvedProviderAuth;
 
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
 
+function isCompactionStopReason(stopReason: unknown): stopReason is "compaction" {
+  return stopReason === "compaction";
+}
+
 /**
  * Best-effort backfill of sessionKey from sessionId when not explicitly provided.
  * The return value is normalized: whitespace-only inputs collapse to undefined, and
@@ -1626,7 +1630,7 @@ export async function runEmbeddedPiAgent(
             continue;
           }
           const compactionOnlyStop =
-            attempt.lastAssistant?.stopReason === "compaction" &&
+            isCompactionStopReason(attempt.lastAssistant?.stopReason) &&
             !aborted &&
             !timedOut &&
             !attempt.clientToolCall &&

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -417,6 +417,7 @@ export async function runEmbeddedPiAgent(
 
       const MAX_TIMEOUT_COMPACTION_ATTEMPTS = 2;
       const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
+      const MAX_SERVER_COMPACTION_CONTINUE_ATTEMPTS = 1;
       const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
       let overflowCompactionAttempts = 0;
       let toolResultTruncationAttempted = false;
@@ -429,6 +430,7 @@ export async function runEmbeddedPiAgent(
       let runLoopIterations = 0;
       let overloadProfileRotations = 0;
       let planningOnlyRetryAttempts = 0;
+      let serverCompactionContinueAttempts = 0;
       let sameModelIdleTimeoutRetries = 0;
       let lastRetryFailoverReason: FailoverReason | null = null;
       let planningOnlyRetryInstruction: string | null = null;
@@ -1620,6 +1622,26 @@ export async function runEmbeddedPiAgent(
               `planning-only turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${provider}/${modelId} contract=${executionContract} configured=${configuredExecutionContract} — retrying ` +
                 `${planningOnlyRetryAttempts}/${maxPlanningOnlyRetryAttempts} with act-now steer`,
+            );
+            continue;
+          }
+          const compactionOnlyStop =
+            attempt.lastAssistant?.stopReason === "compaction" &&
+            !aborted &&
+            !timedOut &&
+            !attempt.clientToolCall &&
+            !attempt.yieldDetected &&
+            !attempt.didSendDeterministicApprovalPrompt &&
+            !attempt.lastToolError &&
+            (payloadsWithToolMedia?.length ?? 0) === 0;
+          if (
+            compactionOnlyStop &&
+            serverCompactionContinueAttempts < MAX_SERVER_COMPACTION_CONTINUE_ATTEMPTS
+          ) {
+            serverCompactionContinueAttempts += 1;
+            log.info(
+              `server compaction pause detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                `provider=${provider}/${modelId} — retrying ${serverCompactionContinueAttempts}/${MAX_SERVER_COMPACTION_CONTINUE_ATTEMPTS}`,
             );
             continue;
           }

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -41,6 +41,10 @@ type RunLivenessAttempt = Pick<
   "lastAssistant" | "promptErrorSource" | "replayMetadata" | "timedOutDuringCompaction"
 >;
 
+function isCompactionStopReason(stopReason: unknown): stopReason is "compaction" {
+  return stopReason === "compaction";
+}
+
 export function isIncompleteTerminalAssistantTurn(params: {
   hasAssistantVisibleText: boolean;
   lastAssistant?: { stopReason?: string } | null;
@@ -168,7 +172,7 @@ export function resolveIncompleteTurnPayloadText(params: {
     return null;
   }
 
-  if (stopReason === "compaction") {
+  if (isCompactionStopReason(stopReason)) {
     return "⚠️ Agent compacted the conversation before finishing the reply. Please try again if the response does not continue automatically.";
   }
 
@@ -198,7 +202,7 @@ export function resolveRunLivenessState(params: {
 }): EmbeddedRunLivenessState {
   if (
     params.incompleteTurnText &&
-    params.attempt.lastAssistant?.stopReason === "compaction"
+    isCompactionStopReason(params.attempt.lastAssistant?.stopReason)
   ) {
     return "paused";
   }

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -173,7 +173,9 @@ export function resolveIncompleteTurnPayloadText(params: {
   }
 
   if (isCompactionStopReason(stopReason)) {
-    return "⚠️ Agent compacted the conversation before finishing the reply. Please try again if the response does not continue automatically.";
+    return params.attempt.replayMetadata.hadPotentialSideEffects
+      ? "⚠️ Agent compacted the conversation before finishing the reply. Note: some tool actions may have already been executed — please verify before retrying if the response does not continue automatically."
+      : "⚠️ Agent compacted the conversation before finishing the reply. Please try again if the response does not continue automatically.";
   }
 
   return params.attempt.replayMetadata.hadPotentialSideEffects

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -45,7 +45,11 @@ export function isIncompleteTerminalAssistantTurn(params: {
   hasAssistantVisibleText: boolean;
   lastAssistant?: { stopReason?: string } | null;
 }): boolean {
-  return !params.hasAssistantVisibleText && params.lastAssistant?.stopReason === "toolUse";
+  return (
+    !params.hasAssistantVisibleText &&
+    (params.lastAssistant?.stopReason === "toolUse" ||
+      params.lastAssistant?.stopReason === "compaction")
+  );
 }
 
 const PLANNING_ONLY_PROMISE_RE =
@@ -164,6 +168,10 @@ export function resolveIncompleteTurnPayloadText(params: {
     return null;
   }
 
+  if (stopReason === "compaction") {
+    return "⚠️ Agent compacted the conversation before finishing the reply. Please try again if the response does not continue automatically.";
+  }
+
   return params.attempt.replayMetadata.hadPotentialSideEffects
     ? "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying."
     : "⚠️ Agent couldn't generate a response. Please try again.";
@@ -188,6 +196,12 @@ export function resolveRunLivenessState(params: {
   attempt: RunLivenessAttempt;
   incompleteTurnText?: string | null;
 }): EmbeddedRunLivenessState {
+  if (
+    params.incompleteTurnText &&
+    params.attempt.lastAssistant?.stopReason === "compaction"
+  ) {
+    return "paused";
+  }
   if (params.incompleteTurnText) {
     return "abandoned";
   }

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -1,6 +1,25 @@
 import type { Api, Context, Model } from "@mariozechner/pi-ai";
+import { coerceTransportToolCallArguments } from "./transport-stream-shared.js";
 
 type PendingToolCall = { id: string; name: string };
+type AssistantToolCallBlock = {
+  type: "toolCall";
+  id: string;
+  name: string;
+  arguments: unknown;
+  thoughtSignature?: string;
+};
+type TransformableAssistantContentBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string; thinkingSignature?: string; redacted?: boolean }
+  | AssistantToolCallBlock
+  | { type: "compaction"; content: string | null };
+type TransformableAssistantMessage = Omit<
+  Extract<Context["messages"][number], { role: "assistant" }>,
+  "content"
+> & {
+  content: TransformableAssistantContentBlock[] | string;
+};
 
 function appendMissingToolResults(
   result: Context["messages"],
@@ -44,17 +63,16 @@ export function transformTransportMessages(
     if (msg.role !== "assistant") {
       return msg;
     }
+    const assistantMessage = msg as TransformableAssistantMessage;
     const isSameModel =
-      msg.provider === model.provider && msg.api === model.api && msg.model === model.id;
-    const content: typeof msg.content = [];
-    const assistantContent = (
-      typeof msg.content === "string" ? [{ type: "text" as const, text: msg.content }] : msg.content
-    ) as Array<
-      | { type: "text"; text: string }
-      | { type: "thinking"; thinking: string; thinkingSignature?: string; redacted?: boolean }
-      | { type: "toolCall"; id: string; name: string; arguments: unknown; thoughtSignature?: string }
-      | { type: "compaction"; content: string | null }
-    >;
+      assistantMessage.provider === model.provider &&
+      assistantMessage.api === model.api &&
+      assistantMessage.model === model.id;
+    const content: TransformableAssistantContentBlock[] = [];
+    const assistantContent =
+      typeof assistantMessage.content === "string"
+        ? [{ type: "text" as const, text: assistantMessage.content }]
+        : assistantMessage.content;
     for (const block of assistantContent) {
       if (block.type === "thinking") {
         if (block.redacted) {
@@ -81,13 +99,16 @@ export function transformTransportMessages(
         content.push(block);
         continue;
       }
-      let normalizedToolCall = block;
+      let normalizedToolCall: AssistantToolCallBlock = {
+        ...block,
+        arguments: coerceTransportToolCallArguments(block.arguments),
+      };
       if (!isSameModel && block.thoughtSignature) {
         normalizedToolCall = { ...normalizedToolCall };
         delete normalizedToolCall.thoughtSignature;
       }
       if (!isSameModel && normalizeToolCallId) {
-        const normalizedId = normalizeToolCallId(block.id, model, msg);
+        const normalizedId = normalizeToolCallId(block.id, model, assistantMessage);
         if (normalizedId !== block.id) {
           toolCallIdMap.set(block.id, normalizedId);
           normalizedToolCall = { ...normalizedToolCall, id: normalizedId };
@@ -95,7 +116,7 @@ export function transformTransportMessages(
       }
       content.push(normalizedToolCall);
     }
-    return { ...msg, content };
+    return { ...assistantMessage, content } as unknown as Context["messages"][number];
   });
 
   const result: Context["messages"] = [];

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -1,5 +1,4 @@
 import type { Api, Context, Model } from "@mariozechner/pi-ai";
-import { coerceTransportToolCallArguments } from "./transport-stream-shared.js";
 
 type PendingToolCall = { id: string; name: string };
 type AssistantToolCallBlock = {
@@ -101,7 +100,6 @@ export function transformTransportMessages(
       }
       let normalizedToolCall: AssistantToolCallBlock = {
         ...block,
-        arguments: coerceTransportToolCallArguments(block.arguments),
       };
       if (!isSameModel && block.thoughtSignature) {
         normalizedToolCall = { ...normalizedToolCall };

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -47,7 +47,15 @@ export function transformTransportMessages(
     const isSameModel =
       msg.provider === model.provider && msg.api === model.api && msg.model === model.id;
     const content: typeof msg.content = [];
-    for (const block of msg.content) {
+    const assistantContent = (
+      typeof msg.content === "string" ? [{ type: "text" as const, text: msg.content }] : msg.content
+    ) as Array<
+      | { type: "text"; text: string }
+      | { type: "thinking"; thinking: string; thinkingSignature?: string; redacted?: boolean }
+      | { type: "toolCall"; id: string; name: string; arguments: unknown; thoughtSignature?: string }
+      | { type: "compaction"; content: string | null }
+    >;
+    for (const block of assistantContent) {
       if (block.type === "thinking") {
         if (block.redacted) {
           if (isSameModel) {


### PR DESCRIPTION
## Summary
Closes #65287.

This adds Anthropic-native compaction support and a mixed Anthropic cache-retention policy that uses `1h` retention for the stable system/tool/workspace prefix and `5m` retention for high-churn conversation content. It also round-trips Anthropic compaction blocks through request history and streaming so provider-native active-context compaction can manage the live Claude prompt without giving up durable searchable memory in `lossless-claw`.

## What Changed
- Added Anthropic run/model params:
  - `anthropicServerCompaction`
  - `anthropicCompactThreshold`
  - `anthropicCompactPauseAfter`
  - `anthropicCompactInstructions`
- Injected `context_management.edits` with `compact_20260112` when Anthropic native compaction is enabled.
- Added the required Anthropic beta features only when native compaction is active or compaction blocks must be round-tripped.
- Extended Anthropic history conversion and streaming to preserve `compaction` blocks.
- Updated Anthropic cache policy so long retention keeps the stable prefix at `1h` while trailing conversation content remains `5m`/ephemeral.

## Why
- Anthropic prompt caching is exact-prefix, so local prompt rewrites can burn a hot conversation cache.
- Long-running Claude coding sessions benefit from a stable `1h` cached prefix, but paying `1h` write cost for fast-changing conversation blocks is wasteful.
- This pairs well with the `lossless-claw` deferred/background compaction work: provider-native compaction manages the active prompt, while `lossless-claw` stays the searchable lossless sidecar.

## Validation
- `pnpm test -- --run src/agents/anthropic-payload-policy.test.ts src/agents/anthropic-transport-stream.test.ts src/agents/pi-embedded-runner-extraparams.test.ts` passed
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.json --noEmit` reports only the pre-existing unrelated Telegram `AbortSignal` baseline in `extensions/telegram/src/bot.ts`

## Related Work
- openclaw/openclaw#65233
- Martian-Engineering/lossless-claw#407
- Martian-Engineering/lossless-claw#408
