### PR TITLE
fix(acpx): use plugin service stateDir and stop writing into plugin root

### DIFF
--- a/extensions/acpx/AGENTS.md
+++ b/extensions/acpx/AGENTS.md
@@ -47,7 +47,7 @@ When ACPX integration changes here, prefer this sequence:
 
 - Prefer the plugin-local ACPX binary under `extensions/acpx/node_modules/.bin/acpx`.
 - Do not rely on a globally installed `acpx` binary for OpenClaw ACP validation.
-- If the plugin-local ACPX binary is missing or on the wrong version, reinstall it from the version pinned in `extensions/acpx/package.json`.
+- If the plugin-local ACPX binary is missing or on the wrong version, repair via `pnpm install --filter ./extensions/acpx`. Do not run bare `npm install` inside the plugin root; the directory may be read-only on global or packaged installs.
 
 ## Boundary Rule
 

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -85,7 +85,7 @@
     },
     "stateDir": {
       "label": "State Directory",
-      "help": "Directory used for embedded ACP session state and persistence."
+      "help": "Directory used for embedded ACP session state and persistence. Defaults to the plugin service state directory when available."
     },
     "permissionMode": {
       "label": "Permission Mode",

--- a/extensions/acpx/skills/acp-router/SKILL.md
+++ b/extensions/acpx/skills/acp-router/SKILL.md
@@ -102,9 +102,10 @@ Required behavior when ACP backend is unavailable:
 
 1. Do not immediately ask the user to pick an alternate path.
 2. First attempt automatic local repair:
-   - ensure plugin-local pinned acpx is installed in the bundled ACPX plugin package
-   - verify `${ACPX_CMD} --version`
-3. After reinstall/repair, restart the gateway and explicitly offer to run that restart for the user.
+   - the embedded ACP runtime loads from the `acpx` npm package; no separate binary install is needed for this path
+   - run `pnpm install --filter ./extensions/acpx` to restore missing dependencies
+   - verify the gateway can load the ACPX plugin after reinstall
+3. After repair, restart the gateway and explicitly offer to run that restart for the user.
 4. Retry ACP thread spawn once after repair.
 5. Only if repair+retry fails, report the concrete error and then offer fallback options.
 
@@ -123,8 +124,9 @@ For this repo, direct `acpx` calls must follow the same pinned policy as the `@o
    - `${ACPX_PLUGIN_ROOT}/node_modules/.bin/acpx`
 2. Resolve pinned version from extension dependency:
    - `node -e "console.log(require(process.env.ACPX_PLUGIN_ROOT + '/package.json').dependencies.acpx)"`
-3. If binary is missing or version mismatched, install plugin-local pinned version:
-   - `cd "$ACPX_PLUGIN_ROOT" && npm install --omit=dev --no-save acpx@<pinnedVersion>`
+3. If binary is missing or version mismatched, repair via workspace install:
+   - `pnpm install --filter ./extensions/acpx`
+   - Do not run bare `npm install` inside the plugin root; the plugin directory may be read-only on global or packaged installs.
 4. Verify before use:
    - `${ACPX_PLUGIN_ROOT}/node_modules/.bin/acpx --version`
 5. If install/repair changed ACPX artifacts, restart the gateway and offer to run the restart.
@@ -228,7 +230,7 @@ If your local Cursor install still exposes ACP as `agent acp`, set that as the `
 ### Failure handling
 
 - `acpx: command not found`:
-  - for thread-spawn ACP requests, install plugin-local pinned acpx in the bundled ACPX plugin package immediately
+  - for thread-spawn ACP requests, repair via `pnpm install --filter ./extensions/acpx` (do not run bare `npm install` inside the plugin root; it may be read-only)
   - restart gateway after install and offer to run the restart automatically
   - then retry once
   - do not ask for install permission first unless policy explicitly requires it

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -4,6 +4,19 @@ import { describe, expect, it } from "vitest";
 import { resolveAcpxPluginConfig, resolveAcpxPluginRoot } from "./config.js";
 
 describe("embedded acpx plugin config", () => {
+  it("prefers the provided plugin service stateDir over the workspace fallback", () => {
+    const workspaceDir = "/tmp/openclaw-acpx";
+    const stateDir = "/tmp/openclaw-state";
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: undefined,
+      workspaceDir,
+      stateDir,
+    });
+
+    expect(resolved.cwd).toBe(workspaceDir);
+    expect(resolved.stateDir).toBe(path.resolve(stateDir));
+  });
+
   it("resolves workspace stateDir and cwd by default", () => {
     const workspaceDir = "/tmp/openclaw-acpx";
     const resolved = resolveAcpxPluginConfig({

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -205,6 +205,7 @@ export function toAcpMcpServers(mcpServers: Record<string, McpServerConfig>): Ac
 export function resolveAcpxPluginConfig(params: {
   rawConfig: unknown;
   workspaceDir?: string;
+  stateDir?: string;
   moduleUrl?: string;
 }): ResolvedAcpxPluginConfig {
   const parsed = parseAcpxPluginConfig(params.rawConfig);
@@ -215,7 +216,9 @@ export function resolveAcpxPluginConfig(params: {
   const workspaceDir = params.workspaceDir?.trim() || process.cwd();
   const fallbackCwd = workspaceDir;
   const cwd = path.resolve(normalized.cwd?.trim() || fallbackCwd);
-  const stateDir = path.resolve(normalized.stateDir?.trim() || path.join(workspaceDir, "state"));
+  const stateDir = path.resolve(
+    normalized.stateDir?.trim() || params.stateDir?.trim() || path.join(workspaceDir, "state"),
+  );
   const pluginToolsMcpBridge = normalized.pluginToolsMcpBridge === true;
   const mcpServers = resolveConfiguredMcpServers({
     mcpServers: normalized.mcpServers,

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -112,6 +112,42 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
+  it("uses the plugin service context stateDir by default", async () => {
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    const probeAvailability = vi.fn(async () => {
+      await fs.access(ctx.stateDir);
+    });
+    const runtimeFactory = vi.fn(
+      () =>
+        ({
+          ensureSession: vi.fn(),
+          runTurn: vi.fn(),
+          cancel: vi.fn(),
+          close: vi.fn(),
+          probeAvailability,
+          isHealthy: () => true,
+          doctor: async () => ({ ok: true, message: "ok" }),
+        }) as never,
+    );
+    const service = createAcpxRuntimeService({
+      runtimeFactory,
+    });
+
+    await service.start(ctx);
+
+    expect(runtimeFactory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginConfig: expect.objectContaining({
+          stateDir: ctx.stateDir,
+        }),
+      }),
+    );
+    expect(probeAvailability).toHaveBeenCalledOnce();
+
+    await service.stop?.(ctx);
+  });
+
   it("passes the default runtime timeout to the embedded runtime factory", async () => {
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -99,6 +99,7 @@ export function createAcpxRuntimeService(
       const pluginConfig = resolveAcpxPluginConfig({
         rawConfig: params.pluginConfig,
         workspaceDir: ctx.workspaceDir,
+        stateDir: ctx.stateDir,
       });
       await fs.mkdir(pluginConfig.stateDir, { recursive: true });
       warnOnIgnoredLegacyCompatibilityConfig({
@@ -117,7 +118,9 @@ export function createAcpxRuntimeService(
         runtime,
         healthy: () => runtime?.isHealthy() ?? false,
       });
-      ctx.logger.info(`embedded acpx runtime backend registered (cwd: ${pluginConfig.cwd})`);
+      ctx.logger.info(
+        `embedded acpx runtime backend registered (cwd: ${pluginConfig.cwd}, stateDir: ${pluginConfig.stateDir})`,
+      );
 
       if (process.env.OPENCLAW_SKIP_ACPX_RUNTIME_PROBE === "1") {
         return;


### PR DESCRIPTION
## Summary

- The embedded ACPX runtime now prefers `ctx.stateDir` from the plugin service context as the default state directory, instead of only falling back to `path.join(workspaceDir, "state")`. This ensures session state writes target a writable location even when the plugin directory is read-only (global/packaged installs).
- Updates `SKILL.md` and `AGENTS.md` to stop instructing agents to run bare `npm install` inside `ACPX_PLUGIN_ROOT`, which would EACCES on read-only installs. Repair instructions now use `pnpm install --filter ./extensions/acpx`.
- Updates `openclaw.plugin.json` stateDir help text to document the fallback behavior.

## Problem

On global or packaged installs, the ACPX plugin directory (`ACPX_PLUGIN_ROOT`) is read-only. The old skill instructions told AI agents to `cd "$ACPX_PLUGIN_ROOT" && npm install --omit=dev --no-save acpx@<pinnedVersion>`, which fails with EACCES. The runtime config also only fell back to `workspaceDir/state`, missing the plugin service context's own writable stateDir.

## Changes

| File | Change |
|------|--------|
| `extensions/acpx/src/config.ts` | Accept optional `stateDir` param, prefer it over workspace fallback |
| `extensions/acpx/src/service.ts` | Pass `ctx.stateDir` to config resolver, log stateDir in startup message |
| `extensions/acpx/src/config.test.ts` | Test that provided stateDir takes priority |
| `extensions/acpx/src/service.test.ts` | Test that plugin service context stateDir is used |
| `extensions/acpx/openclaw.plugin.json` | Update stateDir help text |
| `extensions/acpx/skills/acp-router/SKILL.md` | Replace `npm install` in plugin root with `pnpm install --filter` |
| `extensions/acpx/AGENTS.md` | Same repair instruction update |

## Test plan

- [x] `pnpm test extensions/acpx/src/config.test.ts extensions/acpx/src/service.test.ts` — 13/13 pass
- [ ] Verify embedded ACP runtime starts correctly on a fresh install
- [ ] Verify direct acpx path works after `pnpm install --filter ./extensions/acpx`