### PR TITLE
docs(active-memory): document cacheTtlMs bounds (#65708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - fix(device-pairing): validate callerScopes against resolved token scopes on repair [AI]. (#72925) Thanks @pgondhi987.
+- Active Memory docs: document the `cacheTtlMs` 1000-120000 ms range and 15000 ms default so setup snippets do not lead users past the schema limit. Fixes #65708. (#65737) Thanks @WuKongAI-CMU.
 - fix(agents): canonicalize provider aliases in byProvider tool policy lookup [AI]. (#72917) Thanks @pgondhi987.
 - fix(security): block npm_execpath injection from workspace .env [AI-assisted]. (#73262) Thanks @pgondhi987.
 - Tools/web_fetch: decode response bodies from raw bytes using declared HTTP, XML, or HTML meta charsets before extraction, so Shift_JIS and other legacy-charset pages no longer return mojibake. Fixes #72916. Thanks @amknight.

--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -547,14 +547,14 @@ The most important fields are:
 
 Useful tuning fields:
 
-| Key                           | Type     | Meaning                                                       |
-| ----------------------------- | -------- | ------------------------------------------------------------- |
-| `config.maxSummaryChars`      | `number` | Maximum total characters allowed in the active-memory summary |
-| `config.recentUserTurns`      | `number` | Prior user turns to include when `queryMode` is `recent`      |
-| `config.recentAssistantTurns` | `number` | Prior assistant turns to include when `queryMode` is `recent` |
-| `config.recentUserChars`      | `number` | Max chars per recent user turn                                |
-| `config.recentAssistantChars` | `number` | Max chars per recent assistant turn                           |
-| `config.cacheTtlMs`           | `number` | Cache reuse for repeated identical queries                    |
+| Key                           | Type     | Meaning                                                                            |
+| ----------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `config.maxSummaryChars`      | `number` | Maximum total characters allowed in the active-memory summary                      |
+| `config.recentUserTurns`      | `number` | Prior user turns to include when `queryMode` is `recent`                           |
+| `config.recentAssistantTurns` | `number` | Prior assistant turns to include when `queryMode` is `recent`                      |
+| `config.recentUserChars`      | `number` | Max chars per recent user turn                                                     |
+| `config.recentAssistantChars` | `number` | Max chars per recent assistant turn                                                |
+| `config.cacheTtlMs`           | `number` | Cache reuse for repeated identical queries (range: 1000-120000 ms; default: 15000) |
 
 ## Recommended setup
 


### PR DESCRIPTION
## Summary
The Active Memory tuning-fields table listed \`cacheTtlMs\` without its bounds. The zod schema and the plugin manifest cap it at 1000–120000 ms with a 15000 ms default. A user following older "paste this in" snippets with \`cacheTtlMs: 300000\` crash-looped the gateway on startup with an opaque schema error before figuring out the real limit (#65708).

Document the range and default inline in the table so the limit is discoverable before boot.

## Test plan
- [x] \`docs/concepts/active-memory.md\` renders correctly in Mintlify markdown preview
- [x] Bounds match \`extensions/active-memory/index.ts:651\` (\`clampInt(raw.cacheTtlMs, DEFAULT_CACHE_TTL_MS, 1000, 120_000)\`) and \`extensions/active-memory/openclaw.plugin.json:57\` (\`minimum: 1000, maximum: 120000\`)
- [x] Default matches \`DEFAULT_CACHE_TTL_MS = 15_000\` at \`extensions/active-memory/index.ts:26\`

Closes #65708

🤖 Generated with [Claude Code](https://claude.com/claude-code)