### PR TITLE
docs: centralize harness syntax guidance

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -566,6 +566,10 @@ Default slash command settings:
     - `[[reply_to_current]]`
     - `[[reply_to:<id>]]`
 
+    Canonical harness contract: [Rich Output Protocol](/reference/rich-output-protocol)
+
+    Use the start-of-message form as the canonical contract even though the parser is more permissive. Keep reply tags out of code samples and literal examples unless quoted or fenced.
+
     Controlled by `channels.discord.replyToMode`:
 
     - `off` (default)

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -436,6 +436,10 @@ Manual reply tags are supported:
 - `[[reply_to_current]]`
 - `[[reply_to:<id>]]`
 
+Canonical harness contract: [Rich Output Protocol](/reference/rich-output-protocol)
+
+Use the start-of-message form as the canonical contract even though the parser is more permissive. Keep reply tags out of code samples and literal examples unless quoted or fenced.
+
 Note: `replyToMode="off"` disables **all** reply threading in Slack, including explicit `[[reply_to_*]]` tags. This differs from Telegram, where explicit tags are still honored in `"off"` mode. The difference reflects the platform threading models: Slack threads hide messages from the channel, while Telegram replies remain visible in the main chat flow.
 
 ## Ack reactions

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -463,6 +463,10 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `[[reply_to_current]]` replies to the triggering message
     - `[[reply_to:<id>]]` replies to a specific Telegram message ID
 
+    Canonical harness contract: [Rich Output Protocol](/reference/rich-output-protocol)
+
+    Use the start-of-message form as the canonical contract even though the parser is more permissive. Keep reply tags out of code samples and literal examples unless quoted or fenced.
+
     `channels.telegram.replyToMode` controls handling:
 
     - `off` (default)
@@ -590,6 +594,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - default: audio file behavior
     - tag `[[audio_as_voice]]` in agent reply to force voice-note send
 
