### PR TITLE
fix(config): auto-heal unrecognized keys during config load to prevent gateway crash

### DIFF
--- a/src/config/config.unrecognized-key-recovery.test.ts
+++ b/src/config/config.unrecognized-key-recovery.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadConfig } from "./config.js";
+import { withTempHomeConfig } from "./test-helpers.js";
+import {
+  applyUnrecognizedKeyRecovery,
+  tryRecoverUnrecognizedKeys,
+  validateConfigObject,
+  validateConfigObjectWithPlugins,
+} from "./validation.js";
+
+describe("unrecognized-key config recovery (#65721)", () => {
+  describe("tryRecoverUnrecognizedKeys", () => {
+    it("recovers config with unrecognized key inside env.shellEnv (issue repro)", () => {
+      const raw = {
+        env: {
+          shellEnv: {
+            enabled: true,
+            vars: { PATH: "/usr/bin" },
+          },
+        },
+      };
+      const result = tryRecoverUnrecognizedKeys(raw);
+      expect(result.recovered).toBe(true);
+      if (result.recovered) {
+        expect(result.strippedPathsDisplay).toEqual(["env.shellEnv.vars"]);
+        expect(result.config.env?.shellEnv?.enabled).toBe(true);
+      }
+    });
+
+    it("does not recover config with non-unrecognized-key errors", () => {
+      const raw = {
+        gateway: {
+          port: "not-a-number",
+        },
+      };
+      const result = tryRecoverUnrecognizedKeys(raw);
+      expect(result.recovered).toBe(false);
+    });
+  });
+
+  describe("applyUnrecognizedKeyRecovery", () => {
+    it("heals within allowed top-level keys and logs at error level", () => {
+      const raw = {
+        env: {
+          shellEnv: {
+            enabled: true,
+            vars: { PATH: "/usr/bin" },
+          },
+        },
+      };
+      const logger = { error: vi.fn(), warn: vi.fn() };
+      const result = applyUnrecognizedKeyRecovery(
+        raw,
+        (cleaned) => validateConfigObjectWithPlugins(cleaned),
+        logger,
+        "/home/user/.openclaw/openclaw.json",
+        { allowedTopLevelKeys: ["agents", "meta", "env"] },
+      );
+      expect(result.healed).toBe(true);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      const errorMsg = logger.error.mock.calls[0]?.[0] as string;
+      expect(errorMsg).toContain("Config auto-healed");
+      expect(errorMsg).toContain("env.shellEnv.vars");
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("blocks healing when stripped keys fall outside allowed top-level keys", () => {
+      const raw = {
+        gateway: {
+          mode: "local",
+          bogus: "should-be-stripped",
+        },
+      };
+      const logger = { error: vi.fn(), warn: vi.fn() };
+      const result = applyUnrecognizedKeyRecovery(
+        raw,
+        (cleaned) => validateConfigObjectWithPlugins(cleaned),
+        logger,
+        "/path/to/config.json",
+        { allowedTopLevelKeys: ["env"] },
+      );
+      expect(result.healed).toBe(false);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      const warnMsg = logger.warn.mock.calls[0]?.[0] as string;
+      expect(warnMsg).toContain("auto-heal skipped");
+      expect(warnMsg).toContain("fail-closed");
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("skips recovery when rawFileSize exceeds limit", () => {
+      const raw = {
+        env: {
+          shellEnv: {
+            enabled: true,
+            vars: { PATH: "/usr/bin" },
+          },
+        },
+      };
+      const logger = { error: vi.fn(), warn: vi.fn() };
+      const result = applyUnrecognizedKeyRecovery(
+        raw,
+        (cleaned) => validateConfigObjectWithPlugins(cleaned),
+        logger,
+        "/path/to/config.json",
+        { rawFileSize: 3 * 1024 * 1024 },
+      );
+      expect(result.healed).toBe(false);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      const warnMsg = logger.warn.mock.calls[0]?.[0] as string;
+      expect(warnMsg).toContain("exceeds");
+    });
+
+    it("ignores allowedTopLevelKeys entries containing dots", () => {
+      // "env.shellEnv" contains a dot and should be silently ignored,
+      // leaving no valid allowed keys → healing should be blocked.
+      const raw = {
+        env: {
+          shellEnv: {
+            enabled: true,
+            vars: { PATH: "/usr/bin" },
+          },
+        },
+      };
+      const logger = { error: vi.fn(), warn: vi.fn() };
+      const result = applyUnrecognizedKeyRecovery(
+        raw,
+        (cleaned) => validateConfigObjectWithPlugins(cleaned),
+        logger,
+        "/path/to/config.json",
+        { allowedTopLevelKeys: ["env.shellEnv"] },
+      );
+      expect(result.healed).toBe(false);
+    });
+  });
+
+  describe("validateConfigObject still rejects unrecognized keys", () => {
+    it("rejects env.shellEnv.vars as invalid", () => {
+      const result = validateConfigObject({
+        env: {
+          shellEnv: {
+            enabled: true,
+            vars: { PATH: "/usr/bin" },
+          },
+        },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues.some((i) => i.message.includes("Unrecognized key"))).toBe(true);
+      }
+    });
+  });
+
+  describe("loadConfig recovers from unrecognized keys", () => {
+    it("loads successfully when env.shellEnv contains unrecognized keys", async () => {
+      await withTempHomeConfig(
+        {
+          env: {
+            shellEnv: {
+              enabled: false,
+              vars: { PATH: "/usr/bin" },
+            },
+          },
+        },
+        async () => {
+          const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+          try {
+            const config = loadConfig();
+            expect(config).toBeDefined();
+            const errorMessages = errorSpy.mock.calls.flat().join(" ");
+            expect(errorMessages).toContain("Config auto-healed");
+            expect(errorMessages).toContain("env.shellEnv.vars");
+          } finally {
+            errorSpy.mockRestore();
+          }
+        },
+      );
+    });
+
+    it("still throws for non-unrecognized-key errors", async () => {
+      await withTempHomeConfig(
+        {
+          gateway: {
+            port: "not-a-number",
+          },
+        },
+        async () => {
+          const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+          try {
+            expect(() => loadConfig()).toThrow();
+          } finally {
+            errorSpy.mockRestore();
+          }
+        },
+      );
+    });
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -85,6 +85,7 @@ import {
 import { resolveShellEnvExpectedKeys } from "./shell-env-expected-keys.js";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import {
+  applyUnrecognizedKeyRecovery,
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
 } from "./validation.js";
@@ -1094,7 +1095,22 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       if (preValidationDuplicates.length > 0) {
         throw new DuplicateAgentDirError(preValidationDuplicates);
       }
-      const validated = validateConfigObjectWithPlugins(effectiveConfigRaw, { env: deps.env });
+      let validated = validateConfigObjectWithPlugins(effectiveConfigRaw, { env: deps.env });
+      if (!validated.ok) {
+        // Attempt self-healing: if every validation issue is an unrecognized key
+        // (e.g. an agent wrote stray fields via direct file edits), strip them
+        // and re-validate so the gateway can start instead of crashing (#65721).
+        const healResult = applyUnrecognizedKeyRecovery(
+          effectiveConfigRaw,
+          (cleaned) => validateConfigObjectWithPlugins(cleaned, { env: deps.env }),
+          deps.logger,
+          configPath,
+          { allowedTopLevelKeys: ["agents", "meta", "env"], rawFileSize: Buffer.byteLength(effectiveRaw, "utf8") },
+        );
+        if (healResult.healed) {
+          validated = healResult.validated;
+        }
+      }
       if (!validated.ok) {
         observeLoadConfigSnapshot({
           ...createConfigFileSnapshot({
@@ -1296,7 +1312,20 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const resolvedConfigRaw = readResolution.resolvedConfigRaw;
       const legacyResolution = resolveLegacyConfigForRead(resolvedConfigRaw, effectiveParsed);
       const effectiveConfigRaw = legacyResolution.effectiveConfigRaw;
-      const validated = validateConfigObjectWithPlugins(effectiveConfigRaw, { env: deps.env });
+      let validated = validateConfigObjectWithPlugins(effectiveConfigRaw, { env: deps.env });
+      if (!validated.ok) {
+        // Attempt self-healing for unrecognized-key-only failures (#65721).
+        const healResult = applyUnrecognizedKeyRecovery(
+          effectiveConfigRaw,
+          (cleaned) => validateConfigObjectWithPlugins(cleaned, { env: deps.env }),
+          deps.logger,
+          configPath,
+          { allowedTopLevelKeys: ["agents", "meta", "env"], rawFileSize: Buffer.byteLength(effectiveRaw, "utf8") },
+        );
+        if (healResult.healed) {
+          validated = healResult.validated;
+        }
+      }
       if (!validated.ok) {
         return await finalizeReadConfigSnapshotInternalResult(deps, {
           snapshot: createConfigFileSnapshot({

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -28,7 +28,9 @@ import {
 } from "../shared/avatar-policy.js";
 import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "../shared/net/ip.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { sanitizeTerminalText } from "../terminal/safe-text.js";
 import { isRecord } from "../utils.js";
+import { isBlockedObjectKey } from "./prototype-keys.js";
 import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
 import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
@@ -478,8 +480,285 @@ function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
   };
 }
 
+/**
+ * Describes a single unrecognized-key location extracted from a Zod validation
+ * error.  `path` is the dot-separated config path to the parent object, and
+ * `keys` lists the specific unknown property names that should be removed.
+ */
+type UnrecognizedKeyLocation = {
+  path: ReadonlyArray<string | number>;
+  keys: readonly string[];
+};
+
+/**
+ * Inspect Zod validation issues and collect every `unrecognized_keys` entry.
+ * Returns `null` when any non-`unrecognized_keys` issue is present, signalling
+ * that the config has structural problems beyond stray keys and must not be
+ * auto-healed.
+ */
+function collectUnrecognizedKeyLocations(
+  issues: ReadonlyArray<unknown>,
+): UnrecognizedKeyLocation[] | null {
+  const locations: UnrecognizedKeyLocation[] = [];
+  for (const issue of issues) {
+    const record = toIssueRecord(issue);
+    if (!record) {
+      return null;
+    }
+    const code = typeof record.code === "string" ? record.code : "";
+    if (code === "unrecognized_keys") {
+      const keys = record.keys;
+      if (!Array.isArray(keys) || keys.length === 0) {
+        return null;
+      }
+      const validKeys = keys.filter((k): k is string => typeof k === "string" && k.length > 0);
+      if (validKeys.length === 0) {
+        return null;
+      }
+      locations.push({
+        path: toConfigPathSegments(record.path),
+        keys: validKeys,
+      });
+    } else {
+      return null;
+    }
+  }
+  return locations.length > 0 ? locations : null;
+}
+
+/**
+ * Remove the specified unrecognized keys from a deep clone of `raw` and return
+ * the sanitised object together with a human-readable summary of what was
+ * stripped.  The original value is never mutated.
+ */
+function stripUnrecognizedKeysFromConfig(
+  raw: unknown,
+  locations: ReadonlyArray<UnrecognizedKeyLocation>,
+): { stripped: unknown; details: string[]; segments: (readonly (string | number)[])[] } {
+  const clone = structuredClone(raw);
+  const details: string[] = [];
+  const segments: (readonly (string | number)[])[] = [];
+
+  for (const loc of locations) {
+    let target: unknown = clone;
+    for (const segment of loc.path) {
+      if (Array.isArray(target)) {
+        const index = typeof segment === "number" ? segment : Number(segment);
+        if (Number.isNaN(index) || index < 0 || index >= target.length) {
+          target = undefined;
+          break;
+        }
+        target = target[index] as unknown;
+      } else if (isRecord(target)) {
+        const seg = String(segment);
+        if (isBlockedObjectKey(seg) || !Object.prototype.hasOwnProperty.call(target, seg)) {
+          target = undefined;
+          break;
+        }
+        target = target[seg];
+      } else {
+        target = undefined;
+        break;
+      }
+    }
+    if (!isRecord(target)) {
+      continue;
+    }
+    for (const key of loc.keys) {
+      if (isBlockedObjectKey(key)) {
+        continue;
+      }
+      if (Object.prototype.hasOwnProperty.call(target, key)) {
+        delete target[key];
+        const fullSegments: readonly (string | number)[] = [...loc.path, key];
+        segments.push(fullSegments);
+        details.push(fullSegments.map(String).join("."));
+      }
+    }
+  }
+
+  return { stripped: clone, details, segments };
+}
+
+export type UnrecognizedKeyRecoveryResult =
+  | {
+      recovered: true;
+      config: OpenClawConfig;
+      /** Structured path segments for programmatic comparison (e.g. allowedPrefixes). */
+      strippedSegments: ReadonlyArray<readonly (string | number)[]>;
+      /** Dot-joined display strings for human-readable log output. */
+      strippedPathsDisplay: readonly string[];
+    }
+  | { recovered: false };
+
+/**
+ * Attempt to recover a config that failed Zod validation **solely** due to
+ * unrecognized keys.  The function performs its own `safeParse` to obtain the
+ * raw Zod issues, inspects whether every issue is `unrecognized_keys`, strips
+ * the offending properties, and re-validates.  If the second pass succeeds the
+ * cleaned config is returned; otherwise the original failure stands.
+ *
+ * This is the core self-healing mechanism for Issue #65721: agents (or external
+ * tools) may inject unknown fields into the config file via direct filesystem
+ * writes, bypassing the validated `writeConfigFile` API.  Rather than crashing
+ * the gateway on next startup, we strip the foreign keys and continue.
+ */
+export function tryRecoverUnrecognizedKeys(raw: unknown): UnrecognizedKeyRecoveryResult {
+  const firstPass = OpenClawSchema.safeParse(raw);
+  if (firstPass.success) {
+    // Config is already valid — nothing to recover.
+    return { recovered: false };
+  }
+
+  const locations = collectUnrecognizedKeyLocations(firstPass.error.issues);
+  if (!locations) {
+    return { recovered: false };
+  }
+
+  const { stripped, details, segments } = stripUnrecognizedKeysFromConfig(raw, locations);
+  if (details.length === 0) {
+    return { recovered: false };
+  }
+
+  const revalidated = OpenClawSchema.safeParse(stripped);
+  if (!revalidated.success) {
+    return { recovered: false };
+  }
+
+  return {
+    recovered: true,
+    config: revalidated.data as OpenClawConfig,
+    strippedSegments: segments,
+    strippedPathsDisplay: details,
+  };
+}
+
+/**
+ * Options for {@link applyUnrecognizedKeyRecovery}.
+ *
+ * `allowedTopLevelKeys` – when provided, **only** unrecognized keys whose
+ * first path segment (i.e. top-level config namespace) matches one of the
+ * listed strings will be stripped.  Keys outside those namespaces are left
+ * untouched and the recovery is aborted so the gateway falls back to the
+ * original fail-closed behaviour.  This addresses the CWE-693 concern raised
+ * by the security review: future security-relevant config namespaces can be
+ * excluded from auto-healing by simply omitting them from the allow-list.
+ *
+ * Values must be plain top-level key names (no dots).  Any entry containing a
+ * dot is ignored at runtime to prevent accidental misuse.
+ *
+ * When `allowedTopLevelKeys` is `undefined` (the default) **all** namespaces
+ * are eligible for healing — the current behaviour required to fix Issue
+ * #65721.
+ */
+export interface AutoHealOptions {
+  readonly allowedTopLevelKeys?: readonly string[];
+  /**
+   * Pre-computed byte length of the raw config file on disk.  When provided
+   * the recovery is skipped if this value exceeds the internal limit
+   * ({@link DEFAULT_MAX_AUTOHEAL_BYTES}, 2 MiB) to avoid the CPU/memory cost
+   * of `structuredClone` + repeated Zod validation on abnormally large
+   * payloads (CWE-400 mitigation).  Passing the size from the caller avoids
+   * an extra `JSON.stringify` allocation inside the recovery path.
+   *
+   * When omitted the size guard is skipped (callers that already enforce
+   * file-size limits at read time may choose not to pass this).
+   */
+  readonly rawFileSize?: number;
+}
+
+/**
+ * Apply unrecognized-key recovery to a failed validation result.  If the
+ * recovery succeeds **and** the cleaned config also passes plugin-level
+ * validation, the caller receives an updated `validated` result and a
+ * human-readable list of stripped paths.  Otherwise the original failure is
+ * returned unchanged.
+ *
+ * This helper exists so that `loadConfig` and `readConfigFileSnapshotInternal`
+ * share a single implementation instead of duplicating the recovery block.
+ *
+ * Security note (CWE-693): auto-healing is effectively a "fail-open" path.
+ * To mitigate the risk of silently stripping security-relevant keys on a
+ * version downgrade, the function:
+ *   1. Logs at **error** level so the change is impossible to miss.
+ *   2. Accepts an optional `allowedTopLevelKeys` list so callers can restrict
+ *      which top-level config namespaces are eligible for healing.
+ *   3. Never mutates the on-disk config — the stripped version is in-memory
+ *      only until the user explicitly runs `openclaw doctor --fix`.
+ */
+/** Default upper bound for auto-heal eligibility (2 MiB, matches MAX_INCLUDE_FILE_BYTES). */
+const DEFAULT_MAX_AUTOHEAL_BYTES = 2 * 1024 * 1024;
+
+export function applyUnrecognizedKeyRecovery(
+  rawConfig: unknown,
+  revalidate: (cleaned: OpenClawConfig) => { ok: true; config: OpenClawConfig; warnings: ConfigValidationIssue[] } | { ok: false; issues: ConfigValidationIssue[]; warnings: ConfigValidationIssue[] },
+  logger: Pick<typeof console, "error" | "warn">,
+  configPath: string,
+  options?: AutoHealOptions,
+): { healed: true; validated: { ok: true; config: OpenClawConfig; warnings: ConfigValidationIssue[] }; strippedPaths: readonly string[] } | { healed: false } {
+  // --- CWE-400 mitigation: skip recovery for abnormally large configs ------
+  // The caller passes the raw file size obtained at read time so we avoid an
+  // extra JSON.stringify allocation inside the recovery hot path.
+  const rawFileSize = options?.rawFileSize;
+  if (rawFileSize !== undefined && rawFileSize > DEFAULT_MAX_AUTOHEAL_BYTES) {
+    logger.warn(
+      `Config auto-heal skipped: raw config size (${rawFileSize} bytes) exceeds ` +
+        `limit (${DEFAULT_MAX_AUTOHEAL_BYTES} bytes). Falling back to fail-closed behaviour.`,
+    );
+    return { healed: false };
+  }
+
+  const recovery = tryRecoverUnrecognizedKeys(rawConfig);
+  if (!recovery.recovered) {
+    return { healed: false };
+  }
+
+  // --- CWE-284 / CWE-693 mitigation: restrict healing to allowed namespaces.
+  // Comparison is segment-wise on the **first** path segment (top-level key)
+  // to avoid ambiguity when JSON keys themselves contain dots.  Entries in
+  // `allowedTopLevelKeys` that contain a dot are silently ignored so that
+  // callers cannot accidentally introduce path-separator confusion.
+  if (options?.allowedTopLevelKeys !== undefined) {
+    // Filter out entries containing dots to prevent misuse.
+    const validKeys = options.allowedTopLevelKeys.filter((k) => !k.includes("."));
+    const disallowed = recovery.strippedSegments.filter(
+      (segs) => {
+        const firstSegment = String(segs[0] ?? "");
+        return !validKeys.some((key) => firstSegment === key);
+      },
+    );
+    if (disallowed.length > 0) {
+      const disallowedDisplay = disallowed.map((segs) => segs.map(String).join("."));
+      logger.warn(
+        `Config auto-heal skipped: key(s) ${disallowedDisplay.map((p) => `"${sanitizeTerminalText(p)}"`).join(", ")} in ${sanitizeTerminalText(configPath)} ` +
+          "fall outside the allowed auto-heal namespaces. Falling back to fail-closed behaviour.",
+      );
+      return { healed: false };
+    }
+  }
+
+  const revalidated = revalidate(recovery.config);
+  if (revalidated.ok) {
+    // Log at error level so the auto-heal is impossible to miss (CWE-693).
+    logger.error(
+      `Config auto-healed: stripped unrecognized key(s) ${recovery.strippedPathsDisplay.map((p) => `"${sanitizeTerminalText(p)}"`).join(", ")} from ${sanitizeTerminalText(configPath)}. ` +
+        'Run "openclaw doctor --fix" to persist the fix.',
+    );
+    return { healed: true, validated: revalidated, strippedPaths: recovery.strippedPathsDisplay };
+  }
+  // Recovery stripped stray keys but plugin-level validation still fails.
+  // Log a diagnostic so the failure path is not completely silent (#65766).
+  logger.warn(
+    `Config auto-heal attempted: stripped key(s) ${recovery.strippedPathsDisplay.map((p) => `"${sanitizeTerminalText(p)}"`).join(", ")} from ${sanitizeTerminalText(configPath)}, but validation still fails. ` +
+      'Run "openclaw doctor --fix" for details.',
+  );
+  return { healed: false };
+}
+
 export const __testing = {
   mapZodIssueToConfigIssue,
+  collectUnrecognizedKeyLocations,
+  stripUnrecognizedKeysFromConfig,
 };
 
 function isWorkspaceAvatarPath(value: string, workspaceDir: string): boolean {


### PR DESCRIPTION
fix(config): auto-heal unrecognized keys during config load to prevent gateway crash

### Summary

- **Problem**: When an Agent (or external tool) modifies `~/.openclaw/openclaw.json` directly via the filesystem and injects invalid fields into strict objects (e.g., writing `vars` into `env.shellEnv`), the gateway crashes on startup with a "Config invalid" error. This is a Beta release blocker (Issue #65721) because it requires manual intervention (`openclaw doctor --fix`) to recover.
- **Root Cause**: `loadConfig` and `readConfigFileSnapshotInternal` use `OpenClawSchema.safeParse()` which correctly rejects `unrecognized_keys` in `.strict()` objects. However, the failure path immediately throws or returns invalid, offering no fault tolerance for stray keys injected by agents.
- **Fix**: Introduced a self-healing mechanism (`applyUnrecognizedKeyRecovery`) in the validation failure path. If the *only* validation errors are `unrecognized_keys`, it precisely strips those keys from the raw config and re-validates. If successful, the gateway starts normally and logs an `error`-level diagnostic prompting the user to run `openclaw doctor --fix` to persist the cleanup.
- **What changed**:
  - `src/config/validation.ts`: Added `tryRecoverUnrecognizedKeys` and `applyUnrecognizedKeyRecovery` to handle the stripping and re-validation logic.
  - `src/config/validation.ts`: Updated `stripUnrecognizedKeysFromConfig` to support array index traversal and added `isBlockedObjectKey` protection against prototype tampering (CWE-1321).
  - `src/config/io.ts`: Replaced immediate failure in `loadConfig` and `readConfigFileSnapshotInternal` with calls to `applyUnrecognizedKeyRecovery`.
  - `src/config/config.unrecognized-key-recovery.test.ts`: Added comprehensive regression tests for the recovery logic, namespace restrictions, and size guards.
- **What did NOT change (scope boundary)**:
  - The Zod schemas themselves were not relaxed; `.strict()` remains intact.
  - The on-disk config file is not mutated automatically; the healed config is in-memory only.
  - Non-`unrecognized_keys` errors (e.g., type mismatches) still cause immediate fail-closed crashes.

### Reproduction

1. Start the gateway with a valid config.
2. Manually edit `~/.openclaw/openclaw.json` and add `"vars": { "PATH": "/usr/bin" }` inside `env.shellEnv`.
3. Restart the gateway.
4. **Before**: Gateway crashes with "Config invalid".
5. **After**: Gateway starts successfully, logs an error about the stripped key, and ignores the invalid field.

### Risk / Mitigation

- **Risk**: CWE-693 (Fail-open) - Auto-healing might silently strip security-relevant keys if a user downgrades to an older version where those keys are unrecognized.
- **Mitigation**: 
  1. Added `allowedTopLevelKeys: ["agents", "meta", "env"]` to restrict healing to specific namespaces. Security/gateway configs will still fail-closed.
  2. Healing logs at `error` level to ensure visibility.
  3. Path comparison is segment-wise to prevent `dot-in-key` bypasses (CWE-284).
- **Risk**: CWE-400 (DoS) - Expensive `structuredClone` and re-validation on massive config files.
- **Mitigation**: Added `rawFileSize` check. Healing is skipped if the config exceeds 2 MiB.
- **Risk**: Silent coercion of union types (e.g., ACP bindings).
- **Mitigation**: Removed `invalid_union` traversal entirely. The core issue (`env.shellEnv.vars`) does not involve unions, so we strictly avoid union-aware recovery to prevent unintended structural changes.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Config
- [x] Validation


