### PR TITLE
fix(whatsapp): add reconnect safety timer to connection controller

### DIFF
--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -136,7 +136,7 @@ describe("WhatsAppConnectionController", () => {
   it("starts reconnect safety timer on close and clears on reopen", async () => {
     vi.useFakeTimers();
     try {
-      const infoSpy = vi.spyOn(await import("openclaw/plugin-sdk/runtime-env"), "info");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const sock = { ws: { close: vi.fn() } };
       const listener = {
         sendMessage: vi.fn(async () => ({ messageId: "m1" })),
@@ -156,11 +156,9 @@ describe("WhatsAppConnectionController", () => {
 
       // Advance past the safety timeout
       await vi.advanceTimersByTimeAsync(91_000);
-      expect(infoSpy).toHaveBeenCalledWith(
-        expect.stringContaining("reconnect may be stuck"),
-      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("reconnect may be stuck"));
 
-      infoSpy.mockRestore();
+      warnSpy.mockRestore();
     } finally {
       vi.useRealTimers();
     }
@@ -195,9 +193,7 @@ describe("WhatsAppConnectionController", () => {
 
       // Advance past the safety timeout — timer should have been cleared
       await vi.advanceTimersByTimeAsync(91_000);
-      expect(infoSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("reconnect may be stuck"),
-      );
+      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining("reconnect may be stuck"));
 
       infoSpy.mockRestore();
     } finally {
@@ -229,9 +225,7 @@ describe("WhatsAppConnectionController", () => {
 
       // Advance past the safety timeout — timer should have been cleared by shutdown
       await vi.advanceTimersByTimeAsync(91_000);
-      expect(infoSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("reconnect may be stuck"),
-      );
+      expect(infoSpy).not.toHaveBeenCalledWith(expect.stringContaining("reconnect may be stuck"));
 
       infoSpy.mockRestore();
     } finally {

--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -132,4 +132,110 @@ describe("WhatsAppConnectionController", () => {
       await liveController.shutdown();
     }
   });
+
+  it("starts reconnect safety timer on close and clears on reopen", async () => {
+    vi.useFakeTimers();
+    try {
+      const infoSpy = vi.spyOn(await import("openclaw/plugin-sdk/runtime-env"), "info");
+      const sock = { ws: { close: vi.fn() } };
+      const listener = {
+        sendMessage: vi.fn(async () => ({ messageId: "m1" })),
+        sendPoll: vi.fn(async () => ({ messageId: "p1" })),
+        sendReaction: vi.fn(async () => {}),
+        sendComposingTo: vi.fn(async () => {}),
+      };
+      createWaSocketMock.mockResolvedValueOnce(sock as never);
+      waitForWaConnectionMock.mockResolvedValueOnce(undefined);
+      await controller.openConnection({
+        connectionId: "conn-guard",
+        createListener: async () => listener,
+      });
+
+      // Close the connection — safety timer should start
+      await controller.closeCurrentConnection();
+
+      // Advance past the safety timeout
+      await vi.advanceTimersByTimeAsync(91_000);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining("reconnect may be stuck"),
+      );
+
+      infoSpy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears reconnect safety timer when new connection opens", async () => {
+    vi.useFakeTimers();
+    try {
+      const infoSpy = vi.spyOn(await import("openclaw/plugin-sdk/runtime-env"), "info");
+      const sock = { ws: { close: vi.fn() } };
+      const listener = {
+        sendMessage: vi.fn(async () => ({ messageId: "m1" })),
+        sendPoll: vi.fn(async () => ({ messageId: "p1" })),
+        sendReaction: vi.fn(async () => {}),
+        sendComposingTo: vi.fn(async () => {}),
+      };
+
+      createWaSocketMock.mockResolvedValue(sock as never);
+      waitForWaConnectionMock.mockResolvedValue(undefined);
+
+      await controller.openConnection({
+        connectionId: "conn-1",
+        createListener: async () => listener,
+      });
+      await controller.closeCurrentConnection();
+
+      // Reopen before safety timer fires
+      await controller.openConnection({
+        connectionId: "conn-2",
+        createListener: async () => listener,
+      });
+
+      // Advance past the safety timeout — timer should have been cleared
+      await vi.advanceTimersByTimeAsync(91_000);
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("reconnect may be stuck"),
+      );
+
+      infoSpy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears reconnect safety timer on shutdown", async () => {
+    vi.useFakeTimers();
+    try {
+      const infoSpy = vi.spyOn(await import("openclaw/plugin-sdk/runtime-env"), "info");
+      const sock = { ws: { close: vi.fn() } };
+      const listener = {
+        sendMessage: vi.fn(async () => ({ messageId: "m1" })),
+        sendPoll: vi.fn(async () => ({ messageId: "p1" })),
+        sendReaction: vi.fn(async () => {}),
+        sendComposingTo: vi.fn(async () => {}),
+      };
+
+      createWaSocketMock.mockResolvedValueOnce(sock as never);
+      waitForWaConnectionMock.mockResolvedValueOnce(undefined);
+
+      await controller.openConnection({
+        connectionId: "conn-shutdown",
+        createListener: async () => listener,
+      });
+      await controller.closeCurrentConnection();
+      await controller.shutdown();
+
+      // Advance past the safety timeout — timer should have been cleared by shutdown
+      await vi.advanceTimersByTimeAsync(91_000);
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("reconnect may be stuck"),
+      );
+
+      infoSpy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -496,9 +496,11 @@ export class WhatsAppConnectionController {
     // isn't opened within 90s, something is likely stuck.
     this.clearReconnectSafetyTimer();
     this.reconnectSafetyTimer = setTimeout(() => {
-      info(
-        `WA listener guard: ${RECONNECT_SAFETY_TIMEOUT_MS / 1000}s since connection closed ` +
-          `(account=${this.accountId}), reconnect may be stuck`,
+      console.warn(
+        info(
+          `WA listener guard: ${RECONNECT_SAFETY_TIMEOUT_MS / 1000}s since connection closed ` +
+            `(account=${this.accountId}), reconnect may be stuck`,
+        ),
       );
     }, RECONNECT_SAFETY_TIMEOUT_MS);
 

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -497,10 +497,8 @@ export class WhatsAppConnectionController {
     this.clearReconnectSafetyTimer();
     this.reconnectSafetyTimer = setTimeout(() => {
       console.warn(
-        info(
-          `WA listener guard: ${RECONNECT_SAFETY_TIMEOUT_MS / 1000}s since connection closed ` +
-            `(account=${this.accountId}), reconnect may be stuck`,
-        ),
+        `WA listener guard: ${RECONNECT_SAFETY_TIMEOUT_MS / 1000}s since connection closed ` +
+          `(account=${this.accountId}), reconnect may be stuck`,
       );
     }, RECONNECT_SAFETY_TIMEOUT_MS);
 

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -216,6 +216,8 @@ export async function waitForWhatsAppLoginResult(params: {
   }
 }
 
+const RECONNECT_SAFETY_TIMEOUT_MS = 90_000;
+
 export class WhatsAppConnectionController {
   readonly accountId: string;
   readonly authDir: string;
@@ -235,6 +237,7 @@ export class WhatsAppConnectionController {
 
   private current: WhatsAppLiveConnection | null = null;
   private reconnectAttempts = 0;
+  private reconnectSafetyTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(params: {
     accountId: string;
@@ -362,6 +365,9 @@ export class WhatsAppConnectionController {
       const listener = await params.createListener({ sock, connection });
       connection.listener = listener;
       this.current = connection;
+      // Clear the reconnect safety timer — listener was successfully
+      // re-established, so the reconnect is not stuck.
+      this.clearReconnectSafetyTimer();
       registerWhatsAppConnectionController(this.accountId, this);
       this.startTimers(connection, {
         onHeartbeat: params.onHeartbeat,
@@ -486,6 +492,16 @@ export class WhatsAppConnectionController {
     }
     this.current = null;
 
+    // Start a safety timer to detect stuck reconnects. If a new connection
+    // isn't opened within 90s, something is likely stuck.
+    this.clearReconnectSafetyTimer();
+    this.reconnectSafetyTimer = setTimeout(() => {
+      info(
+        `WA listener guard: ${RECONNECT_SAFETY_TIMEOUT_MS / 1000}s since connection closed ` +
+          `(account=${this.accountId}), reconnect may be stuck`,
+      );
+    }, RECONNECT_SAFETY_TIMEOUT_MS);
+
     if (this.socketRef.current === connection.sock) {
       this.socketRef.current = null;
     }
@@ -515,6 +531,7 @@ export class WhatsAppConnectionController {
   async shutdown(): Promise<void> {
     this.stopDisconnectRetries();
     await this.closeCurrentConnection();
+    this.clearReconnectSafetyTimer();
     unregisterWhatsAppConnectionController(this.accountId, this);
   }
 
@@ -554,6 +571,13 @@ export class WhatsAppConnectionController {
         error: "watchdog-timeout",
       });
     }, this.watchdogCheckMs);
+  }
+
+  private clearReconnectSafetyTimer(): void {
+    if (this.reconnectSafetyTimer) {
+      clearTimeout(this.reconnectSafetyTimer);
+      this.reconnectSafetyTimer = null;
+    }
   }
 
   private stopDisconnectRetries(): void {


### PR DESCRIPTION
## Problem

When the WhatsApp watchdog triggers a reconnect, `closeCurrentConnection()` nulls the active listener immediately while the reconnect loop sleeps before re-registering. During this gap (up to 30s+ with exponential backoff), inbound messages are silently dropped because there is no active listener to handle them.

There is no mechanism to detect when this gap exceeds a reasonable threshold, so stuck reconnects go unnoticed.

## Fix

Add a **reconnect safety timer** to `WhatsAppConnectionController` that detects when the listener gap exceeds 90 seconds:

- `closeCurrentConnection()` starts a 90s safety timer
- `openConnection()` clears the timer on successful reconnect
- `shutdown()` clears the timer to prevent dangling timers after exit
- If the timer fires, it logs a warning indicating the reconnect may be stuck

The timer is scoped to the controller instance and properly cleaned up in all code paths.

## Tests

Three new tests in `connection-controller.test.ts`:
- Timer fires after 90s timeout when reconnect doesn't complete
- Timer is cleared when a new connection opens before timeout
- Timer is cleared on controller shutdown

## Related

This PR addresses one root cause behind the widely reported "No active WhatsApp Web listener" family of issues — specifically the **reconnect gap** where the listener is null while the watchdog reconnect loop is in progress.

See also #65759 (companion PR — adds application-level health probe to detect silent connection failures).

Related user reports:
- #61250, #56363, #56089 — outbound fails despite connected status
- #52768, #50231, #50208 — message tool fails with "No active WhatsApp Web listener"
- #53162, #51493 — cron/announce delivery fails during reconnect
- #50383, #50489 — proactive sends silently fail
- #38734 (closed) — original report, partially addressed by #54232 (shared-map fix)

Supersedes #62000 (adapted to current controller-based architecture).
