### PR TITLE
fix(speech): allow media-only tagged TTS replies

### DIFF
--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -240,6 +240,26 @@ describe("speech-core native voice-note routing", () => {
     }
   });
 
+  it("keeps allowText=false from synthesizing hidden [[tts:text]] content", async () => {
+    const cfg = createTtsConfig("openclaw-speech-core-tts-allowtext-disabled", {
+      auto: "tagged",
+      modelOverrides: { enabled: true, allowText: false },
+    });
+    const payload: ReplyPayload = {
+      text: "[[tts:text]]This hidden text should not synthesize when allowText is false.[[/tts:text]]",
+    };
+
+    const result = await maybeApplyTtsToPayload({
+      payload,
+      cfg,
+      channel: "slack",
+      kind: "final",
+    });
+
+    expect(result).toEqual({ text: undefined });
+    expect(synthesizeMock).not.toHaveBeenCalled();
+  });
+
   it("keeps visible text when tagged TTS also includes explicit spoken text", async () => {
     const cfg = createTtsConfig("openclaw-speech-core-tts-visible-text-test", { auto: "tagged" });
     const payload: ReplyPayload = {

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -295,7 +295,7 @@ describe("speech-core native voice-note routing", () => {
     const cfg = createTtsConfig("openclaw-speech-core-tts-hint-test", { auto: "tagged" });
 
     expect(buildTtsSystemPromptHint(cfg)).toContain(
-      "Only use TTS when you include a [[tts]] tag or a [[tts:text]]...[[/tts:text]] block.",
+      "Only use TTS when you either prefix visible text with [[tts]] or wrap spoken-only text as [[tts:text]]your spoken text here[[/tts:text]].",
     );
   });
 });

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -50,17 +50,21 @@ vi.mock("../api.js", async () => {
   };
 });
 
-const { _test, maybeApplyTtsToPayload } = await import("./tts.js");
+const { _test, buildTtsSystemPromptHint, maybeApplyTtsToPayload } = await import("./tts.js");
 
 const nativeVoiceNoteChannels = ["discord", "feishu", "matrix", "telegram", "whatsapp"] as const;
 
