### PR TITLE
fix(agents): isolate skills tests from personal home

### DIFF
--- a/src/agents/skills.buildworkspaceskillsnapshot.test.ts
+++ b/src/agents/skills.buildworkspaceskillsnapshot.test.ts
@@ -3,15 +3,25 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { withPathResolutionEnv } from "../test-utils/env.js";
 import { createFixtureSuite } from "../test-utils/fixture-suite.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 import { writeSkill } from "./skills.e2e-test-helpers.js";
 import { buildWorkspaceSkillSnapshot, buildWorkspaceSkillsPrompt } from "./skills.js";
+import {
+  restoreMockSkillsHomeEnv,
+  setMockSkillsHomeEnv,
+  type SkillsHomeEnvSnapshot,
+} from "./skills/home-env.test-support.js";
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-snapshot-suite-");
 let truncationWorkspaceTemplateDir = "";
 let nestedRepoTemplateDir = "";
+let tempHome: TempHomeEnv | null = null;
+let skillsHomeEnv: SkillsHomeEnvSnapshot | null = null;
 
 beforeAll(async () => {
   await fixtureSuite.setup();
+  tempHome = await createTempHomeEnv("openclaw-skills-snapshot-home-");
+  skillsHomeEnv = setMockSkillsHomeEnv(tempHome.home);
   truncationWorkspaceTemplateDir = await fixtureSuite.createCaseDir(
     "template-truncation-workspace",
   );
@@ -36,6 +46,14 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (skillsHomeEnv) {
+    await restoreMockSkillsHomeEnv(skillsHomeEnv);
+    skillsHomeEnv = null;
+  }
+  if (tempHome) {
+    await tempHome.restore();
+    tempHome = null;
+  }
   await fixtureSuite.cleanup();
 });
 

--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -1,16 +1,23 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { withPathResolutionEnv } from "../test-utils/env.js";
 import { writeSkill } from "./skills.e2e-test-helpers.js";
 import { loadWorkspaceSkillEntries } from "./skills.js";
+import {
+  restoreMockSkillsHomeEnv,
+  setMockSkillsHomeEnv,
+  type SkillsHomeEnvSnapshot,
+} from "./skills/home-env.test-support.js";
 import { readSkillFrontmatterSafe } from "./skills/local-loader.js";
 import { writePluginWithSkill } from "./test-helpers/skill-plugin-fixtures.js";
 
 const tempDirs: string[] = [];
