### PR TITLE
fix: prevent WhatsApp credentials corruption on media upload

### DIFF
--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -133,13 +133,16 @@ async function safeSaveCreds(
     try {
       const backupRaw = readCredsJsonRaw(backupPath);
       if (backupRaw) {
+        JSON.parse(backupRaw); // Validate backup before restoring
         fsSync.copyFileSync(backupPath, credsPath);
         try {
           fsSync.chmodSync(credsPath, 0o600);
         } catch {}
         logger.info({ credsPath }, "restored WhatsApp creds from backup after validation failure");
       }
-    } catch {}
+    } catch (restoreErr) {
+      logger.warn({ error: String(restoreErr) }, "failed to restore WhatsApp creds from backup after validation failure");
+    }
   }
 }
 

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -120,12 +120,6 @@ async function safeSaveCreds(
       throw new Error("creds.json empty after save");
     }
     JSON.parse(savedRaw); // Validate JSON
-
-    // Update backup with validated new creds
-    fsSync.copyFileSync(credsPath, backupPath);
-    try {
-      fsSync.chmodSync(backupPath, 0o600);
-    } catch {}
   } catch (err) {
     logger.warn({ error: String(err) }, "creds validation failed after save");
 

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -64,15 +64,15 @@ async function safeSaveCreds(
   saveCreds: () => Promise<void> | void,
   logger: ReturnType<typeof getChildLogger>,
 ): Promise<void> {
+  const credsPath = resolveWebCredsPath(authDir);
+  const backupPath = resolveWebCredsBackupPath(authDir);
+
+  // 1. Ensure backup exists and is valid before save
   try {
-    // Best-effort backup so we can recover after abrupt restarts.
-    // Important: don't clobber a good backup with a corrupted/truncated creds.json.
-    const credsPath = resolveWebCredsPath(authDir);
-    const backupPath = resolveWebCredsBackupPath(authDir);
     const raw = readCredsJsonRaw(credsPath);
     if (raw) {
       try {
-        JSON.parse(raw);
+        JSON.parse(raw); // Validate current creds before backing up
         fsSync.copyFileSync(credsPath, backupPath);
         try {
           fsSync.chmodSync(backupPath, 0o600);
@@ -80,21 +80,66 @@ async function safeSaveCreds(
           // best-effort on platforms that support it
         }
       } catch {
-        // keep existing backup
+        // keep existing backup if current creds is corrupted
       }
     }
   } catch {
     // ignore backup failures
   }
+
+  // 2. Perform save
   try {
     await Promise.resolve(saveCreds());
     try {
-      fsSync.chmodSync(resolveWebCredsPath(authDir), 0o600);
+      fsSync.chmodSync(credsPath, 0o600);
     } catch {
       // best-effort on platforms that support it
     }
   } catch (err) {
     logger.warn({ error: String(err) }, "failed saving WhatsApp creds");
+
+    // 3. Restore from backup on save failure
+    try {
+      const backupRaw = readCredsJsonRaw(backupPath);
+      if (backupRaw) {
+        JSON.parse(backupRaw); // Validate backup
+        fsSync.copyFileSync(backupPath, credsPath);
+        try {
+          fsSync.chmodSync(credsPath, 0o600);
+        } catch {}
+        logger.info({ credsPath }, "restored WhatsApp creds from backup after save failure");
+      }
+    } catch {}
+    return; // Don't throw, allow session to continue with backup
+  }
+
+  // 4. Validate saved file integrity
+  try {
+    const savedRaw = readCredsJsonRaw(credsPath);
+    if (!savedRaw) {
+      throw new Error("creds.json empty after save");
+    }
+    JSON.parse(savedRaw); // Validate JSON
+
+    // Update backup with validated new creds
+    fsSync.copyFileSync(credsPath, backupPath);
+    try {
+      fsSync.chmodSync(backupPath, 0o600);
+    } catch {}
+  } catch (err) {
+    logger.warn({ error: String(err) }, "creds validation failed after save");
+
+    // Restore from backup if validation failed
+    try {
+      const backupRaw = readCredsJsonRaw(backupPath);
+      if (backupRaw) {
+        fsSync.copyFileSync(backupPath, credsPath);
+        try {
+          fsSync.chmodSync(credsPath, 0o600);
+        } catch {}
+        logger.info({ credsPath }, "restored WhatsApp creds from backup after validation failure");
+      }
+    } catch {}
   }
 }
 

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -109,7 +109,12 @@ async function safeSaveCreds(
         } catch {}
         logger.info({ credsPath }, "restored WhatsApp creds from backup after save failure");
       }
-    } catch {}
+    } catch (restoreErr) {
+      logger.warn(
+        { error: String(restoreErr) },
+        "failed to restore WhatsApp creds from backup after save failure",
+      );
+    }
     return; // Don't throw, allow session to continue with backup
   }
 
@@ -135,7 +140,10 @@ async function safeSaveCreds(
         logger.info({ credsPath }, "restored WhatsApp creds from backup after validation failure");
       }
     } catch (restoreErr) {
-      logger.warn({ error: String(restoreErr) }, "failed to restore WhatsApp creds from backup after validation failure");
+      logger.warn(
+        { error: String(restoreErr) },
+        "failed to restore WhatsApp creds from backup after validation failure",
+      );
     }
   }
 }


### PR DESCRIPTION
## Problem

Sending large media files (MP4 videos >1MB) via WhatsApp causes `creds.json` corruption, leading to Gateway crash loops.

### Symptoms
- Gateway disconnects repeatedly (status 499/428)
- Log shows: `restored corrupted WhatsApp creds.json from backup`
- Manual intervention required to restore credentials

### Root Cause
Baileys `useMultiFileAuthState` writes directly to `creds.json` without atomic write or post-save validation.

## Solution
Enhanced `safeSaveCreds` with pre-save backup, post-save validation, and auto-recovery from backup.

### Changes
- `extensions/whatsapp/src/session.ts`

### Testing
- Built successfully
- No TypeScript errors