### PR TITLE
fix(agents): widen strict-agentic auto-activation for prefixed model IDs

### DIFF
--- a/src/agents/execution-contract.test.ts
+++ b/src/agents/execution-contract.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./agent-scope.js", () => ({
+  resolveAgentExecutionContract: () => "strict-agentic",
+  resolveSessionAgentIds: () => ({ sessionAgentId: "default" }),
+}));
+
+import { isStrictAgenticExecutionContractActive } from "./execution-contract.js";
+
+describe("isStrictAgenticExecutionContractActive", () => {
+  const base = { provider: "openai" };
+
+  describe("matches standard model IDs", () => {
+    it.each([
+      "gpt-5",
+      "gpt-5.4",
+      "gpt-5.4-2025-03",
+      "gpt-5-preview",
+      "gpt-5-turbo",
+      "gpt-5-mini",
+      "gpt-5o",
+      "GPT-5.4",
+    ])("activates for %s", (modelId) => {
+      expect(isStrictAgenticExecutionContractActive({ ...base, modelId })).toBe(true);
+    });
+  });
+
+  describe("matches prefixed model IDs", () => {
+    it.each([
+      "openai/gpt-5.4",
+      "openai:gpt-5.4",
+      "openai-codex/gpt-5",
+      "custom-provider/gpt-5o",
+    ])("activates for %s", (modelId) => {
+      expect(isStrictAgenticExecutionContractActive({ ...base, modelId })).toBe(true);
+    });
+  });
+
+  describe("does not match non-gpt-5 models", () => {
+    it.each([
+      "gpt-4.5",
+      "gpt-4o",
+      "gpt-6",
+      "claude-opus-4-6",
+      "gemini-2.5-pro",
+      "",
+      null,
+    ])("does not activate for %s", (modelId) => {
+      expect(isStrictAgenticExecutionContractActive({ ...base, modelId })).toBe(false);
+    });
+  });
+
+  describe("requires openai provider", () => {
+    it("does not activate for non-openai provider", () => {
+      expect(
+        isStrictAgenticExecutionContractActive({ provider: "anthropic", modelId: "gpt-5.4" }),
+      ).toBe(false);
+    });
+
+    it("activates for openai-codex provider", () => {
+      expect(
+        isStrictAgenticExecutionContractActive({ provider: "openai-codex", modelId: "gpt-5.4" }),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/agents/execution-contract.ts
+++ b/src/agents/execution-contract.ts
@@ -21,5 +21,7 @@ export function isStrictAgenticExecutionContractActive(params: {
   if (provider !== "openai" && provider !== "openai-codex") {
     return false;
   }
-  return /^gpt-5(?:[.-]|$)/i.test(params.modelId?.trim() ?? "");
+  const rawModelId = params.modelId?.trim() ?? "";
+  const modelId = rawModelId.replace(/^[^/:]+[/:]/, "");
+  return /^gpt-5(?:[.\-o]|$)/i.test(modelId);
 }


### PR DESCRIPTION
`isStrictAgenticExecutionContractActive` uses a `^`-anchored regex, so prefixed model IDs like `openai/gpt-5.4` or `openai:gpt-5.4` silently fail to match. Auto-activation doesn't fire and the model falls through to the looser default behavior.

The fix strips any `<provider>/` or `<provider>:` prefix before matching and widens the regex character class to cover the `gpt-5o` variant.

Added 21 test cases (this file had zero coverage before) pinning prefixed, unprefixed, variant, and negative cases per the acceptance criteria in #64886.

Fixes #64886
Part of #64227