### PR TITLE
feat(plugins): narrow channel loads from manifests

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -527,10 +527,12 @@ actual behavior such as hooks, tools, commands, or provider flows.
 Optional manifest `activation` and `setup` blocks stay on the control plane.
 They are metadata-only descriptors for activation planning and setup discovery;
 they do not replace runtime registration, `register(...)`, or `setupEntry`.
-The first live activation consumers now use manifest command and provider hints
+The first live activation consumers now use manifest command, channel, and provider hints
 to narrow plugin loading before broader registry materialization:
 
 - CLI loading narrows to plugins that own the requested primary command
+- channel setup/plugin resolution narrows to plugins that own the requested
+  channel id
 - explicit provider setup/runtime resolution narrows to plugins that own the
   requested provider id
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -249,6 +249,8 @@ Current live consumers:
 
 - command-triggered CLI planning falls back to legacy
   `commandAliases[].cliCommand` or `commandAliases[].name`
+- channel-triggered setup/channel planning falls back to legacy `channels[]`
+  ownership when explicit channel activation metadata is missing
 - provider-triggered setup/runtime planning falls back to legacy
   `providers[]` and top-level `cliBackends[]` ownership when explicit provider
   activation metadata is missing

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -723,6 +723,84 @@ describe("ensureChannelSetupPluginInstalled", () => {
     ).toBeUndefined();
   });
 
