### PR TITLE
[codex] Plugin SDK: add reply activity callbacks for channel plugins

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -485,6 +485,60 @@ should use `resolveInboundMentionDecision({ facts, policy })`.
 
   </Step>
 
+  <Step title="Stream live agent activity">
+    If your channel wants to show live reasoning, tool calls, approvals, or
+    command output, attach a reply-activity listener to the same
+    `replyOptions` object you pass into inbound dispatch.
+
+    Prefer this direct reply path over the global `runtime.events.onAgentEvent`
+    bus. The reply callbacks fire for the current run even when your channel is
+    not an internal Control UI surface.
+
+    ```typescript
+    import { dispatchInboundReplyWithBase } from "openclaw/plugin-sdk/inbound-reply-dispatch";
+    import { createReplyActivityCallbacks } from "openclaw/plugin-sdk/reply-runtime";
+
+    const activityReplyOptions = createReplyActivityCallbacks({
+      onEvent: async (event) => {
+        await publishActivityToClient({
+          sessionKey: route.sessionKey,
+          event,
+        });
+      },
+    });
+
+    await dispatchInboundReplyWithBase({
+      cfg,
+      channel: "acme-chat",
+      route,
+      storePath,
+      ctxPayload,
+      core,
+      deliver: async (payload) => {
+        await deliverAcmeReply(payload);
+      },
+      onRecordError: (err) => runtime.error?.(String(err)),
+      onDispatchError: (err) => runtime.error?.(String(err)),
+      replyOptions: {
+        ...activityReplyOptions,
+      },
+    });
+    ```
+
+    `createReplyActivityCallbacks(...)` normalizes live run events into one
+    ordered stream:
+
+    - agent-run start
+    - reasoning deltas and reasoning-end markers
+    - tool-start, item, plan-update, approval, command-output, and patch-summary events
+    - assistant-message and compaction boundaries
+
+    Partial text deltas stay opt-in. If your plugin already handles streamed
+    reply text separately, keep the default. If you also want text deltas on
+    the activity stream, pass `includePartialReplies: true`.
+
+  </Step>
+
   <Step title="Handle inbound messages">
     Your plugin needs to receive messages from the platform and forward them to
     OpenClaw. The typical pattern is a webhook that verifies the request and

--- a/src/plugin-sdk/reply-activity.ts
+++ b/src/plugin-sdk/reply-activity.ts
@@ -1,0 +1,95 @@
+import type { GetReplyOptions } from "../auto-reply/types.js";
+
+type ReplyActivityOnEvent = (event: ReplyActivityEvent) => Promise<void> | void;
+
+type ToolStartPayload = Parameters<NonNullable<GetReplyOptions["onToolStart"]>>[0];
+type ItemEventPayload = Parameters<NonNullable<GetReplyOptions["onItemEvent"]>>[0];
+type PlanUpdatePayload = Parameters<NonNullable<GetReplyOptions["onPlanUpdate"]>>[0];
+type ApprovalEventPayload = Parameters<NonNullable<GetReplyOptions["onApprovalEvent"]>>[0];
+type CommandOutputPayload = Parameters<NonNullable<GetReplyOptions["onCommandOutput"]>>[0];
+type PatchSummaryPayload = Parameters<NonNullable<GetReplyOptions["onPatchSummary"]>>[0];
+type PartialReplyPayload = Parameters<NonNullable<GetReplyOptions["onPartialReply"]>>[0];
+type ReasoningPayload = Parameters<NonNullable<GetReplyOptions["onReasoningStream"]>>[0];
+
+export type ReplyActivityEvent =
+  | { type: "agent_run_start"; payload: { runId: string } }
+  | { type: "assistant_message_start" }
+  | { type: "partial_reply"; payload: PartialReplyPayload }
+  | { type: "reasoning"; payload: ReasoningPayload }
+  | { type: "reasoning_end" }
+  | { type: "tool_start"; payload: ToolStartPayload }
+  | { type: "item"; payload: ItemEventPayload }
+  | { type: "plan_update"; payload: PlanUpdatePayload }
+  | { type: "approval"; payload: ApprovalEventPayload }
+  | { type: "command_output"; payload: CommandOutputPayload }
+  | { type: "patch_summary"; payload: PatchSummaryPayload }
+  | { type: "compaction_start" }
+  | { type: "compaction_end" };
+
+export type ReplyActivityCallbacks = Pick<
+  GetReplyOptions,
+  | "onAgentRunStart"
+  | "onAssistantMessageStart"
+  | "onPartialReply"
+  | "onReasoningStream"
+  | "onReasoningEnd"
+  | "onToolStart"
+  | "onItemEvent"
+  | "onPlanUpdate"
+  | "onApprovalEvent"
+  | "onCommandOutput"
+  | "onPatchSummary"
+  | "onCompactionStart"
+  | "onCompactionEnd"
+>;
+
+export type CreateReplyActivityCallbacksOptions = {
+  /**
+   * Receive normalized live activity emitted directly from the reply execution
+   * path. This avoids relying on the global agent-event bus for channel-local
+   * UI/status updates.
+   */
+  onEvent: ReplyActivityOnEvent;
+  /**
+   * Text deltas are opt-in so plugins can keep existing partial-reply handling
+   * without accidentally duplicating outbound text on their activity stream.
+   */
+  includePartialReplies?: boolean;
+};
+
+function emitNoPayload(
+  onEvent: ReplyActivityOnEvent,
+  type: "assistant_message_start" | "reasoning_end" | "compaction_start" | "compaction_end",
+): Promise<void> | void {
+  return onEvent({ type });
+}
+
+function emit(onEvent: ReplyActivityOnEvent, event: ReplyActivityEvent): Promise<void> | void {
+  return onEvent(event);
+}
+
+export function createReplyActivityCallbacks(
+  params: CreateReplyActivityCallbacksOptions,
+): ReplyActivityCallbacks {
+  return {
+    onAgentRunStart: (runId) =>
+      emit(params.onEvent, {
+        type: "agent_run_start",
+        payload: { runId },
+      }),
+    onAssistantMessageStart: () => emitNoPayload(params.onEvent, "assistant_message_start"),
+    onPartialReply: params.includePartialReplies
+      ? (payload) => emit(params.onEvent, { type: "partial_reply", payload })
+      : undefined,
+    onReasoningStream: (payload) => emit(params.onEvent, { type: "reasoning", payload }),
+    onReasoningEnd: () => emitNoPayload(params.onEvent, "reasoning_end"),
+    onToolStart: (payload) => emit(params.onEvent, { type: "tool_start", payload }),
+    onItemEvent: (payload) => emit(params.onEvent, { type: "item", payload }),
+    onPlanUpdate: (payload) => emit(params.onEvent, { type: "plan_update", payload }),
+    onApprovalEvent: (payload) => emit(params.onEvent, { type: "approval", payload }),
+    onCommandOutput: (payload) => emit(params.onEvent, { type: "command_output", payload }),
+    onPatchSummary: (payload) => emit(params.onEvent, { type: "patch_summary", payload }),
+    onCompactionStart: () => emitNoPayload(params.onEvent, "compaction_start"),
+    onCompactionEnd: () => emitNoPayload(params.onEvent, "compaction_end"),
+  };
+}

