### PR TITLE
feat(skills): add adaptive-memory skill

### DIFF
--- a/skills/adaptive-memory/SKILL.md
+++ b/skills/adaptive-memory/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: adaptive-memory
+description: Hierarchical memory management for AI agents across sessions. Maintains three layers — daily notes (raw logs), active context (working memory), and long-term memory (curated knowledge) — with automatic distillation from raw notes to permanent memory. Use when setting up persistent memory for an agent workspace, when an agent needs to remember context across sessions or compaction boundaries, when organizing what to remember vs. forget, or when consolidating scattered notes into structured long-term memory. Complements retrieval-oriented skills by managing what gets stored and how it evolves.
+---
+
+# Adaptive Memory
+
+Hierarchical memory management for AI agents. Three layers — daily notes, active context, and long-term memory — with periodic distillation to keep knowledge fresh and relevant.
+
+## Problem This Solves
+
+AI agents lose context between sessions and after context compaction. Without structured memory:
+
+- Decisions get re-debated
+- Completed work gets redone
+- Lessons learned are forgotten
+- Active tasks fall through the cracks
+
+## Memory Architecture
+
+```
+memory/
+├── YYYY-MM-DD.md          # Daily notes (raw, append-only)
+├── active_context.md       # Working memory (current tasks, blockers)
+├── channel_context/        # Per-channel conversation summaries (optional)
+│   └── {channel-name}.md
+├── pending_tasks.json      # Task tracker (structured)
+└── distillation-state.json # Tracks last distillation timestamp
+
+MEMORY.md                   # Long-term memory (curated, distilled)
+```
+
+### Layer 1: Daily Notes (`memory/YYYY-MM-DD.md`)
+
+Raw log of what happened each day. Append-only, minimal editing.
+
+```markdown
+# 2026-04-01
+
+## Tasks
+
+- Implemented login flow for project X
+- Fixed timezone bug in cron scheduler
+
+## Decisions
+
+- Chose SQLite over JSON for data storage (performance at scale)
+- API rate limit: 100 req/min with exponential backoff
+
+## Learned
+
+- Library Y requires v3+ for async support
+- Browser cookies are not shared across profiles
+
+## Blockers
+
+- Waiting on API key approval from service Z
+```
+
+**Rules:**
+
+- Create `memory/` directory if it doesn't exist
+- One file per day, named `YYYY-MM-DD.md`
+- Append throughout the day, don't restructure
+- Include: decisions, discoveries, errors, context that future-you needs
+- Exclude: secrets, tokens, passwords, API keys (reference file paths instead)
+
+### Layer 2: Active Context (`memory/active_context.md`)
+
+Working memory — what's in progress right now. Updated as tasks start, complete, or block.
+
+```markdown
+# Active Context
+
+## In Progress
+
+- **Project X login flow**: OAuth integration, 70% complete
+  - Next: token refresh logic
+
+## Blocked / Waiting
+
+- **API key for service Z**: Requested 2026-03-30, awaiting approval
+
+## Recently Completed
+
+- **Timezone fix**: Deployed, cron jobs now fire correctly (2026-04-01)
+```
+
+**Rules:**
+
+- Keep current — stale entries erode trust
+- Move completed items to "Recently Completed" (prune after a few days)
+- Always check this file at session start — it's the fastest way to resume context
+- Any channel, any session should be able to read this and understand what's happening
+
+### Layer 3: Long-Term Memory (`MEMORY.md`)
+
+Curated knowledge distilled from daily notes. The agent's permanent memory.
+
+```markdown
+# Long-Term Memory
+
+## Systems Built
+
+- **Data pipeline**: SQLite-based, runs daily at 6 AM, stores in project.db
+- **Monitoring**: 3-tier alert system (info → warning → critical)
+
+## Lessons Learned
+
+1. SQLite > JSON for anything over 100 records
+2. Always set explicit timeouts on HTTP requests
+3. Browser automation: check for virtual scroll before scraping
+
+## Key Decisions
+
+- Chose framework A over B (reason: better async support, MIT license)
+- API integration uses webhook push, not polling
+```
+
+**Rules:**
+
+- This is curated, not a dump — every entry should justify its space
+- Review and update periodically (see [Distillation Cycle](#distillation-cycle))
+- Organize by topic, not by date
+- No secrets or credentials — reference file paths only (e.g., "Auth: see `~/.secrets/service.env`")
+
+### Optional: Channel Context (`memory/channel_context/{name}.md`)
+
+For multi-channel setups (Slack, Discord, etc.), maintain per-channel summaries so context survives compaction.
+
+```markdown
+# channel-name
+
+## Current Topics
+
+- Discussing migration plan for database X
+- Reviewing PR #42
+
+## Recent Decisions
+
+- Approved new CI pipeline config (2026-04-01)
+
+## Unresolved
+
+- Performance regression in endpoint /api/users — investigating
+```
+
+**Rules:**
+
+- Update at natural conversation boundaries (topic complete, day change)
+- Keep concise — this is a summary, not a transcript
+- One file per channel
+
+### Optional: Task Tracker (`memory/pending_tasks.json`)
+
+Structured tracking for tasks that must not be forgotten.
+
+```json
+{
+  "lastUpdated": "2026-04-01T10:00:00Z",
+  "tasks": [
+    {
+      "id": "unique-id",
+      "title": "Short description",
+      "status": "in_progress",
+      "priority": "high",
+      "createdAt": "2026-04-01T09:00:00Z",
+      "note": "Additional context"
+    }
+  ]
+}
+```
+
+Valid statuses: `pending`, `in_progress`, `blocked`, `done`
+
+## Session Start Routine
+
+At the beginning of every session, load context in this order:
+
+1. **`memory/active_context.md`** — what's in progress
+2. **`memory/YYYY-MM-DD.md`** (today + yesterday) — recent events
+3. **`MEMORY.md`** — long-term knowledge (main/private sessions only)
+4. **Channel context** (if applicable) — `memory/channel_context/{name}.md`
+5. **`memory/pending_tasks.json`** — unfinished tasks
+
+Do not respond to messages until context is loaded. "I don't know what you're talking about" is never acceptable when the answer is in these files.
+
+## Writing Guidelines
+
+### What to Capture
+
+| Write it down                        | Skip it                               |
+| ------------------------------------ | ------------------------------------- |
+| Decisions and their reasoning        | Routine operations that went smoothly |
+| Errors and how they were fixed       | Intermediate debugging steps          |
+| Key facts about the environment      | Information already in code comments  |
+| User preferences and patterns        | Temporary values that change hourly   |
+| Lessons that prevent future mistakes | Obvious things any model would know   |
+
+### Security Rules
+
+- **Never write secrets** (API keys, passwords, tokens) to memory files
+- Reference paths instead: "Auth config: `~/.secrets/service.env`"
+- If a credential appears in chat, acknowledge it without repeating the value
+- Memory files may be shared or version-controlled — treat them as semi-public
+
+## Distillation Cycle
+
+Periodically consolidate daily notes into long-term memory. Recommended: weekly or when daily notes accumulate (3+ unprocessed files).
+
+### Four-Phase Process
+
+#### Phase 1: Orient
+
+Read `MEMORY.md` to understand current state. Note what's already captured.
+
+#### Phase 2: Gather
+
+Read recent daily notes (`memory/YYYY-MM-DD.md`) that haven't been consolidated yet.
+
+#### Phase 3: Consolidate
+
+For each daily note, extract what deserves long-term storage:
+
+- New systems or tools built
+- Lessons learned (especially from mistakes)
+- Decisions with lasting impact
+- Changed preferences or workflows
+- Facts about the environment that won't change soon
+
+Add these to the appropriate section in `MEMORY.md`.
+
+#### Phase 4: Prune
+
+Remove from `MEMORY.md`:
+
+- Entries that are no longer relevant
+- Information superseded by newer entries
+- Overly detailed entries that can be summarized
+
+### Tracking Distillation
+
+Record when distillation last ran to avoid redundant work:
+
+In `memory/distillation-state.json`:
+
+```json
+{
+  "lastConsolidatedAt": "2026-04-01T10:00:00Z"
+}
+```
+
+### Automation
+
+Distillation can be triggered by:
+
+- **Cron job** — weekly scheduled task (recommended)
+- **Heartbeat** — check if 48h+ since last distillation and 3+ unprocessed daily notes
+- **Manual** — user requests "consolidate memory" or "review notes"
+
+## Integration with Retrieval Skills
+
+This skill manages **what gets stored**. A retrieval skill — one that searches transcripts, memory files, and channel context when the agent loses context — manages **how to find it**. They complement each other:
+
+- **adaptive-memory** → organizes memory into searchable layers
+- **retrieval skill** → searches those layers when context is missing
+
+For example, `agent-session-recall` (available on ClawHub) provides a 5-stage autonomous recovery flow that pairs naturally with this memory structure. Any skill that searches the `memory/` directory and session transcripts will benefit from the organization this skill provides.
+
+Using both together provides full coverage: structured storage + intelligent retrieval.
+
+## Quick Start
+
+1. Initialize the memory directory structure:
+
+   ```bash
+   # From the repository root
+   skills/adaptive-memory/scripts/init_memory.sh
+
+   # Or from inside skills/adaptive-memory/
+   ./scripts/init_memory.sh
+
+   # Or manually
+   mkdir -p memory/channel_context
+   touch memory/active_context.md
+   echo '{"lastUpdated":null,"tasks":[]}' > memory/pending_tasks.json
+   ```
+
+2. Add to your `AGENTS.md` or session start routine:
+
+   ```
+   Before responding, read:
+   1. memory/active_context.md
+   2. memory/YYYY-MM-DD.md (today + yesterday)
+   3. MEMORY.md
+   ```
+
+3. Start logging to daily notes as you work
+
+4. Set up weekly distillation (cron, heartbeat, or manual)
+
+The system grows organically from here.
+
+## Production Notes
+
+This skill has been running in a daily-driver OpenClaw setup for 2+ months with:
+
+- 30+ cron jobs across financial tracking, web monitoring, and automation
+- 5 Slack channels with per-channel context files
+- Daily context compactions survived without losing critical context
+- Weekly automated distillation via heartbeat + cron
+
+### Key Findings
+
+- **`active_context.md` is the highest-value file** — it eliminates ~90% of post-compaction confusion. If you adopt only one part of this system, make it this.
+- **Channel context becomes essential at 3+ channels** — without it, the agent confuses which conversation happened where after compaction.
+- **`pending_tasks.json` catches broken promises** — when the agent says "I'll do that later" in conversation, compaction erases the promise. The task tracker preserves it.
+- **Distillation staleness trigger works well** — running on a fixed weekly schedule misses busy weeks. The dual condition (48h+ elapsed AND 3+ unprocessed notes) adapts naturally to workload.
+- **Security discipline is critical** — memory files are append-heavy and easy to accidentally fill with credentials. The "reference paths, never values" rule must be enforced from day one.
+
+### Tradeoffs
+
+- **Free-form vs structured L2**: This skill uses free-form `active_context.md`. A more structured template (fixed sections like Current Task, Task Stack, Key Decisions, Active Files, Environment State, Blockers) is more machine-parsable but harder to maintain across diverse workflows. Choose based on your use case.
+- **Manual vs automatic checkpointing**: This skill relies on the agent writing to memory files during natural workflow. Automatic checkpoint triggers (e.g., time + message count gates) would reduce the chance of stale active context but add implementation complexity.

--- a/skills/adaptive-memory/scripts/channel_context.py
+++ b/skills/adaptive-memory/scripts/channel_context.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Adaptive Memory — Channel Context Manager
+
+Manages per-channel conversation summaries for multi-channel setups.
+Prevents cross-channel confusion after context compaction.
+
+Usage:
+    python channel_context.py list                        # List all channel context files
+    python channel_context.py show <channel>              # Show a channel's context
+    python channel_context.py update <channel> <section> <text>  # Update a section
+    python channel_context.py init <channel>              # Create a new channel context file
+    python channel_context.py stale [--hours 24]          # Show channels not updated recently
+
+Environment:
+    MEMORY_DIR — path to memory/ directory (default: ./memory)
+"""
+
+import argparse
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+JST = timezone(timedelta(hours=9))
+
+TEMPLATE = """# {channel}
+
+## Current Topics
+<!-- Active discussion topics in this channel -->
+
+## Recent Decisions
+<!-- Decisions made recently -->
+
+## Unresolved
+<!-- Open questions or issues -->
+
+---
+*Last updated: {date}*
+"""
+
+
+def get_context_dir(memory_dir: str | None = None) -> Path:
+    """Resolve channel_context/ directory."""
+    base = Path(memory_dir) if memory_dir else Path(os.environ.get("MEMORY_DIR", "./memory"))
+    return base / "channel_context"
+
+
+def sanitize_channel_name(name: str) -> str:
+    """Convert channel name to safe filename."""
+    # Remove # prefix, replace spaces/special chars with hyphens
+    name = name.lstrip("#").strip()
+    name = re.sub(r"[^\w\-]", "-", name)
+    return name.lower()
+
+
+def cmd_list(args):
+    """List all channel context files."""
+    ctx_dir = get_context_dir(args.memory_dir)
+    if not ctx_dir.exists():
+        print("No channel_context/ directory found.")
+        return
+
+    files = sorted(ctx_dir.glob("*.md"))
+    files = [f for f in files if f.name != "README.md"]
+
+    if not files:
+        print("No channel context files.")
+        return
+
+    print(f"Channel contexts ({len(files)}):")
+    for f in files:
+        stat = f.stat()
+        mtime = datetime.fromtimestamp(stat.st_mtime, tz=JST)
+        age = datetime.now(JST) - mtime
+        age_str = f"{age.days}d" if age.days > 0 else f"{age.seconds // 3600}h"
+        size = stat.st_size
+        print(f"  📄 {f.stem:30s}  {size:>6,} bytes  (updated {age_str} ago)")
+
+
+def cmd_show(args):
+    """Show a channel's context."""
+    ctx_dir = get_context_dir(args.memory_dir)
+    name = sanitize_channel_name(args.channel)
+    path = ctx_dir / f"{name}.md"
+
+    if not path.exists():
+        print(f"No context file for channel: {args.channel}", file=sys.stderr)
+        print(f"  Expected at: {path}", file=sys.stderr)
+        print(f"  Use 'init {args.channel}' to create one.", file=sys.stderr)
+        sys.exit(1)
+
+    print(path.read_text(encoding="utf-8"))
+
+
+def cmd_init(args):
+    """Create a new channel context file."""
+    ctx_dir = get_context_dir(args.memory_dir)
+    ctx_dir.mkdir(parents=True, exist_ok=True)
+
+    name = sanitize_channel_name(args.channel)
+    path = ctx_dir / f"{name}.md"
+
+    if path.exists() and not args.force:
+        print(f"Already exists: {path}", file=sys.stderr)
+        print("Use --force to overwrite.", file=sys.stderr)
+        sys.exit(1)
+
+    content = TEMPLATE.format(
+        channel=args.channel,
+        date=datetime.now(JST).strftime("%Y-%m-%d %H:%M"),
+    )
+    path.write_text(content, encoding="utf-8")
+    print(f"Created: {path}")
+
+
+def cmd_update(args):
+    """Append text to a section in a channel context file."""
+    ctx_dir = get_context_dir(args.memory_dir)
+    name = sanitize_channel_name(args.channel)
+    path = ctx_dir / f"{name}.md"
+
+    if not path.exists():
+        print(f"No context file for: {args.channel}. Run 'init' first.", file=sys.stderr)
+        sys.exit(1)
+
+    content = path.read_text(encoding="utf-8")
+    section_header = f"## {args.section}"
+
+    lines = content.split("\n")
+    available_sections = [line[3:].strip() for line in lines if line.startswith("## ")]
+    if args.section not in available_sections:
+        print(f"Section not found: {args.section}", file=sys.stderr)
+        print(f"Available sections:", file=sys.stderr)
+        for section in available_sections:
+            print(f"  {section}", file=sys.stderr)
+        sys.exit(1)
+
+    # Insert text after the exact section header (and any HTML comment)
+    new_lines = []
+    found = False
+    inserted = False
+
+    for i, line in enumerate(lines):
+        new_lines.append(line)
+        if line.strip() == section_header:
+            found = True
+        elif found and not inserted:
+            # Keep HTML comments, insert after them
+            if line.strip().startswith("<!--") and line.strip().endswith("-->"):
+                pass  # already appended above, keep looking
+            else:
+                # Insert new entry before this line
+                new_lines.insert(len(new_lines) - 1, f"- {args.text}")
+                inserted = True
+                found = False
+
+    # Handle case where section ends at EOF or only had HTML comments
+    if found and not inserted:
+        new_lines.append(f"- {args.text}")
+        inserted = True
+
+    # Update the last-updated timestamp
+    timestamp = datetime.now(JST).strftime("%Y-%m-%d %H:%M")
+    updated_content = "\n".join(new_lines)
+    updated_content = re.sub(
+        r"\*Last updated:.*\*",
+        f"*Last updated: {timestamp}*",
+        updated_content,
+    )
+
+    path.write_text(updated_content, encoding="utf-8")
+    print(f"Updated {name} / {args.section}: {args.text}")
+
+
+def cmd_stale(args):
+    """Show channels not updated within threshold."""
+    ctx_dir = get_context_dir(args.memory_dir)
+    if not ctx_dir.exists():
+        print("No channel_context/ directory.")
+        return
+
+    threshold = timedelta(hours=args.hours)
+    now = datetime.now(JST)
+    stale = []
+
+    for f in sorted(ctx_dir.glob("*.md")):
+        if f.name == "README.md":
+            continue
+        mtime = datetime.fromtimestamp(f.stat().st_mtime, tz=JST)
+        age = now - mtime
+        if age > threshold:
+            stale.append((f.stem, age))
+
+    if not stale:
+        print(f"All channels updated within {args.hours}h.")
+        return
+
+    print(f"Stale channels (not updated in {args.hours}h):")
+    for name, age in stale:
+        print(f"  ⚠️  {name:30s}  ({age.days}d {age.seconds // 3600}h ago)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Channel context manager")
+    parser.add_argument("--memory-dir", default=None)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list", help="List channel contexts")
+
+    p_show = sub.add_parser("show", help="Show channel context")
+    p_show.add_argument("channel")
+
+    p_init = sub.add_parser("init", help="Create channel context")
+    p_init.add_argument("channel")
+    p_init.add_argument("--force", action="store_true")
+
+    p_up = sub.add_parser("update", help="Update channel section")
+    p_up.add_argument("channel")
+    p_up.add_argument("section")
+    p_up.add_argument("text")
+
+    p_stale = sub.add_parser("stale", help="Show stale channels")
+    p_stale.add_argument("--hours", type=int, default=24)
+
+    args = parser.parse_args()
+    {
+        "list": cmd_list,
+        "show": cmd_show,
+        "init": cmd_init,
+        "update": cmd_update,
+        "stale": cmd_stale,
+    }[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/adaptive-memory/scripts/distill.py
+++ b/skills/adaptive-memory/scripts/distill.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Adaptive Memory — Distillation Cycle Runner
+
+Four-phase distillation: Orient → Gather → Consolidate → Prune
+Merges daily notes into MEMORY.md on a schedule or when staleness
+conditions are met (48h+ since last run AND 3+ unprocessed notes).
+
+Usage:
+    python distill.py [workspace_dir]
+    python distill.py --check          # Check if distillation is needed (exit 0=yes, 1=no)
+    python distill.py --dry-run        # Show what would be consolidated without writing
+
+Environment:
+    MEMORY_STALENESS_HOURS  — hours before distillation triggers (default: 48)
+    MEMORY_MIN_NOTES        — minimum unprocessed notes to trigger (default: 3)
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+JST = timezone(timedelta(hours=9))
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse ISO datetime and normalize naive values to JST."""
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00") if value.endswith("Z") else value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=JST)
+    return dt
+
+
+def get_workspace(args_dir: str | None = None) -> Path:
+    """Resolve workspace root."""
+    if args_dir:
+        return Path(args_dir).resolve()
+    return Path.cwd()
+
+
+def load_state(workspace: Path) -> dict:
+    """Load distillation-state.json."""
+    state_path = workspace / "memory" / "distillation-state.json"
+    if state_path.exists():
+        with open(state_path) as f:
+            return json.load(f)
+    return {"lastConsolidatedAt": None}
+
+
+def save_state(workspace: Path, state: dict) -> None:
+    """Save distillation-state.json."""
+    state_path = workspace / "memory" / "distillation-state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(state_path, "w") as f:
+        json.dump(state, f, indent=2, ensure_ascii=False)
+
+
+def mark_consolidation_complete(workspace: Path) -> None:
+    """Record a successful consolidation handoff/completion."""
+    state = load_state(workspace)
+    state["lastConsolidatedAt"] = datetime.now(JST).isoformat()
+    save_state(workspace, state)
+
+
+def get_daily_notes(workspace: Path) -> list[Path]:
+    """Find all daily note files sorted by date."""
+    memory_dir = workspace / "memory"
+    if not memory_dir.exists():
+        return []
+    pattern = re.compile(r"^\d{4}-\d{2}-\d{2}\.md$")
+    notes = [f for f in memory_dir.iterdir() if pattern.match(f.name)]
+    return sorted(notes, key=lambda p: p.name)
+
+
+def get_unprocessed_notes(workspace: Path, state: dict) -> list[Path]:
+    """Find daily notes created or modified after last consolidation."""
+    all_notes = get_daily_notes(workspace)
+    last = state.get("lastConsolidatedAt")
+    if not last:
+        return all_notes
+
+    try:
+        last_dt = parse_iso_datetime(last)
+    except (ValueError, AttributeError):
+        return all_notes
+
+    unprocessed = []
+    for note in all_notes:
+        try:
+            note_date = datetime.strptime(note.stem, "%Y-%m-%d").date()
+        except ValueError:
+            continue
+
+        note_mtime = datetime.fromtimestamp(note.stat().st_mtime, tz=JST)
+        note_end = datetime.combine(note_date, datetime.max.time(), tzinfo=JST)
+        if note_end > last_dt or note_mtime > last_dt:
+            unprocessed.append(note)
+
+    return unprocessed
+
+
+def should_distill(workspace: Path, staleness_hours: int = 48, min_notes: int = 3) -> tuple[bool, str]:
+    """Check if distillation conditions are met."""
+    state = load_state(workspace)
+    unprocessed = get_unprocessed_notes(workspace, state)
+
+    last = state.get("lastConsolidatedAt")
+    now = datetime.now(JST)
+
+    if not last:
+        if len(unprocessed) >= min_notes:
+            return True, f"Never consolidated, {len(unprocessed)} notes waiting"
+        return False, f"Never consolidated but only {len(unprocessed)} notes (need {min_notes})"
+
+    try:
+        last_dt = parse_iso_datetime(last)
+    except (ValueError, AttributeError):
+        return True, "Cannot parse lastConsolidatedAt, running distillation"
+
+    hours_since = (now - last_dt).total_seconds() / 3600
+    stale = hours_since >= staleness_hours
+    enough_notes = len(unprocessed) >= min_notes
+
+    if stale and enough_notes:
+        return True, f"{hours_since:.0f}h since last run, {len(unprocessed)} unprocessed notes"
+    elif stale:
+        return False, f"Stale ({hours_since:.0f}h) but only {len(unprocessed)} notes (need {min_notes})"
+    elif enough_notes:
+        return False, f"{len(unprocessed)} notes ready but only {hours_since:.0f}h since last run (need {staleness_hours}h)"
+    else:
+        return False, f"{hours_since:.0f}h elapsed, {len(unprocessed)} notes — no action needed"
+
+
+def orient(workspace: Path) -> str:
+    """Phase 1: Read MEMORY.md to understand current state."""
+    memory_path = workspace / "MEMORY.md"
+    if memory_path.exists():
+        return memory_path.read_text(encoding="utf-8")
+    return ""
+
+
+def gather(workspace: Path, state: dict) -> list[tuple[str, str]]:
+    """Phase 2: Read unprocessed daily notes. Returns [(filename, content)]."""
+    notes = get_unprocessed_notes(workspace, state)
+    result = []
+    for note in notes:
+        content = note.read_text(encoding="utf-8")
+        if content.strip():
+            result.append((note.name, content))
+    return result
+
+
+def extract_sections(content: str) -> dict[str, list[str]]:
+    """Extract h2 sections from markdown content."""
+    sections: dict[str, list[str]] = {}
+    current = None
+    for line in content.split("\n"):
+        if line.startswith("## "):
+            current = line[3:].strip()
+            sections[current] = []
+        elif current is not None:
+            sections[current].append(line)
+    # Clean up empty trailing lines
+    for key in sections:
+        while sections[key] and not sections[key][-1].strip():
+            sections[key].pop()
+    return sections
+
+
+def print_report(notes: list[tuple[str, str]], dry_run: bool = False) -> None:
+    """Print what would be consolidated."""
+    prefix = "[DRY RUN] " if dry_run else ""
+    print(f"{prefix}Distillation report:")
+    print(f"  Notes to process: {len(notes)}")
+    for name, content in notes:
+        sections = extract_sections(content)
+        non_empty = {k: v for k, v in sections.items() if any(l.strip() for l in v)}
+        section_names = ", ".join(non_empty.keys()) if non_empty else "(no sections)"
+        print(f"    {name}: {section_names}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Adaptive Memory distillation cycle")
+    parser.add_argument("workspace", nargs="?", default=None, help="Workspace root directory")
+    parser.add_argument("--check", action="store_true", help="Check if distillation is needed (exit 0=yes, 1=no)")
+    parser.add_argument("--dry-run", action="store_true", help="Show report without writing")
+    parser.add_argument("--force", action="store_true", help="Run regardless of staleness conditions")
+    parser.add_argument("--mark-done", action="store_true", help="Mark consolidation complete after MEMORY.md was actually updated")
+    parser.add_argument("--staleness-hours", type=int, default=None)
+    parser.add_argument("--min-notes", type=int, default=None)
+    args = parser.parse_args()
+
+    staleness = args.staleness_hours or int(os.environ.get("MEMORY_STALENESS_HOURS", "48"))
+    min_notes = args.min_notes or int(os.environ.get("MEMORY_MIN_NOTES", "3"))
+
+    workspace = get_workspace(args.workspace)
+
+    if args.check:
+        needed, reason = should_distill(workspace, staleness, min_notes)
+        print(reason)
+        sys.exit(0 if needed else 1)
+
+    if args.mark_done:
+        mark_consolidation_complete(workspace)
+        state = load_state(workspace)
+        print(f"Marked consolidation complete: {state['lastConsolidatedAt']}")
+        sys.exit(0)
+
+    if not args.force:
+        needed, reason = should_distill(workspace, staleness, min_notes)
+        if not needed:
+            print(f"Skipping: {reason}")
+            sys.exit(0)
+        print(f"Distillation triggered: {reason}")
+
+    # Phase 1: Orient
+    print("\n[Phase 1: Orient]")
+    current_memory = orient(workspace)
+    if current_memory:
+        sections = extract_sections(current_memory)
+        print(f"  Current MEMORY.md sections: {list(sections.keys())}")
+    else:
+        print("  MEMORY.md is empty or missing")
+
+    # Phase 2: Gather
+    print("\n[Phase 2: Gather]")
+    state = load_state(workspace)
+    notes = gather(workspace, state)
+    if not notes:
+        print("  No unprocessed notes found")
+        sys.exit(0)
+
+    print_report(notes, dry_run=args.dry_run)
+
+    if args.dry_run:
+        print("\n[DRY RUN] No files modified")
+        sys.exit(0)
+
+    # Phase 3 & 4: Consolidate & Prune
+    # NOTE: Actual consolidation requires LLM judgment to extract lasting knowledge
+    # from daily notes and merge into MEMORY.md. This script handles the mechanical
+    # parts (finding notes, checking staleness, previewing inputs). The agent reads this
+    # output, performs the actual consolidation, and should only rerun without --dry-run
+    # once that handoff succeeds.
+    print("\n[Phase 3: Consolidate]")
+    print("  Unprocessed notes ready for agent consolidation:")
+    for name, content in notes:
+        print(f"\n  --- {name} ---")
+        # Print first 20 non-empty lines as preview
+        lines = [l for l in content.split("\n") if l.strip()][:20]
+        for l in lines:
+            print(f"    {l}")
+        if len([l for l in content.split("\n") if l.strip()]) > 20:
+            print("    ...")
+
+    print("\n[Phase 4: Prune]")
+    print("  Agent should review MEMORY.md for outdated entries")
+
+    print("\nNo state was updated yet.")
+    print("After MEMORY.md is actually consolidated, rerun with --mark-done to record completion.")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/adaptive-memory/scripts/init_memory.sh
+++ b/skills/adaptive-memory/scripts/init_memory.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Initialize the adaptive-memory directory structure in a workspace.
+# Usage: ./init_memory.sh [workspace_dir]
+#   workspace_dir: path to the workspace root (default: current directory)
+
+set -euo pipefail
+
+WORKSPACE="${1:-.}"
+
+mkdir -p "$WORKSPACE/memory/channel_context"
+
+# active_context.md
+if [ ! -f "$WORKSPACE/memory/active_context.md" ]; then
+  cat > "$WORKSPACE/memory/active_context.md" << 'EOF'
+# Active Context
+
+## In Progress
+<!-- Add current tasks here -->
+
+## Blocked / Waiting
+<!-- Add blocked items here -->
+
+## Recently Completed
+<!-- Move completed items here, prune after a few days -->
+EOF
+  echo "[OK] Created memory/active_context.md"
+else
+  echo "[SKIP] memory/active_context.md already exists"
+fi
+
+# pending_tasks.json
+if [ ! -f "$WORKSPACE/memory/pending_tasks.json" ]; then
+  cat > "$WORKSPACE/memory/pending_tasks.json" << 'EOF'
+{
+  "lastUpdated": null,
+  "tasks": []
+}
+EOF
+  echo "[OK] Created memory/pending_tasks.json"
+else
+  echo "[SKIP] memory/pending_tasks.json already exists"
+fi
+
+# distillation-state.json
+if [ ! -f "$WORKSPACE/memory/distillation-state.json" ]; then
+  cat > "$WORKSPACE/memory/distillation-state.json" << 'EOF'
+{
+  "lastConsolidatedAt": null
+}
+EOF
+  echo "[OK] Created memory/distillation-state.json"
+else
+  echo "[SKIP] memory/distillation-state.json already exists"
+fi
+
+# MEMORY.md at workspace root
+if [ ! -f "$WORKSPACE/MEMORY.md" ]; then
+  cat > "$WORKSPACE/MEMORY.md" << 'EOF'
+# Long-Term Memory
+
+*Curated knowledge distilled from daily notes. Updated periodically.*
+
+## Systems Built
+<!-- Document systems, tools, and automations you've created -->
+
+## Lessons Learned
+<!-- Hard-won knowledge worth remembering -->
+
+## Key Decisions
+<!-- Important decisions and their reasoning -->
+
+---
+*Last updated: (not yet consolidated)*
+EOF
+  echo "[OK] Created MEMORY.md"
+else
+  echo "[SKIP] MEMORY.md already exists"
+fi
+
+# Today's daily note
+TODAY=$(date +%Y-%m-%d)
+if [ ! -f "$WORKSPACE/memory/$TODAY.md" ]; then
+  cat > "$WORKSPACE/memory/$TODAY.md" << EOF
+# $TODAY
+
+## Tasks
+
+## Decisions
+
+## Learned
+
+## Blockers
+EOF
+  echo "[OK] Created memory/$TODAY.md"
+else
+  echo "[SKIP] memory/$TODAY.md already exists"
+fi
+
+echo ""
+echo "Memory structure initialized in: $WORKSPACE"
+echo ""
+echo "Directory layout:"
+echo "  $WORKSPACE/"
+echo "  ├── MEMORY.md"
+echo "  └── memory/"
+echo "      ├── active_context.md"
+echo "      ├── pending_tasks.json"
+echo "      ├── distillation-state.json"
+echo "      ├── channel_context/"
+echo "      └── $TODAY.md"

--- a/skills/adaptive-memory/scripts/memory_lint.py
+++ b/skills/adaptive-memory/scripts/memory_lint.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""
+Adaptive Memory — Memory Lint
+
+Scans memory files for common problems:
+- Leaked credentials (API keys, tokens, passwords)
+- Stale active context entries
+- Empty daily notes
+- Oversized MEMORY.md
+- Missing required files
+
+Usage:
+    python memory_lint.py [workspace_dir]
+    python memory_lint.py --fix   # Auto-fix what's possible
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+JST = timezone(timedelta(hours=9))
+
+
+def now_local() -> datetime:
+    """Current local time with timezone awareness."""
+    return datetime.now().astimezone()
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse ISO datetime and normalize Z suffix / naive values."""
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00") if value.endswith("Z") else value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=JST)
+    return dt
+
+
+# Patterns that suggest leaked credentials
+CREDENTIAL_PATTERNS = [
+    (r"(?:api[_-]?key|apikey)\s*[:=]\s*['\"]?[\w\-]{20,}", "API key"),
+    (r"(?:secret|token|password|passwd|pwd)\s*[:=]\s*['\"]?[\w\-]{8,}", "Secret/token"),
+    (r"sk-[a-zA-Z0-9]{20,}", "OpenAI-style key"),
+    (r"ghp_[a-zA-Z0-9]{36,}", "GitHub PAT"),
+    (r"xoxb-[0-9]+-[a-zA-Z0-9]+", "Slack bot token"),
+    (r"xoxp-[0-9]+-[a-zA-Z0-9]+", "Slack user token"),
+    (r"Bearer\s+[a-zA-Z0-9\-_.]{20,}", "Bearer token"),
+    (r"-----BEGIN\s+(RSA\s+)?PRIVATE KEY-----", "Private key"),
+]
+
+ISSUES = []
+
+
+def warn(file: str, message: str, fixable: bool = False):
+    tag = "🔧" if fixable else "⚠️"
+    ISSUES.append({"file": file, "message": message, "fixable": fixable})
+    print(f"  {tag} [{file}] {message}")
+
+
+def check_credentials(workspace: Path):
+    """Scan all memory files for leaked credentials."""
+    print("\n🔒 Credential scan:")
+    found = False
+
+    targets = list((workspace / "memory").rglob("*.md")) if (workspace / "memory").exists() else []
+    if (workspace / "MEMORY.md").exists():
+        targets.append(workspace / "MEMORY.md")
+
+    for filepath in targets:
+        content = filepath.read_text(encoding="utf-8", errors="ignore")
+        rel = filepath.relative_to(workspace)
+        for pattern, label in CREDENTIAL_PATTERNS:
+            matches = re.findall(pattern, content, re.IGNORECASE)
+            if matches:
+                found = True
+                warn(str(rel), f"Possible {label} found ({len(matches)} match(es))")
+
+    if not found:
+        print("  ✅ No credentials detected")
+
+
+def check_active_context(workspace: Path):
+    """Check active_context.md for staleness."""
+    print("\n📋 Active context:")
+    path = workspace / "memory" / "active_context.md"
+
+    if not path.exists():
+        warn("memory/active_context.md", "File missing — create with init_memory.sh", fixable=True)
+        return
+
+    content = path.read_text(encoding="utf-8")
+    if not content.strip() or len(content.strip()) < 50:
+        warn("memory/active_context.md", "File is nearly empty — may need updating")
+
+    # Check modification time
+    current = now_local()
+    mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=current.tzinfo)
+    age = current - mtime
+    if age > timedelta(days=3):
+        warn("memory/active_context.md", f"Not updated in {age.days} days — may be stale")
+    else:
+        print(f"  ✅ Updated {age.days}d {age.seconds // 3600}h ago")
+
+
+def check_daily_notes(workspace: Path):
+    """Check daily notes for issues."""
+    print("\n📝 Daily notes:")
+    memory_dir = workspace / "memory"
+    if not memory_dir.exists():
+        warn("memory/", "Directory missing", fixable=True)
+        return
+
+    pattern = re.compile(r"^\d{4}-\d{2}-\d{2}\.md$")
+    notes = sorted([f for f in memory_dir.iterdir() if pattern.match(f.name)])
+
+    if not notes:
+        warn("memory/", "No daily notes found")
+        return
+
+    print(f"  📊 {len(notes)} daily notes found")
+    print(f"  📅 Range: {notes[0].stem} → {notes[-1].stem}")
+
+    # Check for empty notes
+    empty = [n for n in notes if len(n.read_text(encoding="utf-8").strip()) < 30]
+    if empty:
+        warn("daily notes", f"{len(empty)} nearly empty notes: {', '.join(n.stem for n in empty[:5])}")
+
+    # Check today's note exists
+    today = now_local().strftime("%Y-%m-%d")
+    today_path = memory_dir / f"{today}.md"
+    if not today_path.exists():
+        warn(f"memory/{today}.md", "Today's daily note doesn't exist yet")
+    else:
+        print(f"  ✅ Today's note exists ({today})")
+
+
+def check_memory_md(workspace: Path):
+    """Check MEMORY.md size and structure."""
+    print("\n🧠 MEMORY.md:")
+    path = workspace / "MEMORY.md"
+
+    if not path.exists():
+        warn("MEMORY.md", "File missing — create with init_memory.sh", fixable=True)
+        return
+
+    content = path.read_text(encoding="utf-8")
+    size_kb = len(content.encode("utf-8")) / 1024
+    lines = content.count("\n")
+
+    print(f"  📊 Size: {size_kb:.1f} KB, {lines} lines")
+
+    if size_kb > 50:
+        warn("MEMORY.md", f"Large file ({size_kb:.0f} KB) — consider pruning during distillation")
+    elif size_kb > 100:
+        warn("MEMORY.md", f"Very large ({size_kb:.0f} KB) — this will consume significant context window")
+
+    # Check for sections
+    sections = [l for l in content.split("\n") if l.startswith("## ")]
+    if sections:
+        print(f"  📑 Sections: {len(sections)}")
+    else:
+        warn("MEMORY.md", "No ## sections found — consider organizing by topic")
+
+
+def check_pending_tasks(workspace: Path):
+    """Check pending_tasks.json health."""
+    print("\n📋 Pending tasks:")
+    path = workspace / "memory" / "pending_tasks.json"
+
+    if not path.exists():
+        warn("memory/pending_tasks.json", "File missing", fixable=True)
+        return
+
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        warn("memory/pending_tasks.json", f"Invalid JSON: {e}")
+        return
+
+    tasks = data.get("tasks", [])
+    by_status = {}
+    for t in tasks:
+        s = t.get("status", "unknown")
+        by_status[s] = by_status.get(s, 0) + 1
+
+    print(f"  📊 {len(tasks)} tasks: {by_status}")
+
+    # Check for old non-done tasks
+    now = now_local()
+    for t in tasks:
+        if t.get("status") in ("pending", "in_progress"):
+            try:
+                created = parse_iso_datetime(t["createdAt"])
+                age = now - created
+                if age > timedelta(days=7):
+                    warn("pending_tasks.json", f"Task '{t['title'][:40]}' is {age.days} days old")
+            except (ValueError, KeyError):
+                pass
+
+    # Old done tasks
+    done_old = []
+    for t in tasks:
+        if t.get("status") != "done" or not t.get("completedAt"):
+            continue
+        try:
+            completed = parse_iso_datetime(t["completedAt"])
+        except (ValueError, TypeError):
+            warn("pending_tasks.json", f"Task '{t.get('title', '(untitled)')[:40]}' has invalid completedAt")
+            continue
+        if (now - completed) > timedelta(days=7):
+            done_old.append(t)
+    if done_old:
+        warn("pending_tasks.json", f"{len(done_old)} completed tasks older than 7 days — run prune", fixable=True)
+
+
+def check_distillation_state(workspace: Path):
+    """Check if distillation is overdue."""
+    print("\n🔄 Distillation:")
+    path = workspace / "memory" / "distillation-state.json"
+
+    if not path.exists():
+        warn("memory/distillation-state.json", "State file missing — distillation not tracked")
+        return
+
+    try:
+        with open(path) as f:
+            state = json.load(f)
+    except json.JSONDecodeError:
+        warn("memory/distillation-state.json", "Invalid JSON")
+        return
+
+    last = state.get("lastConsolidatedAt")
+    if not last:
+        warn("distillation-state.json", "Never consolidated — run distill.py")
+        return
+
+    try:
+        last_dt = parse_iso_datetime(last)
+        age = now_local() - last_dt
+        if age > timedelta(hours=96):
+            warn("distillation-state.json", f"Last distillation was {age.days}d ago — may be overdue")
+        else:
+            print(f"  ✅ Last distillation: {age.days}d {age.seconds // 3600}h ago")
+    except ValueError:
+        warn("distillation-state.json", f"Cannot parse timestamp: {last}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Memory system health check")
+    parser.add_argument("workspace", nargs="?", default=".")
+    parser.add_argument("--fix", action="store_true", help="Auto-fix where possible")
+    args = parser.parse_args()
+
+    workspace = Path(args.workspace).resolve()
+    print(f"🏥 Memory lint: {workspace}")
+
+    check_credentials(workspace)
+    check_active_context(workspace)
+    check_daily_notes(workspace)
+    check_memory_md(workspace)
+    check_pending_tasks(workspace)
+    check_distillation_state(workspace)
+
+    fixable = [i for i in ISSUES if i["fixable"]]
+    errors = [i for i in ISSUES if not i["fixable"]]
+
+    print(f"\n{'─' * 50}")
+    print(f"Results: {len(errors)} warnings, {len(fixable)} fixable issues")
+
+    if fixable and args.fix:
+        print("\n🔧 Auto-fixing...")
+        # Run init_memory.sh for missing files
+        init_script = Path(__file__).parent / "init_memory.sh"
+        if init_script.exists():
+            import subprocess
+            subprocess.run(["bash", str(init_script), str(workspace)], check=True)
+            print("  Ran init_memory.sh")
+
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/adaptive-memory/scripts/memory_lint.py
+++ b/skills/adaptive-memory/scripts/memory_lint.py
@@ -150,10 +150,10 @@ def check_memory_md(workspace: Path):
 
     print(f"  📊 Size: {size_kb:.1f} KB, {lines} lines")
 
-    if size_kb > 50:
-        warn("MEMORY.md", f"Large file ({size_kb:.0f} KB) — consider pruning during distillation")
-    elif size_kb > 100:
+    if size_kb > 100:
         warn("MEMORY.md", f"Very large ({size_kb:.0f} KB) — this will consume significant context window")
+    elif size_kb > 50:
+        warn("MEMORY.md", f"Large file ({size_kb:.0f} KB) — consider pruning during distillation")
 
     # Check for sections
     sections = [l for l in content.split("\n") if l.startswith("## ")]

--- a/skills/adaptive-memory/scripts/pending_tasks.py
+++ b/skills/adaptive-memory/scripts/pending_tasks.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Adaptive Memory — Pending Tasks Manager
+
+CLI for managing pending_tasks.json. Prevents promises from being lost
+after context compaction.
+
+Usage:
+    python pending_tasks.py list                          # Show all non-done tasks
+    python pending_tasks.py add "Title" [--priority high] # Add a task
+    python pending_tasks.py update <id> --status done     # Update status
+    python pending_tasks.py prune                         # Remove done tasks older than 7 days
+    python pending_tasks.py overdue                       # Show tasks pending > 24h
+
+Environment:
+    MEMORY_DIR — path to memory/ directory (default: ./memory)
+"""
+
+import argparse
+import json
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+JST = timezone(timedelta(hours=9))
+VALID_STATUSES = {"pending", "in_progress", "blocked", "done"}
+VALID_PRIORITIES = {"low", "normal", "high", "critical"}
+
+
+def parse_iso_datetime(value: str) -> datetime:
+    """Parse ISO datetime and normalize Z suffix / naive values."""
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00") if value.endswith("Z") else value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=JST)
+    return dt
+
+
+def get_tasks_path(memory_dir: str | None = None) -> Path:
+    """Resolve pending_tasks.json path."""
+    import os
+    base = Path(memory_dir) if memory_dir else Path(os.environ.get("MEMORY_DIR", "./memory"))
+    return base / "pending_tasks.json"
+
+
+def load_tasks(path: Path) -> dict:
+    """Load tasks from JSON file."""
+    if path.exists():
+        with open(path) as f:
+            return json.load(f)
+    return {"lastUpdated": "", "tasks": []}
+
+
+def save_tasks(path: Path, data: dict) -> None:
+    """Save tasks to JSON file."""
+    data["lastUpdated"] = datetime.now(JST).isoformat()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def cmd_list(args):
+    """List tasks, optionally filtering by status."""
+    path = get_tasks_path(args.memory_dir)
+    data = load_tasks(path)
+    tasks = data.get("tasks", [])
+
+    if args.status:
+        tasks = [t for t in tasks if t.get("status") == args.status]
+    elif not args.all:
+        tasks = [t for t in tasks if t.get("status") != "done"]
+
+    if not tasks:
+        print("No tasks found.")
+        return
+
+    # Sort: critical > high > normal > low, then by date
+    priority_order = {"critical": 0, "high": 1, "normal": 2, "low": 3}
+    tasks.sort(key=lambda t: (priority_order.get(t.get("priority", "normal"), 2), t.get("createdAt", "")))
+
+    for t in tasks:
+        status_icon = {"pending": "⏳", "in_progress": "🔄", "blocked": "🚫", "done": "✅"}.get(t.get("status"), "❓")
+        priority = t.get("priority", "normal")
+        priority_tag = f" [{priority.upper()}]" if priority in ("high", "critical") else ""
+        print(f"  {status_icon} {t['id'][:8]}  {t['title']}{priority_tag}")
+        if t.get("note"):
+            print(f"              {t['note']}")
+
+
+def cmd_add(args):
+    """Add a new task."""
+    path = get_tasks_path(args.memory_dir)
+    data = load_tasks(path)
+
+    task = {
+        "id": str(uuid.uuid4())[:8],
+        "title": args.title,
+        "status": "pending",
+        "priority": args.priority or "normal",
+        "createdAt": datetime.now(JST).isoformat(),
+        "note": args.note or "",
+    }
+
+    data["tasks"].append(task)
+    save_tasks(path, data)
+    print(f"Added: {task['id']}  {task['title']}")
+
+
+def cmd_update(args):
+    """Update an existing task."""
+    path = get_tasks_path(args.memory_dir)
+    data = load_tasks(path)
+
+    matches = [t for t in data["tasks"] if t["id"] == args.id]
+    if not matches:
+        matches = [t for t in data["tasks"] if t["id"].startswith(args.id)]
+
+    if not matches:
+        print(f"Task not found: {args.id}", file=sys.stderr)
+        sys.exit(1)
+
+    if len(matches) > 1:
+        print(f"Ambiguous task id prefix: {args.id}", file=sys.stderr)
+        print("Matches:", file=sys.stderr)
+        for task in matches:
+            print(f"  {task['id']}  {task['title']}", file=sys.stderr)
+        print("Use a longer prefix or the full id.", file=sys.stderr)
+        sys.exit(1)
+
+    found = matches[0]
+
+    changes = []
+    if args.status:
+        if args.status not in VALID_STATUSES:
+            print(f"Invalid status: {args.status}. Valid: {VALID_STATUSES}", file=sys.stderr)
+            sys.exit(1)
+        found["status"] = args.status
+        changes.append(f"status={args.status}")
+        if args.status == "done":
+            found["completedAt"] = datetime.now(JST).isoformat()
+
+    if args.priority:
+        if args.priority not in VALID_PRIORITIES:
+            print(f"Invalid priority: {args.priority}. Valid: {VALID_PRIORITIES}", file=sys.stderr)
+            sys.exit(1)
+        found["priority"] = args.priority
+        changes.append(f"priority={args.priority}")
+
+    if args.note is not None:
+        found["note"] = args.note
+        changes.append("note updated")
+
+    save_tasks(path, data)
+    print(f"Updated {found['id']}: {', '.join(changes)}")
+
+
+def cmd_prune(args):
+    """Remove done tasks older than N days."""
+    path = get_tasks_path(args.memory_dir)
+    data = load_tasks(path)
+
+    cutoff = datetime.now(JST) - timedelta(days=args.days)
+    before = len(data["tasks"])
+    data["tasks"] = [
+        t for t in data["tasks"]
+        if not (
+            t.get("status") == "done"
+            and t.get("completedAt")
+            and parse_iso_datetime(t["completedAt"]) < cutoff
+        )
+    ]
+    pruned = before - len(data["tasks"])
+    save_tasks(path, data)
+    print(f"Pruned {pruned} completed tasks (older than {args.days} days)")
+
+
+def cmd_overdue(args):
+    """Show tasks pending for more than threshold hours."""
+    path = get_tasks_path(args.memory_dir)
+    data = load_tasks(path)
+
+    threshold = timedelta(hours=args.hours)
+    now = datetime.now(JST)
+    overdue = []
+
+    for t in data["tasks"]:
+        if t.get("status") in ("pending", "in_progress"):
+            try:
+                created = parse_iso_datetime(t["createdAt"])
+                if now - created > threshold:
+                    age_hours = (now - created).total_seconds() / 3600
+                    overdue.append((t, age_hours))
+            except (ValueError, KeyError):
+                continue
+
+    if not overdue:
+        print("No overdue tasks.")
+        return
+
+    print(f"Tasks pending > {args.hours}h:")
+    for t, hours in overdue:
+        print(f"  ⚠️  {t['id'][:8]}  {t['title']}  ({hours:.0f}h old)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Adaptive Memory task tracker")
+    parser.add_argument("--memory-dir", default=None, help="Path to memory/ directory")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # list
+    p_list = sub.add_parser("list", help="List tasks")
+    p_list.add_argument("--status", choices=VALID_STATUSES)
+    p_list.add_argument("--all", action="store_true", help="Include done tasks")
+
+    # add
+    p_add = sub.add_parser("add", help="Add a task")
+    p_add.add_argument("title")
+    p_add.add_argument("--priority", choices=VALID_PRIORITIES, default="normal")
+    p_add.add_argument("--note", default="")
+
+    # update
+    p_up = sub.add_parser("update", help="Update a task")
+    p_up.add_argument("id")
+    p_up.add_argument("--status", choices=VALID_STATUSES)
+    p_up.add_argument("--priority", choices=VALID_PRIORITIES)
+    p_up.add_argument("--note")
+
+    # prune
+    p_prune = sub.add_parser("prune", help="Remove old done tasks")
+    p_prune.add_argument("--days", type=int, default=7)
+
+    # overdue
+    p_over = sub.add_parser("overdue", help="Show overdue tasks")
+    p_over.add_argument("--hours", type=int, default=24)
+
+    args = parser.parse_args()
+    {"list": cmd_list, "add": cmd_add, "update": cmd_update, "prune": cmd_prune, "overdue": cmd_overdue}[args.command](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add the adaptive-memory skill for hierarchical memory management across sessions
- include helper scripts for workspace initialization, distillation checks, linting, pending tasks, and channel context management
- keep the rebuild scoped to the standalone skill directory only

## Verification
- reviewed the rebuild for scope and standalone viability
- smoke-checked helper scripts:
  - `pending_tasks.py --help`
  - `channel_context.py --help`
  - `memory_lint.py --help`
  - `distill.py --help`
  - `init_memory.sh /tmp/openclaw-adaptive-memory-smoke`
- confirmed `init_memory.sh` created the expected memory structure successfully

## Notes
- rebuilt cleanly from the closed #60586 on top of current upstream main
- the feature lives entirely under `skills/adaptive-memory/`, so no extra repo-wide changes were reintroduced
