### PR TITLE
fix(discord): skip false stale-socket restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/health: skip stale-socket restarts for healthy idle Discord gateway sessions so the health monitor no longer cycles otherwise stable connections every ~35 minutes. Fixes #65613.
+
 ## 2026.4.12-beta.1
 
 ### Changes

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -114,6 +114,10 @@ describe("discordPlugin outbound", () => {
     expect(source).not.toContain('require("./channel-actions.js")');
   });
 
+  it("skips stale-socket health restarts for healthy idle sessions", () => {
+    expect(discordPlugin.status?.skipStaleSocketHealthCheck).toBe(true);
+  });
+
   it("honors per-account replyToMode overrides", () => {
     const resolveReplyToMode = discordPlugin.threading?.resolveReplyToMode;
     if (!resolveReplyToMode) {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -602,6 +602,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
           lastDisconnect: null,
           lastEventAt: null,
         }),
+        skipStaleSocketHealthCheck: true,
         collectStatusIssues: collectDiscordStatusIssues,
         buildChannelSummary: ({ snapshot }) =>
           buildTokenChannelStatusSummary(snapshot, { includeMode: false }),

--- a/src/plugin-sdk/status-helpers.test.ts
+++ b/src/plugin-sdk/status-helpers.test.ts
@@ -99,6 +99,7 @@ function createComputedStatusAdapter() {
     { ok: boolean }
   >({
     defaultRuntime: createDefaultChannelRuntimeState("default"),
+    skipStaleSocketHealthCheck: true,
     resolveAccountSnapshot: ({ account, runtime, probe }) => ({
       accountId: account.accountId,
       enabled: account.enabled,
@@ -118,6 +119,7 @@ function createAsyncStatusAdapter() {
     { ok: boolean }
   >({
     defaultRuntime: createDefaultChannelRuntimeState("default"),
+    skipStaleSocketHealthCheck: true,
     resolveAccountSnapshot: async ({ account, runtime, probe }) => ({
       accountId: account.accountId,
       enabled: account.enabled,
@@ -270,6 +272,19 @@ describe("buildComputedAccountStatusSnapshot", () => {
 });
 
 describe("computed account status adapters", () => {
+  it.each([
+    {
+      name: "sync",
+      createStatus: createComputedStatusAdapter,
+    },
+    {
+      name: "async",
+      createStatus: createAsyncStatusAdapter,
+    },
+  ])("preserves skipStaleSocketHealthCheck on $name adapters", ({ createStatus }) => {
+    expect(createStatus().skipStaleSocketHealthCheck).toBe(true);
+  });
+
   it.each([
     {
       name: "sync",

--- a/src/plugin-sdk/status-helpers.ts
+++ b/src/plugin-sdk/status-helpers.ts
@@ -213,6 +213,7 @@ export function createComputedAccountStatusAdapter<
 ): ChannelStatusAdapter<ResolvedAccount, Probe, Audit> {
   return {
     defaultRuntime: options.defaultRuntime,
+    skipStaleSocketHealthCheck: options.skipStaleSocketHealthCheck,
     buildChannelSummary: options.buildChannelSummary,
     probeAccount: options.probeAccount,
     formatCapabilitiesProbe: options.formatCapabilitiesProbe,
@@ -255,6 +256,7 @@ export function createAsyncComputedAccountStatusAdapter<
 ): ChannelStatusAdapter<ResolvedAccount, Probe, Audit> {
   return {
     defaultRuntime: options.defaultRuntime,
+    skipStaleSocketHealthCheck: options.skipStaleSocketHealthCheck,
     buildChannelSummary: options.buildChannelSummary,
     probeAccount: options.probeAccount,
     formatCapabilitiesProbe: options.formatCapabilitiesProbe,


### PR DESCRIPTION
## Summary

- Problem: the Discord channel health monitor could restart otherwise healthy idle gateway sessions every ~35 minutes with `stale-socket`.
- Why it matters: Discord reconnects cleanly, but the repeated cycle is noisy and creates avoidable connection churn for stable bots.
- What changed: Discord now opts out of stale-socket health restarts, and the shared computed status-adapter helpers now preserve `skipStaleSocketHealthCheck` so that opt-out actually reaches gateway health evaluation.
- What did NOT change (scope boundary): this PR does not add a new low-level Discord socket liveness heuristic or alter Discord reconnect behavior outside the health-monitor decision.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65613
- Related #38395
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `createComputedAccountStatusAdapter()` and `createAsyncComputedAccountStatusAdapter()` dropped the `skipStaleSocketHealthCheck` field when they returned the channel status adapter, so Discord's status adapter could request the stale-socket opt-out without that flag ever reaching `getChannelPlugin(channelId)?.status?.skipStaleSocketHealthCheck` in gateway health evaluation.
- Missing detection / guardrail: we had policy tests for stale-socket behavior, but no regression test that asserted computed status adapters preserve the stale-socket opt-out flag.
- Contributing context (if known): Discord updates `lastEventAt` from user-facing inbound activity, so long idle periods can look stale even when the underlying gateway socket is still healthy.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugin-sdk/status-helpers.test.ts`, `extensions/discord/src/channel.test.ts`, `src/gateway/channel-health-policy.test.ts`, `src/gateway/channel-health-monitor.test.ts`, `src/gateway/server/readiness.test.ts`
- Scenario the test should lock in: a computed channel status adapter that sets `skipStaleSocketHealthCheck: true` must preserve that flag, and the Discord plugin must publish that opt-out on its status adapter.
- Why this is the smallest reliable guardrail: the regression happens before any runtime Discord traffic; the minimal reliable check is the shared adapter seam that gateway health reads from.
- Existing test that already covers this (if any): the gateway health policy and readiness tests already cover stale-socket evaluation behavior once the flag reaches the health layer.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord bots that stay idle for longer than the stale-socket threshold no longer get health-monitor restarts purely because no user-facing events arrived.

## Diagram (if applicable)

```text
Before:
[idle Discord gateway session] -> [computed status adapter drops skipStaleSocketHealthCheck] -> [health monitor sees stale-socket] -> [restart loop]

After:
[idle Discord gateway session] -> [status adapter preserves skipStaleSocketHealthCheck] -> [health monitor skips stale-socket restart] -> [connection stays stable]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 15.3
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): default Discord channel config with gateway health monitoring enabled

### Steps

1. Configure the Discord channel and let the gateway reach a connected idle state.
2. Leave the session idle past the stale-socket threshold.
3. Observe whether health evaluation treats the connection as `stale-socket` and restarts it.

### Expected

- Healthy idle Discord sessions remain connected and do not restart solely because no user-facing inbound events arrived.

### Actual

- Before this fix, computed status adapters dropped Discord's stale-socket opt-out, so the gateway health layer could still classify an idle Discord session as `stale-socket` and restart it.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: traced the Discord health path from `discordPlugin.status` into gateway health evaluation, confirmed the adapter flag was being dropped, added regression coverage for the shared adapter seam and Discord plugin, and ran the targeted test set plus `pnpm build`.
- Edge cases checked: both sync and async computed status adapters now preserve `skipStaleSocketHealthCheck`; existing stale-socket gateway tests still pass.
- What you did **not** verify: I did not run a live 35-minute Discord idle session locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: disabling stale-socket restarts for Discord could leave a genuinely dead-but-quiet session up longer if Carbon does not surface another reconnect signal.
  - Mitigation: the change is limited to Discord, and the existing Discord gateway lifecycle/reconnect paths continue handling explicit disconnect and reconnect events.

## AI Assistance

- [x] AI-assisted
- Testing: targeted regression tests and `pnpm build` completed

Made with [Cursor](https://cursor.com)