### PR TITLE
fix(memory-wiki): persist capability in plugin registry cache rollback paths

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1743,6 +1743,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousAgentHarnesses = listRegisteredAgentHarnesses();
       const previousCompactionProviders = listRegisteredCompactionProviders();
       const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
+      const previousMemoryCapability = getMemoryCapabilityRegistration();
       const previousMemoryFlushPlanResolver = getMemoryFlushPlanResolver();
       const previousMemoryPromptBuilder = getMemoryPromptSectionBuilder();
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
@@ -1765,6 +1766,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           restoreRegisteredCompactionProviders(previousCompactionProviders);
           restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
           restoreMemoryPluginState({
+            capability: previousMemoryCapability,
             corpusSupplements: previousMemoryCorpusSupplements,
             promptBuilder: previousMemoryPromptBuilder,
             promptSupplements: previousMemoryPromptSupplements,
@@ -1779,6 +1781,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         restoreRegisteredCompactionProviders(previousCompactionProviders);
         restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
         restoreMemoryPluginState({
+          capability: previousMemoryCapability,
           corpusSupplements: previousMemoryCorpusSupplements,
           promptBuilder: previousMemoryPromptBuilder,
           promptSupplements: previousMemoryPromptSupplements,


### PR DESCRIPTION
## Summary

- **Problem**: `listActiveMemoryPublicArtifacts()` returns an empty array after plugin re-registration via snapshot-load or error-recovery rollback paths, causing bridge sync to always report 0 artifacts.
- **Root cause**: The primary cache write/restore path (`setCachedPluginRegistry` / cache-hit `restoreMemoryPluginState`) correctly includes `memoryCapability`, but the per-plugin rollback paths in `loadOpenClawPlugins` omit `capability` when saving and restoring `memoryPluginState`. When `restoreMemoryPluginState()` is called without `capability`, it resets to `undefined`.
- **Fix**: Save `previousMemoryCapability` via `getMemoryCapabilityRegistration()` before each plugin registration attempt, and pass it to both `restoreMemoryPluginState()` call sites (snapshot-load restore and error-catch restore).

## What changed

`src/plugins/loader.ts`:
1. Save `previousMemoryCapability` alongside other memory state fields before plugin registration
2. Include `capability: previousMemoryCapability` in both `restoreMemoryPluginState()` calls within the per-plugin loop (snapshot path + error catch path)

## Verification

Patched the corresponding dist files locally. `bridgePublicArtifactCount` went from 0 to 13, confirming bridge sync now sees the expected artifacts.

## Test plan

- [x] Existing test "restores cached memory capability public artifacts on cache hits" continues to pass (covers the primary cache path)
- [ ] Manual verification with memory-wiki bridge sync end-to-end