### PR TITLE
fix: add missing runtime entries for /status command

### DIFF
--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -113,6 +113,22 @@ describe("tsdown config", () => {
     }
   });
 
+  // Regression tests for /status command runtime entries
+  // See: https://github.com/openclaw/openclaw/pull/65735
+  it("includes auto-reply/reply/commands-status-deps.runtime entry", () => {
+    const unifiedGraph = unifiedDistGraph();
+    const entries = entryKeys(unifiedGraph!);
+
+    expect(entries).toContain("auto-reply/reply/commands-status-deps.runtime");
+  });
+
+  it("includes auto-reply/status.runtime entry", () => {
+    const unifiedGraph = unifiedDistGraph();
+    const entries = entryKeys(unifiedGraph!);
+
+    expect(entries).toContain("auto-reply/status.runtime");
+  });
+
   it("suppresses unresolved imports from extension source", () => {
     const configured = unifiedDistGraph()?.inputOptions?.({})?.onLog;
     const handled: TsdownLog[] = [];

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -148,6 +148,8 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
+    "auto-reply/status.runtime": "src/auto-reply/status.runtime.ts",
+    "auto-reply/reply/commands-status-deps.runtime": "src/auto-reply/reply/commands-status-deps.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",
     "plugins/provider-discovery.runtime": "src/plugins/provider-discovery.runtime.ts",
     "plugins/provider-runtime.runtime": "src/plugins/provider-runtime.runtime.ts",


### PR DESCRIPTION
## Problem

The `/status` slash command fails silently with module not found errors:

```
Cannot find module "commands-status-deps.runtime.js"
Cannot find module "status.runtime.js"
```

## Root Cause

`commands-status.ts` uses `importRuntimeModule()` to dynamically load two runtime modules via `new URL() + import()`:

```ts
const STATUS_RUNTIME_SPEC = ["../status.runtime", ".js"];
const COMMANDS_STATUS_DEPS_RUNTIME_SPEC = ["./commands-status-deps.runtime", ".js"];
```

tsdown cannot statically analyze this pattern, so these modules need explicit entries in `buildCoreDistEntries()`. Both `status.runtime.ts` and `commands-status-deps.runtime.ts` were missing from the list, causing them to not be emitted as standalone chunks.

## Fix

Added two entries to `buildCoreDistEntries()` in `tsdown.config.ts`:

```ts
"commands-status-deps.runtime": "src/auto-reply/reply/commands-status-deps.runtime.ts",
"status.runtime": "src/auto-reply/status.runtime.ts",
```

## Testing

- `npm run build` succeeds and emits both files to `dist/`
- `npm run check` passes (lint, cycles, tsgo all clean)
- Gateway restart confirms `/status` command works correctly