### PR TITLE
feat(skills): add discussion_comment support to secret-scanning skill

### DIFF
--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -69,6 +69,7 @@ The `fetch-content` output includes:
 | `issue_comment`               | Comment: delete+recreate |
 | `pull_request_comment`        | Comment: delete+recreate |
 | `pull_request_review_comment` | Comment: delete+recreate |
+| `discussion_comment`          | Discussion comment: delete+recreate (GraphQL) |
 | `issue_body`                  | Body: redact in place    |
 | `pull_request_body`           | Body: redact in place    |
 | `commit`                      | Notify only              |
@@ -100,14 +101,25 @@ node secret-scanning.mjs redact-body <issue|pr> <NUMBER> <redacted-body-file>
 
 ### Comments — Delete and Recreate
 
+For issue/PR comments:
 ```bash
 # Delete original (all edit history gone)
 node secret-scanning.mjs delete-comment <COMMENT_ID>
 
 # Recreate with redacted content
-# Agent prepares the body file with maintainer header + redacted content
 node secret-scanning.mjs recreate-comment <ISSUE_NUMBER> <body-file>
 ```
+
+For discussion comments (uses GraphQL):
+```bash
+# Delete original
+node secret-scanning.mjs delete-discussion-comment <COMMENT_NODE_ID>
+
+# Recreate with redacted content
+node secret-scanning.mjs recreate-discussion-comment <DISCUSSION_NODE_ID> <body-file>
+```
+
+The `fetch-content` output for `discussion_comment` includes `comment_node_id` and `discussion_node_id` for these commands.
 
 The recreated comment should follow this format:
 

--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -61,6 +61,7 @@ The `fetch-content` output includes:
 - `issue_number` / `pr_number`: where it is
 - `edit_history_count`: number of existing edits
 - `type`: location type for routing
+- For `discussion_comment`, it also includes `comment_node_id`, `discussion_node_id`, and `reply_to_node_id` when the original comment was a reply.
 
 ### Location type routing
 
@@ -118,10 +119,10 @@ For discussion comments (uses GraphQL):
 node secret-scanning.mjs delete-discussion-comment <COMMENT_NODE_ID>
 
 # Recreate with redacted content
-node secret-scanning.mjs recreate-discussion-comment <DISCUSSION_NODE_ID> <body-file>
+node secret-scanning.mjs recreate-discussion-comment <DISCUSSION_NODE_ID> <body-file> [REPLY_TO_NODE_ID]
 ```
 
-The `fetch-content` output for `discussion_comment` includes `comment_node_id` and `discussion_node_id` for these commands.
+The `fetch-content` output for `discussion_comment` includes `comment_node_id` and `discussion_node_id` for these commands. When the original discussion comment was a reply, it also includes `reply_to_node_id`; pass that optional third argument so the redacted replacement stays in the original thread.
 
 The recreated comment should follow this format:
 
@@ -154,11 +155,12 @@ Cannot clean. Notify author to delete branch or force-push (for unmerged PRs).
 ## Step 5: Notify
 
 ```bash
-node secret-scanning.mjs notify <TARGET> <AUTHOR> <LOCATION_TYPE> <SECRET_TYPES>
+node secret-scanning.mjs notify <TARGET> <AUTHOR> <LOCATION_TYPE> <SECRET_TYPES> [REPLY_TO_NODE_ID]
 ```
 
 - For non-discussion types, `<TARGET>` is the issue/PR number.
 - For `discussion_comment`, `<TARGET>` is the `discussion_node_id` returned by `fetch-content`.
+- For reply-style `discussion_comment` locations, pass the optional `reply_to_node_id` from `fetch-content` so the notification stays in the same thread.
 
 Secret types are comma-separated: `"Discord Bot Token,Feishu App Secret"`
 

--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -64,16 +64,16 @@ The `fetch-content` output includes:
 
 ### Location type routing
 
-| type                          | Flow                     |
-| ----------------------------- | ------------------------ |
-| `issue_comment`               | Comment: delete+recreate |
-| `pull_request_comment`        | Comment: delete+recreate |
-| `pull_request_review_comment` | Comment: delete+recreate |
+| type                          | Flow                                          |
+| ----------------------------- | --------------------------------------------- |
+| `issue_comment`               | Comment: delete+recreate                      |
+| `pull_request_comment`        | Comment: delete+recreate                      |
+| `pull_request_review_comment` | Comment: delete+recreate                      |
 | `discussion_comment`          | Discussion comment: delete+recreate (GraphQL) |
-| `issue_body`                  | Body: redact in place    |
-| `pull_request_body`           | Body: redact in place    |
-| `commit`                      | Notify only              |
-| _other_                       | Skip and report          |
+| `issue_body`                  | Body: redact in place                         |
+| `pull_request_body`           | Body: redact in place                         |
+| `commit`                      | Notify only                                   |
+| _other_                       | Skip and report                               |
 
 ## Step 2: Decide (Agent)
 
@@ -102,6 +102,7 @@ node secret-scanning.mjs redact-body <issue|pr> <NUMBER> <redacted-body-file>
 ### Comments — Delete and Recreate
 
 For issue/PR comments:
+
 ```bash
 # Delete original (all edit history gone)
 node secret-scanning.mjs delete-comment <COMMENT_ID>
