### PR TITLE
security: use timing-safe token comparison in MCP loopback validator

### DIFF
--- a/src/agents/payload-redaction.ts
+++ b/src/agents/payload-redaction.ts
@@ -11,6 +11,7 @@ const NON_CREDENTIAL_FIELD_NAMES = new Set([
   "tokenfield",
   "tokenlimit",
   "tokens",
+  "credentialscope",
 ]);
 
 function normalizeFieldName(value: string): string {
@@ -30,9 +31,12 @@ function isCredentialFieldName(key: string): boolean {
     normalized.endsWith("password") ||
     normalized.endsWith("passwd") ||
     normalized.endsWith("passphrase") ||
+    normalized.endsWith("privatekey") ||
     normalized.endsWith("secret") ||
     normalized.endsWith("secretkey") ||
-    normalized.endsWith("token")
+    normalized.endsWith("token") ||
+    normalized === "credential" ||
+    normalized === "credentials"
   );
 }
 

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { safeEqualSecret } from "../security/secret-equal.js";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -55,7 +56,10 @@ export function validateMcpLoopbackRequest(params: {
   }
 
   const authHeader = getHeader(params.req, "authorization") ?? "";
-  if (authHeader !== `Bearer ${params.token}`) {
+  // Use timing-safe comparison to avoid leaking token length/content via
+  // response-time side-channels. Matches the safeEqualSecret approach used
+  // by the main gateway auth path.
+  if (!safeEqualSecret(authHeader, `Bearer ${params.token}`)) {
     params.res.writeHead(401, { "Content-Type": "application/json" });
     params.res.end(JSON.stringify({ error: "unauthorized" }));
     return false;


### PR DESCRIPTION
## Summary

Two small hardening changes in the credential handling path:

### 1. Timing-safe bearer token comparison in MCP loopback ()

`validateMcpLoopbackRequest` was comparing the incoming `Authorization` header against the expected bearer token with a plain JavaScript `!==` string comparison:

```ts
if (authHeader !== `Bearer ${params.token}`) {
```

Plain equality checks on secrets are susceptible to timing side-channels — an attacker with high-precision response-time measurement can infer the correct token one byte at a time. The main gateway auth path already uses `safeEqualSecret` (backed by `crypto.timingSafeEqual` via SHA-256 hashing) for exactly this reason. This patch brings the MCP loopback validator in line with that pattern.

### 2. Broader credential field coverage in diagnostic redaction ()

`isCredentialFieldName` (used by `sanitizeDiagnosticPayload`) matched common credential suffixes but missed a few patterns that appear in provider auth configs and MCP server setups:

- `private_key` / `privateKey` style fields (normalized to `privatekey`) — now matched via `endsWith("privatekey")`
- Bare `credential` and `credentials` field names — now matched via exact normalized equality
- `credentialscope` added to `NON_CREDENTIAL_FIELD_NAMES` so OAuth scope strings are not incorrectly suppressed from diagnostic output

## Files changed

- `src/gateway/mcp-http.request.ts` — import `safeEqualSecret`, swap `!==` for `!safeEqualSecret()`
- `src/agents/payload-redaction.ts` — add `privatekey` suffix, `credential`/`credentials` exact matches, `credentialscope` exclusion

## Testing

Existing tests in `src/gateway/mcp-http.test.ts` cover the 401 path (missing/wrong token). The behavioral contract is unchanged — wrong tokens still return 401; the comparison is just constant-time now.