### PR TITLE
fix(sessions): clear model override on /new and /reset

### DIFF
--- a/src/auto-reply/reply/session-reset-model.test.ts
+++ b/src/auto-reply/reply/session-reset-model.test.ts
@@ -85,4 +85,28 @@ describe("applyResetModelOverride", () => {
     expect(sessionEntry.modelOverride).toBeUndefined();
     expect(sessionCtx.BodyStripped).toBe("minimax summarize");
   });
+
+  it("clears model override when resetTriggered is true but body is empty", async () => {
+    const fixture = createResetFixture({
+      modelOverride: "gpt-5.4",
+      providerOverride: "openai",
+    });
+    await applyResetModelOverride({
+      cfg: fixture.cfg,
+      resetTriggered: true,
+      bodyStripped: undefined,
+      sessionCtx: fixture.sessionCtx,
+      ctx: fixture.ctx,
+      sessionEntry: fixture.sessionEntry,
+      sessionStore: fixture.sessionStore,
+      sessionKey: "agent:main:dm:1",
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      aliasIndex: fixture.aliasIndex,
+      modelCatalog,
+    });
+
+    expect(fixture.sessionEntry.modelOverride).toBeUndefined();
+    expect(fixture.sessionEntry.providerOverride).toBeUndefined();
+  });
 });

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -107,6 +107,16 @@ export async function applyResetModelOverride(params: {
   }
   const rawBody = normalizeOptionalString(params.bodyStripped);
   if (!rawBody) {
+    if (params.sessionEntry) {
+      applyModelOverrideToSessionEntry({
+        entry: params.sessionEntry,
+        selection: {
+          provider: params.defaultProvider,
+          model: params.defaultModel,
+          isDefault: true,
+        },
+      });
+    }
     return {};
   }
 


### PR DESCRIPTION
## Summary

When `/new` or `/reset` is called without a model argument, clear any existing `modelOverride`/`providerOverride` by treating it as a reset to defaults.

## Changes

- `src/auto-reply/reply/session-reset-model.ts`: when `resetTriggered=true` and no body is provided, call `applyModelOverrideToSessionEntry` with `isDefault: true` to clear overrides
- `src/auto-reply/reply/session-reset-model.test.ts`: add test for the empty-body reset case
