### PR TITLE
[codex] Agents: preserve Pi compaction overrides after reload

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -70,7 +70,10 @@ import {
   consumeCompactionSafeguardCancelReason,
   setCompactionSafeguardCancelReason,
 } from "../pi-hooks/compaction-safeguard-runtime.js";
-import { createPreparedEmbeddedPiSettingsManager } from "../pi-project-settings.js";
+import {
+  createPreparedEmbeddedPiSettingsManager,
+  reloadEmbeddedPiResourceLoader,
+} from "../pi-project-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
 import { registerProviderStreamForModel } from "../provider-stream.js";
@@ -806,7 +809,11 @@ export async function compactEmbeddedPiSessionDirect(
           settingsManager,
           extensionFactories,
         });
-        await resourceLoader.reload();
+        await reloadEmbeddedPiResourceLoader({
+          resourceLoader,
+          settingsManager,
+          cfg: params.config,
+        });
       }
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -84,7 +84,10 @@ import {
   resolveBootstrapTotalMaxChars,
 } from "../../pi-embedded-helpers.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
-import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
+import {
+  createPreparedEmbeddedPiSettingsManager,
+  reloadEmbeddedPiResourceLoader,
+} from "../../pi-project-settings.js";
 import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
@@ -924,7 +927,12 @@ export async function runEmbeddedAttempt(
           settingsManager,
           extensionFactories,
         });
-        await resourceLoader.reload();
+        await reloadEmbeddedPiResourceLoader({
+          resourceLoader,
+          settingsManager,
+          cfg: params.config,
+          contextEngineInfo: params.contextEngine?.info,
+        });
       }
 
       // Get hook runner early so it's available when creating tools

--- a/src/agents/pi-project-settings.test.ts
+++ b/src/agents/pi-project-settings.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildEmbeddedPiSettingsSnapshot,
   DEFAULT_EMBEDDED_PI_PROJECT_SETTINGS_POLICY,
+  reloadEmbeddedPiResourceLoader,
   resolveEmbeddedPiProjectSettingsPolicy,
 } from "./pi-project-settings.js";
+import type { PiSettingsManagerLike } from "./pi-settings.js";
 
 type EmbeddedPiSettingsArgs = Parameters<typeof buildEmbeddedPiSettingsSnapshot>[0];
 
@@ -124,5 +126,116 @@ describe("buildEmbeddedPiSettingsSnapshot", () => {
         args: ["/workspace/probe.ts"],
       },
     });
+  });
+});
+
+describe("reloadEmbeddedPiResourceLoader", () => {
+  function createSettingsManager(params?: {
+    keepRecentTokens?: number;
+    reserveTokens?: number;
+    compactionEnabled?: boolean;
+  }): PiSettingsManagerLike & {
+    getCompactionEnabled: () => boolean;
+  } {
+    let reserveTokens = params?.reserveTokens ?? 16_384;
+    let keepRecentTokens = params?.keepRecentTokens ?? 20_000;
+    let compactionEnabled = params?.compactionEnabled ?? true;
+    return {
+      getCompactionReserveTokens: () => reserveTokens,
+      getCompactionKeepRecentTokens: () => keepRecentTokens,
+      applyOverrides: (overrides) => {
+        reserveTokens = overrides.compaction.reserveTokens ?? reserveTokens;
+        keepRecentTokens = overrides.compaction.keepRecentTokens ?? keepRecentTokens;
+      },
+      setCompactionEnabled: (enabled) => {
+        compactionEnabled = enabled;
+      },
+      getCompactionEnabled: () => compactionEnabled,
+    };
+  }
+
+  it("reapplies configured reserveTokens after resource loader reload resets settings", async () => {
+    const settingsManager = createSettingsManager({ reserveTokens: 40_000 });
+    const resourceLoader = {
+      reload: async () => {
+        settingsManager.applyOverrides({ compaction: { reserveTokens: 16_384 } });
+      },
+    };
+
+    await reloadEmbeddedPiResourceLoader({
+      resourceLoader,
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokens: 40_000,
+            },
+          },
+        },
+      },
+    });
+
+    expect(settingsManager.getCompactionReserveTokens()).toBe(40_000);
+  });
+
+  it("reapplies the reserveTokens floor after reload", async () => {
+    const settingsManager = createSettingsManager({ reserveTokens: 24_000 });
+    const resourceLoader = {
+      reload: async () => {
+        settingsManager.applyOverrides({ compaction: { reserveTokens: 16_384 } });
+      },
+    };
+
+    await reloadEmbeddedPiResourceLoader({
+      resourceLoader,
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokensFloor: 24_000,
+            },
+          },
+        },
+      },
+    });
+
+    expect(settingsManager.getCompactionReserveTokens()).toBe(24_000);
+  });
+
+  it("reapplies the Pi auto-compaction guard after reload", async () => {
+    const settingsManager = createSettingsManager({
+      reserveTokens: 40_000,
+      compactionEnabled: false,
+    });
+    const resourceLoader = {
+      reload: async () => {
+        settingsManager.applyOverrides({ compaction: { reserveTokens: 16_384 } });
+        settingsManager.setCompactionEnabled?.(true);
+      },
+    };
+
+    await reloadEmbeddedPiResourceLoader({
+      resourceLoader,
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokens: 40_000,
+            },
+          },
+        },
+      },
+      contextEngineInfo: {
+        id: "pi-context",
+        name: "Pi Context",
+        ownsCompaction: true,
+      },
+    });
+
+    expect(settingsManager.getCompactionReserveTokens()).toBe(40_000);
+    expect(settingsManager.getCompactionEnabled()).toBe(false);
   });
 });

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { SettingsManager } from "@mariozechner/pi-coding-agent";
 import { applyMergePatch } from "../config/merge-patch.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ContextEngineInfo } from "../context-engine/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
