### PR TITLE
fix(gateway): reduce shared auth rotation test teardown flake

### DIFF
--- a/src/gateway/server.shared-auth-rotation.test.ts
+++ b/src/gateway/server.shared-auth-rotation.test.ts
@@ -22,23 +22,15 @@ const NEW_TOKEN = "shared-token-new";
 const DEFERRED_RESTART_DELAY_MS = 1_000;
 const SECRET_REF_TOKEN_ID = "OPENCLAW_SHARED_AUTH_ROTATION_SECRET_REF";
 
-let server: Awaited<ReturnType<typeof startGatewayServer>>;
 let port = 0;
 
-beforeAll(async () => {
-  port = await getFreePort();
-  testState.gatewayAuth = { mode: "token", token: OLD_TOKEN };
-  server = await startGatewayServer(port, { controlUiEnabled: true });
-});
-
-afterAll(async () => {
+afterAll(() => {
   testState.gatewayAuth = ORIGINAL_GATEWAY_AUTH;
   if (ORIGINAL_GATEWAY_TOKEN_ENV === undefined) {
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
   } else {
     process.env.OPENCLAW_GATEWAY_TOKEN = ORIGINAL_GATEWAY_TOKEN_ENV;
   }
-  await server.close();
 });
 
 async function openAuthenticatedWs(token: string): Promise<WebSocket> {
@@ -95,6 +87,32 @@ async function waitForClose(ws: WebSocket): Promise<{ code: number; reason: stri
   });
 }
 
+async function closeWsAndWait(ws: WebSocket, timeoutMs = 2_000): Promise<void> {
+  if (ws.readyState === WebSocket.CLOSED) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const onClose = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      ws.off("close", onClose);
+      resolve();
+    }, timeoutMs);
+    ws.once("close", onClose);
+    try {
+      if (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN) {
+        ws.close();
+      }
+    } catch {
+      clearTimeout(timer);
+      ws.off("close", onClose);
+      resolve();
+    }
+  });
+}
+
 async function loadCurrentConfig(ws: WebSocket): Promise<{
   hash: string;
   config: Record<string, unknown>;
@@ -129,8 +147,20 @@ async function applyCurrentConfig(ws: WebSocket) {
 }
 
 describe("gateway shared auth rotation", () => {
+  let server: Awaited<ReturnType<typeof startGatewayServer>>;
+
+  beforeAll(async () => {
+    port = await getFreePort();
+    testState.gatewayAuth = { mode: "token", token: OLD_TOKEN };
+    server = await startGatewayServer(port, { controlUiEnabled: true });
+  });
+
   beforeEach(() => {
     testState.gatewayAuth = { mode: "token", token: OLD_TOKEN };
+  });
+
+  afterAll(async () => {
+    await server.close();
   });
 
   it("disconnects existing shared-token websocket sessions after config.patch rotates auth", async () => {
@@ -145,7 +175,7 @@ describe("gateway shared auth rotation", () => {
         reason: "gateway auth changed",
       });
     } finally {
-      ws.close();
+      await closeWsAndWait(ws);
     }
   });
 
@@ -159,7 +189,7 @@ describe("gateway shared auth rotation", () => {
       expect(followUp.ok).toBe(true);
       expect(typeof followUp.payload?.hash).toBe("string");
     } finally {
-      ws.close();
+      await closeWsAndWait(ws);
     }
   });
 });
@@ -226,7 +256,7 @@ describe("gateway shared auth rotation with unchanged SecretRefs", () => {
         reason: "gateway auth changed",
       });
     } finally {
-      ws.close();
+      await closeWsAndWait(ws);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Problem: `src/gateway/server.shared-auth-rotation.test.ts` could hang in suite teardown during aggressive local full-suite runs, timing out in the shared gateway test `afterAll` hook.
- Why it matters: this makes local `pnpm test` noisy and undermines confidence in the recent host-aware faster local test defaults.
- What changed: tightened the test fixture lifetime so the first gateway server only lives inside its own `describe`, and switched websocket cleanup to await socket close instead of fire-and-forget `ws.close()`.
- What did NOT change (scope boundary): no gateway production auth/reload behavior changed; this PR only adjusts test lifecycle and cleanup in one flaky suite.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #65264
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the flaky suite kept one gateway server alive across both `describe` blocks and used fire-and-forget websocket cleanup, which could leave teardown work in flight until the shared suite `afterAll` timed out.
- Missing detection / guardrail: the test relied on implicit socket/server shutdown ordering instead of scoping fixtures tightly and awaiting socket close.
- Contributing context (if known): the flake was surfaced more often during aggressive local full-suite runs.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server.shared-auth-rotation.test.ts`
- Scenario the test should lock in:
  - repeated runs of the shared-auth rotation suite should complete without hanging in shared suite teardown
- Why this is the smallest reliable guardrail:
  - the failure was in this suite's fixture lifetime and teardown path, so the suite itself is the narrowest realistic guardrail.
- Existing test that already covers this (if any): the file already covered the behavior assertions; this change stabilizes its fixture management.
- If no new test is added, why not:
  - no new behavior path was introduced; the validation is repeated execution of the existing suite.

## User-visible / Behavior Changes

- None.

## Diagram (if applicable)

```text
Before:
shared-auth rotation suite -> first server spans both describe blocks -> ws.close() fire-and-forget -> occasional teardown timeout

After:
shared-auth rotation suite -> server scoped to owning describe -> await websocket close -> teardown completes reliably
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node / pnpm dev env
- Model/provider: N/A
- Integration/channel (if any): gateway websocket test suite
- Relevant config (redacted): isolated temp `HOME` for full-suite validation

### Steps

1. Run `pnpm test src/gateway/server.shared-auth-rotation.test.ts` repeatedly.
2. Run a few isolated-home full local `pnpm test` rounds.
3. Check whether `src/gateway/server.shared-auth-rotation.test.ts` still fails with the shared suite `afterAll` hook timeout.

### Expected

- The targeted suite stays green repeatedly.
- The original shared-auth rotation teardown timeout does not reappear.

### Actual

- Targeted suite passed repeatedly.
- The original shared-auth rotation timeout did not reappear in the sampled full-suite rounds.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/gateway/server.shared-auth-rotation.test.ts`
  - repeated targeted runs: 5/5 passes
  - isolated-home full local `pnpm test` runs: the original shared-auth rotation timeout did not reappear in 3 rounds
  - `pnpm check`
- Edge cases checked:
  - both gateway-server lifecycles still close cleanly
  - websocket cleanup tolerates already-closed sockets
- What you did **not** verify:
  - CI yet
  - unrelated failing full-suite tests outside this scope

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: websocket close waiting could hide a different shutdown issue if the helper waits too long.
  - Mitigation: the helper has a short timeout and is scoped only to this test file.
