### PR TITLE
fix(mattermost): forward media access context in handleAction send

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -453,6 +453,60 @@ describe("mattermostPlugin", () => {
         }),
       );
     });
+
+    it("forwards mediaLocalRoots and mediaReadFile on handleAction send", async () => {
+      const cfg = createMattermostTestConfig();
+      const mockReadFile = vi.fn().mockResolvedValue(Buffer.from("test"));
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+            media: "/tmp/workspace/image.png",
+          },
+          cfg,
+          accountId: "default",
+          mediaLocalRoots: ["/tmp/workspace"],
+          mediaReadFile: mockReadFile,
+        }),
+      );
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({
+          mediaUrl: "/tmp/workspace/image.png",
+          mediaLocalRoots: ["/tmp/workspace"],
+          mediaReadFile: mockReadFile,
+        }),
+      );
+    });
+
+    it("forwards cfg on handleAction send", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+          },
+          cfg,
+          accountId: "default",
+        }),
+      );
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({
+          cfg,
+        }),
+      );
+    });
   });
 
   describe("outbound", () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -142,7 +142,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
   supportsAction: ({ action }) => {
     return action === "send" || action === "react";
   },
-  handleAction: async ({ action, params, cfg, accountId }) => {
+  handleAction: async ({ action, params, cfg, accountId, mediaLocalRoots, mediaReadFile }) => {
     if (action === "react") {
       const resolvedAccountId = accountId ?? resolveDefaultMattermostAccountId(cfg);
       const mattermostConfig = cfg.channels?.mattermost as MattermostConfig | undefined;
@@ -220,11 +220,14 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     const result = await (
       await loadMattermostChannelRuntime()
     ).sendMessageMattermost(to, message, {
+      cfg,
       accountId: resolvedAccountId,
       replyToId,
       buttons: Array.isArray(params.buttons) ? params.buttons : undefined,
       attachmentText: typeof params.attachmentText === "string" ? params.attachmentText : undefined,
       mediaUrl,
+      mediaLocalRoots,
+      mediaReadFile,
     });
 
     return {


### PR DESCRIPTION
## Summary

- Forward `mediaLocalRoots`, `mediaReadFile`, and `cfg` from the `ChannelMessageActionContext` to `sendMessageMattermost()` in the Mattermost plugin's `handleAction` send path
- Without these fields, file uploads through the agent `message` tool fail because the send function cannot resolve local media paths within the agent's sandbox
- The reply-delivery path already forwarded these correctly; only the `handleAction` send path was missing them
- Every other channel plugin (Discord, Slack, MS Teams, Google Chat) already forwards these fields

## Test plan

- [x] Added unit tests verifying `mediaLocalRoots`, `mediaReadFile`, and `cfg` forwarding
- [x] Ran `pnpm test extensions/mattermost/src/channel.test.ts` — all tests pass
- [x] Manual test: sent PNG image via `openclaw message send --channel mattermost --media /tmp/test-red.png` — image attachment delivered
- [x] Manual test: sent Excel file via `openclaw message send --channel mattermost --media /tmp/test-data.xlsx` — file attachment delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)