### PR TITLE
fix(google): update Gemini 3.1 CLI template IDs to correct 3.1 versions

### DIFF
--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -16,9 +16,9 @@ const GEMMA_PREFIX = "gemma-";
 const GEMINI_2_5_PRO_TEMPLATE_IDS = ["gemini-2.5-pro"] as const;
 const GEMINI_2_5_FLASH_LITE_TEMPLATE_IDS = ["gemini-2.5-flash-lite"] as const;
 const GEMINI_2_5_FLASH_TEMPLATE_IDS = ["gemini-2.5-flash"] as const;
-const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
+const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview"] as const;
 const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = ["gemini-3.1-flash-lite-preview"] as const;
-const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3.1-flash-preview"] as const;
 // Gemma uses the Gemini flash template as a forward-compat approximation
 // until a dedicated Gemma template is registered in the catalog.
 const GEMMA_TEMPLATE_IDS = GEMINI_3_1_FLASH_TEMPLATE_IDS;


### PR DESCRIPTION
## Fix: Gemini 3.1 CLI template IDs corrected

**Issue:** #65363

### Problem
In extensions/google/provider-models.ts, GEMINI_3_1_PRO_TEMPLATE_IDS and GEMINI_3_1_FLASH_TEMPLATE_IDS were incorrectly mapped to 3.0 preview versions:
- GEMINI_3_1_PRO_TEMPLATE_IDS was [gemini-3-pro-preview] (3.0, wrong)
- GEMINI_3_1_FLASH_TEMPLATE_IDS was [gemini-3-flash-preview] (3.0, wrong)

When a user selected gemini-3.1-pro-preview, the Google Gemini CLI provider passed the old 3.0 preview model ID, causing silent failures.

### Fix
Updated template IDs to correct 3.1 versions:
- GEMINI_3_1_PRO_TEMPLATE_IDS = [gemini-3.1-pro-preview]
- GEMINI_3_1_FLASH_TEMPLATE_IDS = [gemini-3.1-flash-preview]

### Files changed
- extensions/google/provider-models.ts: 2 lines changed