### PR TITLE
test: add missing extractTextCached assertions to final-tag regression tests

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -77,6 +77,39 @@ describe("extractTextCached", () => {
     expect(extractText(message)).toBeNull();
     expect(extractTextCached(message)).toBeNull();
   });
+
+  it("strips <final> tags from assistant content", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "<final>Hello</final>" }],
+    };
+    expect(extractText(message)).toBe("Hello");
+    expect(extractTextCached(message)).toBe("Hello");
+  });
+
+  it("strips multiline <final> blocks from assistant content", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "<final>\n\nHello there\n\n</final>" }],
+    };
+    expect(extractText(message)).toBe("Hello there\n\n");
+  });
+
+  it("strips mixed <think> and <final> tags from assistant content", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "<think>reasoning\n</think>\n\n<final>Hello</final>" }],
+    };
+    expect(extractText(message)).toBe("Hello");
+  });
+
+  it("strips <final> tags from assistant text property", () => {
+    const message = {
+      role: "assistant",
+      text: "<final>Hello world</final>",
+    };
+    expect(extractText(message)).toBe("Hello world");
+  });
 });
 
 describe("extractThinkingCached", () => {

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -93,6 +93,7 @@ describe("extractTextCached", () => {
       content: [{ type: "text", text: "<final>\n\nHello there\n\n</final>" }],
     };
     expect(extractText(message)).toBe("Hello there\n\n");
+    expect(extractTextCached(message)).toBe("Hello there\n\n");
   });
 
   it("strips mixed <think> and <final> tags from assistant content", () => {
@@ -101,6 +102,7 @@ describe("extractTextCached", () => {
       content: [{ type: "text", text: "<think>reasoning\n</think>\n\n<final>Hello</final>" }],
     };
     expect(extractText(message)).toBe("Hello");
+    expect(extractTextCached(message)).toBe("Hello");
   });
 
   it("strips <final> tags from assistant text property", () => {
@@ -109,6 +111,7 @@ describe("extractTextCached", () => {
       text: "<final>Hello world</final>",
     };
     expect(extractText(message)).toBe("Hello world");
+    expect(extractTextCached(message)).toBe("Hello world");
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses review feedback from [PR #65187](https://github.com/openclaw/openclaw/pull/65187) — specifically the Greptile P2 comment about missing `extractTextCached` assertions.

## Changes

- Added `expect(extractTextCached(message)).toBe(...)` to 3 of the 4 new regression tests that were missing it:
  - "strips multiline `<final>` blocks from assistant content"
  - "strips mixed `<think>` and `<final>` tags from assistant content"
  - "strips `<final>` tags from assistant text property"

The first new test already had both assertions correctly; the remaining three now match that pattern.

## Testing

All 4 new regression tests pass, including both `extractText` and `extractTextCached` assertions.

Related: openclaw/openclaw#65182