### PR TITLE
fix(image-tool): resolve default provider from config instead of hardcoding openai

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1612,6 +1612,69 @@ describe("runWithImageModelFallback", () => {
       ["google", "gemini-2.5-flash-image-preview"],
     ]);
   });
+
+  it("uses configured provider for bare image model names instead of hardcoding openai", async () => {
+    // When the user's primary model is ollama-based and they set imageModel
+    // to a bare name like "qwen3.5:latest", the image tool should resolve it
+    // as "ollama/qwen3.5:latest" — not "openai/qwen3.5:latest".
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: { primary: "ollama/llama3.1:latest" },
+          imageModel: { primary: "qwen3.5:latest" },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce("described");
+
+    const result = await runWithImageModelFallback({ cfg, run });
+
+    expect(result.result).toBe("described");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0]?.[0]).toBe("ollama");
+    expect(run.mock.calls[0]?.[1]).toBe("qwen3.5:latest");
+  });
+
+  it("falls back to openai when no primary model is configured", async () => {
+    // With no agents.defaults.model configured, bare image model names
+    // should still default to openai (backwards compatible).
+    const cfg = {
+      agents: {
+        defaults: {
+          imageModel: { primary: "gpt-image-1" },
+        },
+      },
+    } as OpenClawConfig;
+    const run = vi.fn().mockResolvedValueOnce("described");
+
+    const result = await runWithImageModelFallback({ cfg, run });
+
+    expect(result.result).toBe("described");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0]?.[0]).toBe("openai");
+    expect(run.mock.calls[0]?.[1]).toBe("gpt-image-1");
+  });
+
+  it("respects explicit provider prefix even when default provider differs", async () => {
+    // When image model has explicit "google/" prefix but default provider is
+    // ollama, the explicit prefix should win.
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: { primary: "ollama/llama3.1:latest" },
+          imageModel: { primary: "google/gemini-2.5-flash-image-preview" },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce("described");
+
+    const result = await runWithImageModelFallback({ cfg, run });
+
+    expect(result.result).toBe("described");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0]?.[0]).toBe("google");
+    expect(run.mock.calls[0]?.[1]).toBe("gemini-2.5-flash-image-preview");
+  });
 });
 
 describe("isAnthropicBillingError", () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -907,9 +907,22 @@ export async function runWithImageModelFallback<T>(params: {
   run: (provider: string, model: string) => Promise<T>;
   onError?: ModelFallbackErrorHandler;
 }): Promise<ModelFallbackRunResult<T>> {
+  // Resolve the default provider from user config so that bare model names
+  // (e.g. "qwen3.5:latest") are attributed to the configured provider
+  // (e.g. "ollama") instead of always defaulting to "openai".  This mirrors
+  // the pattern used in resolveFallbackCandidates for the main model chain.
+  const configuredPrimary = params.cfg
+    ? resolveConfiguredModelRef({
+        cfg: params.cfg,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      })
+    : null;
+  const defaultProvider = configuredPrimary?.provider ?? DEFAULT_PROVIDER;
+
   const candidates = resolveImageFallbackCandidates({
     cfg: params.cfg,
-    defaultProvider: DEFAULT_PROVIDER,
+    defaultProvider,
     modelOverride: params.modelOverride,
   });
   if (candidates.length === 0) {


### PR DESCRIPTION
## Summary

Fixes #65595 — the `image` tool hardcodes `openai/` as the provider prefix for bare model names, breaking non-OpenAI vision models (Ollama, Google, etc.).

**Root cause:** `runWithImageModelFallback` passes `DEFAULT_PROVIDER` (`"openai"`) to `resolveImageFallbackCandidates`, so when a user configures `agents.defaults.imageModel` to a bare name like `qwen3.5:latest`, it resolves to `openai/qwen3.5:latest` instead of using their configured provider.

**Fix:** Resolve the default provider from the user's `agents.defaults.model` config before passing it to the image fallback resolver — the same pattern already used by `resolveFallbackCandidates` (the main model fallback chain). When no primary model is configured, the behavior is unchanged (falls back to `openai`).

This also benefits the PDF tool, which shares the same `runWithImageModelFallback` code path.

## Changes

- `src/agents/model-fallback.ts`: In `runWithImageModelFallback`, resolve the configured primary model ref to determine the default provider instead of hardcoding `DEFAULT_PROVIDER`.
- `src/agents/model-fallback.test.ts`: Added 3 test cases:
  - Bare image model name uses configured provider (e.g. `ollama`)
  - Falls back to `openai` when no primary model is configured (backwards compat)
  - Explicit provider prefix takes precedence even when default provider differs

## Test plan

- [x] All 68 tests in `model-fallback.test.ts` pass (including 3 new)
- [x] All 35 tests in `image-tool.test.ts` pass (unchanged)
- [x] All 82 tests in `model-selection.test.ts` pass (unchanged)
- [x] Pre-commit hooks pass (tsgo, oxlint, import cycle checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)