### PR TITLE
fix(agent): preserve original prompt in fallback retry instead of replacing it

### DIFF
--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -73,7 +73,7 @@ export function resolveFallbackRetryPrompt(params: {
   if (!params.sessionHasHistory) {
     return params.body;
   }
-  return "Continue where you left off. The previous model attempt failed or timed out.";
+  return `[System: Previous model attempt failed. Continuing from where you left off.]\n\n${params.body}`;
 }
 
 export function createAcpVisibleTextAccumulator() {

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -27,7 +27,9 @@ describe("resolveFallbackRetryPrompt", () => {
         isFallbackRetry: true,
         sessionHasHistory: true,
       }),
-    ).toBe("Continue where you left off. The previous model attempt failed or timed out.");
+    ).toBe(
+      "[System: Previous model attempt failed. Continuing from where you left off.]\n\nSummarize the quarterly earnings report and highlight key trends.",
+    );
   });
 
   it("preserves original body for fallback retry when session has no history (subagent spawn)", () => {


### PR DESCRIPTION
## Summary

When a model call fails and OpenClaw triggers a fallback retry, `resolveFallbackRetryPrompt()` was replacing the entire original user prompt with the fixed string `"Continue where you left off. The previous model attempt failed or timed out."`. This caused the agent to lose the original task context and potentially produce incorrect or unintended results.

This change prepends the retry notice to the original prompt so the agent retains full context of what it was asked to do.

## Change Type

- [x] Bug fix

## Related Issue

Fixes #65760

## Testing

- `pnpm test src/agents/command/attempt-execution.test.ts` — 17/17 passed
- `pnpm tsgo` — passed
- `pnpm lint` — 0 warnings, 0 errors