### PR TITLE
fix(slack): print manifest JSON without box-drawing borders

### DIFF
--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -23,6 +23,7 @@ import {
 import { inspectSlackAccount } from "./account-inspect.js";
 import { resolveSlackAccount } from "./accounts.js";
 import {
+  buildSlackManifest,
   buildSlackSetupLines,
   SLACK_CHANNEL as channel,
   isSlackSetupAccountConfigured,
@@ -271,6 +272,11 @@ export function createSlackSetupWizardBase(handlers: {
       return {
         cfg: setSlackInteractiveReplies(cfg, accountId, enableInteractiveReplies),
       };
+    },
+    prepare: async ({ cfg, accountId }) => {
+      if (!isSlackSetupAccountConfigured(resolveSlackAccount({ cfg, accountId }))) {
+        console.log(buildSlackManifest("OpenClaw"));
+      }
     },
     disable: (cfg: OpenClawConfig) => setSetupChannelEnabled(cfg, channel, false),
   } satisfies ChannelSetupWizard;

--- a/extensions/slack/src/shared.ts
+++ b/extensions/slack/src/shared.ts
@@ -22,7 +22,7 @@ import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./
 
 export const SLACK_CHANNEL = "slack" as const;
 
-function buildSlackManifest(botName: string) {
+export function buildSlackManifest(botName: string) {
   const safeName = botName.trim() || "OpenClaw";
   const manifest = {
     display_information: {
@@ -97,7 +97,7 @@ function buildSlackManifest(botName: string) {
   return JSON.stringify(manifest, null, 2);
 }
 
-export function buildSlackSetupLines(botName = "OpenClaw"): string[] {
+export function buildSlackSetupLines(_botName = "OpenClaw"): string[] {
   return [
     "1) Slack API -> Create App -> From scratch or From manifest (with the JSON below)",
     "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
@@ -107,8 +107,7 @@ export function buildSlackSetupLines(botName = "OpenClaw"): string[] {
     "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
     `Docs: ${formatDocsLink("/slack", "slack")}`,
     "",
-    "Manifest (JSON):",
-    buildSlackManifest(botName),
+    "(Raw manifest JSON is printed below.)",
   ];
 }
 


### PR DESCRIPTION
## Summary

Fixes CLI Slack JSON manifest being framed by box-drawing characters (`│`) from `@clack/prompts` `note()`, making the JSON invalid and difficult to copy-paste.

## Changes

- Export `buildSlackManifest` from `extensions/slack/src/shared.ts` so `setup-core` can reuse it.
- Remove the multiline manifest JSON from `introNote.lines` (which was wrapped in UI borders) and replace it with a hint that the raw JSON is printed below.
- Add a `prepare` hook in the Slack setup wizard that logs the raw manifest via `console.log`, producing unframed, copy-paste-friendly JSON.

## Related issue

Fixes #65751

## Testing

- `pnpm tsgo` passes
- `pnpm lint` passes
- `pnpm build` passes
- `pnpm test extensions/slack/src/setup-surface.test.ts` passes
