### PR TITLE
perf(cli): lazy-load browser help subcommands

### DIFF
--- a/extensions/browser/src/cli/browser-cli.lazy.test.ts
+++ b/extensions/browser/src/cli/browser-cli.lazy.test.ts
@@ -1,0 +1,83 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { manageAction, registerBrowserManageCommands } = vi.hoisted(() => {
+  const action = vi.fn();
+  const register = vi.fn((browser: Command) => {
+    browser.command("status").description("Show browser status").action(action);
+  });
+  return { manageAction: action, registerBrowserManageCommands: register };
+});
+
+const { registerBrowserInspectCommands } = vi.hoisted(() => ({
+  registerBrowserInspectCommands: vi.fn(),
+}));
+const { registerBrowserActionInputCommands } = vi.hoisted(() => ({
+  registerBrowserActionInputCommands: vi.fn(),
+}));
+const { registerBrowserActionObserveCommands } = vi.hoisted(() => ({
+  registerBrowserActionObserveCommands: vi.fn(),
+}));
+const { registerBrowserDebugCommands } = vi.hoisted(() => ({
+  registerBrowserDebugCommands: vi.fn(),
+}));
+const { registerBrowserStateCommands } = vi.hoisted(() => ({
+  registerBrowserStateCommands: vi.fn(),
+}));
+
+vi.mock("./browser-cli-manage.js", () => ({ registerBrowserManageCommands }));
+vi.mock("./browser-cli-inspect.js", () => ({ registerBrowserInspectCommands }));
+vi.mock("./browser-cli-actions-input.js", () => ({ registerBrowserActionInputCommands }));
+vi.mock("./browser-cli-actions-observe.js", () => ({ registerBrowserActionObserveCommands }));
+vi.mock("./browser-cli-debug.js", () => ({ registerBrowserDebugCommands }));
+vi.mock("./browser-cli-state.js", () => ({ registerBrowserStateCommands }));
+
+const { registerBrowserCli } = await import("./browser-cli.js");
+
+describe("registerBrowserCli lazy browser subcommands", () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    registerBrowserManageCommands.mockClear();
+    manageAction.mockClear();
+    registerBrowserInspectCommands.mockClear();
+    registerBrowserActionInputCommands.mockClear();
+    registerBrowserActionObserveCommands.mockClear();
+    registerBrowserDebugCommands.mockClear();
+    registerBrowserStateCommands.mockClear();
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+  });
+
+  it("registers browser placeholders without loading handlers for help", () => {
+    process.argv = ["node", "openclaw", "browser", "--help"];
+    const program = new Command();
+    program.name("openclaw");
+
+    registerBrowserCli(program, process.argv);
+
+    const browser = program.commands.find((command) => command.name() === "browser");
+    expect(browser?.commands.map((command) => command.name())).toContain("status");
+    expect(browser?.commands.map((command) => command.name())).toContain("snapshot");
+    expect(registerBrowserManageCommands).not.toHaveBeenCalled();
+    expect(registerBrowserInspectCommands).not.toHaveBeenCalled();
+  });
+
+  it("registers only the primary browser placeholder and dispatches", async () => {
+    process.argv = ["node", "openclaw", "browser", "status"];
+    const program = new Command();
+    program.name("openclaw");
+
+    registerBrowserCli(program, process.argv);
+
+    const browser = program.commands.find((command) => command.name() === "browser");
+    expect(browser?.commands.map((command) => command.name())).toEqual(["status"]);
+
+    await program.parseAsync(["browser", "status"], { from: "user" });
+
+    expect(registerBrowserManageCommands).toHaveBeenCalledTimes(1);
+    expect(manageAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/browser/src/cli/browser-cli.ts
+++ b/extensions/browser/src/cli/browser-cli.ts
@@ -1,12 +1,12 @@
 import type { Command } from "commander";
-import { registerBrowserActionInputCommands } from "./browser-cli-actions-input.js";
-import { registerBrowserActionObserveCommands } from "./browser-cli-actions-observe.js";
-import { registerBrowserDebugCommands } from "./browser-cli-debug.js";
+import { resolveCliArgvInvocation } from "../../../../src/cli/argv-invocation.js";
+import { shouldEagerRegisterSubcommands } from "../../../../src/cli/command-registration-policy.js";
+import {
+  registerCommandGroups,
+  type CommandGroupEntry,
+} from "../../../../src/cli/program/register-command-groups.js";
 import { browserActionExamples, browserCoreExamples } from "./browser-cli-examples.js";
-import { registerBrowserInspectCommands } from "./browser-cli-inspect.js";
-import { registerBrowserManageCommands } from "./browser-cli-manage.js";
 import type { BrowserParentOpts } from "./browser-cli-shared.js";
-import { registerBrowserStateCommands } from "./browser-cli-state.js";
 import {
   addGatewayClientOptions,
   danger,
@@ -17,7 +17,191 @@ import {
   theme,
 } from "./core-api.js";
 
-export function registerBrowserCli(program: Command) {
+const browserCommandDescriptors = [
+  { name: "status", description: "Show browser status", hasSubcommands: false },
+  {
+    name: "start",
+    description: "Start the browser (no-op if already running)",
+    hasSubcommands: false,
+  },
+  { name: "stop", description: "Stop the browser (best-effort)", hasSubcommands: false },
+  {
+    name: "reset-profile",
+    description: "Reset browser profile (moves it to Trash)",
+    hasSubcommands: false,
+  },
+  { name: "tabs", description: "List open tabs", hasSubcommands: false },
+  { name: "tab", description: "Tab shortcuts (index-based)", hasSubcommands: true },
+  { name: "open", description: "Open a URL in a new tab", hasSubcommands: false },
+  {
+    name: "focus",
+    description: "Focus a tab by target id (or unique prefix)",
+    hasSubcommands: false,
+  },
+  { name: "close", description: "Close a tab (target id optional)", hasSubcommands: false },
+  { name: "profiles", description: "List all browser profiles", hasSubcommands: false },
+  { name: "create-profile", description: "Create a new browser profile", hasSubcommands: false },
+  { name: "delete-profile", description: "Delete a browser profile", hasSubcommands: false },
+  { name: "screenshot", description: "Capture a screenshot (MEDIA:<path>)", hasSubcommands: false },
+  {
+    name: "snapshot",
+    description: "Capture a snapshot (default: ai; aria is the accessibility tree)",
+    hasSubcommands: false,
+  },
+  { name: "navigate", description: "Navigate the current tab to a URL", hasSubcommands: false },
+  { name: "resize", description: "Resize the viewport", hasSubcommands: false },
+  { name: "click", description: "Click an element by ref from snapshot", hasSubcommands: false },
+  { name: "type", description: "Type into an element by ref from snapshot", hasSubcommands: false },
+  { name: "press", description: "Press a key", hasSubcommands: false },
+  { name: "hover", description: "Hover an element by ai ref", hasSubcommands: false },
+  {
+    name: "scrollintoview",
+    description: "Scroll an element into view by ref from snapshot",
+    hasSubcommands: false,
+  },
+  { name: "drag", description: "Drag from one ref to another", hasSubcommands: false },
+  { name: "select", description: "Select option(s) in a select element", hasSubcommands: false },
+  {
+    name: "upload",
+    description: "Arm file upload for the next file chooser",
+    hasSubcommands: false,
+  },
+  {
+    name: "waitfordownload",
+    description: "Wait for the next download (and save it)",
+    hasSubcommands: false,
+  },
+  {
+    name: "download",
+    description: "Click a ref and save the resulting download",
+    hasSubcommands: false,
+  },
+  {
+    name: "dialog",
+    description: "Arm the next modal dialog (alert/confirm/prompt)",
+    hasSubcommands: false,
+  },
+  { name: "fill", description: "Fill a form with JSON field descriptors", hasSubcommands: false },
+  {
+    name: "wait",
+    description: "Wait for time, selector, URL, load state, or JS conditions",
+    hasSubcommands: false,
+  },
+  {
+    name: "evaluate",
+    description: "Evaluate a function against the page or a ref",
+    hasSubcommands: false,
+  },
+  { name: "console", description: "Get recent console messages", hasSubcommands: false },
+  { name: "pdf", description: "Save page as PDF", hasSubcommands: false },
+  {
+    name: "responsebody",
+    description: "Wait for a network response and return its body",
+    hasSubcommands: false,
+  },
+  { name: "highlight", description: "Highlight an element by ref", hasSubcommands: false },
+  { name: "errors", description: "Get recent page errors", hasSubcommands: false },
+  {
+    name: "requests",
+    description: "Get recent network requests (best-effort)",
+    hasSubcommands: false,
+  },
+  { name: "trace", description: "Record a Playwright trace", hasSubcommands: true },
+  { name: "cookies", description: "Read/write cookies", hasSubcommands: true },
+  { name: "storage", description: "Read/write localStorage/sessionStorage", hasSubcommands: true },
+  { name: "set", description: "Browser environment settings", hasSubcommands: true },
+] as const;
+
+function makeCommandGroupEntry(
+  commandNames: readonly string[],
+  register: () => Promise<void>,
+): CommandGroupEntry {
+  return {
+    placeholders: browserCommandDescriptors.filter((descriptor) =>
+      commandNames.includes(descriptor.name),
+    ),
+    register,
+  };
+}
+
+function registerLazyBrowserCommands(
+  browser: Command,
+  parentOpts: (cmd: Command) => BrowserParentOpts,
+  argv: string[] = process.argv,
+) {
+  const { primary, commandPath } = resolveCliArgvInvocation(argv);
+  const [, subcommand] = commandPath;
+  const commandGroups: CommandGroupEntry[] = [
+    makeCommandGroupEntry(
+      [
+        "status",
+        "start",
+        "stop",
+        "reset-profile",
+        "tabs",
+        "tab",
+        "open",
+        "focus",
+        "close",
+        "profiles",
+        "create-profile",
+        "delete-profile",
+      ],
+      async () => {
+        const module = await import("./browser-cli-manage.js");
+        module.registerBrowserManageCommands(browser, parentOpts);
+      },
+    ),
+    makeCommandGroupEntry(["screenshot", "snapshot"], async () => {
+      const module = await import("./browser-cli-inspect.js");
+      module.registerBrowserInspectCommands(browser, parentOpts);
+    }),
+    makeCommandGroupEntry(
+      [
+        "navigate",
+        "resize",
+        "click",
+        "type",
+        "press",
+        "hover",
+        "scrollintoview",
+        "drag",
+        "select",
+        "upload",
+        "waitfordownload",
+        "download",
+        "dialog",
+        "fill",
+        "wait",
+        "evaluate",
+      ],
+      async () => {
+        const module = await import("./browser-cli-actions-input.js");
+        module.registerBrowserActionInputCommands(browser, parentOpts);
+      },
+    ),
+    makeCommandGroupEntry(["console", "pdf", "responsebody"], async () => {
+      const module = await import("./browser-cli-actions-observe.js");
+      module.registerBrowserActionObserveCommands(browser, parentOpts);
+    }),
+    makeCommandGroupEntry(["highlight", "errors", "requests", "trace"], async () => {
+      const module = await import("./browser-cli-debug.js");
+      module.registerBrowserDebugCommands(browser, parentOpts);
+    }),
+    makeCommandGroupEntry(["cookies", "storage", "set"], async () => {
+      const module = await import("./browser-cli-state.js");
+      module.registerBrowserStateCommands(browser, parentOpts);
+    }),
+  ];
+
+  registerCommandGroups(browser, commandGroups, {
+    eager: shouldEagerRegisterSubcommands(),
+    primary: primary === "browser" ? subcommand : null,
+    registerPrimaryOnly: primary === "browser" && Boolean(subcommand),
+  });
+}
+
+export function registerBrowserCli(program: Command, argv: string[] = process.argv) {
   const browser = program
     .command("browser")
     .description("Manage OpenClaw's dedicated browser (Chrome/Chromium)")
@@ -46,10 +230,5 @@ export function registerBrowserCli(program: Command) {
 
   const parentOpts = (cmd: Command) => cmd.parent?.opts?.() as BrowserParentOpts;
 
-  registerBrowserManageCommands(browser, parentOpts);
-  registerBrowserInspectCommands(browser, parentOpts);
-  registerBrowserActionInputCommands(browser, parentOpts);
-  registerBrowserActionObserveCommands(browser, parentOpts);
-  registerBrowserDebugCommands(browser, parentOpts);
-  registerBrowserStateCommands(browser, parentOpts);
+  registerLazyBrowserCommands(browser, parentOpts, argv);
 }


### PR DESCRIPTION
Closes #65400

## Summary
- lazily register browser subcommand groups so `openclaw browser --help` does not import the full browser CLI stack up front
- keep targeted command execution working by eagerly resolving only the requested browser subcommand group when one is invoked
- add regression coverage for help-time lazy behavior and command dispatch

## Testing
- AI-assisted: yes
- Testing depth: fully tested for the changed CLI path
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/browser/src/cli/browser-cli.lazy.test.ts extensions/browser/src/cli/browser-cli.test.ts`
- `pnpm check`
- `pnpm check:docs`
- `pnpm protocol:check`
