### PR TITLE
test(ui): cover nested qualified chat model refs

### DIFF
--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -234,6 +234,20 @@ describe("chat-model-ref helpers", () => {
     );
   });
 
+  it("keeps nested provider-qualified server values stable when the catalog already confirms them", () => {
+    const nestedModel = {
+      id: "deepseek-ai/deepseek-v3.2",
+      name: "DeepSeek V3.2",
+      provider: "nvidia",
+    };
+
+    expect(
+      resolvePreferredServerChatModelValue("nvidia/deepseek-ai/deepseek-v3.2", "nvidia", [
+        nestedModel,
+      ]),
+    ).toBe("nvidia/deepseek-ai/deepseek-v3.2");
+  });
+
   it("uses catalog resolution for provider-less raw server model values", () => {
     expect(resolvePreferredServerChatModelValue("gpt-5-mini", null, [OPENAI_GPT5_MINI_MODEL])).toBe(
       "openai/gpt-5-mini",


### PR DESCRIPTION
## Summary

Adds regression coverage for nested provider-qualified chat model refs in the Control UI.

## Why

The original slash-delimited provider-prefix fix is already present on current main. This follow-up PR keeps that behavior protected with an explicit regression test on top of current main.

## Testing

- [x] corepack pnpm --dir ui test src/ui/chat-model-ref.test.ts
