### PR TITLE
Fix: configure Nested CommandLane so sessions_send isn't serialized (Resolves #65470)

### DIFF
--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_AGENT_MAX_CONCURRENT } from "../config/agent-limits.js";
+import { CommandLane } from "../process/lanes.js";
+
+const setCommandLaneConcurrency = vi.fn();
+
+vi.mock("../process/command-queue.js", () => ({
+  setCommandLaneConcurrency: (lane: string, max: number) => setCommandLaneConcurrency(lane, max),
+}));
+
+describe("applyGatewayLaneConcurrency", () => {
+  beforeEach(() => {
+    setCommandLaneConcurrency.mockClear();
+  });
+
+  it("configures the nested lane so sessions_send agent-to-agent runs are not serialized", async () => {
+    const { applyGatewayLaneConcurrency } = await import("./server-lanes.js");
+
+    applyGatewayLaneConcurrency({
+      agents: { defaults: { maxConcurrent: 50 } },
+    });
+
+    const calls = setCommandLaneConcurrency.mock.calls;
+    const lanes = calls.map(([lane]) => lane);
+    expect(lanes).toContain(CommandLane.Nested);
+
+    const nestedCall = calls.find(([lane]) => lane === CommandLane.Nested);
+    expect(nestedCall?.[1]).toBe(50);
+  });
+
+  it("falls back to the default agent max concurrent for the nested lane", async () => {
+    const { applyGatewayLaneConcurrency } = await import("./server-lanes.js");
+
+    applyGatewayLaneConcurrency({});
+
+    const nestedCall = setCommandLaneConcurrency.mock.calls.find(
+      ([lane]) => lane === CommandLane.Nested,
+    );
+    expect(nestedCall?.[1]).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+  });
+});

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -7,4 +7,8 @@ export function applyGatewayLaneConcurrency(cfg: OpenClawConfig) {
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  // Nested runs (sessions_send agent-to-agent, cron-initiated inner ops) share
+  // the main agent-lane budget so peer sends aren't serialized through the
+  // queue's default maxConcurrent=1.
+  setCommandLaneConcurrency(CommandLane.Nested, resolveAgentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -138,6 +138,7 @@ export function createGatewayReloadHandlers(params: {
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
+    setCommandLaneConcurrency(CommandLane.Nested, resolveAgentMaxConcurrent(nextConfig));
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);


### PR DESCRIPTION
Fixes #65470.

`applyGatewayLaneConcurrency` (and its hot-reload counterpart) configured Main, Cron, and Subagent lanes but never set `CommandLane.Nested`, leaving it at the command-queue default of `maxConcurrent: 1`. `sessions_send` (agent-to-agent) and cron-initiated inner ops route through the Nested lane, so every peer send — even across distinct agents — ran fully serialized regardless of `agents.defaults.maxConcurrent`.

This sets the Nested lane budget to `resolveAgentMaxConcurrent(cfg)` during both startup and config hot reload so `sessions_send` runs share the main agent-lane budget. Added `src/gateway/server-lanes.test.ts` covering the configured-value and default fallback paths for the Nested lane.