### PR TITLE
fix(agents): stop leaking session lock exit listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat/scheduling: spread interval heartbeats across stable per-agent phases derived from gateway identity, so provider traffic is distributed more uniformly across the configured interval instead of clustering around startup-relative times. (#64560) Thanks @odysseus0.
 - Config/media: accept `tools.media.asyncCompletion.directSend` in strict config validation so gateways no longer reject the generated-schema-backed async media completion setting at startup. (#63618) Thanks @qiziAI.
 - Telegram/exec: preserve delayed exec completion routing for forum topics by pinning background exec completions to the topic where the run started even if the session route later drifts. (#64580) thanks @jalehman.
+- Agents/locks: unregister the session write-lock `exit` cleanup handler during teardown so repeated lock lifecycle resets stop stacking process listeners in long-running gateway processes. (#65391) Thanks @adminfedres and @vincentkoc.
 
 ## 2026.4.9
 

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -426,6 +426,20 @@ describe("acquireSessionWriteLock", () => {
       await expect(fs.access(lockPath)).rejects.toThrow();
     });
   });
+
+  it("does not accumulate exit listeners across reset cycles", async () => {
+    const baselineExitListeners = process.listenerCount("exit");
+
+    await withTempSessionLockFile(async ({ sessionFile }) => {
+      for (let i = 0; i < 3; i += 1) {
+        const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+        await lock.release();
+        resetSessionWriteLockStateForTest();
+        expect(process.listenerCount("exit")).toBe(baselineExitListeners);
+      }
+    });
+  });
+
   it("keeps other signal listeners registered", () => {
     const keepAlive = () => {};
     const originalKill = process.kill.bind(process);

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -49,6 +49,7 @@ const MAX_LOCK_HOLD_MS = 2_147_000_000;
 
 type CleanupState = {
   registered: boolean;
+  exitHandler?: () => void;
   cleanupHandlers: Map<CleanupSignal, () => void>;
 };
 
@@ -72,6 +73,7 @@ function resolveCleanupState(): CleanupState {
   if (!proc[CLEANUP_STATE_KEY]) {
     proc[CLEANUP_STATE_KEY] = {
       registered: false,
+      exitHandler: undefined,
       cleanupHandlers: new Map<CleanupSignal, () => void>(),
     };
   }
@@ -256,10 +258,13 @@ function registerCleanupHandlers(): void {
   const cleanupState = resolveCleanupState();
   if (!cleanupState.registered) {
     cleanupState.registered = true;
+  }
+  if (!cleanupState.exitHandler) {
     // Cleanup on normal exit and process.exit() calls
-    process.on("exit", () => {
+    cleanupState.exitHandler = () => {
       releaseAllLocksSync();
-    });
+    };
+    process.on("exit", cleanupState.exitHandler);
   }
 
   ensureWatchdogStarted(DEFAULT_WATCHDOG_INTERVAL_MS);
@@ -281,6 +286,10 @@ function registerCleanupHandlers(): void {
 
 function unregisterCleanupHandlers(): void {
   const cleanupState = resolveCleanupState();
+  if (cleanupState.exitHandler) {
+    process.off("exit", cleanupState.exitHandler);
+    cleanupState.exitHandler = undefined;
+  }
   for (const [signal, handler] of cleanupState.cleanupHandlers) {
     process.off(signal, handler);
   }

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -256,9 +256,7 @@ function handleTerminationSignal(signal: CleanupSignal): void {
 
 function registerCleanupHandlers(): void {
   const cleanupState = resolveCleanupState();
-  if (!cleanupState.registered) {
-    cleanupState.registered = true;
-  }
+  cleanupState.registered = true;
   if (!cleanupState.exitHandler) {
     // Cleanup on normal exit and process.exit() calls
     cleanupState.exitHandler = () => {


### PR DESCRIPTION
## Summary

- Problem: `session-write-lock` registers a process `exit` cleanup listener when the first lock is acquired, but teardown only unregisters the signal handlers.
- Why it matters: repeated test/runtime reset cycles keep stacking `process` listeners, which matches the listener-growth warning reported in #65391 and contributes to avoidable memory growth in long-running processes.
- What changed: store the `exit` handler in cleanup state, unregister it during teardown, and add a regression test that proves repeated reset/register cycles return the `exit` listener count to baseline.
- What did NOT change (scope boundary): lock semantics, watchdog behavior, and signal cleanup logic are otherwise unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65391
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `registerCleanupHandlers()` used an inline `process.on("exit", ...)` callback that was never retained, so `unregisterCleanupHandlers()` had no way to remove it.
- Missing detection / guardrail: existing tests covered signal cleanup and lock release on exit, but did not assert listener counts across repeated teardown/reset cycles.
- Contributing context (if known): the issue says `beforeExit`, but the actual leaking listener was `exit`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/session-write-lock.test.ts`
- Scenario the test should lock in: repeated acquire/release + reset cycles must return `process.listenerCount("exit")` to the baseline instead of accumulating listeners.
- Why this is the smallest reliable guardrail: the leak lives entirely inside cleanup registration state, so a file-local unit test can verify it directly without a larger runtime harness.
- Existing test that already covers this (if any): existing tests already covered signal cleanup and lock removal on exit.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Long-running gateway/test processes no longer accumulate stale `session-write-lock` `exit` listeners across teardown cycles.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22+/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): session write-lock lifecycle
- Relevant config (redacted): default repo test/build config

### Steps

1. Acquire and release a session write lock.
2. Reset the write-lock test state repeatedly.
3. Assert that `process.listenerCount("exit")` returns to baseline after each reset, then run the focused test file and a full build.

### Expected

- `exit` listener count does not grow across reset cycles.
- The repo still builds.

### Actual

- Matches expected on this branch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `OPENCLAW_LOCAL_CHECK=0 pnpm test:serial src/agents/session-write-lock.test.ts` and `OPENCLAW_LOCAL_CHECK=0 pnpm build` on this branch.
- Edge cases checked: the existing `process.emit("exit")` cleanup path still releases lock files, and the new reset-cycle regression stays at the original `exit` listener baseline.
- What you did **not** verify: I did not run a live heap snapshot/soak test against a long-running gateway process.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: removing the stored `exit` listener during teardown could accidentally skip lock cleanup for still-held locks.
  - Mitigation: teardown helpers already release all held locks before unregistering handlers, and the existing exit-cleanup regression test still passes.
