### PR TITLE
feat(entur): add Norwegian public transit plugin

### DIFF
--- a/extensions/entur/index.ts
+++ b/extensions/entur/index.ts
@@ -1,0 +1,15 @@
+import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import { createGetDeparturesTool } from "./src/get-departures-tool.js";
+import { createGetNearbyStopsTool } from "./src/get-nearby-stops-tool.js";
+import { createSearchStopsTool } from "./src/search-stops-tool.js";
+
+export default definePluginEntry({
+  id: "entur",
+  name: "Entur",
+  description: "Norwegian public transit real-time departures (Ruter, Vy, AtB, etc.) via Entur",
+  register(api) {
+    api.registerTool(createSearchStopsTool(api) as AnyAgentTool);
+    api.registerTool(createGetDeparturesTool(api) as AnyAgentTool);
+    api.registerTool(createGetNearbyStopsTool(api) as AnyAgentTool);
+  },
+});

--- a/extensions/entur/openclaw.plugin.json
+++ b/extensions/entur/openclaw.plugin.json
@@ -1,0 +1,44 @@
+{
+  "id": "entur",
+  "contracts": {
+    "tools": ["entur_search_stops", "entur_get_departures", "entur_get_nearby_stops"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "clientName": {
+        "type": "string",
+        "description": "ET-Client-Name header value sent to Entur API. Defaults to 'openclaw-entur'."
+      },
+      "defaultStopId": {
+        "type": "string",
+        "description": "Default stop ID for quick departure lookups (e.g. 'NSR:StopPlace:58366')."
+      },
+      "defaultNumDepartures": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 50
+      },
+      "defaultTransportModes": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": ["bus", "tram", "metro", "rail", "water", "air", "coach"]
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "clientName": {
+      "label": "Client Name",
+      "help": "Identifier sent to Entur API (e.g. 'mycompany-myapp'). Defaults to 'openclaw-entur'.",
+      "placeholder": "openclaw-entur"
+    },
+    "defaultStopId": {
+      "label": "Default Stop",
+      "help": "Your home stop ID. Use entur_search_stops to find it (e.g. 'NSR:StopPlace:58366' for Jernbanetorget).",
+      "placeholder": "NSR:StopPlace:58366"
+    }
+  }
+}

--- a/extensions/entur/package.json
+++ b/extensions/entur/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/entur",
+  "version": "2026.4.12",
+  "private": true,
+  "description": "Norwegian public transit plugin for OpenClaw (Entur/Ruter)",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/entur/src/config.ts
+++ b/extensions/entur/src/config.ts
@@ -1,0 +1,29 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+
+export const DEFAULT_CLIENT_NAME = "openclaw-entur";
+export const DEFAULT_NUM_DEPARTURES = 10;
+export const DEFAULT_TIMEOUT_MS = 15_000;
+
+export type EnturPluginConfig = {
+  clientName: string;
+  defaultStopId: string | undefined;
+  defaultNumDepartures: number;
+  defaultTransportModes: string[] | undefined;
+};
+
+type PluginEntryConfig = {
+  clientName?: string;
+  defaultStopId?: string;
+  defaultNumDepartures?: number;
+  defaultTransportModes?: string[];
+};
+
+export function resolveEnturConfig(cfg?: OpenClawConfig): EnturPluginConfig {
+  const pluginConfig = cfg?.plugins?.entries?.entur?.config as PluginEntryConfig | undefined;
+  return {
+    clientName: pluginConfig?.clientName || DEFAULT_CLIENT_NAME,
+    defaultStopId: pluginConfig?.defaultStopId || undefined,
+    defaultNumDepartures: pluginConfig?.defaultNumDepartures || DEFAULT_NUM_DEPARTURES,
+    defaultTransportModes: pluginConfig?.defaultTransportModes || undefined,
+  };
+}

