### PR TITLE
fix(feishu): handle new card action payload format with open_chat_id

### DIFF
--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -13,7 +13,7 @@ import { sendCardFeishu, sendMessageFeishu } from "./send.js";
 export type FeishuCardActionEvent = {
   operator: {
     open_id: string;
-    user_id: string;
+    user_id?: string;  // optional - Feishu new payloads don't always send this
     union_id: string;
   };
   token: string;
@@ -22,8 +22,8 @@ export type FeishuCardActionEvent = {
     tag: string;
   };
   context: {
-    open_id: string;
-    user_id: string;
+    open_id?: string;   // optional - new Feishu payloads don't send this
+    user_id?: string;   // optional - new Feishu payloads don't send this
     chat_id: string;
   };
 };

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -259,24 +259,32 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
   const actionValue = action.value;
   const contextOpenId = readString(context.open_id);
   const contextUserId = readString(context.user_id);
-  const chatId = readString(context.chat_id);
+  const chatId = readString(context.chat_id) || readString(context.open_chat_id);
+
+  // New Feishu payloads don't send operator.user_id, context.open_id, context.user_id
+  // Fall back to operator.open_id for these
+  const finalOpenId = openId || contextOpenId;
+  const finalUserId = userId || finalOpenId;
+  const finalContextOpenId = contextOpenId || finalOpenId;
+  const finalContextUserId = contextUserId || finalOpenId;
+
   if (
     !token ||
-    !openId ||
-    !userId ||
+    !finalOpenId ||
+    !finalUserId ||
     !unionId ||
     !tag ||
     !isRecord(actionValue) ||
-    !contextOpenId ||
-    !contextUserId ||
+    !finalContextOpenId ||
+    !finalContextUserId ||
     !chatId
   ) {
     return null;
   }
   return {
     operator: {
-      open_id: openId,
-      user_id: userId,
+      open_id: finalOpenId,
+      user_id: finalUserId,
       union_id: unionId,
     },
     token,
@@ -285,8 +293,8 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
       tag,
     },
     context: {
-      open_id: contextOpenId,
-      user_id: contextUserId,
+      open_id: finalContextOpenId,
+      user_id: finalContextUserId,
       chat_id: chatId,
     },
   };


### PR DESCRIPTION
## Problem

Feishu recently changed the `card.action.trigger` event payload format. The new format:
- Does NOT send `operator.user_id`
- Does NOT send `context.open_id`  
- Does NOT send `context.user_id`
- Uses `context.open_chat_id` instead of `context.chat_id`

OpenClaw's `parseFeishuCardActionEventPayload` function requires all these fields, causing it to return `null` (malformed) for all new-format payloads, making card button clicks fail silently.

## Solution

1. Updated `FeishuCardActionEvent` type to make `user_id` and `open_id` fields optional
2. Added fallback logic: use `operator.open_id` when `operator.user_id` / `context.open_id` / `context.user_id` is missing
3. Added support for `context.open_chat_id` as alternative to `context.chat_id`

## Test

A card with buttons was sent to a Feishu group. Clicking the button now correctly triggers the callback and updates the card.

Closes [internal #2026-04-06]