--- a/src/plugin-sdk/reply-runtime.test.ts
+++ b/src/plugin-sdk/reply-runtime.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReplyActivityEvent } from "./reply-runtime.js";
+import { createReplyActivityCallbacks } from "./reply-runtime.js";
+
+describe("plugin-sdk/reply-runtime", () => {
+  it("maps live reply activity callbacks into one ordered event stream", async () => {
+    const seen: ReplyActivityEvent[] = [];
+    const callbacks = createReplyActivityCallbacks({
+      onEvent: (event) => {
+        seen.push(event);
+      },
+    });
+
+    callbacks.onAgentRunStart?.("run-1");
+    await callbacks.onReasoningStream?.({ text: "Thinking...", isReasoning: true });
+    await callbacks.onToolStart?.({ name: "exec", phase: "start" });
+    await callbacks.onItemEvent?.({
+      itemId: "item-1",
+      title: "Inspect repo",
+      phase: "running",
+    });
+    await callbacks.onPlanUpdate?.({
+      phase: "update",
+      explanation: "Inspect, patch, verify.",
+      steps: ["Inspect", "Patch", "Verify"],
+    });
+    await callbacks.onApprovalEvent?.({
+      status: "pending",
+      command: "pnpm test",
+    });
+    await callbacks.onCommandOutput?.({
+      output: "ok",
+      exitCode: 0,
+    });
+    await callbacks.onPatchSummary?.({
+      summary: "1 modified",
+    });
+    await callbacks.onAssistantMessageStart?.();
+    await callbacks.onReasoningEnd?.();
+
+    expect(callbacks.onPartialReply).toBeUndefined();
+    expect(seen).toEqual([
+      { type: "agent_run_start", payload: { runId: "run-1" } },
+      { type: "reasoning", payload: { text: "Thinking...", isReasoning: true } },
+      { type: "tool_start", payload: { name: "exec", phase: "start" } },
+      {
+        type: "item",
+        payload: {
+          itemId: "item-1",
+          title: "Inspect repo",
+          phase: "running",
+        },
+      },
+      {
+        type: "plan_update",
+        payload: {
+          phase: "update",
+          explanation: "Inspect, patch, verify.",
+          steps: ["Inspect", "Patch", "Verify"],
+        },
+      },
+      {
+        type: "approval",
+        payload: {
+          status: "pending",
+          command: "pnpm test",
+        },
+      },
+      {
+        type: "command_output",
+        payload: {
+          output: "ok",
+          exitCode: 0,
+        },
+      },
+      {
+        type: "patch_summary",
+        payload: {
+          summary: "1 modified",
+        },
+      },
+      { type: "assistant_message_start" },
+      { type: "reasoning_end" },
+    ]);
+  });
+
+  it("can opt into partial reply deltas when a plugin wants them on the activity stream", async () => {
+    const onEvent = vi.fn();
+    const callbacks = createReplyActivityCallbacks({
+      onEvent,
+      includePartialReplies: true,
+    });
+
+    await callbacks.onPartialReply?.({ text: "Partial answer" });
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: "partial_reply",
+      payload: { text: "Partial answer" },
+    });
+  });
+});

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -10,6 +10,12 @@ export {
   resolveTextChunkLimit,
 } from "../auto-reply/chunk.js";
 export type { ChunkMode } from "../auto-reply/chunk.js";
