### PR TITLE
fix(ui): handle null/undefined value in renderMapField

### DIFF
--- a/ui/src/ui/views/config-form.mapfield.test.ts
+++ b/ui/src/ui/views/config-form.mapfield.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+// Minimal reproduction of the null-spread guard pattern used in renderMapField.
+// The actual renderMapField is a lit template function that is hard to unit-test
+// in a node/vitest environment without a DOM. These tests verify the core
+// logic pattern that was fixed.
+
+describe("renderMapField value guard", () => {
+  // This pattern is used in three places inside renderMapField:
+  // 1. Add Entry click handler
+  // 2. Key rename @change handler
+  // 3. Remove entry @click handler
+
+  it("does not throw when spreading null", () => {
+    const value = null;
+    // Old code: would throw "TypeError: Cannot spread null"
+    expect(() => void ({ ...value })).toThrow(TypeError);
+    // Fixed code with null guard:
+    expect(() => void ({ ...(value ?? {}) })).not.toThrow();
+  });
+
+  it("does not throw when spreading undefined", () => {
+    const value = undefined;
+    expect(() => void ({ ...(value ?? {}) })).not.toThrow();
+  });
+
+  it("preserves object behavior for all three renderMapField patterns", () => {
+    // Pattern 1: Add new entry (null value)
+    const value1: Record<string, unknown> | null = null;
+    const next1 = { ...(value1 ?? {}) };
+    expect(next1).toEqual({});
+
+    // Pattern 2: Rename key (key already in map)
+    const value2 = { "custom-1": "foo" };
+    const next2 = { ...(value2 ?? {}) };
+    expect(next2).toEqual({ "custom-1": "foo" });
+
+    // Pattern 3: Remove key (null value)
+    const value3: Record<string, unknown> | null = null;
+    const next3 = { ...(value3 ?? {}) };
+    delete next3["custom-1"]; // should be no-op
+    expect(next3).toEqual({});
+  });
+});

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -1223,7 +1223,7 @@ function renderMapField(params: {
           class="cfg-map__add"
           ?disabled=${disabled}
           @click=${() => {
-            const next = { ...value };
+            const next = { ...(value ?? {}) };
             let index = 1;
             let key = `custom-${index}`;
             while (key in next) {
@@ -1268,7 +1268,7 @@ function renderMapField(params: {
                             if (!nextKey || nextKey === key) {
                               return;
                             }
-                            const next = { ...value };
+                            const next = { ...(value ?? {}) };
                             if (nextKey in next) {
                               return;
                             }
@@ -1284,7 +1284,7 @@ function renderMapField(params: {
                         title="Remove entry"
                         ?disabled=${disabled}
                         @click=${() => {
-                          const next = { ...value };
+                          const next = { ...(value ?? {}) };
                           delete next[key];
                           onPatch(path, next);
                         }}


### PR DESCRIPTION
## Summary

Fix three locations in `renderMapField` where spreading `value` directly could throw when `value` is `null` or `undefined`. Use `(value ?? {})` instead.

## Changes

- `ui/src/ui/views/config-form.node.ts`: three locations in `renderMapField` fixed
