### PR TITLE
feat: add HOL Guard pre-execution plugin

### DIFF
--- a/extensions/hol-guard/index.test.ts
+++ b/extensions/hol-guard/index.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.ts";
+import plugin from "./index.js";
+
+type HookHandler = (event: Record<string, unknown>, ctx: Record<string, unknown>) => unknown;
+
+type RegisteredHooks = Map<string, HookHandler>;
+
+function createJsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function setupPlugin(config?: Record<string, unknown>): RegisteredHooks {
+  const hooks = new Map<string, HookHandler>();
+  const api = createTestPluginApi({
+    id: "hol-guard",
+    name: "HOL Guard",
+    pluginConfig: config ?? {},
+    on: (hookName, handler) => {
+      hooks.set(hookName, handler as HookHandler);
+    },
+  });
+  void plugin.register(api);
+  return hooks;
+}
+
+describe("hol-guard plugin", () => {
+  const originalGuardToken = process.env.OPENCLAW_GUARD_TOKEN;
+
+  beforeEach(() => {
+    process.env.OPENCLAW_GUARD_TOKEN = "guard-token";
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalGuardToken === undefined) {
+      delete process.env.OPENCLAW_GUARD_TOKEN;
+    } else {
+      process.env.OPENCLAW_GUARD_TOKEN = originalGuardToken;
+    }
+  });
+
+  it("blocks malicious tool execution and emits receipt plus pain signal", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          decision: "block",
+          rationale: "Known malicious MCP launcher",
+          scope: "workspace",
+        }),
+      )
+      .mockResolvedValueOnce(createJsonResponse({ ok: true }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hooks = setupPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+      failOpen: false,
+    });
+    const beforeToolCall = hooks.get("before_tool_call");
+
+    const result = await beforeToolCall?.(
+      {
+        toolName: "mcp_bash_proxy",
+        toolCallId: "tool-1",
+        params: {
+          guardArtifact: {
+            artifactId: "mcp-server:openclaw:malicious-proxy",
+            artifactName: "malicious proxy",
+            artifactSlug: "malicious-proxy",
+            artifactType: "mcp-server",
+            publisher: "bad-actor",
+            domain: "exfil.bad",
+            launchSummary: "bash wrapper exfiltrates ~/.env over HTTPS",
+          },
+        },
+      },
+      {
+        runId: "run-1",
+        toolName: "mcp_bash_proxy",
+        toolCallId: "tool-1",
+      },
+    );
+
+    expect(result).toEqual({
+      block: true,
+      blockReason: "Known malicious MCP launcher",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://guard.example/api/v1/consumer/verdict/pre-execution",
+    );
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://guard.example/api/v1/consumer/receipts/submit",
+    );
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("https://guard.example/api/v1/consumer/signals/pain");
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: "POST",
+      headers: {
+        Authorization: "Bearer guard-token",
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
+  it("requires approval for review verdicts and records a receipt after allowed execution", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          decision: "review",
+          rationale: "Artifact changed domains since last approval",
+          scope: "workspace",
+        }),
+      )
+      .mockResolvedValueOnce(createJsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hooks = setupPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+      painSignalsEnabled: false,
+    });
+    const beforeToolCall = hooks.get("before_tool_call");
+    const afterToolCall = hooks.get("after_tool_call");
+
+    const reviewResult = (await beforeToolCall?.(
+      {
+        toolName: "mcp_changed_proxy",
+        toolCallId: "tool-2",
+        params: {
+          artifactId: "mcp-server:openclaw:changed-proxy",
+          artifactName: "changed proxy",
+          artifactSlug: "changed-proxy",
+          artifactType: "mcp-server",
+          launchSummary: "changed domain from safe.example to risky.example",
+        },
+      },
+      {
+        runId: "run-2",
+        toolName: "mcp_changed_proxy",
+        toolCallId: "tool-2",
+      },
+    )) as {
+      requireApproval?: {
+        title: string;
+        onResolution?: (decision: "allow-once" | "allow-always" | "deny") => Promise<void>;
+      };
+    };
+
+    expect(reviewResult.requireApproval?.title).toContain("changed proxy");
+    await reviewResult.requireApproval?.onResolution?.("allow-once");
+    await afterToolCall?.(
+      {
+        toolName: "mcp_changed_proxy",
+        toolCallId: "tool-2",
+        params: {
+          artifactId: "mcp-server:openclaw:changed-proxy",
+          artifactName: "changed proxy",
+          artifactSlug: "changed-proxy",
+          artifactType: "mcp-server",
+        },
+        result: { ok: true },
+      },
+      {
+        runId: "run-2",
+        toolName: "mcp_changed_proxy",
+        toolCallId: "tool-2",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://guard.example/api/v1/consumer/receipts/submit",
+    );
+  });
+
+  it("records denial outcomes for review verdicts", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          decision: "review",
+          rationale: "Needs explicit review",
+          scope: "workspace",
+        }),
+      )
+      .mockResolvedValueOnce(createJsonResponse({ ok: true }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hooks = setupPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+    });
+    const beforeToolCall = hooks.get("before_tool_call");
+
+    const reviewResult = (await beforeToolCall?.(
+      {
+        toolName: "mcp_reviewable",
+        toolCallId: "tool-3",
+        params: {
+          artifactId: "mcp-server:openclaw:reviewable",
+          artifactName: "reviewable",
+          artifactSlug: "reviewable",
+          artifactType: "mcp-server",
+          launchSummary: "suspicious but not auto-blocked",
+        },
+      },
+      {
+        runId: "run-3",
+        toolName: "mcp_reviewable",
+        toolCallId: "tool-3",
+      },
+    )) as {
+      requireApproval?: {
+        onResolution?: (decision: "deny") => Promise<void>;
+      };
+    };
+
+    await reviewResult.requireApproval?.onResolution?.("deny");
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://guard.example/api/v1/consumer/receipts/submit",
+    );
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("https://guard.example/api/v1/consumer/signals/pain");
+  });
+
+  it("fails closed when verdict lookup errors and failOpen is disabled", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hooks = setupPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+      failOpen: false,
+    });
+    const beforeToolCall = hooks.get("before_tool_call");
+
+    const result = await beforeToolCall?.(
+      {
+        toolName: "mcp_unreachable",
+        toolCallId: "tool-4",
+        params: {
+          artifactId: "mcp-server:openclaw:unreachable",
+          artifactName: "unreachable",
+          artifactSlug: "unreachable",
+          artifactType: "mcp-server",
+          launchSummary: "guard service unavailable",
+        },
+      },
+      {
+        runId: "run-4",
+        toolName: "mcp_unreachable",
+        toolCallId: "tool-4",
+      },
+    );
+
+    expect(result).toEqual({
+      block: true,
+      blockReason: "HOL Guard policy lookup failed: network down",
+    });
+  });
+});

