### PR TITLE
fix(security): broaden shell-wrapper detection and block env-argv assignment injection [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(security): broaden shell-wrapper detection and block env-argv assignment injection [AI-assisted]. (#65717) Thanks @pgondhi987.
 - Gateway/startup: defer scheduled services until sidecars finish, gate chat history and model listing during sidecar resume, and let Control UI retry startup-gated history loads so Sandbox wake resumes channels first. (#65365) Thanks @lml2468.
 - Control UI/chat: load the live gateway slash-command catalog into the composer and command palette so dock commands, plugin commands, and direct skill aliases appear in chat, while keeping trusted local commands authoritative and bounding remote command metadata. (#65620) Thanks @BunsDev.
 

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -152,28 +152,97 @@ function scanWrapperInvocation(
 }
 
 export function unwrapEnvInvocation(argv: string[]): string[] | null {
-  return scanWrapperInvocation(argv, {
-    separators: new Set(["--", "-"]),
-    onToken: (token, lower) => {
-      if (isEnvAssignment(token)) {
-        return "continue";
+  const parsed = parseEnvInvocationPrelude(argv);
+  return parsed ? argv.slice(parsed.commandIndex) : null;
+}
+
+type ParsedEnvInvocationPrelude = {
+  assignmentKeys: string[];
+  commandIndex: number;
+};
+
+function parseEnvInvocationPrelude(argv: string[]): ParsedEnvInvocationPrelude | null {
+  let idx = 1;
+  let expectsOptionValue = false;
+  const assignmentKeys: string[] = [];
+  while (idx < argv.length) {
+    const token = argv[idx]?.trim() ?? "";
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (expectsOptionValue) {
+      expectsOptionValue = false;
+      idx += 1;
+      continue;
+    }
+    if (token === "--" || token === "-") {
+      idx += 1;
+      break;
+    }
+    if (isEnvAssignment(token)) {
+      const delimiter = token.indexOf("=");
+      if (delimiter > 0) {
+        assignmentKeys.push(token.slice(0, delimiter));
       }
-      if (!token.startsWith("-") || token === "-") {
-        return "stop";
+      idx += 1;
+      continue;
+    }
+    if (!token.startsWith("-") || token === "-") {
+      break;
+    }
+    const lower = normalizeLowercaseStringOrEmpty(token);
+    const [flag] = lower.split("=", 2);
+    if (ENV_FLAG_OPTIONS.has(flag)) {
+      idx += 1;
+      continue;
+    }
+    if (ENV_OPTIONS_WITH_VALUE.has(flag)) {
+      if (lower.includes("=")) {
+        idx += 1;
+        continue;
       }
-      const [flag] = lower.split("=", 2);
-      if (ENV_FLAG_OPTIONS.has(flag)) {
-        return "continue";
+      expectsOptionValue = true;
+      idx += 1;
+      continue;
+    }
+    if (hasEnvInlineValuePrefix(lower)) {
+      idx += 1;
+      continue;
+    }
+    return null;
+  }
+
+  if (expectsOptionValue || idx >= argv.length) {
+    return null;
+  }
+
+  return {
+    assignmentKeys,
+    commandIndex: idx,
+  };
+}
+
+export function extractEnvAssignmentKeysFromDispatchWrappers(
+  argv: string[],
+  maxDepth = MAX_DISPATCH_WRAPPER_DEPTH,
+): string[] {
+  let current = argv;
+  const assignmentKeys: string[] = [];
+  for (let depth = 0; depth < maxDepth; depth += 1) {
+    const unwrap = unwrapKnownDispatchWrapperInvocation(current);
+    if (unwrap.kind !== "unwrapped" || unwrap.argv.length === 0) {
+      break;
+    }
+    if (unwrap.wrapper === "env") {
+      const parsed = parseEnvInvocationPrelude(current);
+      if (parsed) {
+        assignmentKeys.push(...parsed.assignmentKeys);
       }
-      if (ENV_OPTIONS_WITH_VALUE.has(flag)) {
-        return lower.includes("=") ? "continue" : "consume-next";
-      }
-      if (hasEnvInlineValuePrefix(lower)) {
-        return "continue";
-      }
-      return "invalid";
-    },
-  });
+    }
+    current = unwrap.argv;
+  }
+  return Array.from(new Set(assignmentKeys)).toSorted((a, b) => a.localeCompare(b));
 }
 
 function envInvocationUsesModifiers(argv: string[]): boolean {

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "vitest";
 import {
   basenameLower,
+  extractEnvAssignmentKeysFromDispatchWrappers,
   extractShellWrapperCommand,
   extractShellWrapperInlineCommand,
   hasEnvManipulationBeforeShellWrapper,
   isDispatchWrapperExecutable,
   isShellWrapperExecutable,
+  isShellWrapperInvocation,
   normalizeExecutableToken,
   resolveDispatchWrapperTrustPlan,
   resolveShellWrapperTransportArgv,
@@ -399,6 +401,52 @@ describe("resolveShellWrapperTransportArgv", () => {
     },
   ])("resolves wrapper transport argv for %j", ({ argv, expected }) => {
     expect(resolveShellWrapperTransportArgv(argv)).toEqual(expected);
+  });
+});
+
+describe("isShellWrapperInvocation", () => {
+  test.each([
+    {
+      argv: ["bash", "script.sh"],
+      expected: true,
+    },
+    {
+      argv: ["/usr/bin/env", "SHELLOPTS=xtrace", "bash", "-lc", "echo hi"],
+      expected: true,
+    },
+    {
+      argv: ["busybox", "sh", "script.sh"],
+      expected: true,
+    },
+    {
+      argv: ["/usr/bin/env", "FOO=bar", "/usr/bin/printf", "ok"],
+      expected: false,
+    },
+  ])("detects shell-wrapper executable invocations for %j", ({ argv, expected }) => {
+    expect(isShellWrapperInvocation(argv)).toBe(expected);
+  });
+});
+
+describe("extractEnvAssignmentKeysFromDispatchWrappers", () => {
+  test.each([
+    {
+      argv: ["env", "FOO=bar", "BAR=baz", "bash", "-lc", "echo hi"],
+      expected: ["BAR", "FOO"],
+    },
+    {
+      argv: ["nice", "-n", "5", "env", "-u", "PATH", "TERM=xterm", "bash", "-lc", "echo hi"],
+      expected: ["TERM"],
+    },
+    {
+      argv: ["env", "--split-string", "FOO=bar", "bash", "-lc", "echo hi"],
+      expected: [],
+    },
+    {
+      argv: ["env", "--", "bash", "-lc", "echo hi"],
+      expected: [],
+    },
+  ])("extracts env assignment prelude keys for %j", ({ argv, expected }) => {
+    expect(extractEnvAssignmentKeysFromDispatchWrappers(argv)).toEqual(expected);
   });
 });
 

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -1201,11 +1201,13 @@ describe("sanitizeSystemRunEnvOverrides", () => {
         TOKEN: "abc",
         LANG: "C",
         LC_ALL: "C",
+        LC_TIME: "C",
       },
     });
     expect(overrides).toEqual({
       LANG: "C",
       LC_ALL: "C",
+      LC_TIME: "C",
     });
   });
 
@@ -1228,11 +1230,13 @@ describe("sanitizeSystemRunEnvOverrides", () => {
         overrides: {
           lang: "C",
           ColorTerm: "truecolor",
+          lc_numeric: "C",
         },
       }),
     ).toEqual({
       lang: "C",
       ColorTerm: "truecolor",
+      lc_numeric: "C",
     });
   });
 });

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -32,6 +32,8 @@ export const HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_KEY_VALUES: readonly string
   "NO_COLOR",
   "FORCE_COLOR",
 ]);