+export { createReplyActivityCallbacks } from "./reply-activity.js";
+export type {
+  CreateReplyActivityCallbacksOptions,
+  ReplyActivityCallbacks,
+  ReplyActivityEvent,
+} from "./reply-activity.js";
 export {
   dispatchInboundMessage,
   dispatchInboundMessageWithBufferedDispatcher,


### PR DESCRIPTION
## Summary

- Problem: custom channel plugins can dispatch inbound runs through the shared reply pipeline, but they do not have a simple plugin-facing seam for live reasoning/tool/item/approval activity. Plugin authors are pushed toward `runtime.events.onAgentEvent(...)`, which is the wrong model for non-Control-UI channels.
- Why it matters: the global agent-event bus depends on Control UI visibility and session-key attachment, so third-party channels can miss internal traces even though the direct run path already emits them.
- What changed: added `createReplyActivityCallbacks(...)` to `openclaw/plugin-sdk/reply-runtime`, which normalizes the direct `replyOptions` callbacks into one ordered activity stream for channel plugins, plus docs showing the intended pattern.
- What did NOT change (scope boundary): no change to `isInternalMessageChannel(...)`, Control UI visibility rules, webchat routing, or the global agent-event bus. This stays additive and plugin-local.
- AI-assisted: Codex
- Branch base note: this branch was authored from upstream release tag `v2026.4.11` as requested, not from `main`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: channel plugins already receive direct per-run `replyOptions` callbacks from `agent-runner-execution`, but the SDK did not expose a simple channel-facing contract that gathered those callbacks into a usable activity stream. That gap encouraged integrations to depend on the global agent-event bus instead.
- Missing detection / guardrail: there was no plugin-SDK helper or channel-plugin doc path that made the direct callback seam obvious.
- Contributing context (if known): global agent events are keyed for internal Control UI flows, while third-party channel plugins are not internal surfaces by default.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugin-sdk/reply-runtime.test.ts`
- Scenario the test should lock in: channel plugins can build one ordered live activity stream from direct `replyOptions` callbacks, and partial text deltas remain opt-in.
- Why this is the smallest reliable guardrail: the change is an additive SDK helper with no transport-specific behavior; the contract lives entirely in the helper mapping.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Channel plugin authors can import `createReplyActivityCallbacks(...)` from `openclaw/plugin-sdk/reply-runtime` instead of wiring many low-level callbacks by hand or relying on `runtime.events.onAgentEvent(...)`.
- `docs/plugins/sdk-channel-plugins.md` now documents the direct activity-stream pattern for custom channels.
- No behavior change for existing built-in channels unless they opt into the helper.

## Diagram (if applicable)

```text
Before:
[channel plugin] -> runtime.events.onAgentEvent(...) -> Control UI visibility/sessionKey coupling -> missed live activity

After:
[channel plugin] -> direct replyOptions callbacks -> createReplyActivityCallbacks(...) -> ordered plugin-owned activity stream
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm repo toolchain
- Model/provider: N/A
- Integration/channel (if any): custom channel plugin SDK surface
- Relevant config (redacted): N/A

### Steps

1. Build a channel plugin that dispatches inbound replies through `dispatchInboundReplyWithBase(...)`.
2. Try to surface live reasoning/tool/item/approval activity by listening on `runtime.events.onAgentEvent(...)`.
3. Compare that with using the direct `replyOptions` callback path.

### Expected

- Channel plugins should have a first-class, documented way to receive live internal activity from the run they dispatched.

### Actual

- The SDK exposed the raw callbacks internally, but there was no simple plugin-facing contract around them, so non-Control-UI channels were pushed toward the wrong global event seam.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: the new helper emits ordered activity events for run start, reasoning, tool start, item updates, plan updates, approval updates, command output, patch summary, and assistant-message/reasoning boundaries; partial deltas stay disabled by default and can be enabled explicitly.
- Edge cases checked: opt-in partial reply forwarding; SDK API baseline regeneration/check; full build and local check gates on the release-tag branch.
- What you did **not** verify: a live third-party channel plugin consuming the helper over an actual transport.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: plugin authors may assume this helper mirrors the global agent-event payloads exactly.
  - Mitigation: the helper uses its own explicit event union and the docs call it out as the direct `replyOptions` seam, not a wrapper around the global event bus.
- Risk: plugins that already stream partial replies separately could duplicate text if they forward deltas twice.
  - Mitigation: partial reply forwarding is opt-in via `includePartialReplies: true`.
