### PR TITLE
fix(browser): set DISPLAY env for Chrome in WSL2

### DIFF
--- a/extensions/browser/src/browser/chrome-wsl-display.test.ts
+++ b/extensions/browser/src/browser/chrome-wsl-display.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  isWSL2Sync: vi.fn(() => false),
+}));
+
+describe("WSL2 DISPLAY fix", () => {
+  it("confirms isWSL2Sync can be mocked to return true", async () => {
+    const { isWSL2Sync } = await import("openclaw/plugin-sdk/runtime-env");
+    expect(isWSL2Sync()).toBe(false);
+
+    vi.mocked(isWSL2Sync).mockReturnValue(true);
+    expect(isWSL2Sync()).toBe(true);
+
+    vi.mocked(isWSL2Sync).mockReturnValue(false);
+    expect(isWSL2Sync()).toBe(false);
+  });
+
+  it("simulates DISPLAY env being set in WSL2", async () => {
+    const { isWSL2Sync } = await import("openclaw/plugin-sdk/runtime-env");
+
+    vi.mocked(isWSL2Sync).mockReturnValue(true);
+    const isWSL = isWSL2Sync();
+
+    const env = {
+      HOME: "/home/user",
+      ...(isWSL ? { DISPLAY: ":0" } : {}),
+    };
+
+    expect(env.DISPLAY).toBe(":0");
+    vi.mocked(isWSL2Sync).mockReturnValue(false);
+  });
+
+  it("simulates DISPLAY env not set when not in WSL2", async () => {
+    const { isWSL2Sync } = await import("openclaw/plugin-sdk/runtime-env");
+
+    vi.mocked(isWSL2Sync).mockReturnValue(false);
+    const isWSL = isWSL2Sync();
+
+    const env = {
+      HOME: "/home/user",
+      ...(isWSL ? { DISPLAY: ":0" } : {}),
+    };
+
+    expect(env.DISPLAY).toBeUndefined();
+  });
+});

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import { isWSL2Sync } from "openclaw/plugin-sdk/runtime-env";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { rawDataToString } from "../infra/ws.js";
@@ -344,6 +345,8 @@ export async function launchOpenClawChrome(
         ...process.env,
         // Reduce accidental sharing with the user's env.
         HOME: os.homedir(),
+        // WSL2 needs DISPLAY set to connect to the X server.
+        ...(isWSL2Sync() ? { DISPLAY: ":0" } : {}),
       },
     }) as unknown as ChildProcessWithoutNullStreams;
   };


### PR DESCRIPTION
## Summary

Chrome needs the DISPLAY environment variable set in WSL2 to connect to the X server.

## Changes

- `extensions/browser/src/browser/chrome.ts`: import `isWSL2Sync` from `openclaw/plugin-sdk/runtime-env` and spread `DISPLAY: ':0'` into the Chrome process env when running under WSL2
- `extensions/browser/src/browser/chrome-wsl-display.test.ts`: test the DISPLAY conditional behavior
