### PR TITLE
fix(comfy): read plugin-owned provider config

### DIFF
--- a/docs/providers/comfy.md
+++ b/docs/providers/comfy.md
@@ -37,6 +37,64 @@ sections:
 
 ```json5
 {
+  plugins: {
+    entries: {
+      comfy: {
+        config: {
+          mode: "local",
+          baseUrl: "http://127.0.0.1:8188",
+          image: {
+            workflowPath: "./workflows/flux-api.json",
+            promptNodeId: "6",
+            outputNodeId: "9",
+          },
+          video: {
+            workflowPath: "./workflows/video-api.json",
+            promptNodeId: "12",
+            outputNodeId: "21",
+          },
+          music: {
+            workflowPath: "./workflows/music-api.json",
+            promptNodeId: "3",
+            outputNodeId: "18",
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Shared keys under `plugins.entries.comfy.config`:
+
+- `mode`: `local` or `cloud`
+- `baseUrl`: defaults to `http://127.0.0.1:8188` for local or `https://cloud.comfy.org` for cloud
+- `apiKey`: optional inline key alternative to env vars
+- `allowPrivateNetwork`: allow a private/LAN `baseUrl` in cloud mode
+
+Per-capability keys under `image`, `video`, or `music`:
+
+- `workflow` or `workflowPath`: required
+- `promptNodeId`: required
+- `promptInputName`: defaults to `text`
+- `outputNodeId`: optional
+- `pollIntervalMs`: optional
+- `timeoutMs`: optional
+
+Image and video sections also support:
+
+- `inputImageNodeId`: required when you pass a reference image
+- `inputImageInputName`: defaults to `image`
+
+## Backward compatibility
+
+Use `plugins.entries.comfy.config` in `openclaw.json` so the plugin schema can
+validate the workflow fields. Runtime provider config that still supplies
+`models.providers.comfy` is also read for compatibility and overrides matching
+plugin config keys:
+
+```json5
+{
   models: {
     providers: {
       comfy: {
@@ -63,30 +121,7 @@ sections:
 }
 ```
 
