### PR TITLE
fix(fallback): preserve original prompt in resolveFallbackRetryPrompt

### DIFF
--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -73,7 +73,12 @@ export function resolveFallbackRetryPrompt(params: {
   if (!params.sessionHasHistory) {
     return params.body;
   }
-  return "Continue where you left off. The previous model attempt failed or timed out.";
+  // Preserve the original prompt so the fallback model retains full task context.
+  // When session history exists the model can infer prior progress, but dropping
+  // the original instruction caused agents to lose their task entirely (#65760).
+  const retryNotice =
+    "[System: The previous model attempt failed or timed out. Continue where you left off.]";
+  return `${retryNotice}\n\n${params.body}`;
 }
 
 export function createAcpVisibleTextAccumulator() {

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -20,14 +20,18 @@ describe("resolveFallbackRetryPrompt", () => {
     ).toBe(originalBody);
   });
 
-  it("returns recovery prompt for fallback retry with existing session history", () => {
-    expect(
-      resolveFallbackRetryPrompt({
-        body: originalBody,
-        isFallbackRetry: true,
-        sessionHasHistory: true,
-      }),
-    ).toBe("Continue where you left off. The previous model attempt failed or timed out.");
+  it("prepends retry notice and preserves original body for fallback retry with session history", () => {
+    const result = resolveFallbackRetryPrompt({
+      body: originalBody,
+      isFallbackRetry: true,
+      sessionHasHistory: true,
+    });
+    expect(result).toContain(originalBody);
+    expect(result).toMatch(/^\[System:.*failed or timed out/);
+    // The original prompt must appear after the retry notice
+    const noticeEnd = result.indexOf("]");
+    const bodyStart = result.indexOf(originalBody);
+    expect(bodyStart).toBeGreaterThan(noticeEnd);
   });
 
   it("preserves original body for fallback retry when session has no history (subagent spawn)", () => {


### PR DESCRIPTION
## Summary

When a model call fails and triggers a fallback retry on a session with existing history, `resolveFallbackRetryPrompt()` replaces the original user prompt with the generic string `"Continue where you left off. The previous model attempt failed or timed out."`. This causes the fallback model to lose the original task instruction entirely, forcing it to infer the task from session history alone — which can produce incorrect or unintended results.

## Root Cause

```ts
// Before: original body is discarded
if (params.sessionHasHistory) {
  return "Continue where you left off. The previous model attempt failed or timed out.";
}
```

When `isFallbackRetry=true` and `sessionHasHistory=true`, the function returned only the generic retry message, discarding `params.body`.

## Fix

Prepend the retry notice to the original body instead of replacing it:

```ts
const retryNotice =
  "[System: The previous model attempt failed or timed out. Continue where you left off.]";
return \`\${retryNotice}\\n\\n\${params.body}\`;
```

The fallback model now receives both:
1. Context that a retry occurred (so it can leverage session history)
2. The full original task instruction (so it knows what to do)

## Test Changes

Updated the existing test to verify:
- The original body is preserved in the output
- The retry notice appears as a prefix
- The original body follows after the notice

All 17 existing tests pass.

## Impact

- **All users** with model fallback/retry configured benefit
- Agents no longer silently lose their task when a model times out
- Subagent spawns are most affected since their task instruction is their only context

Fixes #65760