### PR TITLE
fix(agents+misc): compaction reload + memory-alt dedup + plugin model allowlist

### DIFF
--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -16,9 +16,9 @@ const GEMMA_PREFIX = "gemma-";
 const GEMINI_2_5_PRO_TEMPLATE_IDS = ["gemini-2.5-pro"] as const;
 const GEMINI_2_5_FLASH_LITE_TEMPLATE_IDS = ["gemini-2.5-flash-lite"] as const;
 const GEMINI_2_5_FLASH_TEMPLATE_IDS = ["gemini-2.5-flash"] as const;
-const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
+const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview"] as const;
 const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = ["gemini-3.1-flash-lite-preview"] as const;
-const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3.1-flash-preview"] as const;
 // Gemma uses the Gemini flash template as a forward-compat approximation
 // until a dedicated Gemma template is registered in the catalog.
 const GEMMA_TEMPLATE_IDS = GEMINI_3_1_FLASH_TEMPLATE_IDS;


### PR DESCRIPTION
## Fixes\n\n### #65602 — reserveTokens overwritten by resourceLoader.reload()\n`resourceLoader.reload()` calls `settingsManager.reload()` which resets the override state set by `applyPiCompactionSettingsFromConfig()`. Fix: call it again after reload.\n\n### #65769 — memory-alt-main collection not found on macOS case-insensitive fs\nOn macOS HFS+/APFS, `MEMORY.md` and `memory.md` resolve to the same inode. Fix: stat both files and skip memory-alt if inode matches memory-root.\n\n### #65763 — Plugin-registered provider models return 'model not allowed'\nWhen allowAny=false (explicit allowlist configured), plugin-registered provider models were silently dropped because they are not in cfg.models.providers. Fix: mark plugin entries isFromPlugin=true in augmentModelCatalogWithProviderPlugins, then auto-add them to allowedKeys in buildAllowedModelSet.\n\n## Testing\n- pi-settings (8✅) + backend-config (19✅) + qmd-manager (83✅) + model-selection (82✅) + model-catalog (10✅)\n