-function createTtsConfig(prefsName: string): OpenClawConfig {
+function createTtsConfig(
+  prefsName: string,
+  overrides?: Partial<NonNullable<OpenClawConfig["messages"]>["tts"]>,
+): OpenClawConfig {
   return {
     messages: {
       tts: {
         enabled: true,
         provider: "mock",
         prefsPath: `/tmp/${prefsName}.json`,
+        ...overrides,
       },
     },
   };
@@ -136,5 +140,142 @@ describe("speech-core native voice-note routing", () => {
         rmSync(mediaDir, { recursive: true, force: true });
       }
     }
+  });
+
+  it("supports bare [[tts]] tags in tagged mode by speaking the remaining visible text", async () => {
+    const cfg = createTtsConfig("openclaw-speech-core-tts-bare-tag-test", { auto: "tagged" });
+    const payload: ReplyPayload = {
+      text: "[[tts]] This bare tag should now synthesize from visible text alone.",
+    };
+
+    let mediaDir: string | undefined;
+    try {
+      const result = await maybeApplyTtsToPayload({
+        payload,
+        cfg,
+        channel: "slack",
+        kind: "final",
+      });
+
+      expect(result.text).toBe("This bare tag should now synthesize from visible text alone.");
+      expect(result.mediaUrl).toMatch(/voice-\d+\.ogg$/);
+      expect(synthesizeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "This bare tag should now synthesize from visible text alone.",
+        }),
+      );
+
+      mediaDir = result.mediaUrl ? path.dirname(result.mediaUrl) : undefined;
+    } finally {
+      if (mediaDir) {
+        rmSync(mediaDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("synthesizes directive-only tagged replies into media-only payloads", async () => {
+    const cfg = createTtsConfig("openclaw-speech-core-tts-directive-only-test", {
+      auto: "tagged",
+    });
+    const payload: ReplyPayload = {
+      text: "[[tts:text]]This tagged reply should be delivered as audio only.[[/tts:text]]",
+    };
+
+    let mediaDir: string | undefined;
+    try {
+      const result = await maybeApplyTtsToPayload({
+        payload,
+        cfg,
+        channel: "slack",
+        kind: "final",
+      });
+
+      expect(result.text).toBeUndefined();
+      expect(result.mediaUrl).toMatch(/voice-\d+\.ogg$/);
+      expect(synthesizeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "This tagged reply should be delivered as audio only.",
+        }),
+      );
+
+      mediaDir = result.mediaUrl ? path.dirname(result.mediaUrl) : undefined;
+    } finally {
+      if (mediaDir) {
+        rmSync(mediaDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("still honors explicit [[tts:text]] blocks when model override directives are disabled", async () => {
+    const cfg = createTtsConfig("openclaw-speech-core-tts-directive-text-disabled-overrides", {
+      auto: "tagged",
+      modelOverrides: { enabled: false },
+    });
+    const payload: ReplyPayload = {
+      text: "[[tts:text]]This explicit spoken text should still synthesize.[[/tts:text]]",
+    };
+
+    let mediaDir: string | undefined;
+    try {
+      const result = await maybeApplyTtsToPayload({
+        payload,
+        cfg,
+        channel: "slack",
+        kind: "final",
+      });
+
+      expect(result.text).toBeUndefined();
+      expect(result.mediaUrl).toMatch(/voice-\d+\.ogg$/);
+      expect(synthesizeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "This explicit spoken text should still synthesize.",
+        }),
+      );
+
+      mediaDir = result.mediaUrl ? path.dirname(result.mediaUrl) : undefined;
+    } finally {
+      if (mediaDir) {
+        rmSync(mediaDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("keeps visible text when tagged TTS also includes explicit spoken text", async () => {
+    const cfg = createTtsConfig("openclaw-speech-core-tts-visible-text-test", { auto: "tagged" });
+    const payload: ReplyPayload = {
+      text: "Visible reply text.\n[[tts:text]]Spoken audio content that should still synthesize.[[/tts:text]]",
+    };
+
+    let mediaDir: string | undefined;
+    try {
+      const result = await maybeApplyTtsToPayload({
+        payload,
+        cfg,
+        channel: "slack",
+        kind: "final",
+      });
+
+      expect(result.text).toBe("Visible reply text.");
+      expect(result.mediaUrl).toMatch(/voice-\d+\.ogg$/);
+      expect(synthesizeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "Spoken audio content that should still synthesize.",
+        }),
+      );
+
+      mediaDir = result.mediaUrl ? path.dirname(result.mediaUrl) : undefined;
+    } finally {
+      if (mediaDir) {
+        rmSync(mediaDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("advertises the supported bare tag and explicit text block syntax in tagged mode", () => {
+    const cfg = createTtsConfig("openclaw-speech-core-tts-hint-test", { auto: "tagged" });
+
+    expect(buildTtsSystemPromptHint(cfg)).toContain(
+      "Only use TTS when you include a [[tts]] tag or a [[tts:text]]...[[/tts:text]] block.",
+    );
   });
 });

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -386,13 +386,13 @@ export function buildTtsSystemPromptHint(cfg: OpenClawConfig): string | undefine
     autoMode === "inbound"
       ? "Only use TTS when the user's last message includes audio/voice."
       : autoMode === "tagged"
-        ? "Only use TTS when you include a [[tts]] tag or a [[tts:text]]...[[/tts:text]] block."
+        ? "Only use TTS when you either prefix visible text with [[tts]] or wrap spoken-only text as [[tts:text]]your spoken text here[[/tts:text]]."
         : undefined;
   return [
     "Voice (TTS) is enabled.",
     autoHint,
     `Keep spoken text ≤${maxLength} chars to avoid auto-summary (summary ${summarize}).`,
-    "Use [[tts:...]] and optional [[tts:text]]...[[/tts:text]] to control voice/expressiveness.",
+    "Use [[tts:key=value]] for voice/provider overrides, and use [[tts:text]]your spoken text here[[/tts:text]] when the spoken text should differ from the visible reply.",
   ]
     .filter(Boolean)
     .join("\n");

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -222,9 +222,6 @@ function asProviderConfigMap(value: unknown): Record<string, unknown> {
 }
 
 function resolveRawProviderConfig(raw: TtsConfig = {}, providerId: string): SpeechProviderConfig {
-  if (!raw) {
-    return {};
-  }
   const rawProviders = asProviderConfigMap(raw.providers);
   const direct = rawProviders[providerId] ?? (raw as Record<string, unknown>)[providerId];
   return asProviderConfig(direct);

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -9,7 +9,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import path from "node:path";
-import { normalizeChannelId, type ChannelId } from "openclaw/plugin-sdk/channel-targets";
+import { normalizeChannelId } from "openclaw/plugin-sdk/channel-targets";
 import type {
   OpenClawConfig,
   TtsAutoMode,
@@ -148,9 +148,7 @@ function resolveConfiguredTtsAutoMode(raw: TtsConfig): TtsAutoMode {
   return normalizeTtsAutoMode(raw.auto) ?? (raw.enabled ? "always" : "off");
 }
 
-function normalizeConfiguredSpeechProviderId(
-  providerId: string | undefined,
-): TtsProvider | undefined {
+function normalizeConfiguredSpeechProviderId(providerId?: string) {
   const normalized = normalizeSpeechProviderId(providerId);
   if (!normalized) {
     return undefined;
@@ -169,9 +167,7 @@ function resolveTtsPrefsPathValue(prefsPath: string | undefined): string {
   return path.join(resolveConfigDir(process.env), "settings", "tts.json");
 }
 
-function resolveModelOverridePolicy(
-  overrides: TtsModelOverrideConfig | undefined,
-): ResolvedTtsModelOverrides {
+function resolveModelOverridePolicy(overrides?: TtsModelOverrideConfig): ResolvedTtsModelOverrides {
   const enabled = overrides?.enabled ?? true;
   if (!enabled) {
     return {
@@ -225,10 +221,7 @@ function asProviderConfigMap(value: unknown): Record<string, unknown> {
     : {};
 }
 
-function resolveRawProviderConfig(
-  raw: TtsConfig | undefined,
-  providerId: string,
-): SpeechProviderConfig {
+function resolveRawProviderConfig(raw: TtsConfig = {}, providerId: string): SpeechProviderConfig {
   if (!raw) {
     return {};
   }
@@ -337,7 +330,7 @@ export function resolveTtsPrefsPath(config: ResolvedTtsConfig): string {
   return resolveTtsPrefsPathValue(config.prefsPath);
 }
 
-function resolveTtsAutoModeFromPrefs(prefs: TtsUserPrefs): TtsAutoMode | undefined {
+function resolveTtsAutoModeFromPrefs(prefs: TtsUserPrefs) {
   const auto = normalizeTtsAutoMode(prefs.tts?.auto);
   if (auto) {
     return auto;
@@ -396,7 +389,7 @@ export function buildTtsSystemPromptHint(cfg: OpenClawConfig): string | undefine
     autoMode === "inbound"
       ? "Only use TTS when the user's last message includes audio/voice."
       : autoMode === "tagged"
-        ? "Only use TTS when you include [[tts]] or [[tts:text]] tags."
+        ? "Only use TTS when you include a [[tts]] tag or a [[tts:text]]...[[/tts:text]] block."
         : undefined;
   return [
     "Voice (TTS) is enabled.",
@@ -585,7 +578,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 
 const OPUS_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix", "discord"]);
 
-function resolveChannelId(channel: string | undefined): ChannelId | null {
+function resolveChannelId(channel: string | undefined) {
   return channel ? normalizeChannelId(channel) : null;
 }
 
@@ -930,9 +923,7 @@ export async function textToSpeechTelephony(params: {
         logVerbose(`TTS telephony: provider ${provider} skipped (${resolvedProvider.message})`);
         continue;
       }
-      const synthesizeTelephony = resolvedProvider.provider.synthesizeTelephony as NonNullable<
-        typeof resolvedProvider.provider.synthesizeTelephony
-      >;
+      const synthesizeTelephony = resolvedProvider.provider.synthesizeTelephony;
       const synthesis = await synthesizeTelephony({
         text: params.text,
         cfg: params.cfg,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -122,14 +122,17 @@ const ttsMocks = vi.hoisted(() => {
         payload: ReplyPayload;
         kind: "tool" | "block" | "final";
       };
-      if (
-        state.synthesizeFinalAudio &&
-        params.kind === "final" &&
-        typeof params.payload?.text === "string" &&
-        params.payload.text.trim()
-      ) {
+      const sourceText = typeof params.payload?.text === "string" ? params.payload.text : "";
+      const explicitTtsMatch = sourceText.match(/\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/i);
+      const cleanedText = sourceText
+        .replace(/\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi, "")
+        .replace(/\[\[tts\]\]/gi, "")
+        .trim();
+      const spokenText = explicitTtsMatch?.[1]?.trim() || cleanedText;
+      if (state.synthesizeFinalAudio && params.kind === "final" && spokenText) {
         return {
           ...params.payload,
+          text: cleanedText || undefined,
           mediaUrl: "https://example.com/tts-synth.opus",
           audioAsVoice: true,
         };
@@ -1920,6 +1923,35 @@ describe("dispatchReplyFromConfig", () => {
     const finalPayload = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock
       .calls[0]?.[0] as ReplyPayload | undefined;
     expect(finalPayload?.mediaUrl).toBe("https://example.com/tts-synth.opus");
+    expect(finalPayload?.text).toBeUndefined();
+  });
+
+  it("queues media-only final replies when tagged TTS strips all visible text", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      SessionKey: "agent:main:whatsapp:+1555",
+      BodyForAgent: "send audio only",
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () =>
+        ({
+          text: "[[tts:text]]This tagged reply should be delivered as audio only.[[/tts:text]]",
+        }) satisfies ReplyPayload,
+    });
+
+    const finalPayload = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as ReplyPayload | undefined;
+    expect(result.queuedFinal).toBe(true);
+    expect(finalPayload?.mediaUrl).toBe("https://example.com/tts-synth.opus");
+    expect(finalPayload?.audioAsVoice).toBe(true);
     expect(finalPayload?.text).toBeUndefined();
   });
 

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -52,7 +52,7 @@ export function parseTtsDirectives(
   const blockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
   cleanedText = cleanedText.replace(blockRegex, (_match, inner: string) => {
     hasDirective = true;
-    if (overrides.ttsText == null) {
+    if (overrides.ttsText == null && (!policy.enabled || policy.allowText)) {
       overrides.ttsText = inner.trim();
     }
     return "";
@@ -61,10 +61,13 @@ export function parseTtsDirectives(
   const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
   cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
     hasDirective = true;
+    const trimmedBody = body.trim();
+    const tokens = trimmedBody.split(/\s+/).filter(Boolean);
+
     if (!policy.enabled) {
       return "";
     }
-    const tokens = body.split(/\s+/).filter(Boolean);
+
     for (const token of tokens) {
       const eqIndex = token.indexOf("=");
       if (eqIndex === -1) {

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -43,10 +43,6 @@ export function parseTtsDirectives(
   policy: SpeechModelOverridePolicy,
   options?: ParseTtsDirectiveOptions,
 ): TtsDirectiveParseResult {
-  if (!policy.enabled) {
-    return { cleanedText: text, overrides: {}, warnings: [], hasDirective: false };
-  }
-
   const providers = resolveDirectiveProviders(options);
   const overrides: TtsDirectiveOverrides = {};
   const warnings: string[] = [];
@@ -56,7 +52,7 @@ export function parseTtsDirectives(
   const blockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
   cleanedText = cleanedText.replace(blockRegex, (_match, inner: string) => {
     hasDirective = true;
-    if (policy.allowText && overrides.ttsText == null) {
+    if (overrides.ttsText == null) {
       overrides.ttsText = inner.trim();
     }
     return "";
@@ -65,6 +61,9 @@ export function parseTtsDirectives(
   const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
   cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
     hasDirective = true;
+    if (!policy.enabled) {
+      return "";
+    }
     const tokens = body.split(/\s+/).filter(Boolean);
     for (const token of tokens) {
       const eqIndex = token.indexOf("=");
@@ -121,6 +120,12 @@ export function parseTtsDirectives(
         continue;
       }
     }
+    return "";
+  });
+
+  const bareDirectiveRegex = /\[\[tts\]\]/gi;
+  cleanedText = cleanedText.replace(bareDirectiveRegex, () => {
+    hasDirective = true;
     return "";
   });
 


### PR DESCRIPTION
## Summary

- Problem: tagged TTS replies that only contain TTS directives could resolve to no visible text and get dropped before a media-only reply was treated as final content.
- Why it matters: tagged auto-TTS could fail silently for intentional audio-only replies even though tagged TTS with visible text already worked.
- What changed: support bare `[[tts]]`, keep explicit `[[tts:text]]...[[/tts:text]]` spoken content parseable even when override directives are disabled, and add regression tests for media-only final payload delivery.
- What did NOT change (scope boundary): non-tagged TTS modes, existing visible-text-plus-TTS behavior, and downstream media routing after audio exists.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the tagged-mode hint advertised bare `[[tts]]`, but the parser only understood `[[tts:text]]...[[/tts:text]]` and `[[tts:key=value]]`; explicit spoken-text blocks were also gated behind the model-override policy even though they are reply content, not just overrides.
- Missing detection / guardrail: there was no focused regression test proving a tagged TTS-only reply becomes a queued media-only final payload.
- Contributing context (if known): once tags were stripped, a directive-only payload could look empty unless TTS synthesis had already produced media.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/speech-core/src/tts.test.ts`, `src/auto-reply/reply/dispatch-from-config.test.ts`
- Scenario the test should lock in: directive-only tagged TTS synthesizes audio and queues a media-only final reply; visible-text-plus-tagged-TTS still keeps visible text; bare `[[tts]]` stays aligned with the prompt hint.
- Why this is the smallest reliable guardrail: the bug is in the generic TTS parse/apply path before channel-specific delivery, so the parser/TTS seam plus final-dispatch seam catches it without requiring a live WhatsApp lane.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Tagged TTS replies can now synthesize and send audio even when no visible reply text remains.
- Bare `[[tts]]` is now supported consistently with the tagged-mode hint.
- Empty tag-only replies with no spoken content still short-circuit as empty.

## Diagram (if applicable)

```text
Before:
[tagged TTS-only reply] -> [tags stripped / no visible text] -> [no media queued] -> [turn dropped]

After:
[tagged TTS-only reply] -> [spoken text parsed] -> [audio synthesized] -> [media-only final payload queued]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm workspace test runner
- Model/provider: mock speech provider in targeted tests
- Integration/channel (if any): generic auto-reply/TTS pipeline, WhatsApp final-delivery seam
- Relevant config (redacted): `messages.tts.auto=tagged`

### Steps

1. Configure tagged auto-TTS.
2. Return a reply that is only `[[tts:text]]...[[/tts:text]]` with no visible text.
3. Let final reply dispatch run.

### Expected

- The reply synthesizes audio and queues a media-only outbound payload.

### Actual

- The turn could end with no text/media queued and get skipped as an empty reply.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: bare `[[tts]]` synthesis in tagged mode, directive-only `[[tts:text]]` media-only output, visible text plus explicit spoken text, and final dispatch queuing a media-only payload.
- Edge cases checked: empty tag-only payloads with no spoken content still short-circuit; explicit `[[tts:text]]` still works when override directives are disabled.
- What you did **not** verify: live WhatsApp end-to-end delivery against a real channel account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: tagged parsing now recognizes bare `[[tts]]`, so models that already emitted that syntax will start producing audio instead of being ignored.
- Mitigation: targeted tests cover bare-tag parsing, explicit spoken-text blocks, visible-text preservation, and media-only final payload dispatch.
