### PR TITLE
fix: Device pairing alone exposes exec-capable nodes before admin...

### DIFF
--- a/src/gateway/node-connect-reconcile.ts
+++ b/src/gateway/node-connect-reconcile.ts
@@ -81,7 +81,7 @@ export async function reconcileNodePairingOnConnect(params: {
     );
     return {
       nodeId,
-      effectiveCommands: declared,
+      effectiveCommands: [],
       pendingPairing,
     };
   }

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -98,6 +98,90 @@ async function requestAllowOnceApproval(
   return approvalId;
 }
 
+async function connectPairedLinuxNode(params: {
+  port: number;
+  deviceIdentity: DeviceIdentity;
+  commands: string[];
+  onInvoke: (payload: unknown) => void;
+}): Promise<GatewayClient> {
+  const startClient = async () => {
+    let readyResolve: (() => void) | null = null;
+    const ready = new Promise<void>((resolve) => {
+      readyResolve = resolve;
+    });
+
+    const client = new GatewayClient({
+      url: `ws://127.0.0.1:${params.port}`,
+      // Keep challenge timeout realistic in tests; 0 maps to a 250ms timeout and can
+      // trigger reconnect backoff loops under load.
+      connectChallengeTimeoutMs: 2_000,
+      token: "secret",
+      role: "node",
+      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      clientVersion: "1.0.0",
+      platform: "linux",
+      mode: GATEWAY_CLIENT_MODES.NODE,
+      scopes: [],
+      commands: params.commands,
+      deviceIdentity: params.deviceIdentity,
+      onHelloOk: () => readyResolve?.(),
+      onEvent: (evt) => {
+        if (evt.event !== "node.invoke.request") {
+          return;
+        }
+        params.onInvoke(evt.payload);
+        const payload = evt.payload as {
+          id?: string;
+          nodeId?: string;
+        };
+        const id = typeof payload?.id === "string" ? payload.id : "";
+        const nodeId = typeof payload?.nodeId === "string" ? payload.nodeId : "";
+        if (!id || !nodeId) {
+          return;
+        }
+        void client.request("node.invoke.result", {
+          id,
+          nodeId,
+          ok: true,
+          payloadJSON: JSON.stringify({ ok: true }),
+        });
+      },
+    });
+    client.start();
+    await Promise.race([
+      ready,
+      sleep(NODE_CONNECT_TIMEOUT_MS).then(() => {
+        throw new Error("timeout waiting for node to connect");
+      }),
+    ]);
+    return client;
+  };
+
+  let client = await startClient();
+  const { approveNodePairing, listNodePairing, requestNodePairing } = await import(
+    "../infra/node-pairing.js"
+  );
+  const nodeId = params.deviceIdentity.deviceId;
+  const existingRequest = (await listNodePairing()).pending.find((pending) => pending.nodeId === nodeId);
+  const requestId =
+    existingRequest?.requestId ??
+    (
+      await requestNodePairing({
+        nodeId,
+        platform: "linux",
+        commands: params.commands,
+      })
+    ).request.requestId;
+  await approveNodePairing(requestId, {
+    callerScopes: ["operator.pairing", "operator.admin", "operator.write"],
+  });
+
+  // Node pairing approval only affects the next connect, so reconnect to refresh the live session.
+  await client.stopAndWait();
+  client = await startClient();
+  return client;
+}
+
 describe("node.invoke approval bypass", () => {
   let server: Awaited<ReturnType<typeof startServerWithClient>>["server"];
   let port: number;
@@ -205,57 +289,13 @@ describe("node.invoke approval bypass", () => {
     deviceIdentity?: DeviceIdentity,
     commands: string[] = ["system.run"],
   ) => {
-    let readyResolve: (() => void) | null = null;
-    const ready = new Promise<void>((resolve) => {
-      readyResolve = resolve;
-    });
-
     const resolvedDeviceIdentity = deviceIdentity ?? createDeviceIdentity();
-    const client = new GatewayClient({
-      url: `ws://127.0.0.1:${port}`,
-      // Keep challenge timeout realistic in tests; 0 maps to a 250ms timeout and can
-      // trigger reconnect backoff loops under load.
-      connectChallengeTimeoutMs: 2_000,
-      token: "secret",
-      role: "node",
-      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
-      clientVersion: "1.0.0",
-      platform: "linux",
-      mode: GATEWAY_CLIENT_MODES.NODE,
-      scopes: [],
-      commands,
+    return await connectPairedLinuxNode({
+      port,
       deviceIdentity: resolvedDeviceIdentity,
-      onHelloOk: () => readyResolve?.(),
-      onEvent: (evt) => {
-        if (evt.event !== "node.invoke.request") {
-          return;
-        }
-        onInvoke(evt.payload);
-        const payload = evt.payload as {
-          id?: string;
-          nodeId?: string;
-        };
-        const id = typeof payload?.id === "string" ? payload.id : "";
-        const nodeId = typeof payload?.nodeId === "string" ? payload.nodeId : "";
-        if (!id || !nodeId) {
-          return;
-        }
-        void client.request("node.invoke.result", {
-          id,
-          nodeId,
-          ok: true,
-          payloadJSON: JSON.stringify({ ok: true }),
-        });
-      },
+      commands,
+      onInvoke,
     });
-    client.start();
-    await Promise.race([
-      ready,
-      sleep(NODE_CONNECT_TIMEOUT_MS).then(() => {
-        throw new Error("timeout waiting for node to connect");
-      }),
-    ]);
-    return client;
   };
 
   test("rejects malformed/forbidden node.invoke payloads before forwarding", async () => {

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -270,4 +270,79 @@ describe("gateway node pairing authorization", () => {
       expectedVisibleCommands: [],
     });
   });
+
+  test("keeps commands hidden before any node pairing approval exists", async () => {
+    const started = await startServerWithClient("secret");
+    const pairedNode = await pairDeviceIdentity({
+      name: "node-device-paired-only",
+      role: "node",
+      scopes: [],
+      clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      clientMode: GATEWAY_CLIENT_MODES.NODE,
+    });
+    const operator = await issueOperatorToken({
+      name: "node-device-paired-only-operator",
+      approvedScopes: ["operator.write"],
+      tokenScopes: ["operator.write"],
+      clientId: GATEWAY_CLIENT_NAMES.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+
+    let controlWs: WebSocket | undefined;
+    let nodeClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+    try {
+      controlWs = await openTrackedWs(started.port);
+      await connectOk(controlWs, {
+        skipDefaultAuth: true,
+        deviceToken: operator.token,
+        deviceIdentityPath: operator.identityPath,
+        scopes: ["operator.write"],
+      });
+
+      nodeClient = await connectNodeClient({
+        port: started.port,
+        deviceIdentity: pairedNode.identity,
+        commands: ["system.run"],
+      });
+
+      const deadline = Date.now() + 2_000;
+      let connectedNode:
+        | { nodeId: string; connected?: boolean; commands?: string[]; displayName?: string }
+        | undefined;
+      while (Date.now() < deadline) {
+        const list = await rpcReq<{
+          nodes?: Array<{
+            nodeId: string;
+            connected?: boolean;
+            commands?: string[];
+            displayName?: string;
+          }>;
+        }>(controlWs, "node.list", {});
+        connectedNode = (list.payload?.nodes ?? []).find(
+          (entry) => entry.nodeId === pairedNode.identity.deviceId && entry.connected,
+        );
+        if (connectedNode) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+
+      expect(connectedNode?.commands ?? []).toEqual([]);
+
+      const invoke = await rpcReq(controlWs, "node.invoke", {
+        nodeId: pairedNode.identity.deviceId,
+        command: "system.run",
+        params: { command: "echo blocked" },
+        idempotencyKey: "node-unpaired-system-run",
+      });
+      expect(invoke.ok).toBe(false);
+      expect(invoke.error?.message ?? "").toContain("node command not allowed");
+    } finally {
+      controlWs?.close();
+      await nodeClient?.stopAndWait();
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
 });

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -410,7 +410,7 @@ describe("gateway node command allowlist", () => {
     }
   });
 
-  test("keeps allowlisted declared commands available before node pairing exists", async () => {
+  test("keeps pending pairing commands hidden before node pairing exists", async () => {
     const displayName = "node-device-paired-only";
     let nodeClient: GatewayClient | undefined;
 
@@ -428,13 +428,22 @@ describe("gateway node command allowlist", () => {
           const node = await findConnectedNodeByDisplayName(displayName);
           return node?.commands?.toSorted() ?? [];
         }, FAST_WAIT_OPTS)
-        .toEqual(["canvas.snapshot", "system.run"]);
+        .toEqual([]);
 
       const node = await findConnectedNodeByDisplayName(displayName);
       const nodeId = node?.nodeId ?? "";
       expect(nodeId).toBeTruthy();
 
       await expectPendingPairingCommands(nodeId, ["canvas.snapshot", "system.run"]);
+
+      const blockedInvoke = await rpcReq(ws, "node.invoke", {
+        nodeId,
+        command: "system.run",
+        params: { command: "echo blocked" },
+        idempotencyKey: "allowlist-pending-node-pairing",
+      });
+      expect(blockedInvoke.ok).toBe(false);
+      expect(blockedInvoke.error?.message ?? "").toContain("node command not allowed");
     } finally {
       await nodeClient?.stopAndWait();
     }


### PR DESCRIPTION
## Fix Summary
Device pairing alone is enough for a reconnecting macOS or Linux node to publish `system.run` into the live node session, and `node.invoke` trusts that live command list. An operator with only `operator.write` can therefore forward remote `system.run` requests without passing the admin-gated `node.pair.approve` flow that is supposed to establish trust for exec-capable nodes.

## Issue Linkage
Fixes #65542

## Security Snapshot
- CVSS v3.1: 9.9 (Critical)
- CVSS v4.0: 9.4 (Critical)

## Implementation Details
### Files Changed
- `src/gateway/node-connect-reconcile.ts` (+1/-1)
- `src/gateway/server.node-invoke-approval-bypass.test.ts` (+88/-48)
- `src/gateway/server.node-pairing-authz.test.ts` (+75/-0)
- `src/gateway/server.roles-allowlist-update.test.ts` (+11/-2)

### Technical Analysis
1. Pair a device as `role: "node"` through the generic device-pair flow. `device.pair.approve` is only pairing-scoped (`src/gateway/method-scopes.ts:54-67`), and `approveDevicePairing()` only enforces requested operator scopes; a node-role request with no operator scopes is approved without any extra node-specific admin check (`src/infra/device-pairing.ts:572-591`, `src/infra/device-pairing.ts:620-640`).
2. Reconnect a macOS or Linux node that declares `system.run`. When no node-pair record exists, `reconcileNodePairingOnConnect()` still returns `effectiveCommands: declared` while creating a pending node-pair request (`src/gateway/node-connect-reconcile.ts:73-86`), and the WebSocket connect handler stores that command list on the live session (`src/gateway/server/ws-connection/message-handler.ts:1143-1158`).
3. From an operator session that has `operator.write` but not `operator.admin`, call `node.invoke` for `system.run`. The method itself is a write-scoped RPC (`src/gateway/method-scopes.ts:117-132`), and the invoke path only checks the gateway allowlist plus `nodeSession.commands` (`src/gateway/server-methods/nodes.ts:993-1034`).
4. Observe that the request is forwarded to the node even though exec-capable node pairing approvals are separately defined as `operator.pairing` + `operator.admin` (`src/infra/node-pairing-authz.ts:9-21`, `src/gateway/server-methods/nodes.ts:579-621`).

## Validation Evidence
- Command: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
- non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: github-copilot/gpt-5.4