--- a/extensions/hol-guard/index.test.ts
+++ b/extensions/hol-guard/index.test.ts
@@ -38,6 +38,7 @@ describe("hol-guard plugin", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     if (originalGuardToken === undefined) {
       delete process.env.OPENCLAW_GUARD_TOKEN;
     } else {

--- a/extensions/hol-guard/index.test.ts
+++ b/extensions/hol-guard/index.test.ts
@@ -305,6 +305,46 @@ describe("hol-guard plugin", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("preserves valid guard settings when tokenEnvVar is malformed", async () => {
+    delete process.env.OPENCLAW_GUARD_TOKEN;
+
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hooks = setupPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+      failOpen: false,
+      tokenEnvVar: "   ",
+    });
+    const beforeToolCall = hooks.get("before_tool_call");
+
+    const result = await beforeToolCall?.(
+      {
+        toolName: "mcp_invalid_token_env",
+        toolCallId: "tool-invalid-token-env",
+        params: {
+          artifactId: "mcp-server:openclaw:invalid-token-env",
+          artifactName: "invalid token env",
+          artifactSlug: "invalid-token-env",
+          artifactType: "mcp-server",
+          launchSummary: "guard config uses a whitespace token env var",
+        },
+      },
+      {
+        runId: "run-invalid-token-env",
+        toolName: "mcp_invalid_token_env",
+        toolCallId: "tool-invalid-token-env",
+      },
+    );
+
+    expect(result).toEqual({
+      block: true,
+      blockReason:
+        "HOL Guard policy lookup failed: Missing HOL Guard token in OPENCLAW_GUARD_TOKEN",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("fails closed when the guard verdict payload is malformed", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(createJsonResponse({ ok: true }));
     vi.stubGlobal("fetch", fetchMock);

--- a/extensions/hol-guard/index.test.ts
+++ b/extensions/hol-guard/index.test.ts
@@ -305,6 +305,42 @@ describe("hol-guard plugin", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("fails closed when the guard verdict payload is malformed", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(createJsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hooks = setupPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+      failOpen: false,
+    });
+    const beforeToolCall = hooks.get("before_tool_call");
+
+    const result = await beforeToolCall?.(
+      {
+        toolName: "mcp_invalid_verdict",
+        toolCallId: "tool-invalid-verdict",
+        params: {
+          artifactId: "mcp-server:openclaw:invalid-verdict",
+          artifactName: "invalid verdict",
+          artifactSlug: "invalid-verdict",
+          artifactType: "mcp-server",
+          launchSummary: "guard returned malformed verdict payload",
+        },
+      },
+      {
+        runId: "run-invalid-verdict",
+        toolName: "mcp_invalid_verdict",
+        toolCallId: "tool-invalid-verdict",
+      },
+    );
+
+    expect(result).toEqual({
+      block: true,
+      blockReason: "HOL Guard policy lookup failed: Invalid HOL Guard verdict payload.",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves a block verdict when receipt signaling fails", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()

--- a/extensions/hol-guard/index.test.ts
+++ b/extensions/hol-guard/index.test.ts
@@ -265,4 +265,88 @@ describe("hol-guard plugin", () => {
       blockReason: "HOL Guard policy lookup failed: network down",
     });
   });
+
+  it("fails closed when the configured guard token is missing and failOpen is disabled", async () => {
+    delete process.env.OPENCLAW_GUARD_TOKEN;
+
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hooks = setupPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+      failOpen: false,
+    });
+    const beforeToolCall = hooks.get("before_tool_call");
+
+    const result = await beforeToolCall?.(
+      {
+        toolName: "mcp_missing_token",
+        toolCallId: "tool-5",
+        params: {
+          artifactId: "mcp-server:openclaw:missing-token",
+          artifactName: "missing token",
+          artifactSlug: "missing-token",
+          artifactType: "mcp-server",
+          launchSummary: "guard token missing",
+        },
+      },
+      {
+        runId: "run-5",
+        toolName: "mcp_missing_token",
+        toolCallId: "tool-5",
+      },
+    );
+
+    expect(result).toEqual({
+      block: true,
+      blockReason:
+        "HOL Guard policy lookup failed: Missing HOL Guard token in OPENCLAW_GUARD_TOKEN",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves a block verdict when receipt signaling fails", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          decision: "block",
+          rationale: "Known malicious MCP launcher",
+          scope: "workspace",
+        }),
+      )
+      .mockRejectedValueOnce(new Error("receipt endpoint unavailable"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hooks = setupPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+      failOpen: true,
+    });
+    const beforeToolCall = hooks.get("before_tool_call");
+
+    const result = await beforeToolCall?.(
+      {
+        toolName: "mcp_bash_proxy",
+        toolCallId: "tool-6",
+        params: {
+          artifactId: "mcp-server:openclaw:malicious-proxy",
+          artifactName: "malicious proxy",
+          artifactSlug: "malicious-proxy",
+          artifactType: "mcp-server",
+          launchSummary: "bash wrapper exfiltrates ~/.env over HTTPS",
+        },
+      },
+      {
+        runId: "run-6",
+        toolName: "mcp_bash_proxy",
+        toolCallId: "tool-6",
+      },
+    );
+
+    expect(result).toEqual({
+      block: true,
+      blockReason: "Known malicious MCP launcher",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
 });

--- a/extensions/hol-guard/index.test.ts
+++ b/extensions/hol-guard/index.test.ts
@@ -349,4 +349,66 @@ describe("hol-guard plugin", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
+
+  it("does not retain pending execution tracking when receipts are disabled", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      createJsonResponse({
+        decision: "review",
+        rationale: "Needs explicit review",
+        scope: "workspace",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const hooks = setupPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+      receiptsEnabled: false,
+      painSignalsEnabled: false,
+    });
+    const beforeToolCall = hooks.get("before_tool_call");
+    const afterToolCall = hooks.get("after_tool_call");
+
+    const reviewResult = (await beforeToolCall?.(
+      {
+        toolName: "mcp_receiptless_review",
+        toolCallId: "tool-7",
+        params: {
+          artifactId: "mcp-server:openclaw:receiptless-review",
+          artifactName: "receiptless review",
+          artifactSlug: "receiptless-review",
+          artifactType: "mcp-server",
+          launchSummary: "review flow with receipts disabled",
+        },
+      },
+      {
+        runId: "run-7",
+        toolName: "mcp_receiptless_review",
+        toolCallId: "tool-7",
+      },
+    )) as {
+      requireApproval?: {
+        onResolution?: (decision: "allow-once") => Promise<void>;
+      };
+    };
+
+    await reviewResult.requireApproval?.onResolution?.("allow-once");
+    await afterToolCall?.(
+      {
+        toolName: "mcp_receiptless_review",
+        toolCallId: "tool-7",
+        params: {},
+        result: { ok: true },
+      },
+      {
+        runId: "run-7",
+        toolName: "mcp_receiptless_review",
+        toolCallId: "tool-7",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://guard.example/api/v1/consumer/verdict/pre-execution",
+    );
+  });
 });

--- a/extensions/hol-guard/index.ts
+++ b/extensions/hol-guard/index.ts
@@ -70,8 +70,6 @@ const DEFAULT_GUARD_SETTINGS: GuardSettings = {
   painSignalsEnabled: true,
 };
 
-const pendingExecutions = new Map<string, PendingGuardExecution>();
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -186,9 +184,6 @@ async function postGuardJson(
   payload: Record<string, unknown>,
 ): Promise<unknown> {
   const headers = createAuthHeaders(settings);
-  if (!headers) {
-    return undefined;
-  }
   const response = await fetch(`${settings.baseUrl}${path}`, {
     method: "POST",
     headers,
@@ -338,6 +333,7 @@ async function settleResolution(
 }
 
 function rememberPendingExecution(
+  pendingExecutions: Map<string, PendingGuardExecution>,
   runId: string | undefined,
   toolCallId: string | undefined,
   pending: PendingGuardExecution,
@@ -363,6 +359,7 @@ export default definePluginEntry({
   configSchema: buildPluginConfigSchema(guardPluginConfigSchema),
   register(api) {
     const settings = readGuardSettings(api.pluginConfig);
+    const pendingExecutions = new Map<string, PendingGuardExecution>();
 
     api.on("before_tool_call", async (event, ctx) => {
       if (!settings.enabled) {
@@ -376,7 +373,7 @@ export default definePluginEntry({
       try {
         const verdict = await resolvePreExecutionVerdict(settings, artifact);
         if (!verdict || verdict.decision === "allow") {
-          rememberPendingExecution(ctx.runId, event.toolCallId, {
+          rememberPendingExecution(pendingExecutions, ctx.runId, event.toolCallId, {
             artifact,
             recommendation: "monitor",
             rationale: verdict?.rationale || "Guard allowed tool execution.",
@@ -407,7 +404,7 @@ export default definePluginEntry({
             severity: severityForVerdict(verdict),
             async onResolution(resolution) {
               if (resolution === "allow-once" || resolution === "allow-always") {
-                rememberPendingExecution(ctx.runId, event.toolCallId, {
+                rememberPendingExecution(pendingExecutions, ctx.runId, event.toolCallId, {
                   artifact,
                   recommendation: "review",
                   rationale: verdict.rationale || `Guard reviewed ${artifact.artifactName}.`,

--- a/extensions/hol-guard/index.ts
+++ b/extensions/hol-guard/index.ts
@@ -1,0 +1,435 @@
+import { buildPluginConfigSchema, definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { z } from "zod";
+
+const guardPluginConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    baseUrl: z.string().trim().url().optional(),
+    timeoutSeconds: z.number().positive().max(30).optional(),
+    failOpen: z.boolean().optional(),
+    tokenEnvVar: z.string().trim().min(1).optional(),
+    receiptsEnabled: z.boolean().optional(),
+    painSignalsEnabled: z.boolean().optional(),
+  })
+  .strict();
+
+type GuardPluginConfig = z.infer<typeof guardPluginConfigSchema>;
+
+type GuardSettings = {
+  enabled: boolean;
+  baseUrl: string;
+  timeoutMs: number;
+  failOpen: boolean;
+  tokenEnvVar: string;
+  receiptsEnabled: boolean;
+  painSignalsEnabled: boolean;
+};
+
+type GuardArtifact = {
+  artifactId: string;
+  artifactName: string;
+  artifactSlug: string;
+  artifactType: string;
+  harness: string;
+  toolName: string;
+  publisher?: string;
+  domain?: string;
+  launchSummary: string;
+};
+
+type GuardVerdictDecision = "allow" | "review" | "block";
+
+type GuardPreExecutionVerdict = {
+  decision: GuardVerdictDecision;
+  rationale: string;
+  scope: string;
+};
+
+type PendingGuardExecution = {
+  artifact: GuardArtifact;
+  recommendation: string;
+  rationale: string;
+  source: string;
+};
+
+type GuardResolutionReceipt = {
+  recommendation: string;
+  rationale: string;
+  source: string;
+};
+
+type PluginApprovalResolution = "allow-once" | "allow-always" | "deny" | "timeout" | "cancelled";
+
+const DEFAULT_GUARD_SETTINGS: GuardSettings = {
+  enabled: true,
+  baseUrl: "https://hol.org/api/v1/consumer",
+  timeoutMs: 5_000,
+  failOpen: true,
+  tokenEnvVar: "OPENCLAW_GUARD_TOKEN",
+  receiptsEnabled: true,
+  painSignalsEnabled: true,
+};
+
+const pendingExecutions = new Map<string, PendingGuardExecution>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function buildPendingKey(
+  runId: string | undefined,
+  toolCallId: string | undefined,
+): string | undefined {
+  if (!toolCallId) {
+    return undefined;
+  }
+  return runId ? `${runId}:${toolCallId}` : toolCallId;
+}
+
+function readGuardSettings(rawConfig: unknown): GuardSettings {
+  const parsed = guardPluginConfigSchema.safeParse(rawConfig);
+  const config: GuardPluginConfig = parsed.success ? parsed.data : {};
+  return {
+    enabled: config.enabled ?? DEFAULT_GUARD_SETTINGS.enabled,
+    baseUrl: (config.baseUrl ?? DEFAULT_GUARD_SETTINGS.baseUrl).replace(/\/+$/, ""),
+    timeoutMs: Math.round(
+      (config.timeoutSeconds ?? DEFAULT_GUARD_SETTINGS.timeoutMs / 1000) * 1000,
+    ),
+    failOpen: config.failOpen ?? DEFAULT_GUARD_SETTINGS.failOpen,
+    tokenEnvVar: config.tokenEnvVar ?? DEFAULT_GUARD_SETTINGS.tokenEnvVar,
+    receiptsEnabled: config.receiptsEnabled ?? DEFAULT_GUARD_SETTINGS.receiptsEnabled,
+    painSignalsEnabled: config.painSignalsEnabled ?? DEFAULT_GUARD_SETTINGS.painSignalsEnabled,
+  };
+}
+
+function resolveGuardArtifact(
+  toolName: string,
+  params: Record<string, unknown>,
+): GuardArtifact | undefined {
+  const nested = isRecord(params.guardArtifact) ? params.guardArtifact : undefined;
+  const source = nested ?? params;
+  const fallbackName = toolName.startsWith("mcp_")
+    ? toolName.slice(4).replace(/_/g, " ")
+    : toolName;
+  const artifactName =
+    readString(source.guardArtifactName) ??
+    readString(source.artifactName) ??
+    readString(source.name) ??
+    fallbackName;
+
+  if (!artifactName) {
+    return undefined;
+  }
+
+  const artifactType =
+    readString(source.guardArtifactType) ??
+    readString(source.artifactType) ??
+    (toolName.startsWith("mcp_") ? "mcp-server" : "plugin");
+  const artifactSlug =
+    readString(source.guardArtifactSlug) ??
+    readString(source.artifactSlug) ??
+    slugify(artifactName);
+  const artifactId =
+    readString(source.guardArtifactId) ??
+    readString(source.artifactId) ??
+    `${artifactType}:openclaw:${artifactSlug}`;
+  const publisher = readString(source.guardPublisher) ?? readString(source.publisher);
+  const domain = readString(source.guardDomain) ?? readString(source.domain);
+  const launchSummary =
+    readString(source.guardLaunchSummary) ??
+    readString(source.launchSummary) ??
+    `${toolName} ${JSON.stringify(params)}`;
+
+  return {
+    artifactId,
+    artifactName,
+    artifactSlug,
+    artifactType,
+    harness: "openclaw",
+    toolName,
+    publisher,
+    domain,
+    launchSummary,
+  };
+}
+
+function createAuthHeaders(settings: GuardSettings): HeadersInit | undefined {
+  const token = process.env[settings.tokenEnvVar]?.trim();
+  if (!token) {
+    return undefined;
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+async function postGuardJson(
+  settings: GuardSettings,
+  path: string,
+  payload: Record<string, unknown>,
+): Promise<unknown> {
+  const headers = createAuthHeaders(settings);
+  if (!headers) {
+    return undefined;
+  }
+  const response = await fetch(`${settings.baseUrl}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(settings.timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`Guard request failed: ${response.status}`);
+  }
+  return await response.json();
+}
+
+async function resolvePreExecutionVerdict(
+  settings: GuardSettings,
+  artifact: GuardArtifact,
+): Promise<GuardPreExecutionVerdict | undefined> {
+  const response = await postGuardJson(settings, "/verdict/pre-execution", {
+    harness: artifact.harness,
+    artifactId: artifact.artifactId,
+    artifactName: artifact.artifactName,
+    artifactSlug: artifact.artifactSlug,
+    artifactType: artifact.artifactType,
+    publisher: artifact.publisher,
+    domain: artifact.domain,
+    launchSummary: artifact.launchSummary,
+  });
+  if (!isRecord(response)) {
+    return undefined;
+  }
+  const decisionRaw = readString(response.decision);
+  if (!decisionRaw) {
+    return undefined;
+  }
+  const decision = decisionRaw.toLowerCase();
+  if (decision !== "allow" && decision !== "review" && decision !== "block") {
+    return undefined;
+  }
+  return {
+    decision,
+    rationale: readString(response.rationale) ?? "",
+    scope: readString(response.scope) ?? "guard",
+  };
+}
+
+function receiptPayload(
+  artifact: GuardArtifact,
+  outcome: GuardResolutionReceipt,
+): Record<string, unknown> {
+  return {
+    items: [
+      {
+        artifactId: artifact.artifactId,
+        artifactName: artifact.artifactName,
+        artifactSlug: artifact.artifactSlug,
+        artifactType: artifact.artifactType,
+        harness: artifact.harness,
+        summary: outcome.rationale,
+        recommendation: outcome.recommendation,
+        source: outcome.source,
+        toolName: artifact.toolName,
+      },
+    ],
+  };
+}
+
+async function emitReceipt(
+  settings: GuardSettings,
+  artifact: GuardArtifact,
+  outcome: GuardResolutionReceipt,
+): Promise<void> {
+  if (!settings.receiptsEnabled) {
+    return;
+  }
+  await postGuardJson(settings, "/receipts/submit", receiptPayload(artifact, outcome));
+}
+
+async function emitPainSignal(
+  settings: GuardSettings,
+  artifact: GuardArtifact,
+  outcome: GuardResolutionReceipt,
+): Promise<void> {
+  if (!settings.painSignalsEnabled) {
+    return;
+  }
+  await postGuardJson(settings, "/signals/pain", {
+    items: [
+      {
+        artifactId: artifact.artifactId,
+        artifactName: artifact.artifactName,
+        artifactSlug: artifact.artifactSlug,
+        artifactType: artifact.artifactType,
+        harness: artifact.harness,
+        summary: outcome.rationale,
+        recommendation: outcome.recommendation,
+        source: outcome.source,
+      },
+    ],
+  });
+}
+
+function verdictSource(verdict: GuardPreExecutionVerdict): string {
+  return `preexecution-${verdict.scope || "guard"}`;
+}
+
+function severityForVerdict(verdict: GuardPreExecutionVerdict): "warning" | "critical" {
+  return verdict.decision === "block" ? "critical" : "warning";
+}
+
+async function settleResolution(
+  settings: GuardSettings,
+  artifact: GuardArtifact,
+  verdict: GuardPreExecutionVerdict,
+  resolution: PluginApprovalResolution,
+): Promise<void> {
+  if (resolution === "allow-once" || resolution === "allow-always") {
+    return;
+  }
+
+  const denial: GuardResolutionReceipt = {
+    recommendation: verdict.decision === "block" ? "block" : "review",
+    rationale: verdict.rationale || `Guard denied ${artifact.artifactName}.`,
+    source: verdictSource(verdict),
+  };
+  await emitReceipt(settings, artifact, denial);
+  await emitPainSignal(settings, artifact, denial);
+}
+
+function rememberPendingExecution(
+  runId: string | undefined,
+  toolCallId: string | undefined,
+  pending: PendingGuardExecution,
+): void {
+  const key = buildPendingKey(runId, toolCallId);
+  if (!key) {
+    return;
+  }
+  pendingExecutions.set(key, pending);
+  if (pendingExecutions.size > 512) {
+    const oldest = pendingExecutions.keys().next().value;
+    if (oldest) {
+      pendingExecutions.delete(oldest);
+    }
+  }
+}
+
+export default definePluginEntry({
+  id: "hol-guard",
+  name: "HOL Guard",
+  description:
+    "Guard cloud verdicts, approvals, receipts, and pain-signal gating for OpenClaw tool execution.",
+  configSchema: buildPluginConfigSchema(guardPluginConfigSchema),
+  register(api) {
+    const settings = readGuardSettings(api.pluginConfig);
+
+    api.on("before_tool_call", async (event, ctx) => {
+      if (!settings.enabled) {
+        return undefined;
+      }
+      const artifact = resolveGuardArtifact(event.toolName, event.params);
+      if (!artifact) {
+        return undefined;
+      }
+
+      try {
+        const verdict = await resolvePreExecutionVerdict(settings, artifact);
+        if (!verdict || verdict.decision === "allow") {
+          rememberPendingExecution(ctx.runId, event.toolCallId, {
+            artifact,
+            recommendation: "monitor",
+            rationale: verdict?.rationale || "Guard allowed tool execution.",
+            source: verdict ? verdictSource(verdict) : "preexecution-guard",
+          });
+          return undefined;
+        }
+
+        if (verdict.decision === "block") {
+          const blockedOutcome = {
+            recommendation: "block",
+            rationale: verdict.rationale || `Guard blocked ${artifact.artifactName}.`,
+            source: verdictSource(verdict),
+          } satisfies GuardResolutionReceipt;
+          await emitReceipt(settings, artifact, blockedOutcome);
+          await emitPainSignal(settings, artifact, blockedOutcome);
+          return {
+            block: true,
+            blockReason: blockedOutcome.rationale,
+          };
+        }
+
+        return {
+          requireApproval: {
+            title: `Guard review required for ${artifact.artifactName}`,
+            description: verdict.rationale || `Guard requires review for ${artifact.artifactName}.`,
+            severity: severityForVerdict(verdict),
+            async onResolution(resolution) {
+              if (resolution === "allow-once" || resolution === "allow-always") {
+                rememberPendingExecution(ctx.runId, event.toolCallId, {
+                  artifact,
+                  recommendation: "review",
+                  rationale: verdict.rationale || `Guard reviewed ${artifact.artifactName}.`,
+                  source: verdictSource(verdict),
+                });
+                return;
+              }
+              await settleResolution(settings, artifact, verdict, resolution);
+            },
+          },
+        };
+      } catch (error) {
+        if (settings.failOpen) {
+          return undefined;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          block: true,
+          blockReason: `HOL Guard policy lookup failed: ${message}`,
+        };
+      }
+    });
+
+    api.on("after_tool_call", async (event, ctx) => {
+      if (!settings.enabled || !settings.receiptsEnabled) {
+        return;
+      }
+      const key = buildPendingKey(ctx.runId, event.toolCallId);
+      if (!key) {
+        return;
+      }
+      const pending = pendingExecutions.get(key);
+      if (!pending) {
+        return;
+      }
+      pendingExecutions.delete(key);
+      const outcome: GuardResolutionReceipt = {
+        recommendation: pending.recommendation,
+        rationale: event.error
+          ? `${pending.rationale} Execution error: ${event.error}`
+          : pending.rationale,
+        source: pending.source,
+      };
+      await emitReceipt(settings, pending.artifact, outcome);
+    });
+  },
+});

--- a/extensions/hol-guard/index.ts
+++ b/extensions/hol-guard/index.ts
@@ -70,6 +70,16 @@ const DEFAULT_GUARD_SETTINGS: GuardSettings = {
   painSignalsEnabled: true,
 };
 
+const guardPluginConfigFieldSchemas = {
+  enabled: z.boolean(),
+  baseUrl: z.string().trim().url(),
+  timeoutSeconds: z.number().positive().max(30),
+  failOpen: z.boolean(),
+  tokenEnvVar: z.string().trim().min(1),
+  receiptsEnabled: z.boolean(),
+  painSignalsEnabled: z.boolean(),
+} as const;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -101,8 +111,52 @@ function buildPendingKey(
 }
 
 function readGuardSettings(rawConfig: unknown): GuardSettings {
-  const parsed = guardPluginConfigSchema.safeParse(rawConfig);
-  const config: GuardPluginConfig = parsed.success ? parsed.data : {};
+  if (!isRecord(rawConfig)) {
+    return { ...DEFAULT_GUARD_SETTINGS };
+  }
+
+  const config: GuardPluginConfig = {};
+  const enabled = guardPluginConfigFieldSchemas.enabled.safeParse(rawConfig.enabled);
+  if (enabled.success) {
+    config.enabled = enabled.data;
+  }
+
+  const baseUrl = guardPluginConfigFieldSchemas.baseUrl.safeParse(rawConfig.baseUrl);
+  if (baseUrl.success) {
+    config.baseUrl = baseUrl.data;
+  }
+
+  const timeoutSeconds = guardPluginConfigFieldSchemas.timeoutSeconds.safeParse(
+    rawConfig.timeoutSeconds,
+  );
+  if (timeoutSeconds.success) {
+    config.timeoutSeconds = timeoutSeconds.data;
+  }
+
+  const failOpen = guardPluginConfigFieldSchemas.failOpen.safeParse(rawConfig.failOpen);
+  if (failOpen.success) {
+    config.failOpen = failOpen.data;
+  }
+
+  const tokenEnvVar = guardPluginConfigFieldSchemas.tokenEnvVar.safeParse(rawConfig.tokenEnvVar);
+  if (tokenEnvVar.success) {
+    config.tokenEnvVar = tokenEnvVar.data;
+  }
+
+  const receiptsEnabled = guardPluginConfigFieldSchemas.receiptsEnabled.safeParse(
+    rawConfig.receiptsEnabled,
+  );
+  if (receiptsEnabled.success) {
+    config.receiptsEnabled = receiptsEnabled.data;
+  }
+
+  const painSignalsEnabled = guardPluginConfigFieldSchemas.painSignalsEnabled.safeParse(
+    rawConfig.painSignalsEnabled,
+  );
+  if (painSignalsEnabled.success) {
+    config.painSignalsEnabled = painSignalsEnabled.data;
+  }
+
   return {
     enabled: config.enabled ?? DEFAULT_GUARD_SETTINGS.enabled,
     baseUrl: (config.baseUrl ?? DEFAULT_GUARD_SETTINGS.baseUrl).replace(/\/+$/, ""),

--- a/extensions/hol-guard/index.ts
+++ b/extensions/hol-guard/index.ts
@@ -334,10 +334,14 @@ async function settleResolution(
 
 function rememberPendingExecution(
   pendingExecutions: Map<string, PendingGuardExecution>,
+  receiptsEnabled: boolean,
   runId: string | undefined,
   toolCallId: string | undefined,
   pending: PendingGuardExecution,
 ): void {
+  if (!receiptsEnabled) {
+    return;
+  }
   const key = buildPendingKey(runId, toolCallId);
   if (!key) {
     return;
@@ -373,12 +377,18 @@ export default definePluginEntry({
       try {
         const verdict = await resolvePreExecutionVerdict(settings, artifact);
         if (!verdict || verdict.decision === "allow") {
-          rememberPendingExecution(pendingExecutions, ctx.runId, event.toolCallId, {
-            artifact,
-            recommendation: "monitor",
-            rationale: verdict?.rationale || "Guard allowed tool execution.",
-            source: verdict ? verdictSource(verdict) : "preexecution-guard",
-          });
+          rememberPendingExecution(
+            pendingExecutions,
+            settings.receiptsEnabled,
+            ctx.runId,
+            event.toolCallId,
+            {
+              artifact,
+              recommendation: "monitor",
+              rationale: verdict?.rationale || "Guard allowed tool execution.",
+              source: verdict ? verdictSource(verdict) : "preexecution-guard",
+            },
+          );
           return undefined;
         }
 
@@ -404,12 +414,18 @@ export default definePluginEntry({
             severity: severityForVerdict(verdict),
             async onResolution(resolution) {
               if (resolution === "allow-once" || resolution === "allow-always") {
-                rememberPendingExecution(pendingExecutions, ctx.runId, event.toolCallId, {
-                  artifact,
-                  recommendation: "review",
-                  rationale: verdict.rationale || `Guard reviewed ${artifact.artifactName}.`,
-                  source: verdictSource(verdict),
-                });
+                rememberPendingExecution(
+                  pendingExecutions,
+                  settings.receiptsEnabled,
+                  ctx.runId,
+                  event.toolCallId,
+                  {
+                    artifact,
+                    recommendation: "review",
+                    rationale: verdict.rationale || `Guard reviewed ${artifact.artifactName}.`,
+                    source: verdictSource(verdict),
+                  },
+                );
                 return;
               }
               await settleResolution(settings, artifact, verdict, resolution);

--- a/extensions/hol-guard/index.ts
+++ b/extensions/hol-guard/index.ts
@@ -211,15 +211,15 @@ async function resolvePreExecutionVerdict(
     launchSummary: artifact.launchSummary,
   });
   if (!isRecord(response)) {
-    return undefined;
+    throw new Error("Invalid HOL Guard verdict payload.");
   }
   const decisionRaw = readString(response.decision);
   if (!decisionRaw) {
-    return undefined;
+    throw new Error("Invalid HOL Guard verdict payload.");
   }
   const decision = decisionRaw.toLowerCase();
   if (decision !== "allow" && decision !== "review" && decision !== "block") {
-    return undefined;
+    throw new Error("Invalid HOL Guard verdict payload.");
   }
   return {
     decision,

--- a/extensions/hol-guard/index.ts
+++ b/extensions/hol-guard/index.ts
@@ -172,7 +172,7 @@ function resolveGuardArtifact(
 function createAuthHeaders(settings: GuardSettings): HeadersInit | undefined {
   const token = process.env[settings.tokenEnvVar]?.trim();
   if (!token) {
-    return undefined;
+    throw new Error(`Missing HOL Guard token in ${settings.tokenEnvVar}`);
   }
   return {
     Authorization: `Bearer ${token}`,
@@ -289,6 +289,28 @@ async function emitPainSignal(
   });
 }
 
+async function emitObservabilitySignals(
+  settings: GuardSettings,
+  artifact: GuardArtifact,
+  outcome: GuardResolutionReceipt,
+): Promise<void> {
+  const tasks: Promise<void>[] = [];
+  if (settings.receiptsEnabled) {
+    tasks.push(emitReceipt(settings, artifact, outcome));
+  }
+  if (settings.painSignalsEnabled) {
+    tasks.push(emitPainSignal(settings, artifact, outcome));
+  }
+  if (tasks.length === 0) {
+    return;
+  }
+  const results = await Promise.allSettled(tasks);
+  const rejected = results.find((result) => result.status === "rejected");
+  if (rejected?.status === "rejected") {
+    throw rejected.reason;
+  }
+}
+
 function verdictSource(verdict: GuardPreExecutionVerdict): string {
   return `preexecution-${verdict.scope || "guard"}`;
 }
@@ -312,8 +334,7 @@ async function settleResolution(
     rationale: verdict.rationale || `Guard denied ${artifact.artifactName}.`,
     source: verdictSource(verdict),
   };
-  await emitReceipt(settings, artifact, denial);
-  await emitPainSignal(settings, artifact, denial);
+  await emitObservabilitySignals(settings, artifact, denial);
 }
 
 function rememberPendingExecution(
@@ -370,8 +391,9 @@ export default definePluginEntry({
             rationale: verdict.rationale || `Guard blocked ${artifact.artifactName}.`,
             source: verdictSource(verdict),
           } satisfies GuardResolutionReceipt;
-          await emitReceipt(settings, artifact, blockedOutcome);
-          await emitPainSignal(settings, artifact, blockedOutcome);
+          try {
+            await emitObservabilitySignals(settings, artifact, blockedOutcome);
+          } catch {}
           return {
             block: true,
             blockReason: blockedOutcome.rationale,

--- a/extensions/hol-guard/openclaw.plugin.json
+++ b/extensions/hol-guard/openclaw.plugin.json
@@ -1,0 +1,36 @@
+{
+  "id": "hol-guard",
+  "enabledByDefault": false,
+  "contracts": {},
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean"
+      },
+      "baseUrl": {
+        "type": "string",
+        "format": "uri"
+      },
+      "timeoutSeconds": {
+        "type": "number",
+        "minimum": 0.1,
+        "maximum": 30
+      },
+      "failOpen": {
+        "type": "boolean"
+      },
+      "tokenEnvVar": {
+        "type": "string",
+        "minLength": 1
+      },
+      "receiptsEnabled": {
+        "type": "boolean"
+      },
+      "painSignalsEnabled": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/extensions/hol-guard/openclaw.plugin.json
+++ b/extensions/hol-guard/openclaw.plugin.json
@@ -23,7 +23,8 @@
       },
       "tokenEnvVar": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "pattern": ".*\\S.*"
       },
       "receiptsEnabled": {
         "type": "boolean"

--- a/extensions/hol-guard/package.json
+++ b/extensions/hol-guard/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/hol-guard",
+  "version": "2026.4.12",
+  "private": true,
+  "description": "OpenClaw HOL Guard plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/hol-guard/tsconfig.json
+++ b/extensions/hol-guard/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -639,6 +639,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/hol-guard:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/huggingface:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.ts";
 import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import {
   initializeGlobalHookRunner,
@@ -8,7 +7,6 @@ import {
 import { addTestHook, createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import type { PluginHookRegistration } from "../plugins/types.js";
-import { resolveRelativeBundledPluginPublicModuleId } from "../test-utils/bundled-plugin-public-surface.js";
 
 type ToolDefinitionAdapterModule = typeof import("./pi-tool-definition-adapter.js");
 type PiToolsAbortModule = typeof import("./pi-tools.abort.js");
@@ -27,12 +25,6 @@ let wrapToolWithAbortSignal!: WrapToolWithAbortSignal;
 let beforeToolCallTesting!: BeforeToolCallTesting;
 let consumeAdjustedParamsForToolCall!: ConsumeAdjustedParamsForToolCall;
 let wrapToolWithBeforeToolCallHook!: WrapToolWithBeforeToolCallHook;
-
-const holGuardPluginModuleId = resolveRelativeBundledPluginPublicModuleId({
-  fromModuleUrl: import.meta.url,
-  pluginId: "hol-guard",
-  artifactBasename: "index.js",
-});
 
 beforeEach(async () => {
   if (!wrapToolWithBeforeToolCallHook) {
@@ -83,34 +75,6 @@ function installBeforeToolCallHooks(hooks: BeforeToolCallHookInstall[]): void {
     });
   }
   initializeGlobalHookRunner(registry);
-}
-
-async function installHolGuardPlugin(config?: Record<string, unknown>): Promise<void> {
-  resetGlobalHookRunner();
-  const hooks = new Map<string, PluginHookRegistration["handler"]>();
-  const api = createTestPluginApi({
-    id: "hol-guard",
-    name: "HOL Guard",
-    pluginConfig: config ?? {},
-    on: (hookName, handler) => {
-      hooks.set(hookName, handler);
-    },
-  });
-  const { default: holGuardPlugin } = await import(holGuardPluginModuleId);
-  await holGuardPlugin.register(api);
-  const beforeToolCallHandler = hooks.get("before_tool_call");
-  if (!beforeToolCallHandler) {
-    throw new Error("HOL Guard plugin did not register before_tool_call");
-  }
-  initializeGlobalHookRunner(
-    createMockPluginRegistry([
-      {
-        hookName: "before_tool_call",
-        pluginId: "hol-guard",
-        handler: beforeToolCallHandler as (...args: unknown[]) => unknown,
-      },
-    ]),
-  );
 }
 
 describe("before_tool_call hook integration", () => {
@@ -175,77 +139,6 @@ describe("before_tool_call hook integration", () => {
     await expect(
       tool.execute("call-3", { cmd: "rm -rf /" }, undefined, extensionContext),
     ).rejects.toThrow("blocked");
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  it("blocks malicious tool execution through the real HOL Guard plugin hook", async () => {
-    process.env.OPENCLAW_GUARD_TOKEN = "guard-token";
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn<typeof fetch>()
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              decision: "block",
-              rationale: "Known malicious MCP launcher",
-              scope: "workspace",
-            }),
-            {
-              status: 200,
-              headers: {
-                "Content-Type": "application/json",
-              },
-            },
-          ),
-        )
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ ok: true }), {
-            status: 200,
-            headers: {
-              "Content-Type": "application/json",
-            },
-          }),
-        )
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ ok: true }), {
-            status: 200,
-            headers: {
-              "Content-Type": "application/json",
-            },
-          }),
-        ),
-    );
-    await installHolGuardPlugin({
-      baseUrl: "https://guard.example/api/v1/consumer",
-      failOpen: false,
-    });
-
-    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
-    const tool = wrapToolWithBeforeToolCallHook({ name: "mcp_bash_proxy", execute } as any, {
-      runId: "guard-run",
-      agentId: "main",
-      sessionKey: "main",
-    });
-    const extensionContext = {} as Parameters<typeof tool.execute>[3];
-
-    await expect(
-      tool.execute(
-        "guard-call-1",
-        {
-          guardArtifact: {
-            artifactId: "mcp-server:openclaw:malicious-proxy",
-            artifactName: "malicious proxy",
-            artifactSlug: "malicious-proxy",
-            artifactType: "mcp-server",
-            launchSummary: "bash wrapper exfiltrates ~/.env over HTTPS",
-          },
-        },
-        undefined,
-        extensionContext,
-      ),
-    ).rejects.toThrow("Known malicious MCP launcher");
-
     expect(execute).not.toHaveBeenCalled();
   });
 

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import holGuardPlugin from "../../extensions/hol-guard/index.js";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.ts";
 import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import {
   initializeGlobalHookRunner,
@@ -77,6 +79,33 @@ function installBeforeToolCallHooks(hooks: BeforeToolCallHookInstall[]): void {
   initializeGlobalHookRunner(registry);
 }
 
+function installHolGuardPlugin(config?: Record<string, unknown>): void {
+  resetGlobalHookRunner();
+  const hooks = new Map<string, PluginHookRegistration["handler"]>();
+  const api = createTestPluginApi({
+    id: "hol-guard",
+    name: "HOL Guard",
+    pluginConfig: config ?? {},
+    on: (hookName, handler) => {
+      hooks.set(hookName, handler);
+    },
+  });
+  void holGuardPlugin.register(api);
+  const beforeToolCallHandler = hooks.get("before_tool_call");
+  if (!beforeToolCallHandler) {
+    throw new Error("HOL Guard plugin did not register before_tool_call");
+  }
+  initializeGlobalHookRunner(
+    createMockPluginRegistry([
+      {
+        hookName: "before_tool_call",
+        pluginId: "hol-guard",
+        handler: beforeToolCallHandler as (...args: unknown[]) => unknown,
+      },
+    ]),
+  );
+}
+
 describe("before_tool_call hook integration", () => {
   let beforeToolCallHook: BeforeToolCallHandlerMock;
 
@@ -139,6 +168,77 @@ describe("before_tool_call hook integration", () => {
     await expect(
       tool.execute("call-3", { cmd: "rm -rf /" }, undefined, extensionContext),
     ).rejects.toThrow("blocked");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("blocks malicious tool execution through the real HOL Guard plugin hook", async () => {
+    process.env.OPENCLAW_GUARD_TOKEN = "guard-token";
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              decision: "block",
+              rationale: "Known malicious MCP launcher",
+              scope: "workspace",
+            }),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+              },
+            },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }),
+        ),
+    );
+    installHolGuardPlugin({
+      baseUrl: "https://guard.example/api/v1/consumer",
+      failOpen: false,
+    });
+
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const tool = wrapToolWithBeforeToolCallHook({ name: "mcp_bash_proxy", execute } as any, {
+      runId: "guard-run",
+      agentId: "main",
+      sessionKey: "main",
+    });
+    const extensionContext = {} as Parameters<typeof tool.execute>[3];
+
+    await expect(
+      tool.execute(
+        "guard-call-1",
+        {
+          guardArtifact: {
+            artifactId: "mcp-server:openclaw:malicious-proxy",
+            artifactName: "malicious proxy",
+            artifactSlug: "malicious-proxy",
+            artifactType: "mcp-server",
+            launchSummary: "bash wrapper exfiltrates ~/.env over HTTPS",
+          },
+        },
+        undefined,
+        extensionContext,
+      ),
+    ).rejects.toThrow("Known malicious MCP launcher");
+
     expect(execute).not.toHaveBeenCalled();
   });
 

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import holGuardPlugin from "../../extensions/hol-guard/index.js";
 import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.ts";
 import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import {
@@ -9,6 +8,7 @@ import {
 import { addTestHook, createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import type { PluginHookRegistration } from "../plugins/types.js";
+import { resolveRelativeBundledPluginPublicModuleId } from "../test-utils/bundled-plugin-public-surface.js";
 
 type ToolDefinitionAdapterModule = typeof import("./pi-tool-definition-adapter.js");
 type PiToolsAbortModule = typeof import("./pi-tools.abort.js");
@@ -27,6 +27,12 @@ let wrapToolWithAbortSignal!: WrapToolWithAbortSignal;
 let beforeToolCallTesting!: BeforeToolCallTesting;
 let consumeAdjustedParamsForToolCall!: ConsumeAdjustedParamsForToolCall;
 let wrapToolWithBeforeToolCallHook!: WrapToolWithBeforeToolCallHook;
+
+const holGuardPluginModuleId = resolveRelativeBundledPluginPublicModuleId({
+  fromModuleUrl: import.meta.url,
+  pluginId: "hol-guard",
+  artifactBasename: "index.js",
+});
 
 beforeEach(async () => {
   if (!wrapToolWithBeforeToolCallHook) {
@@ -79,7 +85,7 @@ function installBeforeToolCallHooks(hooks: BeforeToolCallHookInstall[]): void {
   initializeGlobalHookRunner(registry);
 }
 
-function installHolGuardPlugin(config?: Record<string, unknown>): void {
+async function installHolGuardPlugin(config?: Record<string, unknown>): Promise<void> {
   resetGlobalHookRunner();
   const hooks = new Map<string, PluginHookRegistration["handler"]>();
   const api = createTestPluginApi({
@@ -90,7 +96,8 @@ function installHolGuardPlugin(config?: Record<string, unknown>): void {
       hooks.set(hookName, handler);
     },
   });
-  void holGuardPlugin.register(api);
+  const { default: holGuardPlugin } = await import(holGuardPluginModuleId);
+  await holGuardPlugin.register(api);
   const beforeToolCallHandler = hooks.get("before_tool_call");
   if (!beforeToolCallHandler) {
     throw new Error("HOL Guard plugin did not register before_tool_call");
@@ -209,7 +216,7 @@ describe("before_tool_call hook integration", () => {
           }),
         ),
     );
-    installHolGuardPlugin({
+    await installHolGuardPlugin({
       baseUrl: "https://guard.example/api/v1/consumer",
       failOpen: false,
     });


### PR DESCRIPTION
## Summary
- add a bundled HOL Guard plugin that checks pre-execution verdicts before tool calls
- emit Guard receipts and pain signals for blocked or reviewed executions
- add bundled-plugin and hook-runner tests covering the blocked execution path

## Verification
- pnpm test -- extensions/hol-guard/index.test.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
- pnpm exec oxfmt --check extensions/hol-guard/index.ts extensions/hol-guard/index.test.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
- pnpm exec oxlint extensions/hol-guard/index.ts extensions/hol-guard/index.test.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts