### PR TITLE
feat(skills): add secret-scanning-maintainer skill

### DIFF
--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -134,31 +134,42 @@ gh api repos/openclaw/openclaw/contents/<FILE_PATH> | jq -r '.content' | base64 
 All secrets MUST be replaced with this format:
 
 ```
-[REDACTED <secret_type>: <prefix>...<suffix>]
+[REDACTED <secret_type>]
 ```
+
+Do NOT include any portion of the actual secret value in the redaction marker. No prefix, no suffix, no character count. Even a few characters can help an attacker confirm or narrow down the full value.
 
 Examples:
 
-- `[REDACTED discord_bot_token: MTQ4...Aacg]`
-- `[REDACTED feishu_app_secret: HOd***]`
-- `[REDACTED github_pat: ghp_...x7Qz]`
-
-Preserve 3-4 chars from prefix and suffix for identification. **Never include more than 30% of the original secret.**
+- `[REDACTED discord_bot_token]`
+- `[REDACTED feishu_app_secret]`
+- `[REDACTED github_pat]`
+- `[REDACTED google_oauth_client_id]`
 
 One comment/body may contain **multiple different secrets**. Scan the entire content and redact ALL of them.
 
 ### For issue_comment
 
+Always use a temp file with heredoc to avoid shell quoting issues:
+
 ```bash
+cat > /tmp/redacted_comment.md <<'BODY'
+<redacted content>
+BODY
 gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> \
-  -X PATCH -f body='<redacted content>'
+  -X PATCH -F body=@/tmp/redacted_comment.md
 ```
 
 ### For issue_body
 
+Always use a temp file with heredoc to avoid shell quoting issues:
+
 ```bash
+cat > /tmp/redacted_issue.md <<'BODY'
+<redacted content>
+BODY
 gh api repos/openclaw/openclaw/issues/<NUMBER> \
-  -X PATCH -f body='<redacted content>'
+  -X PATCH -F body=@/tmp/redacted_issue.md
 ```
 
 ### For pull_request_body
@@ -243,19 +254,26 @@ If the PR is not merged, consider deleting the branch or force-pushing a cleaned
 
 Post a notification comment on the same issue/PR. **All comments MUST be in English.**
 
+> **Security:** Do NOT include any portion of the secret value or the alert URL in public comments. The alert URL is only accessible to repo admins and reveals internal tracking info. Only reference the secret by its type name.
+
+Use a temp file with heredoc to avoid shell quoting issues:
+
 ```bash
-gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
-  -X POST -f body='@<AUTHOR> :warning: **Security Notice: Secret Leakage Detected**
+cat > /tmp/notify_comment.md <<'BODY'
+@<AUTHOR> :warning: **Security Notice: Secret Leakage Detected**
 
-Your comment contained the following exposed secrets detected by GitHub Secret Scanning:
+GitHub Secret Scanning detected the following exposed secret types in your content:
 
-1. **<Secret Type Display Name>**: `<redacted_preview>` (alert [#<N>](https://github.com/openclaw/openclaw/security/secret-scanning/<N>))
+1. **<Secret Type Display Name>**
 
-The original comment has been removed and replaced with a redacted version.
+The affected content has been redacted.
 
 **Please rotate these credentials immediately.**
 
-These secrets were publicly exposed and should be considered compromised.'
+These secrets were publicly exposed and should be considered compromised.
+BODY
+gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
+  -X POST -F body=@/tmp/notify_comment.md
 ```
 
 Adjust the rotation guidance based on secret type when possible (e.g., link to Discord developer portal for Discord tokens).
@@ -339,9 +357,12 @@ Please update the skill to define handling for these types:
 - **Always read the content before editing.** Never blindly patch.
 - **Preserve the original message intent.** Only redact secrets, keep all other content intact.
 - **Check for multiple secrets** in a single comment/body — alerts may only flag one, but there could be more.
-- **Do not expose full secrets** in notification comments — use the redacted format.
+- **Never include any portion of a secret** in public comments, redaction markers, or terminal output. Use type-only redaction: `[REDACTED <type>]`.
+- **Never include secret scanning alert URLs** in public comments — they are admin-only and leak internal info.
 - **Ask for confirmation** before deleting any comment or issue.
 - **One alert at a time** unless the user explicitly requests batch processing.
 - **Always print the summary** after processing, with all alert/issue/PR links for verification.
 - **All comments and notifications MUST be written in English.**
 - **Skip unsupported location types.** If a location type is not defined in this skill (e.g., not `issue_comment`, `issue_body`, `pull_request_body`, or `commit`), do not process it. Report it in the summary and note that the skill needs to be updated.
+- **Use temp files with heredoc** for all `gh api` calls that set body content. Never inline body text with `-f body='...'` — it is vulnerable to shell quoting issues and command injection via copy/paste.
+- **Never print raw API response bodies to stdout.** When fetching alert details or comment content for analysis, pipe through `jq` to extract only the fields you need (e.g., `jq '{number, state, secret_type}'`). Avoid printing `.secret` or `.body` fields that contain plaintext secrets.

--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -163,11 +163,13 @@ Resolution is `revoked` by default. As maintainers we cannot control whether use
 
 ## Step 7: Summary
 
-After processing, create a JSON results file and pass it to summary:
+After processing, create a JSON results file and pass it to the summary command:
 
 ```bash
 node secret-scanning.mjs summary /tmp/results.json
 ```
+
+**The script output IS the final summary.** Do NOT rewrite, reformat, or create your own summary table. Just run the script and present its output directly to the user. The script already includes full URLs for every alert and location.
 
 The JSON format:
 