--- a/extensions/entur/src/entur-client.test.ts
+++ b/extensions/entur/src/entur-client.test.ts
@@ -1,0 +1,223 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import plugin from "../index.js";
+import { resolveEnturConfig } from "./config.js";
+
+const { searchStops, getDepartures, getNearbyStops } = vi.hoisted(() => ({
+  searchStops: vi.fn(),
+  getDepartures: vi.fn(),
+  getNearbyStops: vi.fn(),
+}));
+
+vi.mock("./entur-client.js", () => ({
+  searchStops,
+  getDepartures,
+  getNearbyStops,
+  __testing: {},
+}));
+
+function fakeApi(config?: Record<string, unknown>): OpenClawPluginApi {
+  return {
+    config: config ?? {},
+  } as OpenClawPluginApi;
+}
+
+describe("entur plugin", () => {
+  let createSearchStopsTool: typeof import("./search-stops-tool.js").createSearchStopsTool;
+  let createGetDeparturesTool: typeof import("./get-departures-tool.js").createGetDeparturesTool;
+  let createGetNearbyStopsTool: typeof import("./get-nearby-stops-tool.js").createGetNearbyStopsTool;
+
+  beforeAll(async () => {
+    vi.resetModules();
+    ({ createSearchStopsTool } = await import("./search-stops-tool.js"));
+    ({ createGetDeparturesTool } = await import("./get-departures-tool.js"));
+    ({ createGetNearbyStopsTool } = await import("./get-nearby-stops-tool.js"));
+  });
+
+  beforeEach(() => {
+    searchStops.mockReset();
+    getDepartures.mockReset();
+    getNearbyStops.mockReset();
+  });
+
+  it("registers three tools", () => {
+    const registrations: unknown[] = [];
+    const mockApi = {
+      registerTool(tool: unknown) {
+        registrations.push(tool);
+      },
+      config: {},
+    };
+
+    plugin.register(mockApi as unknown as OpenClawPluginApi);
+
+    expect(registrations).toHaveLength(3);
+    const names = registrations.map((t) => (t as { name: string }).name);
+    expect(names).toContain("entur_search_stops");
+    expect(names).toContain("entur_get_departures");
+    expect(names).toContain("entur_get_nearby_stops");
+  });
+
+  describe("config resolution", () => {
+    it("returns defaults when no config is set", () => {
+      const config = resolveEnturConfig({} as never);
+      expect(config.clientName).toBe("openclaw-entur");
+      expect(config.defaultStopId).toBeUndefined();
+      expect(config.defaultNumDepartures).toBe(10);
+      expect(config.defaultTransportModes).toBeUndefined();
+    });
+
+    it("reads plugin config", () => {
+      const config = resolveEnturConfig({
+        plugins: {
+          entries: {
+            entur: {
+              config: {
+                clientName: "my-app",
+                defaultStopId: "NSR:StopPlace:123",
+                defaultNumDepartures: 5,
+                defaultTransportModes: ["tram"],
+              },
+            },
+          },
+        },
+      } as never);
+      expect(config.clientName).toBe("my-app");
+      expect(config.defaultStopId).toBe("NSR:StopPlace:123");
+      expect(config.defaultNumDepartures).toBe(5);
+      expect(config.defaultTransportModes).toEqual(["tram"]);
+    });
+  });
+
+  describe("entur_search_stops", () => {
+    it("passes query and max_results to searchStops", async () => {
+      const mockStops = [
+        {
+          id: "NSR:StopPlace:58366",
+          name: "Jernbanetorget",
+          locality: "Oslo",
+          county: "Oslo",
+          latitude: 59.91,
+          longitude: 10.75,
+          transportModes: ["metro", "tram", "bus"],
+        },
+      ];
+      searchStops.mockResolvedValue(mockStops);
+
+      const tool = createSearchStopsTool(fakeApi());
+      const result = await tool.execute("call-1", { query: "Jernbanetorget", max_results: 3 });
+
+      expect(searchStops).toHaveBeenCalledWith("Jernbanetorget", 3, "openclaw-entur");
+      const text = (result as { content: Array<{ text: string }> }).content[0].text;
+      expect(text).toContain("Jernbanetorget");
+    });
+
+    it("defaults max_results to 5", async () => {
+      searchStops.mockResolvedValue([]);
+
+      const tool = createSearchStopsTool(fakeApi());
+      await tool.execute("call-2", { query: "Majorstuen" });
+
+      expect(searchStops).toHaveBeenCalledWith("Majorstuen", 5, "openclaw-entur");
+    });
+  });
+
+  describe("entur_get_departures", () => {
+    it("passes parameters to getDepartures", async () => {
+      const mockResult = {
+        stop: { id: "NSR:StopPlace:58366", name: "Jernbanetorget" },
+        departures: [
+          {
+            line: "17",
+            destination: "Rikshospitalet",
+            transportMode: "tram",
+            scheduledTime: "2026-04-12T10:00:00+02:00",
+            expectedTime: "2026-04-12T10:02:00+02:00",
+            minutesUntil: 5,
+            realtime: true,
+            cancelled: false,
+            platform: "1",
+          },
+        ],
+      };
+      getDepartures.mockResolvedValue(mockResult);
+
+      const tool = createGetDeparturesTool(fakeApi());
+      const result = await tool.execute("call-3", {
+        stop_id: "NSR:StopPlace:58366",
+        num_departures: 5,
+        transport_modes: ["tram"],
+        time_range_minutes: 60,
+      });
+
+      expect(getDepartures).toHaveBeenCalledWith(
+        "NSR:StopPlace:58366",
+        5,
+        ["tram"],
+        60,
+        "openclaw-entur",
+      );
+      const text = (result as { content: Array<{ text: string }> }).content[0].text;
+      expect(text).toContain("Rikshospitalet");
+    });
+
+    it("uses default stop ID from config when stop_id is omitted", async () => {
+      getDepartures.mockResolvedValue({
+        stop: { id: "NSR:StopPlace:123", name: "Home" },
+        departures: [],
+      });
+
+      const api = fakeApi({
+        plugins: {
+          entries: {
+            entur: {
+              config: {
+                defaultStopId: "NSR:StopPlace:123",
+              },
+            },
+          },
+        },
+      });
+      const tool = createGetDeparturesTool(api);
+      await tool.execute("call-4", {});
+
+      expect(getDepartures).toHaveBeenCalledWith(
+        "NSR:StopPlace:123",
+        10,
+        undefined,
+        120,
+        "openclaw-entur",
+      );
+    });
+
+    it("throws when no stop_id and no default configured", async () => {
+      const tool = createGetDeparturesTool(fakeApi());
+      await expect(tool.execute("call-5", {})).rejects.toThrow("No stop_id provided");
+    });
+  });
+
+  describe("entur_get_nearby_stops", () => {
+    it("passes coordinates and options to getNearbyStops", async () => {
+      getNearbyStops.mockResolvedValue([]);
+
+      const tool = createGetNearbyStopsTool(fakeApi());
+      await tool.execute("call-6", {
+        latitude: 59.91,
+        longitude: 10.75,
+        radius_meters: 300,
+        max_results: 3,
+      });
+
+      expect(getNearbyStops).toHaveBeenCalledWith(59.91, 10.75, 300, 3, "openclaw-entur");
+    });
+
+    it("uses default radius and max_results", async () => {
+      getNearbyStops.mockResolvedValue([]);
+
+      const tool = createGetNearbyStopsTool(fakeApi());
+      await tool.execute("call-7", { latitude: 59.91, longitude: 10.75 });
+
+      expect(getNearbyStops).toHaveBeenCalledWith(59.91, 10.75, 500, 5, "openclaw-entur");
+    });
+  });
+});