@@ -111,6 +112,7 @@ node secret-scanning.mjs recreate-comment <ISSUE_NUMBER> <body-file>
 ```
 
 For discussion comments (uses GraphQL):
+
 ```bash
 # Delete original
 node secret-scanning.mjs delete-discussion-comment <COMMENT_NODE_ID>
@@ -152,8 +154,11 @@ Cannot clean. Notify author to delete branch or force-push (for unmerged PRs).
 ## Step 5: Notify
 
 ```bash
-node secret-scanning.mjs notify <ISSUE_NUMBER> <AUTHOR> <LOCATION_TYPE> <SECRET_TYPES>
+node secret-scanning.mjs notify <TARGET> <AUTHOR> <LOCATION_TYPE> <SECRET_TYPES>
 ```
+
+- For non-discussion types, `<TARGET>` is the issue/PR number.
+- For `discussion_comment`, `<TARGET>` is the `discussion_node_id` returned by `fetch-content`.
 
 Secret types are comma-separated: `"Discord Bot Token,Feishu App Secret"`
 

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -94,42 +94,56 @@ function cmdFetchContent(locationJson) {
   const details = location.details;
 
   if (type === "discussion_comment") {
-    // Discussion comments 只能通过 GraphQL 操作
+    // Discussion comments can only be operated via GraphQL
     const commentUrl = details.discussion_comment_url;
     if (!commentUrl) fail("No discussion_comment_url in location details");
 
-    // 从 URL 提取 discussion number 和 comment id
-    // 格式: https://github.com/owner/repo/discussions/123#discussioncomment-456
+    // Extract discussion number and comment id from URL
+    // Format: https://github.com/owner/repo/discussions/123#discussioncomment-456
     const urlMatch = commentUrl.match(/discussions\/(\d+)#discussioncomment-(\d+)/);
     if (!urlMatch) fail(`Cannot parse discussion comment URL: ${commentUrl}`);
     const discussionNumber = urlMatch[1];
     const discussionCommentDbId = urlMatch[2];
 
-    // 用 GraphQL 获取 discussion comment 内容
-    const gql = ghGraphQL(`{
-      repository(owner: "${REPO.split("/")[0]}", name: "${REPO.split("/")[1]}") {
-        discussion(number: ${discussionNumber}) {
-          id
-          url
-          comments(first: 50) {
-            nodes {
-              id
-              databaseId
-              author { login }
-              body
-              url
+    // Fetch discussion comment via GraphQL with pagination
+    const [owner, name] = REPO.split("/");
+    let comment = null;
+    let discussionId = null;
+    let cursor = null;
+    let hasNextPage = true;
+
+    while (hasNextPage && !comment) {
+      const afterClause = cursor ? `, after: "${cursor}"` : "";
+      const gql = ghGraphQL(`{
+        repository(owner: "${owner}", name: "${name}") {
+          discussion(number: ${discussionNumber}) {
+            id
+            url
+            comments(first: 50${afterClause}) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                databaseId
+                author { login }
+                body
+                url
+              }
             }
           }
         }
-      }
-    }`, { allowFailure: true });
+      }`, { allowFailure: true });
 
-    const discussion = gql?.data?.repository?.discussion;
-    if (!discussion) fail(`Discussion #${discussionNumber} not found — it may have been deleted. The alert cannot be processed via this skill.`);
+      const discussion = gql?.data?.repository?.discussion;
+      if (!discussion) fail(`Discussion #${discussionNumber} not found — it may have been deleted. The alert cannot be processed via this skill.`);
 
-    const comment = discussion.comments.nodes.find(
-      (c) => String(c.databaseId) === discussionCommentDbId,
-    );
+      discussionId = discussion.id;
+      comment = discussion.comments.nodes.find(
+        (c) => String(c.databaseId) === discussionCommentDbId,
+      );
+      hasNextPage = discussion.comments.pageInfo.hasNextPage;
+      cursor = discussion.comments.pageInfo.endCursor;
+    }
+
     if (!comment) fail(`Discussion comment #${discussionCommentDbId} not found in discussion #${discussionNumber}`);
 
     const bodyFile = tmpFile("body.md");