--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -169,7 +169,7 @@ After processing, create a JSON results file and pass it to the summary command:
 node secret-scanning.mjs summary /tmp/results.json
 ```
 
-**The script output IS the final summary.** Do NOT rewrite, reformat, or create your own summary table. Just run the script and present its output directly to the user. The script already includes full URLs for every alert and location.
+The script outputs a block delimited by `---BEGIN SUMMARY---` and `---END SUMMARY---`. **You MUST output the content between these markers verbatim to the user. Do NOT rephrase, reformat, abbreviate, or create your own summary.** The script already includes full URLs for every alert and location.
 
 The JSON format:
 

--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -1,0 +1,347 @@
+---
+name: openclaw-secret-scanning-maintainer
+description: Maintainer-only workflow for handling GitHub Secret Scanning alerts on OpenClaw. Use when Codex needs to triage, redact, clean up, and resolve secret leakage found in issue comments, issue bodies, PR comments, or other GitHub content.
+---
+
+# OpenClaw Secret Scanning Maintainer
+
+**Maintainer-only.** This skill requires repo admin / maintainer permissions to edit or delete other users' comments and resolve secret scanning alerts.
+
+Use this skill when processing alerts from `https://github.com/openclaw/openclaw/security/secret-scanning`.
+
+**Language rule:** All skill content, notification comments, and replacement comments MUST be written in English.
+
+## Overall Flow
+
+Supports processing a single alert or multiple alerts. For multiple alerts, process them in ascending order by number.
+
+For each alert:
+
+1. **Identify** — fetch alert details + location + content + edit history
+2. **Redact** — edit the content to mask all secrets
+3. **Purge history** — remove old revisions that contain plaintext secrets
+4. **Notify** — @ mention the original author with redacted info and rotation instructions
+5. **Resolve** — close the alert as `revoked`
+6. **Summary** — print a result summary with all relevant links
+
+## Step 1: Identify the Alert
+
+```bash
+# Fetch alert details
+gh api repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER>
+
+# Fetch leak locations
+gh api repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER>/locations
+```
+
+Location `type` determines the processing branch:
+
+| type                | Meaning               | Branch                |
+| ------------------- | --------------------- | --------------------- |
+| `issue_comment`     | Issue / PR comment    | → Comment flow        |
+| `issue_body`        | Issue body            | → Issue Body flow     |
+| `pull_request_body` | PR body               | → PR Body flow        |
+| `commit`            | Code commit           | → Commit flow         |
+| _any other type_    | Unknown / unsupported | → **Skip and report** |
+
+**If a location type is not listed in the table above, do NOT attempt to process it.** Skip the alert, note it in the summary, and remind the user that this skill needs to be updated to handle the new type.
+
+## Step 2: Fetch Content and Edit History
+
+### For issue_comment
+
+```bash
+# REST: fetch current comment content
+gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID>
+
+# GraphQL: fetch node_id and edit history
+# node_id is in the REST response "node_id" field
+gh api graphql -f query='
+{
+  node(id: "<NODE_ID>") {
+    ... on IssueComment {
+      body
+      userContentEdits(first: 10) {
+        totalCount
+        nodes { id createdAt diff editor { login } }
+      }
+    }
+  }
+}'
+```
+
+### For issue_body
+
+```bash
+# REST: fetch current issue content
+gh api repos/openclaw/openclaw/issues/<NUMBER>
+
+# GraphQL: fetch issue body edit history
+gh api graphql -f query='
+{
+  repository(owner: "openclaw", name: "openclaw") {
+    issue(number: <NUMBER>) {
+      body
+      bodyText
+      id
+      userContentEdits(first: 10) {
+        totalCount
+        nodes { id createdAt diff editor { login } }
+      }
+    }
+  }
+}'
+```
+
+### For pull_request_body
+
+```bash
+# REST: fetch current PR content
+gh api repos/openclaw/openclaw/pulls/<NUMBER>
+
+# GraphQL: fetch PR body edit history
+# node_id is in the REST response "node_id" field
+gh api graphql -f query='
+{
+  node(id: "<NODE_ID>") {
+    ... on PullRequest {
+      body
+      userContentEdits(first: 10) {
+        totalCount
+        nodes { id createdAt diff editor { login } }
+      }
+    }
+  }
+}'
+```
+
+### For commit
+
+No edit history to fetch (commits have no edit history). Confirm the following:
+
+```bash
+# Check if the commit's PR is merged
+gh api repos/openclaw/openclaw/pulls/<PR_NUMBER> | jq '{merged, state, head_ref}'
+
+# Check if the file on main still contains the secret
+gh api repos/openclaw/openclaw/contents/<FILE_PATH> | jq -r '.content' | base64 -d
+```
+
+## Step 3: Redact Secrets
+
+### Redaction format
+
+All secrets MUST be replaced with this format:
+
+```
+[REDACTED <secret_type>: <prefix>...<suffix>]
+```
+
+Examples:
+
+- `[REDACTED discord_bot_token: MTQ4...Aacg]`
+- `[REDACTED feishu_app_secret: HOd***]`
+- `[REDACTED github_pat: ghp_...x7Qz]`
+
+Preserve 3-4 chars from prefix and suffix for identification. **Never include more than 30% of the original secret.**
+
+One comment/body may contain **multiple different secrets**. Scan the entire content and redact ALL of them.
+
+### For issue_comment
+
+```bash
+gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> \
+  -X PATCH -f body='<redacted content>'
+```
+
+### For issue_body
+
+```bash
+gh api repos/openclaw/openclaw/issues/<NUMBER> \
+  -X PATCH -f body='<redacted content>'
+```
+
+### For pull_request_body
+
+For long body content, save to a temp file first and upload with `-F body=@file`:
+
+```bash
+# Save original body
+gh api repos/openclaw/openclaw/pulls/<NUMBER> | jq -r '.body' > /tmp/pr_body.md
+
+# Edit to redact (manual or sed/editor)
+# ...
+
+# Update PR body
+gh api repos/openclaw/openclaw/pulls/<NUMBER> \
+  -X PATCH -F body=@/tmp/pr_body.md
+```
+
+## Step 4: Purge Edit History
+
+> **Critical:** GitHub has removed the `deleteUserContentEdit` mutation. There is NO API to delete individual edit revisions.
+
+### issue_comment — Delete and Recreate
+
+This is the only way to fully purge edit history from comments.
+
+```bash
+# 1. Delete the original comment (including all edit history)
+gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> -X DELETE
+
+# 2. Recreate a redacted version
+gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
+  -X POST -f body='> **Note from maintainer (@<YOUR_LOGIN>):** The original comment by @<AUTHOR> has been removed due to secret leakage. Below is the redacted version of the original content.
+
+---
+
+<redacted original content>'
+```
+
+### issue_body / pull_request_body — Cannot Fully Purge
+
+Edit history for issue body and PR body **cannot be cleared via API**, because:
+
+- Cannot delete and recreate an issue/PR (would lose all comments, labels, reviews, PR associations)
+- `deleteUserContentEdit` mutation has been removed by GitHub
+
+**Important limitation:** Editing a body automatically creates a new edit history revision. GitHub stores the **pre-edit original content** (containing plaintext secrets) in that revision. Anyone can view it by clicking the "edited" button. This applies even if the original body was never edited before.
+
+**What to do:**
+
+1. Edit to redact the body (Step 3)
+2. **Only output the warning to the maintainer in terminal** (never in public comments or resolution comments):
+
+```
+⚠️ Issue/PR body edit history still contains plaintext secrets.
+GitHub API cannot clear this history. To fully purge, contact GitHub Support:
+https://support.github.com/contact
+Request a purge of issue/PR #{NUMBER} userContentEdits.
+```
+
+> **CRITICAL:** Do NOT mention edit history or the "edited" button in any public comment, notification, or resolution_comment. Revealing that plaintext secrets exist in edit history directs attackers to them. This information is for the maintainer only.
+
+### commit — Context-dependent handling
+
+| Scenario                                | Action                                                                                              |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| PR not merged, commit on fork branch    | Cannot clean directly (not in this repo). Notify author to delete branch or force-push              |
+| PR merged, secret in main branch        | Requires BFG / git filter-repo to clean history (out of scope for this skill, alert the maintainer) |
+| File deleted/modified in a later commit | Still notify — old commits remain accessible                                                        |
+
+Include commit info only in the terminal output for the maintainer. In public notification comments, simply say the secret was found in code and the author should rotate — do not list specific commit SHAs or file paths that contain plaintext secrets.
+
+**Terminal-only (maintainer):**
+
+```
+⚠️ The following commits still contain plaintext secrets:
+- <commit_sha_short>: <file_path>
+If the PR is not merged, consider deleting the branch or force-pushing a cleaned version.
+```
+
+## Step 5: Notify the Author
+
+Post a notification comment on the same issue/PR. **All comments MUST be in English.**
+
+```bash
+gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
+  -X POST -f body='@<AUTHOR> :warning: **Security Notice: Secret Leakage Detected**
+
+Your comment contained the following exposed secrets detected by GitHub Secret Scanning:
+
+1. **<Secret Type Display Name>**: `<redacted_preview>` (alert [#<N>](https://github.com/openclaw/openclaw/security/secret-scanning/<N>))
+
+The original comment has been removed and replaced with a redacted version.
+
+**Please rotate these credentials immediately.**
+
+These secrets were publicly exposed and should be considered compromised.'
+```
+
+Adjust the rotation guidance based on secret type when possible (e.g., link to Discord developer portal for Discord tokens).
+
+## Step 6: Resolve the Alert
+
+Close the alert with `revoked`. GitHub suggests confirming the secret has been rotated before revoking, but as maintainers we cannot control whether users rotate — our responsibility is to redact + notify. Once those steps are done, the alert can be closed. The `revoked` resolution means "this secret should be considered leaked/revoked", not "I have confirmed it was revoked".
+
+```bash
+gh api repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER> \
+  -X PATCH -f state=resolved -f resolution=revoked \
+  -f resolution_comment="Content redacted and author notified to rotate credentials."
+```
+
+Available resolution values:
+
+| Value            | When to use                                                   |
+| ---------------- | ------------------------------------------------------------- |
+| `revoked`        | Secret leaked, should be considered invalidated (**default**) |
+| `false_positive` | Not a real secret, false positive                             |
+| `wont_fix`       | Acknowledged but will not address (rarely used)               |
+| `used_in_tests`  | Test-only fake secret (rarely used)                           |
+
+## Batch Processing
+
+When processing multiple alerts:
+
+```bash
+# List all open alerts
+gh api repos/openclaw/openclaw/secret-scanning/alerts \
+  --paginate -q '.[] | select(.state=="open") | "\(.number)\t\(.secret_type_display_name)\t\(.first_location_detected.html_url)"'
+```
+
+Process each alert individually following the flow above. **Always confirm with the user before batch-deleting comments.**
+
+## Summary
+
+After processing each alert (or all alerts in a batch), print a result summary.
+
+**All links MUST be printed as full URLs** (not markdown `[text](url)` syntax), so they are clickable in terminal output.
+
+Format:
+
+```
+## Secret Scanning Results
+
+| Alert | Type | Location | Actions | Edit History |
+|-------|------|----------|---------|--------------|
+| #72 https://github.com/openclaw/openclaw/security/secret-scanning/72 | Discord Bot Token | Issue #63101 comment https://github.com/openclaw/openclaw/issues/63101#issuecomment-xxx | Redacted+Deleted+Recreated+Notified | Cleared |
+| #56 https://github.com/openclaw/openclaw/security/secret-scanning/56 | Google OAuth Client ID | PR #3077 body https://github.com/openclaw/openclaw/pull/3077 | Redacted+Notified | ⚠️ History remains |
+```
+
+Each row MUST include:
+
+- Alert number and full URL: `#<N> https://github.com/openclaw/openclaw/security/secret-scanning/<N>`
+- Leak location with full URL: e.g., `Issue #<N> https://github.com/openclaw/openclaw/issues/<N>` or `PR #<N> https://github.com/openclaw/openclaw/pull/<N>`
+- Actions taken
+- Edit history status: `Cleared`, `⚠️ History remains`, or `Skipped (unsupported type: <type>)`
+
+For issues/PRs with ⚠️ History remains, add a follow-up section (terminal output only, never in public comments):
+
+```
+Issues requiring GitHub Support to purge edit history:
+- Issue #1594 https://github.com/openclaw/openclaw/issues/1594 — Telegram Bot Token
+- Issue #4155 https://github.com/openclaw/openclaw/issues/4155 — Google OAuth Client ID/Secret
+Contact: https://support.github.com/contact — request purge of userContentEdits for the above issues.
+```
+
+> **CRITICAL:** Never mention edit history details, "edited" button, or specific commit SHAs containing plaintext in any public-facing content (comments, PR descriptions, resolution comments). This information must only appear in terminal output for the maintainer.
+
+For any skipped alerts, add a note at the bottom of the summary:
+
+```
+⚠️ The following alerts were skipped because their location type is not supported by this skill.
+Please update the skill to define handling for these types:
+- Alert #<N>: unsupported type "<type>" — https://github.com/openclaw/openclaw/security/secret-scanning/<N>
+```
+
+## Safety Rules
+
+- **Always read the content before editing.** Never blindly patch.
+- **Preserve the original message intent.** Only redact secrets, keep all other content intact.
+- **Check for multiple secrets** in a single comment/body — alerts may only flag one, but there could be more.
+- **Do not expose full secrets** in notification comments — use the redacted format.
+- **Ask for confirmation** before deleting any comment or issue.
+- **One alert at a time** unless the user explicitly requests batch processing.
+- **Always print the summary** after processing, with all alert/issue/PR links for verification.
+- **All comments and notifications MUST be written in English.**
+- **Skip unsupported location types.** If a location type is not defined in this skill (e.g., not `issue_comment`, `issue_body`, `pull_request_body`, or `commit`), do not process it. Report it in the summary and note that the skill needs to be updated.

--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -17,7 +17,7 @@ Supports processing a single alert or multiple alerts. For multiple alerts, proc
 
 For each alert:
 
-1. **Identify** — fetch alert details + location + content + edit history
+1. **Identify** — fetch alert metadata + location + content + edit history
 2. **Redact** — edit the content to mask all secrets
 3. **Purge history** — remove old revisions that contain plaintext secrets
 4. **Notify** — @ mention the original author with redacted info and rotation instructions
@@ -26,9 +26,12 @@ For each alert:
 
 ## Step 1: Identify the Alert
 