+    Canonical harness contract: [Rich Output Protocol](/reference/rich-output-protocol)
+
     Message action example:
 
 ```json5
@@ -625,6 +631,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     Inbound sticker handling:
 
     - static WEBP: downloaded and processed (placeholder `<media:sticker>`)
+
+    Placeholder markers such as `<media:sticker>` are inbound harness context, not assistant-output directives. See [Rich Output Protocol](/reference/rich-output-protocol).
     - animated TGS: skipped
     - video WEBM: skipped
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -250,6 +250,8 @@ When the linked self number is also present in `allowFrom`, WhatsApp self-chat s
     - `<media:document>`
     - `<media:sticker>`
 
+    These placeholders are inbound harness context, not assistant-output directives. See [Rich Output Protocol](/reference/rich-output-protocol).
+
     Location and contact payloads are normalized into textual context before routing.
 
   </Accordion>

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -30,6 +30,7 @@ The prompt is intentionally compact and uses fixed sections:
 
 - **Tooling**: structured-tool source-of-truth reminder plus runtime tool-use guidance.
 - **Safety**: short guardrail reminder to avoid power-seeking behavior or bypassing oversight.
+- **Harness Syntax**: centralized rules for harness-injected markers and assistant-output control syntax such as `MEDIA:`, reply/audio tags, special tokens, and reasoning/final wrappers.
 - **Skills** (when available): tells the model how to load skill instructions on demand.
 - **OpenClaw Self-Update**: how to inspect config safely with
   `config.schema.lookup`, patch config with `config.patch`, replace the full
@@ -42,7 +43,6 @@ The prompt is intentionally compact and uses fixed sections:
 - **Workspace Files (injected)**: indicates bootstrap files are included below.
 - **Sandbox** (when enabled): indicates sandboxed runtime, sandbox paths, and whether elevated exec is available.
 - **Current Date & Time**: user-local time, timezone, and time format.
-- **Reply Tags**: optional reply tag syntax for supported providers.
 - **Heartbeats**: heartbeat prompt and ack behavior, when heartbeats are enabled for the default agent.
 - **Runtime**: host, OS, node, model, repo root (when detected), thinking level (one line).
 - **Reasoning**: current visibility level + /reasoning toggle hint.
@@ -73,6 +73,39 @@ On channels with native approval cards/buttons, the runtime prompt now tells the
 agent to rely on that native approval UI first. It should only include a manual
 `/approve` command when the tool result says chat approvals are unavailable or
 manual approval is the only path.
+
+## Harness Syntax
+
+The system prompt now includes a centralized **Harness Syntax** section for the
+parser-sensitive syntax that OpenClaw injects into context or interprets from
+assistant output.
+
+This section is the core contract for:
+
+- inbound harness annotations such as `[media attached: ...]`,
+  `[Image: source: ...]`, and `<media:image>`
+- outbound attachment directives such as `MEDIA:<path-or-url>`
+- reply/audio tags such as `[[reply_to_current]]`, `[[reply_to:<id>]]`, and
+  `[[audio_as_voice]]`
+- exact control tokens such as `NO_REPLY` and `HEARTBEAT_OK`
+- reasoning/final wrappers such as `<think>...</think>` and
+  `<final>...</final>`
+
+Important rules summarized:
+
+- Inbound harness annotations are **read-only context**, not syntax to echo
+  back as directives.
+- `MEDIA:` is outbound-only metadata. It must be the first non-whitespace token
+  on its own line, with one `MEDIA:` line per attachment.
+- Reply/audio tags are assistant-output metadata. The canonical contract is to
+  place at most one reply tag at the very start of the message.
+- `NO_REPLY` and `HEARTBEAT_OK` are exact control tokens, not ordinary prose.
+- `<think>` / `<final>` wrappers should only be emitted when the runtime
+  explicitly asks for that contract. Otherwise they may be stripped,
+  sanitized, or suppress content outside `<final>`.
+
+For the detailed syntax reference, see
+[Rich Output Protocol](/reference/rich-output-protocol).
 
 ## Prompt modes
 

--- a/docs/reference/rich-output-protocol.md
+++ b/docs/reference/rich-output-protocol.md
@@ -9,6 +9,70 @@ Assistant output can carry a small set of delivery/render directives:
 
 These directives are separate. `MEDIA:` and reply/voice tags remain delivery metadata; `[embed ...]` is the web-only rich render path.
 
+Inbound harness annotations are different. Markers such as `[media attached: ...]`,
+`[media attached 1/2: ...]`, `[Image: source: ...]`, and `<media:image>` describe
+attachments that are already present in the prompt/context. They are read-only
+context for the model, not assistant output syntax to echo back.
+
+## Harness Syntax
+
+The harness may inject special syntax into context and may also interpret
+certain assistant-output markers. Treat these as parser contracts, not stylistic
+suggestions.
+
+## `MEDIA:`
+
+`MEDIA:` is outbound-only assistant metadata for attachment delivery.
+
+Rules:
+
+- Put each `MEDIA:<path-or-url>` directive on its own line.
+- It must be the first non-whitespace token on that line, with no prose before or after it.
+- Use one `MEDIA:` line per attachment.
+- If a path contains spaces, quote the entire path.
+- Only use real `http(s)` URLs or safe file paths; do not use `..` traversal segments or `~` home-directory paths.
+- Use it only when you want the harness/channel to attach media to the assistant reply.
+- Indented `MEDIA:` lines are valid; mid-line prose like `Here is it MEDIA:...` is not.
+- Do not use bare `MEDIA:` in explanatory prose or examples unless you intend delivery.
+- If you need to discuss the syntax literally, wrap it in quotes or a fenced code block.
+
+## Reply And Audio Tags
+
+`[[reply_to_current]]`, `[[reply_to:<id>]]`, and `[[audio_as_voice]]` are
+assistant-output metadata tags.
+
+Rules:
+
+- Put reply tags at the very start of the message for deterministic delivery.
+- Place at most one reply tag in a reply.
+- Prefer `[[reply_to_current]]`; use `[[reply_to:<id>]]` only when an explicit id is available.
+- `[[audio_as_voice]]` only affects attached audio; it does nothing by itself.
+- Keep reply/audio tags out of code samples and literal examples unless quoted or fenced.
+- These tags are stripped before normal user-visible rendering.
+
+## Special Tokens
+
+- `NO_REPLY` is an exact-token silence mechanism. Use only the bare token with
+  optional surrounding whitespace when you want silence; never combine it with
+  visible text, punctuation, markdown, or explanations.
+- `HEARTBEAT_OK` is a heartbeat-only ack token. Use it only for a real
+  heartbeat OK response; do not include it inside ordinary prose, alerts, or
+  status updates.
+
+## Reasoning And Final Wrappers
+
+- Do not casually emit `<think>...</think>`, `<thinking>...</thinking>`,
+  `<thought>...</thought>`, `<antthinking>...</antthinking>`, or
+  `<final>...</final>` in ordinary replies.
+- If the runtime explicitly asks for reasoning/final tags, follow that contract
+  exactly. Otherwise those wrappers are stripped or sanitized by the runtime and
+  may hide or discard content.
+- When final-tag enforcement is enabled, only text that appeared inside
+  `<final>...</final>` is shown to the user; content outside `<final>` can be
+  suppressed.
+- If you need to mention these wrappers literally, quote or fence them as
+  examples instead of using them as live markup.
+
 ## `[embed ...]`
 
 `[embed ...]` is the only agent-facing rich render syntax for the Control UI.
@@ -24,7 +88,9 @@ Rules:
 - `[view ...]` is no longer valid for new output.
 - Embed shortcodes render in the assistant message surface only.
 - Only URL-backed embeds are rendered. Use `ref="..."` or `url="..."`.
+- Quote every attribute value; unquoted attributes are ignored.
 - Block-form inline HTML embed shortcodes are not rendered.
+- Use embed shortcodes outside fenced code blocks; fenced examples are treated as literal text.
 - The web UI strips the shortcode from visible text and renders the embed inline.
 - `MEDIA:` is not an embed alias and should not be used for rich embed rendering.
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -127,6 +127,7 @@ Cron jobs panel notes:
 - Re-sending with the same `idempotencyKey` returns `{ status: "in_flight" }` while running, and `{ status: "ok" }` after completion.
 - `chat.history` responses are size-bounded for UI safety. When transcript entries are too large, Gateway may truncate long text fields, omit heavy metadata blocks, and replace oversized messages with a placeholder (`[chat.history omitted: message too large]`).
 - `chat.history` also strips display-only inline directive tags from visible assistant text (for example `[[reply_to_*]]` and `[[audio_as_voice]]`), plain-text tool-call XML payloads (including `<tool_call>...</tool_call>`, `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`, `<function_calls>...</function_calls>`, and truncated tool-call blocks), and leaked ASCII/full-width model control tokens, and omits assistant entries whose whole visible text is only the exact silent token `NO_REPLY` / `no_reply`.
+- This is display-layer normalization only. The canonical harness syntax contract for `MEDIA:`, reply/audio tags, special tokens, and reasoning/final wrappers lives in [Rich Output Protocol](/reference/rich-output-protocol).
 - `chat.inject` appends an assistant note to the session transcript and broadcasts a `chat` event for UI-only updates (no agent run, no channel delivery).
 - The chat header model and thinking pickers patch the active session immediately through `sessions.patch`; they are persistent session overrides, not one-turn-only send options.
 - Stop:
@@ -143,6 +144,8 @@ Cron jobs panel notes:
 Assistant messages can render hosted web content inline with the `[embed ...]`
 shortcode. The iframe sandbox policy is controlled by
 `gateway.controlUi.embedSandbox`:
+
+Canonical syntax/attribute rules for `[embed ...]` live in [Rich Output Protocol](/reference/rich-output-protocol). This section only describes Control UI rendering and sandbox behavior.
 
 - `strict`: disables script execution inside hosted embeds
 - `scripts`: allows interactive embeds while keeping origin isolation; this is

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -34,6 +34,7 @@ Status: the macOS/iOS SwiftUI chat UI talks directly to the Gateway WebSocket.
   leaked ASCII/full-width model control tokens are stripped from visible text,
   and assistant entries whose whole visible text is only the exact silent
   token `NO_REPLY` / `no_reply` are omitted.
+- This is display-layer normalization only. The canonical harness syntax contract for `MEDIA:`, reply/audio tags, special tokens, and reasoning/final wrappers lives in [Rich Output Protocol](/reference/rich-output-protocol).
 - `chat.inject` appends an assistant note directly to the transcript and broadcasts it to the UI (no agent run).
 - Aborted runs can keep partial assistant output visible in the UI.
 - Gateway persists aborted partial assistant text into transcript history when buffered output exists, and marks those entries with abort metadata.

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -163,10 +163,39 @@ describe("buildAgentSystemPrompt", () => {
       workspaceDir: "/tmp/openclaw",
     });
 
-    expect(prompt).toContain("## Assistant Output Directives");
+    expect(prompt).toContain("## Harness Syntax");
+    expect(prompt).toContain("### Inbound Context Markers");
+    expect(prompt).toContain("### Assistant Output Directives");
+    expect(prompt).toContain(
+      "Inbound attachment markers like `[media attached: ...]`, `[media attached N/M: ...]`, `[Image: source: ...]`, and `<media:image>` may appear in user/context text.",
+    );
+    expect(prompt).toContain("`MEDIA:<path-or-url>` is outbound-only metadata.");
+    expect(prompt).toContain(
+      "It must be the first non-whitespace token on that line, with no prose before or after it.",
+    );
+    expect(prompt).toContain(
+      "Use one `MEDIA:` line per attachment. Indentation is OK; mid-line prose is not.",
+    );
+    expect(prompt).toContain(
+      "If a path contains spaces, quote the entire path. Do not use `..` traversal segments or `~` home-directory paths in `MEDIA:`.",
+    );
+    expect(prompt).toContain(
+      "If you must discuss the syntax literally, quote or fence it so it is not interpreted as metadata.",
+    );
+    expect(prompt).toContain(
+      "`[[audio_as_voice]]` marks attached audio as a voice-note style delivery hint. It only affects attached audio and does nothing by itself.",
+    );
     expect(prompt).toContain("[[reply_to_current]]");
+    expect(prompt).toContain("Place at most one reply tag at the very start");
+    expect(prompt).toContain("Keep reply/audio tags out of code samples and literal examples");
     expect(prompt).not.toContain("Tags are stripped before sending");
     expect(prompt).toContain("Supported tags are stripped before user-visible rendering");
+    expect(prompt).toContain("### Special Tokens");
+    expect(prompt).toContain("`NO_REPLY` is an exact-token silence mechanism.");
+    expect(prompt).toContain("`HEARTBEAT_OK` is a heartbeat-only ack token.");
+    expect(prompt).toContain("### Reasoning And Final Wrappers");
+    expect(prompt).toContain("Do not casually emit `<think>...</think>`");
+    expect(prompt).toContain("When final-tag enforcement is enabled");
   });
 
   it("omits the heartbeat section when no heartbeat prompt is provided", () => {
@@ -177,8 +206,21 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).not.toContain("## Heartbeats");
-    expect(prompt).not.toContain("HEARTBEAT_OK");
+    expect(prompt).not.toContain("If the current user message is a heartbeat poll");
     expect(prompt).not.toContain("Read HEARTBEAT.md");
+  });
+
+  it("tightens heartbeat ack guidance when enabled", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "full",
+      heartbeatPrompt: "ping",
+    });
+
+    expect(prompt).toContain('do NOT include "HEARTBEAT_OK" anywhere in the alert');
+    expect(prompt).toContain(
+      'Outside a real heartbeat ack, do not use "HEARTBEAT_OK" as normal prose, status text, or decoration.',
+    );
   });
 
   it("includes safety guardrails in full prompts", () => {
@@ -234,6 +276,21 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Runtime-generated completion events may ask for a user update.");
     expect(prompt).toContain("Rewrite those in your normal assistant voice");
     expect(prompt).toContain("do not forward raw internal metadata");
+    expect(prompt).toContain("Internal completion-event blocks and ACP/system progress notices");
+    expect(prompt).toContain("do not quote raw block headers");
+    expect(prompt).toContain(
+      "Treat session keys, child session keys, run ids, message ids, and ACP ids as opaque runtime identifiers.",
+    );
+  });
+
+  it("documents silent replies as exact-token-only behavior", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toContain("## Silent Replies");
+    expect(prompt).toContain("This is an exact-token silence mechanism, not normal prose.");
+    expect(prompt).toContain("Use only the bare token with optional surrounding whitespace.");
   });
 
   it("does not include embed guidance in the default global prompt", () => {
@@ -263,6 +320,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       "Never use local filesystem paths or `file://...` URLs in `[embed ...]`.",
     );
