### PR TITLE
qa: relax repo-contract artifact matcher

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -149,6 +149,8 @@ describe("qa scenario catalog", () => {
           workspaceFiles?: Record<string, string>;
           prompt?: string;
           expectedReplyAll?: string[];
+          expectedArtifactAll?: string[];
+          expectedArtifactAny?: string[];
         }
       | undefined;
 
@@ -159,6 +161,8 @@ describe("qa scenario catalog", () => {
     );
     expect(config?.prompt).toContain("Repo contract followthrough check.");
     expect(config?.expectedReplyAll).toEqual(["read:", "wrote:", "status:"]);
+    expect(config?.expectedArtifactAll).toEqual(["repo contract"]);
+    expect(config?.expectedArtifactAny).toContain("evidence path");
     expect(scenario.title).toBe("Instruction followthrough repo contract");
   });
 

--- a/qa/scenarios/instruction-followthrough-repo-contract.md
+++ b/qa/scenarios/instruction-followthrough-repo-contract.md
@@ -51,6 +51,12 @@ execution:
       - "read:"
       - "wrote:"
       - "status:"
+    expectedArtifactAll:
+      - "repo contract"
+    expectedArtifactAny:
+      - "evidence path"
+      - "agent.md"
+      - "followthrough"
     forbiddenNeedles:
       - need permission
       - need your approval
@@ -91,9 +97,16 @@ steps:
         args:
           - lambda:
               async: true
-              expr: "((await fs.readFile(artifactPath, 'utf8').catch(() => null))?.includes('Mission: prove you followed the repo contract.') ? await fs.readFile(artifactPath, 'utf8').catch(() => null) : undefined)"
+              expr: "((await fs.readFile(artifactPath, 'utf8').catch(() => null))?.trim() ? await fs.readFile(artifactPath, 'utf8').catch(() => null) : undefined)"
           - expr: liveTurnTimeoutMs(env, 30000)
           - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+      - set: normalizedArtifact
+        value:
+          expr: "normalizeLowercaseStringOrEmpty(artifact)"
+      - assert:
+          expr: "config.expectedArtifactAll.every((needle) => normalizedArtifact.includes(normalizeLowercaseStringOrEmpty(needle))) && config.expectedArtifactAny.some((needle) => normalizedArtifact.includes(normalizeLowercaseStringOrEmpty(needle)))"
+          message:
+            expr: "`repo contract artifact missing expected followthrough signals: ${artifact}`"
       - set: expectedReplyAll
         value:
           expr: config.expectedReplyAll.map(normalizeLowercaseStringOrEmpty)

--- a/qa/scenarios/instruction-followthrough-repo-contract.md
+++ b/qa/scenarios/instruction-followthrough-repo-contract.md
@@ -97,7 +97,7 @@ steps:
         args:
           - lambda:
               async: true
-              expr: "((await fs.readFile(artifactPath, 'utf8').catch(() => null))?.trim() ? await fs.readFile(artifactPath, 'utf8').catch(() => null) : undefined)"
+              expr: "(() => { const normalize = (value) => normalizeLowercaseStringOrEmpty(value); const matches = (value) => { const normalized = normalize(value); return normalized && config.expectedArtifactAll.every((needle) => normalized.includes(normalize(needle))) && config.expectedArtifactAny.some((needle) => normalized.includes(normalize(needle))); }; return fs.readFile(artifactPath, 'utf8').then((value) => matches(value) ? value : undefined).catch(() => undefined); })()"
           - expr: liveTurnTimeoutMs(env, 30000)
           - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
       - set: normalizedArtifact


### PR DESCRIPTION
## Summary

