### PR TITLE
gateway: always send idempotencyKey on plugin subagent run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ Docs: https://docs.openclaw.ai
 - Infra/net: fix multipart FormData fields (including `model`) being silently dropped when a guarded runtime fetch body crosses a FormData implementation boundary, restoring OpenAI audio transcription requests that failed with HTTP 400. (#64349) Thanks @petr-sloup.
 - Plugins/memory: restore cached memory capability public artifacts on plugin-registry cache hits so memory-backed artifact surfaces stay visible after warm loads. Thanks @sercada and @vincentkoc.
 - Gateway/cron: preserve requested isolated-agent config across runtime reloads so subagent jobs and heartbeat overrides keep the right workspace and heartbeat settings when the hot-loaded snapshot is stale. Thanks @l0cka and @vincentkoc.
-- Cron/isolated sessions: persist the right transcript path for each isolated run, including fresh session rollovers, so cron runs stop appending to stale session files. Thanks @samrusani and @vincentkoc.
 - Gateway/plugins: always send a non-empty `idempotencyKey` for plugin subagent runs, so dreaming narrative jobs stop failing gateway schema validation. (#65354) Thanks @CodeForgeNet and @vincentkoc.
+- Cron/isolated sessions: persist the right transcript path for each isolated run, including fresh session rollovers, so cron runs stop appending to stale session files. Thanks @samrusani and @vincentkoc.
 
 ## 2026.4.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/memory: restore cached memory capability public artifacts on plugin-registry cache hits so memory-backed artifact surfaces stay visible after warm loads. Thanks @sercada and @vincentkoc.
 - Gateway/cron: preserve requested isolated-agent config across runtime reloads so subagent jobs and heartbeat overrides keep the right workspace and heartbeat settings when the hot-loaded snapshot is stale. Thanks @l0cka and @vincentkoc.
 - Cron/isolated sessions: persist the right transcript path for each isolated run, including fresh session rollovers, so cron runs stop appending to stale session files. Thanks @samrusani and @vincentkoc.
+- Gateway/plugins: always send a non-empty `idempotencyKey` for plugin subagent runs, so dreaming narrative jobs stop failing gateway schema validation. (#65354) Thanks @CodeForgeNet and @vincentkoc.
 
 ## 2026.4.11
 

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -556,6 +556,46 @@ describe("loadGatewayPlugins", () => {
     });
   });
 
+  test("forwards caller-supplied idempotencyKey on subagent run", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("idempotency-forward"));
+
+    await runtime.run({
+      sessionKey: "s-idem-forward",
+      message: "hello",
+      deliver: false,
+      idempotencyKey: "caller-provided-key",
+    });
+
+    expect(getLastDispatchedParams()).toMatchObject({
+      sessionKey: "s-idem-forward",
+      message: "hello",
+      idempotencyKey: "caller-provided-key",
+    });
+  });
+
+  test("generates a non-empty idempotencyKey when the caller omits it", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    serverPlugins.setFallbackGatewayContext(createTestContext("idempotency-generate"));
+
+    await runtime.run({
+      sessionKey: "s-idem-generate",
+      message: "hello",
+      deliver: false,
+    });
+
+    const params = getLastDispatchedParams();
+    expect(params).toBeDefined();
+    // The gateway `agent` schema requires `idempotencyKey: NonEmptyString`, so
+    // the runtime must always send a populated value. A missing field here
+    // would reproduce the memory-core dreaming-narrative regression.
+    const generated = params?.idempotencyKey;
+    expect(typeof generated).toBe("string");
+    expect((generated as string).length).toBeGreaterThan(0);
+  });
+
   test("rejects provider/model overrides for fallback runs without explicit authorization", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -338,7 +338,11 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
           ...(allowOverride && params.model && { model: params.model }),
           ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
           ...(params.lane && { lane: params.lane }),
-          ...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
+          // The gateway `agent` schema requires `idempotencyKey: NonEmptyString`,
+          // so fall back to a generated UUID when the caller omits it. Without
+          // this, plugin subagent runs (for example memory-core dreaming
+          // narrative) silently fail schema validation at the gateway.
+          idempotencyKey: params.idempotencyKey || randomUUID(),
         },
         {
           allowSyntheticModelOverride,


### PR DESCRIPTION
## Summary

Fixes #65341.

`createGatewaySubagentRuntime().run()` in `src/gateway/server-plugins.ts` was using a conditional spread to forward `idempotencyKey`:

```ts
...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
Because SubagentRunParams.idempotencyKey is optional on the plugin-facing side, callers that omit it would produce an agent request with no idempotencyKey field. But the gateway agent method schema requires idempotencyKey: NonEmptyString (src/gateway/protocol/schema/agent.ts:158), so the request silently fails schema validation at the gateway boundary — memory-core dreaming narrative never runs and there's no clear signal.
```

Fix
Always forward idempotencyKey, falling back to randomUUID() (already imported from node:crypto) when the caller omits it:


idempotencyKey: params.idempotencyKey || randomUUID(),
This preserves the existing contract for callers that pass their own key (for example memory-core passes params.sessionKey) and makes the runtime robust for every other plugin path.

Tests
Added two regression tests in src/gateway/server-plugins.test.ts:

Forwards caller-supplied idempotencyKey — confirms the caller's key is sent unchanged to the gateway agent method.
Generates a non-empty idempotencyKey when the caller omits it — would fail against the old conditional-spread behavior. Guards against the exact schema-validation regression described in the issue.
Test plan
 pnpm test src/gateway/server-plugins.test.ts — 35/35 pass (including 2 new)
 pnpm tsgo
 Scoped oxlint on touched files — 0 warnings / 0 errors
 Manual smoke: run memory-core dreaming narrative end-to-end against a real gateway
Files changed
src/gateway/server-plugins.ts — replace conditional spread with always-present idempotencyKey + UUID fallback
src/gateway/server-plugins.test.ts — two new regression tests