### PR TITLE
docs: add execution checklist for false-green gateway health

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -30,6 +30,45 @@ Expected healthy signals:
 - `openclaw channels status --probe` shows live per-account transport status and,
   where supported, probe/audit results such as `works` or `audit ok`.
 
+## Execution checklist when health looks green but work still fails
+
+Use this when `/healthz`, `/readyz`, `openclaw gateway status`, or
+`openclaw channels status --probe` look healthy, but real tool calls, paired-device
+RPCs, or operator actions still fail.
+
+1. Normalize paths first.
+   - Use canonical paths only.
+   - On Windows/WSL, prefer the real `/mnt/c/...` path instead of copied shell text.
+   - If you hit `ENOENT`, stop and verify path drift before retrying.
+2. Verify hard prerequisites before any action.
+   - Confirm required IDs such as `sessionId`, node IDs, or canvas IDs exist.
+   - Confirm the runtime/plugin/binary you plan to call is actually installed.
+   - Validate command and RPC arguments against the expected schema.
+3. Check auth before trusting liveness.
+   - If loopback gateway access shows `pairing required`, `scope-upgrade`, or WebSocket close `1008`, treat that as an auth block first, not a transient transport blip.
+   - Re-pair or re-approve scopes before continuing.
+4. Treat liveness as non-authoritative.
+   - `channels.status`, plugin registration, wrapper exit code `0`, and websocket pings are not proof that execution paths are healthy.
+   - Tool outcomes beat liveness signals.
+5. Fail closed on false-green signatures.
+   - Treat auth failures, schema validation failures, `INVALID_REQUEST`, `ENOENT`, compile/build failures, and exit `0` with no artifact or state change as real failures.
+   - Treat SIGTERM or process death with no useful output as a failed run, not a soft success.
+6. Use a safe execution style for non-trivial checks.
+   - Write a real script file, then run `node file.js` or `python file.py`.
+   - Avoid heredocs, inline eval, and fragile shell interpolation when reproducing or verifying a bug.
+7. Suppress repeated missing-file churn.
+   - For optional files, do one existence check.
+   - If the file is absent, record that once and stop retrying the same missing path.
+8. Check for config drift.
+   - Make sure you are using the intended config file.
+   - Nested duplicate configs are a common reason a "fixed" setting appears to have no effect.
+9. Check for runtime skew.
+   - Make sure the running service entrypoint matches the repo/build you think you updated.
+   - Mixed global-install and repo-checkout `dist/` paths often explain why logs, code, and behavior do not line up.
+10. Do not clear the incident until execution proves recovery.
+    - Success means a real authenticated scoped RPC or operator action works.
+    - Do not clear the issue from health endpoints, channel liveness, or wrapper exit codes alone.
+
 ## Anthropic 429 extra usage required for long context
 
 Use this when logs/errors include:

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -36,6 +36,10 @@ Good output in one line:
   gateway is unreachable, the command falls back to config-only summaries.
 - `openclaw logs --follow` → steady activity, no repeating fatal errors.
 
+If those look green but real work still fails, use the
+[/gateway/troubleshooting#execution-checklist-when-health-looks-green-but-work-still-fails](/gateway/troubleshooting#execution-checklist-when-health-looks-green-but-work-still-fails)
+runbook before declaring recovery.
+
 ## Anthropic long context 429
 
 If you see:


### PR DESCRIPTION
## Summary
- add an execution checklist to `docs/gateway/troubleshooting.md` for cases where health checks look green but real work still fails
- link the new checklist from `docs/help/troubleshooting.md` so it is reachable from the fast triage page
- document false-green recovery guidance around auth blocks, prerequisite checks, config drift, runtime skew, and proof-of-recovery

## Validation
- `pnpm exec oxfmt --check docs/gateway/troubleshooting.md docs/help/troubleshooting.md`
- `git diff --check`
- `pnpm dlx markdownlint-cli2 docs/gateway/troubleshooting.md docs/help/troubleshooting.md`

## Notes
- `pnpm docs:check-links:anchors` currently fails on pre-existing MDX parse errors in `docs/providers/anthropic.md` and `docs/providers/litellm.md`, unrelated to this change.
