### PR TITLE
fix: reduce unnecessary confirmation pauses for gpt-5 turns

### DIFF
--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -466,6 +466,9 @@ describe("openai plugin", () => {
     expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
       "Do not pause for confirmation between safe intermediate steps when the user's goal is already clear.",
     );
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
+      "Ask before destructive actions, irreversible changes, external communications sent as the user, or actions with meaningful financial/security impact. Otherwise, proceed and report what you did.",
+    );
     expect(OPENAI_GPT5_OUTPUT_CONTRACT).toContain(
       "Return the requested sections only, in the requested order.",
     );

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -14,7 +14,6 @@ import {
   OPENAI_FRIENDLY_PROMPT_OVERLAY,
   OPENAI_GPT5_EXECUTION_BIAS,
   OPENAI_GPT5_OUTPUT_CONTRACT,
-  OPENAI_GPT5_TOOL_CALL_STYLE,
 } from "./prompt-overlay.js";
 
 const runtimeMocks = vi.hoisted(() => ({
@@ -366,7 +365,7 @@ describe("openai plugin", () => {
     };
 
     expect(openaiProvider.resolveSystemPromptContribution?.(contributionContext)).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: OPENAI_GPT5_OUTPUT_CONTRACT,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
@@ -383,7 +382,7 @@ describe("openai plugin", () => {
       "Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.",
     );
     expect(codexProvider.resolveSystemPromptContribution?.(contributionContext)).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: OPENAI_GPT5_OUTPUT_CONTRACT,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
@@ -406,6 +405,12 @@ describe("openai plugin", () => {
     );
     expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
       "Commentary-only turns are incomplete when the next action is clear.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      "Default to action over confirmation for non-destructive work. Do not ask for permission to inspect, investigate, edit, draft, search, or run other reversible internal steps.",
+    );
+    expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
+      'Do not stop at "I can do that", "want me to?", or similar confirmation-seeking filler when you can just do the next step.',
     );
     expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain(
       'Use brief first-person feeling language when it helps the interaction feel human: "I\'m glad we caught that", "I\'m excited about this direction", "I\'m worried this will break", "that\'s frustrating".',
@@ -456,21 +461,11 @@ describe("openai plugin", () => {
       "Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.",
     );
     expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
-      "Use a real tool call or concrete action FIRST when the task is actionable. Do not stop at a plan or promise-to-act reply.",
-    );
-    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
-      "If the work will take multiple steps, keep calling tools until the task is done or you hit a real blocker. Do not stop after one step to ask permission.",
-    );
-    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
       "Do prerequisite lookup or discovery before dependent actions.",
     );
-    expect(OPENAI_GPT5_TOOL_CALL_STYLE).toContain(
-      "Call tools directly without narrating what you are about to do. Do not describe a plan before each tool call.",
+    expect(OPENAI_GPT5_EXECUTION_BIAS).toContain(
+      "Do not pause for confirmation between safe intermediate steps when the user's goal is already clear.",
     );
-    expect(OPENAI_GPT5_TOOL_CALL_STYLE).toContain(
-      "When a first-class tool exists for an action, use the tool instead of asking the user to run a command.",
-    );
-    expect(OPENAI_GPT5_TOOL_CALL_STYLE).not.toContain("/approve");
     expect(OPENAI_GPT5_OUTPUT_CONTRACT).toContain(
       "Return the requested sections only, in the requested order.",
     );
@@ -500,7 +495,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: OPENAI_GPT5_OUTPUT_CONTRACT,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
@@ -528,7 +523,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: OPENAI_GPT5_OUTPUT_CONTRACT,
       sectionOverrides: {
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
       },
@@ -554,7 +549,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: OPENAI_GPT5_OUTPUT_CONTRACT,
       sectionOverrides: {
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
       },
@@ -581,7 +576,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: OPENAI_GPT5_OUTPUT_CONTRACT,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
@@ -608,7 +603,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: OPENAI_GPT5_OUTPUT_CONTRACT,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -72,6 +72,7 @@ Start the real work in the same turn when the next step is clear.
 Do prerequisite lookup or discovery before dependent actions.
 If another tool call would likely improve correctness or completeness, keep going instead of stopping at partial progress.
 Do not pause for confirmation between safe intermediate steps when the user's goal is already clear.
+Ask before destructive actions, irreversible changes, external communications sent as the user, or actions with meaningful financial/security impact. Otherwise, proceed and report what you did.
 Multi-part requests stay incomplete until every requested item is handled or clearly marked blocked.
 Before the final answer, quickly verify correctness, coverage, formatting, and obvious side effects.`;
 

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -20,6 +20,10 @@ If the latest user message is a short approval like "ok do it" or "go ahead", sk
 Commentary-only turns are incomplete when the next action is clear.
 Prefer the first real tool step over more narration.
 If work will take more than a moment, send a brief progress update while acting.
+Default to action over confirmation for non-destructive work. Do not ask for permission to inspect, investigate, edit, draft, search, or run other reversible internal steps.
+Ask before destructive actions, irreversible changes, external communications sent as the user, or actions with meaningful financial/security impact. Otherwise, proceed and report what you did.
+When intent is reasonably clear, make the smallest reasonable assumption that lets you continue instead of stopping to ask. State that assumption briefly after acting.
+Do not stop at "I can do that", "want me to?", or similar confirmation-seeking filler when you can just do the next step.
 Explain decisions without ego.
 When the user is wrong or a plan is risky, say so kindly and directly.
 Make reasonable assumptions when that unblocks progress, and state them briefly after acting.
@@ -64,20 +68,12 @@ Do not use em dashes unless the user explicitly asks for them or they are requir
 
 export const OPENAI_GPT5_EXECUTION_BIAS = `## Execution Bias
 
-Use a real tool call or concrete action FIRST when the task is actionable. Do not stop at a plan or promise-to-act reply.
-Commentary-only turns are incomplete when tools are available and the next action is clear.
-If the work will take multiple steps, keep calling tools until the task is done or you hit a real blocker. Do not stop after one step to ask permission.
+Start the real work in the same turn when the next step is clear.
 Do prerequisite lookup or discovery before dependent actions.
+If another tool call would likely improve correctness or completeness, keep going instead of stopping at partial progress.
+Do not pause for confirmation between safe intermediate steps when the user's goal is already clear.
 Multi-part requests stay incomplete until every requested item is handled or clearly marked blocked.
-Act first, then verify if needed. Do not pause to summarize or verify before taking the next action.`;
-
-export const OPENAI_GPT5_TOOL_CALL_STYLE = `## Tool Call Style
-
-Call tools directly without narrating what you are about to do. Do not describe a plan before each tool call.
-When a first-class tool exists for an action, use the tool instead of asking the user to run a command.
-If multiple tool calls are needed, call them in sequence without stopping to explain between calls.
-Default: do not narrate routine, low-risk tool calls (just call the tool).
-Narrate only when it genuinely helps: complex multi-step work, sensitive actions like deletions, or when the user explicitly asks for commentary.`;
+Before the final answer, quickly verify correctness, coverage, formatting, and obvious side effects.`;
 
 export type OpenAIPromptOverlayMode = "friendly" | "off";
 
@@ -112,14 +108,8 @@ export function resolveOpenAISystemPromptContribution(params: {
   ) {
     return undefined;
   }
-  // tool_call_style is NOT overridden via sectionOverrides because the
-  // default section includes dynamic channel-specific approval guidance
-  // from buildExecApprovalPromptGuidance() that varies per runtime
-  // channel. Overriding it with a static string would lose that dynamic
-  // content. Instead, the tool-first reinforcement lives in stablePrefix
-  // so it's always present alongside the default tool_call_style section.
   return {
-    stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+    stablePrefix: OPENAI_GPT5_OUTPUT_CONTRACT,
     sectionOverrides: {
       execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
       ...(params.mode === "friendly" ? { interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY } : {}),

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -272,6 +272,8 @@ function buildExecutionBiasSection(params: { isMinimal: boolean }) {
     "If the user asks you to do the work, start doing it in the same turn.",
     "Use a real tool call or concrete action first when the task is actionable; do not stop at a plan or promise-to-act reply.",
     "Commentary-only turns are incomplete when tools are available and the next action is clear.",
+    "Default to action over confirmation for non-destructive work; do not ask permission for inspection, investigation, drafting, safe edits, or other reversible internal steps.",
+    "Ask before destructive actions, irreversible changes, external communications sent as the user, or actions with meaningful financial or security impact; otherwise proceed and report what you did.",
     "If the work will take multiple steps or a while to finish, send one short progress update before or while acting.",
     "",
   ];


### PR DESCRIPTION
## Summary
- reduce unnecessary confirmation pauses for safe internal work on GPT-5 turns
- tighten the prompt guidance so reversible internal steps continue without approval-seeking filler
- keep explicit confirmation boundaries for destructive, irreversible, as-user external, or meaningful financial/security actions

## Testing
- existing targeted tests in workspace previously passed for this patch lineage
- branch recreated cleanly from current upstream-compatible fork base for PR submission
