### PR TITLE
fix: user-facing Gemini auth errors + /connect_ai_subscription command

### DIFF
--- a/extensions/google/gemini-cli-provider.ts
+++ b/extensions/google/gemini-cli-provider.ts
@@ -130,5 +130,8 @@ export function registerGoogleGeminiCliProvider(api: OpenClawPluginApi) {
       };
     },
     fetchUsageSnapshot: async (ctx) => await fetchGeminiCliUsage(ctx),
+    buildAuthDoctorHint: () =>
+      "Your Gemini OAuth connection may be broken. Run /connect_ai_subscription gemini to re-authenticate, " +
+      "or verify that your Google account still has Gemini API access.",
   });
 }

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -10,8 +10,10 @@ export {
   stripThoughtSignatures,
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
+  AUTH_ERROR_USER_MESSAGE,
   BILLING_ERROR_USER_MESSAGE,
   classifyProviderRuntimeFailureKind,
+  formatAuthErrorMessage,
   formatBillingErrorMessage,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -70,6 +70,36 @@ export {
 
 const log = createSubsystemLogger("errors");
 
+// Providers whose OAuth credentials can be repaired via `/connect_ai_subscription gemini`.
+const GEMINI_OAUTH_PROVIDER_IDS = ["google-gemini-cli", "google-antigravity"];
+
+function isGeminiOAuthProvider(provider?: string): boolean {
+  if (!provider) {
+    return false;
+  }
+  const lower = provider.trim().toLowerCase();
+  return GEMINI_OAUTH_PROVIDER_IDS.some((id) => lower === id || lower.startsWith(`${id}/`));
+}
+
+export function formatAuthErrorMessage(provider?: string, model?: string): string {
+  const providerName = provider?.trim();
+  const modelName = model?.trim();
+  if (isGeminiOAuthProvider(providerName)) {
+    return (
+      "⚠️ Your Gemini connection couldn't authenticate. " +
+      "Send /connect_ai_subscription gemini to reconnect, or check that your Google account still has Gemini API access."
+    );
+  }
+  const providerLabel =
+    providerName && modelName ? `${providerName} (${modelName})` : providerName || undefined;
+  if (providerLabel) {
+    return `⚠️ ${providerLabel} returned an authentication error. Check your API key or credentials, or re-authenticate with /connect_ai_subscription.`;
+  }
+  return "⚠️ API provider returned an authentication error. Check your API key or credentials, or re-authenticate with /connect_ai_subscription.";
+}
+
+export const AUTH_ERROR_USER_MESSAGE = formatAuthErrorMessage();
+
 export function isReasoningConstraintErrorMessage(raw: string): boolean {
   if (!raw) {
     return false;
@@ -941,6 +971,10 @@ export function formatAssistantErrorText(
 
   if (isBillingErrorMessage(raw)) {
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
+  }
+
+  if (isAuthPermanentErrorMessage(raw) || isAuthErrorMessage(raw)) {
+    return formatAuthErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
   if (providerRuntimeFailureKind === "schema") {

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -13,6 +13,8 @@ import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
 import { stableStringify } from "../stable-stringify.js";
 import {
+  isAuthErrorMessage,
+  isAuthPermanentErrorMessage,
   isBillingErrorMessage,
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
@@ -31,6 +33,9 @@ export function formatBillingErrorMessage(provider?: string, model?: string): st
 }
 
 export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
+
+const AUTH_ERROR_USER_MESSAGE =
+  "⚠️ API provider returned an authentication error. Check your API key or credentials, or re-authenticate with /connect_ai_subscription.";
 
 const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
 const OVERLOADED_ERROR_USER_MESSAGE =
@@ -417,6 +422,10 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
 
     if (isBillingErrorMessage(trimmed)) {
       return BILLING_ERROR_USER_MESSAGE;
+    }
+
+    if (isAuthPermanentErrorMessage(trimmed) || isAuthErrorMessage(trimmed)) {
+      return AUTH_ERROR_USER_MESSAGE;
     }
 
     if (isInvalidStreamingEventOrderError(trimmed)) {

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -5,6 +5,7 @@ import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import { FailoverError, resolveFailoverStatus } from "../../failover-error.js";
 import {
   formatAssistantErrorText,
+  formatAuthErrorMessage,
   formatBillingErrorMessage,
   isTimeoutErrorMessage,
   type FailoverReason,
@@ -202,7 +203,10 @@ export async function handleAssistantFailover(params: {
                 params.activeErrorContext.model,
               )
             : params.authFailure
-              ? "LLM request unauthorized."
+              ? formatAuthErrorMessage(
+                  params.activeErrorContext.provider,
+                  params.activeErrorContext.model,
+                )
               : "LLM request failed.");
     const status =
       resolveFailoverStatus(decision.reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -840,6 +840,29 @@ export function buildBuiltinChatCommands(): ChatCommandDefinition[] {
         },
       ],
     }),
+    defineChatCommand({
+      key: "connect_ai_subscription",
+      nativeName: "connect_ai_subscription",
+      description: "Connect an AI subscription (Gemini, Codex, or Claude).",
+      textAlias: "/connect_ai_subscription",
+      category: "management",
+      args: [
+        {
+          name: "provider",
+          description: "AI provider to connect",
+          type: "string",
+          choices: [
+            { value: "gemini", label: "Gemini (Google)" },
+            { value: "codex", label: "OpenAI (Codex)" },
+            { value: "anthropic", label: "Anthropic (Claude)" },
+          ],
+        },
+      ],
+      argsMenu: {
+        arg: "provider",
+        title: "Connect an AI subscription.\n" + "Choose a provider to get started:",
+      },
+    }),
   ];
 
   registerAlias(commands, "whoami", "/id");

--- a/src/auto-reply/reply/commands-connect-ai.ts
+++ b/src/auto-reply/reply/commands-connect-ai.ts
@@ -1,0 +1,114 @@
+import { logVerbose } from "../../globals.js";
+import type { CommandHandler } from "./commands-types.js";
+
+const GENIE_WEB_SETTINGS_URL = "https://genie.deva.me/app/settings?tab=server";
+
+const PROVIDER_INSTRUCTIONS: Record<string, { label: string; text: string }> = {
+  gemini: {
+    label: "Gemini (Google)",
+    text: [
+      "To connect your Gemini subscription:",
+      "",
+      "1. Open the LLM Integrations section in your server settings:",
+      GENIE_WEB_SETTINGS_URL,
+      "",
+      '2. Select the "Gemini" tab.',
+      "3. Follow the prompts to authenticate with your Google account.",
+      "",
+      "Once connected, you can use Gemini models in your conversations.",
+    ].join("\n"),
+  },
+  codex: {
+    label: "OpenAI (Codex)",
+    text: [
+      "To connect your OpenAI / Codex subscription:",
+      "",
+      "1. Open the LLM Integrations section in your server settings:",
+      GENIE_WEB_SETTINGS_URL,
+      "",
+      '2. Select the "Codex" tab.',
+      "3. Follow the prompts to authenticate with your OpenAI account.",
+      "",
+      "Once connected, you can use OpenAI models in your conversations.",
+    ].join("\n"),
+  },
+  anthropic: {
+    label: "Anthropic (Claude)",
+    text: [
+      "To connect your Anthropic / Claude subscription:",
+      "",
+      "1. Open the LLM Integrations section in your server settings:",
+      GENIE_WEB_SETTINGS_URL,
+      "",
+      '2. Select the "Claude" tab.',
+      '3. Use the "Claude setup-token" method (recommended) or OAuth.',
+      "",
+      "For setup-token: run `openclaw setup-token` in your terminal to generate a long-lived token, then paste it in the settings page.",
+      "",
+      "Once connected, you can use Claude models in your conversations.",
+    ].join("\n"),
+  },
+};
+
+export const handleConnectAiSubscriptionCommand: CommandHandler = async (
+  params,
+  allowTextCommands,
+) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+
+  const normalized = params.command.commandBodyNormalized;
+  if (
+    normalized !== "/connect_ai_subscription" &&
+    !normalized.startsWith("/connect_ai_subscription ")
+  ) {
+    return null;
+  }
+
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /connect_ai_subscription from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+
+  const parts = normalized.split(/\s+/);
+  const provider = parts[1]?.toLowerCase();
+
+  if (!provider) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: [
+          "Connect an AI subscription to use additional models.",
+          "",
+          "Usage: /connect_ai_subscription <provider>",
+          "",
+          "Providers: gemini, codex, anthropic",
+          "",
+          `Or open the settings page directly: ${GENIE_WEB_SETTINGS_URL}`,
+        ].join("\n"),
+      },
+    };
+  }
+
+  const info = PROVIDER_INSTRUCTIONS[provider];
+  if (!info) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: [
+          `Unknown provider: ${provider}`,
+          "",
+          "Available providers: gemini, codex, anthropic",
+        ].join("\n"),
+      },
+    };
+  }
+
+  return {
+    shouldContinue: false,
+    reply: { text: info.text },
+  };
+};

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -5,6 +5,7 @@ import { handleBashCommand } from "./commands-bash.js";
 import { handleBtwCommand } from "./commands-btw.js";
 import { handleCompactCommand } from "./commands-compact.js";
 import { handleConfigCommand, handleDebugCommand } from "./commands-config.js";
