### PR TITLE
fix(minimax): allow web_search to use MINIMAX_OAUTH_TOKEN

### DIFF
--- a/extensions/minimax/src/minimax-web-search-provider.test.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.test.ts
@@ -14,12 +14,14 @@ describe("minimax web search provider", () => {
   const originalCodePlanKey = process.env.MINIMAX_CODE_PLAN_KEY;
   const originalCodingApiKey = process.env.MINIMAX_CODING_API_KEY;
   const originalApiKey = process.env.MINIMAX_API_KEY;
+  const originalOauthToken = process.env.MINIMAX_OAUTH_TOKEN;
 
   beforeEach(() => {
     delete process.env.MINIMAX_API_HOST;
     delete process.env.MINIMAX_CODE_PLAN_KEY;
     delete process.env.MINIMAX_CODING_API_KEY;
     delete process.env.MINIMAX_API_KEY;
+    delete process.env.MINIMAX_OAUTH_TOKEN;
   });
 
   afterEach(() => {
@@ -27,6 +29,7 @@ describe("minimax web search provider", () => {
     process.env.MINIMAX_CODE_PLAN_KEY = originalCodePlanKey;
     process.env.MINIMAX_CODING_API_KEY = originalCodingApiKey;
     process.env.MINIMAX_API_KEY = originalApiKey;
+    process.env.MINIMAX_OAUTH_TOKEN = originalOauthToken;
   });
 
   describe("resolveMiniMaxRegion", () => {
@@ -138,6 +141,11 @@ describe("minimax web search provider", () => {
     it("falls back to MINIMAX_API_KEY last", () => {
       process.env.MINIMAX_API_KEY = "plain-key";
       expect(resolveMiniMaxApiKey()).toBe("plain-key");
+    });
+
+    it("accepts MINIMAX_OAUTH_TOKEN as a fallback for OAuth-authorized users", () => {
+      process.env.MINIMAX_OAUTH_TOKEN = "oauth-token";
+      expect(resolveMiniMaxApiKey()).toBe("oauth-token");
     });
   });
 

--- a/extensions/minimax/src/minimax-web-search-provider.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.ts
@@ -53,7 +53,11 @@ type MiniMaxSearchResponse = {
 function resolveMiniMaxApiKey(searchConfig?: SearchConfigRecord): string | undefined {
   return (
     readConfiguredSecretString(searchConfig?.apiKey, "tools.web.search.apiKey") ??
-    readProviderEnvValue([...MINIMAX_CODING_PLAN_ENV_VARS, "MINIMAX_API_KEY"])
+    readProviderEnvValue([
+      ...MINIMAX_CODING_PLAN_ENV_VARS,
+      "MINIMAX_API_KEY",
+      "MINIMAX_OAUTH_TOKEN",
+    ])
   );
 }
 
@@ -192,7 +196,7 @@ const MiniMaxSearchSchema = Type.Object({
 function missingMiniMaxKeyPayload() {
   return {
     error: "missing_minimax_api_key",
-    message: `web_search (minimax) needs a MiniMax Coding Plan key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set MINIMAX_CODE_PLAN_KEY, MINIMAX_CODING_API_KEY, or MINIMAX_API_KEY in the Gateway environment.`,
+    message: `web_search (minimax) needs a MiniMax Coding Plan key or OAuth token. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set MINIMAX_CODE_PLAN_KEY, MINIMAX_CODING_API_KEY, MINIMAX_API_KEY, or MINIMAX_OAUTH_TOKEN in the Gateway environment.`,
     docs: "https://docs.openclaw.ai/tools/web",
   };
 }
@@ -277,7 +281,7 @@ export function createMiniMaxWebSearchProvider(): WebSearchProviderPlugin {
     label: "MiniMax Search",
     hint: "Structured results via MiniMax Coding Plan search API",
     credentialLabel: "MiniMax Coding Plan key",
-    envVars: [...MINIMAX_CODING_PLAN_ENV_VARS],
+    envVars: [...MINIMAX_CODING_PLAN_ENV_VARS, "MINIMAX_OAUTH_TOKEN"],
     placeholder: "sk-cp-...",
     signupUrl: "https://platform.minimax.io/user-center/basic-information/interface-key",
     docsUrl: "https://docs.openclaw.ai/tools/minimax-search",


### PR DESCRIPTION
## Summary

The MiniMax `web_search` provider's `resolveMiniMaxApiKey()` only looked up API keys from config and environment variables (`MINIMAX_CODE_PLAN_KEY`, `MINIMAX_CODING_API_KEY`, `MINIMAX_API_KEY`), but did not include `MINIMAX_OAUTH_TOKEN`. Users who authorized via the `minimax-portal` OAuth flow could not use `web_search` without also setting a separate API key.

This change adds `MINIMAX_OAUTH_TOKEN` to the lookup chain and updates the missing-credential error message and provider `envVars` to match.

## Change Type

- [x] Bug fix

## Related Issue

Fixes #65768

## Testing

- `pnpm test extensions/minimax/src/minimax-web-search-provider.test.ts` — 18/18 passed
- `pnpm tsgo` — passed
- `pnpm lint` — 0 warnings, 0 errors