### PR TITLE
fix(heartbeat): inherit delivery context from base session in isolated runs

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -725,6 +725,21 @@ export async function runHeartbeatOnce(opts: {
       nowMs: startedAt,
       forceNew: true,
     });
+    // resolveCronSession with forceNew clears deliveryContext, lastThreadId,
+    // and chatType on the new session entry (session.ts:80-86). For heartbeat
+    // isolated sessions, inherit these from the base session so the heartbeat
+    // response routes to the correct channel/thread/topic instead of falling
+    // back to General (#65693).
+    const baseEntry = cronSession.store[sessionKey];
+    if (baseEntry) {
+      const entry = cronSession.sessionEntry;
+      entry.deliveryContext ??= baseEntry.deliveryContext;
+      entry.lastThreadId ??= baseEntry.lastThreadId;
+      entry.lastChannel ??= baseEntry.lastChannel;
+      entry.lastTo ??= baseEntry.lastTo;
+      entry.lastAccountId ??= baseEntry.lastAccountId;
+      entry.chatType ??= baseEntry.chatType;
+    }
     cronSession.store[isolatedKey] = cronSession.sessionEntry;
     await saveSessionStore(cronSession.storePath, cronSession.store);
     runSessionKey = isolatedKey;


### PR DESCRIPTION
## Summary

When heartbeat creates an isolated session via \`resolveCronSession(forceNew: true)\`, the new session entry has \`deliveryContext\`, \`lastThreadId\`, \`chatType\`, and other routing fields cleared. For Telegram topic-scoped sessions, this causes heartbeat responses to route to the group's **General topic** instead of the correct topic.

Fixes #65693

## Root cause

\`resolveCronSession\` with \`forceNew: true\` clears delivery routing fields on the new session entry (\`session.ts:80-86\`):

\`\`\`ts
...(isNewSession && {
  lastChannel: undefined,
  lastTo: undefined,
  lastAccountId: undefined,
  lastThreadId: undefined,
  deliveryContext: undefined,
}),
\`\`\`

This is correct for most cron jobs (they should start fresh), but **heartbeat isolated sessions** need to inherit routing from the base session so responses go to the same channel/thread/topic.

## Fix

After \`resolveCronSession\`, copy routing fields from the base session entry:

\`\`\`ts
const baseEntry = cronSession.store[sessionKey];
if (baseEntry) {
  const entry = cronSession.sessionEntry;
  entry.deliveryContext ??= baseEntry.deliveryContext;
  entry.lastThreadId ??= baseEntry.lastThreadId;
  entry.lastChannel ??= baseEntry.lastChannel;
  entry.lastTo ??= baseEntry.lastTo;
  entry.lastAccountId ??= baseEntry.lastAccountId;
  entry.chatType ??= baseEntry.chatType;
}
\`\`\`

Using \`??=\` so any explicit values already on the isolated entry are preserved.

### Why heartbeat-runner.ts, not session.ts

\`session.ts\` is a high-contention zone with 5+ competing PRs. Patching the session entry AFTER creation in \`heartbeat-runner.ts\` avoids contention while achieving the same result.

## Scope

- **Files**: \`src/infra/heartbeat-runner.ts\` (+12 lines)
- **oxlint clean**
- **Zero competing PRs** on this specific fix path

Credit to @richardmqq for the exact JSON diff showing the missing \`threadId\` in #65693.