### PR TITLE
fix(models): add image input to MiniMax-M2.7 catalog

### DIFF
--- a/extensions/minimax/model-definitions.ts
+++ b/extensions/minimax/model-definitions.ts
@@ -48,6 +48,10 @@ export const MINIMAX_LM_STUDIO_COST = {
 
 type MinimaxCatalogId = keyof typeof MINIMAX_TEXT_MODEL_CATALOG;
 
+export function isMinimaxImageCapableModel(modelId: string): boolean {
+  return modelId === "MiniMax-M2.7" || modelId.startsWith("MiniMax-M2.7-");
+}
+
 export function resolveMinimaxApiCost(modelId: string): ModelDefinitionConfig["cost"] {
   if (modelId === "MiniMax-M2.5-highspeed") {
     return MINIMAX_M25_API_HIGHSPEED_COST;
@@ -70,13 +74,11 @@ export function buildMinimaxModelDefinition(params: {
   maxTokens: number;
 }): ModelDefinitionConfig {
   const catalog = MINIMAX_TEXT_MODEL_CATALOG[params.id as MinimaxCatalogId];
-  // MiniMax-M2.7 supports image input
-  const isImageCapable = params.id === "MiniMax-M2.7" || params.id.startsWith("MiniMax-M2.7-");
   return {
     id: params.id,
     name: params.name ?? catalog?.name ?? `MiniMax ${params.id}`,
     reasoning: params.reasoning ?? catalog?.reasoning ?? false,
-    input: isImageCapable ? ["text", "image"] : ["text"],
+    input: isMinimaxImageCapableModel(params.id) ? ["text", "image"] : ["text"],
     cost: params.cost,
     contextWindow: params.contextWindow,
     maxTokens: params.maxTokens,

--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_MINIMAX_CONTEXT_WINDOW,
   DEFAULT_MINIMAX_MAX_TOKENS,
   MINIMAX_API_BASE_URL,
+  isMinimaxImageCapableModel,
   resolveMinimaxApiCost,
 } from "./model-definitions.js";
 import { MINIMAX_TEXT_MODEL_CATALOG, MINIMAX_TEXT_MODEL_ORDER } from "./provider-models.js";
@@ -46,19 +47,6 @@ function buildMinimaxModel(params: {
   };
 }
 
-function buildMinimaxTextModel(params: {
-  id: string;
-  name: string;
-  reasoning: boolean;
-  cost: ModelDefinitionConfig["cost"];
-}): ModelDefinitionConfig {
-  return buildMinimaxModel({ ...params, input: ["text"] });
-}
-
-function isImageCapableModel(modelId: string): boolean {
-  return modelId === "MiniMax-M2.7" || modelId.startsWith("MiniMax-M2.7-");
-}
-
 function buildMinimaxCatalog(): ModelDefinitionConfig[] {
   return MINIMAX_TEXT_MODEL_ORDER.map((id) => {
     const model = MINIMAX_TEXT_MODEL_CATALOG[id];
@@ -66,7 +54,7 @@ function buildMinimaxCatalog(): ModelDefinitionConfig[] {
       id,
       name: model.name,
       reasoning: model.reasoning,
-      input: isImageCapableModel(id) ? ["text", "image"] : ["text"],
+      input: isMinimaxImageCapableModel(id) ? ["text", "image"] : ["text"],
       cost: resolveMinimaxApiCost(id),
     });
   });

--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -55,13 +55,18 @@ function buildMinimaxTextModel(params: {
   return buildMinimaxModel({ ...params, input: ["text"] });
 }
 
+function isImageCapableModel(modelId: string): boolean {
+  return modelId === "MiniMax-M2.7" || modelId.startsWith("MiniMax-M2.7-");
+}
+
 function buildMinimaxCatalog(): ModelDefinitionConfig[] {
   return MINIMAX_TEXT_MODEL_ORDER.map((id) => {
     const model = MINIMAX_TEXT_MODEL_CATALOG[id];
-    return buildMinimaxTextModel({
+    return buildMinimaxModel({
       id,
       name: model.name,
       reasoning: model.reasoning,
+      input: isImageCapableModel(id) ? ["text", "image"] : ["text"],
       cost: resolveMinimaxApiCost(id),
     });
   });


### PR DESCRIPTION
## Summary

Adds `input: ["text", "image"]` to the MiniMax-M2.7 and MiniMax-M2.7-highspeed model catalog entries in `provider-catalog.ts`.

MiniMax M2.7 officially supports multimodal (text + image) input via their Anthropic-compatible API, but the provider-catalog code path hardcoded `input: ["text"]` for all MiniMax models via `buildMinimaxTextModel`. This caused `parseMessageWithAttachments` to silently drop all image attachments before they reached the model.

The `model-definitions.ts` code path (used by `buildMinimaxApiModelDefinition`) already had an `isImageCapable` check, but `provider-catalog.ts` — which feeds the actual `buildMinimaxProvider()` and `buildMinimaxPortalProvider()` registrations — did not. Additionally, `mergeProviderModels()` always takes `input` from the implicit (catalog) model, so user-level config overrides cannot work around this.

The fix adds an `isImageCapableModel()` guard matching the existing pattern in `model-definitions.ts` and switches `buildMinimaxCatalog()` from `buildMinimaxTextModel` (which hardcodes `["text"]`) to `buildMinimaxModel` with the correct input array.

Fixes #65424.

## Test plan

- [ ] Send `chat.send` with an image attachment to `minimax/MiniMax-M2.7` — verify image is forwarded to model
- [ ] Confirm `parseMessageWithAttachments` no longer logs "attachment(s) dropped" for MiniMax-M2.7
- [ ] Verify `minimax/MiniMax-M2.7-highspeed` also accepts images
- [ ] Verify non-M2.7 MiniMax models (e.g. M2.5) remain text-only