### PR TITLE
feat(templates): ask user for city/timezone during onboarding and startup

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -15,14 +15,21 @@ If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out w
 
 ## Session Startup
 
-Before doing anything else:
+Use runtime-provided startup context first.
 
-1. Read `SOUL.md` — this is who you are
-2. Read `USER.md` — this is who you're helping
-3. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
-4. **If in MAIN SESSION** (direct chat with your human): Also read `MEMORY.md`
+That context may already include:
 
-Don't ask permission. Just do it.
+- `AGENTS.md`, `SOUL.md`, and `USER.md`
+- recent daily memory such as `memory/YYYY-MM-DD.md`
+- `MEMORY.md` when this is the main session
+
+Do not manually reread startup files unless:
+
+1. The user explicitly asks
+2. The provided context is missing something you need
+3. You need a deeper follow-up read beyond the provided startup context
+
+**If `USER.md` timezone or city is empty or unknown**, ask casually during this session: "By the way, what city are you in? Helps me not message you at 3am." Don't interrogate — weave it in naturally.
 
 ## Memory
 
@@ -136,9 +143,6 @@ Skills provide your tools. When you need one, check its `SKILL.md`. Keep local n
 
 When you receive a heartbeat poll (message matches the configured heartbeat prompt), don't just reply `HEARTBEAT_OK` every time. Use heartbeats productively!
 
-Default heartbeat prompt:
-`Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`
-
 You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it small to limit token burn.
 
 ### Heartbeat vs Cron: When to Use Each
@@ -188,7 +192,7 @@ You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it
 
 **When to stay quiet (HEARTBEAT_OK):**
 
-- Late night (23:00-08:00) unless urgent
+- Late night in *their* timezone (23:00-08:00) unless urgent. If you don't know their timezone, default to UTC but ask when you get a chance.
 - Human is clearly busy
 - Nothing new since last check
 - You just checked &lt;30 minutes ago

--- a/docs/reference/templates/BOOTSTRAP.md
+++ b/docs/reference/templates/BOOTSTRAP.md
@@ -22,9 +22,11 @@ Start with something like:
 Then figure out together:
 
 1. **Your name** — What should they call you?
-2. **Your nature** — What kind of creature are you? (AI assistant is fine, but maybe you're something weirder)
-3. **Your vibe** — Formal? Casual? Snarky? Warm? What feels right?
-4. **Your emoji** — Everyone needs a signature.
+2. **Their name** — What should you call them?
+3. **Where they live** — What city? You need this to derive their timezone, schedule around quiet hours, and not bother them at 3am. Ask naturally: "Where are you based?" or "What city are you in?"
+4. **Your nature** — What kind of creature are you? (AI assistant is fine, but maybe you're something weirder)
+5. **Your vibe** — Formal? Casual? Snarky? Warm? What feels right?
+6. **Your emoji** — Everyone needs a signature.
 
 Offer suggestions if they're stuck. Have fun with it.
 
@@ -33,7 +35,7 @@ Offer suggestions if they're stuck. Have fun with it.
 Update these files with what you learned:
 
 - `IDENTITY.md` — your name, creature, vibe, emoji
-- `USER.md` — their name, how to address them, timezone, notes
+- `USER.md` — their name, how to address them, city/timezone, notes
 
 Then open `SOUL.md` together and talk about:
 

--- a/docs/reference/templates/USER.md
+++ b/docs/reference/templates/USER.md
@@ -12,7 +12,8 @@ _Learn about the person you're helping. Update this as you go._
 - **Name:**
 - **What to call them:**
 - **Pronouns:** _(optional)_
-- **Timezone:**
+- **City:** _(ask if unknown — used to derive timezone and for weather/local info)_.
+- **Timezone:** _(derived from city if possible; ask if unknown — needed for scheduling and quiet hours)**
 - **Notes:**
 
 ## Context


### PR DESCRIPTION
## Problem

Currently, timezone is never proactively collected from the user. If it gets skipped during onboarding, it stays empty forever. This means quiet hours, cron scheduling, and reminders all operate without knowing the user's timezone.

## Changes

### BOOTSTRAP.md
- Add **city/timezone** as an explicit onboarding step (step 3)
- Ask where the user lives (city) to naturally derive timezone — more conversational than "What timezone are you in?"
- Add **their name** as a separate step (was previously buried)

### AGENTS.md
- Add session startup check: if `USER.md` timezone or city is empty, ask casually during the session
- Make quiet hours timezone-aware: change hardcoded "23:00-08:00" to "Late night in *their* timezone" with a fallback to UTC and a reminder to ask

### USER.md
- Add **City** field (used to derive timezone and for weather/local info)
- Make **Timezone** field hint that it should be derived from city or asked if unknown

## Why city instead of timezone?

Asking "What city are you in?" is more natural and conversational than "What timezone are you in?" — most people know their city, not their IANA timezone. The agent can derive the timezone from the city.

## Test plan

- [ ] Verify that a fresh workspace with BOOTSTRAP.md prompts the agent to ask about the user's city
- [ ] Verify that with an empty timezone in USER.md, the agent asks about it during session startup
- [ ] Verify that heartbeat quiet hours guidance references the user's timezone, not a hardcoded range
- [ ] Verify that the USER.md template has both City and Timezone fields with appropriate hints