### PR TITLE
fix: wait for gateway client teardown so CLI cron commands exit cleanly

### DIFF
--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -506,11 +506,14 @@ async function executeGatewayRequestWithScopes<T>(params: {
             timeoutMs: opts.timeoutMs,
           });
           ignoreClose = true;
+          // Wait for the gateway connection to close cleanly before resolving.
+          // client.stop() is fire-and-forget; client.stopAndWait() ensures the
+          // socket/session teardown settles so the CLI process can exit promptly.
+          await client.stopAndWait().catch(() => {});
           stop(undefined, result);
-          client.stop();
         } catch (err) {
           ignoreClose = true;
-          client.stop();
+          await client.stopAndWait().catch(() => {});
           stop(err as Error);
         }
       },
@@ -519,14 +522,14 @@ async function executeGatewayRequestWithScopes<T>(params: {
           return;
         }
         ignoreClose = true;
-        client.stop();
+        void client.stopAndWait().catch(() => {});
         stop(new Error(formatGatewayCloseError(code, reason, params.connectionDetails)));
       },
     });
 
     const timer = setTimeout(() => {
       ignoreClose = true;
-      client.stop();
+      void client.stopAndWait().catch(() => {});
       stop(new Error(formatGatewayTimeoutError(timeoutMs, params.connectionDetails)));
     }, safeTimerTimeoutMs);
 


### PR DESCRIPTION
## Summary

Fixes GitHub issue #65584: cron CLI commands can succeed but hang instead of exiting cleanly.

### Root Cause

In `src/gateway/call.ts`, the `executeGatewayRequestWithScopes` function calls `client.stop()` after a request completes without awaiting the actual socket/session teardown. Since `client.stop()` is fire-and-forget (it calls `void this.beginStop()`), the WebSocket connection could still be closing in the background when the CLI process tries to exit, causing it to hang.

### Fix

Changed all `client.stop()` calls in `executeGatewayRequestWithScopes` to use `client.stopAndWait()`:

1. **Success path** (`onHelloOk`): `await client.stopAndWait().catch(() => {})` before calling `stop(undefined, result)` to ensure the gateway connection is fully closed before the outer Promise resolves
2. **Error path** (`onHelloOk` catch): Same treatment to ensure clean teardown on errors
3. **onClose callback**: `void client.stopAndWait().catch(() => {})` to ensure teardown is tracked without blocking
4. **Timer callback**: Same as onClose

The `.catch(() => {})` handles the case where `stopAndWait()` times out, preventing spurious unhandled rejections.

### Testing

- Existing unit tests pass
- The fix ensures CLI commands that complete successfully (like cron add/rm/edit/list) will exit promptly because the gateway connection is guaranteed to be fully closed before the Promise resolves

### Issue Reference

Fixes #65584
