### PR TITLE
fix(memory-wiki): support token-overlap search for multi-term queries

### DIFF
--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -278,6 +278,43 @@ describe("searchMemoryWiki", () => {
     expect(customPaths).toEqual(["entities/status.md"]);
   });
 
+  it("does not match every page when a non-empty query yields no usable tokens", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "entities", "cpp.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.cpp",
+          title: "C plus plus",
+        },
+        body: "# C plus plus\n\nLanguage note without the symbol form.\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "entities", "noise.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.noise",
+          title: "Unrelated page",
+        },
+        body: "# Unrelated page\n\nNothing here should match the symbol query.\n",
+      }),
+      "utf8",
+    );
+
+    const results = await searchMemoryWiki({ config, query: "c++" });
+    const customPaths = results
+      .map((result) => result.path)
+      .filter((resultPath) => ["entities/cpp.md", "entities/noise.md"].includes(resultPath));
+
+    expect(customPaths).toEqual([]);
+  });
+
   it("ranks fresh supported claims ahead of stale contested claims", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -239,6 +239,45 @@ describe("searchMemoryWiki", () => {
     expect(rankedCustomPaths).toEqual(["entities/exact-match.md", "entities/token-match.md"]);
   });
 
+  it("does not admit substring-only common-word matches as token overlap", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "entities", "status.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.status.real",
+          title: "Current status",
+        },
+        body: "# Current status\n\nThe system status is healthy today.\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "entities", "substring-noise.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.substring.noise",
+          title: "This other phone",
+        },
+        body: "# This other phone\n\nInside those notes we avoid the target concept.\n",
+      }),
+      "utf8",
+    );
+
+    const results = await searchMemoryWiki({ config, query: "what is the status" });
+    const customPaths = results
+      .map((result) => result.path)
+      .filter((resultPath) =>
+        ["entities/status.md", "entities/substring-noise.md"].includes(resultPath),
+      );
+
+    expect(customPaths).toEqual(["entities/status.md"]);
+  });
+
   it("ranks fresh supported claims ahead of stale contested claims", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -153,6 +153,92 @@ describe("searchMemoryWiki", () => {
     });
   });
 
+  it("matches long multi-term queries through token overlap when the digest path is active", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "entities", "medalii.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.medalii.regate",
+          title: "Medalii istorice",
+          claims: [
+            {
+              id: "claim.medalii.regate",
+              text: "Aceste medalii au circulat în mai multe regate europene.",
+              status: "supported",
+              confidence: 0.94,
+              evidence: [{ sourceId: "source.regate", lines: "4-8" }],
+            },
+          ],
+        },
+        body: "# Medalii istorice\n\nRezumat fără fraza exactă.\n",
+      }),
+      "utf8",
+    );
+    await compileMemoryWikiVault(config);
+
+    const results = await searchMemoryWiki({ config, query: "medalii regate" });
+    const medaliiResult = results.find((result) => result.path === "entities/medalii.md");
+
+    expect(medaliiResult).toMatchObject({
+      corpus: "wiki",
+      path: "entities/medalii.md",
+      snippet: "Aceste medalii au circulat în mai multe regate europene.",
+    });
+  });
+
+  it("keeps exact phrase matches ahead of token-only overlap", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "entities", "exact-match.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.medalii.regate.exact",
+          title: "Medalii regate",
+        },
+        body: "# Medalii regate\n\nPotrivire exactă în titlu.\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "entities", "token-match.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.medalii.regate.partial",
+          title: "Medalii istorice",
+          claims: [
+            {
+              id: "claim.medalii.regate.partial",
+              text: "Aceste medalii apar în mai multe regate distincte.",
+              status: "supported",
+              confidence: 0.87,
+              evidence: [{ sourceId: "source.regate", lines: "1-3" }],
+            },
+          ],
+        },
+        body: "# Medalii istorice\n\nPotrivire doar prin tokeni.\n",
+      }),
+      "utf8",
+    );
+    await compileMemoryWikiVault(config);
+
+    const results = await searchMemoryWiki({ config, query: "medalii regate" });
+    const rankedCustomPaths = results
+      .map((result) => result.path)
+      .filter((resultPath) =>
+        ["entities/exact-match.md", "entities/token-match.md"].includes(resultPath),
+      );
+
+    expect(rankedCustomPaths).toEqual(["entities/exact-match.md", "entities/token-match.md"]);
+  });
+
   it("ranks fresh supported claims ahead of stale contested claims", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -209,13 +209,25 @@ function buildQuerySignals(query: string): QuerySignals {
   return { queryLower, queryTerms };
 }
 
+function tokenizeText(textLower: string): Set<string> {
+  return new Set(textLower.match(/[\p{L}\p{N}]+/gu) ?? []);
+}
+
+function minimumMatchingTerms(queryTerms: string[]): number {
+  if (queryTerms.length <= 1) {
+    return queryTerms.length;
+  }
+  return 2;
+}
+
 function countMatchingTerms(textLower: string, queryTerms: string[]): number {
   if (!textLower || queryTerms.length === 0) {
     return 0;
   }
+  const textTokens = tokenizeText(textLower);
   let count = 0;
   for (const term of queryTerms) {
-    if (textLower.includes(term)) {
+    if (textTokens.has(term)) {
       count += 1;
     }
   }
@@ -229,7 +241,9 @@ function matchesQuery(textLower: string, signals: QuerySignals): boolean {
   if (signals.queryLower && textLower.includes(signals.queryLower)) {
     return true;
   }
-  return countMatchingTerms(textLower, signals.queryTerms) > 0;
+  return (
+    countMatchingTerms(textLower, signals.queryTerms) >= minimumMatchingTerms(signals.queryTerms)
+  );
 }
 
 function scoreTokenCoverage(

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -179,12 +179,12 @@ async function readQueryDigestBundle(rootDir: string): Promise<QueryDigestBundle
 }
 
 function buildSnippet(raw: string, query: string): string {
-  const queryLower = normalizeLowercaseStringOrEmpty(query);
+  const signals = buildQuerySignals(query);
   const matchingLine = raw
     .split(/\r?\n/)
     .find(
       (line) =>
-        normalizeLowercaseStringOrEmpty(line).includes(queryLower) && line.trim().length > 0,
+        line.trim().length > 0 && matchesQuery(normalizeLowercaseStringOrEmpty(line), signals),
     );
   return (
     matchingLine?.trim() ||
@@ -194,6 +194,54 @@ function buildSnippet(raw: string, query: string): string {
       ?.trim() ||
     ""
   );
+}
+
+type QuerySignals = {
+  queryLower: string;
+  queryTerms: string[];
+};
+
+function buildQuerySignals(query: string): QuerySignals {
+  const queryLower = normalizeLowercaseStringOrEmpty(query);
+  const queryTerms = Array.from(
+    new Set((queryLower.match(/[\p{L}\p{N}]+/gu) ?? []).filter((term) => term.length >= 2)),
+  );
+  return { queryLower, queryTerms };
+}
+
+function countMatchingTerms(textLower: string, queryTerms: string[]): number {
+  if (!textLower || queryTerms.length === 0) {
+    return 0;
+  }
+  let count = 0;
+  for (const term of queryTerms) {
+    if (textLower.includes(term)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function matchesQuery(textLower: string, signals: QuerySignals): boolean {
+  if (!textLower) {
+    return false;
+  }
+  if (signals.queryLower && textLower.includes(signals.queryLower)) {
+    return true;
+  }
+  return countMatchingTerms(textLower, signals.queryTerms) > 0;
+}
+
+function scoreTokenCoverage(
+  textLower: string,
+  signals: QuerySignals,
+  pointsPerTerm: number,
+  maxScore: number,
+): number {
+  if (signals.queryTerms.length === 0) {
+    return 0;
+  }
+  return Math.min(maxScore, countMatchingTerms(textLower, signals.queryTerms) * pointsPerTerm);
 }
 
 function buildPageSearchText(page: QueryableWikiPage): string {
@@ -226,14 +274,18 @@ function buildDigestPageSearchText(page: QueryDigestPage, claims: QueryDigestCla
     .join("\n");
 }
 
-function scoreDigestClaimMatch(claim: QueryDigestClaim, queryLower: string): number {
+function scoreDigestClaimMatch(claim: QueryDigestClaim, signals: QuerySignals): number {
   let score = 0;
-  if (normalizeLowercaseStringOrEmpty(claim.text).includes(queryLower)) {
+  const claimTextLower = normalizeLowercaseStringOrEmpty(claim.text);
+  const claimIdLower = normalizeLowercaseStringOrEmpty(claim.id);
+  if (signals.queryLower && claimTextLower.includes(signals.queryLower)) {
     score += 25;
   }
-  if (normalizeLowercaseStringOrEmpty(claim.id).includes(queryLower)) {
+  score += scoreTokenCoverage(claimTextLower, signals, 4, 16);
+  if (signals.queryLower && claimIdLower.includes(signals.queryLower)) {
     score += 10;
   }
+  score += scoreTokenCoverage(claimIdLower, signals, 2, 6);
   if (typeof claim.confidence === "number") {
     score += Math.round(claim.confidence * 10);
   }
@@ -260,7 +312,7 @@ function buildDigestCandidatePaths(params: {
   query: string;
   maxResults: number;
 }): string[] {
-  const queryLower = normalizeLowercaseStringOrEmpty(params.query);
+  const signals = buildQuerySignals(params.query);
   const claimsByPage = new Map<string, QueryDigestClaim[]>();
   for (const claim of params.digest.claims) {
     const current = claimsByPage.get(claim.pagePath) ?? [];
@@ -274,44 +326,47 @@ function buildDigestCandidatePaths(params: {
       const metadataLower = normalizeLowercaseStringOrEmpty(
         buildDigestPageSearchText(page, claims),
       );
-      if (!metadataLower.includes(queryLower)) {
+      if (!matchesQuery(metadataLower, signals)) {
         return { path: page.path, score: 0 };
       }
       let score = 1;
       const titleLower = normalizeLowercaseStringOrEmpty(page.title);
       const pathLower = normalizeLowercaseStringOrEmpty(page.path);
       const idLower = normalizeLowercaseStringOrEmpty(page.id);
-      if (titleLower === queryLower) {
+      if (titleLower === signals.queryLower) {
         score += 50;
-      } else if (titleLower.includes(queryLower)) {
+      } else if (signals.queryLower && titleLower.includes(signals.queryLower)) {
         score += 20;
       }
-      if (pathLower.includes(queryLower)) {
+      score += scoreTokenCoverage(titleLower, signals, 3, 9);
+      if (signals.queryLower && pathLower.includes(signals.queryLower)) {
         score += 10;
       }
-      if (idLower.includes(queryLower)) {
+      score += scoreTokenCoverage(pathLower, signals, 2, 6);
+      if (signals.queryLower && idLower.includes(signals.queryLower)) {
         score += 20;
       }
+      score += scoreTokenCoverage(idLower, signals, 3, 9);
       if (
         page.sourceIds.some((sourceId) =>
-          normalizeLowercaseStringOrEmpty(sourceId).includes(queryLower),
+          matchesQuery(normalizeLowercaseStringOrEmpty(sourceId), signals),
         )
       ) {
         score += 12;
       }
       const matchingClaims = claims
         .filter((claim) => {
-          if (normalizeLowercaseStringOrEmpty(claim.text).includes(queryLower)) {
+          if (matchesQuery(normalizeLowercaseStringOrEmpty(claim.text), signals)) {
             return true;
           }
-          return normalizeLowercaseStringOrEmpty(claim.id).includes(queryLower);
+          return matchesQuery(normalizeLowercaseStringOrEmpty(claim.id), signals);
         })
         .toSorted(
           (left, right) =>
-            scoreDigestClaimMatch(right, queryLower) - scoreDigestClaimMatch(left, queryLower),
+            scoreDigestClaimMatch(right, signals) - scoreDigestClaimMatch(left, signals),
         );
       if (matchingClaims.length > 0) {
-        score += scoreDigestClaimMatch(matchingClaims[0], queryLower);
+        score += scoreDigestClaimMatch(matchingClaims[0], signals);
         score += Math.min(10, (matchingClaims.length - 1) * 2);
       }
       return { path: page.path, score };
@@ -327,21 +382,25 @@ function buildDigestCandidatePaths(params: {
     .map((candidate) => candidate.path);
 }
 
-function isClaimMatch(claim: WikiClaim, queryLower: string): boolean {
-  if (normalizeLowercaseStringOrEmpty(claim.text).includes(queryLower)) {
+function isClaimMatch(claim: WikiClaim, signals: QuerySignals): boolean {
+  if (matchesQuery(normalizeLowercaseStringOrEmpty(claim.text), signals)) {
     return true;
   }
-  return normalizeLowercaseStringOrEmpty(claim.id).includes(queryLower);
+  return matchesQuery(normalizeLowercaseStringOrEmpty(claim.id), signals);
 }
 
-function rankClaimMatch(page: QueryableWikiPage, claim: WikiClaim, queryLower: string): number {
+function rankClaimMatch(page: QueryableWikiPage, claim: WikiClaim, signals: QuerySignals): number {
   let score = 0;
-  if (normalizeLowercaseStringOrEmpty(claim.text).includes(queryLower)) {
+  const claimTextLower = normalizeLowercaseStringOrEmpty(claim.text);
+  const claimIdLower = normalizeLowercaseStringOrEmpty(claim.id);
+  if (signals.queryLower && claimTextLower.includes(signals.queryLower)) {
     score += 25;
   }
-  if (normalizeLowercaseStringOrEmpty(claim.id).includes(queryLower)) {
+  score += scoreTokenCoverage(claimTextLower, signals, 4, 16);
+  if (signals.queryLower && claimIdLower.includes(signals.queryLower)) {
     score += 10;
   }
+  score += scoreTokenCoverage(claimIdLower, signals, 2, 6);
   if (typeof claim.confidence === "number") {
     score += Math.round(claim.confidence * 10);
   }
@@ -364,18 +423,17 @@ function rankClaimMatch(page: QueryableWikiPage, claim: WikiClaim, queryLower: s
   return score;
 }
 
-function getMatchingClaims(page: QueryableWikiPage, queryLower: string): WikiClaim[] {
+function getMatchingClaims(page: QueryableWikiPage, signals: QuerySignals): WikiClaim[] {
   return page.claims
-    .filter((claim) => isClaimMatch(claim, queryLower))
+    .filter((claim) => isClaimMatch(claim, signals))
     .toSorted(
-      (left, right) =>
-        rankClaimMatch(page, right, queryLower) - rankClaimMatch(page, left, queryLower),
+      (left, right) => rankClaimMatch(page, right, signals) - rankClaimMatch(page, left, signals),
     );
 }
 
 function buildPageSnippet(page: QueryableWikiPage, query: string): string {
-  const queryLower = normalizeLowercaseStringOrEmpty(query);
-  const matchingClaim = getMatchingClaims(page, queryLower)[0];
+  const signals = buildQuerySignals(query);
+  const matchingClaim = getMatchingClaims(page, signals)[0];
   if (matchingClaim) {
     return matchingClaim.text;
   }
@@ -383,7 +441,7 @@ function buildPageSnippet(page: QueryableWikiPage, query: string): string {
 }
 
 function scorePage(page: QueryableWikiPage, query: string): number {
-  const queryLower = normalizeLowercaseStringOrEmpty(query);
+  const signals = buildQuerySignals(query);
   const titleLower = normalizeLowercaseStringOrEmpty(page.title);
   const pathLower = normalizeLowercaseStringOrEmpty(page.relativePath);
   const idLower = normalizeLowercaseStringOrEmpty(page.id);
@@ -391,42 +449,46 @@ function scorePage(page: QueryableWikiPage, query: string): number {
   const rawLower = normalizeLowercaseStringOrEmpty(page.raw);
   if (
     !(
-      titleLower.includes(queryLower) ||
-      pathLower.includes(queryLower) ||
-      idLower.includes(queryLower) ||
-      metadataLower.includes(queryLower) ||
-      rawLower.includes(queryLower)
+      matchesQuery(titleLower, signals) ||
+      matchesQuery(pathLower, signals) ||
+      matchesQuery(idLower, signals) ||
+      matchesQuery(metadataLower, signals) ||
+      matchesQuery(rawLower, signals)
     )
   ) {
     return 0;
   }
 
   let score = 1;
-  if (titleLower === queryLower) {
+  if (titleLower === signals.queryLower) {
     score += 50;
-  } else if (titleLower.includes(queryLower)) {
+  } else if (signals.queryLower && titleLower.includes(signals.queryLower)) {
     score += 20;
   }
-  if (pathLower.includes(queryLower)) {
+  score += scoreTokenCoverage(titleLower, signals, 3, 9);
+  if (signals.queryLower && pathLower.includes(signals.queryLower)) {
     score += 10;
   }
-  if (idLower.includes(queryLower)) {
+  score += scoreTokenCoverage(pathLower, signals, 2, 6);
+  if (signals.queryLower && idLower.includes(signals.queryLower)) {
     score += 20;
   }
+  score += scoreTokenCoverage(idLower, signals, 3, 9);
   if (
     page.sourceIds.some((sourceId) =>
-      normalizeLowercaseStringOrEmpty(sourceId).includes(queryLower),
+      matchesQuery(normalizeLowercaseStringOrEmpty(sourceId), signals),
     )
   ) {
     score += 12;
   }
-  const matchingClaims = getMatchingClaims(page, queryLower);
+  const matchingClaims = getMatchingClaims(page, signals);
   if (matchingClaims.length > 0) {
-    score += rankClaimMatch(page, matchingClaims[0], queryLower);
+    score += rankClaimMatch(page, matchingClaims[0], signals);
     score += Math.min(10, (matchingClaims.length - 1) * 2);
   }
-  const bodyOccurrences = rawLower.split(queryLower).length - 1;
+  const bodyOccurrences = signals.queryLower ? rawLower.split(signals.queryLower).length - 1 : 0;
   score += Math.min(10, bodyOccurrences);
+  score += scoreTokenCoverage(metadataLower, signals, 1, 6);
   return score;
 }
 

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -241,6 +241,9 @@ function matchesQuery(textLower: string, signals: QuerySignals): boolean {
   if (signals.queryLower && textLower.includes(signals.queryLower)) {
     return true;
   }
+  if (signals.queryTerms.length === 0) {
+    return false;
+  }
   return (
     countMatchingTerms(textLower, signals.queryTerms) >= minimumMatchingTerms(signals.queryTerms)
   );


### PR DESCRIPTION
## Summary
- tokenize normalized wiki queries into meaningful terms
- replace full-string-only candidate gating with token-overlap matching
- preserve exact-phrase bonuses while allowing long multi-term queries to return relevant candidates
- add regression tests covering digest-path multi-term matches and exact-phrase ranking

## Why
`memory_search(corpus=wiki)` currently drops long multi-term queries before scoring because the lexical path requires the full normalized query string to appear contiguously.

That means queries with strong token overlap can still return `[]` even with `minScore=0`, while short single-term queries on the same corpus succeed.

This change keeps the current ranking shape, but relaxes candidate gating so:
- exact phrase matches still rank highest
- partial token coverage can enter scoring
- claim freshness/confidence weighting still applies

Addresses #64453.

## Validation
- `./node_modules/.bin/vitest run extensions/memory-wiki/src/query.test.ts`
- pre-commit pipeline via `git commit` (after `pnpm install --frozen-lockfile` restored missing repo dependencies)