+Always use `hide_secret=true` to prevent plaintext secrets from appearing in terminal output:
+
 ```bash
-# Fetch alert details
-gh api repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER>
+# Fetch alert metadata (secret value hidden)
+gh api "repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER>?hide_secret=true" \
+  | jq '{number, state, secret_type, secret_type_display_name, validity, first_location_detected}'
 
 # Fetch leak locations
 gh api repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER>/locations
@@ -36,34 +39,42 @@ gh api repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER>/locations
 
 Location `type` determines the processing branch:
 
-| type                | Meaning               | Branch                |
-| ------------------- | --------------------- | --------------------- |
-| `issue_comment`     | Issue / PR comment    | → Comment flow        |
-| `issue_body`        | Issue body            | → Issue Body flow     |
-| `pull_request_body` | PR body               | → PR Body flow        |
-| `commit`            | Code commit           | → Commit flow         |
-| _any other type_    | Unknown / unsupported | → **Skip and report** |
+| type                          | Meaning                 | Branch                |
+| ----------------------------- | ----------------------- | --------------------- |
+| `issue_comment`               | Issue comment           | → Comment flow        |
+| `pull_request_comment`        | PR comment (non-review) | → Comment flow        |
+| `pull_request_review_comment` | PR review comment       | → Comment flow        |
+| `issue_body`                  | Issue body              | → Issue Body flow     |
+| `pull_request_body`           | PR body                 | → PR Body flow        |
+| `commit`                      | Code commit             | → Commit flow         |
+| _any other type_              | Unknown / unsupported   | → **Skip and report** |
 
 **If a location type is not listed in the table above, do NOT attempt to process it.** Skip the alert, note it in the summary, and remind the user that this skill needs to be updated to handle the new type.
 
 ## Step 2: Fetch Content and Edit History
 
-### For issue_comment
+> **Security:** Never print `.body` or `.secret` fields to stdout. Always pipe through `jq` to extract only the fields needed for processing. The full body content is needed internally for redaction but should not be displayed.
+
+### For issue_comment / pull_request_comment / pull_request_review_comment
+
+All PR comment types use the same `issues/comments` API. The comment ID comes from the location's `issue_comment_url` or `pull_request_comment_url`.
 
 ```bash
-# REST: fetch current comment content
-gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID>
+# Save full comment for internal processing (do NOT print to terminal)
+gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> > /tmp/secretscan_comment.json
 
