### PR TITLE
docs: add 2MB size limit note for avatar images

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -167,7 +167,7 @@ Avatar paths resolve relative to the workspace root.
 - `name`
 - `theme`
 - `emoji`
-- `avatar` (workspace-relative path, http(s) URL, or data URI)
+- `avatar` (workspace-relative path, http(s) URL, or data URI; **max 2MB for local images**)
 
 Options:
 
@@ -186,6 +186,7 @@ Notes:
 - `--agent` or `--workspace` can be used to select the target agent.
 - If you rely on `--workspace` and multiple agents share that workspace, the command fails and asks you to pass `--agent`.
 - When no explicit identity fields are provided, the command reads identity data from `IDENTITY.md`.
+- **Avatar images must be under 2MB**. Larger images will fail silently with a 404 error.
 
 Load from `IDENTITY.md`:
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1660,7 +1660,7 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `fastModeDefault`: optional per-agent default for fast mode (`true | false`). Applies when no per-message or session fast-mode override is set.
 - `embeddedHarness`: optional per-agent low-level harness policy override. Use `{ runtime: "codex", fallback: "none" }` to make one agent Codex-only while other agents keep the default PI fallback.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
-- `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
+- `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI. **Local images must be under 2MB**; larger images will fail silently with a 404 error.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.


### PR DESCRIPTION
## Summary

This PR adds documentation about the 2MB size limit for avatar images, addressing issue #65312.

## Changes

- **docs/cli/agents.md**: Added note about 2MB limit in the `set-identity` command documentation
- **docs/gateway/configuration-reference.md**: Added note about 2MB limit in the `identity.avatar` field documentation

## Problem

Users were spending time trying to figure out why their avatars don't work, putting them in the right folders, specifying correct paths, only to discover that avatars must be under 2MB. The error is silent and gives no hints as to why the avatar gets a 404.

## Solution

Added clear documentation about the 2MB size limit for avatar images in two key locations:
1. CLI reference for `openclaw agents set-identity`
2. Configuration reference for `agents.list[].identity.avatar`

## Impact

- Users will now be aware of the 2MB limit before attempting to use large avatar images
- Saves time and frustration for users who would otherwise encounter silent 404 errors
- Improves overall user experience

Fixes #65312
