### PR TITLE
Set OpenAI Codex defaults to GPT-5.4

### DIFF
--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -9,8 +9,9 @@ const ANTHROPIC_PREFIXES = [
   "claude-sonnet-4-5",
   "claude-haiku-4-5",
 ];
-const OPENAI_MODELS = ["gpt-5.2", "gpt-5.0"];
+const OPENAI_MODELS = ["gpt-5.4", "gpt-5.2", "gpt-5.0"];
 const CODEX_MODELS = [
+  "gpt-5.4",
   "gpt-5.2",
   "gpt-5.2-codex",
   "gpt-5.3-codex",

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -140,7 +140,7 @@ describe("getApiKeyForModel", () => {
       } catch (err) {
         error = err;
       }
-      expect(String(error)).toContain("openai-codex/gpt-5.3-codex");
+      expect(String(error)).toContain("openai-codex/gpt-5.4");
     } finally {
       if (previousOpenAiKey === undefined) {
         delete process.env.OPENAI_API_KEY;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -213,7 +213,7 @@ export async function resolveApiKeyForProvider(params: {
     const hasCodex = listProfilesForProvider(store, "openai-codex").length > 0;
     if (hasCodex) {
       throw new Error(
-        'No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.3-codex (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.1-codex.',
+        'No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.2.',
       );
     }
   }

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -135,7 +135,7 @@ describe("resolveModel", () => {
     expect(result.model?.id).toBe("missing-model");
   });
 
-  it("builds an openai-codex fallback for gpt-5.3-codex", () => {
+  it("builds an openai-codex fallback for gpt-5.4", () => {
     const templateModel = {
       id: "gpt-5.2-codex",
       name: "GPT-5.2 Codex",
@@ -158,12 +158,49 @@ describe("resolveModel", () => {
       }),
     } as unknown as ReturnType<typeof discoverModels>);
 
-    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
 
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject({
       provider: "openai-codex",
-      id: "gpt-5.3-codex",
+      id: "gpt-5.4",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      contextWindow: 272000,
+      maxTokens: 128000,
+    });
+  });
+
+  it("builds an openai-codex fallback for gpt-5.2", () => {
+    const templateModel = {
+      id: "gpt-5.2-codex",
+      name: "GPT-5.2 Codex",
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text", "image"] as const,
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 272000,
+      maxTokens: 128000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai-codex" && modelId === "gpt-5.2-codex") {
+          return templateModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "gpt-5.2", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.2",
       api: "openai-codex-responses",
       baseUrl: "https://chatgpt.com/backend-api",
       reasoning: true,
@@ -222,7 +259,7 @@ describe("resolveModel", () => {
         providers: {
           "openai-codex": {
             baseUrl: "https://custom.example.com",
-            // No models array, or models without gpt-5.3-codex
+            // No models array, or models without gpt-5.4
           },
         },
       },
@@ -232,11 +269,11 @@ describe("resolveModel", () => {
       find: vi.fn(() => null),
     } as unknown as ReturnType<typeof discoverModels>);
 
-    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent", cfg);
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent", cfg);
 
     expect(result.error).toBeUndefined();
     expect(result.model?.api).toBe("openai-codex-responses");
-    expect(result.model?.id).toBe("gpt-5.3-codex");
+    expect(result.model?.id).toBe("gpt-5.4");
     expect(result.model?.provider).toBe("openai-codex");
   });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -19,7 +19,7 @@ type InlineProviderConfig = {
   models?: ModelDefinitionConfig[];
 };
 
-const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
+const OPENAI_CODEX_FORWARD_COMPAT_MODEL_IDS = ["gpt-5.4", "gpt-5.3-codex", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
@@ -29,17 +29,18 @@ const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
 const ANTHROPIC_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
 const ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS = ["claude-opus-4-5", "claude-opus-4.5"] as const;
 
-function resolveOpenAICodexGpt53FallbackModel(
+function resolveOpenAICodexForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
   const normalizedProvider = normalizeProviderId(provider);
   const trimmedModelId = modelId.trim();
+  const normalizedModelId = trimmedModelId.toLowerCase();
   if (normalizedProvider !== "openai-codex") {
     return undefined;
   }
-  if (trimmedModelId.toLowerCase() !== OPENAI_CODEX_GPT_53_MODEL_ID) {
+  if (!OPENAI_CODEX_FORWARD_COMPAT_MODEL_IDS.some((entry) => entry === normalizedModelId)) {
     return undefined;
   }
 
@@ -180,14 +181,10 @@ export function resolveModel(
         modelRegistry,
       };
     }
-    // Codex gpt-5.3 forward-compat fallback must be checked BEFORE the generic providerCfg fallback.
+    // Codex forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.
     // Otherwise, if cfg.models.providers["openai-codex"] is configured, the generic fallback fires
     // with api: "openai-responses" instead of the correct "openai-codex-responses".
-    const codexForwardCompat = resolveOpenAICodexGpt53FallbackModel(
-      provider,
-      modelId,
-      modelRegistry,
-    );
+    const codexForwardCompat = resolveOpenAICodexForwardCompatModel(provider, modelId, modelRegistry);
     if (codexForwardCompat) {
       return { model: codexForwardCompat, authStorage, modelRegistry };
     }

--- a/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
@@ -100,6 +100,62 @@ describe("directive behavior", () => {
       expect(texts).toContain("Thinking level set to xhigh.");
     });
   });
+  it("accepts /thinking xhigh for openai-codex gpt-5.4", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+
+      const res = await getReplyFromConfig(
+        {
+          Body: "/thinking xhigh",
+          From: "+1004",
+          To: "+2000",
+          CommandAuthorized: true,
+        },
+        {},
+        {
+          agents: {
+            defaults: {
+              model: "openai-codex/gpt-5.4",
+              workspace: path.join(home, "openclaw"),
+            },
+          },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+          session: { store: storePath },
+        },
+      );
+
+      const texts = (Array.isArray(res) ? res : [res]).map((entry) => entry?.text).filter(Boolean);
+      expect(texts).toContain("Thinking level set to xhigh.");
+    });
+  });
+  it("accepts /thinking xhigh for openai-codex gpt-5.2", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+
+      const res = await getReplyFromConfig(
+        {
+          Body: "/thinking xhigh",
+          From: "+1004",
+          To: "+2000",
+          CommandAuthorized: true,
+        },
+        {},
+        {
+          agents: {
+            defaults: {
+              model: "openai-codex/gpt-5.2",
+              workspace: path.join(home, "openclaw"),
+            },
+          },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+          session: { store: storePath },
+        },
+      );
+
+      const texts = (Array.isArray(res) ? res : [res]).map((entry) => entry?.text).filter(Boolean);
+      expect(texts).toContain("Thinking level set to xhigh.");
+    });
+  });
   it("accepts /thinking xhigh for openai gpt-5.2", async () => {
     await withTempHome(async (home) => {
       const storePath = path.join(home, "sessions.json");
@@ -154,7 +210,7 @@ describe("directive behavior", () => {
 
       const texts = (Array.isArray(res) ? res : [res]).map((entry) => entry?.text).filter(Boolean);
       expect(texts).toContain(
-        'Thinking level "xhigh" is only supported for openai/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.2-codex or openai-codex/gpt-5.1-codex.',
+        'Thinking level "xhigh" is only supported for openai-codex/gpt-5.4, openai/gpt-5.2, openai-codex/gpt-5.2, openai-codex/gpt-5.3-codex, openai-codex/gpt-5.2-codex or openai-codex/gpt-5.1-codex.',
       );
     });
   });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -41,7 +41,9 @@ describe("normalizeThinkLevel", () => {
 });
 
 describe("listThinkingLevels", () => {
-  it("includes xhigh for codex models", () => {
+  it("includes xhigh for supported openai-codex models", () => {
+    expect(listThinkingLevels("openai-codex", "gpt-5.4")).toContain("xhigh");
+    expect(listThinkingLevels("openai-codex", "gpt-5.2")).toContain("xhigh");
     expect(listThinkingLevels(undefined, "gpt-5.2-codex")).toContain("xhigh");
     expect(listThinkingLevels(undefined, "gpt-5.3-codex")).toContain("xhigh");
   });

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -22,7 +22,9 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 }
 
 export const XHIGH_MODEL_REFS = [
+  "openai-codex/gpt-5.4",
   "openai/gpt-5.2",
+  "openai-codex/gpt-5.2",
   "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -26,6 +26,10 @@ import { isRemoteEnvironment } from "../oauth-env.js";
 import { createVpsAwareOAuthHandlers } from "../oauth-flow.js";
 import { applyAuthProfileConfig } from "../onboard-auth.js";
 import { openUrl } from "../onboard-helpers.js";
+import {
+  applyOpenAICodexModelDefault,
+  OPENAI_CODEX_DEFAULT_MODEL,
+} from "../openai-codex-model-default.js";
 import { updateConfig } from "./shared.js";
 
 const confirm = (params: Parameters<typeof clackConfirm>[0]) =>
@@ -410,6 +414,10 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
     });
   }
 
+  const normalizedProviderId = normalizeProviderId(selectedProvider.id);
+  const resolvedDefaultModel =
+    normalizedProviderId === "openai-codex" ? OPENAI_CODEX_DEFAULT_MODEL : result.defaultModel;
+
   await updateConfig((cfg) => {
     let next = cfg;
     if (result.configPatch) {
@@ -422,8 +430,11 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
         mode: credentialMode(profile.credential),
       });
     }
-    if (opts.setDefault && result.defaultModel) {
-      next = applyDefaultModel(next, result.defaultModel);
+    if (opts.setDefault && resolvedDefaultModel) {
+      next =
+        normalizedProviderId === "openai-codex"
+          ? applyOpenAICodexModelDefault(next).next
+          : applyDefaultModel(next, resolvedDefaultModel);
     }
     return next;
   });
@@ -434,11 +445,11 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
       `Auth profile: ${profile.profileId} (${profile.credential.provider}/${credentialMode(profile.credential)})`,
     );
   }
-  if (result.defaultModel) {
+  if (resolvedDefaultModel) {
     runtime.log(
       opts.setDefault
-        ? `Default model set to ${result.defaultModel}`
-        : `Default model available: ${result.defaultModel} (use --set-default to apply)`,
+        ? `Default model set to ${resolvedDefaultModel}`
+        : `Default model available: ${resolvedDefaultModel} (use --set-default to apply)`,
     );
   }
   if (result.notes && result.notes.length > 0) {

--- a/src/commands/openai-codex-model-default.test.ts
+++ b/src/commands/openai-codex-model-default.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   applyOpenAICodexModelDefault,
+  OPENAI_CODEX_DEFAULT_FALLBACKS,
   OPENAI_CODEX_DEFAULT_MODEL,
 } from "./openai-codex-model-default.js";
 import { OPENAI_DEFAULT_MODEL } from "./openai-model-default.js";
@@ -13,7 +14,10 @@ describe("applyOpenAICodexModelDefault", () => {
     expect(applied.changed).toBe(true);
     expect(applied.next.agents?.defaults?.model).toEqual({
       primary: OPENAI_CODEX_DEFAULT_MODEL,
+      fallbacks: [...OPENAI_CODEX_DEFAULT_FALLBACKS],
     });
+    expect(applied.next.agents?.defaults?.models?.[OPENAI_CODEX_DEFAULT_MODEL]).toEqual({});
+    expect(applied.next.agents?.defaults?.models?.[OPENAI_CODEX_DEFAULT_FALLBACKS[0]]).toEqual({});
   });
 
   it("sets openai-codex default when model is openai/*", () => {
@@ -24,12 +28,51 @@ describe("applyOpenAICodexModelDefault", () => {
     expect(applied.changed).toBe(true);
     expect(applied.next.agents?.defaults?.model).toEqual({
       primary: OPENAI_CODEX_DEFAULT_MODEL,
+      fallbacks: [...OPENAI_CODEX_DEFAULT_FALLBACKS],
+    });
+  });
+
+  it("prepends the default fallback before existing fallbacks", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: OPENAI_DEFAULT_MODEL,
+            fallbacks: ["anthropic/claude-opus-4-5", OPENAI_CODEX_DEFAULT_FALLBACKS[0]],
+          },
+        },
+      },
+    };
+    const applied = applyOpenAICodexModelDefault(cfg);
+    expect(applied.changed).toBe(true);
+    expect(applied.next.agents?.defaults?.model).toEqual({
+      primary: OPENAI_CODEX_DEFAULT_MODEL,
+      fallbacks: [...OPENAI_CODEX_DEFAULT_FALLBACKS, "anthropic/claude-opus-4-5"],
+    });
+  });
+
+  it("upgrades legacy openai-codex defaults to gpt-5.4", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.3-codex",
+            fallbacks: ["openai-codex/gpt-5.2-codex"],
+          },
+        },
+      },
+    };
+    const applied = applyOpenAICodexModelDefault(cfg);
+    expect(applied.changed).toBe(true);
+    expect(applied.next.agents?.defaults?.model).toEqual({
+      primary: OPENAI_CODEX_DEFAULT_MODEL,
+      fallbacks: ["openai-codex/gpt-5.2", "openai-codex/gpt-5.2-codex"],
     });
   });
 
   it("does not override openai-codex/*", () => {
     const cfg: OpenClawConfig = {
-      agents: { defaults: { model: OPENAI_CODEX_DEFAULT_MODEL } },
+      agents: { defaults: { model: "openai-codex/custom-model" } },
     };
     const applied = applyOpenAICodexModelDefault(cfg);
     expect(applied.changed).toBe(false);

--- a/src/commands/openai-codex-model-default.ts
+++ b/src/commands/openai-codex-model-default.ts
@@ -1,7 +1,15 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { AgentModelListConfig } from "../config/types.js";
+import { ensureModelAllowlistEntry } from "./model-allowlist.js";
 
-export const OPENAI_CODEX_DEFAULT_MODEL = "openai-codex/gpt-5.3-codex";
+export const OPENAI_CODEX_DEFAULT_MODEL = "openai-codex/gpt-5.4";
+export const OPENAI_CODEX_DEFAULT_FALLBACKS = ["openai-codex/gpt-5.2"] as const;
+const OPENAI_CODEX_LEGACY_DEFAULT_MODELS = new Set([
+  "openai-codex/gpt-5.2",
+  "openai-codex/gpt-5.2-codex",
+  "openai-codex/gpt-5.3-codex",
+  "openai-codex/gpt-5.1-codex",
+]);
 
 function shouldSetOpenAICodexModel(model?: string): boolean {
   const trimmed = model?.trim();
@@ -10,7 +18,10 @@ function shouldSetOpenAICodexModel(model?: string): boolean {
   }
   const normalized = trimmed.toLowerCase();
   if (normalized.startsWith("openai-codex/")) {
-    return false;
+    return (
+      normalized !== OPENAI_CODEX_DEFAULT_MODEL &&
+      OPENAI_CODEX_LEGACY_DEFAULT_MODELS.has(normalized)
+    );
   }
   if (normalized.startsWith("openai/")) {
     return true;
@@ -28,28 +39,51 @@ function resolvePrimaryModel(model?: AgentModelListConfig | string): string | un
   return undefined;
 }
 
+function resolveFallbackModels(model?: AgentModelListConfig | string): string[] {
+  if (!model || typeof model !== "object" || !Array.isArray(model.fallbacks)) {
+    return [];
+  }
+  return model.fallbacks
+    .map((entry) => String(entry ?? "").trim())
+    .filter(Boolean)
+    .filter((entry) => entry !== OPENAI_CODEX_DEFAULT_MODEL);
+}
+
+function buildFallbackModels(model?: AgentModelListConfig | string): string[] {
+  return [...new Set([...OPENAI_CODEX_DEFAULT_FALLBACKS, ...resolveFallbackModels(model)])];
+}
+
 export function applyOpenAICodexModelDefault(cfg: OpenClawConfig): {
   next: OpenClawConfig;
   changed: boolean;
 } {
-  const current = resolvePrimaryModel(cfg.agents?.defaults?.model);
+  const currentModelConfig = cfg.agents?.defaults?.model;
+  const current = resolvePrimaryModel(currentModelConfig);
   if (!shouldSetOpenAICodexModel(current)) {
     return { next: cfg, changed: false };
   }
+  const fallbacks = buildFallbackModels(currentModelConfig);
+  let next = ensureModelAllowlistEntry({
+    cfg,
+    modelRef: OPENAI_CODEX_DEFAULT_MODEL,
+  });
+  for (const fallback of fallbacks) {
+    next = ensureModelAllowlistEntry({
+      cfg: next,
+      modelRef: fallback,
+    });
+  }
   return {
     next: {
-      ...cfg,
+      ...next,
       agents: {
-        ...cfg.agents,
+        ...next.agents,
         defaults: {
-          ...cfg.agents?.defaults,
-          model:
-            cfg.agents?.defaults?.model && typeof cfg.agents.defaults.model === "object"
-              ? {
-                  ...cfg.agents.defaults.model,
-                  primary: OPENAI_CODEX_DEFAULT_MODEL,
-                }
-              : { primary: OPENAI_CODEX_DEFAULT_MODEL },
+          ...next.agents?.defaults,
+          model: {
+            primary: OPENAI_CODEX_DEFAULT_MODEL,
+            ...(fallbacks.length > 0 ? { fallbacks } : undefined),
+          },
         },
       },
     },

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -1,6 +1,7 @@
 export type ModelApi =
   | "openai-completions"
   | "openai-responses"
+  | "openai-codex-responses"
   | "anthropic-messages"
   | "google-generative-ai"
   | "github-copilot"

--- a/src/config/zod-schema.core.test.ts
+++ b/src/config/zod-schema.core.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { ModelApiSchema, ModelProviderSchema } from "./zod-schema.core.js";
+
+describe("ModelApiSchema", () => {
+  it("accepts openai-codex-responses", () => {
+    expect(ModelApiSchema.safeParse("openai-codex-responses").success).toBe(true);
+  });
+});
+
+describe("ModelProviderSchema", () => {
+  it("accepts openai-codex-responses for provider configs", () => {
+    const parsed = ModelProviderSchema.safeParse({
+      baseUrl: "https://chatgpt.com/backend-api",
+      auth: "oauth",
+      api: "openai-codex-responses",
+      models: [],
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -4,6 +4,7 @@ import { isSafeExecutableValue } from "../infra/exec-safety.js";
 export const ModelApiSchema = z.union([
   z.literal("openai-completions"),
   z.literal("openai-responses"),
+  z.literal("openai-codex-responses"),
   z.literal("anthropic-messages"),
   z.literal("google-generative-ai"),
   z.literal("github-copilot"),


### PR DESCRIPTION
## Summary
- switch OpenAI Codex default selection to openai-codex/gpt-5.4 with openai-codex/gpt-5.2 fallback
- allow xhigh thinking for openai-codex/gpt-5.4 and openai-codex/gpt-5.2
- add forward-compatible Codex model resolution for gpt-5.4 and gpt-5.2, and accept openai-codex-responses in config schema

## Validation
- pnpm exec vitest run src/config/zod-schema.core.test.ts src/commands/openai-codex-model-default.test.ts src/agents/model-auth.test.ts src/auto-reply/thinking.test.ts src/agents/pi-embedded-runner/model.test.ts
- pnpm exec vitest run --config vitest.e2e.config.ts src/auto-reply/reply.directive.directive-behavior.accepts-thinking-xhigh-codex-models.e2e.test.ts
- verified local config resolves openai-codex/gpt-5.4 primary, openai-codex/gpt-5.2 fallback, and 	hinkingDefault: xhigh