@@ -140,7 +154,7 @@ function cmdFetchContent(locationJson) {
         {
           type,
           comment_node_id: comment.id,
-          discussion_node_id: discussion.id,
+          discussion_node_id: discussionId,
           discussion_number: Number(discussionNumber),
           discussion_comment_db_id: Number(discussionCommentDbId),
           author: comment.author?.login,
@@ -156,7 +170,7 @@ function cmdFetchContent(locationJson) {
     type === "pull_request_comment" ||
     type === "pull_request_review_comment"
   ) {
-    // 从 url 中提取 comment ID
+    // Extract comment ID from URL
     const commentUrl =
       details.issue_comment_url ||
       details.pull_request_comment_url ||
@@ -167,7 +181,7 @@ function cmdFetchContent(locationJson) {
     const bodyFile = tmpFile("body.md");
     fs.writeFileSync(bodyFile, comment.body || "");
 
-    // 获取编辑历史
+    // Fetch edit history
     const nodeId = comment.node_id;
     const typeName =
       type === "pull_request_review_comment" ? "PullRequestReviewComment" : "IssueComment";
@@ -182,7 +196,7 @@ function cmdFetchContent(locationJson) {
     }`);
     const editCount = gql?.data?.node?.userContentEdits?.totalCount ?? 0;
 
-    // 提取 issue number（从 html_url）
+    // Extract issue number from html_url
     const htmlUrl = comment.html_url || details.html_url || "";
     const issueMatch = htmlUrl.match(/\/(issues|pull)\/(\d+)/);
     const issueNumber = issueMatch ? issueMatch[2] : null;
@@ -287,7 +301,7 @@ function cmdFetchContent(locationJson) {
           start_line: details.start_line,
           end_line: details.end_line,
           html_url: details.html_url || details.commit_url || details.blob_url || null,
-          // commit 没有 body 文件
+          // No body file for commits
           body_file: null,
         },
         null,
@@ -358,8 +372,8 @@ function cmdRecreateDiscussionComment(discussionNodeId, bodyFile) {
   if (!fs.existsSync(bodyFile)) fail(`File not found: ${bodyFile}`);
 
   const body = fs.readFileSync(bodyFile, "utf8");
-  // GraphQL 字符串需要转义
-  const escapedBody = body.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+  // Escape for GraphQL string literal
+  const escapedBody = body.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n");
   const result = ghGraphQL(`mutation { addDiscussionComment(input: { discussionId: "${discussionNodeId}", body: "${escapedBody}" }) { comment { id url } } }`);
   if (result?.errors) {
     fail(`Failed to create discussion comment: ${JSON.stringify(result.errors)}`);
@@ -452,6 +466,25 @@ function cmdNotify(issueNumber, author, locationType, secretTypes) {
     .filter((line) => line !== undefined)
     .join("\n");
 
+  // Discussion comments must be notified via GraphQL
+  if (locationType === "discussion_comment") {
+    const escapedBody = body.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n");
+    const result = ghGraphQL(`mutation { addDiscussionComment(input: { discussionId: "${issueNumber}", body: "${escapedBody}" }) { comment { id url } } }`);
+    if (result?.errors) {
+      fail(`Failed to post discussion notification: ${JSON.stringify(result.errors)}`);
+    }
+    const newComment = result?.data?.addDiscussionComment?.comment;
+    console.log(
+      JSON.stringify({
+        ok: true,
+        node_id: newComment?.id,
+        html_url: newComment?.url,
+      }),
+    );
+    return;
+  }
+
+  // Issue/PR comments via REST
   const bodyFile = tmpFile("notify.md");
   fs.writeFileSync(bodyFile, body);
 

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -38,8 +38,8 @@ function gh(args, { json = true, allowFailure = false } = {}) {
   }
 }
 
-function ghGraphQL(query) {
-  return gh(["api", "graphql", "-f", `query=${query}`]);
+function ghGraphQL(query, options = {}) {
+  return gh(["api", "graphql", "-f", `query=${query}`], options);
 }
 
 // ─── Commands ───────────────────────────────────────────────────────────────
@@ -93,7 +93,65 @@ function cmdFetchContent(locationJson) {
   const type = location.type;
   const details = location.details;
 
-  if (
+  if (type === "discussion_comment") {
+    // Discussion comments 只能通过 GraphQL 操作
+    const commentUrl = details.discussion_comment_url;
+    if (!commentUrl) fail("No discussion_comment_url in location details");
+
+    // 从 URL 提取 discussion number 和 comment id
+    // 格式: https://github.com/owner/repo/discussions/123#discussioncomment-456
+    const urlMatch = commentUrl.match(/discussions\/(\d+)#discussioncomment-(\d+)/);
+    if (!urlMatch) fail(`Cannot parse discussion comment URL: ${commentUrl}`);
+    const discussionNumber = urlMatch[1];
+    const discussionCommentDbId = urlMatch[2];
+
+    // 用 GraphQL 获取 discussion comment 内容
+    const gql = ghGraphQL(`{
+      repository(owner: "${REPO.split("/")[0]}", name: "${REPO.split("/")[1]}") {
+        discussion(number: ${discussionNumber}) {
+          id
+          url
+          comments(first: 50) {
+            nodes {
+              id
+              databaseId
+              author { login }
+              body
+              url
+            }
+          }
+        }
+      }
+    }`, { allowFailure: true });
+
+    const discussion = gql?.data?.repository?.discussion;
+    if (!discussion) fail(`Discussion #${discussionNumber} not found — it may have been deleted. The alert cannot be processed via this skill.`);
+
+    const comment = discussion.comments.nodes.find(
+      (c) => String(c.databaseId) === discussionCommentDbId,
+    );
+    if (!comment) fail(`Discussion comment #${discussionCommentDbId} not found in discussion #${discussionNumber}`);
+
+    const bodyFile = tmpFile("body.md");
+    fs.writeFileSync(bodyFile, comment.body || "");
+
+    console.log(
+      JSON.stringify(
+        {
+          type,
+          comment_node_id: comment.id,
+          discussion_node_id: discussion.id,
+          discussion_number: Number(discussionNumber),
+          discussion_comment_db_id: Number(discussionCommentDbId),
+          author: comment.author?.login,
+          html_url: comment.url || commentUrl,
+          body_file: bodyFile,
+        },
+        null,
+        2,
+      ),
+    );
+  } else if (
     type === "issue_comment" ||
     type === "pull_request_comment" ||
     type === "pull_request_review_comment"
@@ -279,6 +337,44 @@ function cmdDeleteComment(commentId) {
 }
 
 /**
+ * delete-discussion-comment <node-id>
+ * Delete a discussion comment via GraphQL (and all its edit history).
+ */
+function cmdDeleteDiscussionComment(nodeId) {
+  if (!nodeId) fail("Usage: delete-discussion-comment <node-id>");
+  const result = ghGraphQL(`mutation { deleteDiscussionComment(input: { id: "${nodeId}" }) { comment { id } } }`);
+  if (result?.errors) {
+    fail(`Failed to delete discussion comment: ${JSON.stringify(result.errors)}`);
+  }
+  console.log(JSON.stringify({ ok: true, deleted_node_id: nodeId }));
+}
+
+/**
+ * recreate-discussion-comment <discussion-node-id> <body-file>
+ * Create a new discussion comment via GraphQL.
+ */
+function cmdRecreateDiscussionComment(discussionNodeId, bodyFile) {
+  if (!discussionNodeId || !bodyFile) fail("Usage: recreate-discussion-comment <discussion-node-id> <body-file>");
+  if (!fs.existsSync(bodyFile)) fail(`File not found: ${bodyFile}`);
+
+  const body = fs.readFileSync(bodyFile, "utf8");
+  // GraphQL 字符串需要转义
+  const escapedBody = body.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+  const result = ghGraphQL(`mutation { addDiscussionComment(input: { discussionId: "${discussionNodeId}", body: "${escapedBody}" }) { comment { id url } } }`);
+  if (result?.errors) {
+    fail(`Failed to create discussion comment: ${JSON.stringify(result.errors)}`);
+  }
+  const newComment = result?.data?.addDiscussionComment?.comment;
+  console.log(
+    JSON.stringify({
+      ok: true,
+      node_id: newComment?.id,
+      html_url: newComment?.url,
+    }),
+  );
+}
+
+/**
  * recreate-comment <issue-number> <body-file>
  * Create a new comment from a file.
  */
@@ -321,7 +417,8 @@ function cmdNotify(issueNumber, author, locationType, secretTypes) {
   if (
     locationType === "issue_comment" ||
     locationType === "pull_request_comment" ||
-    locationType === "pull_request_review_comment"
+    locationType === "pull_request_review_comment" ||
+    locationType === "discussion_comment"
   ) {
     locationDesc = "your comment";
     actionDesc = "The affected comment has been removed and replaced with a redacted version.";
@@ -508,7 +605,9 @@ const commands = {
   "fetch-content": () => cmdFetchContent(args[0]),
   "redact-body": () => cmdRedactBody(args[0], args[1], args[2]),
   "delete-comment": () => cmdDeleteComment(args[0]),
+  "delete-discussion-comment": () => cmdDeleteDiscussionComment(args[0]),
   "recreate-comment": () => cmdRecreateComment(args[0], args[1]),
+  "recreate-discussion-comment": () => cmdRecreateDiscussionComment(args[0], args[1]),
   notify: () => cmdNotify(args[0], args[1], args[2], args[3]),
   resolve: () => cmdResolve(args[0], args[1], args[2]),
   "list-open": () => cmdListOpen(),
@@ -525,7 +624,9 @@ if (!command || !commands[command]) {
       "  fetch-content '<location-json>'   Fetch content for a location",
       "  redact-body <issue|pr> <n> <file> PATCH body with redacted file",
       "  delete-comment <comment-id>       Delete a comment",
+      "  delete-discussion-comment <node-id> Delete a discussion comment (GraphQL)",
       "  recreate-comment <issue-n> <file> Create replacement comment",
+      "  recreate-discussion-comment <disc-node-id> <file> Create discussion comment (GraphQL)",
       "  notify <n> <author> <type> <types> Post notification",
       "  resolve <n> [resolution] [comment] Close alert",
       "  list-open                          List open alerts",

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -114,7 +114,8 @@ function cmdFetchContent(locationJson) {
 
     while (hasNextPage && !comment) {
       const afterClause = cursor ? `, after: "${cursor}"` : "";
-      const gql = ghGraphQL(`{
+      const gql = ghGraphQL(
+        `{
         repository(owner: "${owner}", name: "${name}") {
           discussion(number: ${discussionNumber}) {
             id
@@ -131,10 +132,15 @@ function cmdFetchContent(locationJson) {
             }
           }
         }
-      }`, { allowFailure: true });
+      }`,
+        { allowFailure: true },
+      );
 
       const discussion = gql?.data?.repository?.discussion;
-      if (!discussion) fail(`Discussion #${discussionNumber} not found — it may have been deleted. The alert cannot be processed via this skill.`);
+      if (!discussion)
+        fail(
+          `Discussion #${discussionNumber} not found — it may have been deleted. The alert cannot be processed via this skill.`,
+        );
 
       discussionId = discussion.id;
       comment = discussion.comments.nodes.find(
@@ -144,7 +150,10 @@ function cmdFetchContent(locationJson) {
       cursor = discussion.comments.pageInfo.endCursor;
     }
 
-    if (!comment) fail(`Discussion comment #${discussionCommentDbId} not found in discussion #${discussionNumber}`);
+    if (!comment)
+      fail(
+        `Discussion comment #${discussionCommentDbId} not found in discussion #${discussionNumber}`,
+      );
 
     const bodyFile = tmpFile("body.md");
     fs.writeFileSync(bodyFile, comment.body || "");
@@ -356,7 +365,9 @@ function cmdDeleteComment(commentId) {
  */
 function cmdDeleteDiscussionComment(nodeId) {
   if (!nodeId) fail("Usage: delete-discussion-comment <node-id>");
-  const result = ghGraphQL(`mutation { deleteDiscussionComment(input: { id: "${nodeId}" }) { comment { id } } }`);
+  const result = ghGraphQL(
+    `mutation { deleteDiscussionComment(input: { id: "${nodeId}" }) { comment { id } } }`,
+  );
   if (result?.errors) {
     fail(`Failed to delete discussion comment: ${JSON.stringify(result.errors)}`);
   }
@@ -368,13 +379,20 @@ function cmdDeleteDiscussionComment(nodeId) {
  * Create a new discussion comment via GraphQL.
  */
 function cmdRecreateDiscussionComment(discussionNodeId, bodyFile) {
-  if (!discussionNodeId || !bodyFile) fail("Usage: recreate-discussion-comment <discussion-node-id> <body-file>");
+  if (!discussionNodeId || !bodyFile)
+    fail("Usage: recreate-discussion-comment <discussion-node-id> <body-file>");
   if (!fs.existsSync(bodyFile)) fail(`File not found: ${bodyFile}`);
 
   const body = fs.readFileSync(bodyFile, "utf8");
   // Escape for GraphQL string literal
-  const escapedBody = body.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n");
-  const result = ghGraphQL(`mutation { addDiscussionComment(input: { discussionId: "${discussionNodeId}", body: "${escapedBody}" }) { comment { id url } } }`);
+  const escapedBody = body
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n");
+  const result = ghGraphQL(
+    `mutation { addDiscussionComment(input: { discussionId: "${discussionNodeId}", body: "${escapedBody}" }) { comment { id url } } }`,
+  );
   if (result?.errors) {
     fail(`Failed to create discussion comment: ${JSON.stringify(result.errors)}`);
   }
@@ -415,12 +433,13 @@ function cmdRecreateComment(issueNumber, bodyFile) {
 }
 
 /**
- * notify <issue-or-pr-number> <author> <location-type> <secret-types>
+ * notify <target> <author> <location-type> <secret-types>
  * Post a notification comment with the correct template for the location type.
+ * target = issue/PR number for non-discussion types, discussion node ID for discussion_comment.
  */
-function cmdNotify(issueNumber, author, locationType, secretTypes) {
-  if (!issueNumber || !author || !locationType || !secretTypes) {
-    fail("Usage: notify <issue-or-pr-number> <author> <location-type> <secret-types-comma-sep>");
+function cmdNotify(target, author, locationType, secretTypes) {
+  if (!target || !author || !locationType || !secretTypes) {
+    fail("Usage: notify <target> <author> <location-type> <secret-types-comma-sep>");
   }
 
   const types = secretTypes.split(",").map((s) => s.trim());
@@ -468,8 +487,14 @@ function cmdNotify(issueNumber, author, locationType, secretTypes) {
 
   // Discussion comments must be notified via GraphQL
   if (locationType === "discussion_comment") {
-    const escapedBody = body.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n");
-    const result = ghGraphQL(`mutation { addDiscussionComment(input: { discussionId: "${issueNumber}", body: "${escapedBody}" }) { comment { id url } } }`);
+    const escapedBody = body
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/\r/g, "\\r")
+      .replace(/\n/g, "\\n");
+    const result = ghGraphQL(
+      `mutation { addDiscussionComment(input: { discussionId: "${target}", body: "${escapedBody}" }) { comment { id url } } }`,
+    );
     if (result?.errors) {
       fail(`Failed to post discussion notification: ${JSON.stringify(result.errors)}`);
     }
@@ -490,7 +515,7 @@ function cmdNotify(issueNumber, author, locationType, secretTypes) {
 
   const result = gh([
     "api",
-    `repos/${REPO}/issues/${issueNumber}/comments`,
+    `repos/${REPO}/issues/${target}/comments`,
     "-X",
     "POST",
     "-F",
@@ -660,7 +685,7 @@ if (!command || !commands[command]) {
       "  delete-discussion-comment <node-id> Delete a discussion comment (GraphQL)",
       "  recreate-comment <issue-n> <file> Create replacement comment",
       "  recreate-discussion-comment <disc-node-id> <file> Create discussion comment (GraphQL)",
-      "  notify <n> <author> <type> <types> Post notification",
+      "  notify <target> <author> <type> <types> Post notification",
       "  resolve <n> [resolution] [comment] Close alert",
       "  list-open                          List open alerts",
       "  summary <json-file>               Print formatted summary",

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -42,6 +42,145 @@ function ghGraphQL(query, options = {}) {
   return gh(["api", "graphql", "-f", `query=${query}`], options);
 }
 
+function escapeGraphQLString(value) {
+  return String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n");
+}
+
+function formatGraphQLAfterClause(cursor) {
+  return cursor ? `, after: "${escapeGraphQLString(cursor)}"` : "";
+}
+
+function findDiscussionCommentNode(nodes, discussionCommentDbId) {
+  return (
+    nodes.find((node) => String(node.databaseId) === String(discussionCommentDbId)) || null
+  );
+}
+
+function fetchDiscussionReplyPage(commentNodeId, cursor) {
+  const afterClause = formatGraphQLAfterClause(cursor);
+  return ghGraphQL(`{
+    node(id: "${escapeGraphQLString(commentNodeId)}") {
+      ... on DiscussionComment {
+        replies(first: 100${afterClause}) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            databaseId
+            author { login }
+            body
+            url
+            replyTo { id }
+            userContentEdits(first: 50) {
+              totalCount
+            }
+          }
+        }
+      }
+    }
+  }}`);
+}
+
+function fetchDiscussionComment(discussionNumber, discussionCommentDbId) {
+  const [owner, name] = REPO.split("/");
+  let discussionId = null;
+  let cursor = null;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const afterClause = formatGraphQLAfterClause(cursor);
+    const gql = ghGraphQL(
+      `{
+        repository(owner: "${owner}", name: "${name}") {
+          discussion(number: ${discussionNumber}) {
+            id
+            comments(first: 50${afterClause}) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                id
+                databaseId
+                author { login }
+                body
+                url
+                replyTo { id }
+                userContentEdits(first: 50) {
+                  totalCount
+                }
+                replies(first: 100) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    id
+                    databaseId
+                    author { login }
+                    body
+                    url
+                    replyTo { id }
+                    userContentEdits(first: 50) {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }`,
+      { allowFailure: true },
+    );
+
+    const discussion = gql?.data?.repository?.discussion;
+    if (!discussion)
+      fail(
+        `Discussion #${discussionNumber} not found — it may have been deleted. The alert cannot be processed via this skill.`,
+      );
+
+    discussionId = discussion.id;
+
+    for (const topLevelComment of discussion.comments.nodes) {
+      if (String(topLevelComment.databaseId) === String(discussionCommentDbId)) {
+        return { discussionId, comment: topLevelComment };
+      }
+
+      let reply = findDiscussionCommentNode(topLevelComment.replies.nodes, discussionCommentDbId);
+      let replyCursor = topLevelComment.replies.pageInfo.endCursor;
+      let hasMoreReplies = topLevelComment.replies.pageInfo.hasNextPage;
+
+      while (!reply && hasMoreReplies) {
+        const replyPage = fetchDiscussionReplyPage(topLevelComment.id, replyCursor);
+        const replies = replyPage?.data?.node?.replies;
+        if (!replies) fail(`Failed to paginate replies for discussion comment ${topLevelComment.id}`);
+
+        reply = findDiscussionCommentNode(replies.nodes, discussionCommentDbId);
+        hasMoreReplies = replies.pageInfo.hasNextPage;
+        replyCursor = replies.pageInfo.endCursor;
+      }
+
+      if (reply) return { discussionId, comment: reply };
+    }
+
+    hasNextPage = discussion.comments.pageInfo.hasNextPage;
+    cursor = discussion.comments.pageInfo.endCursor;
+  }
+
+  return { discussionId, comment: null };
+}
+
+function createDiscussionComment(discussionNodeId, body, replyToNodeId) {
+  const replyToClause = replyToNodeId
+    ? `, replyToId: "${escapeGraphQLString(replyToNodeId)}"`
+    : "";
+  const result = ghGraphQL(
+    `mutation { addDiscussionComment(input: { discussionId: "${escapeGraphQLString(discussionNodeId)}"${replyToClause}, body: "${escapeGraphQLString(body)}" }) { comment { id url } } }`,
+  );
+  if (result?.errors) {
+    fail(`Failed to create discussion comment: ${JSON.stringify(result.errors)}`);
+  }
+  return result?.data?.addDiscussionComment?.comment;
+}
+
 // ─── Commands ───────────────────────────────────────────────────────────────
 
 /**
@@ -94,62 +233,15 @@ function cmdFetchContent(locationJson) {
   const details = location.details;
 
   if (type === "discussion_comment") {
-    // Discussion comments can only be operated via GraphQL
     const commentUrl = details.discussion_comment_url;
     if (!commentUrl) fail("No discussion_comment_url in location details");
 
-    // Extract discussion number and comment id from URL
-    // Format: https://github.com/owner/repo/discussions/123#discussioncomment-456
     const urlMatch = commentUrl.match(/discussions\/(\d+)#discussioncomment-(\d+)/);
     if (!urlMatch) fail(`Cannot parse discussion comment URL: ${commentUrl}`);
     const discussionNumber = urlMatch[1];
     const discussionCommentDbId = urlMatch[2];
 
-    // Fetch discussion comment via GraphQL with pagination
-    const [owner, name] = REPO.split("/");
-    let comment = null;
-    let discussionId = null;
-    let cursor = null;
-    let hasNextPage = true;
-
-    while (hasNextPage && !comment) {
-      const afterClause = cursor ? `, after: "${cursor}"` : "";
-      const gql = ghGraphQL(
-        `{
-        repository(owner: "${owner}", name: "${name}") {
-          discussion(number: ${discussionNumber}) {
-            id
-            url
-            comments(first: 50${afterClause}) {
-              pageInfo { hasNextPage endCursor }
-              nodes {
-                id
-                databaseId
-                author { login }
-                body
-                url
-              }
-            }
-          }
-        }
-      }`,
-        { allowFailure: true },
-      );
-
-      const discussion = gql?.data?.repository?.discussion;
-      if (!discussion)
-        fail(
-          `Discussion #${discussionNumber} not found — it may have been deleted. The alert cannot be processed via this skill.`,
-        );
-
-      discussionId = discussion.id;
-      comment = discussion.comments.nodes.find(
-        (c) => String(c.databaseId) === discussionCommentDbId,
-      );
-      hasNextPage = discussion.comments.pageInfo.hasNextPage;
-      cursor = discussion.comments.pageInfo.endCursor;
-    }
-
+    const { discussionId, comment } = fetchDiscussionComment(discussionNumber, discussionCommentDbId);
     if (!comment)
       fail(
         `Discussion comment #${discussionCommentDbId} not found in discussion #${discussionNumber}`,
@@ -164,10 +256,12 @@ function cmdFetchContent(locationJson) {
           type,
           comment_node_id: comment.id,
           discussion_node_id: discussionId,
+          reply_to_node_id: comment.replyTo?.id ?? null,
           discussion_number: Number(discussionNumber),
           discussion_comment_db_id: Number(discussionCommentDbId),
           author: comment.author?.login,
           html_url: comment.url || commentUrl,
+          edit_history_count: comment.userContentEdits?.totalCount ?? 0,
           body_file: bodyFile,
         },
         null,
@@ -375,28 +469,16 @@ function cmdDeleteDiscussionComment(nodeId) {
 }
 
 /**
- * recreate-discussion-comment <discussion-node-id> <body-file>
+ * recreate-discussion-comment <discussion-node-id> <body-file> [reply-to-node-id]
  * Create a new discussion comment via GraphQL.
  */
-function cmdRecreateDiscussionComment(discussionNodeId, bodyFile) {
+function cmdRecreateDiscussionComment(discussionNodeId, bodyFile, replyToNodeId) {
   if (!discussionNodeId || !bodyFile)
-    fail("Usage: recreate-discussion-comment <discussion-node-id> <body-file>");
+    fail("Usage: recreate-discussion-comment <discussion-node-id> <body-file> [reply-to-node-id]");
   if (!fs.existsSync(bodyFile)) fail(`File not found: ${bodyFile}`);
 
   const body = fs.readFileSync(bodyFile, "utf8");
-  // Escape for GraphQL string literal
-  const escapedBody = body
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"')
-    .replace(/\r/g, "\\r")
-    .replace(/\n/g, "\\n");
-  const result = ghGraphQL(
-    `mutation { addDiscussionComment(input: { discussionId: "${discussionNodeId}", body: "${escapedBody}" }) { comment { id url } } }`,
-  );
-  if (result?.errors) {
-    fail(`Failed to create discussion comment: ${JSON.stringify(result.errors)}`);
-  }
-  const newComment = result?.data?.addDiscussionComment?.comment;
+  const newComment = createDiscussionComment(discussionNodeId, body, replyToNodeId);
   console.log(
     JSON.stringify({
       ok: true,
@@ -433,13 +515,15 @@ function cmdRecreateComment(issueNumber, bodyFile) {
 }
 
 /**
- * notify <target> <author> <location-type> <secret-types>
+ * notify <target> <author> <location-type> <secret-types> [reply-to-node-id]
  * Post a notification comment with the correct template for the location type.
  * target = issue/PR number for non-discussion types, discussion node ID for discussion_comment.
  */
-function cmdNotify(target, author, locationType, secretTypes) {
+function cmdNotify(target, author, locationType, secretTypes, replyToNodeId) {
   if (!target || !author || !locationType || !secretTypes) {
-    fail("Usage: notify <target> <author> <location-type> <secret-types-comma-sep>");
+    fail(
+      "Usage: notify <target> <author> <location-type> <secret-types-comma-sep> [reply-to-node-id]",
+    );
   }
 
   const types = secretTypes.split(",").map((s) => s.trim());
@@ -487,18 +571,7 @@ function cmdNotify(target, author, locationType, secretTypes) {
 
   // Discussion comments must be notified via GraphQL
   if (locationType === "discussion_comment") {
-    const escapedBody = body
-      .replace(/\\/g, "\\\\")
-      .replace(/"/g, '\\"')
-      .replace(/\r/g, "\\r")
-      .replace(/\n/g, "\\n");
-    const result = ghGraphQL(
-      `mutation { addDiscussionComment(input: { discussionId: "${target}", body: "${escapedBody}" }) { comment { id url } } }`,
-    );
-    if (result?.errors) {
-      fail(`Failed to post discussion notification: ${JSON.stringify(result.errors)}`);
-    }
-    const newComment = result?.data?.addDiscussionComment?.comment;
+    const newComment = createDiscussionComment(target, body, replyToNodeId);
     console.log(
       JSON.stringify({
         ok: true,
@@ -665,8 +738,8 @@ const commands = {
   "delete-comment": () => cmdDeleteComment(args[0]),
   "delete-discussion-comment": () => cmdDeleteDiscussionComment(args[0]),
   "recreate-comment": () => cmdRecreateComment(args[0], args[1]),
-  "recreate-discussion-comment": () => cmdRecreateDiscussionComment(args[0], args[1]),
-  notify: () => cmdNotify(args[0], args[1], args[2], args[3]),
+  "recreate-discussion-comment": () => cmdRecreateDiscussionComment(args[0], args[1], args[2]),
+  notify: () => cmdNotify(args[0], args[1], args[2], args[3], args[4]),
   resolve: () => cmdResolve(args[0], args[1], args[2]),
   "list-open": () => cmdListOpen(),
   summary: () => cmdSummary(args[0]),
@@ -684,8 +757,8 @@ if (!command || !commands[command]) {
       "  delete-comment <comment-id>       Delete a comment",
       "  delete-discussion-comment <node-id> Delete a discussion comment (GraphQL)",
       "  recreate-comment <issue-n> <file> Create replacement comment",
-      "  recreate-discussion-comment <disc-node-id> <file> Create discussion comment (GraphQL)",
-      "  notify <target> <author> <type> <types> Post notification",
+      "  recreate-discussion-comment <disc-node-id> <file> [reply-to-node-id] Create discussion comment (GraphQL)",
+      "  notify <target> <author> <type> <types> [reply-to-node-id] Post notification",
       "  resolve <n> [resolution] [comment] Close alert",
       "  list-open                          List open alerts",
       "  summary <json-file>               Print formatted summary",

--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -30,6 +30,14 @@ function gh(args, { json = true, allowFailure = false } = {}) {
   if (proc.status !== 0 && !allowFailure) {
     fail(`gh ${args.slice(0, 3).join(" ")} failed:\n${(proc.stderr || proc.stdout || "").trim()}`);
   }
+  if (proc.status !== 0) {
+    return {
+      gh_failed: true,
+      status: proc.status,
+      stdout: proc.stdout,
+      stderr: proc.stderr,
+    };
+  }
   if (!json) return proc.stdout;
   try {
     return JSON.parse(proc.stdout);
@@ -40,6 +48,16 @@ function gh(args, { json = true, allowFailure = false } = {}) {
 
 function ghGraphQL(query, options = {}) {
   return gh(["api", "graphql", "-f", `query=${query}`], options);
+}
+
+function failOnGraphQLFailure(result, message) {
+  if (result?.gh_failed) {
+    const details = (result.stderr || result.stdout || `gh exited with status ${result.status}`).trim();
+    fail(`${message}: ${details}`);
+  }
+  if (Array.isArray(result?.errors) && result.errors.length > 0) {
+    fail(`${message}: ${JSON.stringify(result.errors)}`);
+  }
 }
 
 function escapeGraphQLString(value) {
@@ -130,6 +148,7 @@ function fetchDiscussionComment(discussionNumber, discussionCommentDbId) {
       }`,
       { allowFailure: true },
     );
+    failOnGraphQLFailure(gql, `Failed to fetch discussion #${discussionNumber}`);
 
     const discussion = gql?.data?.repository?.discussion;
     if (!discussion)
@@ -150,6 +169,7 @@ function fetchDiscussionComment(discussionNumber, discussionCommentDbId) {
 
       while (!reply && hasMoreReplies) {
         const replyPage = fetchDiscussionReplyPage(topLevelComment.id, replyCursor);
+        failOnGraphQLFailure(replyPage, `Failed to fetch replies for discussion comment ${topLevelComment.id}`);
         const replies = replyPage?.data?.node?.replies;
         if (!replies) fail(`Failed to paginate replies for discussion comment ${topLevelComment.id}`);
 


### PR DESCRIPTION
## Summary

- Add `discussion_comment` location type support to the secret-scanning maintainer skill
- Discussion comments require GraphQL (no REST API available), so two new commands are added:
  - `delete-discussion-comment <node-id>` — deletes via `deleteDiscussionComment` mutation
  - `recreate-discussion-comment <discussion-node-id> <body-file>` — creates via `addDiscussionComment` mutation
- `fetch-content` now handles `discussion_comment` type: parses discussion URL, fetches comment via GraphQL, returns node IDs for delete/recreate
- Graceful error when discussion has been deleted ("Discussion #N not found — it may have been deleted")
- `ghGraphQL` helper now accepts options (e.g. `allowFailure`) for graceful error handling

Triggered by alert #43 (Azure AI Services Key in discussion comment) being skipped as unsupported.

## Test plan

- [x] `fetch-content` with discussion_comment type correctly parses URL and returns node IDs
- [x] Graceful error message when discussion is deleted
- [x] Script usage help shows new commands
- [ ] End-to-end test on a live discussion comment (when one is available)