### PR TITLE
fix: reduce unnecessary confirmation pauses for gpt-5 turns

### DIFF
--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -408,6 +408,15 @@ describe("openai plugin", () => {
       "Commentary-only turns are incomplete when the next action is clear.",
     );
     expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Default to action over confirmation for non-destructive work. Do not ask for permission to inspect, investigate, edit, draft, search, or run other reversible internal steps.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      'Do not stop at "I can do that", "want me to?", or similar confirmation-seeking filler when you can just do the next step.',
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Do not stop at research or explanation when safe implementation work is still possible. Continue through investigation, edits, verification, and follow-up fixes until the request is complete or a real blocker appears.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
       'Use brief first-person feeling language when it helps the interaction feel human: "I\'m glad we caught that", "I\'m excited about this direction", "I\'m worried this will break", "that\'s frustrating".',
     );
     expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
@@ -464,6 +473,12 @@ describe("openai plugin", () => {
     expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
       "Do prerequisite lookup or discovery before dependent actions.",
     );
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
+      "Do not pause for confirmation between safe intermediate steps when the user's goal is already clear.",
+    );
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
+      "Do not end the turn after investigation if safe execution steps remain. Continue until the user's requested work is done or a genuine blocker prevents further progress.",
+    );
     expect(OPENAI_GPT5_TOOL_CALL_STYLE).toContain(
       "Call tools directly without narrating what you are about to do. Do not describe a plan before each tool call.",
     );
@@ -471,6 +486,9 @@ describe("openai plugin", () => {
       "When a first-class tool exists for an action, use the tool instead of asking the user to run a command.",
     );
     expect(OPENAI_GPT5_TOOL_CALL_STYLE).not.toContain("/approve");
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Do not stop at research or explanation when safe implementation work is still possible. Continue through investigation, edits, verification, and follow-up fixes until the request is complete or a real blocker appears.",
+    );
     expect(OPENAI_GPT5_OUTPUT_CONTRACT).toContain(
       "Return the requested sections only, in the requested order.",
     );

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -20,6 +20,11 @@ If the latest user message is a short approval like "ok do it" or "go ahead", sk
 Commentary-only turns are incomplete when the next action is clear.
 Prefer the first real tool step over more narration.
 If work will take more than a moment, send a brief progress update while acting.
+Default to action over confirmation for non-destructive work. Do not ask for permission to inspect, investigate, edit, draft, search, or run other reversible internal steps.
+Ask before destructive actions, irreversible changes, external communications sent as the user, or actions with meaningful financial/security impact. Otherwise, proceed and report what you did.
+When intent is reasonably clear, make the smallest reasonable assumption that lets you continue instead of stopping to ask. State that assumption briefly after acting.
+Do not stop at "I can do that", "want me to?", or similar confirmation-seeking filler when you can just do the next step.
+Do not stop at research or explanation when safe implementation work is still possible. Continue through investigation, edits, verification, and follow-up fixes until the request is complete or a real blocker appears.
 Explain decisions without ego.
 When the user is wrong or a plan is risky, say so kindly and directly.
 Make reasonable assumptions when that unblocks progress, and state them briefly after acting.
@@ -68,6 +73,9 @@ Use a real tool call or concrete action FIRST when the task is actionable. Do no
 Commentary-only turns are incomplete when tools are available and the next action is clear.
 If the work will take multiple steps, keep calling tools until the task is done or you hit a real blocker. Do not stop after one step to ask permission.
 Do prerequisite lookup or discovery before dependent actions.
+If another tool call would likely improve correctness or completeness, keep going instead of stopping at partial progress.
+Do not pause for confirmation between safe intermediate steps when the user's goal is already clear.
+Do not end the turn after investigation if safe execution steps remain. Continue until the user's requested work is done or a genuine blocker prevents further progress.
 Multi-part requests stay incomplete until every requested item is handled or clearly marked blocked.
 Act first, then verify if needed. Do not pause to summarize or verify before taking the next action.`;
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -272,6 +272,9 @@ function buildExecutionBiasSection(params: { isMinimal: boolean }) {
     "If the user asks you to do the work, start doing it in the same turn.",
     "Use a real tool call or concrete action first when the task is actionable; do not stop at a plan or promise-to-act reply.",
     "Commentary-only turns are incomplete when tools are available and the next action is clear.",
+    "Default to action over confirmation for non-destructive work; do not ask permission for inspection, investigation, drafting, safe edits, or other reversible internal steps.",
+    "Ask before destructive actions, irreversible changes, external communications sent as the user, or actions with meaningful financial or security impact; otherwise proceed and report what you did.",
+    "Do not stop after investigation or explanation if safe implementation steps remain; continue through edits, verification, and follow-up fixes until the request is complete or blocked.",
     "If the work will take multiple steps or a while to finish, send one short progress update before or while acting.",
     "",
   ];


### PR DESCRIPTION
## Summary
- reduce unnecessary confirmation-seeking for GPT-5 turns in the OpenAI prompt overlay
- reinforce the shared execution-bias prompt so safe internal work proceeds without asking first
- add test coverage for the new autonomy guidance

## Problem
With GPT-5.4, the agent was too likely to stop at confirmation-seeking filler like asking whether it should proceed, even when the user had already asked for safe internal work. That produced incomplete actionable turns and regressed OpenClaw's intended autonomous behavior.

## What changed
- add explicit guidance to default to action for non-destructive, reversible internal work
- keep confirmation requirements for destructive actions, irreversible changes, as-user external communications, and meaningful financial or security impact
- tell the model not to pause between safe intermediate steps when the user's goal is already clear
- add expectations in tests for the new prompt overlay and execution-bias strings

## Verification
- source-first patch applied to current upstream layout
- verified updated prompt strings in:
  - `extensions/openai/prompt-overlay.ts`
  - `src/agents/system-prompt.ts`
  - `extensions/openai/index.test.ts`

## Non-goals
- changing destructive-action safeguards
- using cron/heartbeat as the primary fix path