- Problem: the live `instruction-followthrough-repo-contract` qa-lab scenario timed out on `openai-codex/gpt-5.4` even when the agent read the files in order, wrote `repo-contract-summary.txt`, and returned the required three-line reply.
- Why it matters: the scenario was failing the real Codex OAuth lane for the wrong reason, which made the live QA signal look like a product/runtime regression when the agent had actually completed the user-facing task.
- What changed: the scenario now waits for a non-empty artifact, then asserts broader followthrough signals (`repo contract` plus evidence-path/read-order markers) instead of requiring one exact copied mission sentence.
- What did NOT change (scope boundary): no agent runtime logic, no OpenAI/Codex provider behavior, no qa-lab gateway orchestration, and no model-selection defaults changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `qa/scenarios/instruction-followthrough-repo-contract.md` encoded a hidden exact-string artifact requirement (`Mission: prove you followed the repo contract.`) that was stricter than the scenario objective and success criteria.
- Missing detection / guardrail: the mock lane passed because the scripted mock artifact used that exact sentence, but the real Codex OAuth lane produced a different valid artifact, so there was no coverage protecting against overly literal artifact matching.
- Contributing context (if known): the step waits up to the live-turn timeout for the artifact predicate, so the mismatch surfaced as a slow 120s timeout rather than an immediate meaningful assertion failure.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] End-to-end test
  - [ ] Seam / integration test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/qa-lab/src/scenario-catalog.test.ts`
  - live `qa suite` smoke on `instruction-followthrough-repo-contract`
- Scenario the test should lock in: the repo-contract scenario should accept a valid followthrough artifact that proves the contract/evidence path without requiring one exact copied mission sentence.
- Why this is the smallest reliable guardrail: the bug lives in the scenario contract itself, so the scenario-catalog assertion plus a live scenario smoke are the narrowest checks that validate both the spec and the real lane.
- Existing test that already covers this (if any): `extensions/qa-lab/src/mock-openai-server.test.ts` already covers the deterministic repo-contract tool sequence on the mock lane.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- The live qa-lab `instruction-followthrough-repo-contract` scenario no longer times out on valid Codex OAuth followthrough artifacts that use slightly different wording.

## Diagram (if applicable)

```text
Before:
[live Codex lane writes valid artifact + valid reply] -> [scenario waits for exact mission sentence] -> [120s timeout]

After:
[live Codex lane writes valid artifact + valid reply] -> [scenario checks artifact for repo-contract/evidence-path signals] -> [pass]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: repo checkout from `main`
- Model/provider: `openai-codex/gpt-5.4`
- Integration/channel (if any): qa-lab / qa-channel
- Relevant config (redacted): Codex OAuth auth available locally; no `OPENAI_API_KEY`

### Steps

1. Run `pnpm openclaw qa suite --provider-mode live-frontier --model openai-codex/gpt-5.4 --alt-model openai-codex/gpt-5.4 --fast --scenario instruction-followthrough-repo-contract` on `main` before this patch.
2. Observe the child gateway read `AGENT.md`, `SOUL.md`, `FOLLOWTHROUGH_INPUT.md`, write `repo-contract-summary.txt`, and return the three-line `Read / Wrote / Status` reply.
3. Observe the outer suite still time out after 120000ms because the artifact did not contain the exact mission sentence.
4. Re-run after this patch.

### Expected

- The scenario should pass when the artifact and final reply prove the repo-contract followthrough, even if the artifact wording is not an exact sentence copy.

### Actual

- Before the patch, the live run timed out after 120000ms.
- After the patch, the same live lane passes in ~22s.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test extensions/qa-lab/src/scenario-catalog.test.ts`
  - `pnpm test extensions/qa-lab/src/mock-openai-server.test.ts -t "drives repo-contract followthrough as read-read-read-write-then-report"`
  - `pnpm openclaw qa suite --provider-mode mock-openai --scenario instruction-followthrough-repo-contract --output-dir .artifacts/qa-e2e/mock-openai-repo-contract-postfix-20260412-2230`
  - `pnpm openclaw qa suite --provider-mode live-frontier --model openai-codex/gpt-5.4 --alt-model openai-codex/gpt-5.4 --fast --scenario instruction-followthrough-repo-contract --output-dir .artifacts/qa-e2e/live-frontier-openai-codex-repo-contract-postfix-20260412-2231`
  - `pnpm openclaw qa suite --provider-mode live-frontier --model openai-codex/gpt-5.4 --alt-model openai-codex/gpt-5.4 --fast --scenario approval-turn-tool-followthrough --scenario instruction-followthrough-repo-contract --output-dir .artifacts/qa-e2e/live-frontier-openai-codex-dual-smoke-20260412-2232`
  - `pnpm check`
- Edge cases checked:
  - mock lane still passes
  - exact mock-server flow test still passes
  - live Codex OAuth lane now passes both the repo-contract scenario and the adjacent approval-followthrough scenario
- What you did **not** verify:
  - live `openai/gpt-5.4` API-key lane
  - anthropic parity lane

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the scenario could become too permissive and accept a low-information artifact.
  - Mitigation: it still requires `repo contract` plus at least one evidence/read-order signal, and the final reply must still include explicit `Read / Wrote / Status` lines.
