### PR TITLE
fix(mattermost): harden native slash command callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/startup: defer scheduled services until sidecars finish, gate chat history and model listing during sidecar resume, and let Control UI retry startup-gated history loads so Sandbox wake resumes channels first. (#65365) Thanks @lml2468.
+- Mattermost/slash commands: require HTTPS callback URLs before registering native slash commands, and bind each Mattermost slash token to its original trigger so captured tokens cannot be replayed across different slash commands. (#65624)
 
 ## 2026.4.12-beta.1
 

--- a/extensions/mattermost/src/mattermost/monitor-slash.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-slash.test.ts
@@ -145,12 +145,42 @@ describe("mattermost monitor slash", () => {
     );
   });
 
-  it("warns on loopback callback urls and reports partial team failures", async () => {
+  it("fails closed when the resolved slash callback url is not https", async () => {
+    resolveSlashCommandConfig.mockReturnValue({ enabled: true, nativeSkills: false });
+    isSlashCommandsEnabled.mockReturnValue(true);
+    parseStrictPositiveInteger.mockReturnValue(undefined);
+    fetchMattermostUserTeams.mockResolvedValue([{ id: "team-1" }]);
+    resolveCallbackUrl.mockReturnValue("http://127.0.0.1:18789/slash");
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await registerMattermostMonitorSlashCommands({
+      client: {} as never,
+      cfg: { gateway: { customBindHost: "loopback" } } as never,
+      runtime: runtime as never,
+      account: { config: { commands: {} }, accountId: "default" } as never,
+      baseUrl: "https://chat.example.com",
+      botUserId: "bot-user",
+    });
+
+    expect(registerSlashCommands).not.toHaveBeenCalled();
+    expect(activateSlashCommands).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("native slash commands require an HTTPS callbackUrl"),
+    );
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("http://127.0.0.1:18789/slash"),
+    );
+  });
+
+  it("reports partial team failures for https callbacks", async () => {
     resolveSlashCommandConfig.mockReturnValue({ enabled: true, nativeSkills: false });
     isSlashCommandsEnabled.mockReturnValue(true);
     parseStrictPositiveInteger.mockReturnValue(undefined);
     fetchMattermostUserTeams.mockResolvedValue([{ id: "team-1" }, { id: "team-2" }]);
-    resolveCallbackUrl.mockReturnValue("http://127.0.0.1:18789/slash");
+    resolveCallbackUrl.mockReturnValue("https://openclaw.test/slash");
     registerSlashCommands
       .mockResolvedValueOnce([{ token: "token-1", trigger: "ping" }])
       .mockRejectedValueOnce(new Error("boom"));
@@ -168,11 +198,6 @@ describe("mattermost monitor slash", () => {
       botUserId: "bot-user",
     });
 
-    expect(runtime.error).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "slash commands callbackUrl resolved to http://127.0.0.1:18789/slash",
-      ),
-    );
     expect(runtime.error).toHaveBeenCalledWith(
       "mattermost: failed to register slash commands for team team-2: Error: boom",
     );

--- a/extensions/mattermost/src/mattermost/monitor-slash.ts
+++ b/extensions/mattermost/src/mattermost/monitor-slash.ts
@@ -98,6 +98,14 @@ function warnOnSuspiciousCallbackUrl(params: {
   }
 }
 
+function isHttpsCallbackUrl(callbackUrl: string): boolean {
+  try {
+    return new URL(callbackUrl).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 async function registerSlashCommandsAcrossTeams(params: {
   client: MattermostClient;
   teams: Array<{ id: string }>;
@@ -159,6 +167,13 @@ export async function registerMattermostMonitorSlashCommands(params: {
       gatewayPort: slashGatewayPort,
       gatewayHost: params.cfg.gateway?.customBindHost ?? undefined,
     });
+
+    if (!isHttpsCallbackUrl(slashCallbackUrl)) {
+      params.runtime.error?.(
+        `mattermost: native slash commands require an HTTPS callbackUrl. Resolved ${slashCallbackUrl}. Set channels.mattermost.commands.callbackUrl to an HTTPS URL reachable from the Mattermost server.`,
+      );
+      return;
+    }
 
     warnOnSuspiciousCallbackUrl({
       runtime: params.runtime,

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -127,7 +127,7 @@ let createSlashCommandHttpHandler: typeof import("./slash-http.js").createSlashC
 
 function createRequest(body = "token=valid-token"): IncomingMessage {
   const req = new PassThrough();
-  const incoming = req as PassThrough & IncomingMessage;
+  const incoming = req as unknown as IncomingMessage;
   incoming.method = "POST";
   incoming.headers = {
     "content-type": "application/x-www-form-urlencoded",
@@ -148,17 +148,9 @@ function createResponse(): {
       return this;
     }
 
-    override end(): this;
-    override end(cb: () => void): this;
-    override end(chunk: string | Buffer | Uint8Array, cb?: () => void): this;
     override end(
-      chunk: string | Buffer | Uint8Array,
-      encoding: BufferEncoding,
-      cb?: () => void,
-    ): this;
-    override end(
-      chunkOrCb?: string | Buffer | Uint8Array | (() => void),
-      encodingOrCb?: BufferEncoding | (() => void),
+      chunkOrCb?: string | Uint8Array | (() => void),
+      encodingOrCb?: string | (() => void),
       cb?: () => void,
     ): this {
       const chunk = typeof chunkOrCb === "function" ? undefined : chunkOrCb;
@@ -260,5 +252,21 @@ describe("slash-http cfg threading", () => {
     expect(response.res.statusCode).toBe(200);
     expect(response.getBody()).toContain("Processing");
     expect(hasSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows known tokens without a recorded trigger binding", async () => {
+    const handler = createSlashCommandHttpHandler({
+      account: accountFixture,
+      cfg: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+      commandTokens: new Set(["valid-token"]),
+      commandTokenBindings: new Map([["other-token", "oc_status"]]),
+    });
+    const response = createResponse();
+
+    await handler(createRequest(), response.res);
+
+    expect(response.res.statusCode).toBe(200);
+    expect(response.getBody()).toContain("Processing");
   });
 });

--- a/extensions/mattermost/src/mattermost/slash-http.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.test.ts
@@ -12,7 +12,7 @@ function createRequest(params: {
   autoEnd?: boolean;
 }): IncomingMessage {
   const req = new PassThrough();
-  const incoming = req as PassThrough & IncomingMessage;
+  const incoming = req as unknown as IncomingMessage;
   incoming.method = params.method ?? "POST";
   incoming.headers = {
     "content-type": params.contentType ?? "application/x-www-form-urlencoded",
@@ -40,7 +40,7 @@ function createResponse(): {
     setHeader(name: string, value: string) {
       headers.set(name.toLowerCase(), value);
     },
-    end(chunk?: string | Buffer) {
+    end(chunk?: string | Uint8Array) {
       body = chunk ? String(chunk) : "";
     },
   } as ServerResponse;
@@ -63,6 +63,7 @@ const accountFixture: ResolvedMattermostAccount = {
 
 async function runSlashRequest(params: {
   commandTokens: Set<string>;
+  commandTokenBindings?: ReadonlyMap<string, string>;
   body: string;
   method?: string;
 }) {
@@ -71,6 +72,7 @@ async function runSlashRequest(params: {
     cfg: {} as OpenClawConfig,
     runtime: {} as RuntimeEnv,
     commandTokens: params.commandTokens,
+    commandTokenBindings: params.commandTokenBindings,
   });
   const req = createRequest({ method: params.method, body: params.body });
   const response = createResponse();
@@ -126,6 +128,17 @@ describe("slash-http", () => {
     const response = await runSlashRequest({
       commandTokens: new Set(["known-token"]),
       body: "token=unknown&team_id=t1&channel_id=c1&user_id=u1&command=%2Foc_status&text=",
+    });
+
+    expect(response.res.statusCode).toBe(401);
+    expect(response.getBody()).toContain("Unauthorized: invalid command token.");
+  });
+
+  it("rejects tokens replayed against a different registered trigger", async () => {
+    const response = await runSlashRequest({
+      commandTokens: new Set(["known-token"]),
+      commandTokenBindings: new Map([["known-token", "oc_status"]]),
+      body: "token=known-token&team_id=t1&channel_id=c1&user_id=u1&command=%2Foc_model&text=",
     });
 
     expect(response.res.statusCode).toBe(401);

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -103,7 +103,8 @@ function matchesRegisteredCommandBinding(
       return trigger === expectedTrigger;
     }
   }
-  return false;
+  // Token has no binding recorded, so there is no extra trigger constraint to enforce.
+  return true;
 }
 
 type SlashInvocationAuth = {

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -51,6 +51,8 @@ type SlashHttpHandlerParams = {
   runtime: RuntimeEnv;
   /** Expected token from registered commands (for validation). */
   commandTokens: Set<string>;
+  /** Bind each registered token to the trigger Mattermost issued it for. */
+  commandTokenBindings?: ReadonlyMap<string, string>;
   /** Map from trigger to original command name (for skill commands that start with oc_). */
   triggerMap?: ReadonlyMap<string, string>;
   log?: (msg: string) => void;
@@ -86,6 +88,19 @@ function matchesRegisteredCommandToken(
   for (const token of commandTokens) {
     if (safeEqualSecret(candidate, token)) {
       return true;
+    }
+  }
+  return false;
+}
+
+function matchesRegisteredCommandBinding(
+  commandTokenBindings: ReadonlyMap<string, string>,
+  candidate: string,
+  trigger: string,
+): boolean {
+  for (const [token, expectedTrigger] of commandTokenBindings) {
+    if (safeEqualSecret(candidate, token)) {
+      return trigger === expectedTrigger;
     }
   }
   return false;
@@ -219,7 +234,7 @@ async function authorizeSlashInvocation(params: {
  * from the Mattermost server when a user invokes a registered slash command.
  */
 export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
-  const { account, cfg, runtime, commandTokens, triggerMap, log } = params;
+  const { account, cfg, runtime, commandTokens, commandTokenBindings, triggerMap, log } = params;
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     if (req.method !== "POST") {
@@ -253,6 +268,8 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       return;
     }
 
+    const trigger = payload.command.replace(/^\//, "").trim();
+
     // Validate token — fail closed: reject when no tokens are registered
     // (e.g. registration failed or startup was partial)
     if (commandTokens.size === 0 || !matchesRegisteredCommandToken(commandTokens, payload.token)) {
@@ -263,8 +280,20 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       return;
     }
 
+    // Preserve Mattermost's per-command token binding so a captured token
+    // cannot be replayed against a different slash trigger.
+    if (
+      commandTokenBindings?.size &&
+      !matchesRegisteredCommandBinding(commandTokenBindings, payload.token, trigger)
+    ) {
+      sendJsonResponse(res, 401, {
+        response_type: "ephemeral",
+        text: "Unauthorized: invalid command token.",
+      });
+      return;
+    }
+
     // Extract command info
-    const trigger = payload.command.replace(/^\//, "").trim();
     const commandText = resolveCommandText(trigger, payload.text, triggerMap);
     const channelId = payload.channel_id;
     const senderId = payload.user_id;

--- a/extensions/mattermost/src/mattermost/slash-state.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.test.ts
@@ -4,6 +4,7 @@ import type { ResolvedMattermostAccount } from "./accounts.js";
 import {
   activateSlashCommands,
   deactivateSlashCommands,
+  getSlashCommandState,
   resolveSlashHandlerForToken,
 } from "./slash-state.js";
 
@@ -62,5 +63,26 @@ describe("slash-state token routing", () => {
     const match = resolveSlashHandlerForToken("tok-shared");
     expect(match.kind).toBe("ambiguous");
     expect(match.accountIds?.toSorted()).toEqual(["a1", "a2"]);
+  });
+
+  it("stores per-command token bindings for the active account", () => {
+    deactivateSlashCommands();
+    activateSlashCommands({
+      account: createResolvedMattermostAccount("a1"),
+      commandTokens: ["tok-a"],
+      registeredCommands: [
+        {
+          id: "cmd-1",
+          trigger: "oc_status",
+          teamId: "team-1",
+          token: "tok-a",
+          managed: true,
+        },
+      ],
+      api: slashApi,
+    });
+
+    const state = getSlashCommandState("a1");
+    expect(state?.commandTokenBindings).toEqual(new Map([["tok-a", "oc_status"]]));
   });
 });

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -21,6 +21,8 @@ import { createSlashCommandHttpHandler } from "./slash-http.js";
 export type SlashCommandAccountState = {
   /** Tokens from registered commands, used for validation. */
   commandTokens: Set<string>;
+  /** Bind each registered token to the trigger Mattermost issued it for. */
+  commandTokenBindings: Map<string, string>;
   /** Registered command IDs for cleanup on shutdown. */
   registeredCommands: MattermostRegisteredCommand[];
   /** Current HTTP handler for this account. */
@@ -96,18 +98,26 @@ export function activateSlashCommands(params: {
   const accountId = account.accountId;
 
   const tokenSet = new Set(commandTokens);
+  const commandTokenBindings = new Map<string, string>();
+  for (const command of registeredCommands) {
+    if (command.token && command.trigger) {
+      commandTokenBindings.set(command.token, command.trigger);
+    }
+  }
 
   const handler = createSlashCommandHttpHandler({
     account,
     cfg: api.cfg,
     runtime: api.runtime,
     commandTokens: tokenSet,
+    commandTokenBindings,
     triggerMap,
     log,
   });
 
   accountStates.set(accountId, {
     commandTokens: tokenSet,
+    commandTokenBindings,
     registeredCommands,
     handler,
     account,
@@ -127,6 +137,7 @@ export function deactivateSlashCommands(accountId?: string) {
     const state = accountStates.get(accountId);
     if (state) {
       state.commandTokens.clear();
+      state.commandTokenBindings.clear();
       state.registeredCommands = [];
       state.handler = null;
       accountStates.delete(accountId);
@@ -135,6 +146,7 @@ export function deactivateSlashCommands(accountId?: string) {
     // Deactivate all accounts (full shutdown)
     for (const [, state] of accountStates) {
       state.commandTokens.clear();
+      state.commandTokenBindings.clear();
       state.registeredCommands = [];
       state.handler = null;
     }


### PR DESCRIPTION
## Summary

- Problem: Mattermost native slash commands derived a plain-HTTP callback URL by default and accepted any registered token for any slash trigger on the same account.
- Why it matters: a captured slash-command token could be replayed to invoke a different `/oc_*` or native slash command, and the default callback path transported those reusable tokens without HTTPS.
- What changed: Mattermost native slash command registration now fails closed unless the resolved callback URL is HTTPS, and the callback handler now binds each registered token to its original trigger before authorizing the request.
- What did NOT change (scope boundary): this PR does not change Mattermost interaction callback source-IP policy or broader channel authorization behavior beyond native slash command callback validation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65624
- Related #65624
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Mattermost slash monitor used the derived callback URL directly even when it resolved to `http://...`, and slash activation reduced registered commands to a token set without preserving the trigger each token was issued for.
- Missing detection / guardrail: the regression tests covered known-vs-unknown tokens and loopback warning behavior, but did not assert HTTPS-only registration or per-command token binding.
- Contributing context (if known): native slash command registration treated callback reachability as a warning-only concern, and the callback handler trusted the incoming command name after token membership passed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/mattermost/src/mattermost/monitor-slash.test.ts`, `extensions/mattermost/src/mattermost/slash-http.test.ts`, `extensions/mattermost/src/mattermost/slash-state.test.ts`
- Scenario the test should lock in: non-HTTPS slash callbacks must not register native slash commands, and a valid token for one slash command must be rejected when replayed against a different trigger.
- Why this is the smallest reliable guardrail: these tests exercise the exact registration and HTTP validation seams without needing a live Mattermost server.
- Existing test that already covers this (if any): existing slash tests already covered known-vs-unknown tokens and registration flow wiring.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Mattermost native slash commands now require an HTTPS callback URL.
- If the resolved callback URL is not HTTPS, OpenClaw logs an error and leaves native slash command callbacks inactive instead of registering them insecurely.

## Diagram (if applicable)

```text
Before:
[Mattermost command registration] -> [derived http:// callback] -> [token set only] -> [captured token can authorize a different trigger]

After:
[Mattermost command registration] -> [require https:// callback] -> [token bound to trigger] -> [mismatched trigger replay rejected]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (Yes)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: native slash-command callback auth is stricter now. The monitor refuses non-HTTPS callback URLs, and the HTTP handler rejects token replays that do not match the trigger Mattermost registered for that token.

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Mattermost bundled plugin
- Relevant config (redacted): `channels.mattermost.commands.native=true`, derived or explicit callback URL

### Steps

1. Enable Mattermost native slash commands without an HTTPS `channels.mattermost.commands.callbackUrl`.
2. Start the Mattermost monitor and attempt slash-command registration.
3. Replay a valid command token against a different slash trigger in the callback handler.

### Expected

- Registration fails closed unless the callback URL is HTTPS.
- A token registered for one trigger cannot authorize a different trigger.

### Actual

- With this patch, both behaviors now hold.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: inspected the Mattermost slash registration and callback path at `origin/main`, confirmed the bug, added focused regression tests, and reran the Mattermost extension lane plus repo build/check gates after the fix.
- Edge cases checked: non-HTTPS callback URLs are rejected before registration, partial team registration failures still report correctly for HTTPS callbacks, and cross-trigger token replay is denied while valid token membership checks remain intact.
- What you did **not** verify: a live Mattermost server roundtrip with a real reverse proxy.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (No)
- Config/env changes? (No)
- Migration needed? (Yes)
- If yes, exact upgrade steps: if you rely on Mattermost native slash commands, set `channels.mattermost.commands.callbackUrl` to an HTTPS URL reachable from the Mattermost server before upgrading.

## Risks and Mitigations

- Risk: existing Mattermost setups that relied on derived or explicit non-HTTPS slash callbacks will stop registering native slash commands.
  - Mitigation: the monitor now logs the exact callback URL it rejected and tells operators to configure an HTTPS callback URL.

## AI Assistance

- [x] AI-assisted.
- Testing status: fully tested.
- I reviewed the final code and verification output before opening this PR.

Made with [Cursor](https://cursor.com)