### PR TITLE
fix(onboard): use max_tokens=16 for OpenAI-compat verification probes (Closes #65703)

### DIFF
--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -202,7 +202,7 @@ describe("promptCustomApiConfig", () => {
 
     const firstCall = fetchMock.mock.calls[0]?.[1] as { body?: string } | undefined;
     expect(firstCall?.body).toBeDefined();
-    expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
+    expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 16 });
   });
 
   it("uses azure responses-specific headers and body for openai verification probes", async () => {
@@ -259,7 +259,7 @@ describe("promptCustomApiConfig", () => {
     expect(body).toEqual({
       model: "deepseek-v3-0324",
       messages: [{ role: "user", content: "Hi" }],
-      max_tokens: 1,
+      max_tokens: 16,
       stream: false,
     });
   });

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -400,7 +400,10 @@ async function requestOpenAiVerification(params: {
       body: {
         model: params.modelId,
         messages: [{ role: "user", content: "Hi" }],
-        max_tokens: 1,
+        // OpenAI (and several compatible providers, including proxies routing
+        // to recent OpenAI models) enforce max_tokens >= 16. Use 16 so the
+        // probe succeeds on both older providers and current OpenAI.
+        max_tokens: 16,
         stream: false,
       },
     });


### PR DESCRIPTION
## Summary
The chat-completions verification probe in \`requestOpenAICompatVerification\` (\`src/commands/onboard-custom.ts\`) sent \`max_tokens: 1\`, which fails against OpenAI — and compatible proxies routing to recent OpenAI models — because they enforce \`max_tokens >= 16\`. The failure surfaces as \`format_error\` on \`openclaw models status --probe\` for any \`zenmux-openai-chat/*\` (or similar) model (#65703).

The Azure Responses API path already uses \`max_output_tokens: 16\`, so there's precedent for a higher minimum. This PR raises the chat-completions path to match.

The Anthropic probe is left alone — Anthropic accepts \`max_tokens: 1\`.

Closes #65703.

## Changes
- \`src/commands/onboard-custom.ts\`: chat-completions probe now sends \`max_tokens: 16\` with a short comment explaining why
- \`src/commands/onboard-custom.test.ts\`: update the OpenAI probe test and the Azure Foundry chat-completions test to expect \`max_tokens: 16\`; leave the Anthropic test at \`max_tokens: 1\`

## Test plan
- [x] Two affected tests updated to match new expected value
- [x] Anthropic probe tests untouched
- [x] Minimal diff, no behavior change for non-probe paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)