### PR TITLE
fix(update-cli): respawn plugin refresh after self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat/scheduling: spread interval heartbeats across stable per-agent phases derived from gateway identity, so provider traffic is distributed more uniformly across the configured interval instead of clustering around startup-relative times. (#64560) Thanks @odysseus0.
 - Config/media: accept `tools.media.asyncCompletion.directSend` in strict config validation so gateways no longer reject the generated-schema-backed async media completion setting at startup. (#63618) Thanks @qiziAI.
 - Telegram/exec: preserve delayed exec completion routing for forum topics by pinning background exec completions to the topic where the run started even if the session route later drifts. (#64580) thanks @jalehman.
+- CLI/update: respawn tracked plugin refresh from the updated entrypoint after package self-updates so `openclaw update` stops failing on stale hashed `dist/install.runtime-*.js` chunk imports. (#65368) Thanks @songshikang0111 and @vincentkoc.
 
 ## 2026.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/mentions: keep room mention gating strict while accepting visible `@displayName` Matrix URI labels, so `requireMention` works for non-OpenClaw Matrix clients again. (#64796) Thanks @hclsys.
 - Doctor: warn when on-disk agent directories still exist under `~/.openclaw/agents/<id>/agent` but the matching `agents.list[]` entries are missing from config. (#65113) Thanks @neeravmakwana.
 - Telegram: route approval button callback queries onto a separate sequentializer lane so plugin approval clicks can resolve immediately instead of deadlocking behind the blocked agent turn. (#64979) Thanks @nk3750.
+- CLI/update: respawn tracked plugin refresh from the updated entrypoint after package self-updates so `openclaw update` stops failing on stale hashed `dist/install.runtime-*.js` chunk imports. (#65368) Thanks @songshikang0111 and @vincentkoc.
 - Plugins/memory-core dreaming: keep bundled `memory-core` loaded alongside an explicit external memory slot owner only when that owner enables dreaming, while preserving `plugins.slots.memory = "none"` disable semantics. (#65411) Thanks @pradeep7127 and @vincentkoc.
 - Agents/Anthropic replay: preserve immutable signed-thinking replay safety across stored and live reruns, keep non-thinking embedded `tool_result` user blocks intact, and drop conflicting preserved tool IDs before validation so retries stop degrading into omitted tool calls. (#65126) Thanks @shakkernerd.
 - Telegram/direct sessions: keep commentary-only assistant fallback payloads out of visible direct delivery, so Codex planning chatter cannot leak into Telegram DMs when a run has no `final_answer` text. (#65112) Thanks @vincentkoc.
@@ -208,7 +209,6 @@ Docs: https://docs.openclaw.ai
 - Heartbeat/scheduling: spread interval heartbeats across stable per-agent phases derived from gateway identity, so provider traffic is distributed more uniformly across the configured interval instead of clustering around startup-relative times. (#64560) Thanks @odysseus0.
 - Config/media: accept `tools.media.asyncCompletion.directSend` in strict config validation so gateways no longer reject the generated-schema-backed async media completion setting at startup. (#63618) Thanks @qiziAI.
 - Telegram/exec: preserve delayed exec completion routing for forum topics by pinning background exec completions to the topic where the run started even if the session route later drifts. (#64580) thanks @jalehman.
-- CLI/update: respawn tracked plugin refresh from the updated entrypoint after package self-updates so `openclaw update` stops failing on stale hashed `dist/install.runtime-*.js` chunk imports. (#65368) Thanks @songshikang0111 and @vincentkoc.
 
 ## 2026.4.9
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -30,6 +31,7 @@ const pathExists = vi.fn();
 const syncPluginsForUpdateChannel = vi.fn();
 const updateNpmInstalledPlugins = vi.fn();
 const nodeVersionSatisfiesEngine = vi.fn();
+const spawn = vi.fn();
 const { defaultRuntime: runtimeCapture, resetRuntimeCapture } = createCliRuntimeCapture();
 
 vi.mock("@clack/prompts", () => ({
@@ -112,6 +114,7 @@ vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
+    spawn,
     spawnSync: vi.fn(() => ({
       pid: 0,
       output: [],
@@ -346,6 +349,15 @@ describe("update-cli", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetRuntimeCapture();
+    spawn.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        once: EventEmitter["once"];
+      };
+      queueMicrotask(() => {
+        child.emit("exit", 0, null);
+      });
+      return child;
+    });
     vi.mocked(defaultRuntime.exit).mockImplementation(() => {});
     vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(process.cwd());
     vi.mocked(readConfigFileSnapshot).mockResolvedValue(baseSnapshot);
@@ -442,6 +454,68 @@ describe("update-cli", () => {
     vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
     setTty(false);
     setStdoutTty(false);
+  });
+
+  it("respawns into the updated package root before running post-update tasks", async () => {
+    const { entryPath } = setupUpdatedRootRefresh();
+
+    await updateCommand({ yes: true });
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.stringMatching(/node/),
+      [entryPath, "update", "--yes"],
+      expect.objectContaining({
+        stdio: "inherit",
+        env: expect.objectContaining({
+          OPENCLAW_UPDATE_POST_CORE: "1",
+          OPENCLAW_UPDATE_POST_CORE_CHANNEL: "dev",
+        }),
+      }),
+    );
+    expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(runDaemonInstall).not.toHaveBeenCalled();
+    expect(runDaemonRestart).not.toHaveBeenCalled();
+  });
+
+  it("fails the update when the fresh process exits non-zero", async () => {
+    setupUpdatedRootRefresh();
+    spawn.mockImplementationOnce(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        once: EventEmitter["once"];
+      };
+      queueMicrotask(() => {
+        child.emit("exit", 2, null);
+      });
+      return child;
+    });
+
+    await expect(updateCommand({ yes: true })).rejects.toThrow(
+      "post-update process exited with code 2",
+    );
+
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(2);
+    expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
+  });
+
+  it("post-core resume mode skips the core update and only runs post-update tasks", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+      },
+      async () => {
+        await updateCommand({ restart: false });
+      },
+    );
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(runCommandWithTimeout).not.toHaveBeenCalledWith(
+      ["npm", "i", "-g", expect.any(String)],
+      expect.anything(),
+    );
+    expect(syncPluginsForUpdateChannel).toHaveBeenCalledTimes(1);
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -783,7 +783,9 @@ async function runPostCorePluginUpdate(params: {
 async function continuePostCoreUpdateInFreshProcess(params: {
   root: string;
   channel: "stable" | "beta" | "dev";
-  resultMode: "npm" | "pnpm" | "bun";
+  root: string;
+  channel: "stable" | "beta" | "dev";
+  opts: UpdateCommandOptions;
   opts: UpdateCommandOptions;
 }): Promise<boolean> {
   const entryPath = path.join(params.root, "dist", "entry.js");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { confirm, isCancel } from "@clack/prompts";
 import {
@@ -75,6 +76,8 @@ import { suppressDeprecations } from "./suppress-deprecations.js";
 
 const CLI_NAME = resolveCliName();
 const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
+const POST_CORE_UPDATE_ENV = "OPENCLAW_UPDATE_POST_CORE";
+const POST_CORE_UPDATE_CHANNEL_ENV = "OPENCLAW_UPDATE_POST_CORE_CHANNEL";
 const SERVICE_REFRESH_PATH_ENV_KEYS = [
   "OPENCLAW_HOME",
   "OPENCLAW_STATE_DIR",
@@ -106,6 +109,10 @@ const UPDATE_QUIPS = [
 
 function pickUpdateQuip(): string {
   return UPDATE_QUIPS[Math.floor(Math.random() * UPDATE_QUIPS.length)] ?? "Update complete.";
+}
+
+function isPackageManagerUpdateMode(mode: UpdateRunResult["mode"]): mode is "npm" | "pnpm" | "bun" {
+  return mode === "npm" || mode === "pnpm" || mode === "bun";
 }
 
 function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
@@ -759,9 +766,74 @@ async function maybeRestartService(params: {
   }
 }
 
+async function runPostCorePluginUpdate(params: {
+  root: string;
+  channel: "stable" | "beta" | "dev";
+  configSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
+  opts: UpdateCommandOptions;
+}): Promise<void> {
+  await updatePluginsAfterCoreUpdate({
+    root: params.root,
+    channel: params.channel,
+    configSnapshot: params.configSnapshot,
+    opts: params.opts,
+  });
+}
+
+async function continuePostCoreUpdateInFreshProcess(params: {
+  root: string;
+  channel: "stable" | "beta" | "dev";
+  resultMode: "npm" | "pnpm" | "bun";
+  opts: UpdateCommandOptions;
+}): Promise<boolean> {
+  const entryPath = path.join(params.root, "dist", "entry.js");
+  if (!(await pathExists(entryPath))) {
+    return false;
+  }
+
+  const argv = [entryPath, "update"];
+  if (params.opts.json) {
+    argv.push("--json");
+  }
+  if (params.opts.restart === false) {
+    argv.push("--no-restart");
+  }
+  if (params.opts.yes) {
+    argv.push("--yes");
+  }
+
+  const child = spawn(resolveNodeRunner(), argv, {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      [POST_CORE_UPDATE_ENV]: "1",
+      [POST_CORE_UPDATE_CHANNEL_ENV]: params.channel,
+    },
+  });
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`post-update process terminated by signal ${signal}`));
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+
+  if (exitCode !== 0) {
+    defaultRuntime.exit(exitCode);
+    throw new Error(`post-update process exited with code ${exitCode}`);
+  }
+  return true;
+}
+
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   suppressDeprecations();
   const invocationCwd = tryResolveInvocationCwd();
+  const postCoreUpdateResume = process.env[POST_CORE_UPDATE_ENV] === "1";
+  const postCoreUpdateChannel = process.env[POST_CORE_UPDATE_CHANNEL_ENV]?.trim();
 
   const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
   const shouldRestart = opts.restart !== false;
@@ -770,6 +842,26 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   }
 
   const root = await resolveUpdateRoot();
+  if (postCoreUpdateResume) {
+    if (
+      postCoreUpdateChannel !== "stable" &&
+      postCoreUpdateChannel !== "beta" &&
+      postCoreUpdateChannel !== "dev"
+    ) {
+      defaultRuntime.error("Missing post-core update channel context.");
+      defaultRuntime.exit(1);
+      return;
+    }
+
+    await runPostCorePluginUpdate({
+      root,
+      channel: postCoreUpdateChannel,
+      configSnapshot: await readConfigFileSnapshot(),
+      opts,
+    });
+    return;
+  }
+
   const updateStatus = await checkUpdateStatus({
     root,
     timeoutMs: timeoutMs ?? 3500,
@@ -960,24 +1052,6 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   const { progress, stop } = createUpdateProgress(showProgress);
   const startedAt = Date.now();
 
-  let restartScriptPath: string | null = null;
-  let refreshGatewayServiceEnv = false;
-  const gatewayPort = resolveGatewayPort(
-    configSnapshot.valid ? configSnapshot.config : undefined,
-    process.env,
-  );
-  if (shouldRestart) {
-    try {
-      const loaded = await resolveGatewayService().isLoaded({ env: process.env });
-      if (loaded) {
-        restartScriptPath = await prepareRestartScript(process.env, gatewayPort);
-        refreshGatewayServiceEnv = true;
-      }
-    } catch {
-      // Ignore errors during pre-check; fallback to standard restart
-    }
-  }
-
   const result =
     updateInstallKind === "package"
       ? await runPackageInstallUpdate({
@@ -1089,11 +1163,16 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
 
   const postUpdateRoot = result.root ?? root;
 
-  // A package -> git switch still runs inside the pre-update CLI process.
-  // Any follow-up work that re-enters the CLI can then compare new bundled
-  // plugin minima against the old host version and fail even though the
-  // install itself succeeded. Leave the switched checkout alone and let the
-  // new git install handle follow-up commands in a fresh process.
+  let pluginsUpdatedInFreshProcess = false;
+  if (isPackageManagerUpdateMode(result.mode)) {
+    pluginsUpdatedInFreshProcess = await continuePostCoreUpdateInFreshProcess({
+      root: postUpdateRoot,
+      channel,
+      resultMode: result.mode,
+      opts,
+    });
+  }
+
   const deferOldProcessPostUpdateWork = switchToGit && result.mode === "git";
   if (deferOldProcessPostUpdateWork) {
     if (!opts.json) {
@@ -1103,13 +1182,31 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
         ),
       );
     }
-  } else {
-    await updatePluginsAfterCoreUpdate({
+  } else if (!pluginsUpdatedInFreshProcess) {
+    await runPostCorePluginUpdate({
       root: postUpdateRoot,
       channel,
       configSnapshot: postUpdateConfigSnapshot,
       opts,
     });
+  }
+
+  let restartScriptPath: string | null = null;
+  let refreshGatewayServiceEnv = false;
+  const gatewayPort = resolveGatewayPort(
+    postUpdateConfigSnapshot.valid ? postUpdateConfigSnapshot.config : undefined,
+    process.env,
+  );
+  if (shouldRestart) {
+    try {
+      const loaded = await resolveGatewayService().isLoaded({ env: process.env });
+      if (loaded) {
+        restartScriptPath = await prepareRestartScript(process.env, gatewayPort);
+        refreshGatewayServiceEnv = true;
+      }
+    } catch {
+      // Ignore errors during pre-check; fallback to standard restart
+    }
   }
 
   if (deferOldProcessPostUpdateWork) {


### PR DESCRIPTION
## Summary

- Problem: after a package-manager self-update, `openclaw update` can keep running old lazy-import paths while it enters `Updating plugins...`, which breaks tracked plugin refresh with `ERR_MODULE_NOT_FOUND` on stale hashed `dist/install.runtime-*.js` chunks.
- Why it matters: the host update succeeds but plugin refresh fails immediately afterward, leaving `openclaw update` half-finished.
- What changed: package-manager updates now hand off the post-core plugin refresh to a fresh process started from the updated `dist/entry.js`, then resume the existing completion/restart flow in the original process after the fresh child exits successfully.
- What did NOT change (scope boundary): git-update behavior, hook-pack updates, and the broader plugin update semantics remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65368
- Related #58352
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the pre-update CLI process continues executing after the package files are replaced, so later lazy imports still reference the old hashed runtime chunk names.
- Missing detection / guardrail: update-cli coverage did not assert a fresh-process handoff for post-core plugin refresh after package self-updates.
- Contributing context (if known): this rebases and narrows the already-reviewed fix from #58352 onto current `main`, including the addressed review feedback about non-zero child exits.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/update-cli.test.ts`
- Scenario the test should lock in: package self-updates respawn into the updated entrypoint before plugin refresh, resume mode skips the core update, and non-zero child exits fail the update instead of pretending the respawn succeeded.
- Why this is the smallest reliable guardrail: the bug is in CLI control flow around process lifetime and can be exercised directly in the update-cli seam without a full global-install harness.
- Existing test that already covers this (if any): existing update-cli coverage already covered the surrounding restart/service-refresh behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw update` no longer refreshes tracked npm plugins inside the stale pre-update process after a package self-update.

## Diagram (if applicable)

```text
Before:
openclaw update -> replace global package files -> old process runs plugin refresh -> stale chunk import fails

After:
openclaw update -> replace global package files -> updated entrypoint runs plugin refresh -> original process resumes completion/restart flow
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22+/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): update-cli + tracked npm plugins
- Relevant config (redacted): default repo test/build config

### Steps

1. Simulate a package self-update that returns a new package root containing `dist/entry.js`.
2. Run `updateCommand()` and assert that plugin refresh respawns into the updated entrypoint instead of running in-process.
3. Verify non-zero child exits fail the update, then run the focused update-cli test file and a full build.

### Expected

- The fresh child handles post-core plugin refresh.
- Resume mode skips the core update.
- Failed child exits surface an error instead of silently continuing.
- The repo still builds.

### Actual

- Matches expected on this branch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `OPENCLAW_LOCAL_CHECK=0 pnpm test:serial src/cli/update-cli.test.ts` and `OPENCLAW_LOCAL_CHECK=0 pnpm build` on this branch.
- Edge cases checked: respawn argv/env wiring, resume-mode short-circuit, and non-zero child exits.
- What you did **not** verify: I did not run a packaged end-to-end global-install upgrade on this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: if the updated entrypoint is missing, the respawn handoff could fail unexpectedly.
  - Mitigation: the code only respawns when `dist/entry.js` exists and otherwise keeps the in-process plugin update path.
- Risk: resume-mode env handling could accidentally re-run the core update.
  - Mitigation: the resumed path is explicitly gated by `OPENCLAW_UPDATE_POST_CORE` and returns after plugin refresh.
