### PR TITLE
Fix: disable chat-thread aria-live to stop per-token screen reader announcements (Resolves #65538)

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -939,7 +939,7 @@ export function renderChat(props: ChatProps) {
     <div
       class="chat-thread"
       role="log"
-      aria-live="polite"
+      aria-live="off"
       @scroll=${props.onChatScroll}
       @click=${handleCodeBlockCopy}
     >

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -939,7 +939,7 @@ export function renderChat(props: ChatProps) {
     <div
       class="chat-thread"
       role="log"
-      aria-live="off"
+      aria-live=${props.stream !== null || props.sending ? "off" : "polite"}
       @scroll=${props.onChatScroll}
       @click=${handleCodeBlockCopy}
     >


### PR DESCRIPTION
Fixes #65538.

## Problem

The Control UI chat thread is rendered with `role=\"log\"` and
`aria-live=\"polite\"`. `role=\"log\"` already has an implicit
`aria-live=\"polite\"` in the ARIA spec, and while streaming an
assistant response, every appended token mutates the DOM inside that
live region. Screen readers (NVDA, JAWS, VoiceOver) therefore announce
each incremental update, producing a continuous stream of fragmented
speech and making the UI unusable for screen reader users whenever a
response is being generated.

## Fix

Explicitly set `aria-live=\"off\"` on the `.chat-thread` container in
`ui/src/ui/views/chat.ts`. This overrides the implicit polite live
region that comes from `role=\"log\"` and suppresses the per-token
announcements. The `role=\"log\"` is retained so the thread is still
exposed as a log landmark, and screen reader users can navigate to and
read finalized messages normally - they just no longer get
continuously-firing partial announcements while the response streams
in. This matches the accessibility pattern used by other streaming
chat UIs.

## Test plan
- [x] `pnpm test ui/src/ui/app-chat.test.ts ui/src/ui/chat-markdown.browser.test.ts ui/src/ui/chat-event-reload.test.ts ui/src/ui/navigation.browser.test.ts`

---

AI-assisted (Claude). Lightly tested. Manual verification with a live
screen reader was not performed in this environment; the change is a
scoped ARIA attribute flip and does not alter rendering or behavior
for sighted users.