+    expect(prompt).toContain("Use `[embed ...]` outside code fences.");
     expect(prompt).toContain(
       "The active hosted embed root for this session is: `/Users/example/.openclaw-dev/canvas`.",
     );

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -127,7 +127,8 @@ function buildHeartbeatSection(params: { isMinimal: boolean; heartbeatPrompt?: s
     "## Heartbeats",
     "If the current user message is a heartbeat poll and nothing needs attention, reply exactly:",
     "HEARTBEAT_OK",
-    'If something needs attention, do NOT include "HEARTBEAT_OK"; reply with the alert text instead.',
+    'If something needs attention, do NOT include "HEARTBEAT_OK" anywhere in the alert; reply with the alert text only.',
+    'Outside a real heartbeat ack, do not use "HEARTBEAT_OK" as normal prose, status text, or decoration.',
     "",
   ];
 }
@@ -219,22 +220,36 @@ function buildTimeSection(params: { userTimezone?: string }) {
   return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
 }
 
-function buildAssistantOutputDirectivesSection(isMinimal: boolean) {
+function buildHarnessSyntaxSection(isMinimal: boolean) {
   if (isMinimal) {
     return [];
   }
   return [
-    "## Assistant Output Directives",
-    "Use these when you need delivery metadata in an assistant message:",
-    "- `MEDIA:<path-or-url>` on its own line requests attachment delivery. The web UI strips supported MEDIA lines and renders them inline; channels still decide actual delivery behavior.",
-    "- `[[audio_as_voice]]` marks attached audio as a voice-note style delivery hint. The web UI may show a voice-note badge when audio is present; channels still own delivery semantics.",
+    "## Harness Syntax",
+    "The harness may inject special syntax into context and may also interpret certain assistant-output markers. Follow these contracts exactly:",
+    "### Inbound Context Markers",
+    "- Inbound attachment markers like `[media attached: ...]`, `[media attached N/M: ...]`, `[Image: source: ...]`, and `<media:image>` may appear in user/context text. Treat them as harness-provided context about files that already exist; do not echo them back unless the user explicitly asks.",
+    "### Assistant Output Directives",
+    "- `MEDIA:<path-or-url>` is outbound-only metadata. Put each `MEDIA:` directive on its own line when you want attachment delivery. It must be the first non-whitespace token on that line, with no prose before or after it. The web UI strips supported MEDIA lines and renders them inline; channels still decide actual delivery behavior.",
+    "- Use one `MEDIA:` line per attachment. Indentation is OK; mid-line prose is not. Fenced code blocks and quoted examples are treated as literal text, not delivery metadata.",
+    "- Use real `http(s)` URLs or safe file paths only. If a path contains spaces, quote the entire path. Do not use `..` traversal segments or `~` home-directory paths in `MEDIA:`.",
+    "- Do not use `MEDIA:` for explanation prose, examples, or docs unless you actually want delivery. If you must discuss the syntax literally, quote or fence it so it is not interpreted as metadata.",
+    "- `[[audio_as_voice]]` marks attached audio as a voice-note style delivery hint. It only affects attached audio and does nothing by itself. The web UI may show a voice-note badge when audio is present; channels still own delivery semantics.",
     "- To request a native reply/quote on supported surfaces, include one reply tag in your reply:",
-    "- Reply tags must be the very first token in the message (no leading text/newlines): [[reply_to_current]] your reply.",
+    "- Place at most one reply tag at the very start of the message for deterministic delivery (no leading text/newlines): [[reply_to_current]] your reply.",
     "- [[reply_to_current]] replies to the triggering message.",
     "- Prefer [[reply_to_current]]. Use [[reply_to:<id>]] only when an id was explicitly provided (e.g. by the user or a tool).",
-    "Whitespace inside the tag is allowed (e.g. [[ reply_to_current ]] / [[ reply_to: 123 ]]).",
+    "Whitespace inside the tag is allowed (e.g. [[ reply_to_current ]] / [[ reply_to: 123 ]]). Keep reply/audio tags out of code samples and literal examples unless quoted or fenced.",
     "- Channel-specific interactive directives are separate and should not be mixed into this web render guidance.",
     "Supported tags are stripped before user-visible rendering; support still depends on the current channel config.",
+    "### Special Tokens",
+    `- \`${SILENT_REPLY_TOKEN}\` is an exact-token silence mechanism. Use only the bare token with optional surrounding whitespace when you want silence; never combine it with visible text, punctuation, markdown, or explanations.`,
+    "- `HEARTBEAT_OK` is a heartbeat-only ack token. Use it only for a real heartbeat OK response; do not include it inside normal prose, alerts, or status updates.",
+    "### Reasoning And Final Wrappers",
+    "- Do not casually emit `<think>...</think>`, `<thinking>...</thinking>`, `<thought>...</thought>`, `<antthinking>...</antthinking>`, or `<final>...</final>` in ordinary replies.",
+    "- If the runtime explicitly asks for reasoning/final tags, follow that contract exactly. Otherwise those wrappers are stripped or sanitized by the runtime and may hide or discard content.",
+    "- When final-tag enforcement is enabled, only text that appeared inside `<final>...</final>` is shown to the user; content outside `<final>` can be suppressed.",
+    "- If you need to mention these wrappers literally, quote or fence them as examples instead of using them as live markup.",
     "",
   ];
 }
@@ -255,6 +270,7 @@ function buildWebchatCanvasSection(params: {
     '- Use self-closing form for hosted embed documents: `[embed ref="cv_123" title="Status" height="320" /]`.',
     '- You may also use an explicit hosted URL: `[embed url="/__openclaw__/canvas/documents/cv_123/index.html" title="Status" height="320" /]`.',
     '- Never use local filesystem paths or `file://...` URLs in `[embed ...]`. Hosted embeds must point at `/__openclaw__/canvas/...` URLs or use `ref="..."`.',
+    "- Use `[embed ...]` outside code fences. Fenced or malformed embed examples are treated as literal text.",
     params.canvasRootDir
       ? `- The active hosted embed root for this session is: \`${sanitizeForPromptLiteral(params.canvasRootDir)}\`. If you manually stage a hosted embed file, write it there, not in the workspace.`
       : "- The active hosted embed root is profile-scoped, not workspace-scoped. If you manually stage a hosted embed file, write it under the active profile embed root, not in the workspace.",
@@ -313,6 +329,8 @@ function buildMessagingSection(params: {
     "- Cross-session messaging → use sessions_send(sessionKey, message)",
     "- Sub-agent orchestration → use subagents(action=list|steer|kill)",
     `- Runtime-generated completion events may ask for a user update. Rewrite those in your normal assistant voice and send the update (do not forward raw internal metadata or default to ${SILENT_REPLY_TOKEN}).`,
+    "- Internal completion-event blocks and ACP/system progress notices are runtime telemetry, not user-authored content. Summarize only the user-relevant outcome; do not quote raw block headers, `Action:` instructions, `session_key`, `session_id`, stats lines, or announce types back to the user.",
+    "- Treat session keys, child session keys, run ids, message ids, and ACP ids as opaque runtime identifiers. Never invent, shorten, translate, or normalize them; only reuse ids supplied by the user, tools, or runtime context.",
     "- Never use exec/curl for provider messaging; OpenClaw handles all routing internally.",
     params.availableTools.has("message")
       ? [
@@ -815,7 +833,7 @@ export function buildAgentSystemPrompt(params: {
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",
     "",
-    ...buildAssistantOutputDirectivesSection(isMinimal),
+    ...buildHarnessSyntaxSection(isMinimal),
     ...buildWebchatCanvasSection({
       isMinimal,
       runtimeChannel,
@@ -879,6 +897,7 @@ export function buildAgentSystemPrompt(params: {
     lines.push(
       "## Silent Replies",
       `When you have nothing to say, respond with ONLY: ${SILENT_REPLY_TOKEN}`,
+      `This is an exact-token silence mechanism, not normal prose. Use only the bare token with optional surrounding whitespace.`,
       "",
       "⚠️ Rules:",
       "- It must be your ENTIRE message — nothing else",


### PR DESCRIPTION
We found that the harness contract was fragmented and underspecified. The agent prompt, the docs, and several channel/web pages all described pieces of the behavior, but not the real parser/runtime rules in one place. That showed up most clearly around `MEDIA:` lines, reply/audio tags, special silent/heartbeat tokens, and `<think>` / `<final>` wrappers.

What changed:

- In `src/agents/system-prompt.ts`, this replaces the narrower output-directives wording with a centralized `Harness Syntax` section.
- That section now explains:
  - inbound harness markers like `[media attached: ...]`, `[Image: source: ...]`, and `<media:image>` are read-only context
  - `MEDIA:` is outbound-only metadata and must follow the real parser contract: first non-whitespace token on its own line, one line per attachment, quote spaced paths, no `..` or `~`
  - reply/audio tags use a stricter canonical form even though the parser is more permissive
  - `NO_REPLY` and `HEARTBEAT_OK` are exact control tokens, not normal prose
  - `<think>` / `<final>` wrappers should only be used when the runtime explicitly asks for them, and with final-tag enforcement only `<final>` content is shown
  - internal completion-event blocks / ACP progress notices are runtime telemetry, and runtime ids must be treated as opaque
- In `docs/reference/rich-output-protocol.md` and `docs/concepts/system-prompt.md`, this aligns the docs with that centralized contract.
- In the main channel docs and web docs, this removes local drift by pointing them back to the centralized contract while keeping channel/rendering specifics in place:
  - `docs/channels/telegram.md`
  - `docs/channels/slack.md`
  - `docs/channels/discord.md`
  - `docs/channels/whatsapp.md`
  - `docs/web/control-ui.md`
  - `docs/web/webchat.md`
- This also adds regression coverage in `src/agents/system-prompt.test.ts` so the prompt keeps documenting the real harness contracts.

Verification:

- `pnpm vitest src/agents/system-prompt.test.ts` passed with `54` tests.

Note: unrelated preexisting doctor-file edits were intentionally left out of this PR.