### PR TITLE
fix(gateway): wire AbortController into agent handler to enable chat.abort cascading

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -5,6 +5,7 @@ import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
+import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
 import {
   buildSessionStartupContextPrelude,
@@ -72,6 +73,7 @@ import {
   resolveGatewayModelSupportsImages,
   resolveSessionModelRef,
 } from "../session-utils.js";
+import { resolveChatRunExpiresAtMs } from "../chat-abort.js";
 import { formatForLog } from "../ws-log.js";
 import { waitForAgentJob } from "./agent-job.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
@@ -204,6 +206,7 @@ function dispatchAgentRunFromGateway(params: {
   idempotencyKey: string;
   respond: GatewayRequestHandlerOptions["respond"];
   context: GatewayRequestHandlerOptions["context"];
+  abortSignal?: AbortSignal;
 }) {
   const inputProvenance = normalizeInputProvenance(params.ingressOpts.inputProvenance);
   const shouldTrackTask =
@@ -231,7 +234,11 @@ function dispatchAgentRunFromGateway(params: {
       // Best-effort only: background task tracking must not block agent runs.
     }
   }
-  void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
+  void agentCommandFromIngress(
+    { ...params.ingressOpts, abortSignal: params.abortSignal },
+    defaultRuntime,
+    params.context.deps,
+  )
     .then((result) => {
       const payload = {
         runId: params.runId,
@@ -273,6 +280,9 @@ function dispatchAgentRunFromGateway(params: {
         runId: params.runId,
         error: formatForLog(err),
       });
+    })
+    .finally(() => {
+      params.context.chatAbortControllers.delete(params.runId);
     });
 }
 
@@ -788,17 +798,32 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
 
+    const now = Date.now();
+    const timeoutMs = resolveAgentTimeoutMs({
+      cfg,
+      overrideMs: request.timeout,
+    });
+    const abortController = new AbortController();
+    context.chatAbortControllers.set(runId, {
+      controller: abortController,
+      sessionId: resolvedSessionId ?? runId,
+      sessionKey: resolvedSessionKey ?? "",
+      startedAtMs: now,
+      expiresAtMs: resolveChatRunExpiresAtMs({ now, timeoutMs }),
+      ownerConnId: connId,
+    });
+
     const accepted = {
       runId,
       status: "accepted" as const,
-      acceptedAt: Date.now(),
+      acceptedAt: now,
     };
     // Store an in-flight ack so retries do not spawn a second run.
     setGatewayDedupeEntry({
       dedupe: context.dedupe,
       key: `agent:${idem}`,
       entry: {
-        ts: Date.now(),
+        ts: now,
         ok: true,
         payload: accepted,
       },
@@ -844,6 +869,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
 
     dispatchAgentRunFromGateway({
+      abortSignal: abortController.signal,
       ingressOpts: {
         message,
         images,


### PR DESCRIPTION
## Summary

The `agent` gateway handler dispatches agent runs via `dispatchAgentRunFromGateway` but never
creates an `AbortController` or registers the run in `context.chatAbortControllers`. This means
`chat.abort` (which iterates `chatAbortControllers` to call `controller.abort()`) has no entry
to look up — the abort signal never reaches the running agent's LLM stream or tool execution.

In practice, when a user sends a stop/abort command mid-run:
1. `abortChatRunById()` in `chat-abort.ts` looks up the `runId` in `chatAbortControllers`
2. The map is empty because the agent handler never registered the run
3. The function returns `{ aborted: false }` — **the agent run continues to completion uninterrupted**
4. LLM tokens keep streaming and tools keep executing until natural completion, wasting resources
   and leaving the user unable to cancel

## Root Cause

In `src/gateway/server-methods/agent.ts`, the `agent` request handler:
- Generates a `runId` and calls `dispatchAgentRunFromGateway()`
- But **never creates an `AbortController`**
- Never calls `context.chatAbortControllers.set(runId, ...)`
- Never passes `abortSignal` to `agentCommandFromIngress()`

The downstream plumbing already supports abort propagation — `AgentCommandIngressOpts` accepts
an optional `abortSignal` field, and `agentCommandFromIngress` threads it through the run
pipeline. The missing piece is exclusively in the agent gateway handler where the controller
is created and registered.

## Changes

**File:** `src/gateway/server-methods/agent.ts`

1. **Create `AbortController` and register in `chatAbortControllers`** before dispatching the run:
   - Compute `timeoutMs` via `resolveAgentTimeoutMs()` to derive an accurate expiration
   - Compute `expiresAtMs` via `resolveChatRunExpiresAtMs()` for stale-run reaping
   - Store the entry with full metadata (`sessionId`, `sessionKey`, `startedAtMs`,
     `expiresAtMs`, `ownerConnId`) so `chat.abort` can validate ownership

2. **Pass `abortSignal` through the dispatch chain:**
   - Add `abortSignal?: AbortSignal` to `dispatchAgentRunFromGateway` params
   - Spread `abortSignal` into `agentCommandFromIngress` opts

3. **Clean up on completion** — add `.finally()` to delete the entry from
   `chatAbortControllers` after the run resolves (success or error), preventing map leaks

4. **Consolidate `Date.now()` calls** — capture `now = Date.now()` once and reuse for
   `acceptedAt`, dedup entry `ts`, abort controller `startedAtMs`, and expiration calculation,
   ensuring consistent timestamps across the acceptance flow

## Before / After

**Before** (no abort support):
```
User sends "stop" → chat.abort handler → chatAbortControllers.get(runId) → undefined → no-op
Agent run continues streaming tokens and executing tools until natural completion
```

**After** (abort wired):
```
User sends "stop" → chat.abort handler → chatAbortControllers.get(runId) → entry found
  → controller.abort() → signal propagates to LLM stream + tool execution → run stops
  → .finally() cleans up map entry → broadcast "aborted" state to clients
```

## Test plan

- [ ] Start an agent run via gateway, send `chat.abort` mid-stream — verify the run stops
      and clients receive the `aborted` state with any partial text
- [ ] Verify that after a run completes normally, `chatAbortControllers` no longer contains
      the `runId` entry (no map leak)
- [ ] Verify that after a run errors, the `.finally()` cleanup still fires
- [ ] Verify `abortChatRunsForSessionKey` correctly aborts multiple concurrent runs
- [ ] Verify dedup entry timestamps are consistent (single `now` value)
- [ ] Run `pnpm build && pnpm check && pnpm test` — all passing