### PR TITLE
fix(gateway): prevent crash on late tool_execution_update after agent run teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Dreaming/cron: wake managed dreaming jobs immediately instead of waiting for the next heartbeat, so scheduled dreaming runs start when the cron fires. (#65053) Thanks @l0cka and @vincentkoc.
 - QA/packaging: stop packaged QA helpers from crashing when optional scenario execution config is unavailable, so npm distributions can skip the repo-only scenario pack without breaking completion-cache and startup paths. (#65118) Thanks @EdderTalmor and @vincentkoc.
 - Media/audio transcription: surface the real provider failure when every audio transcription attempt fails, so status output and the CLI stop collapsing those errors into generic skips. (#65096) Thanks @l0cka and @vincentkoc.
+- Gateway/agents: suppress the late `Agent listener invoked outside active run` teardown race in the global unhandled-rejection handler, so stale post-run tool updates stop crashing the gateway into restart loops. (#65285) Thanks @openperf and @vincentkoc.
 
 ## 2026.4.11
 

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -207,5 +207,15 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         expect.stringContaining("This operation was aborted"),
       );
     });
+
+    it("does not exit on agent-lifecycle race error and logs suppression warning (#65285)", () => {
+      const raceErr = new Error("Agent listener invoked outside active run");
+
+      expectExitCodeFromUnhandled(raceErr, []);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[openclaw] Suppressed agent-lifecycle race (continuing):",
+        expect.stringContaining("Agent listener invoked outside active run"),
+      );
+    });
   });
 });

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isAbortError,
+  isAgentLifecycleRaceError,
   isTransientNetworkError,
   isTransientSqliteError,
   isTransientUnhandledRejectionError,
@@ -254,6 +255,54 @@ describe("isTransientSqliteError", () => {
     const error = new Error("database is locked");
 
     expect(isTransientSqliteError(error)).toBe(false);
+  });
+});
+
+describe("isAgentLifecycleRaceError", () => {
+  it("returns true for the exact pi-agent-core race message", () => {
+    const error = new Error("Agent listener invoked outside active run");
+    expect(isAgentLifecycleRaceError(error)).toBe(true);
+  });
+
+  it("returns true when pi-agent-core appends context to the message", () => {
+    const error = new Error("Agent listener invoked outside active run (runId: abc-123)");
+    expect(isAgentLifecycleRaceError(error)).toBe(true);
+  });
+
+  it("returns false for similar but non-matching messages", () => {
+    expect(isAgentLifecycleRaceError(new Error("Agent listener error"))).toBe(false);
+    expect(isAgentLifecycleRaceError(new Error("invoked outside active run"))).toBe(false);
+    expect(isAgentLifecycleRaceError(new Error("listener invoked outside"))).toBe(false);
+  });
+
+  it.each([null, undefined, "string error", 42, { message: "plain object" }])(
+    "returns false for non-error input %#",
+    (value) => {
+      expect(isAgentLifecycleRaceError(value)).toBe(false);
+    },
+  );
+
+  it("returns false for error objects without a message property", () => {
+    expect(isAgentLifecycleRaceError({ name: "Error" })).toBe(false);
+    expect(isAgentLifecycleRaceError({})).toBe(false);
+  });
+
+  it("returns true when the race error is wrapped in a cause chain", () => {
+    const inner = new Error("Agent listener invoked outside active run");
+    const outer = new Error("tool execution failed", { cause: inner });
+    expect(isAgentLifecycleRaceError(outer)).toBe(true);
+  });
+
+  it("returns true when the race error is inside an AggregateError", () => {
+    const raceError = new Error("Agent listener invoked outside active run");
+    const aggregate = new AggregateError([new Error("unrelated"), raceError], "multiple failures");
+    expect(isAgentLifecycleRaceError(aggregate)).toBe(true);
+  });
+
+  it("returns false when cause chain contains no matching error", () => {
+    const inner = new Error("some other error");
+    const outer = new Error("wrapper", { cause: inner });
+    expect(isAgentLifecycleRaceError(outer)).toBe(false);
   });
 });
 

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -313,6 +313,34 @@ export function isTransientUnhandledRejectionError(err: unknown): boolean {
   return isTransientNetworkError(err) || isTransientSqliteError(err);
 }
 
