### PR TITLE
fix(gateway): defer cron/heartbeat activation until sidecars ready (#65322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/startup: defer heartbeat, cron, and pending delivery recovery until sidecars finish so Sandbox wake and chat history startup gates cannot block channel resume. (#65365) Thanks @lml2468.
+
 ## 2026.4.12-beta.1
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Gateway/startup: defer heartbeat, cron, and pending delivery recovery until sidecars finish so Sandbox wake and chat history startup gates cannot block channel resume. (#65365) Thanks @lml2468.
+- Gateway/startup: defer scheduled services until sidecars finish, gate chat history and model listing during sidecar resume, and let Control UI retry startup-gated history loads so Sandbox wake resumes channels first. (#65365) Thanks @lml2468.
 
 ## 2026.4.12-beta.1
 

--- a/src/gateway/server-methods.control-plane-rate-limit.test.ts
+++ b/src/gateway/server-methods.control-plane-rate-limit.test.ts
@@ -139,11 +139,11 @@ describe("gateway control-plane write rate limit", () => {
     };
     const context = {
       ...buildContext(),
-      unavailableGatewayMethods: new Set(["chat.history"]),
+      unavailableGatewayMethods: new Set(["chat.history", "models.list"]),
     } as Parameters<typeof handleGatewayRequest>[0]["context"];
     const client = buildClient();
 
-    const blocked = await runRequest({ method: "chat.history", context, client, handler });
+    const blocked = await runRequest({ method: "models.list", context, client, handler });
 
     expect(handlerCalls).not.toHaveBeenCalled();
     expect(blocked).toHaveBeenCalledWith(
@@ -152,6 +152,8 @@ describe("gateway control-plane write rate limit", () => {
       expect.objectContaining({
         code: "UNAVAILABLE",
         retryable: true,
+        retryAfterMs: 500,
+        details: { method: "models.list" },
       }),
     );
   });

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -114,6 +114,7 @@ export async function handleGatewayRequest(
       undefined,
       errorShape(ErrorCodes.UNAVAILABLE, `${req.method} unavailable during gateway startup`, {
         retryable: true,
+        retryAfterMs: 500,
         details: { method: req.method },
       }),
     );

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const heartbeatRunner = {
+    stop: vi.fn(),
+    updateConfig: vi.fn(),
+  };
+  return {
+    heartbeatRunner,
+    startHeartbeatRunner: vi.fn(() => heartbeatRunner),
+    startChannelHealthMonitor: vi.fn(() => ({ stop: vi.fn() })),
+    startGatewayModelPricingRefresh: vi.fn(() => vi.fn()),
+    recoverPendingDeliveries: vi.fn(async () => undefined),
+    deliverOutboundPayloads: vi.fn(),
+  };
+});
+
+vi.mock("../infra/heartbeat-runner.js", () => ({
+  startHeartbeatRunner: hoisted.startHeartbeatRunner,
+}));
+
+vi.mock("../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: hoisted.deliverOutboundPayloads,
+}));
+
+vi.mock("../infra/outbound/delivery-queue.js", () => ({
+  recoverPendingDeliveries: hoisted.recoverPendingDeliveries,
+}));
+
+vi.mock("./channel-health-monitor.js", () => ({
+  startChannelHealthMonitor: hoisted.startChannelHealthMonitor,
+}));
+
+vi.mock("./model-pricing-cache.js", () => ({
+  startGatewayModelPricingRefresh: hoisted.startGatewayModelPricingRefresh,
+}));
+
+const { activateGatewayScheduledServices, startGatewayRuntimeServices } =
+  await import("./server-runtime-services.js");
+
+describe("server-runtime-services", () => {
+  beforeEach(() => {
+    hoisted.heartbeatRunner.stop.mockClear();
+    hoisted.heartbeatRunner.updateConfig.mockClear();
+    hoisted.startHeartbeatRunner.mockClear();
+    hoisted.startChannelHealthMonitor.mockClear();
+    hoisted.startGatewayModelPricingRefresh.mockClear();
+    hoisted.recoverPendingDeliveries.mockClear();
+    hoisted.deliverOutboundPayloads.mockClear();
+  });
+
+  it("keeps scheduled services inert during initial runtime setup", () => {
+    const services = startGatewayRuntimeServices({
+      minimalTestGateway: false,
+      cfgAtStart: {} as never,
+      channelManager: {
+        getRuntimeSnapshot: vi.fn(),
+        isHealthMonitorEnabled: vi.fn(),
+        isManuallyStopped: vi.fn(),
+      } as never,
+      log: createLog(),
+    });
+
+    expect(hoisted.startChannelHealthMonitor).toHaveBeenCalledTimes(1);
+    expect(hoisted.startHeartbeatRunner).not.toHaveBeenCalled();
+    expect(hoisted.recoverPendingDeliveries).not.toHaveBeenCalled();
+
+    services.heartbeatRunner.stop();
+    expect(hoisted.heartbeatRunner.stop).not.toHaveBeenCalled();
+  });
+
+  it("activates heartbeat, cron, and delivery recovery after sidecars are ready", async () => {
+    const cron = { start: vi.fn(async () => undefined) };
+    const log = createLog();
+
+    const services = activateGatewayScheduledServices({
+      minimalTestGateway: false,
+      cfgAtStart: {} as never,
+      cron,
+      logCron: { error: vi.fn() },
+      log,
+    });
+
+    expect(hoisted.startHeartbeatRunner).toHaveBeenCalledTimes(1);
+    expect(cron.start).toHaveBeenCalledTimes(1);
+    expect(services.heartbeatRunner).toBe(hoisted.heartbeatRunner);
+    await vi.waitFor(() => {
+      expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deliver: hoisted.deliverOutboundPayloads,
+          cfg: {},
+        }),
+      );
+    });
+  });
+
+  it("keeps scheduled services disabled for minimal test gateways", () => {
+    const cron = { start: vi.fn(async () => undefined) };
+
+    const services = activateGatewayScheduledServices({
+      minimalTestGateway: true,
+      cfgAtStart: {} as never,
+      cron,
+      logCron: { error: vi.fn() },
+      log: createLog(),
+    });
+
+    expect(hoisted.startHeartbeatRunner).not.toHaveBeenCalled();
+    expect(cron.start).not.toHaveBeenCalled();
+    expect(hoisted.recoverPendingDeliveries).not.toHaveBeenCalled();
+
+    services.heartbeatRunner.stop();
+    expect(hoisted.heartbeatRunner.stop).not.toHaveBeenCalled();
+  });
+});
+
+function createLog() {
+  return {
+    child: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+    error: vi.fn(),
+  };
+}

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -71,39 +71,68 @@ export function startGatewayRuntimeServices(params: {
   minimalTestGateway: boolean;
   cfgAtStart: OpenClawConfig;
   channelManager: GatewayChannelManager;
-  cron: { start: () => Promise<void> };
-  logCron: { error: (message: string) => void };
   log: GatewayRuntimeServiceLogger;
 }): {
   heartbeatRunner: HeartbeatRunner;
   channelHealthMonitor: ChannelHealthMonitor | null;
   stopModelPricingRefresh: () => void;
 } {
-  const heartbeatRunner = params.minimalTestGateway
-    ? createNoopHeartbeatRunner()
-    : startHeartbeatRunner({ cfg: params.cfgAtStart });
+  // Return a noop heartbeat runner for now.  The real runner is created
+  // in activateGatewayScheduledServices() after sidecars finish and
+  // chat.history becomes available.  See #65322.
   const channelHealthMonitor = startGatewayChannelHealthMonitor({
     cfg: params.cfgAtStart,
     channelManager: params.channelManager,
   });
 
-  if (!params.minimalTestGateway) {
-    startGatewayCronWithLogging({
-      cron: params.cron,
-      logCron: params.logCron,
-    });
-    recoverPendingOutboundDeliveries({
-      cfg: params.cfgAtStart,
-      log: params.log,
-    });
-  }
-
   return {
-    heartbeatRunner,
+    heartbeatRunner: createNoopHeartbeatRunner(),
     channelHealthMonitor,
     stopModelPricingRefresh:
       !params.minimalTestGateway && process.env.VITEST !== "1"
         ? startGatewayModelPricingRefresh({ config: params.cfgAtStart })
         : () => {},
   };
+}
+
+/**
+ * Activate cron scheduler and pending delivery recovery AFTER gateway
+ * sidecars are fully started and chat.history is available.
+ *
+ * Previously these ran inside startGatewayRuntimeServices(), which
+ * fires before sidecars finish — creating a race where cron/heartbeat
+ * jobs could call chat.history while it was still marked unavailable.
+ * See: https://github.com/openclaw/openclaw/issues/65322
+ */
+/**
+ * Activate cron scheduler, heartbeat runner, and pending delivery recovery
+ * AFTER gateway sidecars are fully started and chat.history is available.
+ *
+ * Previously these ran inside startGatewayRuntimeServices(), which fires
+ * before sidecars finish — creating a race where cron/heartbeat jobs
+ * could call chat.history while it was still marked unavailable.
+ * See: https://github.com/openclaw/openclaw/issues/65322
+ *
+ * Returns the real heartbeat runner so the caller can update runtimeState.
+ */
+export function activateGatewayScheduledServices(params: {
+  minimalTestGateway: boolean;
+  cfgAtStart: OpenClawConfig;
+  cron: { start: () => Promise<void> };
+  logCron: { error: (message: string) => void };
+  log: GatewayRuntimeServiceLogger;
+}): { heartbeatRunner: HeartbeatRunner } {
+  if (params.minimalTestGateway) {
+    return { heartbeatRunner: createNoopHeartbeatRunner() };
+  }
+  const heartbeatRunner = startHeartbeatRunner({ cfg: params.cfgAtStart });
+  startGatewayCronWithLogging({
+    cron: params.cron,
+    logCron: params.logCron,
+  });
+  recoverPendingOutboundDeliveries({
+    cfg: params.cfgAtStart,
+    log: params.log,
+  });
+  return { heartbeatRunner };
 }

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -77,9 +77,7 @@ export function startGatewayRuntimeServices(params: {
   channelHealthMonitor: ChannelHealthMonitor | null;
   stopModelPricingRefresh: () => void;
 } {
-  // Return a noop heartbeat runner for now.  The real runner is created
-  // in activateGatewayScheduledServices() after sidecars finish and
-  // chat.history becomes available.  See #65322.
+  // Keep scheduled work inert until post-attach sidecars finish.
   const channelHealthMonitor = startGatewayChannelHealthMonitor({
     cfg: params.cfgAtStart,
     channelManager: params.channelManager,
@@ -96,24 +94,8 @@ export function startGatewayRuntimeServices(params: {
 }
 
 /**
- * Activate cron scheduler and pending delivery recovery AFTER gateway
- * sidecars are fully started and chat.history is available.
- *
- * Previously these ran inside startGatewayRuntimeServices(), which
- * fires before sidecars finish — creating a race where cron/heartbeat
- * jobs could call chat.history while it was still marked unavailable.
- * See: https://github.com/openclaw/openclaw/issues/65322
- */
-/**
  * Activate cron scheduler, heartbeat runner, and pending delivery recovery
- * AFTER gateway sidecars are fully started and chat.history is available.
- *
- * Previously these ran inside startGatewayRuntimeServices(), which fires
- * before sidecars finish — creating a race where cron/heartbeat jobs
- * could call chat.history while it was still marked unavailable.
- * See: https://github.com/openclaw/openclaw/issues/65322
- *
- * Returns the real heartbeat runner so the caller can update runtimeState.
+ * after gateway sidecars are fully started and chat.history is available.
  */
 export function activateGatewayScheduledServices(params: {
   minimalTestGateway: boolean;

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -123,8 +123,8 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.reconcilePendingSessionIdentities.mockClear();
   });
 
-  it("re-enables chat.history after post-attach sidecars start", async () => {
-    const unavailableGatewayMethods = new Set<string>(["chat.history"]);
+  it("re-enables startup-gated methods after post-attach sidecars start", async () => {
+    const unavailableGatewayMethods = new Set<string>(["chat.history", "models.list"]);
 
     await startGatewayPostAttachRuntime({
       minimalTestGateway: false,
@@ -168,7 +168,7 @@ describe("startGatewayPostAttachRuntime", () => {
       unavailableGatewayMethods,
     });
 
-    expect(unavailableGatewayMethods.has("chat.history")).toBe(false);
+    expect([...unavailableGatewayMethods]).toEqual([]);
     expect(hoisted.startPluginServices).toHaveBeenCalledTimes(1);
     expect(hoisted.setInternalHooksEnabled).toHaveBeenCalledWith(false);
     expect(hoisted.logGatewayStartup).toHaveBeenCalledWith(

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -43,6 +43,7 @@ import {
 } from "./server-restart-sentinel.js";
 import { logGatewayStartup } from "./server-startup-log.js";
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
+import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./server-startup-unavailable-methods.js";
 import { startGatewayTailscaleExposure } from "./server-tailscale.js";
 
 const SESSION_LOCK_STALE_MS = 30 * 60 * 1000;
@@ -322,7 +323,9 @@ export async function startGatewayPostAttachRuntime(params: {
       logHooks: params.logHooks,
       logChannels: params.logChannels,
     }));
-    params.unavailableGatewayMethods.delete("chat.history");
+    for (const method of STARTUP_UNAVAILABLE_GATEWAY_METHODS) {
+      params.unavailableGatewayMethods.delete(method);
+    }
   }
 
   if (!params.minimalTestGateway) {

--- a/src/gateway/server-startup-unavailable-methods.ts
+++ b/src/gateway/server-startup-unavailable-methods.ts
@@ -1,0 +1,1 @@
+export const STARTUP_UNAVAILABLE_GATEWAY_METHODS = ["chat.history", "models.list"] as const;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -74,6 +74,7 @@ import {
   prepareGatewayStartupConfig,
 } from "./server-startup-config.js";
 import { prepareGatewayPluginBootstrap } from "./server-startup-plugins.js";
+import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./server-startup-unavailable-methods.js";
 import { startGatewayEarlyRuntime, startGatewayPostAttachRuntime } from "./server-startup.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
 import { attachGatewayWsHandlers } from "./server-ws-runtime.js";
@@ -625,7 +626,9 @@ export async function startGatewayServer(
 
     const canvasHostServerPort = (canvasHostServer as CanvasHostServer | null)?.port;
 
-    const unavailableGatewayMethods = new Set<string>(minimalTestGateway ? [] : ["chat.history"]);
+    const unavailableGatewayMethods = new Set<string>(
+      minimalTestGateway ? [] : STARTUP_UNAVAILABLE_GATEWAY_METHODS,
+    );
     const gatewayRequestContext = createGatewayRequestContext({
       deps,
       runtimeState,
@@ -756,10 +759,7 @@ export async function startGatewayServer(
       unavailableGatewayMethods,
     }));
 
-    // Activate cron scheduler, heartbeat runner, and pending delivery
-    // recovery now that sidecars are ready and chat.history is available.
-    // Previously these ran before sidecars finished, causing a race.
-    // See #65322.
+    // Keep scheduled work inert until post-attach sidecars finish.
     const activated = activateGatewayScheduledServices({
       minimalTestGateway,
       cfgAtStart,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -56,7 +56,10 @@ import { setFallbackGatewayContextResolver } from "./server-plugins.js";
 import { startManagedGatewayConfigReloader } from "./server-reload-handlers.js";
 import { createGatewayRequestContext } from "./server-request-context.js";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
-import { startGatewayRuntimeServices } from "./server-runtime-services.js";
+import {
+  activateGatewayScheduledServices,
+  startGatewayRuntimeServices,
+} from "./server-runtime-services.js";
 import { createGatewayRuntimeState } from "./server-runtime-state.js";
 import { startGatewayEventSubscriptions } from "./server-runtime-subscriptions.js";
 import { resolveSessionKeyForRun } from "./server-session-key.js";
@@ -608,8 +611,6 @@ export async function startGatewayServer(
         minimalTestGateway,
         cfgAtStart,
         channelManager,
-        cron: runtimeState.cronState.cron,
-        logCron,
         log,
       }),
     );
@@ -754,6 +755,19 @@ export async function startGatewayServer(
       logChannels,
       unavailableGatewayMethods,
     }));
+
+    // Activate cron scheduler, heartbeat runner, and pending delivery
+    // recovery now that sidecars are ready and chat.history is available.
+    // Previously these ran before sidecars finished, causing a race.
+    // See #65322.
+    const activated = activateGatewayScheduledServices({
+      minimalTestGateway,
+      cfgAtStart,
+      cron: runtimeState.cronState.cron,
+      logCron,
+      log,
+    });
+    runtimeState.heartbeatRunner = activated.heartbeatRunner;
 
     runtimeState.configReloader = startManagedGatewayConfigReloader({
       minimalTestGateway,

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -681,6 +681,49 @@ describe("abortChatRun", () => {
 });
 
 describe("loadChatHistory", () => {
+  it("retries retryable startup unavailability before showing history", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new GatewayRequestError({
+            code: "UNAVAILABLE",
+            message: "chat.history unavailable during gateway startup",
+            details: { method: "chat.history" },
+            retryable: true,
+            retryAfterMs: 250,
+          }),
+        )
+        .mockResolvedValueOnce({
+          messages: [{ role: "assistant", content: [{ type: "text", text: "awake" }] }],
+          thinkingLevel: "low",
+        });
+      const state = createState({
+        connected: true,
+        client: { request } as unknown as ChatState["client"],
+      });
+
+      const load = loadChatHistory(state);
+      await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+      expect(state.chatLoading).toBe(true);
+      expect(state.lastError).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(250);
+      await load;
+
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(state.chatMessages).toEqual([
+        { role: "assistant", content: [{ type: "text", text: "awake" }] },
+      ]);
+      expect(state.chatThinkingLevel).toBe("low");
+      expect(state.chatLoading).toBe(false);
+      expect(state.lastError).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("filters assistant NO_REPLY messages and keeps user NO_REPLY messages", async () => {
     const request = vi.fn().mockResolvedValue({
       messages: [

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,7 +1,7 @@
 import { resetToolStream } from "../app-tool-stream.ts";
 import { extractText } from "../chat/message-extract.ts";
 import { formatConnectError } from "../connect-error.ts";
-import type { GatewayBrowserClient } from "../gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../gateway.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 import type { ChatAttachment } from "../ui-types.ts";
 import { generateUUID } from "../uuid.ts";
@@ -13,6 +13,9 @@ import {
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
+const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
+const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
+const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
 const chatHistoryRequestVersions = new WeakMap<object, number>();
 
 function beginChatHistoryRequest(state: ChatState): number {
@@ -72,6 +75,31 @@ function shouldHideHistoryMessage(message: unknown): boolean {
   return isAssistantSilentReply(message) || isSyntheticTranscriptRepairToolResult(message);
 }
 
+function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {
+  if (!(err instanceof GatewayRequestError)) {
+    return false;
+  }
+  if (err.gatewayCode !== "UNAVAILABLE" || !err.retryable) {
+    return false;
+  }
+  const details = err.details;
+  if (!details || typeof details !== "object") {
+    return true;
+  }
+  const detailMethod = (details as { method?: unknown }).method;
+  return typeof detailMethod !== "string" || detailMethod === method;
+}
+
+function resolveStartupRetryDelayMs(err: GatewayRequestError): number {
+  const retryAfterMs =
+    typeof err.retryAfterMs === "number" ? err.retryAfterMs : STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS;
+  return Math.min(Math.max(retryAfterMs, 100), STARTUP_CHAT_HISTORY_MAX_RETRY_MS);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export type ChatState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
@@ -114,16 +142,37 @@ export async function loadChatHistory(state: ChatState) {
   }
   const sessionKey = state.sessionKey;
   const requestVersion = beginChatHistoryRequest(state);
+  const startedAt = Date.now();
   state.chatLoading = true;
   state.lastError = null;
   try {
-    const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
-      "chat.history",
-      {
-        sessionKey,
-        limit: 200,
-      },
-    );
+    let res: { messages?: Array<unknown>; thinkingLevel?: string };
+    for (;;) {
+      try {
+        res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
+          "chat.history",
+          {
+            sessionKey,
+            limit: 200,
+          },
+        );
+        break;
+      } catch (err) {
+        if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey)) {
+          return;
+        }
+        const withinStartupRetryWindow =
+          Date.now() - startedAt < STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS;
+        if (withinStartupRetryWindow && isRetryableStartupUnavailable(err, "chat.history")) {
+          await sleep(resolveStartupRetryDelayMs(err));
+          if (!state.client || !state.connected) {
+            return;
+          }
+          continue;
+        }
+        throw err;
+      }
+    }
     if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey)) {
       return;
     }

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -27,24 +27,36 @@ export type GatewayResponseFrame = {
   id: string;
   ok: boolean;
   payload?: unknown;
-  error?: { code: string; message: string; details?: unknown };
+  error?: {
+    code: string;
+    message: string;
+    details?: unknown;
+    retryable?: boolean;
+    retryAfterMs?: number;
+  };
 };
 
 export type GatewayErrorInfo = {
   code: string;
   message: string;
   details?: unknown;
+  retryable?: boolean;
+  retryAfterMs?: number;
 };
 
 export class GatewayRequestError extends Error {
   readonly gatewayCode: string;
   readonly details?: unknown;
+  readonly retryable: boolean;
+  readonly retryAfterMs?: number;
 
   constructor(error: GatewayErrorInfo) {
     super(error.message);
     this.name = "GatewayRequestError";
     this.gatewayCode = error.code;
     this.details = error.details;
+    this.retryable = error.retryable === true;
+    this.retryAfterMs = error.retryAfterMs;
   }
 }
 
@@ -478,6 +490,8 @@ export class GatewayBrowserClient {
         code: err.gatewayCode,
         message: err.message,
         details: err.details,
+        retryable: err.retryable,
+        retryAfterMs: err.retryAfterMs,
       };
     } else {
       this.pendingConnectError = undefined;
@@ -555,6 +569,8 @@ export class GatewayBrowserClient {
             code: res.error?.code ?? "UNAVAILABLE",
             message: res.error?.message ?? "request failed",
             details: res.error?.details,
+            retryable: res.error?.retryable,
+            retryAfterMs: res.error?.retryAfterMs,
           }),
         );
       }


### PR DESCRIPTION
## Summary

Fixes #65322

Gateway startup race condition: cron scheduler and heartbeat runner started **before** `chat.history` became available, causing `GatewayRequestError: chat.history unavailable during gateway startup` on every restart.

## Root Cause

`startGatewayRuntimeServices()` fires `cron.start()` and `startHeartbeatRunner()` before `startGatewayPostAttachRuntime()` finishes and removes `"chat.history"` from `unavailableGatewayMethods`. Any cron job or heartbeat tick that calls `chat.history` during this window gets a hard UNAVAILABLE error with no retry.

## Fix

Split scheduled-service activation into a new `activateGatewayScheduledServices()` function, called **after** `startGatewayPostAttachRuntime()` completes.

- `startGatewayRuntimeServices()` still creates heartbeat runner instance and starts `channelHealthMonitor` + `modelPricingRefresh` (these do not depend on `chat.history`)
- Cron scheduler start + pending delivery recovery are deferred to `activateGatewayScheduledServices()`
- Config reload path (`server-reload-handlers.ts`) is unaffected

## AI-assisted Checklist

- [x] Marked as AI-assisted
- [x] Root cause analysis by luban, cross-validated by tongluo
- [x] Code change reviewed and understood
- [x] Minimal change footprint: 2 files, +47/-16 lines