-Shared keys:
-
-- `mode`: `local` or `cloud`
-- `baseUrl`: defaults to `http://127.0.0.1:8188` for local or `https://cloud.comfy.org` for cloud
-- `apiKey`: optional inline key alternative to env vars
-- `allowPrivateNetwork`: allow a private/LAN `baseUrl` in cloud mode
-
-Per-capability keys under `image`, `video`, or `music`:
-
-- `workflow` or `workflowPath`: required
-- `promptNodeId`: required
-- `promptInputName`: defaults to `text`
-- `outputNodeId`: optional
-- `pollIntervalMs`: optional
-- `timeoutMs`: optional
-
-Image and video sections also support:
-
-- `inputImageNodeId`: required when you pass a reference image
-- `inputImageInputName`: defaults to `image`
-
-## Backward compatibility
-
-Existing top-level image config still works:
+Top-level image workflow config in that legacy runtime shape still works:
 
 ```json5
 {
@@ -124,15 +159,17 @@ Reference-image editing example:
 
 ```json5
 {
-  models: {
-    providers: {
+  plugins: {
+    entries: {
       comfy: {
-        image: {
-          workflowPath: "./workflows/edit-api.json",
-          promptNodeId: "6",
-          inputImageNodeId: "7",
-          inputImageInputName: "image",
-          outputNodeId: "9",
+        config: {
+          image: {
+            workflowPath: "./workflows/edit-api.json",
+            promptNodeId: "6",
+            inputImageNodeId: "7",
+            inputImageInputName: "image",
+            outputNodeId: "9",
+          },
         },
       },
     },
@@ -177,7 +214,7 @@ Use `mode: "cloud"` plus one of:
 
 - `COMFY_API_KEY`
 - `COMFY_CLOUD_API_KEY`
-- `models.providers.comfy.apiKey`
+- `plugins.entries.comfy.config.apiKey`
 
 Cloud mode still uses the same `image`, `video`, and `music` workflow sections.
 

--- a/extensions/comfy/image-generation-provider.test.ts
+++ b/extensions/comfy/image-generation-provider.test.ts
@@ -5,6 +5,7 @@ import {
   _setComfyFetchGuardForTesting,
   buildComfyImageGenerationProvider,
 } from "./image-generation-provider.js";
+import { getComfyConfig } from "./workflow-runtime.js";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -21,6 +22,18 @@ function buildComfyConfig(config: Record<string, unknown>): OpenClawConfig {
     models: {
       providers: {
         comfy: config,
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+function buildComfyPluginConfig(config: Record<string, unknown>): OpenClawConfig {
+  return {
+    plugins: {
+      entries: {
+        comfy: {
+          config,
+        },
       },
     },
   } as unknown as OpenClawConfig;
@@ -48,6 +61,47 @@ describe("comfy image-generation provider", () => {
         }),
       }),
     ).toBe(true);
+  });
+
+  it("reads workflows from the comfy plugin config entry", () => {
+    const provider = buildComfyImageGenerationProvider();
+    const cfg = buildComfyPluginConfig({
+      image: {
+        workflow: {
+          "6": { inputs: { text: "" } },
+        },
+        promptNodeId: "6",
+      },
+    });
+
+    expect(getComfyConfig(cfg).image).toEqual({
+      workflow: {
+        "6": { inputs: { text: "" } },
+      },
+      promptNodeId: "6",
+    });
+    expect(
+      provider.isConfigured?.({
+        cfg,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps models.providers.comfy as a runtime override", () => {
+    expect(
+      getComfyConfig({
+        ...buildComfyPluginConfig({
+          baseUrl: "http://127.0.0.1:8188",
+          mode: "local",
+        }),
+        ...buildComfyConfig({
+          baseUrl: "http://comfy.internal:8188",
+        }),
+      }),
+    ).toEqual({
+      baseUrl: "http://comfy.internal:8188",
+      mode: "local",
+    });
   });
 
   it("submits a local workflow, waits for history, and downloads images", async () => {

--- a/extensions/comfy/image-generation-provider.test.ts
+++ b/extensions/comfy/image-generation-provider.test.ts
@@ -5,7 +5,7 @@ import {
   _setComfyFetchGuardForTesting,
   buildComfyImageGenerationProvider,
 } from "./image-generation-provider.js";
-import { getComfyConfig } from "./workflow-runtime.js";
+import { getComfyCapabilityConfig, getComfyConfig } from "./workflow-runtime.js";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -101,6 +101,45 @@ describe("comfy image-generation provider", () => {
     ).toEqual({
       baseUrl: "http://comfy.internal:8188",
       mode: "local",
+    });
+  });
+
+  it("merges nested runtime capability overrides without dropping plugin workflows", () => {
+    const cfg = {
+      ...buildComfyPluginConfig({
+        image: {
+          workflow: {
+            "6": { inputs: { text: "" } },
+          },
+          promptNodeId: "6",
+          outputNodeIds: ["9"],
+        },
+      }),
+      ...buildComfyConfig({
+        image: {
+          baseUrl: "http://comfy.internal:8188",
+          pollIntervalMs: 500,
+        },
+      }),
+    };
+
+    expect(getComfyConfig(cfg).image).toEqual({
+      workflow: {
+        "6": { inputs: { text: "" } },
+      },
+      promptNodeId: "6",
+      outputNodeIds: ["9"],
+      baseUrl: "http://comfy.internal:8188",
+      pollIntervalMs: 500,
+    });
+    expect(getComfyCapabilityConfig(getComfyConfig(cfg), "image")).toEqual({
+      workflow: {
+        "6": { inputs: { text: "" } },
+      },
+      promptNodeId: "6",
+      outputNodeIds: ["9"],
+      baseUrl: "http://comfy.internal:8188",
+      pollIntervalMs: 500,
     });
   });
 

--- a/extensions/comfy/image-generation-provider.test.ts
+++ b/extensions/comfy/image-generation-provider.test.ts
@@ -143,6 +143,32 @@ describe("comfy image-generation provider", () => {
     });
   });
 
+  it("drops plugin inline workflow when provider overrides with workflowPath", () => {
+    const cfg = {
+      ...buildComfyPluginConfig({
+        image: {
+          workflow: {
+            "6": { inputs: { text: "" } },
+          },
+          promptNodeId: "6",
+        },
+      }),
+      ...buildComfyConfig({
+        image: {
+          workflowPath: "./workflows/override.json",
+          promptNodeId: "6",
+        },
+      }),
+    };
+
+    const merged = getComfyConfig(cfg);
+    expect(merged.image).toEqual({
+      workflowPath: "./workflows/override.json",
+      promptNodeId: "6",
+    });
+    expect(merged.image).not.toHaveProperty("workflow");
+  });
+
   it("submits a local workflow, waits for history, and downloads images", async () => {
     _setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
     fetchWithSsrFGuardMock

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -132,8 +132,15 @@ function mergeSsrFPolicies(...policies: Array<SsrFPolicy | undefined>): SsrFPoli
 }
 
 export function getComfyConfig(cfg?: OpenClawConfig): ComfyProviderConfig {
-  const raw = cfg?.models?.providers?.comfy;
-  return isRecord(raw) ? raw : {};
+  const pluginConfig = cfg?.plugins?.entries?.comfy?.config;
+  const providerConfig = cfg?.models?.providers?.comfy;
+  if (isRecord(pluginConfig) && isRecord(providerConfig)) {
+    return { ...pluginConfig, ...providerConfig };
+  }
+  if (isRecord(providerConfig)) {
+    return providerConfig;
+  }
+  return isRecord(pluginConfig) ? pluginConfig : {};
 }
 
 function stripNestedCapabilityConfig(config: ComfyProviderConfig): ComfyProviderConfig {
@@ -163,7 +170,7 @@ export function resolveComfyMode(config: ComfyProviderConfig): ComfyMode {
 function getRequiredConfigString(config: ComfyProviderConfig, key: string): string {
   const value = normalizeOptionalString(config[key]);
   if (!value) {
-    throw new Error(`models.providers.comfy.${key} is required`);
+    throw new Error(`Comfy config ${key} is required`);
   }
   return value;
 }
@@ -186,7 +193,7 @@ async function loadComfyWorkflow(config: ComfyProviderConfig): Promise<ComfyWork
     return source.workflow;
   }
   if (!source.workflowPath) {
-    throw new Error("models.providers.comfy.<capability>.workflow or workflowPath is required");
+    throw new Error("Comfy config workflow or workflowPath is required");
   }
 
   const resolvedPath = resolveUserPath(source.workflowPath);
@@ -648,9 +655,7 @@ export async function runComfyWorkflow(params: {
 
   if (params.inputImage) {
     if (!inputImageNodeId) {
-      throw new Error(
-        "Comfy edit requests require models.providers.comfy.<capability>.inputImageNodeId to be configured",
-      );
+      throw new Error("Comfy edit requests require inputImageNodeId to be configured");
     }
     const uploadedName = await uploadInputImage({
       baseUrl: normalizedBaseUrl,

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -87,6 +87,7 @@ export type ComfyWorkflowResult = {
 };
 
 let comfyFetchGuard = fetchWithSsrFGuard;
+const COMFY_CAPABILITIES = ["image", "music", "video"] as const satisfies readonly ComfyCapability[];
 
 export function _setComfyFetchGuardForTesting(impl: typeof fetchWithSsrFGuard | null): void {
   comfyFetchGuard = impl ?? fetchWithSsrFGuard;
@@ -135,7 +136,18 @@ export function getComfyConfig(cfg?: OpenClawConfig): ComfyProviderConfig {
   const pluginConfig = cfg?.plugins?.entries?.comfy?.config;
   const providerConfig = cfg?.models?.providers?.comfy;
   if (isRecord(pluginConfig) && isRecord(providerConfig)) {
-    return { ...pluginConfig, ...providerConfig };
+    const merged = { ...pluginConfig, ...providerConfig };
+    for (const capability of COMFY_CAPABILITIES) {
+      const pluginCapabilityConfig = pluginConfig[capability];
+      const providerCapabilityConfig = providerConfig[capability];
+      if (isRecord(pluginCapabilityConfig) && isRecord(providerCapabilityConfig)) {
+        merged[capability] = {
+          ...pluginCapabilityConfig,
+          ...providerCapabilityConfig,
+        };
+      }
+    }
+    return merged;
   }
   if (isRecord(providerConfig)) {
     return providerConfig;

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -141,10 +141,17 @@ export function getComfyConfig(cfg?: OpenClawConfig): ComfyProviderConfig {
       const pluginCapabilityConfig = pluginConfig[capability];
       const providerCapabilityConfig = providerConfig[capability];
       if (isRecord(pluginCapabilityConfig) && isRecord(providerCapabilityConfig)) {
-        merged[capability] = {
+        const capMerged = {
           ...pluginCapabilityConfig,
           ...providerCapabilityConfig,
         };
+        if (providerCapabilityConfig.workflowPath && pluginCapabilityConfig.workflow) {
+          delete capMerged.workflow;
+        }
+        if (providerCapabilityConfig.workflow && pluginCapabilityConfig.workflowPath) {
+          delete capMerged.workflowPath;
+        }
+        merged[capability] = capMerged;
       }
     }
     return merged;
@@ -624,15 +631,19 @@ export async function runComfyWorkflow(params: {
     value: params.prompt,
   });
 
-  const resolvedAuth =
+  let resolvedAuth =
     mode === "cloud"
       ? await resolveApiKeyForProvider({
           provider: "comfy",
           cfg: params.cfg,
           agentDir: params.agentDir,
           store: params.authStore,
-        })
+        }).catch(() => null)
       : null;
+  const pluginApiKey = normalizeOptionalString(capabilityConfig.apiKey);
+  if (mode === "cloud" && !resolvedAuth?.apiKey && pluginApiKey) {
+    resolvedAuth = { apiKey: pluginApiKey, source: "plugin-config", mode: "api-key" };
+  }
   if (mode === "cloud" && !resolvedAuth?.apiKey) {
     throw new Error("Comfy Cloud API key missing");
   }

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -548,6 +548,29 @@ describe("config plugin validation", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts comfy workflow settings on the plugin-owned config path", async () => {
+    const res = validateInSuite({
+      plugins: {
+        enabled: true,
+        entries: {
+          comfy: {
+            enabled: true,
+            config: {
+              mode: "local",
+              baseUrl: "http://127.0.0.1:8188",
+              image: {
+                workflowPath: "./workflows/flux-api.json",
+                promptNodeId: "6",
+                outputNodeId: "9",
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts plugin heartbeat targets", async () => {
     const res = validateInSuite({
       agents: { defaults: { heartbeat: { target: "bluebubbles" } }, list: [{ id: "pi" }] },


### PR DESCRIPTION
## Summary
- read Comfy config data from the plugin-owned `plugins.entries.comfy.config` path while keeping `models.providers.comfy` as a runtime override for backwards compatibility
- update the Comfy docs and tests so plugin config stays documented and validated

## Testing
- node scripts/run-vitest.mjs run extensions/comfy/image-generation-provider.test.ts
- node scripts/run-vitest.mjs run src/config/config.plugin-validation.test.ts