+/**
+ * Detects the "Agent listener invoked outside active run" error from
+ * `pi-agent-core`.  This is a non-fatal race condition where a
+ * `tool_execution_update` event is emitted after the agent run has already
+ * been torn down — see #65285.
+ *
+ * Uses `startsWith` rather than strict equality so the classifier remains
+ * effective if `pi-agent-core` later appends context (e.g. a run ID) to
+ * the message.
+ *
+ * The error may be wrapped in a `cause` chain or an `AggregateError`, so
+ * we walk the full nested error graph via
+ * {@link collectNestedUnhandledErrorCandidates}.
+ */
+export function isAgentLifecycleRaceError(err: unknown): boolean {
+  for (const candidate of collectNestedUnhandledErrorCandidates(err)) {
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const message =
+      "message" in candidate && typeof candidate.message === "string" ? candidate.message : "";
+    if (message.startsWith("Agent listener invoked outside active run")) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function registerUnhandledRejectionHandler(handler: UnhandledRejectionHandler): () => void {
   handlers.add(handler);
   return () => {
@@ -369,6 +397,19 @@ export function installUnhandledRejectionHandler(): void {
     if (isTransientUnhandledRejectionError(reason)) {
       console.warn(
         "[openclaw] Non-fatal unhandled rejection (continuing):",
+        formatUncaughtError(reason),
+      );
+      return;
+    }
+
+    // Agent-lifecycle race: a tool_execution_update was emitted after the
+    // agent run was torn down.  Non-fatal — the existing guards (updatesDisabled
+    // on process exit, disableUpdates on tool abort) cover normal-exit and abort
+    // paths; this classifier catches the remaining non-abort teardown path
+    // where finishRun() clears activeRun without firing the abort signal (#65285).
+    if (isAgentLifecycleRaceError(reason)) {
+      console.warn(
+        "[openclaw] Suppressed agent-lifecycle race (continuing):",
         formatUncaughtError(reason),
       );
       return;


### PR DESCRIPTION

### Summary

- **Problem**: Gateway crashes with `Error: Agent listener invoked outside active run` (#65285). The crash occurs when a `tool_execution_update` event is emitted by the `exec` tool after the agent run has already been torn down. In the reporter's environment, this caused **23 gateway restarts in a single day**, each triggering a `cache_write` costing ~$0.41.

- **Root Cause**: The `exec` tool's `emitUpdate` closure captures `opts.onUpdate`, which internally calls `processEvents` in `pi-agent-core`. When the agent run ends abnormally — for example, a transient listener error during parallel tool execution propagates to `runWithLifecycle`, which calls `finishRun()` to clear `activeRun` — the exec process (especially with PTY, where `onExit` fires before the final `onData` events are drained) may still be producing output. When `onData` fires, `emitUpdate` pushes an event into the now-disposed agent loop, causing `processEvents` to throw because `this.activeRun` is `undefined`. This becomes an unhandled promise rejection, and the default handler in `unhandled-rejections.ts` calls `process.exit`, crashing the gateway. The existing guards (`updatesDisabled` on process exit, and `disableUpdates()` on tool abort) only cover the normal-exit and tool-abort paths. Critically, `finishRun()` does **not** call `abortController.abort()`, so neither guard fires on the non-abort teardown path — which is exactly the path that triggers this crash.

- **Fix**: Add `isAgentLifecycleRaceError` to `unhandled-rejections.ts` to classify the "Agent listener invoked outside active run" error as a non-fatal agent-lifecycle race condition. When detected, the gateway logs a warning (`[openclaw] Suppressed agent-lifecycle race (continuing)`) instead of calling `process.exit`. The classifier uses `startsWith` for resilience against future `pi-agent-core` message changes, and walks the full nested error graph via `collectNestedUnhandledErrorCandidates` (the same utility used by `isTransientNetworkError` and `isTransientSqliteError`) to detect the error even when wrapped in a `cause` chain or `AggregateError`.

- **What changed**:
  - `src/infra/unhandled-rejections.ts`: Added `isAgentLifecycleRaceError` classifier using `collectNestedUnhandledErrorCandidates` for nested error traversal and `startsWith` matching; integrated it into the unhandled rejection handler before the fatal `process.exit` path.
  - `src/infra/unhandled-rejections.test.ts`: Added 10 unit tests for the new classifier — exact match, appended context (future-proofing), non-matching messages, non-error inputs, missing message property, `cause` chain wrapping, `AggregateError` wrapping, and negative `cause` chain case.
  - `src/infra/unhandled-rejections.fatal-detection.test.ts`: Added 1 integration test verifying the error is suppressed (does not trigger `process.exit`) in the full handler pipeline.

- **What did NOT change (scope boundary)**: No changes to `bash-tools.exec-runtime.ts`, `bash-tools.exec.ts`, the process supervisor, PTY adapter, or `pi-agent-core`'s agent loop. The existing Layer 1 (`updatesDisabled` on process exit) and Layer 2 (`disableUpdates()` on tool abort) guards remain untouched and continue to cover their respective paths. This fix is purely at the global error handler level, adding a safety net for the one path those guards cannot cover.

### Reproduction

1. Start an agent run with a long-running `exec` tool using PTY (`pty: true`).
2. While the tool is running and producing output, trigger an abnormal agent run termination (e.g., simulate a listener throwing an error during a parallel tool execution update, or trigger a Telegram polling restart that tears down the run).
3. The exec process continues producing output; `onData` fires and calls `emitUpdate`.
4. **Without the fix**: `processEvents` throws "Agent listener invoked outside active run" → unhandled rejection → `process.exit` → gateway crash.
5. **With the fix**: The error is caught by `isAgentLifecycleRaceError`, a warning is logged, and the gateway continues running.

### Risk / Mitigation

- **Risk**: Suppressing this error might mask legitimate bugs where `tool_execution_update` events are emitted incorrectly after a run has ended.
- **Mitigation**: The suppression is highly targeted — it matches only errors whose message starts with the distinctive phrase "Agent listener invoked outside active run", and logs a clear warning on every suppression for observability. The classifier reuses the project's established `collectNestedUnhandledErrorCandidates` pattern, consistent with how `isTransientNetworkError` and `isTransientSqliteError` are implemented. Test coverage includes 11 new tests (10 unit + 1 integration) ensuring the classifier correctly identifies the target error in direct, wrapped, and aggregated forms, while rejecting similar-but-different messages and non-error inputs.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Infra (unhandled-rejections)

### Linked Issue/PR

Fixes #65285