+let fakeHome = "";
+let envSnapshot: SkillsHomeEnvSnapshot;
 
 async function createTempWorkspaceDir() {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-"));
@@ -22,13 +29,23 @@ function withWorkspaceHome<T>(workspaceDir: string, cb: () => T): T {
   return withPathResolutionEnv(workspaceDir, { PATH: "" }, () => cb());
 }
 
+beforeEach(async () => {
+  fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-home-"));
+  tempDirs.push(fakeHome);
+  envSnapshot = setMockSkillsHomeEnv(fakeHome);
+});
+
 afterEach(async () => {
   setLoggerOverride(null);
   loggingState.rawConsole = null;
   resetLogger();
-  await Promise.all(
-    tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
-  );
+  await restoreMockSkillsHomeEnv(envSnapshot, async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0, tempDirs.length)
+        .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
 });
 
 async function setupWorkspaceWithProsePlugin() {

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -19,9 +19,15 @@ import {
   loadWorkspaceSkillEntries,
 } from "./skills.js";
 import { getActiveSkillEnvKeys } from "./skills/env-overrides.js";
+import {
+  restoreMockSkillsHomeEnv,
+  setMockSkillsHomeEnv,
+  type SkillsHomeEnvSnapshot,
+} from "./skills/home-env.test-support.js";
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-suite-");
 let tempHome: TempHomeEnv | null = null;
+let skillsHomeEnv: SkillsHomeEnvSnapshot | null = null;
 
 const resolveTestSkillDirs = (workspaceDir: string) => ({
   managedSkillsDir: path.join(workspaceDir, ".managed"),
@@ -72,12 +78,17 @@ async function writeEnvSkill(workspaceDir: string) {
 beforeAll(async () => {
   await fixtureSuite.setup();
   tempHome = await createTempHomeEnv("openclaw-skills-home-");
+  skillsHomeEnv = setMockSkillsHomeEnv(tempHome.home);
   await fs.mkdir(path.join(tempHome.home, ".openclaw", "agents", "main", "sessions"), {
     recursive: true,
   });
 });
 
 afterAll(async () => {
+  if (skillsHomeEnv) {
+    await restoreMockSkillsHomeEnv(skillsHomeEnv);
+    skillsHomeEnv = null;
+  }
   if (tempHome) {
     await tempHome.restore();
     tempHome = null;


### PR DESCRIPTION
## Summary

- Problem: several `src/agents/skills*.test.ts` suites were loading real personal `~/.agents/skills` entries from the developer machine.
- Why it matters: local `pnpm test` became nondeterministic, with skills tests failing based on whoever's personal home directory was present.
- What changed: reused the existing `skills/home-env.test-support.ts` helper so the affected suites mock both home env vars and `os.homedir()` to an isolated temp home.
- What did NOT change (scope boundary): no production skills loading behavior changed; this PR only isolates the affected tests from personal machine state.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #65296
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the affected tests only overrode `HOME`-style env vars, but the skills loader also reads personal skills using `os.homedir()`, so real `~/.agents/skills` entries leaked into test discovery.
- Missing detection / guardrail: the tests did not use the existing helper that mocks both env-based home resolution and `os.homedir()`.
- Contributing context (if known): local machines with installed personal skills surfaced extra commands such as `find-skills` and `zendesk-zencli-investigation`, breaking deterministic expectations.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/skills.test.ts`
  - `src/agents/skills.buildworkspaceskillsnapshot.test.ts`
  - `src/agents/skills.loadworkspaceskillentries.test.ts`
- Scenario the test should lock in:
  - these suites should pass regardless of whatever real personal skills exist under `~/.agents/skills`
- Why this is the smallest reliable guardrail:
  - the failure is entirely in test environment setup, and these are the exact suites that were leaking real-home state.
- Existing test that already covers this (if any): `src/agents/skills.agents-skills-directory.test.ts` already uses the same mock-home helper correctly.
- If no new test is added, why not:
  - no new behavior was added; the fix is making existing tests use the correct isolated-home harness.

## User-visible / Behavior Changes

- None.

## Diagram (if applicable)

```text
Before:
skills tests -> fake HOME env only -> loader still reads os.homedir() -> real ~/.agents/skills leaks into expectations

After:
skills tests -> existing mock-home helper -> env + os.homedir() both isolated -> deterministic skill discovery
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node / pnpm dev env
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): local machine had personal `~/.agents/skills` entries installed

### Steps

1. Run `pnpm test src/agents/skills.test.ts -t "sanitizes and de-duplicates command names"` on a machine with personal `~/.agents/skills`.
2. Observe unexpected extra command names from personal skills.
3. Apply the isolated-home fix and rerun the affected skills test files.

### Expected

- The skills tests ignore personal `~/.agents/skills` and only see the test fixture setup.

### Actual

- After the fix, the affected skills test files pass using isolated home resolution.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/agents/skills.test.ts src/agents/skills.buildworkspaceskillsnapshot.test.ts src/agents/skills.loadworkspaceskillentries.test.ts`
  - `pnpm test src/agents/skills.test.ts -t "sanitizes and de-duplicates command names"`
  - `pnpm check`
- Edge cases checked:
  - test suites now isolate both env-based home resolution and `os.homedir()`
  - production skills loading code remained untouched
- What you did **not** verify:
  - full `pnpm test` after this change
  - unrelated local test failures outside the skills suites

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: restoring the mocked home environment could interfere with other file-local mocks if done too broadly.
  - Mitigation: reuse the existing helper only inside the affected skills test suites, and keep the scope limited to those files.
