### PR TITLE
fix: use randomUUID fallback when idempotencyKey is falsy

### DIFF
--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -336,7 +336,7 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
           ...(allowOverride && params.model && { model: params.model }),
           ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
           ...(params.lane && { lane: params.lane }),
-          ...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
+          idempotencyKey: params.idempotencyKey || randomUUID(),
         },
         {
           allowSyntheticModelOverride,


### PR DESCRIPTION
## Fix: memory-core dreaming narrative silent failure (issue #65341)

### Problem
In , the  field was passed using a conditional spread:
```typescript
...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
```
When `params.idempotencyKey` is falsy (null, undefined, empty string), the field is **completely omitted**. However, `AgentParamsSchema` requires this field to be non-empty, causing the `agent` gateway method to reject the request silently.

The secondary problem: cron jobs report `lastRunStatus: 'ok'` and `consecutiveErrors: 0` even when the dreaming narrative fails, because the error is swallowed at the schema validation layer.

### Fix
Replace the conditional spread with an explicit field that falls back to `crypto.randomUUID()` when `idempotencyKey` is falsy:

```typescript
idempotencyKey: params.idempotencyKey || randomUUID(),
```

### Changes
- `src/gateway/server-plugins.ts`: Line 339 - replace conditional spread with randomUUID fallback

### Testing
- The fix ensures `idempotencyKey` is **always** a valid non-empty string
- Verified: `randomUUID` is already imported from `node:crypto` in this file
- Existing test suite (`pnpm test`) should continue to pass