### PR TITLE
Raise video generation save cap for generated videos

### DIFF
--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { MAX_VIDEO_BYTES } from "../../media/constants.js";
 import * as mediaStore from "../../media/store.js";
 import * as videoGenerationRuntime from "../../video-generation/runtime.js";
 import * as videoGenerateBackground from "./video-generate-background.js";
@@ -160,6 +161,7 @@ describe("createVideoGenerateTool", () => {
 
     expect(text).toContain("Generated 1 video with qwen/wan2.6-t2v.");
     expect(text).toContain("MEDIA:/tmp/generated-lobster.mp4");
+    expect(vi.mocked(mediaStore.saveMediaBuffer).mock.calls[0]?.[3]).toBe(MAX_VIDEO_BYTES);
     expect(result.details).toMatchObject({
       provider: "qwen",
       model: "wan2.6-t2v",

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { maxBytesForKind } from "../../media/constants.js";
 import { saveMediaBuffer } from "../../media/store.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
@@ -617,7 +618,7 @@ async function executeVideoGenerationJob(params: {
         video.buffer,
         video.mimeType,
         "tool-video-generation",
-        undefined,
+        maxBytesForKind("video"),
         params.filename || video.fileName,
       ),
     ),


### PR DESCRIPTION
Fix video_generate so generated buffer videos are saved with the video media cap instead of the generic 5MB default. This allows generated videos larger than 5MB to be delivered without tripping the shared media-store limit.

Validation:
- pnpm exec vitest run src/agents/tools/video-generate-tool.test.ts