--- a/extensions/entur/src/entur-client.ts
+++ b/extensions/entur/src/entur-client.ts
@@ -1,0 +1,180 @@
+import { DEFAULT_CLIENT_NAME, DEFAULT_TIMEOUT_MS } from "./config.js";
+import type { DepartureResult, GeocoderResponse, StopPlaceResponse, StopResult } from "./types.js";
+
+const JOURNEY_PLANNER_URL = "https://api.entur.io/journey-planner/v3/graphql";
+const GEOCODER_URL = "https://api.entur.io/geocoder/v1/autocomplete";
+const GEOCODER_REVERSE_URL = "https://api.entur.io/geocoder/v1/reverse";
+
+const DEPARTURES_QUERY = `
+query GetDepartures($stopId: String!, $numDepartures: Int!, $timeRange: Int, $whiteListedModes: [TransportMode]) {
+  stopPlace(id: $stopId) {
+    id
+    name
+    estimatedCalls(
+      numberOfDepartures: $numDepartures
+      timeRange: $timeRange
+      whiteListedModes: $whiteListedModes
+    ) {
+      expectedDepartureTime
+      aimedDepartureTime
+      realtime
+      cancellation
+      destinationDisplay {
+        frontText
+      }
+      serviceJourney {
+        line {
+          id
+          publicCode
+          transportMode
+        }
+      }
+      quay {
+        id
+        name
+        publicCode
+      }
+    }
+  }
+}
+`;
+
+function buildHeaders(clientName: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    "ET-Client-Name": clientName,
+  };
+}
+
+export async function searchStops(
+  query: string,
+  size: number = 5,
+  clientName: string = DEFAULT_CLIENT_NAME,
+): Promise<StopResult[]> {
+  const url = new URL(GEOCODER_URL);
+  url.searchParams.set("text", query);
+  url.searchParams.set("layers", "venue");
+  url.searchParams.set("size", String(size));
+
+  const response = await fetch(url.toString(), {
+    headers: { "ET-Client-Name": clientName },
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Entur Geocoder error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as GeocoderResponse;
+  return data.features.map((f) => ({
+    id: f.properties.id,
+    name: f.properties.name,
+    locality: f.properties.locality ?? null,
+    county: f.properties.county ?? null,
+    longitude: f.geometry.coordinates[0],
+    latitude: f.geometry.coordinates[1],
+    transportModes: f.properties.category ?? [],
+  }));
+}
+
+export async function getNearbyStops(
+  latitude: number,
+  longitude: number,
+  radiusMeters: number = 500,
+  size: number = 5,
+  clientName: string = DEFAULT_CLIENT_NAME,
+): Promise<StopResult[]> {
+  const url = new URL(GEOCODER_REVERSE_URL);
+  url.searchParams.set("point.lat", String(latitude));
+  url.searchParams.set("point.lon", String(longitude));
+  url.searchParams.set("boundary.circle.radius", String(radiusMeters / 1000)); // km
+  url.searchParams.set("layers", "venue");
+  url.searchParams.set("size", String(size));
+
+  const response = await fetch(url.toString(), {
+    headers: { "ET-Client-Name": clientName },
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Entur Geocoder reverse error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as GeocoderResponse;
+  return data.features.map((f) => ({
+    id: f.properties.id,
+    name: f.properties.name,
+    locality: f.properties.locality ?? null,
+    county: f.properties.county ?? null,
+    longitude: f.geometry.coordinates[0],
+    latitude: f.geometry.coordinates[1],
+    transportModes: f.properties.category ?? [],
+  }));
+}
+
+export async function getDepartures(
+  stopId: string,
+  numDepartures: number = 10,
+  transportModes?: string[],
+  timeRangeMinutes: number = 120,
+  clientName: string = DEFAULT_CLIENT_NAME,
+): Promise<{ stop: { id: string; name: string }; departures: DepartureResult[] }> {
+  const variables: Record<string, unknown> = {
+    stopId,
+    numDepartures,
+    timeRange: timeRangeMinutes * 60,
+  };
+  if (transportModes?.length) {
+    variables.whiteListedModes = transportModes;
+  }
+
+  const response = await fetch(JOURNEY_PLANNER_URL, {
+    method: "POST",
+    headers: buildHeaders(clientName),
+    body: JSON.stringify({ query: DEPARTURES_QUERY, variables }),
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Entur Journey Planner error: ${response.status} ${response.statusText}`);
+  }
+
+  const result = (await response.json()) as StopPlaceResponse;
+
+  if (result.errors?.length) {
+    throw new Error(`Entur GraphQL error: ${result.errors.map((e) => e.message).join(", ")}`);
+  }
+
+  const stopPlace = result.data.stopPlace;
+  if (!stopPlace) {
+    throw new Error(`Stop place not found: ${stopId}`);
+  }
+
+  const now = Date.now();
+  const departures: DepartureResult[] = stopPlace.estimatedCalls.map((call) => {
+    const expectedMs = new Date(call.expectedDepartureTime).getTime();
+    return {
+      line: call.serviceJourney.line.publicCode,
+      destination: call.destinationDisplay.frontText,
+      transportMode: call.serviceJourney.line.transportMode,
+      scheduledTime: call.aimedDepartureTime,
+      expectedTime: call.expectedDepartureTime,
+      minutesUntil: Math.max(0, Math.round((expectedMs - now) / 60_000)),
+      realtime: call.realtime,
+      cancelled: call.cancellation,
+      platform: call.quay.publicCode || call.quay.name,
+    };
+  });
+
+  return {
+    stop: { id: stopPlace.id, name: stopPlace.name },
+    departures,
+  };
+}
+
+export const __testing = {
+  JOURNEY_PLANNER_URL,
+  GEOCODER_URL,
+  GEOCODER_REVERSE_URL,
+  DEPARTURES_QUERY,
+};

--- a/extensions/entur/src/get-departures-tool.ts
+++ b/extensions/entur/src/get-departures-tool.ts
@@ -1,0 +1,98 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { resolveEnturConfig } from "./config.js";
+import { getDepartures } from "./entur-client.js";
+
+function optionalStringEnum<const T extends readonly string[]>(
+  values: T,
+  options: { description?: string } = {},
+) {
+  return Type.Optional(
+    Type.Unsafe<T[number]>({
+      type: "string",
+      enum: [...values],
+      ...options,
+    }),
+  );
+}
+
+const TRANSPORT_MODES = ["bus", "tram", "metro", "rail", "water", "air", "coach"] as const;
+
+const GetDeparturesSchema = Type.Object(
+  {
+    stop_id: Type.Optional(
+      Type.String({
+        description:
+          "Entur stop ID (e.g. 'NSR:StopPlace:58366'). Use entur_search_stops to find IDs. If omitted, uses configured default stop.",
+      }),
+    ),
+    num_departures: Type.Optional(
+      Type.Number({
+        description: "Number of departures to return (1-50, default 10).",
+        minimum: 1,
+        maximum: 50,
+      }),
+    ),
+    transport_modes: Type.Optional(
+      Type.Array(
+        Type.Unsafe<(typeof TRANSPORT_MODES)[number]>({
+          type: "string",
+          enum: [...TRANSPORT_MODES],
+        }),
+        { description: "Filter by transport mode(s). Omit for all modes." },
+      ),
+    ),
+    time_range_minutes: Type.Optional(
+      Type.Number({
+        description: "Only show departures within this many minutes from now (default: 120).",
+        minimum: 1,
+        maximum: 1440,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createGetDeparturesTool(api: OpenClawPluginApi) {
+  return {
+    name: "entur_get_departures",
+    label: "Entur Departures",
+    description:
+      "Get real-time departures from a Norwegian public transit stop (bus, tram, metro, train, ferry). Shows line number, destination, expected departure time, and minutes until departure.",
+    parameters: GetDeparturesSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const config = resolveEnturConfig(api.config);
+
+      const stopId = readStringParam(rawParams, "stop_id") || config.defaultStopId;
+      if (!stopId) {
+        throw new Error(
+          "No stop_id provided and no default stop configured. Use entur_search_stops to find a stop ID, or configure plugins.entries.entur.config.defaultStopId.",
+        );
+      }
+
+      const numDepartures =
+        readNumberParam(rawParams, "num_departures", { integer: true }) ||
+        config.defaultNumDepartures;
+      const transportModes = Array.isArray(rawParams.transport_modes)
+        ? (rawParams.transport_modes as string[]).filter(Boolean)
+        : config.defaultTransportModes;
+      const timeRangeMinutes =
+        readNumberParam(rawParams, "time_range_minutes", { integer: true }) || 120;
+
+      const result = await getDepartures(
+        stopId,
+        numDepartures,
+        transportModes?.length ? transportModes : undefined,
+        timeRangeMinutes,
+        config.clientName,
+      );
+
+      return jsonResult(result);
+    },
+  };
+}

--- a/extensions/entur/src/get-nearby-stops-tool.ts
+++ b/extensions/entur/src/get-nearby-stops-tool.ts
@@ -1,0 +1,55 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { jsonResult, readNumberParam } from "openclaw/plugin-sdk/provider-web-search";
+import { resolveEnturConfig } from "./config.js";
+import { getNearbyStops } from "./entur-client.js";
+
+const GetNearbyStopsSchema = Type.Object(
+  {
+    latitude: Type.Number({ description: "Latitude coordinate." }),
+    longitude: Type.Number({ description: "Longitude coordinate." }),
+    radius_meters: Type.Optional(
+      Type.Number({
+        description: "Search radius in meters (default 500, max 2000).",
+        minimum: 50,
+        maximum: 2000,
+      }),
+    ),
+    max_results: Type.Optional(
+      Type.Number({
+        description: "Maximum number of stops to return (1-20, default 5).",
+        minimum: 1,
+        maximum: 20,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createGetNearbyStopsTool(api: OpenClawPluginApi) {
+  return {
+    name: "entur_get_nearby_stops",
+    label: "Entur Nearby Stops",
+    description:
+      "Find Norwegian public transit stops near GPS coordinates. Returns stop IDs that can be used with entur_get_departures.",
+    parameters: GetNearbyStopsSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const config = resolveEnturConfig(api.config);
+
+      const latitude = rawParams.latitude as number;
+      const longitude = rawParams.longitude as number;
+      const radiusMeters = readNumberParam(rawParams, "radius_meters", { integer: true }) || 500;
+      const maxResults = readNumberParam(rawParams, "max_results", { integer: true }) || 5;
+
+      const stops = await getNearbyStops(
+        latitude,
+        longitude,
+        radiusMeters,
+        maxResults,
+        config.clientName,
+      );
+
+      return jsonResult({ stops });
+    },
+  };
+}

--- a/extensions/entur/src/search-stops-tool.ts
+++ b/extensions/entur/src/search-stops-tool.ts
@@ -1,0 +1,43 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { resolveEnturConfig } from "./config.js";
+import { searchStops } from "./entur-client.js";
+
+const SearchStopsSchema = Type.Object(
+  {
+    query: Type.String({
+      description: "Stop name to search for (e.g. 'Jernbanetorget', 'Majorstuen').",
+    }),
+    max_results: Type.Optional(
+      Type.Number({
+        description: "Maximum number of stops to return (1-20, default 5).",
+        minimum: 1,
+        maximum: 20,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createSearchStopsTool(api: OpenClawPluginApi) {
+  return {
+    name: "entur_search_stops",
+    label: "Entur Search Stops",
+    description:
+      "Search for Norwegian public transit stops by name. Returns stop IDs that can be used with entur_get_departures to check real-time departures.",
+    parameters: SearchStopsSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const query = readStringParam(rawParams, "query", { required: true });
+      const maxResults = readNumberParam(rawParams, "max_results", { integer: true }) || 5;
+      const config = resolveEnturConfig(api.config);
+
+      const stops = await searchStops(query, maxResults, config.clientName);
+      return jsonResult({ stops });
+    },
+  };
+}

--- a/extensions/entur/src/types.ts
+++ b/extensions/entur/src/types.ts
@@ -1,0 +1,77 @@
+// Entur Geocoder API response types
+
+export type GeocoderFeature = {
+  geometry: {
+    coordinates: [longitude: number, latitude: number];
+  };
+  properties: {
+    id: string;
+    name: string;
+    locality?: string;
+    county?: string;
+    category?: string[];
+  };
+};
+
+export type GeocoderResponse = {
+  features: GeocoderFeature[];
+};
+
+// Entur Journey Planner GraphQL response types
+
+export type EstimatedCall = {
+  expectedDepartureTime: string;
+  aimedDepartureTime: string;
+  realtime: boolean;
+  cancellation: boolean;
+  destinationDisplay: {
+    frontText: string;
+  };
+  serviceJourney: {
+    line: {
+      id: string;
+      publicCode: string;
+      transportMode: string;
+    };
+  };
+  quay: {
+    id: string;
+    name: string;
+    publicCode: string | null;
+  };
+};
+
+export type StopPlaceResponse = {
+  data: {
+    stopPlace: {
+      id: string;
+      name: string;
+      estimatedCalls: EstimatedCall[];
+    } | null;
+  };
+  errors?: Array<{ message: string }>;
+};
+
+// Normalized output types
+
+export type StopResult = {
+  id: string;
+  name: string;
+  locality: string | null;
+  county: string | null;
+  latitude: number;
+  longitude: number;
+  transportModes: string[];
+};
+
+export type DepartureResult = {
+  line: string;
+  destination: string;
+  transportMode: string;
+  scheduledTime: string;
+  expectedTime: string;
+  minutesUntil: number;
+  realtime: boolean;
+  cancelled: boolean;
+  platform: string | null;
+};


### PR DESCRIPTION
## Summary
- Add Entur plugin for real-time Norwegian public transit departures (Ruter, Vy, AtB, etc.)
- Three tools: `entur_search_stops`, `entur_get_departures`, `entur_get_nearby_stops`
- Uses Entur's open GraphQL API — no API key required
- Configurable default stop, transport mode filter, and number of departures

## Test plan
- [x] Unit tests pass (`pnpm test -- extensions/entur/`)
- [x] TypeScript compiles without errors
- [ ] Manual test: search for a stop, get departures, verify real-time data
- [ ] Verify plugin registers correctly when loaded by OpenClaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)