-# GraphQL: fetch node_id and edit history
-# node_id is in the REST response "node_id" field
+# Print only metadata
+gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> \
+  | jq '{id, user: .user.login, created_at, updated_at, node_id}'
+
+# GraphQL: fetch edit history (node_id from REST response)
 gh api graphql -f query='
 {
   node(id: "<NODE_ID>") {
     ... on IssueComment {
-      body
-      userContentEdits(first: 10) {
+      userContentEdits(first: 50) {
         totalCount
-        nodes { id createdAt diff editor { login } }
+        nodes { id createdAt editor { login } }
       }
     }
   }
@@ -73,20 +84,22 @@ gh api graphql -f query='
 ### For issue_body
 
 ```bash
-# REST: fetch current issue content
-gh api repos/openclaw/openclaw/issues/<NUMBER>
+# Print only metadata
+gh api repos/openclaw/openclaw/issues/<NUMBER> \
+  | jq '{number, title, user: .user.login, node_id}'
 
-# GraphQL: fetch issue body edit history
+# Save full body for internal processing
+gh api repos/openclaw/openclaw/issues/<NUMBER> | jq -r '.body' > "$(mktemp /tmp/secretscan_issue_XXXXX.md)"
+
+# GraphQL: fetch edit history
 gh api graphql -f query='
 {
   repository(owner: "openclaw", name: "openclaw") {
     issue(number: <NUMBER>) {
-      body
-      bodyText
       id
-      userContentEdits(first: 10) {
+      userContentEdits(first: 50) {
         totalCount
-        nodes { id createdAt diff editor { login } }
+        nodes { id createdAt editor { login } }
       }
     }
   }
@@ -96,19 +109,21 @@ gh api graphql -f query='
 ### For pull_request_body
 
 ```bash
-# REST: fetch current PR content
-gh api repos/openclaw/openclaw/pulls/<NUMBER>
+# Print only metadata
+gh api repos/openclaw/openclaw/pulls/<NUMBER> \
+  | jq '{number, title, user: .user.login, node_id, merged, state}'
 
-# GraphQL: fetch PR body edit history
-# node_id is in the REST response "node_id" field
+# Save full body for internal processing
+gh api repos/openclaw/openclaw/pulls/<NUMBER> | jq -r '.body' > "$(mktemp /tmp/secretscan_pr_XXXXX.md)"
+
+# GraphQL: fetch edit history (node_id from REST response)
 gh api graphql -f query='
 {
   node(id: "<NODE_ID>") {
     ... on PullRequest {
-      body
-      userContentEdits(first: 10) {
+      userContentEdits(first: 50) {
         totalCount
-        nodes { id createdAt diff editor { login } }
+        nodes { id createdAt editor { login } }
       }
     }
   }
@@ -122,10 +137,9 @@ No edit history to fetch (commits have no edit history). Confirm the following:
 ```bash
 # Check if the commit's PR is merged
 gh api repos/openclaw/openclaw/pulls/<PR_NUMBER> | jq '{merged, state, head_ref}'
-
-# Check if the file on main still contains the secret
-gh api repos/openclaw/openclaw/contents/<FILE_PATH> | jq -r '.content' | base64 -d
 ```
+
+Do NOT fetch or print file contents that may contain secrets.
 
 ## Step 3: Redact Secrets
 
@@ -148,65 +162,61 @@ Examples:
 
 One comment/body may contain **multiple different secrets**. Scan the entire content and redact ALL of them.
 
-### For issue_comment
+### For issue_comment / pull_request_comment / pull_request_review_comment
 
-Always use a temp file with heredoc to avoid shell quoting issues:
-
-```bash
-cat > /tmp/redacted_comment.md <<'BODY'
-<redacted content>
-BODY
-gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> \
-  -X PATCH -F body=@/tmp/redacted_comment.md
-```
+**Skip the PATCH step.** Since the comment will be deleted in Step 4 anyway, editing it first would create a new edit history revision containing the pre-edit plaintext — an unnecessary exposure window. Go directly to Step 4 (delete + recreate with redacted content).
 
 ### For issue_body
 
 Always use a temp file with heredoc to avoid shell quoting issues:
 
 ```bash
-cat > /tmp/redacted_issue.md <<'BODY'
+REDACTED_FILE="$(mktemp /tmp/secretscan_redacted_XXXXX.md)"
+cat > "$REDACTED_FILE" <<'BODY'
 <redacted content>
 BODY
 gh api repos/openclaw/openclaw/issues/<NUMBER> \
-  -X PATCH -F body=@/tmp/redacted_issue.md
+  -X PATCH -F body=@"$REDACTED_FILE"
 ```
 
 ### For pull_request_body
 
-For long body content, save to a temp file first and upload with `-F body=@file`:
+Save to a temp file, edit to redact, then upload:
 
 ```bash
-# Save original body
-gh api repos/openclaw/openclaw/pulls/<NUMBER> | jq -r '.body' > /tmp/pr_body.md
-
-# Edit to redact (manual or sed/editor)
+REDACTED_FILE="$(mktemp /tmp/secretscan_redacted_XXXXX.md)"
+# Save original body to temp file
+gh api repos/openclaw/openclaw/pulls/<NUMBER> | jq -r '.body' > "$REDACTED_FILE"
+# Edit to redact (replace secret values in the file)
 # ...
-
 # Update PR body
 gh api repos/openclaw/openclaw/pulls/<NUMBER> \
-  -X PATCH -F body=@/tmp/pr_body.md
+  -X PATCH -F body=@"$REDACTED_FILE"
 ```
 
 ## Step 4: Purge Edit History
 
 > **Critical:** GitHub has removed the `deleteUserContentEdit` mutation. There is NO API to delete individual edit revisions.
 
-### issue_comment — Delete and Recreate
+### issue_comment / pull_request_comment / pull_request_review_comment — Delete and Recreate
 
-This is the only way to fully purge edit history from comments.
+This is the only way to fully purge edit history from comments. **Do NOT PATCH before DELETE** — the PATCH would create an unnecessary edit history revision exposing plaintext.
 
 ```bash
 # 1. Delete the original comment (including all edit history)
 gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> -X DELETE
 
-# 2. Recreate a redacted version
-gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
-  -X POST -f body='> **Note from maintainer (@<YOUR_LOGIN>):** The original comment by @<AUTHOR> has been removed due to secret leakage. Below is the redacted version of the original content.
+# 2. Recreate a redacted version using temp file
+RECREATE_FILE="$(mktemp /tmp/secretscan_recreate_XXXXX.md)"
+cat > "$RECREATE_FILE" <<'BODY'
+> **Note from maintainer (@<YOUR_LOGIN>):** The original comment by @<AUTHOR> has been removed due to secret leakage. Below is the redacted version of the original content.
 
 ---
 
-<redacted original content>'
+<redacted original content>
+BODY
+gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
+  -X POST -F body=@"$RECREATE_FILE"
 ```
 
 ### issue_body / pull_request_body — Cannot Fully Purge
@@ -216,7 +226,7 @@ Edit history for issue body and PR body **cannot be cleared via API**, because:
 - Cannot delete and recreate an issue/PR (would lose all comments, labels, reviews, PR associations)
 - `deleteUserContentEdit` mutation has been removed by GitHub
 
-**Important limitation:** Editing a body automatically creates a new edit history revision. GitHub stores the **pre-edit original content** (containing plaintext secrets) in that revision. Anyone can view it by clicking the "edited" button. This applies even if the original body was never edited before.
+**Important limitation:** Editing a body automatically creates a new edit history revision. GitHub stores the **pre-edit original content** (containing plaintext secrets) in that revision. This applies even if the original body was never edited before.
 
 **What to do:**
 
@@ -254,26 +264,71 @@ If the PR is not merged, consider deleting the branch or force-pushing a cleaned
 
 Post a notification comment on the same issue/PR. **All comments MUST be in English.**
 
-> **Security:** Do NOT include any portion of the secret value or the alert URL in public comments. The alert URL is only accessible to repo admins and reveals internal tracking info. Only reference the secret by its type name.
+> **Security:** Do NOT include any portion of the secret value, the alert URL, or the alert number in public comments. Only reference the secret by its type name. The alert URL is only accessible to repo admins and reveals internal tracking info.
+
+### Notification template by location type
 
 Use a temp file with heredoc to avoid shell quoting issues:
 
+**For issue_comment / pull_request_comment / pull_request_review_comment:**
+
 ```bash
-cat > /tmp/notify_comment.md <<'BODY'
+NOTIFY_FILE="$(mktemp /tmp/secretscan_notify_XXXXX.md)"
+cat > "$NOTIFY_FILE" <<'BODY'
 @<AUTHOR> :warning: **Security Notice: Secret Leakage Detected**
 
-GitHub Secret Scanning detected the following exposed secret types in your content:
+GitHub Secret Scanning detected the following exposed secret types in your comment:
 
 1. **<Secret Type Display Name>**
 
-The affected content has been redacted.
+The affected comment has been removed and replaced with a redacted version.
 
 **Please rotate these credentials immediately.**
 
 These secrets were publicly exposed and should be considered compromised.
 BODY
 gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
-  -X POST -F body=@/tmp/notify_comment.md
+  -X POST -F body=@"$NOTIFY_FILE"
+```
+
+**For issue_body / pull_request_body:**
+
+```bash
+NOTIFY_FILE="$(mktemp /tmp/secretscan_notify_XXXXX.md)"
+cat > "$NOTIFY_FILE" <<'BODY'
+@<AUTHOR> :warning: **Security Notice: Secret Leakage Detected**
+
+GitHub Secret Scanning detected the following exposed secret types in your <issue/PR> description:
+
+1. **<Secret Type Display Name>**
+
+The affected content has been redacted in place.
+
+**Please rotate these credentials immediately.**
+
+These secrets were publicly exposed and should be considered compromised.
+BODY
+gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
+  -X POST -F body=@"$NOTIFY_FILE"
+```
+
+**For commit:**
+
+```bash
+NOTIFY_FILE="$(mktemp /tmp/secretscan_notify_XXXXX.md)"
+cat > "$NOTIFY_FILE" <<'BODY'
+@<AUTHOR> :warning: **Security Notice: Secret Leakage Detected**
+
+GitHub Secret Scanning detected the following exposed secret types in code you committed:
+
+1. **<Secret Type Display Name>**
+
+**Please rotate these credentials immediately.**
+
+These secrets were publicly exposed and should be considered compromised.
+BODY
+gh api repos/openclaw/openclaw/issues/<ISSUE_OR_PR_NUMBER>/comments \
+  -X POST -F body=@"$NOTIFY_FILE"
 ```
 
 Adjust the rotation guidance based on secret type when possible (e.g., link to Discord developer portal for Discord tokens).
@@ -302,9 +357,9 @@ Available resolution values:
 When processing multiple alerts:
 
 ```bash
-# List all open alerts
-gh api repos/openclaw/openclaw/secret-scanning/alerts \
-  --paginate -q '.[] | select(.state=="open") | "\(.number)\t\(.secret_type_display_name)\t\(.first_location_detected.html_url)"'
+# List all open alerts (use jq to extract fields that actually exist)
+gh api "repos/openclaw/openclaw/secret-scanning/alerts?hide_secret=true" \
+  --paginate -q '.[] | select(.state=="open") | "\(.number)\t\(.secret_type_display_name)\t\(.html_url)"'
 ```
 
 Process each alert individually following the flow above. **Always confirm with the user before batch-deleting comments.**
@@ -322,7 +377,7 @@ Format:
 
 | Alert | Type | Location | Actions | Edit History |
 |-------|------|----------|---------|--------------|
-| #72 https://github.com/openclaw/openclaw/security/secret-scanning/72 | Discord Bot Token | Issue #63101 comment https://github.com/openclaw/openclaw/issues/63101#issuecomment-xxx | Redacted+Deleted+Recreated+Notified | Cleared |
+| #72 https://github.com/openclaw/openclaw/security/secret-scanning/72 | Discord Bot Token | Issue #63101 comment https://github.com/openclaw/openclaw/issues/63101#issuecomment-xxx | Deleted+Recreated+Notified | Cleared |
 | #56 https://github.com/openclaw/openclaw/security/secret-scanning/56 | Google OAuth Client ID | PR #3077 body https://github.com/openclaw/openclaw/pull/3077 | Redacted+Notified | ⚠️ History remains |
 ```
 
@@ -358,11 +413,14 @@ Please update the skill to define handling for these types:
 - **Preserve the original message intent.** Only redact secrets, keep all other content intact.
 - **Check for multiple secrets** in a single comment/body — alerts may only flag one, but there could be more.
 - **Never include any portion of a secret** in public comments, redaction markers, or terminal output. Use type-only redaction: `[REDACTED <type>]`.
-- **Never include secret scanning alert URLs** in public comments — they are admin-only and leak internal info.
+- **Never include secret scanning alert URLs or numbers** in public comments — they are admin-only and leak internal info.
 - **Ask for confirmation** before deleting any comment or issue.
 - **One alert at a time** unless the user explicitly requests batch processing.
 - **Always print the summary** after processing, with all alert/issue/PR links for verification.
 - **All comments and notifications MUST be written in English.**
-- **Skip unsupported location types.** If a location type is not defined in this skill (e.g., not `issue_comment`, `issue_body`, `pull_request_body`, or `commit`), do not process it. Report it in the summary and note that the skill needs to be updated.
-- **Use temp files with heredoc** for all `gh api` calls that set body content. Never inline body text with `-f body='...'` — it is vulnerable to shell quoting issues and command injection via copy/paste.
-- **Never print raw API response bodies to stdout.** When fetching alert details or comment content for analysis, pipe through `jq` to extract only the fields you need (e.g., `jq '{number, state, secret_type}'`). Avoid printing `.secret` or `.body` fields that contain plaintext secrets.
+- **Skip unsupported location types.** If a location type is not defined in this skill, do not process it. Report it in the summary and note that the skill needs to be updated.
+- **Use `mktemp` for all temp files.** Never use fixed paths like `/tmp/redacted.md` — they are world-readable and predictable. Always use `mktemp /tmp/secretscan_<purpose>_XXXXX.md` to create private, unpredictable temp files.
+- **Use heredoc + temp file for all `gh api` body content.** Never inline body text with `-f body='...'` — it is vulnerable to shell quoting issues and command injection via copy/paste.
+- **Never print raw API response bodies to stdout.** Always pipe through `jq` to extract only the fields you need. Avoid printing `.secret` or `.body` fields that contain plaintext secrets.
+- **Always use `hide_secret=true`** when fetching alert details to prevent the API from returning plaintext secret values.
+- **For comments, skip PATCH and go directly to DELETE + recreate.** PATCHing before DELETE creates an unnecessary edit history revision that exposes plaintext.

--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -9,418 +9,191 @@ description: Maintainer-only workflow for handling GitHub Secret Scanning alerts
 
 Use this skill when processing alerts from `https://github.com/openclaw/openclaw/security/secret-scanning`.
 
-**Language rule:** All skill content, notification comments, and replacement comments MUST be written in English.
+**Language rule:** All notification comments and replacement comments MUST be written in English.
+
+## Script
+
+All mechanical operations (API calls, temp file management, security enforcements) are handled by:
+
+```
+$REPO_ROOT/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+```
+
+The script enforces:
+
+- `hide_secret=true` on all alert fetches (no plaintext secrets in stdout)
+- `mktemp` with random UUIDs for all temp files
+- `-F body=@file` for all body uploads (no inline shell quoting)
+- Notification templates branched by location type
+- Never prints `.secret` or `.body` to stdout
 
 ## Overall Flow
 
-Supports processing a single alert or multiple alerts. For multiple alerts, process them in ascending order by number.
+Supports single or multiple alerts. For multiple alerts, process in ascending order.
 
 For each alert:
 
-1. **Identify** — fetch alert metadata + location + content + edit history
-2. **Redact** — edit the content to mask all secrets
-3. **Purge history** — remove old revisions that contain plaintext secrets
-4. **Notify** — @ mention the original author with redacted info and rotation instructions
-5. **Resolve** — close the alert as `revoked`
-6. **Summary** — print a result summary with all relevant links
+1. **Identify** — `fetch-alert` + `fetch-content` to get metadata and body
+2. **Decide** — Agent reads the body file, identifies all secrets, produces redacted version
+3. **Redact** — `redact-body` for issue/PR body; skip for comments (delete directly)
+4. **Purge** — `delete-comment` + `recreate-comment` for comments; cannot purge body history
+5. **Notify** — `notify` posts the right template per location type
+6. **Resolve** — `resolve` closes the alert
+7. **Summary** — `summary` prints formatted results
 
-## Step 1: Identify the Alert
-
-Always use `hide_secret=true` to prevent plaintext secrets from appearing in terminal output:
-
-```bash
-# Fetch alert metadata (secret value hidden)
-gh api "repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER>?hide_secret=true" \
-  | jq '{number, state, secret_type, secret_type_display_name, validity, first_location_detected}'
-
-# Fetch leak locations
-gh api repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER>/locations
-```
-
-Location `type` determines the processing branch:
-
-| type                          | Meaning                 | Branch                |
-| ----------------------------- | ----------------------- | --------------------- |
-| `issue_comment`               | Issue comment           | → Comment flow        |
-| `pull_request_comment`        | PR comment (non-review) | → Comment flow        |
-| `pull_request_review_comment` | PR review comment       | → Comment flow        |
-| `issue_body`                  | Issue body              | → Issue Body flow     |
-| `pull_request_body`           | PR body                 | → PR Body flow        |
-| `commit`                      | Code commit             | → Commit flow         |
-| _any other type_              | Unknown / unsupported   | → **Skip and report** |
-
-**If a location type is not listed in the table above, do NOT attempt to process it.** Skip the alert, note it in the summary, and remind the user that this skill needs to be updated to handle the new type.
-
-## Step 2: Fetch Content and Edit History
-
-> **Security:** Never print `.body` or `.secret` fields to stdout. Always pipe through `jq` to extract only the fields needed for processing. The full body content is needed internally for redaction but should not be displayed.
-
-### For issue_comment / pull_request_comment / pull_request_review_comment
-
-All PR comment types use the same `issues/comments` API. The comment ID comes from the location's `issue_comment_url` or `pull_request_comment_url`.
+## Step 1: Identify
 
 ```bash
-# Save full comment for internal processing (do NOT print to terminal)
-gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> > /tmp/secretscan_comment.json
+# List all open alerts
+node secret-scanning.mjs list-open
 
-# Print only metadata
-gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> \
-  | jq '{id, user: .user.login, created_at, updated_at, node_id}'
+# Fetch specific alert metadata + locations
+node secret-scanning.mjs fetch-alert <NUMBER>
 
-# GraphQL: fetch edit history (node_id from REST response)
-gh api graphql -f query='
-{
-  node(id: "<NODE_ID>") {
-    ... on IssueComment {
-      userContentEdits(first: 50) {
-        totalCount
-        nodes { id createdAt editor { login } }
-      }
-    }
-  }
-}'
+# Fetch content for each location (saves body to temp file)
+node secret-scanning.mjs fetch-content '<location-json>'
 ```
 
-### For issue_body
+The `fetch-content` output includes:
+
+- `body_file`: path to temp file with full body content
+- `author`: who posted it
+- `issue_number` / `pr_number`: where it is
+- `edit_history_count`: number of existing edits
+- `type`: location type for routing
+
+### Location type routing
+
+| type                          | Flow                     |
+| ----------------------------- | ------------------------ |
+| `issue_comment`               | Comment: delete+recreate |
+| `pull_request_comment`        | Comment: delete+recreate |
+| `pull_request_review_comment` | Comment: delete+recreate |
+| `issue_body`                  | Body: redact in place    |
+| `pull_request_body`           | Body: redact in place    |
+| `commit`                      | Notify only              |
+| _other_                       | Skip and report          |
+
+## Step 2: Decide (Agent)
+
+The agent reads the body file from `fetch-content` output and:
+
+1. Identifies ALL secrets in the content (there may be more than the alert flagged)
+2. Replaces each secret with `[REDACTED <secret_type>]` — **no partial values, no prefix/suffix**
+3. Saves the redacted content to a new temp file
+
+This is the only step that requires semantic understanding. Everything else is mechanical.
+
+## Step 3: Redact
+
+### For comments (issue_comment / PR comments)
+
+**Do NOT redact.** Skip directly to Step 4 (delete + recreate). PATCHing before DELETE creates an unnecessary edit history revision.
+
+### For issue_body / pull_request_body
 
 ```bash
-# Print only metadata
-gh api repos/openclaw/openclaw/issues/<NUMBER> \
-  | jq '{number, title, user: .user.login, node_id}'
-
-# Save full body for internal processing
-gh api repos/openclaw/openclaw/issues/<NUMBER> | jq -r '.body' > "$(mktemp /tmp/secretscan_issue_XXXXX.md)"
-
-# GraphQL: fetch edit history
-gh api graphql -f query='
-{
-  repository(owner: "openclaw", name: "openclaw") {
-    issue(number: <NUMBER>) {
-      id
-      userContentEdits(first: 50) {
-        totalCount
-        nodes { id createdAt editor { login } }
-      }
-    }
-  }
-}'
-```
-
-### For pull_request_body
-
-```bash
-# Print only metadata
-gh api repos/openclaw/openclaw/pulls/<NUMBER> \
-  | jq '{number, title, user: .user.login, node_id, merged, state}'
-
-# Save full body for internal processing
-gh api repos/openclaw/openclaw/pulls/<NUMBER> | jq -r '.body' > "$(mktemp /tmp/secretscan_pr_XXXXX.md)"
-
-# GraphQL: fetch edit history (node_id from REST response)
-gh api graphql -f query='
-{
-  node(id: "<NODE_ID>") {
-    ... on PullRequest {
-      userContentEdits(first: 50) {
-        totalCount
-        nodes { id createdAt editor { login } }
-      }
-    }
-  }
-}'
-```
-
-### For commit
-
-No edit history to fetch (commits have no edit history). Confirm the following:
-
-```bash
-# Check if the commit's PR is merged
-gh api repos/openclaw/openclaw/pulls/<PR_NUMBER> | jq '{merged, state, head_ref}'
-```
-
-Do NOT fetch or print file contents that may contain secrets.
-
-## Step 3: Redact Secrets
-
-### Redaction format
-
-All secrets MUST be replaced with this format:
-
-```
-[REDACTED <secret_type>]
-```
-
-Do NOT include any portion of the actual secret value in the redaction marker. No prefix, no suffix, no character count. Even a few characters can help an attacker confirm or narrow down the full value.
-
-Examples:
-
-- `[REDACTED discord_bot_token]`
-- `[REDACTED feishu_app_secret]`
-- `[REDACTED github_pat]`
-- `[REDACTED google_oauth_client_id]`
-
-One comment/body may contain **multiple different secrets**. Scan the entire content and redact ALL of them.
-
-### For issue_comment / pull_request_comment / pull_request_review_comment
-
-**Skip the PATCH step.** Since the comment will be deleted in Step 4 anyway, editing it first would create a new edit history revision containing the pre-edit plaintext — an unnecessary exposure window. Go directly to Step 4 (delete + recreate with redacted content).
-
-### For issue_body
-
-Always use a temp file with heredoc to avoid shell quoting issues:
-
-```bash
-REDACTED_FILE="$(mktemp /tmp/secretscan_redacted_XXXXX.md)"
-cat > "$REDACTED_FILE" <<'BODY'
-<redacted content>
-BODY
-gh api repos/openclaw/openclaw/issues/<NUMBER> \
-  -X PATCH -F body=@"$REDACTED_FILE"
-```
-
-### For pull_request_body
-
-Save to a temp file, edit to redact, then upload:
-
-```bash
-REDACTED_FILE="$(mktemp /tmp/secretscan_redacted_XXXXX.md)"
-# Save original body to temp file
-gh api repos/openclaw/openclaw/pulls/<NUMBER> | jq -r '.body' > "$REDACTED_FILE"
-# Edit to redact (replace secret values in the file)
-# ...
-# Update PR body
-gh api repos/openclaw/openclaw/pulls/<NUMBER> \
-  -X PATCH -F body=@"$REDACTED_FILE"
+node secret-scanning.mjs redact-body <issue|pr> <NUMBER> <redacted-body-file>
 ```
 
 ## Step 4: Purge Edit History
 
-> **Critical:** GitHub has removed the `deleteUserContentEdit` mutation. There is NO API to delete individual edit revisions.
-
-### issue_comment / pull_request_comment / pull_request_review_comment — Delete and Recreate
-
-This is the only way to fully purge edit history from comments. **Do NOT PATCH before DELETE** — the PATCH would create an unnecessary edit history revision exposing plaintext.
+### Comments — Delete and Recreate
 
 ```bash
-# 1. Delete the original comment (including all edit history)
-gh api repos/openclaw/openclaw/issues/comments/<COMMENT_ID> -X DELETE
+# Delete original (all edit history gone)
+node secret-scanning.mjs delete-comment <COMMENT_ID>
 
-# 2. Recreate a redacted version using temp file
-RECREATE_FILE="$(mktemp /tmp/secretscan_recreate_XXXXX.md)"
-cat > "$RECREATE_FILE" <<'BODY'
-> **Note from maintainer (@<YOUR_LOGIN>):** The original comment by @<AUTHOR> has been removed due to secret leakage. Below is the redacted version of the original content.
+# Recreate with redacted content
+# Agent prepares the body file with maintainer header + redacted content
+node secret-scanning.mjs recreate-comment <ISSUE_NUMBER> <body-file>
+```
+
+The recreated comment should follow this format:
+
+```
+> **Note from maintainer (@<LOGIN>):** The original comment by @<AUTHOR> has been removed due to secret leakage. Below is the redacted version of the original content.
 
 ---
 
 <redacted original content>
-BODY
-gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
-  -X POST -F body=@"$RECREATE_FILE"
 ```
 
-### issue_body / pull_request_body — Cannot Fully Purge
+### issue_body / pull_request_body — Cannot Purge
 
-Edit history for issue body and PR body **cannot be cleared via API**, because:
+Editing creates an edit history revision with the pre-edit plaintext. This cannot be cleared via API.
 
-- Cannot delete and recreate an issue/PR (would lose all comments, labels, reviews, PR associations)
-- `deleteUserContentEdit` mutation has been removed by GitHub
-
-**Important limitation:** Editing a body automatically creates a new edit history revision. GitHub stores the **pre-edit original content** (containing plaintext secrets) in that revision. This applies even if the original body was never edited before.
-
-**What to do:**
-
-1. Edit to redact the body (Step 3)
-2. **Only output the warning to the maintainer in terminal** (never in public comments or resolution comments):
+**Output to maintainer terminal only (never in public comments):**
 
 ```
 ⚠️ Issue/PR body edit history still contains plaintext secrets.
-GitHub API cannot clear this history. To fully purge, contact GitHub Support:
-https://support.github.com/contact
-Request a purge of issue/PR #{NUMBER} userContentEdits.
+Contact GitHub Support to purge: https://support.github.com/contact
+Request purge of issue/PR #{NUMBER} userContentEdits.
 ```
 
-> **CRITICAL:** Do NOT mention edit history or the "edited" button in any public comment, notification, or resolution_comment. Revealing that plaintext secrets exist in edit history directs attackers to them. This information is for the maintainer only.
+> **CRITICAL:** Do NOT mention edit history or the "edited" button in any public comment or resolution_comment.
 
-### commit — Context-dependent handling
+### Commits
 
-| Scenario                                | Action                                                                                              |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| PR not merged, commit on fork branch    | Cannot clean directly (not in this repo). Notify author to delete branch or force-push              |
-| PR merged, secret in main branch        | Requires BFG / git filter-repo to clean history (out of scope for this skill, alert the maintainer) |
-| File deleted/modified in a later commit | Still notify — old commits remain accessible                                                        |
+Cannot clean. Notify author to delete branch or force-push (for unmerged PRs).
 
-Include commit info only in the terminal output for the maintainer. In public notification comments, simply say the secret was found in code and the author should rotate — do not list specific commit SHAs or file paths that contain plaintext secrets.
-
-**Terminal-only (maintainer):**
-
-```
-⚠️ The following commits still contain plaintext secrets:
-- <commit_sha_short>: <file_path>
-If the PR is not merged, consider deleting the branch or force-pushing a cleaned version.
-```
-
-## Step 5: Notify the Author
-
-Post a notification comment on the same issue/PR. **All comments MUST be in English.**
-
-> **Security:** Do NOT include any portion of the secret value, the alert URL, or the alert number in public comments. Only reference the secret by its type name. The alert URL is only accessible to repo admins and reveals internal tracking info.
-
-### Notification template by location type
-
-Use a temp file with heredoc to avoid shell quoting issues:
-
-**For issue_comment / pull_request_comment / pull_request_review_comment:**
+## Step 5: Notify
 
 ```bash
-NOTIFY_FILE="$(mktemp /tmp/secretscan_notify_XXXXX.md)"
-cat > "$NOTIFY_FILE" <<'BODY'
-@<AUTHOR> :warning: **Security Notice: Secret Leakage Detected**
-
-GitHub Secret Scanning detected the following exposed secret types in your comment:
-
-1. **<Secret Type Display Name>**
-
-The affected comment has been removed and replaced with a redacted version.
-
-**Please rotate these credentials immediately.**
-
-These secrets were publicly exposed and should be considered compromised.
-BODY
-gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
-  -X POST -F body=@"$NOTIFY_FILE"
+node secret-scanning.mjs notify <ISSUE_NUMBER> <AUTHOR> <LOCATION_TYPE> <SECRET_TYPES>
 ```
 
-**For issue_body / pull_request_body:**
+Secret types are comma-separated: `"Discord Bot Token,Feishu App Secret"`
+
+The script picks the right template:
+
+- **comment types**: "your comment … removed and replaced"
+- **body types**: "your issue/PR description … redacted in place"
+- **commit**: "code you committed"
+
+## Step 6: Resolve
 
 ```bash
-NOTIFY_FILE="$(mktemp /tmp/secretscan_notify_XXXXX.md)"
-cat > "$NOTIFY_FILE" <<'BODY'
-@<AUTHOR> :warning: **Security Notice: Secret Leakage Detected**
-
-GitHub Secret Scanning detected the following exposed secret types in your <issue/PR> description:
-
-1. **<Secret Type Display Name>**
-
-The affected content has been redacted in place.
-
-**Please rotate these credentials immediately.**
-
-These secrets were publicly exposed and should be considered compromised.
-BODY
-gh api repos/openclaw/openclaw/issues/<ISSUE_NUMBER>/comments \
-  -X POST -F body=@"$NOTIFY_FILE"
+node secret-scanning.mjs resolve <ALERT_NUMBER>
+# or with custom resolution:
+node secret-scanning.mjs resolve <ALERT_NUMBER> revoked "Custom comment"
 ```
 
-**For commit:**
+Resolution is `revoked` by default. As maintainers we cannot control whether users rotate — our responsibility is to redact + notify. The `revoked` means "this secret should be considered leaked", not "I confirmed it was revoked".
+
+## Step 7: Summary
+
+After processing, create a JSON results file and pass it to summary:
 
 ```bash
-NOTIFY_FILE="$(mktemp /tmp/secretscan_notify_XXXXX.md)"
-cat > "$NOTIFY_FILE" <<'BODY'
-@<AUTHOR> :warning: **Security Notice: Secret Leakage Detected**
-
-GitHub Secret Scanning detected the following exposed secret types in code you committed:
-
-1. **<Secret Type Display Name>**
-
-**Please rotate these credentials immediately.**
-
-These secrets were publicly exposed and should be considered compromised.
-BODY
-gh api repos/openclaw/openclaw/issues/<ISSUE_OR_PR_NUMBER>/comments \
-  -X POST -F body=@"$NOTIFY_FILE"
+node secret-scanning.mjs summary /tmp/results.json
 ```
 
-Adjust the rotation guidance based on secret type when possible (e.g., link to Discord developer portal for Discord tokens).
+The JSON format:
 
-## Step 6: Resolve the Alert
-
-Close the alert with `revoked`. GitHub suggests confirming the secret has been rotated before revoking, but as maintainers we cannot control whether users rotate — our responsibility is to redact + notify. Once those steps are done, the alert can be closed. The `revoked` resolution means "this secret should be considered leaked/revoked", not "I have confirmed it was revoked".
-
-```bash
-gh api repos/openclaw/openclaw/secret-scanning/alerts/<NUMBER> \
-  -X PATCH -f state=resolved -f resolution=revoked \
-  -f resolution_comment="Content redacted and author notified to rotate credentials."
+```json
+[
+  {
+    "number": 72,
+    "secret_type": "Discord Bot Token",
+    "location_label": "Issue #63101 comment",
+    "location_url": "https://github.com/openclaw/openclaw/issues/63101#issuecomment-xxx",
+    "actions": "Deleted+Recreated+Notified",
+    "history_cleared": true
+  }
+]
 ```
 
-Available resolution values:
-
-| Value            | When to use                                                   |
-| ---------------- | ------------------------------------------------------------- |
-| `revoked`        | Secret leaked, should be considered invalidated (**default**) |
-| `false_positive` | Not a real secret, false positive                             |
-| `wont_fix`       | Acknowledged but will not address (rarely used)               |
-| `used_in_tests`  | Test-only fake secret (rarely used)                           |
-
-## Batch Processing
-
-When processing multiple alerts:
-
-```bash
-# List all open alerts (use jq to extract fields that actually exist)
-gh api "repos/openclaw/openclaw/secret-scanning/alerts?hide_secret=true" \
-  --paginate -q '.[] | select(.state=="open") | "\(.number)\t\(.secret_type_display_name)\t\(.html_url)"'
-```
-
-Process each alert individually following the flow above. **Always confirm with the user before batch-deleting comments.**
-
-## Summary
-
-After processing each alert (or all alerts in a batch), print a result summary.
-
-**All links MUST be printed as full URLs** (not markdown `[text](url)` syntax), so they are clickable in terminal output.
-
-Format:
-
-```
-## Secret Scanning Results
-
-| Alert | Type | Location | Actions | Edit History |
-|-------|------|----------|---------|--------------|
-| #72 https://github.com/openclaw/openclaw/security/secret-scanning/72 | Discord Bot Token | Issue #63101 comment https://github.com/openclaw/openclaw/issues/63101#issuecomment-xxx | Deleted+Recreated+Notified | Cleared |
-| #56 https://github.com/openclaw/openclaw/security/secret-scanning/56 | Google OAuth Client ID | PR #3077 body https://github.com/openclaw/openclaw/pull/3077 | Redacted+Notified | ⚠️ History remains |
-```
-
-Each row MUST include:
-
-- Alert number and full URL: `#<N> https://github.com/openclaw/openclaw/security/secret-scanning/<N>`
-- Leak location with full URL: e.g., `Issue #<N> https://github.com/openclaw/openclaw/issues/<N>` or `PR #<N> https://github.com/openclaw/openclaw/pull/<N>`
-- Actions taken
-- Edit history status: `Cleared`, `⚠️ History remains`, or `Skipped (unsupported type: <type>)`
-
-For issues/PRs with ⚠️ History remains, add a follow-up section (terminal output only, never in public comments):
-
-```
-Issues requiring GitHub Support to purge edit history:
-- Issue #1594 https://github.com/openclaw/openclaw/issues/1594 — Telegram Bot Token
-- Issue #4155 https://github.com/openclaw/openclaw/issues/4155 — Google OAuth Client ID/Secret
-Contact: https://support.github.com/contact — request purge of userContentEdits for the above issues.
-```
-
-> **CRITICAL:** Never mention edit history details, "edited" button, or specific commit SHAs containing plaintext in any public-facing content (comments, PR descriptions, resolution comments). This information must only appear in terminal output for the maintainer.
-
-For any skipped alerts, add a note at the bottom of the summary:
-
-```
-⚠️ The following alerts were skipped because their location type is not supported by this skill.
-Please update the skill to define handling for these types:
-- Alert #<N>: unsupported type "<type>" — https://github.com/openclaw/openclaw/security/secret-scanning/<N>
-```
+For unsupported types, add `"skipped": true, "unsupported_type": "<type>"`.
 
 ## Safety Rules
 
-- **Always read the content before editing.** Never blindly patch.
-- **Preserve the original message intent.** Only redact secrets, keep all other content intact.
-- **Check for multiple secrets** in a single comment/body — alerts may only flag one, but there could be more.
-- **Never include any portion of a secret** in public comments, redaction markers, or terminal output. Use type-only redaction: `[REDACTED <type>]`.
-- **Never include secret scanning alert URLs or numbers** in public comments — they are admin-only and leak internal info.
-- **Ask for confirmation** before deleting any comment or issue.
-- **One alert at a time** unless the user explicitly requests batch processing.
-- **Always print the summary** after processing, with all alert/issue/PR links for verification.
-- **All comments and notifications MUST be written in English.**
-- **Skip unsupported location types.** If a location type is not defined in this skill, do not process it. Report it in the summary and note that the skill needs to be updated.
-- **Use `mktemp` for all temp files.** Never use fixed paths like `/tmp/redacted.md` — they are world-readable and predictable. Always use `mktemp /tmp/secretscan_<purpose>_XXXXX.md` to create private, unpredictable temp files.
-- **Use heredoc + temp file for all `gh api` body content.** Never inline body text with `-f body='...'` — it is vulnerable to shell quoting issues and command injection via copy/paste.
-- **Never print raw API response bodies to stdout.** Always pipe through `jq` to extract only the fields you need. Avoid printing `.secret` or `.body` fields that contain plaintext secrets.
-- **Always use `hide_secret=true`** when fetching alert details to prevent the API from returning plaintext secret values.
-- **For comments, skip PATCH and go directly to DELETE + recreate.** PATCHing before DELETE creates an unnecessary edit history revision that exposes plaintext.
+- **Agent reads content, identifies secrets, produces redaction.** Script handles all API calls.
+- **Never include any portion of a secret** in public comments, redaction markers, or terminal output.
+- **Never include alert URLs or numbers** in public comments.
+- **For comments, skip PATCH — go directly to DELETE + recreate.**
+- **Never mention edit history, "edited" button, or commit SHAs** in any public content.
+- **Ask for confirmation** before deleting any comment.
+- **One alert at a time** unless user requests batch.
+- **All public comments in English.**
+- **Skip unsupported location types** and report in summary.

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -19,7 +19,10 @@ function fail(message) {
 }
 
 function tmpFile(purpose) {
-  return path.join(os.tmpdir(), `secretscan-${purpose}-${crypto.randomUUID()}`);
+  const filePath = path.join(os.tmpdir(), `secretscan-${purpose}-${crypto.randomUUID()}`);
+  // 预创建文件，限制权限为 owner-only
+  fs.writeFileSync(filePath, "", { mode: 0o600 });
+  return filePath;
 }
 
 function gh(args, { json = true, allowFailure = false } = {}) {
@@ -50,7 +53,9 @@ function cmdFetchAlert(alertNumber) {
 
   const alert = gh(["api", `repos/${REPO}/secret-scanning/alerts/${alertNumber}?hide_secret=true`]);
 
-  const locations = gh(["api", `repos/${REPO}/secret-scanning/alerts/${alertNumber}/locations`]);
+  const locations = gh(["api", `repos/${REPO}/secret-scanning/alerts/${alertNumber}/locations`, "--paginate", "--slurp"]);
+  // --paginate + --slurp 确保多页结果合并为一个 JSON 数组
+  const flatLocations = Array.isArray(locations?.[0]) ? locations.flat() : Array.isArray(locations) ? locations : [];
 
   const result = {
     number: alert.number,
@@ -59,7 +64,7 @@ function cmdFetchAlert(alertNumber) {
     secret_type_display_name: alert.secret_type_display_name,
     validity: alert.validity,
     html_url: alert.html_url,
-    locations: locations.map((loc) => ({
+    locations: flatLocations.map((loc) => ({
       type: loc.type,
       details: loc.details,
     })),
@@ -214,7 +219,7 @@ function cmdFetchContent(locationJson) {
           path: details.path,
           start_line: details.start_line,
           end_line: details.end_line,
-          html_url: details.html_url,
+          html_url: details.html_url || details.commit_url || details.blob_url || null,
           // commit 没有 body 文件
           body_file: null,
         },
@@ -405,9 +410,11 @@ function cmdListOpen() {
     "api",
     `repos/${REPO}/secret-scanning/alerts?hide_secret=true&state=open`,
     "--paginate",
+    "--slurp",
   ]);
 
-  const flat = Array.isArray(alerts) ? alerts : [alerts];
+  // --slurp 将分页结果合并为 [[page1], [page2], ...] 需要 flat
+  const flat = Array.isArray(alerts?.[0]) ? alerts.flat() : Array.isArray(alerts) ? alerts : [];
   const rows = flat.map((a) => ({
     number: a.number,
     secret_type_display_name: a.secret_type_display_name,

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -1,0 +1,515 @@
+#!/usr/bin/env node
+// Secret scanning alert handler for OpenClaw maintainers.
+// Usage: node secret-scanning.mjs <command> [options]
+
+import { execFileSync, spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const REPO = "openclaw/openclaw";
+const REPO_URL = `https://github.com/${REPO}`;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function tmpFile(purpose) {
+  return path.join(os.tmpdir(), `secretscan-${purpose}-${crypto.randomUUID()}`);
+}
+
+function gh(args, { json = true, allowFailure = false } = {}) {
+  const proc = spawnSync("gh", args, { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 });
+  if (proc.status !== 0 && !allowFailure) {
+    fail(`gh ${args.slice(0, 3).join(" ")} failed:\n${(proc.stderr || proc.stdout || "").trim()}`);
+  }
+  if (!json) return proc.stdout;
+  try {
+    return JSON.parse(proc.stdout);
+  } catch {
+    return proc.stdout;
+  }
+}
+
+function ghGraphQL(query) {
+  return gh(["api", "graphql", "-f", `query=${query}`]);
+}
+
+// ─── Commands ───────────────────────────────────────────────────────────────
+
+/**
+ * fetch-alert <number>
+ * Fetch alert metadata + locations. Never exposes .secret.
+ */
+function cmdFetchAlert(alertNumber) {
+  if (!alertNumber) fail("Usage: fetch-alert <number>");
+
+  const alert = gh(["api", `repos/${REPO}/secret-scanning/alerts/${alertNumber}?hide_secret=true`]);
+
+  const locations = gh(["api", `repos/${REPO}/secret-scanning/alerts/${alertNumber}/locations`]);
+
+  const result = {
+    number: alert.number,
+    state: alert.state,
+    secret_type: alert.secret_type,
+    secret_type_display_name: alert.secret_type_display_name,
+    validity: alert.validity,
+    html_url: alert.html_url,
+    locations: locations.map((loc) => ({
+      type: loc.type,
+      details: loc.details,
+    })),
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+/**
+ * fetch-content <location-json>
+ * Fetch the content and metadata for a specific location.
+ * Saves full body to a temp file. Prints metadata + file path to stdout.
+ */
+function cmdFetchContent(locationJson) {
+  if (!locationJson) fail("Usage: fetch-content '<location-json>'");
+  const location = JSON.parse(locationJson);
+  const type = location.type;
+  const details = location.details;
+
+  if (
+    type === "issue_comment" ||
+    type === "pull_request_comment" ||
+    type === "pull_request_review_comment"
+  ) {
+    // 从 url 中提取 comment ID
+    const commentUrl =
+      details.issue_comment_url ||
+      details.pull_request_comment_url ||
+      details.pull_request_review_comment_url;
+    if (!commentUrl) fail(`No comment URL in location details`);
+
+    const comment = gh(["api", commentUrl]);
+    const bodyFile = tmpFile("body.md");
+    fs.writeFileSync(bodyFile, comment.body || "");
+
+    // 获取编辑历史
+    const nodeId = comment.node_id;
+    const typeName =
+      type === "pull_request_review_comment" ? "PullRequestReviewComment" : "IssueComment";
+    const gql = ghGraphQL(`{
+      node(id: "${nodeId}") {
+        ... on ${typeName} {
+          userContentEdits(first: 50) {
+            totalCount
+          }
+        }
+      }
+    }`);
+    const editCount = gql?.data?.node?.userContentEdits?.totalCount ?? 0;
+
+    // 提取 issue number（从 html_url）
+    const htmlUrl = comment.html_url || details.html_url || "";
+    const issueMatch = htmlUrl.match(/\/(issues|pull)\/(\d+)/);
+    const issueNumber = issueMatch ? issueMatch[2] : null;
+
+    console.log(
+      JSON.stringify(
+        {
+          type,
+          comment_id: comment.id,
+          node_id: nodeId,
+          author: comment.user?.login,
+          issue_number: issueNumber,
+          html_url: htmlUrl,
+          edit_history_count: editCount,
+          body_file: bodyFile,
+        },
+        null,
+        2,
+      ),
+    );
+  } else if (type === "issue_body") {
+    const issueUrl = details.issue_body_url || details.issue_url;
+    if (!issueUrl) fail("No issue URL in location details");
+
+    const issue = gh(["api", issueUrl]);
+    const bodyFile = tmpFile("body.md");
+    fs.writeFileSync(bodyFile, issue.body || "");
+
+    const nodeId = issue.node_id;
+    const number = issue.number;
+    const gql = ghGraphQL(`{
+      node(id: "${nodeId}") {
+        ... on Issue {
+          userContentEdits(first: 50) {
+            totalCount
+          }
+        }
+      }
+    }`);
+    const editCount = gql?.data?.node?.userContentEdits?.totalCount ?? 0;
+
+    console.log(
+      JSON.stringify(
+        {
+          type,
+          issue_number: number,
+          node_id: nodeId,
+          author: issue.user?.login,
+          html_url: issue.html_url,
+          edit_history_count: editCount,
+          body_file: bodyFile,
+        },
+        null,
+        2,
+      ),
+    );
+  } else if (type === "pull_request_body") {
+    const prUrl = details.pull_request_body_url || details.pull_request_url;
+    if (!prUrl) fail("No PR URL in location details");
+
+    const pr = gh(["api", prUrl]);
+    const bodyFile = tmpFile("body.md");
+    fs.writeFileSync(bodyFile, pr.body || "");
+
+    const nodeId = pr.node_id;
+    const number = pr.number;
+    const gql = ghGraphQL(`{
+      node(id: "${nodeId}") {
+        ... on PullRequest {
+          userContentEdits(first: 50) {
+            totalCount
+          }
+        }
+      }
+    }`);
+    const editCount = gql?.data?.node?.userContentEdits?.totalCount ?? 0;
+
+    console.log(
+      JSON.stringify(
+        {
+          type,
+          pr_number: number,
+          node_id: nodeId,
+          author: pr.user?.login,
+          merged: pr.merged,
+          state: pr.state,
+          html_url: pr.html_url,
+          edit_history_count: editCount,
+          body_file: bodyFile,
+        },
+        null,
+        2,
+      ),
+    );
+  } else if (type === "commit") {
+    console.log(
+      JSON.stringify(
+        {
+          type,
+          commit_sha: details.commit_sha,
+          path: details.path,
+          start_line: details.start_line,
+          end_line: details.end_line,
+          html_url: details.html_url,
+          // commit 没有 body 文件
+          body_file: null,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(
+      JSON.stringify(
+        {
+          type,
+          unsupported: true,
+          details,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+}
+
+/**
+ * redact-body <issue|pr> <number> <redacted-body-file>
+ * PATCH the issue or PR body with redacted content from a file.
+ */
+function cmdRedactBody(kind, number, bodyFile) {
+  if (!kind || !number || !bodyFile) {
+    fail("Usage: redact-body <issue|pr> <number> <redacted-body-file>");
+  }
+  if (!fs.existsSync(bodyFile)) fail(`File not found: ${bodyFile}`);
+
+  const endpoint =
+    kind === "pr" ? `repos/${REPO}/pulls/${number}` : `repos/${REPO}/issues/${number}`;
+
+  gh(["api", endpoint, "-X", "PATCH", "-F", `body=@${bodyFile}`]);
+  console.log(JSON.stringify({ ok: true, kind, number: Number(number) }));
+}
+
+/**
+ * delete-comment <comment-id>
+ * Delete a comment (and all its edit history).
+ */
+function cmdDeleteComment(commentId) {
+  if (!commentId) fail("Usage: delete-comment <comment-id>");
+  gh(["api", `repos/${REPO}/issues/comments/${commentId}`, "-X", "DELETE"], { json: false });
+  console.log(JSON.stringify({ ok: true, deleted_comment_id: Number(commentId) }));
+}
+
+/**
+ * recreate-comment <issue-number> <body-file>
+ * Create a new comment from a file.
+ */
+function cmdRecreateComment(issueNumber, bodyFile) {
+  if (!issueNumber || !bodyFile) fail("Usage: recreate-comment <issue-number> <body-file>");
+  if (!fs.existsSync(bodyFile)) fail(`File not found: ${bodyFile}`);
+
+  const result = gh([
+    "api",
+    `repos/${REPO}/issues/${issueNumber}/comments`,
+    "-X",
+    "POST",
+    "-F",
+    `body=@${bodyFile}`,
+  ]);
+
+  console.log(
+    JSON.stringify({
+      ok: true,
+      comment_id: result.id,
+      html_url: result.html_url,
+    }),
+  );
+}
+
+/**
+ * notify <issue-or-pr-number> <author> <location-type> <secret-types>
+ * Post a notification comment with the correct template for the location type.
+ */
+function cmdNotify(issueNumber, author, locationType, secretTypes) {
+  if (!issueNumber || !author || !locationType || !secretTypes) {
+    fail("Usage: notify <issue-or-pr-number> <author> <location-type> <secret-types-comma-sep>");
+  }
+
+  const types = secretTypes.split(",").map((s) => s.trim());
+  const typeList = types.map((t, i) => `${i + 1}. **${t}**`).join("\n");
+
+  let locationDesc;
+  let actionDesc;
+  if (
+    locationType === "issue_comment" ||
+    locationType === "pull_request_comment" ||
+    locationType === "pull_request_review_comment"
+  ) {
+    locationDesc = "your comment";
+    actionDesc = "The affected comment has been removed and replaced with a redacted version.";
+  } else if (locationType === "issue_body") {
+    locationDesc = "your issue description";
+    actionDesc = "The affected content has been redacted in place.";
+  } else if (locationType === "pull_request_body") {
+    locationDesc = "your pull request description";
+    actionDesc = "The affected content has been redacted in place.";
+  } else if (locationType === "commit") {
+    locationDesc = "code you committed";
+    actionDesc = "";
+  } else {
+    locationDesc = "your content";
+    actionDesc = "";
+  }
+
+  const body = [
+    `@${author} :warning: **Security Notice: Secret Leakage Detected**`,
+    "",
+    `GitHub Secret Scanning detected the following exposed secret types in ${locationDesc}:`,
+    "",
+    typeList,
+    "",
+    actionDesc,
+    "",
+    "**Please rotate these credentials immediately.**",
+    "",
+    "These secrets were publicly exposed and should be considered compromised.",
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+
+  const bodyFile = tmpFile("notify.md");
+  fs.writeFileSync(bodyFile, body);
+
+  const result = gh([
+    "api",
+    `repos/${REPO}/issues/${issueNumber}/comments`,
+    "-X",
+    "POST",
+    "-F",
+    `body=@${bodyFile}`,
+  ]);
+
+  console.log(
+    JSON.stringify({
+      ok: true,
+      comment_id: result.id,
+      html_url: result.html_url,
+    }),
+  );
+}
+
+/**
+ * resolve <alert-number> [resolution] [comment]
+ * Close a secret scanning alert.
+ */
+function cmdResolve(alertNumber, resolution, comment) {
+  if (!alertNumber) fail("Usage: resolve <alert-number> [resolution] [comment]");
+
+  const res = resolution || "revoked";
+  const resComment = comment || "Content redacted and author notified to rotate credentials.";
+
+  const result = gh([
+    "api",
+    `repos/${REPO}/secret-scanning/alerts/${alertNumber}`,
+    "-X",
+    "PATCH",
+    "-f",
+    `state=resolved`,
+    "-f",
+    `resolution=${res}`,
+    "-f",
+    `resolution_comment=${resComment}`,
+  ]);
+
+  console.log(
+    JSON.stringify({
+      ok: true,
+      number: result.number,
+      state: result.state,
+      resolution: result.resolution,
+      resolved_at: result.resolved_at,
+    }),
+  );
+}
+
+/**
+ * list-open
+ * List all open secret scanning alerts.
+ */
+function cmdListOpen() {
+  const alerts = gh([
+    "api",
+    `repos/${REPO}/secret-scanning/alerts?hide_secret=true&state=open`,
+    "--paginate",
+  ]);
+
+  const flat = Array.isArray(alerts) ? alerts : [alerts];
+  const rows = flat.map((a) => ({
+    number: a.number,
+    secret_type_display_name: a.secret_type_display_name,
+    html_url: a.html_url,
+    first_location_html_url: a.first_location_detected?.html_url || null,
+  }));
+
+  console.log(JSON.stringify(rows, null, 2));
+}
+
+/**
+ * summary <json-file>
+ * Print a formatted summary table from a JSON results file.
+ */
+function cmdSummary(jsonFile) {
+  if (!jsonFile) fail("Usage: summary <json-file>");
+  if (!fs.existsSync(jsonFile)) fail(`File not found: ${jsonFile}`);
+
+  const results = JSON.parse(fs.readFileSync(jsonFile, "utf8"));
+
+  console.log("\n## Secret Scanning Results\n");
+  console.log("| Alert | Type | Location | Actions | Edit History |");
+  console.log("|-------|------|----------|---------|--------------|");
+
+  const needsPurge = [];
+
+  for (const r of results) {
+    const alertLink = `#${r.number} ${REPO_URL}/security/secret-scanning/${r.number}`;
+    const locationLink = r.location_url
+      ? `${r.location_label} ${r.location_url}`
+      : r.location_label;
+    const history = r.history_cleared ? "Cleared" : "⚠️ History remains";
+
+    console.log(
+      `| ${alertLink} | ${r.secret_type} | ${locationLink} | ${r.actions} | ${history} |`,
+    );
+
+    if (!r.history_cleared && r.location_url) {
+      needsPurge.push(r);
+    }
+  }
+
+  if (needsPurge.length > 0) {
+    console.log("\nIssues requiring GitHub Support to purge edit history:");
+    for (const r of needsPurge) {
+      console.log(`- ${r.location_label} ${r.location_url} — ${r.secret_type}`);
+    }
+    console.log(
+      `Contact: https://support.github.com/contact — request purge of userContentEdits for the above issues.`,
+    );
+  }
+
+  const skipped = results.filter((r) => r.skipped);
+  if (skipped.length > 0) {
+    console.log(
+      "\n⚠️ The following alerts were skipped because their location type is not supported:",
+    );
+    for (const r of skipped) {
+      console.log(
+        `- Alert #${r.number}: unsupported type "${r.unsupported_type}" — ${REPO_URL}/security/secret-scanning/${r.number}`,
+      );
+    }
+    console.log("Please update the skill to define handling for these types.");
+  }
+
+  console.log("");
+}
+
+// ─── Dispatch ───────────────────────────────────────────────────────────────
+
+const [command, ...args] = process.argv.slice(2);
+
+const commands = {
+  "fetch-alert": () => cmdFetchAlert(args[0]),
+  "fetch-content": () => cmdFetchContent(args[0]),
+  "redact-body": () => cmdRedactBody(args[0], args[1], args[2]),
+  "delete-comment": () => cmdDeleteComment(args[0]),
+  "recreate-comment": () => cmdRecreateComment(args[0], args[1]),
+  notify: () => cmdNotify(args[0], args[1], args[2], args[3]),
+  resolve: () => cmdResolve(args[0], args[1], args[2]),
+  "list-open": () => cmdListOpen(),
+  summary: () => cmdSummary(args[0]),
+};
+
+if (!command || !commands[command]) {
+  console.error(
+    [
+      "Usage: node secret-scanning.mjs <command> [args]",
+      "",
+      "Commands:",
+      "  fetch-alert <number>             Fetch alert metadata + locations",
+      "  fetch-content '<location-json>'   Fetch content for a location",
+      "  redact-body <issue|pr> <n> <file> PATCH body with redacted file",
+      "  delete-comment <comment-id>       Delete a comment",
+      "  recreate-comment <issue-n> <file> Create replacement comment",
+      "  notify <n> <author> <type> <types> Post notification",
+      "  resolve <n> [resolution] [comment] Close alert",
+      "  list-open                          List open alerts",
+      "  summary <json-file>               Print formatted summary",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+commands[command]();

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -427,10 +427,14 @@ function cmdSummary(jsonFile) {
   if (!fs.existsSync(jsonFile)) fail(`File not found: ${jsonFile}`);
 
   const results = JSON.parse(fs.readFileSync(jsonFile, "utf8"));
+  const lines = [];
 
-  console.log("\n## Secret Scanning Results\n");
-  console.log("| Alert | Type | Location | Actions | Edit History |");
-  console.log("|-------|------|----------|---------|--------------|");
+  lines.push("---BEGIN SUMMARY---");
+  lines.push("");
+  lines.push("## Secret Scanning Results");
+  lines.push("");
+  lines.push("| Alert | Type | Location | Actions | Edit History |");
+  lines.push("|-------|------|----------|---------|--------------|");
 
   const needsPurge = [];
 
@@ -441,7 +445,7 @@ function cmdSummary(jsonFile) {
       : r.location_label;
     const history = r.history_cleared ? "Cleared" : "⚠️ History remains";
 
-    console.log(
+    lines.push(
       `| ${alertLink} | ${r.secret_type} | ${locationLink} | ${r.actions} | ${history} |`,
     );
 
@@ -451,29 +455,34 @@ function cmdSummary(jsonFile) {
   }
 
   if (needsPurge.length > 0) {
-    console.log("\nIssues requiring GitHub Support to purge edit history:");
+    lines.push("");
+    lines.push("Issues requiring GitHub Support to purge edit history:");
     for (const r of needsPurge) {
-      console.log(`- ${r.location_label} ${r.location_url} — ${r.secret_type}`);
+      lines.push(`- ${r.location_label} ${r.location_url} — ${r.secret_type}`);
     }
-    console.log(
+    lines.push(
       `Contact: https://support.github.com/contact — request purge of userContentEdits for the above issues.`,
     );
   }
 
   const skipped = results.filter((r) => r.skipped);
   if (skipped.length > 0) {
-    console.log(
-      "\n⚠️ The following alerts were skipped because their location type is not supported:",
+    lines.push("");
+    lines.push(
+      "⚠️ The following alerts were skipped because their location type is not supported:",
     );
     for (const r of skipped) {
-      console.log(
+      lines.push(
         `- Alert #${r.number}: unsupported type "${r.unsupported_type}" — ${REPO_URL}/security/secret-scanning/${r.number}`,
       );
     }
-    console.log("Please update the skill to define handling for these types.");
+    lines.push("Please update the skill to define handling for these types.");
   }
 
-  console.log("");
+  lines.push("");
+  lines.push("---END SUMMARY---");
+
+  console.log(lines.join("\n"));
 }
 
 // ─── Dispatch ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `openclaw-secret-scanning-maintainer` skill for handling GitHub Secret Scanning alerts
- Covers 4 leak location types: `issue_comment`, `issue_body`, `pull_request_body`, `commit`
- Includes redaction, history purge (delete+recreate for comments), author notification, and alert resolution workflows
- Enforces security best practices: no edit history details in public comments, English-only comments, summary with full URLs

## Key design decisions

- **issue_comment**: Delete + recreate to fully purge edit history
- **issue_body / PR body**: Redact only (cannot delete/recreate), warn maintainer in terminal only
- **commit**: Notify author; flag if PR not merged or if BFG cleanup needed
- **Never reveal edit history details publicly** — no "edited button" mentions in any public-facing content
- **All comments in English** per skill requirement
- **Skip unsupported location types** and report in summary for skill improvement

## Test plan

- [ ] Trigger the skill with a secret scanning alert number and verify it follows the full flow
- [ ] Verify notification comments are in English and do not mention edit history
- [ ] Verify summary output contains full clickable URLs