### PR TITLE
fix(gateway): keep explicit loopback binds on 127.0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/macOS: keep explicit `gateway.bind=loopback` pinned to `127.0.0.1` even when a preflight loopback bind probe fails, so foreground gateway startup no longer falls back to `0.0.0.0` and aborts with a non-loopback bind error. (#65619)
+
 ## 2026.4.12-beta.1
 
 ### Changes

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -574,6 +574,14 @@ describe("resolveGatewayBindHost", () => {
     expect(await resolveGatewayBindHost("loopback")).toBe("127.0.0.1");
   });
 
+  it("keeps explicit loopback mode on loopback when the probe fails", async () => {
+    expect(
+      await resolveGatewayBindHost("loopback", undefined, {
+        canBindToHost: async () => false,
+      }),
+    ).toBe("127.0.0.1");
+  });
+
   it("returns 0.0.0.0 for lan mode", async () => {
     expect(await resolveGatewayBindHost("lan")).toBe("0.0.0.0");
   });

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -298,23 +298,24 @@ export function __resetContainerCacheForTest(): void {
 export async function resolveGatewayBindHost(
   bind: GatewayBindMode | undefined,
   customHost?: string,
+  opts?: { canBindToHost?: (host: string) => Promise<boolean> },
 ): Promise<string> {
   const mode = bind ?? "loopback";
+  const canBind = opts?.canBindToHost ?? canBindToHost;
 
   if (mode === "loopback") {
-    // 127.0.0.1 rarely fails, but handle gracefully
-    if (await canBindToHost("127.0.0.1")) {
-      return "127.0.0.1";
-    }
-    return "0.0.0.0"; // extreme fallback
+    // Keep explicit loopback requests pinned to loopback. A best-effort
+    // preflight probe can fail transiently on some hosts, and falling back to
+    // 0.0.0.0 turns a local-only bind into a startup rejection.
+    return "127.0.0.1";
   }
 
   if (mode === "tailnet") {
     const tailnetIP = pickPrimaryTailnetIPv4();
-    if (tailnetIP && (await canBindToHost(tailnetIP))) {
+    if (tailnetIP && (await canBind(tailnetIP))) {
       return tailnetIP;
     }
-    if (await canBindToHost("127.0.0.1")) {
+    if (await canBind("127.0.0.1")) {
       return "127.0.0.1";
     }
     return "0.0.0.0";
@@ -330,7 +331,7 @@ export async function resolveGatewayBindHost(
       return "0.0.0.0";
     } // invalid config → fall back to all
 
-    if (isValidIPv4(host) && (await canBindToHost(host))) {
+    if (isValidIPv4(host) && (await canBind(host))) {
       return host;
     }
     // Custom IP failed → fall back to LAN
@@ -343,7 +344,7 @@ export async function resolveGatewayBindHost(
     if (isContainerEnvironment()) {
       return "0.0.0.0";
     }
-    if (await canBindToHost("127.0.0.1")) {
+    if (await canBind("127.0.0.1")) {
       return "127.0.0.1";
     }
     return "0.0.0.0";


### PR DESCRIPTION
## Summary
- keep explicit `gateway.bind=loopback` pinned to `127.0.0.1` instead of downgrading to `0.0.0.0` after a failed preflight loopback probe
- add a focused regression test for the failed loopback probe path
- add an unreleased changelog note for #65619

## Test plan
- [x] `pnpm test src/gateway/net.test.ts -t "resolveGatewayBindHost"`
- [x] `pnpm test src/gateway/server-runtime-config.test.ts -t "loopback binding that resolves to non-loopback host|respects explicit loopback config even inside a container"`
- [x] IDE lints clean for `src/gateway/net.ts`, `src/gateway/net.test.ts`, and `CHANGELOG.md`

## Notes
- AI assistance: used for implementation and author-reviewed before submission.

Made with [Cursor](https://cursor.com)