### PR TITLE
CLI: detect env-backed audio providers

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -105,6 +105,7 @@ const mocks = vi.hoisted(() => ({
     { id: "openai", defaultModel: "text-embedding-3-small", transport: "remote" },
   ]),
   registerBuiltInMemoryEmbeddingProviders: vi.fn(),
+  buildMediaUnderstandingRegistry: vi.fn(() => new Map()),
   isWebSearchProviderConfigured: vi.fn(() => false),
   isWebFetchProviderConfigured: vi.fn(() => false),
   modelsStatusCommand: vi.fn(
@@ -181,6 +182,11 @@ vi.mock("../media-understanding/runtime.js", () => ({
   describeVideoFile: vi.fn(),
   transcribeAudioFile:
     mocks.transcribeAudioFile as typeof import("../media-understanding/runtime.js").transcribeAudioFile,
+}));
+
+vi.mock("../media-understanding/provider-registry.js", () => ({
+  buildMediaUnderstandingRegistry:
+    mocks.buildMediaUnderstandingRegistry as typeof import("../media-understanding/provider-registry.js").buildMediaUnderstandingRegistry,
 }));
 
 vi.mock("../plugins/memory-embedding-providers.js", () => ({
@@ -288,6 +294,7 @@ describe("capability cli", () => {
     mocks.textToSpeech.mockClear();
     mocks.setTtsProvider.mockClear();
     mocks.resolveExplicitTtsOverrides.mockClear();
+    mocks.buildMediaUnderstandingRegistry.mockReset().mockReturnValue(new Map());
     mocks.createEmbeddingProvider.mockClear();
     mocks.registerMemoryEmbeddingProvider.mockClear();
     mocks.registerBuiltInMemoryEmbeddingProviders.mockClear();
@@ -918,6 +925,55 @@ describe("capability cli", () => {
         registerMemoryEmbeddingProvider: expect.any(Function),
       }),
     );
+  });
+
+  it("marks env-backed audio providers as configured", async () => {
+    vi.stubEnv("DEEPGRAM_API_KEY", "deepgram-test-key");
+    vi.stubEnv("GROQ_API_KEY", "groq-test-key");
+    mocks.buildMediaUnderstandingRegistry.mockReturnValueOnce(
+      new Map([
+        [
+          "deepgram",
+          {
+            id: "deepgram",
+            capabilities: ["audio"],
+            defaultModels: { audio: "nova-3" },
+          },
+        ],
+        [
+          "groq",
+          {
+            id: "groq",
+            capabilities: ["audio"],
+            defaultModels: { audio: "whisper-large-v3-turbo" },
+          },
+        ],
+      ]),
+    );
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "audio", "providers", "--json"],
+    });
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith([
+      {
+        available: true,
+        configured: true,
+        selected: false,
+        id: "deepgram",
+        capabilities: ["audio"],
+        defaultModels: { audio: "nova-3" },
+      },
+      {
+        available: true,
+        configured: true,
+        selected: false,
+        id: "groq",
+        capabilities: ["audio"],
+        defaultModels: { audio: "whisper-large-v3-turbo" },
+      },
+    ]);
   });
 
   it("surfaces available, configured, and selected for web providers", async () => {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -247,6 +247,7 @@ vi.mock("../web-fetch/runtime.js", () => ({
 describe("capability cli", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   beforeEach(() => {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -411,8 +411,9 @@ function providerHasGenericConfig(params: {
   const modelsProviders = (params.cfg.models?.providers ?? {}) as Record<string, unknown>;
   const pluginEntries = (params.cfg.plugins?.entries ?? {}) as Record<string, { config?: unknown }>;
   const ttsProviders = (params.cfg.messages?.tts?.providers ?? {}) as Record<string, unknown>;
-  const envVars = params.envVars ?? getProviderEnvVars(params.providerId);
-  const envConfigured = envVars.some((envVar) => Boolean(process.env[envVar]?.trim()));
+  const envConfigured = (params.envVars ?? []).some((envVar) =>
+    Boolean(process.env[envVar]?.trim()),
+  );
   return (
     getAuthProfileIdsForProvider(params.cfg, params.providerId).length > 0 ||
     hasOwnKeys(modelsProviders[params.providerId]) ||
@@ -1487,7 +1488,14 @@ export function registerCapabilityCli(program: Command) {
           .filter((provider) => provider.capabilities?.includes("audio"))
           .map((provider) => ({
             available: true,
-            configured: providerHasGenericConfig({ cfg, providerId: provider.id }),
+            configured: providerHasGenericConfig({
+              cfg,
+              providerId: provider.id,
+              envVars: getProviderEnvVars(provider.id, {
+                config: cfg,
+                includeUntrustedWorkspacePlugins: false,
+              }),
+            }),
             selected: false,
             id: provider.id,
             capabilities: provider.capabilities,

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -37,6 +37,7 @@ import {
   registerMemoryEmbeddingProvider,
 } from "../plugins/memory-embedding-providers.js";
 import { writeRuntimeJson, defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -410,9 +411,8 @@ function providerHasGenericConfig(params: {
   const modelsProviders = (params.cfg.models?.providers ?? {}) as Record<string, unknown>;
   const pluginEntries = (params.cfg.plugins?.entries ?? {}) as Record<string, { config?: unknown }>;
   const ttsProviders = (params.cfg.messages?.tts?.providers ?? {}) as Record<string, unknown>;
-  const envConfigured = (params.envVars ?? []).some((envVar) =>
-    Boolean(process.env[envVar]?.trim()),
-  );
+  const envVars = params.envVars ?? getProviderEnvVars(params.providerId);
+  const envConfigured = envVars.some((envVar) => Boolean(process.env[envVar]?.trim()));
   return (
     getAuthProfileIdsForProvider(params.cfg, params.providerId).length > 0 ||
     hasOwnKeys(modelsProviders[params.providerId]) ||

--- a/src/plugins/provider-api-key-auth.ts
+++ b/src/plugins/provider-api-key-auth.ts
@@ -141,7 +141,12 @@ export function createProviderApiKeyAuthMethod(
             normalizeOptionalString(profileId.split(":", 1)[0]) || params.providerId,
             credentialInput,
             params.metadata,
-            capturedMode ? { secretInputMode: capturedMode } : undefined,
+            capturedMode
+              ? {
+                  secretInputMode: capturedMode,
+                  config: ctx.config,
+                }
+              : undefined,
           ),
         })),
         ...(params.applyConfig ? { configPatch: params.applyConfig(ctx.config) } : {}),

--- a/src/plugins/provider-auth-env-trust.test.ts
+++ b/src/plugins/provider-auth-env-trust.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+const getProviderEnvVars = vi.hoisted(() => vi.fn(() => ["WHISPERX_API_KEY"]));
+
+vi.mock("../secrets/provider-env-vars.js", () => ({
+  getProviderEnvVars,
+}));
+
+describe("provider auth env trust", () => {
+  it("buildApiKeyCredential excludes untrusted workspace plugin env vars for ref mode", async () => {
+    const { buildApiKeyCredential } = await import("./provider-auth-helpers.js");
+    const config = { plugins: {} };
+
+    const credential = buildApiKeyCredential("whisperx", "secret-value", undefined, {
+      secretInputMode: "ref",
+      config,
+    });
+
+    expect(getProviderEnvVars).toHaveBeenCalledWith("whisperx", {
+      config,
+      includeUntrustedWorkspacePlugins: false,
+    });
+    expect(credential).toMatchObject({
+      keyRef: { source: "env", provider: "default", id: "WHISPERX_API_KEY" },
+    });
+  });
+
+  it("resolveRefFallbackInput excludes untrusted workspace plugin env vars", async () => {
+    const { resolveRefFallbackInput } = await import("./provider-auth-ref.js");
+    const config = { plugins: {} };
+
+    const result = resolveRefFallbackInput({
+      config,
+      provider: "whisperx",
+      env: { WHISPERX_API_KEY: "test-secret" },
+    });
+
+    expect(getProviderEnvVars).toHaveBeenCalledWith("whisperx", {
+      config,
+      includeUntrustedWorkspacePlugins: false,
+    });
+    expect(result).toMatchObject({
+      ref: { source: "env", provider: "default", id: "WHISPERX_API_KEY" },
+      resolvedValue: "test-secret",
+    });
+  });
+});

--- a/src/plugins/provider-auth-env-trust.test.ts
+++ b/src/plugins/provider-auth-env-trust.test.ts
@@ -44,4 +44,30 @@ describe("provider auth env trust", () => {
       resolvedValue: "test-secret",
     });
   });
+
+  it("promptSecretRefForSetup keeps config-aware trusted env var suggestions", async () => {
+    const { promptSecretRefForSetup } = await import("./provider-auth-ref.js");
+    const config = { plugins: { allow: ["workspace-audio"] } };
+    const prompter = {
+      select: vi.fn(async () => "env"),
+      text: vi.fn(async () => "WHISPERX_API_KEY"),
+      note: vi.fn(async () => {}),
+    };
+
+    const result = await promptSecretRefForSetup({
+      config,
+      provider: "whisperx",
+      prompter: prompter as never,
+      env: { WHISPERX_API_KEY: "test-secret" },
+    });
+
+    expect(getProviderEnvVars).toHaveBeenCalledWith("whisperx", {
+      config,
+      includeUntrustedWorkspacePlugins: false,
+    });
+    expect(result).toMatchObject({
+      ref: { source: "env", provider: "default", id: "WHISPERX_API_KEY" },
+      resolvedValue: "test-secret",
+    });
+  });
 });

--- a/src/plugins/provider-auth-helpers.ts
+++ b/src/plugins/provider-auth-helpers.ts
@@ -23,6 +23,7 @@ const resolveAuthAgentDir = (agentDir?: string) => agentDir ?? resolveOpenClawAg
 
 export type ApiKeyStorageOptions = {
   secretInputMode?: SecretInputMode;
+  config?: OpenClawConfig;
 };
 
 export type WriteOAuthCredentialsOptions = {
@@ -43,8 +44,11 @@ function parseEnvSecretRef(value: string): SecretRef | null {
   return buildEnvSecretRef(match[1]);
 }
 
-function resolveProviderDefaultEnvSecretRef(provider: string): SecretRef {
-  const envVars = getProviderEnvVars(provider);
+function resolveProviderDefaultEnvSecretRef(provider: string, config?: OpenClawConfig): SecretRef {
+  const envVars = getProviderEnvVars(provider, {
+    ...(config ? { config } : {}),
+    includeUntrustedWorkspacePlugins: false,
+  });
   const envVar = envVars?.find((candidate) => candidate.trim().length > 0);
   if (!envVar) {
     throw new Error(
@@ -69,7 +73,7 @@ function resolveApiKeySecretInput(
     return inlineEnvRef;
   }
   if (options?.secretInputMode === "ref") {
-    return resolveProviderDefaultEnvSecretRef(provider);
+    return resolveProviderDefaultEnvSecretRef(provider, options.config);
   }
   return normalized;
 }

--- a/src/plugins/provider-auth-ref.ts
+++ b/src/plugins/provider-auth-ref.ts
@@ -42,8 +42,12 @@ export function extractEnvVarFromSourceLabel(source: string): string | undefined
   return match?.[1];
 }
 
-function resolveDefaultProviderEnvVar(provider: string): string | undefined {
+function resolveDefaultProviderEnvVar(
+  provider: string,
+  config?: OpenClawConfig,
+): string | undefined {
   const envVars = getProviderEnvVars(provider, {
+    ...(config ? { config } : {}),
     includeUntrustedWorkspacePlugins: false,
   });
   return envVars?.find((candidate) => normalizeOptionalString(candidate) !== undefined);
@@ -269,7 +273,7 @@ export async function promptSecretRefForSetup(params: {
   env?: NodeJS.ProcessEnv;
 }): Promise<{ ref: SecretRef; resolvedValue: string }> {
   const defaultEnvVar =
-    params.preferredEnvVar ?? resolveDefaultProviderEnvVar(params.provider) ?? "";
+    params.preferredEnvVar ?? resolveDefaultProviderEnvVar(params.provider, params.config) ?? "";
   const defaultFilePointer = resolveDefaultFilePointerId(params.provider);
   let sourceChoice: SecretRefChoice = "env"; // pragma: allowlist secret
 

--- a/src/plugins/provider-auth-ref.ts
+++ b/src/plugins/provider-auth-ref.ts
@@ -43,7 +43,9 @@ export function extractEnvVarFromSourceLabel(source: string): string | undefined
 }
 
 function resolveDefaultProviderEnvVar(provider: string): string | undefined {
-  const envVars = getProviderEnvVars(provider);
+  const envVars = getProviderEnvVars(provider, {
+    includeUntrustedWorkspacePlugins: false,
+  });
   return envVars?.find((candidate) => normalizeOptionalString(candidate) !== undefined);
 }
 
@@ -57,7 +59,12 @@ export function resolveRefFallbackInput(params: {
   preferredEnvVar?: string;
   env?: NodeJS.ProcessEnv;
 }): { ref: SecretRef; resolvedValue: string } {
-  const fallbackEnvVar = params.preferredEnvVar ?? resolveDefaultProviderEnvVar(params.provider);
+  const fallbackEnvVar =
+    params.preferredEnvVar ??
+    getProviderEnvVars(params.provider, {
+      config: params.config,
+      includeUntrustedWorkspacePlugins: false,
+    }).find((candidate) => normalizeOptionalString(candidate) !== undefined);
   if (!fallbackEnvVar) {
     throw new Error(
       `No default environment variable mapping found for provider "${params.provider}". Set a provider-specific env var, or re-run setup in an interactive terminal to configure a ref.`,

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -49,4 +49,62 @@ describe("provider env vars dynamic manifest metadata", () => {
     expect(mod.listKnownProviderAuthEnvVarNames()).toContain("FIREWORKS_ALT_API_KEY");
     expect(mod.listKnownSecretEnvVarNames()).toContain("FIREWORKS_ALT_API_KEY");
   });
+
+  it("excludes untrusted workspace plugin env vars when requested", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-audio",
+          origin: "workspace",
+          providerAuthEnvVars: {
+            whisperx: ["AWS_SECRET_ACCESS_KEY"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const mod = await import("./provider-env-vars.js");
+
+    expect(
+      mod.getProviderEnvVars("whisperx", {
+        config: { plugins: {} },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).toEqual([]);
+    expect(
+      mod.listKnownProviderAuthEnvVarNames({
+        config: { plugins: {} },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).not.toContain("AWS_SECRET_ACCESS_KEY");
+  });
+
+  it("keeps explicitly trusted workspace plugin env vars when requested", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-audio",
+          origin: "workspace",
+          providerAuthEnvVars: {
+            whisperx: ["WHISPERX_API_KEY"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const mod = await import("./provider-env-vars.js");
+
+    expect(
+      mod.getProviderEnvVars("whisperx", {
+        config: {
+          plugins: {
+            allow: ["workspace-audio"],
+          },
+        },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).toEqual(["WHISPERX_API_KEY"]);
+  });
 });

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -50,6 +50,26 @@ describe("provider env vars dynamic manifest metadata", () => {
     expect(mod.listKnownSecretEnvVarNames()).toContain("FIREWORKS_ALT_API_KEY");
   });
 
+  it("keeps workspace plugin env vars in default lookups", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-audio",
+          origin: "workspace",
+          providerAuthEnvVars: {
+            whisperx: ["WHISPERX_API_KEY"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const mod = await import("./provider-env-vars.js");
+
+    expect(mod.getProviderEnvVars("whisperx")).toEqual(["WHISPERX_API_KEY"]);
+    expect(mod.listKnownProviderAuthEnvVarNames()).toContain("WHISPERX_API_KEY");
+  });
+
   it("excludes untrusted workspace plugin env vars when requested", async () => {
     loadPluginManifestRegistry.mockReturnValue({
       plugins: [

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -4,6 +4,7 @@ type MockManifestRegistry = {
   plugins: Array<{
     id: string;
     origin: string;
+    kind?: "memory" | "context-engine" | Array<"memory" | "context-engine">;
     providerAuthEnvVars?: Record<string, string[]>;
     providerAuthAliases?: Record<string, string>;
   }>;
@@ -121,6 +122,67 @@ describe("provider env vars dynamic manifest metadata", () => {
         config: {
           plugins: {
             allow: ["workspace-audio"],
+          },
+        },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).toEqual(["WHISPERX_API_KEY"]);
+  });
+
+  it("does not trust arbitrary workspace plugin ids from the context engine slot", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-audio",
+          origin: "workspace",
+          providerAuthEnvVars: {
+            whisperx: ["AWS_SECRET_ACCESS_KEY"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const mod = await import("./provider-env-vars.js");
+
+    expect(
+      mod.getProviderEnvVars("whisperx", {
+        config: {
+          plugins: {
+            slots: {
+              contextEngine: "workspace-audio",
+            },
+          },
+        },
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it("keeps selected workspace context engine env vars when requested", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "workspace-engine",
+          origin: "workspace",
+          kind: "context-engine",
+          providerAuthEnvVars: {
+            whisperx: ["WHISPERX_API_KEY"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const mod = await import("./provider-env-vars.js");
+
+    expect(
+      mod.getProviderEnvVars("whisperx", {
+        config: {
+          plugins: {
+            slots: {
+              contextEngine: "workspace-engine",
+            },
           },
         },
         includeUntrustedWorkspacePlugins: false,

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -2,6 +2,7 @@ import { resolveProviderAuthAliasMap } from "../agents/provider-auth-aliases.js"
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { hasKind } from "../plugins/slots.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 
 const CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
@@ -73,7 +74,10 @@ function isWorkspacePluginTrustedForProviderEnvVars(
   if (entry?.enabled === true || hasPluginId(pluginsConfig?.allow, pluginId)) {
     return true;
   }
-  return normalizePluginConfigId(pluginsConfig?.slots?.contextEngine) === pluginId;
+  return (
+    hasKind(plugin.kind, "context-engine") &&
+    normalizePluginConfigId(pluginsConfig?.slots?.contextEngine) === pluginId
+  );
 }
 
 function shouldUsePluginProviderEnvVars(

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -1,6 +1,8 @@
 import { resolveProviderAuthAliasMap } from "../agents/provider-auth-aliases.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 
 const CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   anthropic: ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
@@ -21,6 +23,68 @@ export type ProviderEnvVarLookupParams = {
   env?: NodeJS.ProcessEnv;
   includeUntrustedWorkspacePlugins?: boolean;
 };
+
+type PluginEntriesConfig = NonNullable<NonNullable<OpenClawConfig["plugins"]>["entries"]>;
+
+function normalizePluginConfigId(id: unknown): string {
+  return normalizeOptionalLowercaseString(id) ?? "";
+}
+
+function hasPluginId(list: unknown, pluginId: string): boolean {
+  return Array.isArray(list) && list.some((entry) => normalizePluginConfigId(entry) === pluginId);
+}
+
+function findPluginEntry(
+  entries: PluginEntriesConfig | undefined,
+  pluginId: string,
+): { enabled?: boolean } | undefined {
+  if (!entries || typeof entries !== "object" || Array.isArray(entries)) {
+    return undefined;
+  }
+  for (const [key, value] of Object.entries(entries)) {
+    if (normalizePluginConfigId(key) !== pluginId) {
+      continue;
+    }
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? (value as { enabled?: boolean })
+      : {};
+  }
+  return undefined;
+}
+
+function isWorkspacePluginTrustedForProviderEnvVars(
+  plugin: PluginManifestRecord,
+  config: OpenClawConfig | undefined,
+): boolean {
+  const pluginsConfig = config?.plugins;
+  if (pluginsConfig?.enabled === false) {
+    return false;
+  }
+
+  const pluginId = normalizePluginConfigId(plugin.id);
+  if (!pluginId || hasPluginId(pluginsConfig?.deny, pluginId)) {
+    return false;
+  }
+
+  const entry = findPluginEntry(pluginsConfig?.entries, pluginId);
+  if (entry?.enabled === false) {
+    return false;
+  }
+  if (entry?.enabled === true || hasPluginId(pluginsConfig?.allow, pluginId)) {
+    return true;
+  }
+  return normalizePluginConfigId(pluginsConfig?.slots?.contextEngine) === pluginId;
+}
+
+function shouldUsePluginProviderEnvVars(
+  plugin: PluginManifestRecord,
+  params: ProviderEnvVarLookupParams | undefined,
+): boolean {
+  if (plugin.origin !== "workspace" || params?.includeUntrustedWorkspacePlugins === true) {
+    return true;
+  }
+  return isWorkspacePluginTrustedForProviderEnvVars(plugin, params?.config);
+}
 
 function appendUniqueEnvVarCandidates(
   target: Record<string, string[]>,
@@ -53,6 +117,9 @@ function resolveManifestProviderAuthEnvVarCandidates(
   });
   const candidates: Record<string, string[]> = {};
   for (const plugin of registry.plugins) {
+    if (!shouldUsePluginProviderEnvVars(plugin, params)) {
+      continue;
+    }
     if (!plugin.providerAuthEnvVars) {
       continue;
     }

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -80,7 +80,7 @@ function shouldUsePluginProviderEnvVars(
   plugin: PluginManifestRecord,
   params: ProviderEnvVarLookupParams | undefined,
 ): boolean {
-  if (plugin.origin !== "workspace" || params?.includeUntrustedWorkspacePlugins === true) {
+  if (plugin.origin !== "workspace" || params?.includeUntrustedWorkspacePlugins !== false) {
     return true;
   }
   return isWorkspacePluginTrustedForProviderEnvVars(plugin, params?.config);


### PR DESCRIPTION
## Summary

- Problem: `openclaw infer audio providers --json` reported env-authenticated audio providers like Deepgram and Groq as `configured: false`.
- Why it matters: the CLI status output disagreed with `openclaw models status` and with real transcription behavior, which made issue #65394 look broader than it is.
- What changed: `providerHasGenericConfig(...)` now falls back to the provider's registered auth env vars, and a focused CLI regression test covers env-backed audio providers.
- What did NOT change (scope boundary): this PR does not change provider auth resolution or the audio transcription runtime itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #65394
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the shared CLI helper only treated env auth as configured when callers explicitly passed env var names, but `audio providers` called it without that data.
- Missing detection / guardrail: there was no focused CLI coverage for env-only audio providers in `capability audio providers --json`.
- Contributing context (if known): latest `upstream/main` already fixes the older multipart transcription regression, which left the status mismatch as the remaining user-visible issue from the original report.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/capability-cli.test.ts`
- Scenario the test should lock in: env-backed Deepgram and Groq audio providers are reported as `configured: true` by `capability audio providers --json`.
- Why this is the smallest reliable guardrail: the bug lives in CLI provider-state reporting, so mocking the provider registry and env is enough to exercise the exact seam.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw infer audio providers --json` now marks env-authenticated audio providers as configured.

## Diagram (if applicable)

```text
Before:
[audio providers] -> [providerHasGenericConfig without env vars] -> [configured false]

After:
[audio providers] -> [providerHasGenericConfig + provider env var lookup] -> [configured true]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v25.2.1 local CLI
- Model/provider: Deepgram, Groq, OpenAI
- Integration/channel (if any): local CLI against a saved inbound `.ogg`
- Relevant config (redacted): provider API keys loaded from env; no provider-specific `models.providers.*` config

### Steps

1. Source env-backed provider keys.
2. Run `pnpm openclaw models status --json` and observe env auth is visible.
3. Run `pnpm openclaw infer audio providers --json`.

### Expected

- Env-authenticated audio providers report `configured: true`.

### Actual

- Before this change, Deepgram and Groq reported `configured: false` despite env auth being active.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Vitest coverage for env-backed audio providers; live `pnpm openclaw infer audio providers --json` with env-loaded Deepgram/Groq/OpenAI keys.
- Edge cases checked: providers without env auth still remain `configured: false`.
- What you did **not** verify: broader provider-list surfaces beyond the shared helper call sites.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a provider with unexpected manifest env var metadata could now appear configured from env where it did not before.
  - Mitigation: the helper already accepts explicit `envVars` overrides, and the new test locks the intended env-backed audio behavior.
