### PR TITLE
feat(skills): add tier frontmatter field for skill catalog priority

### DIFF
--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -22,11 +22,20 @@ function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/S
   });
 }
 
-function makeEntry(skill: Skill, opts?: { always?: boolean }): SkillEntry {
+function makeEntry(
+  skill: Skill,
+  opts?: { always?: boolean; tier?: "always" | "discoverable" | string },
+): SkillEntry {
   return {
     skill,
     frontmatter: {},
-    metadata: opts?.always !== undefined ? { always: opts.always } : undefined,
+    metadata:
+      opts?.always !== undefined || opts?.tier !== undefined
+        ? {
+            always: opts?.always,
+            tier: opts?.tier as "always" | "discoverable" | undefined,
+          }
+        : undefined,
     exposure: {
       includeInRuntimeRegistry: true,
       includeInAvailableSkillsPrompt: true,
@@ -455,5 +464,142 @@ describe("mixed-tier prompt integration", () => {
     expect(prompt2).toContain("<description>");
     expect(prompt1).not.toContain("mixed-tier");
     expect(prompt2).not.toContain("mixed-tier");
+  });
+});
+
+describe("tier frontmatter field", () => {
+  function buildPromptWithEntries(
+    entries: SkillEntry[],
+    limits: { maxChars?: number; maxCount?: number } = {},
+  ): string {
+    return buildWorkspaceSkillsPrompt("/fake", {
+      entries,
+      config: {
+        skills: {
+          limits: {
+            ...(limits.maxChars !== undefined && { maxSkillsPromptChars: limits.maxChars }),
+            ...(limits.maxCount !== undefined && { maxSkillsInPrompt: limits.maxCount }),
+          },
+        },
+      } satisfies OpenClawConfig,
+    });
+  }
+
+  it('tier: "always" causes skill to be in the always group', () => {
+    const alwaysSkills = Array.from({ length: 3 }, (_, i) =>
+      makeSkill(`always-${i}`, "A".repeat(200)),
+    );
+    const discSkills = Array.from({ length: 20 }, (_, i) =>
+      makeSkill(`disc-${i}`, "B".repeat(200)),
+    );
+    const entries = [
+      ...alwaysSkills.map((s) => makeEntry(s, { tier: "always" })),
+      ...discSkills.map((s) => makeEntry(s)),
+    ];
+    const allSkills = [...alwaysSkills, ...discSkills];
+    const fullLen = formatSkillsForPrompt(allSkills).length;
+    const mixedLen = formatSkillsMixedTier({
+      always: alwaysSkills,
+      discoverable: discSkills,
+    }).length;
+    const budget = Math.floor((fullLen + mixedLen) / 2) + 150;
+    expect(fullLen).toBeGreaterThan(budget);
+    expect(mixedLen + 150).toBeLessThan(budget);
+
+    const prompt = buildPromptWithEntries(entries, { maxChars: budget });
+    // always-tier skills keep descriptions
+    expect(prompt).toContain("always-0");
+    expect(prompt).toContain("A".repeat(200));
+    // discoverable skills lose descriptions
+    expect(prompt).toContain("disc-0");
+    expect(prompt).not.toContain("B".repeat(200));
+    expect(prompt).toContain("mixed-tier format");
+  });
+
+  it('tier: "discoverable" overrides always: true', () => {
+    const alwaysSkills = Array.from({ length: 3 }, (_, i) =>
+      makeSkill(`always-${i}`, "A".repeat(200)),
+    );
+    const discSkills = Array.from({ length: 20 }, (_, i) =>
+      makeSkill(`disc-${i}`, "B".repeat(200)),
+    );
+    // disc skills have always: true BUT tier: "discoverable" — tier wins
+    const entries = [
+      ...alwaysSkills.map((s) => makeEntry(s, { always: true })),
+      ...discSkills.map((s) => makeEntry(s, { always: true, tier: "discoverable" })),
+    ];
+    const allSkills = [...alwaysSkills, ...discSkills];
+    const fullLen = formatSkillsForPrompt(allSkills).length;
+    const mixedLen = formatSkillsMixedTier({
+      always: alwaysSkills,
+      discoverable: discSkills,
+    }).length;
+    const budget = Math.floor((fullLen + mixedLen) / 2) + 150;
+    expect(fullLen).toBeGreaterThan(budget);
+    expect(mixedLen + 150).toBeLessThan(budget);
+
+    const prompt = buildPromptWithEntries(entries, { maxChars: budget });
+    // always-tier skills (only 3 with always:true, no tier override)
+    expect(prompt).toContain("A".repeat(200));
+    // disc skills had always:true overridden by tier:"discoverable" → no description
+    expect(prompt).not.toContain("B".repeat(200));
+    expect(prompt).toContain("mixed-tier format");
+  });
+
+  it("without tier, always: true still works (backward compat)", () => {
+    const alwaysSkills = Array.from({ length: 3 }, (_, i) =>
+      makeSkill(`always-${i}`, "A".repeat(200)),
+    );
+    const discSkills = Array.from({ length: 20 }, (_, i) =>
+      makeSkill(`disc-${i}`, "B".repeat(200)),
+    );
+    // No tier field, just always: true
+    const entries = [
+      ...alwaysSkills.map((s) => makeEntry(s, { always: true })),
+      ...discSkills.map((s) => makeEntry(s, { always: false })),
+    ];
+    const allSkills = [...alwaysSkills, ...discSkills];
+    const fullLen = formatSkillsForPrompt(allSkills).length;
+    const mixedLen = formatSkillsMixedTier({
+      always: alwaysSkills,
+      discoverable: discSkills,
+    }).length;
+    const budget = Math.floor((fullLen + mixedLen) / 2) + 150;
+    expect(fullLen).toBeGreaterThan(budget);
+    expect(mixedLen + 150).toBeLessThan(budget);
+
+    const prompt = buildPromptWithEntries(entries, { maxChars: budget });
+    expect(prompt).toContain("A".repeat(200));
+    expect(prompt).not.toContain("B".repeat(200));
+    expect(prompt).toContain("mixed-tier format");
+  });
+
+  it("invalid tier value is ignored, falls back to always boolean", () => {
+    const alwaysSkills = Array.from({ length: 3 }, (_, i) =>
+      makeSkill(`always-${i}`, "A".repeat(200)),
+    );
+    const discSkills = Array.from({ length: 20 }, (_, i) =>
+      makeSkill(`disc-${i}`, "B".repeat(200)),
+    );
+    // Invalid tier value + always: true → should still be treated as always
+    const entries = [
+      ...alwaysSkills.map((s) => makeEntry(s, { always: true, tier: "invalid" })),
+      ...discSkills.map((s) => makeEntry(s, { always: false })),
+    ];
+    const allSkills = [...alwaysSkills, ...discSkills];
+    const fullLen = formatSkillsForPrompt(allSkills).length;
+    const mixedLen = formatSkillsMixedTier({
+      always: alwaysSkills,
+      discoverable: discSkills,
+    }).length;
+    const budget = Math.floor((fullLen + mixedLen) / 2) + 150;
+    expect(fullLen).toBeGreaterThan(budget);
+    expect(mixedLen + 150).toBeLessThan(budget);
+
+    const prompt = buildPromptWithEntries(entries, { maxChars: budget });
+    // Invalid tier falls back to always: true → descriptions kept
+    expect(prompt).toContain("A".repeat(200));
+    expect(prompt).not.toContain("B".repeat(200));
+    expect(prompt).toContain("mixed-tier format");
   });
 });

--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createCanonicalFixtureSkill } from "../skills.test-helpers.js";
 import { formatSkillsForPrompt, type Skill } from "./skill-contract.js";
+import { formatSkillsMixedTier } from "./skill-contract.js";
 import type { SkillEntry } from "./types.js";
 import {
   formatSkillsCompact,
@@ -21,10 +22,11 @@ function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/S
   });
 }
 