+import { handleConnectAiSubscriptionCommand } from "./commands-connect-ai.js";
 import { handleContextCommand } from "./commands-context-command.js";
 import {
   handleCommandsListCommand,
@@ -64,6 +65,7 @@ export function loadCommandHandlers(): CommandHandler[] {
     handleModelsCommand,
     handleStopCommand,
     handleCompactCommand,
+    handleConnectAiSubscriptionCommand,
     handleAbortTrigger,
   ];
 }


### PR DESCRIPTION
## Summary
- When Gemini OAuth credentials are broken, users now see a helpful error message telling them to run `/connect_ai_subscription gemini` instead of a raw API error or silence
- New `/connect_ai_subscription` Telegram command guides users to connect their AI subscriptions (Gemini, Codex, Anthropic) with provider-specific instructions
- Adds `buildAuthDoctorHint` to Google Gemini CLI provider
- Adds `formatAuthErrorMessage()` alongside existing `formatBillingErrorMessage()` pattern
- Replaces generic "LLM request unauthorized" with provider-specific auth error messages

## Test plan
- [ ] Simulate expired Gemini OAuth token — verify user sees `/connect_ai_subscription gemini` message
- [ ] Send `/connect_ai_subscription` in Telegram — should show provider choices
- [ ] Send `/connect_ai_subscription gemini` — should show Gemini-specific instructions
- [ ] Verify billing errors still show existing billing message (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)