### PR TITLE
fix(exec): respect OPENCLAW_STATE_DIR for exec approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec approvals: honor explicit `OPENCLAW_STATE_DIR` for default JSON and socket paths while keeping the legacy `~/.openclaw` fallback when unset, so custom state roots report and store approvals consistently. Fixes #62917; carries forward #65736. Thanks @oinoom.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -74,6 +74,9 @@ Approvals live in a local JSON file on the execution host:
 ~/.openclaw/exec-approvals.json
 ```
 
+If `OPENCLAW_STATE_DIR` is set explicitly, the default approvals JSON file
+and socket move under that state directory instead.
+
 Example schema:
 
 ```json

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -52,6 +52,17 @@ export function resolveNewStateDir(homedir: () => string = resolveDefaultHomeDir
   return newStateDir(homedir);
 }
 
+export function resolveExplicitStateDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = envHomedir(env),
+): string | null {
+  const override = env.OPENCLAW_STATE_DIR?.trim();
+  if (!override) {
+    return null;
+  }
+  return resolveUserPath(override, env, () => resolveRequiredHomeDir(env, homedir));
+}
+
 /**
  * State directory for mutable data (sessions, logs, caches).
  * Can be overridden via OPENCLAW_STATE_DIR.
@@ -62,9 +73,9 @@ export function resolveStateDir(
   homedir: () => string = envHomedir(env),
 ): string {
   const effectiveHomedir = () => resolveRequiredHomeDir(env, homedir);
-  const override = env.OPENCLAW_STATE_DIR?.trim();
+  const override = resolveExplicitStateDir(env, homedir);
   if (override) {
-    return resolveUserPath(override, env, effectiveHomedir);
+    return override;
   }
   const newDir = newStateDir(effectiveHomedir);
   if (env.OPENCLAW_TEST_FAST === "1") {

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -3,7 +3,7 @@ import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   DEFAULT_EXEC_APPROVAL_ASK_FALLBACK,
   resolveExecApprovalAllowedDecisions,
-  resolveExecApprovalsPath,
+  resolveExecApprovalsDefaultHostPath,
   type ExecApprovalDecision,
   maxAsk,
   minSecurity,
@@ -16,7 +16,6 @@ import {
 
 const DEFAULT_REQUESTED_SECURITY: ExecSecurity = "full";
 const DEFAULT_REQUESTED_ASK: ExecAsk = "off";
-const DEFAULT_HOST_PATH = "~/.openclaw/exec-approvals.json";
 const REQUESTED_DEFAULT_LABEL = {
   security: DEFAULT_REQUESTED_SECURITY,
   ask: DEFAULT_REQUESTED_ASK,
@@ -149,10 +148,6 @@ function resolveAskNote(params: {
   return "more aggressive ask wins";
 }
 
-function resolveDefaultExecApprovalsHostPath(): string {
-  return process.env.OPENCLAW_STATE_DIR?.trim() ? resolveExecApprovalsPath() : DEFAULT_HOST_PATH;
-}
-
 export function collectExecPolicyScopeSnapshots(params: {
   cfg: OpenClawConfig;
   approvals: ExecApprovalsFile;
@@ -239,7 +234,7 @@ export function resolveExecPolicyScopeSnapshot(params: {
       ask: requestedAsk.value,
     },
   });
-  const hostPath = params.hostPath ?? resolveDefaultExecApprovalsHostPath();
+  const hostPath = params.hostPath ?? resolveExecApprovalsDefaultHostPath();
   const effectiveSecurity = minSecurity(requestedSecurity.value, resolved.agent.security);
   const effectiveAsk = maxAsk(requestedAsk.value, resolved.agent.ask);
   const effectiveAskFallback = minSecurity(effectiveSecurity, resolved.agent.askFallback);

--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -3,6 +3,7 @@ import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   DEFAULT_EXEC_APPROVAL_ASK_FALLBACK,
   resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalsPath,
   type ExecApprovalDecision,
   maxAsk,
   minSecurity,
@@ -148,6 +149,10 @@ function resolveAskNote(params: {
   return "more aggressive ask wins";
 }
 
+function resolveDefaultExecApprovalsHostPath(): string {
+  return process.env.OPENCLAW_STATE_DIR?.trim() ? resolveExecApprovalsPath() : DEFAULT_HOST_PATH;
+}
+
 export function collectExecPolicyScopeSnapshots(params: {
   cfg: OpenClawConfig;
   approvals: ExecApprovalsFile;
@@ -234,7 +239,7 @@ export function resolveExecPolicyScopeSnapshot(params: {
       ask: requestedAsk.value,
     },
   });
-  const hostPath = params.hostPath ?? DEFAULT_HOST_PATH;
+  const hostPath = params.hostPath ?? resolveDefaultExecApprovalsHostPath();
   const effectiveSecurity = minSecurity(requestedSecurity.value, resolved.agent.security);
   const effectiveAsk = maxAsk(requestedAsk.value, resolved.agent.ask);
   const effectiveAskFallback = minSecurity(effectiveSecurity, resolved.agent.askFallback);

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -12,6 +12,7 @@ vi.mock("./jsonl-socket.js", () => ({
 import type { ExecApprovalsFile } from "./exec-approvals.js";
 
 type ExecApprovalsModule = typeof import("./exec-approvals.js");
+type ExecApprovalsEffectiveModule = typeof import("./exec-approvals-effective.js");
 
 let addAllowlistEntry: ExecApprovalsModule["addAllowlistEntry"];
 let addDurableCommandApproval: ExecApprovalsModule["addDurableCommandApproval"];
@@ -26,6 +27,7 @@ let requestExecApprovalViaSocket: ExecApprovalsModule["requestExecApprovalViaSoc
 let resolveExecApprovalsPath: ExecApprovalsModule["resolveExecApprovalsPath"];
 let resolveExecApprovalsSocketPath: ExecApprovalsModule["resolveExecApprovalsSocketPath"];
 let saveExecApprovals: ExecApprovalsModule["saveExecApprovals"];
+let resolveExecPolicyScopeSummary: ExecApprovalsEffectiveModule["resolveExecPolicyScopeSummary"];
 
 const tempDirs: string[] = [];
 const originalOpenClawHome = process.env.OPENCLAW_HOME;
@@ -47,6 +49,7 @@ beforeAll(async () => {
     resolveExecApprovalsSocketPath,
     saveExecApprovals,
   } = await import("./exec-approvals.js"));
+  ({ resolveExecPolicyScopeSummary } = await import("./exec-approvals-effective.js"));
 });
 
 beforeEach(() => {
@@ -120,6 +123,45 @@ describe("exec approvals store helpers", () => {
     expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
       path.normalize(path.join(dir, ".openclaw", "exec-approvals.sock")),
     );
+  });
+
+  it("reports explicit OPENCLAW_STATE_DIR exec approvals path in host policy sources", () => {
+    const dir = createHomeDir();
+    const stateDir = path.join(dir, "state-root");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const summary = resolveExecPolicyScopeSummary({
+      approvals: {
+        version: 1,
+        defaults: {
+          security: "allowlist",
+        },
+      },
+      configPath: "tools.exec",
+      scopeLabel: "tools.exec",
+    });
+
+    expect(summary.security.hostSource).toBe(
+      `${path.join(stateDir, "exec-approvals.json")} defaults.security`,
+    );
+  });
+
+  it("keeps legacy fallback out of default exec approvals host policy sources", () => {
+    const dir = createHomeDir();
+    fs.mkdirSync(path.join(dir, ".clawdbot"), { recursive: true });
+
+    const summary = resolveExecPolicyScopeSummary({
+      approvals: {
+        version: 1,
+        defaults: {
+          security: "allowlist",
+        },
+      },
+      configPath: "tools.exec",
+      scopeLabel: "tools.exec",
+    });
+
+    expect(summary.security.hostSource).toBe("~/.openclaw/exec-approvals.json defaults.security");
   });
 
   it("merges socket defaults from normalized, current, and built-in fallback", () => {

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -29,6 +29,7 @@ let saveExecApprovals: ExecApprovalsModule["saveExecApprovals"];
 
 const tempDirs: string[] = [];
 const originalOpenClawHome = process.env.OPENCLAW_HOME;
+const originalOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
 
 beforeAll(async () => {
   ({
@@ -59,6 +60,11 @@ afterEach(() => {
   } else {
     process.env.OPENCLAW_HOME = originalOpenClawHome;
   }
+  if (originalOpenClawStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = originalOpenClawStateDir;
+  }
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -82,6 +88,31 @@ function readApprovalsFile(homeDir: string): ExecApprovalsFile {
 describe("exec approvals store helpers", () => {
   it("expands home-prefixed default file and socket paths", () => {
     const dir = createHomeDir();
+
+    expect(path.normalize(resolveExecApprovalsPath())).toBe(
+      path.normalize(path.join(dir, ".openclaw", "exec-approvals.json")),
+    );
+    expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
+      path.normalize(path.join(dir, ".openclaw", "exec-approvals.sock")),
+    );
+  });
+
+  it("prefers OPENCLAW_STATE_DIR over the home-relative default paths", () => {
+    const dir = createHomeDir();
+    const stateDir = path.join(dir, "state-root");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    expect(path.normalize(resolveExecApprovalsPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.json")),
+    );
+    expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.sock")),
+    );
+  });
+
+  it("keeps exec approvals on ~/.openclaw when only legacy state dirs exist", () => {
+    const dir = createHomeDir();
+    fs.mkdirSync(path.join(dir, ".clawdbot"), { recursive: true });
 
     expect(path.normalize(resolveExecApprovalsPath())).toBe(
       path.normalize(path.join(dir, ".openclaw", "exec-approvals.json")),

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -172,6 +173,8 @@ export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
 const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
 const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+const DEFAULT_SOCKET_FILENAME = "exec-approvals.sock";
+const DEFAULT_FILE_FILENAME = "exec-approvals.json";
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -181,10 +184,16 @@ function hashExecApprovalsRaw(raw: string | null): string {
 }
 
 export function resolveExecApprovalsPath(): string {
+  if (process.env.OPENCLAW_STATE_DIR?.trim()) {
+    return path.join(resolveStateDir(), DEFAULT_FILE_FILENAME);
+  }
   return expandHomePrefix(DEFAULT_FILE);
 }
 
 export function resolveExecApprovalsSocketPath(): string {
+  if (process.env.OPENCLAW_STATE_DIR?.trim()) {
+    return path.join(resolveStateDir(), DEFAULT_SOCKET_FILENAME);
+  }
   return expandHomePrefix(DEFAULT_SOCKET);
 }
 

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveStateDir } from "../config/paths.js";
+import { resolveExplicitStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -184,15 +184,25 @@ function hashExecApprovalsRaw(raw: string | null): string {
 }
 
 export function resolveExecApprovalsPath(): string {
-  if (process.env.OPENCLAW_STATE_DIR?.trim()) {
-    return path.join(resolveStateDir(), DEFAULT_FILE_FILENAME);
+  const stateDir = resolveExplicitStateDir();
+  if (stateDir) {
+    return path.join(stateDir, DEFAULT_FILE_FILENAME);
   }
   return expandHomePrefix(DEFAULT_FILE);
 }
 
+export function resolveExecApprovalsDefaultHostPath(): string {
+  const stateDir = resolveExplicitStateDir();
+  if (stateDir) {
+    return path.join(stateDir, DEFAULT_FILE_FILENAME);
+  }
+  return DEFAULT_FILE;
+}
+
 export function resolveExecApprovalsSocketPath(): string {
-  if (process.env.OPENCLAW_STATE_DIR?.trim()) {
-    return path.join(resolveStateDir(), DEFAULT_SOCKET_FILENAME);
+  const stateDir = resolveExplicitStateDir();
+  if (stateDir) {
+    return path.join(stateDir, DEFAULT_SOCKET_FILENAME);
   }
   return expandHomePrefix(DEFAULT_SOCKET);
 }


### PR DESCRIPTION
Use the configured state directory for exec approvals file and socket resolution so Docker and hosted deployments with relocated state roots stop falling back to ~/.openclaw.

Add regression coverage for OPENCLAW_STATE_DIR path resolution.

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: exec approvals file/socket resolution ignored `OPENCLAW_STATE_DIR` and continued to use `~/.openclaw/exec-approvals.*`.
- Why it matters: Docker and hosted deployments can legitimately relocate state to paths like `/data` or `/data/openclaw`, so exec-backed actions could fail even when the configured state dir was valid and writable.
- What changed: exec approvals path resolution now derives from the configured state dir, and effective-policy reporting reflects the overridden path when `OPENCLAW_STATE_DIR` is set.
- What did NOT change (scope boundary): this does not change default `~/.openclaw` behavior for stock installs, exec approval semantics, approval policy evaluation, or Docker docs/runtime wiring outside this path-resolution bug.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `src/infra/exec-approvals.ts` hardcoded the default approvals file/socket under `~/.openclaw`, while the rest of OpenClaw already supports relocating mutable state via `OPENCLAW_STATE_DIR`.
- Missing detection / guardrail: there was no regression test asserting that exec approvals follow `OPENCLAW_STATE_DIR`, so this inconsistency was not caught.
- Contributing context (if known): official/docs-supported deployments already use relocated state roots in some environments, while Docker examples often still assume `/home/node/.openclaw`, which likely masked the mismatch.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/exec-approvals-store.test.ts`
- Scenario the test should lock in: when `OPENCLAW_STATE_DIR` is set, `resolveExecApprovalsPath()` and `resolveExecApprovalsSocketPath()` should resolve inside that directory instead of expanding `~/.openclaw`.
- Why this is the smallest reliable guardrail: the bug is pure path-resolution logic; a unit test on the resolver captures it directly without needing a full gateway/container setup.
- Existing test that already covers this (if any): none found.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Exec-backed actions now respect `OPENCLAW_STATE_DIR` for approvals file/socket storage. Users with relocated state roots should no longer see host exec approvals fall back to `~/.openclaw` or fail because that home-relative path is unavailable.

## Diagram (if applicable)

```text
Before:
OPENCLAW_STATE_DIR=/data/openclaw
tools.exec -> resolve approvals path -> ~/.openclaw/exec-approvals.json -> host exec can fail

After:
OPENCLAW_STATE_DIR=/data/openclaw
tools.exec -> resolve approvals path -> /data/openclaw/exec-approvals.json -> host exec uses configured state root
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS host with Dockerized OpenClaw runtime
- Runtime/container: Hyperplane Docker Compose service running OpenClaw
- Model/provider: `openai-codex/gpt-5.4`
- Integration/channel (if any): Slack + local `tools.exec` path through the gateway
- Relevant config (redacted): `OPENCLAW_STATE_DIR=/data/openclaw`, `OPENCLAW_WORKSPACE_DIR=/data/workspace`, `OPENCLAW_CONFIG_PATH=/tmp/openclaw.json`

### Steps

1. Export a non-default writable state root, for example `OPENCLAW_STATE_DIR=/tmp/repro-state`.
2. Export a different home directory, for example `HOME=/tmp/repro-home`.
3. Call `resolveExecApprovalsPath()` or `resolveExecApprovalsSocketPath()` and inspect the resolved path.

### Expected

- Exec approvals file/socket resolve under the configured state dir, e.g. `/tmp/repro-state/exec-approvals.json`.

### Actual

- Before this fix, approvals path resolution fell back to `~/.openclaw/exec-approvals.*` under `HOME` instead of the configured state dir. In relocated-state Docker setups, that mismatch could then surface as runtime failures such as `ENOENT` when the home-relative path was unavailable.
- Minimal repro before fix:
  - `resolveExecApprovalsPath()` resolved to `<HOME>/.openclaw/exec-approvals.json`
  - `resolveExecApprovalsSocketPath()` resolved to `<HOME>/.openclaw/exec-approvals.sock`
- Supporting runtime failure before fix:
  - `saveExecApprovals(...)` failed with `ENOENT: no such file or directory, mkdir '<HOME>/.openclaw'`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Targeted tests passed: `pnpm exec vitest run src/infra/exec-approvals-store.test.ts src/infra/exec-approvals-policy.test.ts`
  - Minimal repro before fix: with `OPENCLAW_STATE_DIR` set and `HOME` unusable, `saveExecApprovals(...)` failed trying to create `~/.openclaw`
  - Minimal repro after fix: the same operation succeeded and wrote into the configured state dir
  - Minimal repro after fix:
    - `resolveExecApprovalsPath()` resolved to `<OPENCLAW_STATE_DIR>/exec-approvals.json`
    - `resolveExecApprovalsSocketPath()` resolved to `<OPENCLAW_STATE_DIR>/exec-approvals.sock`
  - Live Docker verification: `tools.exec` ran from `/data/workspace` without the old `/home/node/.openclaw` ENOENT failure after rebuild/restart
  - Documentation contract checked:
    - `OPENCLAW_STATE_DIR` is documented as the mutable state root override
    - hosted install docs such as Fly.io explicitly document `OPENCLAW_STATE_DIR=/data`
- Edge cases checked:
  - Default path reporting remains `~/.openclaw/...` when `OPENCLAW_STATE_DIR` is not explicitly set
  - State-dir override path reporting now reflects the actual resolved approvals path
- What you did **not** verify:
  - Full repo-wide `pnpm build && pnpm check && pnpm test`
  - Non-Docker hosted targets beyond the targeted path-resolution and live Docker repro

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: effective-policy output could become confusing if it still reported `~/.openclaw/...` while the runtime used a relocated state dir.
  - Mitigation: `exec-approvals-effective.ts` now reports the resolved approvals path when `OPENCLAW_STATE_DIR` is explicitly set.
