### PR TITLE
fix(control-ui): stop reloading history after clear (#65719)

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -432,7 +432,11 @@ async function clearChatHistory(host: ChatHost) {
     host.chatSideResultTerminalRuns?.clear();
     host.chatStream = null;
     host.chatRunId = null;
-    await loadChatHistory(host as unknown as ChatState);
+    // Do NOT reload history here: sessions.reset archives the old session
+    // asynchronously on the server, and a follow-up chat.history request
+    // races the flush and pulls back the just-cleared messages (#65719).
+    // Local state is already zeroed; the subscription path will refresh
+    // history on the next interaction.
   } catch (err) {
     host.lastError = String(err);
   }


### PR DESCRIPTION
## Summary
\`clearChatHistory()\` in \`ui/src/ui/app-chat.ts\` called \`loadChatHistory()\` immediately after \`sessions.reset\` resolved, racing the server-side session-archive flush. \`chat.history\` returned the just-archived session's messages, which then overwrote the zeroed local state. Net effect: clicking the "Clear" button flashed the cleared state for a frame, then repopulated with the old history.

Credit to @mickey (issue #65719 reporter) for tracing the exact root cause and proposing this fix — this PR just ports the proposed change to the TS source.

Closes #65719.

## Fix
Remove the follow-up \`loadChatHistory\` call. Local state (\`chatMessages\`, \`chatSideResult\`, \`chatStream\`, \`chatRunId\`) is already zeroed right before this, and the normal subscription path will refresh on the next interaction. Reset button behavior is unaffected (it goes through \`sessions.send('/reset')\`).

## Changes
- \`ui/src/ui/app-chat.ts\` — drop \`await loadChatHistory(host as unknown as ChatState)\` from \`clearChatHistory()\` and add a short comment explaining the race

## Test plan
- [x] Minimal 1-line removal (+4 lines of comment explaining why)
- [x] No behavior change for the Reset button path (separate code path through \`sessions.send('/reset')\`)
- [x] Subscription mechanism continues to handle history refresh on next interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)