+  it("does not trust explicitly disabled workspace activation-only channel ownership during setup", () => {
+    const runtime = makeRuntime();
+    const cfg: OpenClawConfig = {
+      plugins: {
+        enabled: true,
+        allow: ["evil-telegram-shadow"],
+        entries: {
+          "evil-telegram-shadow": { enabled: false },
+        },
+      },
+    };
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "evil-telegram-shadow",
+          channels: [],
+          origin: "workspace",
+          activation: {
+            onChannels: ["telegram"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadChannelSetupPluginRegistrySnapshotForChannel({
+      cfg,
+      runtime,
+      channel: "telegram",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        onlyPluginIds: ["evil-telegram-shadow"],
+      }),
+    );
+    expect(
+      (vi.mocked(loadOpenClawPlugins).mock.calls[0]?.[0] as { onlyPluginIds?: string[] })
+        .onlyPluginIds,
+    ).toBeUndefined();
+  });
+
+  it("does not trust unenabled global activation-only channel ownership during setup", () => {
+    const runtime = makeRuntime();
+    const cfg: OpenClawConfig = {};
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "custom-telegram-global",
+          channels: [],
+          origin: "global",
+          activation: {
+            onChannels: ["telegram"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadChannelSetupPluginRegistrySnapshotForChannel({
+      cfg,
+      runtime,
+      channel: "telegram",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        onlyPluginIds: ["custom-telegram-global"],
+      }),
+    );
+    expect(
+      (vi.mocked(loadOpenClawPlugins).mock.calls[0]?.[0] as { onlyPluginIds?: string[] })
+        .onlyPluginIds,
+    ).toBeUndefined();
+  });
+
   it("scopes snapshots by plugin id when channel and plugin ids differ", () => {
     const runtime = makeRuntime();
     const cfg: OpenClawConfig = {};

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -686,6 +686,11 @@ describe("ensureChannelSetupPluginInstalled", () => {
         onlyPluginIds: ["custom-telegram-plugin"],
       }),
     );
+    expect(loadPluginManifestRegistry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cache: false,
+      }),
+    );
   });
 
   it("uses uncached manifest discovery for activation-declared setup scoping", () => {

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -688,6 +688,37 @@ describe("ensureChannelSetupPluginInstalled", () => {
     );
   });
 
+  it("uses uncached manifest discovery for activation-declared setup scoping", () => {
+    const runtime = makeRuntime();
+    const cfg: OpenClawConfig = {};
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "custom-telegram-plugin",
+          channels: [],
+          activation: {
+            onChannels: ["telegram"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadChannelSetupPluginRegistrySnapshotForChannel({
+      cfg,
+      runtime,
+      channel: "telegram",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(loadPluginManifestRegistry).toHaveBeenCalled();
+    expect(
+      loadPluginManifestRegistry.mock.calls.every(
+        ([params]) => (params as { cache?: boolean }).cache === false,
+      ),
+    ).toBe(true);
+  });
+
   it("does not trust unconfigured workspace activation-only channel ownership during setup", () => {
     const runtime = makeRuntime();
     const cfg: OpenClawConfig = {};
@@ -715,6 +746,84 @@ describe("ensureChannelSetupPluginInstalled", () => {
     expect(loadOpenClawPlugins).toHaveBeenCalledWith(
       expect.not.objectContaining({
         onlyPluginIds: ["evil-telegram-shadow"],
+      }),
+    );
+    expect(
+      (vi.mocked(loadOpenClawPlugins).mock.calls[0]?.[0] as { onlyPluginIds?: string[] })
+        .onlyPluginIds,
+    ).toBeUndefined();
+  });
+
+  it("does not trust allowlist-excluded bundled activation-only channel ownership during setup", () => {
+    const runtime = makeRuntime();
+    const cfg: OpenClawConfig = {
+      plugins: {
+        allow: ["other-plugin"],
+      },
+    };
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "custom-telegram-plugin",
+          channels: [],
+          origin: "bundled",
+          activation: {
+            onChannels: ["telegram"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadChannelSetupPluginRegistrySnapshotForChannel({
+      cfg,
+      runtime,
+      channel: "telegram",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        onlyPluginIds: ["custom-telegram-plugin"],
+      }),
+    );
+    expect(
+      (vi.mocked(loadOpenClawPlugins).mock.calls[0]?.[0] as { onlyPluginIds?: string[] })
+        .onlyPluginIds,
+    ).toBeUndefined();
+  });
+
+  it("does not trust explicitly denied bundled activation-only channel ownership during setup", () => {
+    const runtime = makeRuntime();
+    const cfg: OpenClawConfig = {
+      plugins: {
+        deny: ["custom-telegram-plugin"],
+      },
+    };
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "custom-telegram-plugin",
+          channels: [],
+          origin: "bundled",
+          activation: {
+            onChannels: ["telegram"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadChannelSetupPluginRegistrySnapshotForChannel({
+      cfg,
+      runtime,
+      channel: "telegram",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        onlyPluginIds: ["custom-telegram-plugin"],
       }),
     );
     expect(
@@ -758,6 +867,47 @@ describe("ensureChannelSetupPluginInstalled", () => {
     expect(loadOpenClawPlugins).toHaveBeenCalledWith(
       expect.not.objectContaining({
         onlyPluginIds: ["evil-telegram-shadow"],
+      }),
+    );
+    expect(
+      (vi.mocked(loadOpenClawPlugins).mock.calls[0]?.[0] as { onlyPluginIds?: string[] })
+        .onlyPluginIds,
+    ).toBeUndefined();
+  });
+
+  it("does not trust explicitly disabled bundled activation-only channel ownership during setup", () => {
+    const runtime = makeRuntime();
+    const cfg: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "custom-telegram-plugin": { enabled: false },
+        },
+      },
+    };
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "custom-telegram-plugin",
+          channels: [],
+          origin: "bundled",
+          activation: {
+            onChannels: ["telegram"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadChannelSetupPluginRegistrySnapshotForChannel({
+      cfg,
+      runtime,
+      channel: "telegram",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        onlyPluginIds: ["custom-telegram-plugin"],
       }),
     );
     expect(

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -658,6 +658,71 @@ describe("ensureChannelSetupPluginInstalled", () => {
     );
   });
 
+  it("scopes snapshots by activation-declared channel ownership when direct channel lists are empty", () => {
+    const runtime = makeRuntime();
+    const cfg: OpenClawConfig = {};
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "custom-telegram-plugin",
+          channels: [],
+          activation: {
+            onChannels: ["telegram"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadChannelSetupPluginRegistrySnapshotForChannel({
+      cfg,
+      runtime,
+      channel: "telegram",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["custom-telegram-plugin"],
+      }),
+    );
+  });
+
+  it("does not trust unconfigured workspace activation-only channel ownership during setup", () => {
+    const runtime = makeRuntime();
+    const cfg: OpenClawConfig = {};
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "evil-telegram-shadow",
+          channels: [],
+          origin: "workspace",
+          activation: {
+            onChannels: ["telegram"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    loadChannelSetupPluginRegistrySnapshotForChannel({
+      cfg,
+      runtime,
+      channel: "telegram",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        onlyPluginIds: ["evil-telegram-shadow"],
+      }),
+    );
+    expect(
+      (vi.mocked(loadOpenClawPlugins).mock.calls[0]?.[0] as { onlyPluginIds?: string[] })
+        .onlyPluginIds,
+    ).toBeUndefined();
+  });
+
   it("scopes snapshots by plugin id when channel and plugin ids differ", () => {
     const runtime = makeRuntime();
     const cfg: OpenClawConfig = {};

--- a/src/commands/channel-setup/plugin-install.ts
+++ b/src/commands/channel-setup/plugin-install.ts
@@ -10,13 +10,13 @@ import {
   findBundledPluginSourceInMap,
   resolveBundledPluginSources,
 } from "../../plugins/bundled-sources.js";
+import { resolveDiscoverableScopedChannelPluginIds } from "../../plugins/channel-plugin-ids.js";
 import { clearPluginDiscoveryCache } from "../../plugins/discovery.js";
 import { enablePluginInConfig } from "../../plugins/enable.js";
 import { installPluginFromNpmSpec } from "../../plugins/install.js";
 import { buildNpmResolutionInstallFields, recordPluginInstall } from "../../plugins/installs.js";
 import { loadOpenClawPlugins } from "../../plugins/loader.js";
 import { createPluginLoaderLogger } from "../../plugins/logger.js";
-import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import { getActivePluginChannelRegistry } from "../../plugins/runtime.js";
 import type { RuntimeEnv } from "../../runtime.js";
@@ -286,13 +286,13 @@ function resolveUniqueManifestScopedChannelPluginId(params: {
   channel: string;
   workspaceDir?: string;
 }): string | undefined {
-  const matches = loadPluginManifestRegistry({
+  const matches = resolveDiscoverableScopedChannelPluginIds({
     config: params.cfg,
+    channelIds: [params.channel],
     workspaceDir: params.workspaceDir,
-    cache: false,
     env: process.env,
-  }).plugins.filter((plugin) => plugin.channels.includes(params.channel));
-  return matches.length === 1 ? matches[0]?.id : undefined;
+  });
+  return matches.length === 1 ? matches[0] : undefined;
 }
 
 export function reloadChannelSetupPluginRegistryForChannel(params: {

--- a/src/commands/channel-setup/plugin-install.ts
+++ b/src/commands/channel-setup/plugin-install.ts
@@ -291,6 +291,7 @@ function resolveUniqueManifestScopedChannelPluginId(params: {
     channelIds: [params.channel],
     workspaceDir: params.workspaceDir,
     env: process.env,
+    cache: false,
   });
   return matches.length === 1 ? matches[0] : undefined;
 }

--- a/src/plugins/activation-planner.ts
+++ b/src/plugins/activation-planner.ts
@@ -18,6 +18,7 @@ export function resolveManifestActivationPluginIds(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  cache?: boolean;
   origin?: PluginOrigin;
   onlyPluginIds?: readonly string[];
 }): string[] {
@@ -29,6 +30,7 @@ export function resolveManifestActivationPluginIds(params: {
         config: params.config,
         workspaceDir: params.workspaceDir,
         env: params.env,
+        cache: params.cache,
       })
         .plugins.filter(
           (plugin) =>

--- a/src/plugins/activation-planner.ts
+++ b/src/plugins/activation-planner.ts
@@ -21,6 +21,7 @@ export function resolveManifestActivationPluginIds(params: {
   cache?: boolean;
   origin?: PluginOrigin;
   onlyPluginIds?: readonly string[];
+  cache?: boolean;
 }): string[] {
   const onlyPluginIdSet = createPluginIdScopeSet(normalizePluginIdScope(params.onlyPluginIds));
 

--- a/src/plugins/activation-planner.ts
+++ b/src/plugins/activation-planner.ts
@@ -21,7 +21,6 @@ export function resolveManifestActivationPluginIds(params: {
   cache?: boolean;
   origin?: PluginOrigin;
   onlyPluginIds?: readonly string[];
-  cache?: boolean;
 }): string[] {
   const onlyPluginIdSet = createPluginIdScopeSet(normalizePluginIdScope(params.onlyPluginIds));
 

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -465,6 +465,22 @@ describe("resolveConfiguredChannelPluginIds", () => {
     ).toEqual(["global-activation-channel-plugin"]);
   });
 
+  it("does not treat auto-enabled non-bundled channel owners as explicitly trusted", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: createStartupConfig({
+          channelIds: ["global-activation-channel"],
+          enabledPluginIds: ["global-activation-channel-plugin"],
+        }),
+        activationSourceConfig: createStartupConfig({
+          channelIds: ["global-activation-channel"],
+        }),
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual([]);
+  });
+
   it("blocks bundled activation owners when explicitly disabled", () => {
     expect(
       resolveConfiguredChannelPluginIds({

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -381,6 +381,53 @@ describe("resolveConfiguredChannelPluginIds", () => {
     ).toEqual(["activation-only-channel-plugin"]);
   });
 
+  it("keeps bundled activation owners behind restrictive allowlists", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: createStartupConfig({
+          channelIds: ["activation-only-channel"],
+          allowPluginIds: ["browser"],
+        }),
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual([]);
+  });
+
+  it("blocks bundled activation owners when explicitly denied", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: {
+          channels: {
+            "activation-only-channel": { enabled: true },
+          },
+          plugins: {
+            deny: ["activation-only-channel-plugin"],
+          },
+        } as OpenClawConfig,
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual([]);
+  });
+
+  it("blocks bundled activation owners when plugins are globally disabled", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: {
+          channels: {
+            "activation-only-channel": { enabled: true },
+          },
+          plugins: {
+            enabled: false,
+          },
+        } as OpenClawConfig,
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual([]);
+  });
+
   it("filters untrusted workspace activation owners from configured-channel runtime planning", () => {
     expect(
       resolveConfiguredChannelPluginIds({
@@ -416,5 +463,26 @@ describe("resolveConfiguredChannelPluginIds", () => {
         env: process.env,
       }),
     ).toEqual(["global-activation-channel-plugin"]);
+  });
+
+  it("blocks bundled activation owners when explicitly disabled", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: {
+          channels: {
+            "activation-only-channel": { enabled: true },
+          },
+          plugins: {
+            entries: {
+              "activation-only-channel-plugin": {
+                enabled: false,
+              },
+            },
+          },
+        } as OpenClawConfig,
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -2,17 +2,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
 const listPotentialConfiguredChannelIds = vi.hoisted(() => vi.fn());
+const hasPotentialConfiguredChannels = vi.hoisted(() => vi.fn());
 const loadPluginManifestRegistry = vi.hoisted(() => vi.fn());
 
 vi.mock("../channels/config-presence.js", () => ({
   listPotentialConfiguredChannelIds,
+  hasPotentialConfiguredChannels,
 }));
 
-vi.mock("./manifest-registry.js", () => ({
-  loadPluginManifestRegistry,
-}));
+vi.mock("./manifest-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./manifest-registry.js")>();
+  return {
+    ...actual,
+    loadPluginManifestRegistry,
+  };
+});
 
-import { resolveGatewayStartupPluginIds } from "./channel-plugin-ids.js";
+import {
+  resolveConfiguredChannelPluginIds,
+  resolveGatewayStartupPluginIds,
+} from "./channel-plugin-ids.js";
 
 function createManifestRegistryFixture() {
   return {
@@ -48,6 +57,28 @@ function createManifestRegistryFixture() {
         enabledByDefault: undefined,
         providers: ["demo-provider"],
         cliBackends: ["demo-cli"],
+      },
+      {
+        id: "activation-only-channel-plugin",
+        channels: [],
+        activation: {
+          onChannels: ["activation-only-channel"],
+        },
+        origin: "bundled",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+      },
+      {
+        id: "workspace-activation-channel-plugin",
+        channels: [],
+        activation: {
+          onChannels: ["workspace-activation-channel"],
+        },
+        origin: "workspace",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
       },
       {
         id: "voice-call",
@@ -198,6 +229,12 @@ describe("resolveGatewayStartupPluginIds", () => {
       }
       return ["demo-channel"];
     });
+    hasPotentialConfiguredChannels.mockReset().mockImplementation((config: OpenClawConfig) => {
+      if (Object.prototype.hasOwnProperty.call(config, "channels")) {
+        return Object.keys(config.channels ?? {}).length > 0;
+      }
+      return true;
+    });
     loadPluginManifestRegistry.mockReset().mockReturnValue(createManifestRegistryFixture());
   });
 
@@ -301,5 +338,47 @@ describe("resolveGatewayStartupPluginIds", () => {
       }),
       expected: ["demo-channel", "browser"],
     });
+  });
+});
+
+describe("resolveConfiguredChannelPluginIds", () => {
+  beforeEach(() => {
+    listPotentialConfiguredChannelIds.mockReset().mockImplementation((config: OpenClawConfig) => {
+      if (Object.prototype.hasOwnProperty.call(config, "channels")) {
+        return Object.keys(config.channels ?? {});
+      }
+      return [];
+    });
+    hasPotentialConfiguredChannels.mockReset().mockImplementation((config: OpenClawConfig) => {
+      if (Object.prototype.hasOwnProperty.call(config, "channels")) {
+        return Object.keys(config.channels ?? {}).length > 0;
+      }
+      return false;
+    });
+    loadPluginManifestRegistry.mockReset().mockReturnValue(createManifestRegistryFixture());
+  });
+
+  it("uses manifest activation channel ownership before falling back to direct channel lists", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: createStartupConfig({
+          channelIds: ["activation-only-channel"],
+        }),
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual(["activation-only-channel-plugin"]);
+  });
+
+  it("filters untrusted workspace activation owners from configured-channel runtime planning", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: createStartupConfig({
+          channelIds: ["workspace-activation-channel"],
+        }),
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -81,6 +81,17 @@ function createManifestRegistryFixture() {
         cliBackends: [],
       },
       {
+        id: "global-activation-channel-plugin",
+        channels: [],
+        activation: {
+          onChannels: ["global-activation-channel"],
+        },
+        origin: "global",
+        enabledByDefault: undefined,
+        providers: [],
+        cliBackends: [],
+      },
+      {
         id: "voice-call",
         channels: [],
         origin: "bundled",
@@ -380,5 +391,30 @@ describe("resolveConfiguredChannelPluginIds", () => {
         env: process.env,
       }),
     ).toEqual([]);
+  });
+
+  it("filters untrusted global activation owners from configured-channel runtime planning", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: createStartupConfig({
+          channelIds: ["global-activation-channel"],
+        }),
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps explicitly enabled global activation owners eligible for configured-channel runtime planning", () => {
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config: createStartupConfig({
+          channelIds: ["global-activation-channel"],
+          enabledPluginIds: ["global-activation-channel-plugin"],
+        }),
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual(["global-activation-channel-plugin"]);
   });
 });

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -208,6 +208,7 @@ export function resolveScopedChannelPluginIds(params: {
   channelIds: readonly string[];
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
+  cache?: boolean;
 }): string[] {
   return resolveScopedChannelOwnerPluginIds({
     ...params,

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -1,10 +1,13 @@
 import { listPotentialConfiguredChannelIds } from "../channels/config-presence.js";
+import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolveMemoryDreamingConfig,
   resolveMemoryDreamingPluginConfig,
   resolveMemoryDreamingPluginId,
 } from "../memory-host-sdk/dreaming.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { resolveManifestActivationPluginIds } from "./activation-planner.js";
 import {
   createPluginActivationSource,
   normalizePluginId,
@@ -36,6 +39,176 @@ function isGatewayStartupMemoryPlugin(plugin: PluginManifestRecord): boolean {
 
 function isGatewayStartupSidecar(plugin: PluginManifestRecord): boolean {
   return plugin.channels.length === 0 && !hasRuntimeContractSurface(plugin);
+}
+
+function dedupeSortedPluginIds(values: Iterable<string>): string[] {
+  return [...new Set(values)].toSorted((left, right) => left.localeCompare(right));
+}
+
+function normalizeChannelIds(channelIds: Iterable<string>): string[] {
+  return Array.from(
+    new Set(
+      [...channelIds]
+        .map((channelId) => normalizeOptionalLowercaseString(channelId))
+        .filter((channelId): channelId is string => Boolean(channelId)),
+    ),
+  ).toSorted((left, right) => left.localeCompare(right));
+}
+
+function resolveEffectiveChannelOwnershipConfig(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): OpenClawConfig {
+  return applyPluginAutoEnable({ config, env }).config;
+}
+
+function isChannelPluginEligibleForSetupDiscovery(params: {
+  plugin: PluginManifestRecord;
+  normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
+  rootConfig: OpenClawConfig;
+}): boolean {
+  if (params.plugin.origin !== "workspace") {
+    return true;
+  }
+  const activation = resolveEffectivePluginActivationState({
+    id: params.plugin.id,
+    origin: params.plugin.origin,
+    config: params.normalizedConfig,
+    rootConfig: params.rootConfig,
+    enabledByDefault: params.plugin.enabledByDefault,
+  });
+  if (activation.activated) {
+    return true;
+  }
+  return (
+    params.normalizedConfig.enabled &&
+    !params.normalizedConfig.deny.includes(params.plugin.id) &&
+    params.normalizedConfig.allow.includes(params.plugin.id) &&
+    params.normalizedConfig.entries[params.plugin.id]?.enabled === false
+  );
+}
+
+function isChannelPluginEligibleForRuntimeOwnerActivation(params: {
+  plugin: PluginManifestRecord;
+  normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
+  rootConfig: OpenClawConfig;
+}): boolean {
+  if (!params.normalizedConfig.enabled) {
+    return false;
+  }
+  if (params.normalizedConfig.deny.includes(params.plugin.id)) {
+    return false;
+  }
+  if (params.normalizedConfig.entries[params.plugin.id]?.enabled === false) {
+    return false;
+  }
+  if (
+    params.normalizedConfig.allow.length > 0 &&
+    !params.normalizedConfig.allow.includes(params.plugin.id)
+  ) {
+    return false;
+  }
+  if (params.plugin.origin !== "workspace") {
+    return true;
+  }
+  return resolveEffectivePluginActivationState({
+    id: params.plugin.id,
+    origin: params.plugin.origin,
+    config: params.normalizedConfig,
+    rootConfig: params.rootConfig,
+    enabledByDefault: params.plugin.enabledByDefault,
+  }).activated;
+}
+
+function resolveScopedChannelOwnerPluginIds(params: {
+  config: OpenClawConfig;
+  channelIds: readonly string[];
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+  mode: "runtime" | "setup";
+}): string[] {
+  const channelIds = normalizeChannelIds(params.channelIds);
+  if (channelIds.length === 0) {
+    return [];
+  }
+  const effectiveConfig = resolveEffectiveChannelOwnershipConfig(params.config, params.env);
+  const registry = loadPluginManifestRegistry({
+    config: effectiveConfig,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  const normalizedConfig = normalizePluginsConfig(effectiveConfig.plugins);
+  const candidateIds = dedupeSortedPluginIds(
+    channelIds.flatMap((channelId) => {
+      const planned = resolveManifestActivationPluginIds({
+        trigger: {
+          kind: "channel",
+          channel: channelId,
+        },
+        config: effectiveConfig,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      });
+      if (planned.length > 0) {
+        return planned;
+      }
+      return registry.plugins
+        .filter((plugin) =>
+          plugin.channels.some(
+            (candidateChannelId) =>
+              normalizeOptionalLowercaseString(candidateChannelId) === channelId,
+          ),
+        )
+        .map((plugin) => plugin.id);
+    }),
+  );
+  if (candidateIds.length === 0) {
+    return [];
+  }
+  const candidateIdSet = new Set(candidateIds);
+  return registry.plugins
+    .filter((plugin) => {
+      if (!candidateIdSet.has(plugin.id)) {
+        return false;
+      }
+      return params.mode === "setup"
+        ? isChannelPluginEligibleForSetupDiscovery({
+            plugin,
+            normalizedConfig,
+            rootConfig: effectiveConfig,
+          })
+        : isChannelPluginEligibleForRuntimeOwnerActivation({
+            plugin,
+            normalizedConfig,
+            rootConfig: effectiveConfig,
+          });
+    })
+    .map((plugin) => plugin.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+export function resolveScopedChannelPluginIds(params: {
+  config: OpenClawConfig;
+  channelIds: readonly string[];
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+}): string[] {
+  return resolveScopedChannelOwnerPluginIds({
+    ...params,
+    mode: "runtime",
+  });
+}
+
+export function resolveDiscoverableScopedChannelPluginIds(params: {
+  config: OpenClawConfig;
+  channelIds: readonly string[];
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+}): string[] {
+  return resolveScopedChannelOwnerPluginIds({
+    ...params,
+    mode: "setup",
+  });
 }
 
 function resolveGatewayStartupDreamingPluginIds(config: OpenClawConfig): Set<string> {
@@ -99,7 +272,10 @@ export function resolveConfiguredChannelPluginIds(params: {
   if (configuredChannelIds.size === 0) {
     return [];
   }
-  return resolveChannelPluginIds(params).filter((pluginId) => configuredChannelIds.has(pluginId));
+  return resolveScopedChannelPluginIds({
+    ...params,
+    channelIds: [...configuredChannelIds],
+  });
 }
 
 export function resolveConfiguredDeferredChannelPluginIds(params: {

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -164,7 +164,7 @@ function resolveScopedChannelOwnerPluginIds(params: {
   const normalizedConfig = normalizePluginsConfig(effectiveConfig.plugins);
   const candidateIds = dedupeSortedPluginIds(
     channelIds.flatMap((channelId) => {
-      const planned = resolveManifestActivationPluginIds({
+      return resolveManifestActivationPluginIds({
         trigger: {
           kind: "channel",
           channel: channelId,
@@ -173,17 +173,6 @@ function resolveScopedChannelOwnerPluginIds(params: {
         workspaceDir: params.workspaceDir,
         env: params.env,
       });
-      if (planned.length > 0) {
-        return planned;
-      }
-      return registry.plugins
-        .filter((plugin) =>
-          plugin.channels.some(
-            (candidateChannelId) =>
-              normalizeOptionalLowercaseString(candidateChannelId) === channelId,
-          ),
-        )
-        .map((plugin) => plugin.id);
     }),
   );
   if (candidateIds.length === 0) {

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -1,5 +1,4 @@
 import { listPotentialConfiguredChannelIds } from "../channels/config-presence.js";
-import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolveMemoryDreamingConfig,
@@ -53,13 +52,6 @@ function normalizeChannelIds(channelIds: Iterable<string>): string[] {
         .filter((channelId): channelId is string => Boolean(channelId)),
     ),
   ).toSorted((left, right) => left.localeCompare(right));
-}
-
-function resolveEffectiveChannelOwnershipConfig(
-  config: OpenClawConfig,
-  env: NodeJS.ProcessEnv,
-): OpenClawConfig {
-  return applyPluginAutoEnable({ config, env }).config;
 }
 
 function isBundledChannelOwner(plugin: PluginManifestRecord): boolean {
@@ -146,6 +138,7 @@ function isChannelPluginEligibleForRuntimeOwnerActivation(params: {
 
 function resolveScopedChannelOwnerPluginIds(params: {
   config: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
   channelIds: readonly string[];
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
@@ -156,14 +149,14 @@ function resolveScopedChannelOwnerPluginIds(params: {
   if (channelIds.length === 0) {
     return [];
   }
-  const effectiveConfig = resolveEffectiveChannelOwnershipConfig(params.config, params.env);
   const registry = loadPluginManifestRegistry({
-    config: effectiveConfig,
+    config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
     cache: params.cache,
   });
-  const normalizedConfig = normalizePluginsConfig(effectiveConfig.plugins);
+  const trustConfig = params.activationSourceConfig ?? params.config;
+  const normalizedConfig = normalizePluginsConfig(trustConfig.plugins);
   const candidateIds = dedupeSortedPluginIds(
     channelIds.flatMap((channelId) => {
       return resolveManifestActivationPluginIds({
@@ -171,7 +164,7 @@ function resolveScopedChannelOwnerPluginIds(params: {
           kind: "channel",
           channel: channelId,
         },
-        config: effectiveConfig,
+        config: params.config,
         workspaceDir: params.workspaceDir,
         env: params.env,
         cache: params.cache,
@@ -191,12 +184,12 @@ function resolveScopedChannelOwnerPluginIds(params: {
         ? isChannelPluginEligibleForSetupDiscovery({
             plugin,
             normalizedConfig,
-            rootConfig: effectiveConfig,
+            rootConfig: trustConfig,
           })
         : isChannelPluginEligibleForRuntimeOwnerActivation({
             plugin,
             normalizedConfig,
-            rootConfig: effectiveConfig,
+            rootConfig: trustConfig,
           });
     })
     .map((plugin) => plugin.id)
@@ -205,6 +198,7 @@ function resolveScopedChannelOwnerPluginIds(params: {
 
 export function resolveScopedChannelPluginIds(params: {
   config: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
   channelIds: readonly string[];
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
@@ -218,6 +212,7 @@ export function resolveScopedChannelPluginIds(params: {
 
 export function resolveDiscoverableScopedChannelPluginIds(params: {
   config: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
   channelIds: readonly string[];
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -103,11 +103,11 @@ function isChannelPluginEligibleForSetupDiscovery(params: {
   normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
   rootConfig: OpenClawConfig;
 }): boolean {
-  if (isBundledChannelOwner(params.plugin)) {
-    return true;
-  }
   if (!passesExplicitChannelOwnershipPolicy(params)) {
     return false;
+  }
+  if (isBundledChannelOwner(params.plugin)) {
+    return true;
   }
   if (params.plugin.origin === "global" || params.plugin.origin === "config") {
     return hasExplicitNonBundledChannelOwnerTrust(params);
@@ -126,11 +126,11 @@ function isChannelPluginEligibleForRuntimeOwnerActivation(params: {
   normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
   rootConfig: OpenClawConfig;
 }): boolean {
-  if (isBundledChannelOwner(params.plugin)) {
-    return true;
-  }
   if (!passesExplicitChannelOwnershipPolicy(params)) {
     return false;
+  }
+  if (isBundledChannelOwner(params.plugin)) {
+    return true;
   }
   if (params.plugin.origin === "global" || params.plugin.origin === "config") {
     return hasExplicitNonBundledChannelOwnerTrust(params);
@@ -150,6 +150,7 @@ function resolveScopedChannelOwnerPluginIds(params: {
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
   mode: "runtime" | "setup";
+  cache?: boolean;
 }): string[] {
   const channelIds = normalizeChannelIds(params.channelIds);
   if (channelIds.length === 0) {
@@ -160,6 +161,7 @@ function resolveScopedChannelOwnerPluginIds(params: {
     config: effectiveConfig,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    cache: params.cache,
   });
   const normalizedConfig = normalizePluginsConfig(effectiveConfig.plugins);
   const candidateIds = dedupeSortedPluginIds(
@@ -172,6 +174,7 @@ function resolveScopedChannelOwnerPluginIds(params: {
         config: effectiveConfig,
         workspaceDir: params.workspaceDir,
         env: params.env,
+        cache: params.cache,
       });
     }),
   );
@@ -217,6 +220,7 @@ export function resolveDiscoverableScopedChannelPluginIds(params: {
   channelIds: readonly string[];
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
+  cache?: boolean;
 }): string[] {
   return resolveScopedChannelOwnerPluginIds({
     ...params,

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -62,36 +62,23 @@ function resolveEffectiveChannelOwnershipConfig(
   return applyPluginAutoEnable({ config, env }).config;
 }
 
-function isChannelPluginEligibleForSetupDiscovery(params: {
+function isBundledChannelOwner(plugin: PluginManifestRecord): boolean {
+  return plugin.origin === "bundled";
+}
+
+function hasExplicitNonBundledChannelOwnerTrust(params: {
   plugin: PluginManifestRecord;
   normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
-  rootConfig: OpenClawConfig;
 }): boolean {
-  if (params.plugin.origin !== "workspace") {
-    return true;
-  }
-  const activation = resolveEffectivePluginActivationState({
-    id: params.plugin.id,
-    origin: params.plugin.origin,
-    config: params.normalizedConfig,
-    rootConfig: params.rootConfig,
-    enabledByDefault: params.plugin.enabledByDefault,
-  });
-  if (activation.activated) {
-    return true;
-  }
   return (
-    params.normalizedConfig.enabled &&
-    !params.normalizedConfig.deny.includes(params.plugin.id) &&
-    params.normalizedConfig.allow.includes(params.plugin.id) &&
-    params.normalizedConfig.entries[params.plugin.id]?.enabled === false
+    params.normalizedConfig.allow.includes(params.plugin.id) ||
+    params.normalizedConfig.entries[params.plugin.id]?.enabled === true
   );
 }
 
-function isChannelPluginEligibleForRuntimeOwnerActivation(params: {
+function passesExplicitChannelOwnershipPolicy(params: {
   plugin: PluginManifestRecord;
   normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
-  rootConfig: OpenClawConfig;
 }): boolean {
   if (!params.normalizedConfig.enabled) {
     return false;
@@ -108,8 +95,45 @@ function isChannelPluginEligibleForRuntimeOwnerActivation(params: {
   ) {
     return false;
   }
-  if (params.plugin.origin !== "workspace") {
+  return true;
+}
+
+function isChannelPluginEligibleForSetupDiscovery(params: {
+  plugin: PluginManifestRecord;
+  normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
+  rootConfig: OpenClawConfig;
+}): boolean {
+  if (isBundledChannelOwner(params.plugin)) {
     return true;
+  }
+  if (!passesExplicitChannelOwnershipPolicy(params)) {
+    return false;
+  }
+  if (params.plugin.origin === "global" || params.plugin.origin === "config") {
+    return hasExplicitNonBundledChannelOwnerTrust(params);
+  }
+  return resolveEffectivePluginActivationState({
+    id: params.plugin.id,
+    origin: params.plugin.origin,
+    config: params.normalizedConfig,
+    rootConfig: params.rootConfig,
+    enabledByDefault: params.plugin.enabledByDefault,
+  }).activated;
+}
+
+function isChannelPluginEligibleForRuntimeOwnerActivation(params: {
+  plugin: PluginManifestRecord;
+  normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
+  rootConfig: OpenClawConfig;
+}): boolean {
+  if (isBundledChannelOwner(params.plugin)) {
+    return true;
+  }
+  if (!passesExplicitChannelOwnershipPolicy(params)) {
+    return false;
+  }
+  if (params.plugin.origin === "global" || params.plugin.origin === "config") {
+    return hasExplicitNonBundledChannelOwnerTrust(params);
   }
   return resolveEffectivePluginActivationState({
     id: params.plugin.id,

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -122,14 +122,63 @@ describe("ensurePluginRegistryLoaded", () => {
     });
     expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
       expect.objectContaining({
-        config: resolvedConfig,
-        activationSourceConfig: { plugins: { allow: ["demo-channel"] } },
+        config: expect.objectContaining({
+          ...resolvedConfig,
+          plugins: expect.objectContaining({
+            entries: expect.objectContaining({
+              demo: { enabled: true },
+              "demo-channel": { enabled: true },
+            }),
+            allow: ["demo-channel"],
+          }),
+        }),
+        activationSourceConfig: {
+          plugins: {
+            allow: ["demo-channel"],
+            entries: {
+              "demo-channel": { enabled: true },
+            },
+          },
+        },
         autoEnabledReasons: {
           demo: ["demo configured"],
         },
         workspaceDir: "/resolved-workspace",
         onlyPluginIds: ["demo-channel"],
         throwOnLoadError: true,
+      }),
+    );
+  });
+
+  it("temporarily activates configured-channel owners before loading them", () => {
+    const rawConfig = { channels: { demo: { enabled: true } } };
+
+    mocks.resolveConfiguredChannelPluginIds.mockReturnValue(["activation-only-channel"]);
+
+    ensurePluginRegistryLoaded({
+      scope: "configured-channels",
+      config: rawConfig as never,
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            entries: expect.objectContaining({
+              "activation-only-channel": { enabled: true },
+            }),
+            allow: ["activation-only-channel"],
+          }),
+        }),
+        activationSourceConfig: expect.objectContaining({
+          plugins: expect.objectContaining({
+            entries: expect.objectContaining({
+              "activation-only-channel": { enabled: true },
+            }),
+            allow: ["activation-only-channel"],
+          }),
+        }),
+        onlyPluginIds: ["activation-only-channel"],
       }),
     );
   });

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -112,6 +112,7 @@ describe("ensurePluginRegistryLoaded", () => {
     expect(mocks.resolveConfiguredChannelPluginIds).toHaveBeenCalledWith(
       expect.objectContaining({
         config: resolvedConfig,
+        activationSourceConfig: { plugins: { allow: ["demo-channel"] } },
         env,
         workspaceDir: "/resolved-workspace",
       }),

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -236,4 +236,22 @@ describe("ensurePluginRegistryLoaded", () => {
       }),
     );
   });
+
+  it("does not forward empty channel scopes for broad channel loads", () => {
+    mocks.resolveChannelPluginIds.mockReturnValue([]);
+
+    ensurePluginRegistryLoaded({
+      scope: "channels",
+      config: {} as never,
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        onlyPluginIds: [],
+      }),
+    );
+    expect(
+      (mocks.loadOpenClawPlugins.mock.calls[0]?.[0] as { onlyPluginIds?: string[] }).onlyPluginIds,
+    ).toBeUndefined();
+  });
 });

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -221,4 +221,19 @@ describe("ensurePluginRegistryLoaded", () => {
       }),
     );
   });
+
+  it("preserves empty configured-channel scopes when no owners are activatable", () => {
+    mocks.resolveConfiguredChannelPluginIds.mockReturnValue([]);
+
+    ensurePluginRegistryLoaded({
+      scope: "configured-channels",
+      config: { channels: { demo: { enabled: true } } } as never,
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: [],
+      }),
+    );
+  });
 });

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withActivatedPluginIds } from "../activation-context.js";
 import {
   resolveChannelPluginIds,
   resolveConfiguredChannelPluginIds,
@@ -10,7 +11,10 @@ import {
   normalizePluginIdScope,
 } from "../plugin-scope.js";
 import { getActivePluginRegistry } from "../runtime.js";
-import { buildPluginRuntimeLoadOptions, resolvePluginRuntimeLoadContext } from "./load-context.js";
+import {
+  buildPluginRuntimeLoadOptionsFromValues,
+  resolvePluginRuntimeLoadContext,
+} from "./load-context.js";
 
 let pluginRegistryLoaded: "none" | "configured-channels" | "channels" | "all" = "none";
 
@@ -105,14 +109,35 @@ export function ensurePluginRegistryLoaded(options?: {
     }
     return;
   }
+  const scopedConfig =
+    !scopedLoad && scope === "configured-channels" && expectedChannelPluginIds.length > 0
+      ? (withActivatedPluginIds({
+          config: context.config,
+          pluginIds: expectedChannelPluginIds,
+        }) ?? context.config)
+      : context.config;
+  const scopedActivationSourceConfig =
+    !scopedLoad && scope === "configured-channels" && expectedChannelPluginIds.length > 0
+      ? (withActivatedPluginIds({
+          config: context.activationSourceConfig,
+          pluginIds: expectedChannelPluginIds,
+        }) ?? context.activationSourceConfig)
+      : context.activationSourceConfig;
   loadOpenClawPlugins(
-    buildPluginRuntimeLoadOptions(context, {
-      throwOnLoadError: true,
-      ...(hasExplicitPluginIdScope(requestedPluginIds) ||
-      hasNonEmptyPluginIdScope(expectedChannelPluginIds)
-        ? { onlyPluginIds: expectedChannelPluginIds }
-        : {}),
-    }),
+    buildPluginRuntimeLoadOptionsFromValues(
+      {
+        ...context,
+        config: scopedConfig,
+        activationSourceConfig: scopedActivationSourceConfig,
+      },
+      {
+        throwOnLoadError: true,
+        ...(hasExplicitPluginIdScope(requestedPluginIds) ||
+        hasNonEmptyPluginIdScope(expectedChannelPluginIds)
+          ? { onlyPluginIds: expectedChannelPluginIds }
+          : {}),
+      },
+    ),
   );
   if (!scopedLoad) {
     pluginRegistryLoaded = scope;

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -89,6 +89,7 @@ export function ensurePluginRegistryLoaded(options?: {
     : scope === "configured-channels"
       ? resolveConfiguredChannelPluginIds({
           config: context.config,
+          activationSourceConfig: context.activationSourceConfig,
           workspaceDir: context.workspaceDir,
           env: context.env,
         })

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -66,6 +66,13 @@ function activeRegistrySatisfiesScope(
   throw new Error("Unsupported plugin registry scope");
 }
 
+function shouldForwardChannelScope(params: {
+  scope: PluginRegistryScope;
+  scopedLoad: boolean;
+}): boolean {
+  return !params.scopedLoad && params.scope !== "all";
+}
+
 export function ensurePluginRegistryLoaded(options?: {
   scope?: PluginRegistryScope;
   config?: OpenClawConfig;
@@ -133,6 +140,7 @@ export function ensurePluginRegistryLoaded(options?: {
       {
         throwOnLoadError: true,
         ...(hasExplicitPluginIdScope(requestedPluginIds) ||
+        shouldForwardChannelScope({ scope, scopedLoad }) ||
         hasNonEmptyPluginIdScope(expectedChannelPluginIds)
           ? { onlyPluginIds: expectedChannelPluginIds }
           : {}),

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -70,7 +70,7 @@ function shouldForwardChannelScope(params: {
   scope: PluginRegistryScope;
   scopedLoad: boolean;
 }): boolean {
-  return !params.scopedLoad && params.scope !== "all";
+  return !params.scopedLoad && params.scope === "configured-channels";
 }
 
 export function ensurePluginRegistryLoaded(options?: {


### PR DESCRIPTION
## Summary

- Problem: channel setup and configured-channel runtime narrowing still depended on direct `channels[]` ownership, so activation-only channel manifests could not drive scoped loads.
- Why it matters: that kept channel planning broader than it needed to be, and it left setup/runtime paths inconsistent with the newer manifest-first provider and CLI work.
- What changed: added manifest-driven scoped channel owner resolution, used it in channel setup snapshot scoping and configured-channel runtime loading, and temporarily activates eligible configured-channel owners before the scoped load.
- What did NOT change (scope boundary): this does not replace broader channel runtime fallback paths, remove legacy `channels[]` ownership, or rewrite channel auto-enable.

## Change Type (select all)

- [x] Feature
- [x] Refactor required for the fix
- [x] Docs
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- Related #65120
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: channel planning still treated direct `channels[]` ownership as the only trustworthy scope signal, so manifest activation hints were not part of the real channel load path.
- Missing detection / guardrail: there was no shared guardrail covering trust/disable policy for channel owner planning the way providers now have.
- Contributing context (if known): once we added channel manifest planning, setup/runtime needed the same trust and activation bounds we already learned the hard way on provider planning.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/plugins/channel-plugin-ids.test.ts`, `src/commands/channel-setup/plugin-install.test.ts`, `src/plugins/runtime/runtime-registry-loader.test.ts`
- Scenario the test should lock in: activation-only channel owners narrow scoped loads; untrusted workspace shadows do not get scoped setup/runtime activation; configured-channel runtime loads keep explicit owners activated for the scoped request.
- Why this is the smallest reliable guardrail: these are the first seams where channel manifest planning becomes live behavior.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Channel setup/plugin resolution can now narrow to a plugin that declares channel ownership through `activation.onChannels` even when `channels[]` is empty.
- Configured-channel runtime loads can now narrow to manifest-declared channel owners instead of broad-loading every channel plugin first.
- Untrusted workspace channel shadows are still blocked from setup/runtime scoped loading.

## Diagram (if applicable)

```text
Before:
[channel id] -> direct channels[] match only -> broad or legacy load

After:
[channel id] -> activation.onChannels / channels[] owner planning -> policy filter -> scoped load
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): channel setup + plugin runtime loader
- Relevant config (redacted): local synthetic configs in targeted tests

### Steps

1. Add a plugin manifest that declares `activation.onChannels: ["telegram"]` with no direct `channels[]` entry.
2. Resolve channel setup snapshot or configured-channel runtime load for `telegram`.
3. Verify the scoped plugin ids and trust filtering.

### Expected

- Manifest channel ownership narrows the load to the owning plugin when policy allows it.

### Actual

- Verified locally via targeted tests and build after the fix.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: activation-only channel owner planning, untrusted workspace shadow filtering, configured-channel runtime scoped activation.
- Edge cases checked: explicit empty scopes, setup fallback to trusted catalog, runtime scoped owner activation.
- What you did **not** verify: full repo `pnpm test`; broader bot/security review follow-up has not run yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: manifest channel ownership could over-scope to workspace plugins.
  - Mitigation: runtime/setup channel owner planning now filters through trust and disablement policy before scoping.
- Risk: activation-only channel owners could still miss older broad fallback paths.
  - Mitigation: this PR only makes the first live consumers narrower and keeps legacy `channels[]` fallback in place.

## AI Assistance

- AI-assisted: Yes
- Testing: targeted tests + lint + build
