### PR TITLE
fix: refresh SubsystemLogger file child on rolling log rotation

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -11,7 +11,7 @@ import {
   shouldLogSubsystemToConsole,
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
-import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { getChildLogger, getLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -314,6 +314,15 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  let fileLoggerBase: TsLogger<LogObj> | null = null;
+  const getFileLogger = (): TsLogger<LogObj> => {
+    const currentBase = getLogger();
+    if (!fileLogger || currentBase !== fileLoggerBase) {
+      fileLogger = getChildLogger({ subsystem });
+      fileLoggerBase = currentBase;
+    }
+    return fileLogger;
+  };
 
   const emitLog = (level: LogLevel, message: string, meta?: Record<string, unknown>) => {
     const consoleSettings = getConsoleSettings();
@@ -336,10 +345,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
       fileMeta = Object.keys(rest).length > 0 ? rest : undefined;
     }
     if (fileEnabled) {
-      if (!fileLogger) {
-        fileLogger = getChildLogger({ subsystem });
-      }
-      logToFile(fileLogger, level, message, fileMeta);
+      logToFile(getFileLogger(), level, message, fileMeta);
     }
     if (!consoleEnabled) {
       return;
@@ -402,10 +408,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     },
     raw(message) {
       if (isFileLogLevelEnabled("info")) {
-        if (!fileLogger) {
-          fileLogger = getChildLogger({ subsystem });
-        }
-        logToFile(fileLogger, "info", message, { raw: true });
+        logToFile(getFileLogger(), "info", message, { raw: true });
       }
       if (
         shouldLogToConsole("info", { level: getConsoleSettings().level }) &&


### PR DESCRIPTION
## Summary

- `createSubsystemLogger()` caches a `fileLogger` child on first use, but never invalidates it when the root logger rebuilds at day boundaries (`defaultRollingPathForToday`).
- After midnight, all file log output from long-lived `SubsystemLogger` instances (e.g. channel plugins) continues writing to the **previous day's** log file, making logs appear to "disappear" from today's file.
- This fix introduces a `getFileLogger()` helper that compares the current root logger reference on each emit. Same-day calls see the identical reference (zero overhead); when the root logger rolls to a new file, the stale child is replaced automatically.

## Root Cause

```
gateway startup
  └─ createSubsystemLogger("gateway/channels/kim")
       └─ fileLogger = getChildLogger(...)  // child of root logger → openclaw-2026-04-12.log
            ↓
       midnight passes
            ↓
       getLogger() rebuilds root → openclaw-2026-04-13.log
       BUT fileLogger still points to old root's child → writes to 2026-04-12.log
```

## Changes

- **`src/logging/subsystem.ts`**: Replace the lazy `if (!fileLogger)` cache with a `getFileLogger()` that detects root logger identity changes via reference comparison (`!==`).

## Test Plan

- [ ] Start gateway, verify logs appear in today's file
- [ ] Wait past midnight (or mock date rollover), verify new logs appear in the new day's file
- [ ] Verify console output is unaffected
- [ ] Verify no performance regression (same-day reference check is O(1))