@@ -13,7 +14,11 @@ import {
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { isRecord } from "../utils.js";
 import { loadEmbeddedPiMcpConfig } from "./embedded-pi-mcp.js";
-import { applyPiCompactionSettingsFromConfig } from "./pi-settings.js";
+import {
+  applyPiAutoCompactionGuard,
+  applyPiCompactionSettingsFromConfig,
+  type PiSettingsManagerLike,
+} from "./pi-settings.js";
 
 const log = createSubsystemLogger("embedded-pi-settings");
 
@@ -194,4 +199,21 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     cfg: params.cfg,
   });
   return settingsManager;
+}
+
+export async function reloadEmbeddedPiResourceLoader(params: {
+  resourceLoader: { reload: () => Promise<void> };
+  settingsManager: PiSettingsManagerLike;
+  cfg?: OpenClawConfig;
+  contextEngineInfo?: ContextEngineInfo;
+}): Promise<void> {
+  await params.resourceLoader.reload();
+  applyPiCompactionSettingsFromConfig({
+    settingsManager: params.settingsManager,
+    cfg: params.cfg,
+  });
+  applyPiAutoCompactionGuard({
+    settingsManager: params.settingsManager,
+    contextEngineInfo: params.contextEngineInfo,
+  });
 }

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -3,7 +3,7 @@ import type { ContextEngineInfo } from "../context-engine/types.js";
 
 export const DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
 
-type PiSettingsManagerLike = {
+export type PiSettingsManagerLike = {
   getCompactionReserveTokens: () => number;
   getCompactionKeepRecentTokens: () => number;
   applyOverrides: (overrides: {


### PR DESCRIPTION
## Summary
- preserve embedded Pi compaction overrides after `resourceLoader.reload()` resets in-memory settings
- reuse the same reload helper in both the main embedded attempt path and direct compaction path
- add regression coverage for `reserveTokens`, `reserveTokensFloor`, and owns-compaction guard behavior

## Root cause
`DefaultResourceLoader.reload()` calls back into Pi's settings reload path, which reloads persisted settings and discards the in-memory overrides that OpenClaw applies from `agents.defaults.compaction`. That caused configured `reserveTokens` values to fall back after the resource loader initialized.

## Testing
- `pnpm test src/agents/pi-project-settings.test.ts`
- `pnpm test src/agents/pi-settings.test.ts`
- `pnpm check`
- `pnpm build`

## Notes
A broader `pnpm test` sweep on current `main` is already red in unrelated boundary/schema areas; I verified the same failures reproduce on a clean baseline worktree separate from this change.