+export const HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_PREFIX_VALUES: readonly string[] =
+  Object.freeze(["LC_"]);
 export const HOST_DANGEROUS_ENV_KEYS = new Set<string>(HOST_DANGEROUS_ENV_KEY_VALUES);
 export const HOST_DANGEROUS_INHERITED_ENV_KEYS = new Set<string>(
   HOST_DANGEROUS_INHERITED_ENV_KEY_VALUES,
@@ -42,6 +44,20 @@ export const HOST_DANGEROUS_OVERRIDE_ENV_KEYS = new Set<string>(
 export const HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_KEYS = new Set<string>(
   HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_KEY_VALUES,
 );
+
+function isShellWrapperAllowedOverrideEnvVarName(rawKey: string): boolean {
+  const key = normalizeEnvVarKey(rawKey, { portable: true });
+  if (!key) {
+    return false;
+  }
+  const upper = key.toUpperCase();
+  if (HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_KEYS.has(upper)) {
+    return true;
+  }
+  return HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_PREFIX_VALUES.some((prefix) =>
+    upper.startsWith(prefix),
+  );
+}
 
 export type HostExecEnvSanitizationResult = {
   env: Record<string, string>;
@@ -254,7 +270,7 @@ export function sanitizeSystemRunEnvOverrides(params?: {
   }
   const filtered: Record<string, string> = {};
   for (const [key, value] of listNormalizedEnvEntries(overrides, { portable: true })) {
-    if (!HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_KEYS.has(key.toUpperCase())) {
+    if (!isShellWrapperAllowedOverrideEnvVarName(key)) {
       continue;
     }
     filtered[key] = value;

--- a/src/infra/shell-wrapper-resolution.ts
+++ b/src/infra/shell-wrapper-resolution.ts
@@ -107,6 +107,38 @@ export function isShellWrapperExecutable(token: string): boolean {
   return SHELL_WRAPPER_CANONICAL.has(normalizeExecutableToken(token));
 }
 
+function isShellWrapperInvocationInternal(argv: string[], depth: number): boolean {
+  if (!isWithinDispatchClassificationDepth(depth)) {
+    return false;
+  }
+  const token0 = argv[0]?.trim();
+  if (!token0) {
+    return false;
+  }
+
+  const dispatchUnwrap = unwrapKnownDispatchWrapperInvocation(argv);
+  if (dispatchUnwrap.kind === "blocked") {
+    return false;
+  }
+  if (dispatchUnwrap.kind === "unwrapped") {
+    return isShellWrapperInvocationInternal(dispatchUnwrap.argv, depth + 1);
+  }
+
+  const shellMultiplexerUnwrap = unwrapKnownShellMultiplexerInvocation(argv);
+  if (shellMultiplexerUnwrap.kind === "blocked") {
+    return false;
+  }
+  if (shellMultiplexerUnwrap.kind === "unwrapped") {
+    return isShellWrapperInvocationInternal(shellMultiplexerUnwrap.argv, depth + 1);
+  }
+
+  return isShellWrapperExecutable(token0);
+}
+
+export function isShellWrapperInvocation(argv: string[]): boolean {
+  return isShellWrapperInvocationInternal(argv, 0);
+}
+
 function normalizeRawCommand(rawCommand?: string | null): string | null {
   const trimmed = rawCommand?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;

--- a/src/node-host/exec-policy.test.ts
+++ b/src/node-host/exec-policy.test.ts
@@ -147,6 +147,16 @@ describe("evaluateSystemRunPolicy", () => {
     expect(denied.errorMessage).toContain("Windows shell wrappers like cmd.exe /c");
   });
 
+  it("does not block Windows cmd.exe invocations without inline shell-wrapper transport", () => {
+    const allowed = expectAllowedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({ isWindows: true, cmdInvocation: true, shellWrapperInvocation: false }),
+      ),
+    );
+    expect(allowed.shellWrapperBlocked).toBe(false);
+    expect(allowed.windowsShellWrapperBlocked).toBe(false);
+  });
+
   it("allows execution when policy checks pass", () => {
     const allowed = expectAllowedDecision(
       evaluateSystemRunPolicy(buildPolicyParams({ ask: "on-miss" })),

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -384,6 +384,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     sendNodeEvent?: HandleSystemRunInvokeOptions["sendNodeEvent"];
     skillBinsCurrent?: () => Promise<Array<{ name: string; resolvedPath: string }>>;
     isCmdExeInvocation?: HandleSystemRunInvokeOptions["isCmdExeInvocation"];
+    sanitizeEnv?: HandleSystemRunInvokeOptions["sanitizeEnv"];
   }): Promise<{
     runCommand: MockedRunCommand;
     runViaMacAppExecHost: MockedRunViaMacAppExecHost;
@@ -443,7 +444,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       resolveExecSecurity: () => params.security ?? "full",
       resolveExecAsk: () => params.ask ?? "off",
       isCmdExeInvocation: params.isCmdExeInvocation ?? (() => false),
-      sanitizeEnv: () => undefined,
+      sanitizeEnv: params.sanitizeEnv ?? (() => undefined),
       runCommand,
       runViaMacAppExecHost,
       sendNodeEvent,
@@ -1183,6 +1184,49 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     });
     expectInvokeErrorMessage(sendInvokeResult, {
       message: "CLASSPATH",
+    });
+  });
+
+  it("applies shell-wrapper env allowlist for shell executable commands without inline payload", async () => {
+    const { runCommand, sendInvokeResult } = await runSystemInvoke({
+      preferMacAppExecHost: false,
+      security: "full",
+      ask: "off",
+      command: ["/bin/sh", "./script.sh"],
+      env: {
+        OPENCLAW_TEST: "1",
+        LANG: "C",
+        LC_TIME: "C",
+      },
+      sanitizeEnv: (overrides) => overrides ?? undefined,
+    });
+
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    const passedEnv = runCommand.mock.calls[0]?.[2];
+    expect(passedEnv).toEqual({
+      LANG: "C",
+      LC_TIME: "C",
+    });
+    expectInvokeOk(sendInvokeResult);
+  });
+
+  it("rejects blocked env assignment keys embedded in command argv", async () => {
+    const { runCommand, sendInvokeResult } = await runSystemInvoke({
+      preferMacAppExecHost: false,
+      security: "full",
+      ask: "off",
+      command: ["/usr/bin/env", "SHELLOPTS=xtrace", "PS4=$(id)", "bash", "-lc", "echo ok"],
+    });
+
+    expect(runCommand).not.toHaveBeenCalled();
+    expectInvokeErrorMessage(sendInvokeResult, {
+      message: "SYSTEM_RUN_DENIED: command env assignment rejected",
+    });
+    expectInvokeErrorMessage(sendInvokeResult, {
+      message: "SHELLOPTS",
+    });
+    expectInvokeErrorMessage(sendInvokeResult, {
+      message: "PS4",
     });
   });
 

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -20,7 +20,11 @@ import {
   detectInterpreterInlineEvalArgv,
 } from "../infra/exec-inline-eval.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
-import { resolveShellWrapperTransportArgv } from "../infra/exec-wrapper-resolution.js";
+import {
+  extractEnvAssignmentKeysFromDispatchWrappers,
+  isShellWrapperInvocation,
+  resolveShellWrapperTransportArgv,
+} from "../infra/exec-wrapper-resolution.js";
 import {
   inspectHostExecEnvOverrides,
   sanitizeSystemRunEnvOverrides,
@@ -78,6 +82,7 @@ type ResolvedExecApprovals = ReturnType<typeof resolveExecApprovals>;
 type SystemRunParsePhase = {
   argv: string[];
   shellPayload: string | null;
+  shellWrapperInvocation: boolean;
   commandText: string;
   commandPreview: string | null;
   approvalPlan: import("../infra/exec-approvals.js").SystemRunApprovalPlan | null;
@@ -242,6 +247,7 @@ async function parseSystemRunPhase(
   }
 
   const shellPayload = command.shellPayload;
+  const shellWrapperInvocation = isShellWrapperInvocation(command.argv);
   const commandText = command.commandText;
   const approvalPlan =
     opts.params.systemRunPlan === undefined
@@ -258,6 +264,39 @@ async function parseSystemRunPhase(
   const sessionKey = normalizeOptionalString(opts.params.sessionKey) ?? "node";
   const runId = normalizeOptionalString(opts.params.runId) ?? crypto.randomUUID();
   const suppressNotifyOnExit = opts.params.suppressNotifyOnExit === true;
+  const envAssignmentKeys = extractEnvAssignmentKeysFromDispatchWrappers(command.argv);
+  const envAssignmentOverrides =
+    envAssignmentKeys.length > 0
+      ? Object.fromEntries(envAssignmentKeys.map((key) => [key, "1"]))
+      : undefined;
+  const envAssignmentDiagnostics = inspectHostExecEnvOverrides({
+    overrides: envAssignmentOverrides,
+    blockPathOverrides: true,
+  });
+  if (
+    envAssignmentDiagnostics.rejectedOverrideBlockedKeys.length > 0 ||
+    envAssignmentDiagnostics.rejectedOverrideInvalidKeys.length > 0
+  ) {
+    const details: string[] = [];
+    if (envAssignmentDiagnostics.rejectedOverrideBlockedKeys.length > 0) {
+      details.push(
+        `blocked env assignment keys: ${envAssignmentDiagnostics.rejectedOverrideBlockedKeys.join(", ")}`,
+      );
+    }
+    if (envAssignmentDiagnostics.rejectedOverrideInvalidKeys.length > 0) {
+      details.push(
+        `invalid non-portable env assignment keys: ${envAssignmentDiagnostics.rejectedOverrideInvalidKeys.join(", ")}`,
+      );
+    }
+    await opts.sendInvokeResult({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: `SYSTEM_RUN_DENIED: command env assignment rejected (${details.join("; ")})`,
+      },
+    });
+    return null;
+  }
   const envOverrideDiagnostics = inspectHostExecEnvOverrides({
     overrides: opts.params.env ?? undefined,
     blockPathOverrides: true,
@@ -288,11 +327,12 @@ async function parseSystemRunPhase(
   }
   const envOverrides = sanitizeSystemRunEnvOverrides({
     overrides: opts.params.env ?? undefined,
-    shellWrapper: shellPayload !== null,
+    shellWrapper: shellWrapperInvocation,
   });
   return {
     argv: command.argv,
     shellPayload,
+    shellWrapperInvocation,
     commandText,
     commandPreview: command.previewText,
     approvalPlan,
@@ -384,7 +424,7 @@ async function evaluateSystemRunPolicyPhase(
     approved: parsed.approved,
     isWindows,
     cmdInvocation,
-    shellWrapperInvocation: parsed.shellPayload !== null,
+    shellWrapperInvocation: parsed.shellWrapperInvocation,
   });
   analysisOk = policy.analysisOk;
   allowlistSatisfied = policy.allowlistSatisfied;

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -273,26 +273,14 @@ async function parseSystemRunPhase(
     overrides: envAssignmentOverrides,
     blockPathOverrides: true,
   });
-  if (
-    envAssignmentDiagnostics.rejectedOverrideBlockedKeys.length > 0 ||
-    envAssignmentDiagnostics.rejectedOverrideInvalidKeys.length > 0
-  ) {
-    const details: string[] = [];
-    if (envAssignmentDiagnostics.rejectedOverrideBlockedKeys.length > 0) {
-      details.push(
-        `blocked env assignment keys: ${envAssignmentDiagnostics.rejectedOverrideBlockedKeys.join(", ")}`,
-      );
-    }
-    if (envAssignmentDiagnostics.rejectedOverrideInvalidKeys.length > 0) {
-      details.push(
-        `invalid non-portable env assignment keys: ${envAssignmentDiagnostics.rejectedOverrideInvalidKeys.join(", ")}`,
-      );
-    }
+  // `extractEnvAssignmentKeysFromDispatchWrappers` only emits keys that satisfy
+  // `isEnvAssignment` and therefore portable env-key syntax by construction.
+  if (envAssignmentDiagnostics.rejectedOverrideBlockedKeys.length > 0) {
     await opts.sendInvokeResult({
       ok: false,
       error: {
         code: "INVALID_REQUEST",
-        message: `SYSTEM_RUN_DENIED: command env assignment rejected (${details.join("; ")})`,
+        message: `SYSTEM_RUN_DENIED: command env assignment rejected (blocked env assignment keys: ${envAssignmentDiagnostics.rejectedOverrideBlockedKeys.join(", ")})`,
       },
     });
     return null;

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -424,7 +424,9 @@ async function evaluateSystemRunPolicyPhase(
     approved: parsed.approved,
     isWindows,
     cmdInvocation,
-    shellWrapperInvocation: parsed.shellWrapperInvocation,
+    // Keep cmd.exe approval gating scoped to inline shell-wrapper transport.
+    // Env sanitization uses broader shell-wrapper detection in parse phase.
+    shellWrapperInvocation: parsed.shellPayload !== null,
   });
   analysisOk = policy.analysisOk;
   allowlistSatisfied = policy.allowlistSatisfied;


### PR DESCRIPTION
## Summary

- **Problem:** Shell-wrapper env override filtering only activated for inline `-c`/`-lc` payload patterns (`shellPayload !== null`), leaving direct shell invocations like `sh script.sh` unprotected; additionally, dangerous variables (e.g. `SHELLOPTS`, `PS4`) embedded as `VAR=val` arguments to the `env` dispatch wrapper bypassed the override sanitizer entirely, and `LC_*` locale variables used exact-match allowlisting instead of prefix matching.
- **Why it matters:** Attackers could inject `PROMPT_COMMAND`, `PYTHONSTARTUP`, or other blocked env vars when the shell is invoked without `-c`, or smuggle `SHELLOPTS`/`PS4` via `env VAR=val bash ...` argv, achieving arbitrary command execution.
- **What changed:** (1) `isShellWrapperInvocation()` added to detect shell-wrapper commands broadly (with/without inline payload); (2) `shellWrapperInvocation` flag now uses this check instead of `shellPayload !== null`; (3) `extractEnvAssignmentKeysFromDispatchWrappers()` added to extract and validate `VAR=val` keys embedded in `env` dispatch-wrapper argv, rejecting blocked keys before execution; (4) `LC_*` prefix added to `HOST_SHELL_WRAPPER_ALLOWED_OVERRIDE_ENV_PREFIX_VALUES` so all locale variables pass through correctly.
- **What did NOT change:** General env sanitization logic for non-shell commands, blocked key lists, or any other dispatch-wrapper unwrapping behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `shellWrapperInvocation` flag was derived from `shellPayload !== null`, which is only set for inline `-c` patterns. Direct shell invocations without an inline payload were not recognized as shell wrappers, so the env allowlist was not applied.
- Missing detection / guardrail: No check validated env-variable assignments embedded in `env` command argv (as opposed to the `env` override parameter). `extractEnvAssignmentKeysFromDispatchWrappers` was absent.
- Contributing context (if known): `LC_*` allowlist was limited to `LC_CTYPE` and `LC_MESSAGES` as explicit entries with no prefix fallback.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/node-host/invoke-system-run.test.ts`, `src/infra/exec-wrapper-resolution.test.ts`, `src/infra/host-env-security.test.ts`
- Scenario the test should lock in:
  - `sh script.sh` with `LC_TIME` and `OPENCLAW_TEST` overrides: only `LC_*`/`LANG`/`TERM` pass through
  - `env SHELLOPTS=xtrace PS4=$(id) bash -c echo`: rejected with `SYSTEM_RUN_DENIED: command env assignment rejected`
  - `extractEnvAssignmentKeysFromDispatchWrappers` correctly parses nested dispatch wrappers and skips `--split-string`
  - `isShellWrapperInvocation` detects `busybox sh`, `env SHELLOPTS=x bash`, and rejects non-shell executables
- Why this is the smallest reliable guardrail: Tests directly assert the deny path and the filtered env dict without requiring full E2E gateway execution.
- Existing test that already covers this (if any): None — these are net-new cases.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `sh script.sh` commands with env overrides now apply the same shell-wrapper allowlist as `bash -c "..."` commands. Previously allowed variables (`OPENCLAW_TEST`, `PROMPT_COMMAND`, etc.) are now stripped.
- Commands using `env VAR=val ...` argv with blocked key names (`SHELLOPTS`, `PS4`, etc.) are now denied with an explicit error message instead of passing through.
- All `LC_*` locale variables (e.g. `LC_TIME`, `LC_NUMERIC`) are now accepted as env overrides for shell-wrapper invocations (previously only `LC_CTYPE` and `LC_MESSAGES` were allowed).

## Diagram (if applicable)

```text
Before:
[sh script.sh + env overrides] -> shellPayload=null -> shellWrapper=false -> no filtering -> PROMPT_COMMAND passes
[env SHELLOPTS=x bash -c ...] -> keys parsed from argv -> no key validation -> SHELLOPTS passes

After:
[sh script.sh + env overrides] -> isShellWrapperInvocation=true -> shellWrapper=true -> LC_*/TERM/LANG allowlist applied
[env SHELLOPTS=x bash -c ...] -> extractEnvAssignmentKeysFromDispatchWrappers -> SHELLOPTS in blockedEverywhereKeys -> DENIED
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — shell-wrapper detection is now broader; some previously-passthrough env vars are now filtered or rejected.
- Data access scope changed? No
- Risk + mitigation: The new blocking behavior could reject legitimate `env VAR=val` command patterns if keys appear in the blocked list. Mitigation: the blocked list is restricted to keys with documented injection risk; locale/terminal vars are explicitly allowed.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 22.04)
- Runtime/container: Node 22 / Bun
- Model/provider: N/A (host-side exec sanitization)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run scoped unit tests: `pnpm test src/node-host/invoke-system-run.test.ts src/infra/exec-wrapper-resolution.test.ts src/infra/host-env-security.test.ts`
2. Confirm `SYSTEM_RUN_DENIED: command env assignment rejected` error for `env SHELLOPTS=xtrace PS4=$(id) bash -c echo ok`
3. Confirm `LC_TIME` passes through and `OPENCLAW_TEST` is stripped for `sh script.sh`

### Expected

- All three new test cases pass
- No regressions in existing `invoke-system-run` or `exec-wrapper-resolution` tests

### Actual

- All targeted tests pass

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New tests added directly covering each bypass scenario; tests were verified to fail on the pre-fix code path and pass on the patched code.

## Human Verification (required)

> **AI-assisted PR** — generated by Claude (Sonnet 4.6) via automated Codex security fix pipeline. No human modifications to source files.

- Verified scenarios: N/A (automated)
- Edge cases checked: N/A (automated)
- What you did **not** verify: Manual end-to-end execution on a live gateway instance

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — blocking behavior only applies to keys already in the security policy's blocked lists
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Commands using `env BLOCKED_KEY=val ...` in argv will now be rejected where they previously passed through.
  - Mitigation: Blocked keys are a fixed well-known set (SHELLOPTS, PS4, etc.) with no legitimate use in tool invocations; the error message names the offending keys explicitly.
- Risk: Shell-wrapper env filtering now applies to `sh script.sh` patterns that previously had no filtering.
  - Mitigation: Only `LC_*`, `LANG`, `TERM`, `COLORTERM`, `NO_COLOR`, `FORCE_COLOR` are allowed through; this matches documented intent.