-function makeEntry(skill: Skill): SkillEntry {
+function makeEntry(skill: Skill, opts?: { always?: boolean }): SkillEntry {
   return {
     skill,
     frontmatter: {},
+    metadata: opts?.always !== undefined ? { always: opts.always } : undefined,
     exposure: {
       includeInRuntimeRegistry: true,
       includeInAvailableSkillsPrompt: true,
@@ -38,7 +40,7 @@ function buildPrompt(
   limits: { maxChars?: number; maxCount?: number } = {},
 ): string {
   return buildWorkspaceSkillsPrompt("/fake", {
-    entries: skills.map(makeEntry),
+    entries: skills.map((s) => makeEntry(s)),
     config: {
       skills: {
         limits: {
@@ -264,7 +266,7 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
       makeSkill(`skill-${i}`, "A skill", `${home}/.openclaw/workspace/skills/skill-${i}/SKILL.md`),
     );
     const snapshot = buildWorkspaceSkillSnapshot("/fake", {
-      entries: skills.map(makeEntry),
+      entries: skills.map((s) => makeEntry(s)),
     });
     // Prompt should use compacted paths
     expect(snapshot.prompt).toContain("~/");
@@ -274,5 +276,184 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
       expect(skill.filePath).toContain(home);
       expect(skill.filePath).not.toMatch(/^~\//);
     }
+  });
+});
+
+describe("formatSkillsMixedTier", () => {
+  it("returns empty string when both arrays empty", () => {
+    expect(formatSkillsMixedTier({ always: [], discoverable: [] })).toBe("");
+  });
+
+  it("includes description for always skills, omits for discoverable", () => {
+    const always = [makeSkill("core", "Core skill description")];
+    const discoverable = [makeSkill("optional", "Optional skill description")];
+    const out = formatSkillsMixedTier({ always, discoverable });
+    expect(out).toContain("<name>core</name>");
+    expect(out).toContain("<description>Core skill description</description>");
+    expect(out).toContain("<name>optional</name>");
+    expect(out).toContain("<location>/skills/optional/SKILL.md</location>");
+    expect(out).not.toContain("Optional skill description");
+  });
+
+  it("renders only always skills when discoverable is empty", () => {
+    const always = [makeSkill("core", "Core description")];
+    const out = formatSkillsMixedTier({ always, discoverable: [] });
+    expect(out).toContain("<name>core</name>");
+    expect(out).toContain("<description>Core description</description>");
+    expect(out).toContain("<available_skills>");
+  });
+
+  it("renders only discoverable skills when always is empty", () => {
+    const discoverable = [makeSkill("opt", "Opt desc")];
+    const out = formatSkillsMixedTier({ always: [], discoverable });
+    expect(out).toContain("<name>opt</name>");
+    expect(out).not.toContain("<description>");
+  });
+
+  it("escapes XML special characters in both tiers", () => {
+    const always = [makeSkill("a<b", "desc & more")];
+    const discoverable = [makeSkill("c>d")];
+    const out = formatSkillsMixedTier({ always, discoverable });
+    expect(out).toContain("a&lt;b");
+    expect(out).toContain("desc &amp; more");
+    expect(out).toContain("c&gt;d");
+  });
+
+  it("is smaller than full format but larger than compact", () => {
+    const always = Array.from({ length: 5 }, (_, i) =>
+      makeSkill(`always-${i}`, "A moderately long description for always-tier skills"),
+    );
+    const discoverable = Array.from({ length: 20 }, (_, i) =>
+      makeSkill(`disc-${i}`, "A moderately long description for discoverable-tier skills"),
+    );
+    const all = [...always, ...discoverable];
+    const fullLen = formatSkillsForPrompt(all).length;
+    const compactLen = formatSkillsCompact(all).length;
+    const mixedLen = formatSkillsMixedTier({ always, discoverable }).length;
+    expect(mixedLen).toBeLessThan(fullLen);
+    expect(mixedLen).toBeGreaterThan(compactLen);
+  });
+});
+
+describe("mixed-tier prompt integration", () => {
+  function buildPromptWithEntries(
+    entries: SkillEntry[],
+    limits: { maxChars?: number; maxCount?: number } = {},
+  ): string {
+    return buildWorkspaceSkillsPrompt("/fake", {
+      entries,
+      config: {
+        skills: {
+          limits: {
+            ...(limits.maxChars !== undefined && { maxSkillsPromptChars: limits.maxChars }),
+            ...(limits.maxCount !== undefined && { maxSkillsInPrompt: limits.maxCount }),
+          },
+        },
+      } satisfies OpenClawConfig,
+    });
+  }
+
+  it("uses mixed-tier when full exceeds budget but mixed fits", () => {
+    const alwaysSkills = Array.from({ length: 3 }, (_, i) =>
+      makeSkill(`always-${i}`, "A".repeat(200)),
+    );
+    const discSkills = Array.from({ length: 20 }, (_, i) =>
+      makeSkill(`disc-${i}`, "B".repeat(200)),
+    );
+    const entries = [
+      ...alwaysSkills.map((s) => makeEntry(s, { always: true })),
+      ...discSkills.map((s) => makeEntry(s, { always: false })),
+    ];
+    const allSkills = [...alwaysSkills, ...discSkills];
+    const fullLen = formatSkillsForPrompt(allSkills).length;
+    const mixedLen = formatSkillsMixedTier({
+      always: alwaysSkills,
+      discoverable: discSkills,
+    }).length;
+    // Budget between mixed and full
+    const budget = Math.floor((fullLen + mixedLen) / 2) + 150;
+    expect(fullLen).toBeGreaterThan(budget);
+    expect(mixedLen + 150).toBeLessThan(budget);
+
+    const prompt = buildPromptWithEntries(entries, { maxChars: budget });
+    // always skills keep descriptions
+    expect(prompt).toContain("always-0");
+    expect(prompt).toContain("A".repeat(200));
+    // discoverable skills lose descriptions
+    expect(prompt).toContain("disc-0");
+    expect(prompt).not.toContain("B".repeat(200));
+    expect(prompt).toContain("mixed-tier format");
+  });
+
+  it("falls through to compact when mixed also exceeds budget", () => {
+    const alwaysSkills = Array.from({ length: 10 }, (_, i) =>
+      makeSkill(`always-${i}`, "A".repeat(200)),
+    );
+    const discSkills = Array.from({ length: 10 }, (_, i) =>
+      makeSkill(`disc-${i}`, "B".repeat(200)),
+    );
+    const entries = [
+      ...alwaysSkills.map((s) => makeEntry(s, { always: true })),
+      ...discSkills.map((s) => makeEntry(s, { always: false })),
+    ];
+    const allSkills = [...alwaysSkills, ...discSkills];
+    const compactLen = formatSkillsCompact(allSkills).length;
+    const mixedLen = formatSkillsMixedTier({
+      always: alwaysSkills,
+      discoverable: discSkills,
+    }).length;
+    // Budget below mixed but above compact
+    const budget = Math.floor((compactLen + mixedLen) / 2) + 150;
+    expect(mixedLen).toBeGreaterThan(budget);
+    expect(compactLen + 150).toBeLessThan(budget);
+
+    const prompt = buildPromptWithEntries(entries, { maxChars: budget });
+    expect(prompt).not.toContain("<description>");
+    expect(prompt).toContain("compact format");
+    expect(prompt).not.toContain("mixed-tier");
+  });
+
+  it("skips mixed-tier when no skills have always=true", () => {
+    const skills = Array.from({ length: 20 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
+    const entries = skills.map((s) => makeEntry(s));
+    const fullLen = formatSkillsForPrompt(skills).length;
+    const compactLen = formatSkillsCompact(skills).length;
+    const budget = Math.floor((fullLen + compactLen) / 2);
+    expect(fullLen).toBeGreaterThan(budget);
+    expect(compactLen + 150).toBeLessThan(budget);
+
+    const prompt = buildPromptWithEntries(entries, { maxChars: budget });
+    // Should go straight to compact, not mixed
+    expect(prompt).toContain("compact format");
+    expect(prompt).not.toContain("mixed-tier");
+  });
+
+  it("skips mixed-tier when all skills have always=true", () => {
+    const skills = Array.from({ length: 20 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
+    const entries = skills.map((s) => makeEntry(s, { always: true }));
+    const fullLen = formatSkillsForPrompt(skills).length;
+    const compactLen = formatSkillsCompact(skills).length;
+    const budget = Math.floor((fullLen + compactLen) / 2);
+
+    const prompt = buildPromptWithEntries(entries, { maxChars: budget });
+    // All always → no discoverable → can't use mixed, falls to compact
+    expect(prompt).toContain("compact format");
+    expect(prompt).not.toContain("mixed-tier");
+  });
+
+  it("behavior identical to before when no entries have metadata.always", () => {
+    const skills = Array.from({ length: 5 }, (_, i) => makeSkill(`skill-${i}`, "short desc"));
+    const entriesWithout = skills.map((s) => makeEntry(s));
+    const entriesUndefined = skills.map((s) => ({
+      ...makeEntry(s),
+      metadata: undefined,
+    }));
+    const prompt1 = buildPromptWithEntries(entriesWithout, { maxChars: 50_000 });
+    const prompt2 = buildPromptWithEntries(entriesUndefined, { maxChars: 50_000 });
+    // Both should produce full format with descriptions
+    expect(prompt1).toContain("<description>");
+    expect(prompt2).toContain("<description>");
+    expect(prompt1).not.toContain("mixed-tier");
+    expect(prompt2).not.toContain("mixed-tier");
   });
 });

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -194,8 +194,11 @@ export function resolveOpenClawMetadata(
   const requires = resolveOpenClawManifestRequires(metadataObj);
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
+  const tierRaw = readStringValue(metadataObj.tier);
+  const tier = tierRaw === "always" || tierRaw === "discoverable" ? tierRaw : undefined;
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
+    tier,
     emoji: readStringValue(metadataObj.emoji),
     homepage: readStringValue(metadataObj.homepage),
     skillKey: readStringValue(metadataObj.skillKey),

--- a/src/agents/skills/skill-contract.ts
+++ b/src/agents/skills/skill-contract.ts
@@ -62,3 +62,37 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
   lines.push("</available_skills>");
   return lines.join("\n");
 }
+
+/**
+ * Mixed-tier skill catalog: "always" skills get the full format (name +
+ * description + location) while "discoverable" skills get the compact
+ * format (name + location only). Shares the same XML structure and header
+ * text as {@link formatSkillsForPrompt}.
+ */
+export function formatSkillsMixedTier(tiers: { always: Skill[]; discoverable: Skill[] }): string {
+  if (tiers.always.length === 0 && tiers.discoverable.length === 0) {
+    return "";
+  }
+  const lines = [
+    "\n\nThe following skills provide specialized instructions for specific tasks.",
+    "Use the read tool to load a skill's file when the task matches its description.",
+    "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
+    "",
+    "<available_skills>",
+  ];
+  for (const skill of tiers.always) {
+    lines.push("  <skill>");
+    lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+    lines.push(`    <description>${escapeXml(skill.description)}</description>`);
+    lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+    lines.push("  </skill>");
+  }
+  for (const skill of tiers.discoverable) {
+    lines.push("  <skill>");
+    lines.push(`    <name>${escapeXml(skill.name)}</name>`);
+    lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+    lines.push("  </skill>");
+  }
+  lines.push("</available_skills>");
+  return lines.join("\n");
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -18,6 +18,7 @@ export type SkillInstallSpec = {
 
 export type OpenClawSkillMetadata = {
   always?: boolean;
+  tier?: "always" | "discoverable";
   skillKey?: string;
   primaryEnv?: string;
   emoji?: string;

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -533,6 +533,13 @@ export function formatSkillsCompact(skills: Skill[]): string {
 // Budget reserved for the compact-mode warning line prepended by the caller.
 const COMPACT_WARNING_OVERHEAD = 150;
 
+// tier field takes precedence over always boolean
+function isAlwaysTier(entry: SkillEntry): boolean {
+  if (entry.metadata?.tier === "always") return true;
+  if (entry.metadata?.tier === "discoverable") return false;
+  return entry.metadata?.always === true;
+}
+
 function applySkillsPromptLimits(params: {
   skills: Skill[];
   config?: OpenClawConfig;
@@ -572,7 +579,7 @@ function applySkillsPromptLimits(params: {
         if (!entryNames.has(entry.skill.name)) continue;
         const matched = skillsForPrompt.find((s) => s.name === entry.skill.name);
         if (!matched) continue;
-        if (entry.metadata?.always === true) {
+        if (isAlwaysTier(entry)) {
           alwaysSkills.push(matched);
         } else {
           discoverableSkills.push(matched);
@@ -701,7 +708,7 @@ function resolveWorkspaceSkillPromptState(
   if (mixed) {
     // Split prompt skills back into always / discoverable based on entry metadata.
     const alwaysNames = new Set(
-      promptEntries.filter((e) => e.metadata?.always === true).map((e) => e.skill.name),
+      promptEntries.filter((e) => isAlwaysTier(e)).map((e) => e.skill.name),
     );
     const always: Skill[] = [];
     const discoverable: Skill[] = [];

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -15,7 +15,7 @@ import { resolveOpenClawMetadata, resolveSkillInvocationPolicy } from "./frontma
 import { loadSkillsFromDirSafe, readSkillFrontmatterSafe } from "./local-loader.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
-import { formatSkillsForPrompt, type Skill } from "./skill-contract.js";
+import { formatSkillsForPrompt, formatSkillsMixedTier, type Skill } from "./skill-contract.js";
 import type {
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
@@ -533,10 +533,15 @@ export function formatSkillsCompact(skills: Skill[]): string {
 // Budget reserved for the compact-mode warning line prepended by the caller.
 const COMPACT_WARNING_OVERHEAD = 150;
 
-function applySkillsPromptLimits(params: { skills: Skill[]; config?: OpenClawConfig }): {
+function applySkillsPromptLimits(params: {
+  skills: Skill[];
+  config?: OpenClawConfig;
+  entries?: SkillEntry[];
+}): {
   skillsForPrompt: Skill[];
   truncated: boolean;
   compact: boolean;
+  mixed: boolean;
 } {
   const limits = resolveSkillsLimits(params.config);
   const total = params.skills.length;
@@ -545,40 +550,72 @@ function applySkillsPromptLimits(params: { skills: Skill[]; config?: OpenClawCon
   let skillsForPrompt = byCount;
   let truncated = total > byCount.length;
   let compact = false;
+  let mixed = false;
 
   const fitsFull = (skills: Skill[]): boolean =>
     formatSkillsForPrompt(skills).length <= limits.maxSkillsPromptChars;
 
-  // Reserve space for the warning line the caller prepends in compact mode.
+  // Reserve space for the warning line the caller prepends in compact/mixed mode.
   const compactBudget = limits.maxSkillsPromptChars - COMPACT_WARNING_OVERHEAD;
   const fitsCompact = (skills: Skill[]): boolean =>
     formatSkillsCompact(skills).length <= compactBudget;
 
   if (!fitsFull(skillsForPrompt)) {
-    // Full format exceeds budget. Try compact (name + location, no description)
-    // to preserve awareness of all skills before dropping any.
-    if (fitsCompact(skillsForPrompt)) {
-      compact = true;
-      // No skills dropped — only format downgraded. Preserve existing truncated state.
-    } else {
-      // Compact still too large — binary search the largest prefix that fits.
-      compact = true;
-      let lo = 0;
-      let hi = skillsForPrompt.length;
-      while (lo < hi) {
-        const mid = Math.ceil((lo + hi) / 2);
-        if (fitsCompact(skillsForPrompt.slice(0, mid))) {
-          lo = mid;
+    // Full format exceeds budget. Try mixed-tier first if we have entries
+    // with metadata.always split, then fall through to compact.
+    let mixedFits = false;
+    if (params.entries && params.entries.length > 0) {
+      const entryNames = new Set(skillsForPrompt.map((s) => s.name));
+      const alwaysSkills: Skill[] = [];
+      const discoverableSkills: Skill[] = [];
+      for (const entry of params.entries) {
+        if (!entryNames.has(entry.skill.name)) continue;
+        const matched = skillsForPrompt.find((s) => s.name === entry.skill.name);
+        if (!matched) continue;
+        if (entry.metadata?.always === true) {
+          alwaysSkills.push(matched);
         } else {
-          hi = mid - 1;
+          discoverableSkills.push(matched);
         }
       }
-      skillsForPrompt = skillsForPrompt.slice(0, lo);
-      truncated = true;
+      if (alwaysSkills.length > 0 && discoverableSkills.length > 0) {
+        const mixedOutput = formatSkillsMixedTier({
+          always: alwaysSkills,
+          discoverable: discoverableSkills,
+        });
+        if (mixedOutput.length <= compactBudget) {
+          mixed = true;
+          mixedFits = true;
+        }
+      }
+    }
+
+    if (!mixedFits) {
+      // Mixed didn't apply or didn't fit. Try compact (name + location, no
+      // description) to preserve awareness of all skills before dropping any.
+      if (fitsCompact(skillsForPrompt)) {
+        compact = true;
+        // No skills dropped — only format downgraded. Preserve existing truncated state.
+      } else {
+        // Compact still too large — binary search the largest prefix that fits.
+        compact = true;
+        let lo = 0;
+        let hi = skillsForPrompt.length;
+        while (lo < hi) {
+          const mid = Math.ceil((lo + hi) / 2);
+          if (fitsCompact(skillsForPrompt.slice(0, mid))) {
+            lo = mid;
+          } else {
+            hi = mid - 1;
+          }
+        }
+        skillsForPrompt = skillsForPrompt.slice(0, lo);
+        truncated = true;
+      }
     }
   }
 
-  return { skillsForPrompt, truncated, compact };
+  return { skillsForPrompt, truncated, compact, mixed };
 }
 
 export function buildWorkspaceSkillSnapshot(
@@ -654,22 +691,42 @@ function resolveWorkspaceSkillPromptState(
   // tier decision is based on the exact strings that end up in the prompt.
   // resolvedSkills keeps canonical paths for snapshot / runtime consumers.
   const promptSkills = compactSkillPaths(resolvedSkills);
-  const { skillsForPrompt, truncated, compact } = applySkillsPromptLimits({
+  const { skillsForPrompt, truncated, compact, mixed } = applySkillsPromptLimits({
     skills: promptSkills,
     config: opts?.config,
+    entries: promptEntries,
   });
+
+  let formattedBlock: string;
+  if (mixed) {
+    // Split prompt skills back into always / discoverable based on entry metadata.
+    const alwaysNames = new Set(
+      promptEntries.filter((e) => e.metadata?.always === true).map((e) => e.skill.name),
+    );
+    const always: Skill[] = [];
+    const discoverable: Skill[] = [];
+    for (const s of skillsForPrompt) {
+      if (alwaysNames.has(s.name)) {
+        always.push(s);
+      } else {
+        discoverable.push(s);
+      }
+    }
+    formattedBlock = formatSkillsMixedTier({ always, discoverable });
+  } else if (compact) {
+    formattedBlock = formatSkillsCompact(skillsForPrompt);
+  } else {
+    formattedBlock = formatSkillsForPrompt(skillsForPrompt);
+  }
+
   const truncationNote = truncated
-    ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}${compact ? " (compact format, descriptions omitted)" : ""}. Run \`openclaw skills check\` to audit.`
+    ? `⚠️ Skills truncated: included ${skillsForPrompt.length} of ${resolvedSkills.length}${compact ? " (compact format, descriptions omitted)" : mixed ? " (mixed-tier format)" : ""}. Run \`openclaw skills check\` to audit.`
     : compact
       ? `⚠️ Skills catalog using compact format (descriptions omitted). Run \`openclaw skills check\` to audit.`
-      : "";
-  const prompt = [
-    remoteNote,
-    truncationNote,
-    compact ? formatSkillsCompact(skillsForPrompt) : formatSkillsForPrompt(skillsForPrompt),
-  ]
-    .filter(Boolean)
-    .join("\n");
+      : mixed
+        ? `⚠️ Skills catalog using mixed-tier format (some descriptions omitted). Run \`openclaw skills check\` to audit.`
+        : "";
+  const prompt = [remoteNote, truncationNote, formattedBlock].filter(Boolean).join("\n");
   return { eligible, prompt, resolvedSkills };
 }
 


### PR DESCRIPTION
## Summary

Adds a `tier` frontmatter field to SKILL.md metadata, providing a cleaner semantic alternative to the boolean `always` field for controlling skill catalog placement.

## Changes

- **`types.ts`** — Added `tier?: "always" | "discoverable"` to `OpenClawSkillMetadata`
- **`frontmatter.ts`** — Parse `tier` string value, validate against allowed values
- **`workspace.ts`** — New `isAlwaysTier()` helper with precedence: `tier` field wins over `always` boolean; backward compatible fallback
- **`compact-format.test.ts`** — 4 new tests covering tier parsing, override behavior, backward compat, and invalid value handling

## Motivation

The current `always: true/false` boolean is functional but lacks expressiveness. As skill catalogs grow, a named tier field (`"always"` vs `"discoverable"`) is more readable in SKILL.md frontmatter and opens the door for future tiers without boolean proliferation.

## Backward Compatibility

Fully backward compatible:
- Skills with only `always: true` continue to work identically
- `tier` takes precedence when both are present
- Invalid `tier` values silently fall back to `always` boolean behavior

## Tests

33/33 tests pass (29 existing + 4 new). No existing behavior changed.