### PR TITLE
fix(exec): skip script preflight validation when elevated=full

### DIFF
--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -960,3 +960,43 @@ describe("exec interpreter heuristics ReDoS guard", () => {
     expect(elapsed).toBeLessThan(5000);
   });
 });
+
+describeNonWin("exec preflight bypass when elevated=full", () => {
+  it("skips script-bleed preflight when elevated defaults are full", async () => {
+    await withTempDir("openclaw-exec-preflight-bypass-", async (tmp) => {
+      const pyPath = path.join(tmp, "bad.py");
+      // This file would normally trigger the preflight:
+      await fs.writeFile(
+        pyPath,
+        ["import json", "payload = $DM_JSON", "print(payload)"].join("\n"),
+        "utf-8",
+      );
+
+      const tool = createExecTool({
+        host: "gateway",
+        security: "full",
+        ask: "off",
+        elevated: {
+          enabled: true,
+          allowed: true,
+          defaultLevel: "full",
+        },
+      });
+
+      // Should NOT throw a preflight error — the command may still fail
+      // for other reasons (python not found, etc.), but the preflight
+      // shell-bleed check must be skipped.
+      try {
+        await tool.execute("bypass-call", {
+          command: "python bad.py",
+          workdir: tmp,
+        });
+      } catch (err) {
+        // Any error is acceptable as long as it is NOT the preflight guard
+        expect(String(err)).not.toMatch(
+          /exec preflight: detected likely shell variable injection/,
+        );
+      }
+    });
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1658,7 +1658,12 @@ export function createExecTool(
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.
-      await validateScriptFileForShellBleed({ command: params.command, workdir });
+      // Skip when elevated=full already bypasses all approvals — the preflight
+      // validation is an approval-adjacent guard and should not block fully
+      // trusted sessions (e.g. cron agents configured with elevatedDefault=full).
+      if (!bypassApprovals) {
+        await validateScriptFileForShellBleed({ command: params.command, workdir });
+      }
 
       const run = await runExecProcess({
         command: params.command,


### PR DESCRIPTION
## Problem

`validateScriptFileForShellBleed` runs unconditionally before every exec command, even when `bypassApprovals` is `true` (i.e., the session has `elevated: 'full'`). This causes cron agents and other fully-trusted sessions to get blocked by shell-bleed detection that is effectively an approval-adjacent safety guard.

The preflight catches patterns like `$DM_JSON` in Python/JS files — useful when the model may be confused, but unnecessary when the session already has full elevated access with all approvals bypassed.

## Fix

Guard the `validateScriptFileForShellBleed` call with `if (!bypassApprovals)`.

## Impact

- Cron agents with `elevatedDefault: 'full'` no longer get stuck on preflight false positives
- Non-elevated sessions are unaffected — preflight still runs for them
- Minimal change: 3 lines in the exec path, 1 new test

## Testing

```bash
npm test -- --grep 'preflight bypass'
```
