### PR TITLE
fix: Provider-supplied OAuth URLs inject Windows cmd.exe via openUrl

### DIFF
--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -2,32 +2,14 @@ import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeGatewayTokenInput,
-  openUrl,
   probeGatewayReachable,
-  resolveBrowserOpenCommand,
   resolveControlUiLinks,
   validateGatewayPasswordInput,
 } from "./onboard-helpers.js";
 
 const mocks = vi.hoisted(() => ({
-  runCommandWithTimeout: vi.fn<
-    (
-      argv: string[],
-      options?: { timeoutMs?: number; windowsVerbatimArguments?: boolean },
-    ) => Promise<{ stdout: string; stderr: string; code: number; signal: null; killed: boolean }>
-  >(async () => ({
-    stdout: "",
-    stderr: "",
-    code: 0,
-    signal: null,
-    killed: false,
-  })),
   pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
   probeGateway: vi.fn(),
-}));
-
-vi.mock("../process/exec.js", () => ({
-  runCommandWithTimeout: mocks.runCommandWithTimeout,
 }));
 
 vi.mock("../infra/tailnet.js", () => ({
@@ -39,41 +21,11 @@ vi.mock("../gateway/probe.js", () => ({
 }));
 
 afterEach(() => {
+  mocks.pickPrimaryTailnetIPv4.mockReset();
+  mocks.pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+  mocks.probeGateway.mockReset();
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
-});
-
-describe("openUrl", () => {
-  it("passes provider-supplied Windows URLs to explorer.exe without cmd parsing", async () => {
-    vi.stubEnv("VITEST", "");
-    vi.stubEnv("NODE_ENV", "");
-    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    vi.stubEnv("VITEST", "");
-    vi.stubEnv("NODE_ENV", "development");
-
-    const url = 'https://example.invalid/" & calc & rem "';
-
-    const ok = await openUrl(url);
-    expect(ok).toBe(true);
-
-    expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(1);
-    const [argv, options] = mocks.runCommandWithTimeout.mock.calls[0] ?? [];
-    expect(argv).toEqual(["explorer.exe", url]);
-    expect(options).toMatchObject({ timeoutMs: 5_000 });
-    expect(options?.windowsVerbatimArguments).toBeUndefined();
-
-    platformSpy.mockRestore();
-  });
-});
-
-describe("resolveBrowserOpenCommand", () => {
-  it("uses explorer.exe on win32", async () => {
-    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const resolved = await resolveBrowserOpenCommand();
-    expect(resolved.argv).toEqual(["explorer.exe"]);
-    expect(resolved.command).toBe("explorer.exe");
-    platformSpy.mockRestore();
-  });
 });
 
 describe("probeGatewayReachable", () => {

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -44,15 +44,14 @@ afterEach(() => {
 });
 
 describe("openUrl", () => {
-  it("passes OAuth URLs to explorer.exe on win32 without cmd parsing", async () => {
+  it("passes provider-supplied Windows URLs to explorer.exe without cmd parsing", async () => {
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "");
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     vi.stubEnv("VITEST", "");
     vi.stubEnv("NODE_ENV", "development");
 
-    const url =
-      "https://accounts.google.com/o/oauth2/v2/auth?client_id=abc&response_type=code&redirect_uri=http%3A%2F%2Flocalhost";
+    const url = 'https://example.invalid/" & calc & rem "';
 
     const ok = await openUrl(url);
     expect(ok).toBe(true);

--- a/src/infra/browser-open.test.ts
+++ b/src/infra/browser-open.test.ts
@@ -5,15 +5,15 @@ const detectBinaryMock = vi.hoisted(() => vi.fn(async () => true));
 const isWSLMock = vi.hoisted(() => vi.fn(async () => false));
 
 vi.mock("../process/exec.js", () => ({
-  runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
+  runCommandWithTimeout: runCommandWithTimeoutMock,
 }));
 
 vi.mock("./detect-binary.js", () => ({
-  detectBinary: (...args: unknown[]) => detectBinaryMock(...args),
+  detectBinary: detectBinaryMock,
 }));
 
 vi.mock("./wsl.js", () => ({
-  isWSL: (...args: unknown[]) => isWSLMock(...args),
+  isWSL: isWSLMock,
 }));
 
 const { openUrl, openUrlInBackground, resolveBrowserOpenCommand } = await import("./browser-open.js");

--- a/src/infra/browser-open.test.ts
+++ b/src/infra/browser-open.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
+const detectBinaryMock = vi.hoisted(() => vi.fn(async () => true));
+const isWSLMock = vi.hoisted(() => vi.fn(async () => false));
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
+}));
+
+vi.mock("./detect-binary.js", () => ({
+  detectBinary: (...args: unknown[]) => detectBinaryMock(...args),
+}));
+
+vi.mock("./wsl.js", () => ({
+  isWSL: (...args: unknown[]) => isWSLMock(...args),
+}));
+
+const { openUrl, openUrlInBackground, resolveBrowserOpenCommand } = await import("./browser-open.js");
+
+beforeEach(() => {
+  runCommandWithTimeoutMock.mockReset();
+  detectBinaryMock.mockReset();
+  detectBinaryMock.mockResolvedValue(true);
+  isWSLMock.mockReset();
+  isWSLMock.mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("resolveBrowserOpenCommand", () => {
+  it("uses explorer.exe on win32", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    try {
+      const resolved = await resolveBrowserOpenCommand();
+      expect(resolved.argv).toEqual(["explorer.exe"]);
+      expect(resolved.command).toBe("explorer.exe");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+});
+
+describe("openUrl", () => {
+  it("passes safe Windows URLs to explorer.exe without cmd parsing", async () => {
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "development");
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const url = "https://example.invalid/oauth?code=abc#state=123";
+
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+    });
+
+    try {
+      await expect(openUrl(url)).resolves.toBe(true);
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(1);
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(["explorer.exe", url], {
+        timeoutMs: 5_000,
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("rejects provider-supplied Windows URLs with embedded quotes", async () => {
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "development");
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    try {
+      await expect(openUrl('https://example.invalid/" & calc & rem "')).resolves.toBe(false);
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("rejects non-http browser URLs", async () => {
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "development");
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    try {
+      await expect(openUrl("javascript:alert(1)")).resolves.toBe(false);
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+});
+
+describe("openUrlInBackground", () => {
+  it("rejects quoted URLs before invoking open", async () => {
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "development");
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+
+    try {
+      await expect(openUrlInBackground('https://example.invalid/"bad"')).resolves.toBe(false);
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+});

--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -14,11 +14,27 @@ export type BrowserOpenSupport = {
   command?: string;
 };
 
+const ALLOWED_BROWSER_OPEN_PROTOCOLS = new Set(["http:", "https:"]);
+const FORBIDDEN_BROWSER_OPEN_CHARS = /["\r\n\t]/;
+
 function shouldSkipBrowserOpenInTests(): boolean {
   if (process.env.VITEST) {
     return true;
   }
   return process.env.NODE_ENV === "test";
+}
+
+function resolveSafeBrowserOpenUrl(url: string): string | null {
+  const candidate = url.trim();
+  if (!candidate || FORBIDDEN_BROWSER_OPEN_CHARS.test(candidate)) {
+    return null;
+  }
+  try {
+    const parsed = new URL(candidate);
+    return ALLOWED_BROWSER_OPEN_PROTOCOLS.has(parsed.protocol) ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
 }
 
 export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
@@ -80,12 +96,16 @@ export async function openUrl(url: string): Promise<boolean> {
   if (shouldSkipBrowserOpenInTests()) {
     return false;
   }
+  const safeUrl = resolveSafeBrowserOpenUrl(url);
+  if (!safeUrl) {
+    return false;
+  }
   const resolved = await resolveBrowserOpenCommand();
   if (!resolved.argv) {
     return false;
   }
   const command = [...resolved.argv];
-  command.push(url);
+  command.push(safeUrl);
   try {
     await runCommandWithTimeout(command, { timeoutMs: 5_000 });
     return true;
@@ -98,6 +118,10 @@ export async function openUrlInBackground(url: string): Promise<boolean> {
   if (shouldSkipBrowserOpenInTests()) {
     return false;
   }
+  const safeUrl = resolveSafeBrowserOpenUrl(url);
+  if (!safeUrl) {
+    return false;
+  }
   if (process.platform !== "darwin") {
     return false;
   }
@@ -106,7 +130,7 @@ export async function openUrlInBackground(url: string): Promise<boolean> {
     return false;
   }
   try {
-    await runCommandWithTimeout(["open", "-g", url], { timeoutMs: 5_000 });
+    await runCommandWithTimeout(["open", "-g", safeUrl], { timeoutMs: 5_000 });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Fix Summary
On Windows, a malicious or compromised provider response can turn an OAuth or sign-in URL into arbitrary command execution on the gateway host. The vulnerable helper wraps the raw string in quotes for `cmd /c start` but never parses the URL or escapes embedded quotes, so `"` plus `&` or `|` breaks out of the browser-open argument.

## Issue Linkage
Fixes #64159

## Security Snapshot
- CVSS v3.1: 8.3 (High)
- CVSS v4.0: 9.0 (Critical)

## Implementation Details
### Files Changed
- `src/commands/onboard-helpers.test.ts` (+3/-52)
- `src/infra/browser-open.test.ts` (+114/-0)
- `src/infra/browser-open.ts` (+26/-2)

### Technical Analysis
1. On a Windows gateway, start MiniMax portal OAuth or Ollama Cloud sign-in so OpenClaw will call the shared `openUrl()` helper.
2. Make the provider endpoint return a crafted URL field containing an injected closing quote and command separator:
   ```json
   {"verification_uri":"https://example.invalid/\" & calc & rem \""}
   ```
3. OpenClaw builds `cmd /c start "" "https://example.invalid/" & calc & rem ""` and launches it with `windowsVerbatimArguments: true`.
4. `cmd.exe` treats the injected `"` as the end of the browser argument and executes `calc` on the host.

## Validation Evidence
- Command: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
- non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: github-copilot/gpt-5.4
