### PR TITLE
docs: harden podman env sample guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 **/node_modules/
 .env
+openclaw.podman.env.local
 docker-compose.override.yml
 docker-compose.extra.yml
 dist

--- a/docs/install/podman.md
+++ b/docs/install/podman.md
@@ -16,6 +16,8 @@ The intended model is:
 - Persistent state lives on the host under `~/.openclaw` by default.
 - Day-to-day management uses `openclaw --container <name> ...` instead of `sudo -u openclaw`, `podman exec`, or a separate service user.
 
+Do not use the repo sample `openclaw.podman.env` as your live env file. Copy it to a private path first, then point `OPENCLAW_PODMAN_ENV` at the copied file.
+
 ## Prerequisites
 
 - **Podman** in rootless mode
@@ -49,6 +51,7 @@ Setup details:
 - It creates `~/.openclaw/openclaw.json` with `gateway.mode: "local"` if missing.
 - It creates `~/.openclaw/.env` with `OPENCLAW_GATEWAY_TOKEN` if missing.
 - For manual launches, the helper reads only a small allowlist of Podman-related keys from `~/.openclaw/.env` and passes explicit runtime env vars to the container; it does not hand the full env file to Podman.
+- If `OPENCLAW_PODMAN_ENV` points to a copied env file and `OPENCLAW_GATEWAY_TOKEN` is unset there, `./scripts/run-openclaw-podman.sh launch` generates a token and writes it back to that copied file before starting the container.
 
 Quadlet-managed setup:
 
@@ -73,6 +76,16 @@ Container start:
 ```
 
 The script starts the container as your current uid/gid with `--userns=keep-id` and bind-mounts your OpenClaw state into the container.
+
+If you want to use the sample env file from the repo, copy it first:
+
+```bash
+cp openclaw.podman.env openclaw.podman.env.local
+chmod 600 openclaw.podman.env.local
+OPENCLAW_PODMAN_ENV=$PWD/openclaw.podman.env.local ./scripts/run-openclaw-podman.sh launch
+```
+
+Leave `OPENCLAW_GATEWAY_TOKEN` unset in the copied file if you want the launcher to generate one automatically.
 
 Onboarding:
 

--- a/openclaw.podman.env
+++ b/openclaw.podman.env
@@ -1,11 +1,15 @@
 # OpenClaw Podman environment
-# Copy to openclaw.podman.env.local and set OPENCLAW_GATEWAY_TOKEN (or use -e when running).
-# This file can be used with:
-#   OPENCLAW_PODMAN_ENV=/path/to/openclaw.podman.env ./scripts/run-openclaw-podman.sh launch
+# Copy this file to a private path such as openclaw.podman.env.local before use.
+# Do not point OPENCLAW_PODMAN_ENV at the repo sample directly.
+# Example:
+#   cp openclaw.podman.env openclaw.podman.env.local
+#   chmod 600 openclaw.podman.env.local
+#   OPENCLAW_PODMAN_ENV=/path/to/openclaw.podman.env.local ./scripts/run-openclaw-podman.sh launch
 
-# Required: gateway auth token. Generate with: openssl rand -hex 32
-# Set this before running the container (or use run-openclaw-podman.sh which can generate it).
-OPENCLAW_GATEWAY_TOKEN=
+# Gateway auth token.
+# Leave this unset to let run-openclaw-podman.sh generate and persist one for the copied env file,
+# or set it explicitly first with: openssl rand -hex 32
+# OPENCLAW_GATEWAY_TOKEN=
 
 # Optional: web provider (leave empty to skip)
 # CLAUDE_AI_SESSION_KEY=


### PR DESCRIPTION
## Fix Summary
The shipped Podman sample env file looked like a ready-to-use deployment artifact even though it carried an empty live `OPENCLAW_GATEWAY_TOKEN=` assignment. This update makes the sample explicitly template-only, tells operators to copy it to a private env file first, and documents that the Podman launcher will generate and persist a gateway token automatically when that copied file leaves the token unset.

## Issue Linkage
Fixes #65625

## Security Snapshot
- CVSS v3.1: 8.1 (High)
- CVSS v4.0: 8.6 (High)

## Implementation Details
### Files Changed
- `docs/install/podman.md` (+13/-0)
- `openclaw.podman.env` (+10/-6)

### Technical Analysis
The launcher already auto-generates `OPENCLAW_GATEWAY_TOKEN` and writes it back to the configured env file before startup, but the repo sample still suggested direct use and shipped an empty live assignment. The fix removes the empty assignment from the sample, adds explicit copy-to-private-file guidance, and updates the Podman docs to describe the supported workflow and automatic token persistence behavior.

## Validation Evidence
- Command: docs and sample-file review against `scripts/run-openclaw-podman.sh`
- Status: passed

## Risk and Compatibility
- non-breaking; this changes sample guidance only and aligns the docs with existing launcher behavior

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: github-copilot/gpt-5.4