### PR TITLE
fix(approval-auth): prevent empty approver list from granting explicit approval authorization [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(approval-auth): prevent empty approver list from granting explicit approval authorization [AI]. (#65714) Thanks @pgondhi987.
 - fix(security): broaden shell-wrapper detection and block env-argv assignment injection [AI-assisted]. (#65717) Thanks @pgondhi987.
 - Gateway/startup: defer scheduled services until sidecars finish, gate chat history and model listing during sidecar resume, and let Control UI retry startup-gated history loads so Sandbox wake resumes channels first. (#65365) Thanks @lml2468.
 - Control UI/chat: load the live gateway slash-command catalog into the composer and command palette so dock commands, plugin commands, and direct skill aliases appear in chat, while keeping trusted local commands authoritative and bounding remote command metadata. (#65620) Thanks @BunsDev.

--- a/src/auto-reply/reply/commands-approve.test.ts
+++ b/src/auto-reply/reply/commands-approve.test.ts
@@ -643,6 +643,62 @@ describe("handleApproveCommand", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it("does not allow empty helper approvers to bypass unauthorized sender checks", async () => {
+    const params = buildApproveParams(
+      "/approve abc12345 allow-once",
+      {
+        commands: { text: true },
+        channels: {
+          signal: {
+            allowFrom: [],
+          },
+        },
+      } as OpenClawConfig,
+      {
+        Provider: "signal",
+        Surface: "signal",
+        SenderId: "+15551239999",
+      },
+    );
+    params.command.isAuthorizedSender = false;
+
+    const result = await handleApproveCommand(params, true);
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply).toBeUndefined();
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps same-chat /approve available to authorized senders when helper approvers are empty", async () => {
+    callGatewayMock.mockResolvedValue({ ok: true });
+    const params = buildApproveParams(
+      "/approve abc12345 allow-once",
+      {
+        commands: { text: true },
+        channels: {
+          signal: {
+            allowFrom: [],
+          },
+        },
+      } as OpenClawConfig,
+      {
+        Provider: "signal",
+        Surface: "signal",
+        SenderId: "+15551239999",
+      },
+    );
+    params.command.isAuthorizedSender = true;
+
+    const result = await handleApproveCommand(params, true);
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Approval allow-once submitted");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "exec.approval.resolve",
+        params: { id: "abc12345", decision: "allow-once" },
+      }),
+    );
+  });
+
   it("accepts Telegram /approve from exec target recipients when native approvals are disabled", async () => {
     const params = buildApproveParams(
       "/approve abc12345 allow-once",

--- a/src/auto-reply/reply/commands-approve.test.ts
+++ b/src/auto-reply/reply/commands-approve.test.ts
@@ -115,7 +115,8 @@ const signalApproveTestPlugin: ChannelPlugin = {
   approvalCapability: createResolvedApproverActionAuthAdapter({
     channelLabel: "Signal",
     resolveApprovers: ({ cfg, accountId }) => {
-      const signal = accountId ? cfg.channels?.signal?.accounts?.[accountId] : cfg.channels?.signal;
+      const scopedSignal = accountId ? cfg.channels?.signal?.accounts?.[accountId] : undefined;
+      const signal = scopedSignal ?? cfg.channels?.signal;
       return resolveApprovalApprovers({
         allowFrom: signal?.allowFrom,
         defaultTo: signal?.defaultTo,

--- a/src/infra/channel-approval-auth.test.ts
+++ b/src/infra/channel-approval-auth.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createResolvedApproverActionAuthAdapter } from "../plugin-sdk/approval-auth-helpers.js";
 
 const getChannelPluginMock = vi.hoisted(() => vi.fn());
 
@@ -115,5 +116,43 @@ describe("resolveApprovalCommandAuthorization", () => {
       action: "approve",
       approvalKind: "exec",
     });
+  });
+
+  it("keeps empty approver fallback implicit without bypassing channel sender auth", () => {
+    getChannelPluginMock.mockReturnValue({
+      approvalCapability: createResolvedApproverActionAuthAdapter({
+        channelLabel: "Signal",
+        resolveApprovers: () => [],
+      }),
+    });
+
+    expect(
+      resolveApprovalCommandAuthorization({
+        cfg: {} as never,
+        channel: "signal",
+        accountId: "work",
+        senderId: "uuid:attacker",
+        kind: "exec",
+      }),
+    ).toEqual({ authorized: true, explicit: false });
+  });
+
+  it("keeps configured approvers explicit when sender matches", () => {
+    getChannelPluginMock.mockReturnValue({
+      approvalCapability: createResolvedApproverActionAuthAdapter({
+        channelLabel: "Signal",
+        resolveApprovers: () => ["uuid:owner"],
+      }),
+    });
+
+    expect(
+      resolveApprovalCommandAuthorization({
+        cfg: {} as never,
+        channel: "signal",
+        accountId: "work",
+        senderId: "uuid:owner",
+        kind: "exec",
+      }),
+    ).toEqual({ authorized: true, explicit: true });
   });
 });

--- a/src/infra/channel-approval-auth.ts
+++ b/src/infra/channel-approval-auth.ts
@@ -31,6 +31,8 @@ export function resolveApprovalCommandAuthorization(params: {
   if (!resolved) {
     return { authorized: true, explicit: false };
   }
+  // Keep `resolved` by reference; cloning before this check would drop the
+  // non-enumerable implicit-fallback marker.
   const implicitSameChatAuthorization = isImplicitSameChatApprovalAuthorization(resolved);
   const availability = approvalCapability?.getActionAvailabilityState?.({
     cfg: params.cfg,

--- a/src/infra/channel-approval-auth.ts
+++ b/src/infra/channel-approval-auth.ts
@@ -1,5 +1,6 @@
 import { getChannelPlugin, resolveChannelApprovalCapability } from "../channels/plugins/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isImplicitSameChatApprovalAuthorization } from "../plugin-sdk/approval-auth-helpers.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 
 export type ApprovalCommandAuthorization = {
@@ -30,6 +31,7 @@ export function resolveApprovalCommandAuthorization(params: {
   if (!resolved) {
     return { authorized: true, explicit: false };
   }
+  const implicitSameChatAuthorization = isImplicitSameChatApprovalAuthorization(resolved);
   const availability = approvalCapability?.getActionAvailabilityState?.({
     cfg: params.cfg,
     accountId: params.accountId,
@@ -39,6 +41,8 @@ export function resolveApprovalCommandAuthorization(params: {
   return {
     authorized: resolved.authorized,
     reason: resolved.reason,
-    explicit: resolved.authorized ? availability?.kind !== "disabled" : true,
+    explicit: resolved.authorized
+      ? !implicitSameChatAuthorization && availability?.kind !== "disabled"
+      : true,
   };
 }

--- a/src/plugin-sdk/approval-auth-helpers.test.ts
+++ b/src/plugin-sdk/approval-auth-helpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { createResolvedApproverActionAuthAdapter } from "./approval-auth-helpers.js";
+import {
+  createResolvedApproverActionAuthAdapter,
+  isImplicitSameChatApprovalAuthorization,
+} from "./approval-auth-helpers.js";
 
 describe("createResolvedApproverActionAuthAdapter", () => {
   it.each([
@@ -54,5 +57,37 @@ describe("createResolvedApproverActionAuthAdapter", () => {
         }),
       ).toEqual(testCase.expected);
     }
+  });
+
+  it("marks empty-approver fallback auth as implicit", () => {
+    const auth = createResolvedApproverActionAuthAdapter({
+      channelLabel: "Signal",
+      resolveApprovers: () => [],
+    });
+    const result = auth.authorizeActorAction({
+      cfg: {},
+      senderId: "uuid:attacker",
+      action: "approve",
+      approvalKind: "exec",
+    });
+
+    expect(result).toEqual({ authorized: true });
+    expect(isImplicitSameChatApprovalAuthorization(result)).toBe(true);
+  });
+
+  it("does not mark configured-approver auth as implicit", () => {
+    const auth = createResolvedApproverActionAuthAdapter({
+      channelLabel: "Signal",
+      resolveApprovers: () => ["uuid:owner"],
+    });
+    const result = auth.authorizeActorAction({
+      cfg: {},
+      senderId: "uuid:owner",
+      action: "approve",
+      approvalKind: "exec",
+    });
+
+    expect(result).toEqual({ authorized: true });
+    expect(isImplicitSameChatApprovalAuthorization(result)).toBe(false);
   });
 });

--- a/src/plugin-sdk/approval-auth-helpers.ts
+++ b/src/plugin-sdk/approval-auth-helpers.ts
@@ -13,6 +13,10 @@ const IMPLICIT_SAME_CHAT_APPROVAL_AUTHORIZATION = Symbol(
 function markImplicitSameChatApprovalAuthorization(
   result: ApprovalAuthorizationResult,
 ): ApprovalAuthorizationResult {
+  // Keep this non-enumerable to avoid changing auth payload shape.
+  // Consumers must pass the same object reference to
+  // `isImplicitSameChatApprovalAuthorization`; spread/Object.assign/JSON clones
+  // drop this marker.
   Object.defineProperty(result, IMPLICIT_SAME_CHAT_APPROVAL_AUTHORIZATION, {
     value: true,
     enumerable: false,

--- a/src/plugin-sdk/approval-auth-helpers.ts
+++ b/src/plugin-sdk/approval-auth-helpers.ts
@@ -2,6 +2,36 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { OpenClawConfig } from "./config-runtime.js";
 
 type ApprovalKind = "exec" | "plugin";
+type ApprovalAuthorizationResult = {
+  authorized: boolean;
+  reason?: string;
+};
+const IMPLICIT_SAME_CHAT_APPROVAL_AUTHORIZATION = Symbol(
+  "openclaw.implicitSameChatApprovalAuthorization",
+);
+
+function markImplicitSameChatApprovalAuthorization(
+  result: ApprovalAuthorizationResult,
+): ApprovalAuthorizationResult {
+  Object.defineProperty(result, IMPLICIT_SAME_CHAT_APPROVAL_AUTHORIZATION, {
+    value: true,
+    enumerable: false,
+  });
+  return result;
+}
+
+export function isImplicitSameChatApprovalAuthorization(
+  result: ApprovalAuthorizationResult | null | undefined,
+): boolean {
+  return Boolean(
+    result &&
+    (
+      result as ApprovalAuthorizationResult & {
+        [IMPLICIT_SAME_CHAT_APPROVAL_AUTHORIZATION]?: true;
+      }
+    )[IMPLICIT_SAME_CHAT_APPROVAL_AUTHORIZATION],
+  );
+}
 
 export function createResolvedApproverActionAuthAdapter(params: {
   channelLabel: string;
@@ -25,7 +55,8 @@ export function createResolvedApproverActionAuthAdapter(params: {
     }) {
       const approvers = params.resolveApprovers({ cfg, accountId });
       if (approvers.length === 0) {
-        return { authorized: true } as const;
+        // Empty approver sets are implicit same-chat fallback, not explicit approver bypass.
+        return markImplicitSameChatApprovalAuthorization({ authorized: true });
       }
       const normalizedSenderId = senderId ? normalizeSenderId(senderId) : undefined;
       if (normalizedSenderId && approvers.includes(normalizedSenderId)) {


### PR DESCRIPTION
## Summary

- **Problem:** `createResolvedApproverActionAuthAdapter` returned `{ authorized: true }` when the resolved approver list was empty. `resolveApprovalCommandAuthorization` then converted that into `explicit: true` authorization (because no `getActionAvailabilityState` was provided, so availability was never disabled). In `/approve` handling, `explicit: true` bypasses the normal channel `isAuthorizedSender` gate — allowing a sender with `isAuthorizedSender=false` to submit `exec.approval.resolve` or `plugin.approval.resolve` when the helper-backed channel resolves no approvers.
- **Why it matters:** Exec and plugin approvals are a documented security boundary. This inverted the authorization decision for the empty-approver case, letting an unauthorized channel sender approve pending sensitive actions if they knew a valid approval id.
- **What changed:** Empty-approver fallback in `createResolvedApproverActionAuthAdapter` is now tagged as implicit (via a non-enumerable Symbol). `resolveApprovalCommandAuthorization` detects the tag and forces `explicit: false`, so the normal channel sender auth gate remains in effect. Channels with a configured matching approver continue to produce `explicit: true` as before.
- **What did NOT change:** Same-chat `/approve` for a legitimately authorized sender still works when no dedicated approver list is configured. Non-empty approver lists and all other authorization paths are unaffected.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Auth / tokens

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Empty `resolveApprovers()` result was treated as a permissive fallback (`authorized: true`) without distinguishing it from an explicit configured-approver match. The `explicit` flag computation in `resolveApprovalCommandAuthorization` had no way to tell the two apart.
- Missing detection / guardrail: No regression test covered the `isAuthorizedSender=false` + empty-approvers path.
- Contributing context: The same-chat fallback intent (anyone can approve if no approvers are configured) was conflated with explicit authorization, which bypasses the sender gate.

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
  - [x] Seam / integration test
- Target tests:
  - `src/plugin-sdk/approval-auth-helpers.test.ts` — verifies the Symbol-based implicit/explicit distinction
  - `src/infra/channel-approval-auth.test.ts` — verifies `explicit: false` for empty approvers, `explicit: true` for matching configured approver
  - `src/auto-reply/reply/commands-approve.test.ts` — verifies unauthorized sender is blocked and authorized sender still succeeds with empty approver list
- Scenario the tests lock in: empty-approver + `isAuthorizedSender=false` must not reach `exec.approval.resolve`; empty-approver + `isAuthorizedSender=true` still resolves the approval.
- Why this is the smallest reliable guardrail: directly exercises the exact bypass path without external dependencies.

## User-visible / Behavior Changes

None for users with a properly configured approver list. Users relying on undocumented same-chat approval with an explicitly empty approver list (`allowFrom: []`) will now require the sender to be channel-authorized (`isAuthorizedSender=true`), which matches documented behavior.

## Diagram (if applicable)

```text
Before (vulnerable):
[empty approvers] -> authorized:true, explicit:true -> /approve bypasses isAuthorizedSender gate -> exec.approval.resolve

After (fixed):
[empty approvers] -> authorized:true, explicit:false (implicit) -> /approve checks isAuthorizedSender gate -> blocked for unauthorized senders
[configured approvers match] -> authorized:true, explicit:true -> /approve bypasses gate (intended)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js v22.13.1
- Integration/channel: Signal, WhatsApp, and other helper-backed channels with empty `allowFrom`
- Relevant config: `channels: { signal: { allowFrom: [] } }`

### Steps

1. Configure a helper-backed channel (e.g. Signal) with an empty approver list.
2. Issue `/approve <id> allow-once` from a sender with `isAuthorizedSender=false`.
3. Before fix: `exec.approval.resolve` is reached. After fix: command is silently blocked.

### Expected

- Unauthorized senders are blocked from submitting approvals regardless of approver list configuration.

### Actual (before fix)

- Unauthorized senders could resolve pending approvals when the approver list was empty.

## Evidence

- [x] Failing test/log before + passing after — regression tests added in `commands-approve.test.ts`, `channel-approval-auth.test.ts`, and `approval-auth-helpers.test.ts` directly demonstrate the before/after behavior.

## Human Verification (required)

> ⚠️ This PR was generated by OpenAI Codex (AI-assisted). No human modifications were made to the source changes.

- Verified scenarios: test suite validates all three layers (helper, infra, command handler)
- Edge cases checked: authorized sender with empty approvers still succeeds; non-empty non-matching approvers still denied
- What you did **not** verify: live channel integration on real hardware

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — no API or config surface changes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Same-chat fallback behavior change for users with intentionally empty `allowFrom` lists who relied on any sender being able to approve.
  - Mitigation: Such usage was undocumented and contradicts the approval security model. Authorized senders (normal channel members) are unaffected.