### PR TITLE
fix(cron): pass bashElevated to isolated embedded runs

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,4 +1,5 @@
 import type { SkillSnapshot } from "../../agents/skills.js";
+import type { ExecElevatedDefaults } from "../../agents/bash-tools.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -31,6 +32,26 @@ import { syncCronSessionLiveSelection } from "./run-session-state.js";
 import { isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
 type AgentTurnPayload = Extract<CronJob["payload"], { kind: "agentTurn" }> | null;
+
+function resolveExecElevatedDefaults(cfg: OpenClawConfig): ExecElevatedDefaults {
+  const globalElevated = cfg.tools?.elevated;
+  const agentElevated = cfg.agents?.defaults?.tools?.elevated;
+  const enabled = globalElevated?.enabled !== false && agentElevated?.enabled !== false;
+  const configuredDefault = cfg.agents?.defaults?.elevatedDefault;
+  const defaultLevel =
+    configuredDefault === "off" ||
+    configuredDefault === "on" ||
+    configuredDefault === "ask" ||
+    configuredDefault === "full"
+      ? configuredDefault
+      : "on";
+
+  return {
+    enabled,
+    allowed: enabled,
+    defaultLevel: enabled ? defaultLevel : "off",
+  };
+}
 type CronPromptRunResult = Awaited<ReturnType<typeof runCliAgent>>;
 
 export type CronExecutionResult = {
@@ -160,6 +181,7 @@ export function createCronPromptExecutor(params: {
             sessionEntry: params.cronSession.sessionEntry,
           }).enabled,
           verboseLevel: params.resolvedVerboseLevel,
+          bashElevated: resolveExecElevatedDefaults(params.cfgWithAgentDefaults),
           timeoutMs: params.timeoutMs,
           bootstrapContextMode: params.agentPayload?.lightContext ? "lightweight" : undefined,
           bootstrapContextRunKind: "cron",

--- a/src/cron/isolated-agent/run.owner-auth.test.ts
+++ b/src/cron/isolated-agent/run.owner-auth.test.ts
@@ -12,9 +12,9 @@ const RUN_OWNER_AUTH_TIMEOUT_MS = 300_000;
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 
-function makeParams() {
+function makeParams(cfg: Record<string, unknown> = {}) {
   return {
-    cfg: {},
+    cfg,
     deps: {} as never,
     job: {
       id: "owner-auth",
@@ -66,6 +66,35 @@ describe("runCronIsolatedAgentTurn owner auth", () => {
       expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
       const senderIsOwner = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.senderIsOwner;
       expect(senderIsOwner).toBe(false);
+    },
+  );
+
+  it(
+    "passes resolved bashElevated defaults to isolated cron agent runs",
+    { timeout: RUN_OWNER_AUTH_TIMEOUT_MS },
+    async () => {
+      await runCronIsolatedAgentTurn(
+        makeParams({
+          tools: {
+            elevated: {
+              enabled: true,
+            },
+          },
+          agents: {
+            defaults: {
+              elevatedDefault: "full",
+            },
+          },
+        }),
+      );
+
+      expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+      const bashElevated = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.bashElevated;
+      expect(bashElevated).toEqual({
+        enabled: true,
+        allowed: true,
+        defaultLevel: "full",
+      });
     },
   );
 });


### PR DESCRIPTION
## Problem

Cron jobs running via `createCronPromptExecutor` call `runEmbeddedPiAgent` without passing `bashElevated`. This means cron agents cannot execute elevated shell commands even when the gateway is configured with `tools.elevated.enabled: true` and `agents.defaults.elevatedDefault: 'full'`.

The result is that cron agents using embedded PI get stuck requesting exec approval from a non-existent user, burning tokens in a loop.

## Fix

- Add `resolveExecElevatedDefaults(cfg)` helper that reads the gateway's elevated config and produces the `ExecElevatedDefaults` shape.
- Pass the resolved `bashElevated` to `runEmbeddedPiAgent` in the cron executor path.
- Add test verifying `bashElevated` is forwarded correctly with expected config resolution.

## Testing

```bash
npm test -- --grep 'bashElevated'
```
