### PR TITLE
[codex] Fix LM Studio header-auth follow-ups

### DIFF
--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -42,6 +42,8 @@ describe("lmstudio-models", () => {
     expect(resolveLmstudioInferenceBase("http://localhost:1234/api/v1")).toBe(
       "http://localhost:1234/v1",
     );
+    expect(resolveLmstudioServerBase("localhost:1234/api/v1")).toBe("http://localhost:1234");
+    expect(resolveLmstudioInferenceBase("localhost:1234/api/v1")).toBe("http://localhost:1234/v1");
   });
 
   it("resolves reasoning capability for supported and unsupported options", () => {

--- a/extensions/lmstudio/src/models.ts
+++ b/extensions/lmstudio/src/models.ts
@@ -118,13 +118,36 @@ function normalizeUrlPath(pathname: string): string {
   return trimmed.replace(/\/api\/v1$/i, "").replace(/\/v1$/i, "");
 }
 
+function hasExplicitHttpScheme(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function isLikelyHostBaseUrl(value: string): boolean {
+  return (
+    /^(?:localhost|(?:\d{1,3}\.){3}\d{1,3}|[a-z0-9.-]+\.[a-z]{2,}|[^/\s?#]+:\d+)(?:[/?#].*)?$/i.test(
+      value,
+    ) && !value.startsWith("/")
+  );
+}
+
+function toFetchableLmstudioBaseUrl(value: string): string {
+  if (hasExplicitHttpScheme(value) || !isLikelyHostBaseUrl(value)) {
+    return value;
+  }
+  return `http://${value}`;
+}
+
 /** Resolves LM Studio server base URL (without /v1 or /api/v1). */
 export function resolveLmstudioServerBase(configuredBaseUrl?: string): string {
   // Use configured value when present; otherwise target local LM Studio default.
   const configured = configuredBaseUrl?.trim();
   const resolved = configured && configured.length > 0 ? configured : LMSTUDIO_DEFAULT_BASE_URL;
+  const fetchableBaseUrl = toFetchableLmstudioBaseUrl(resolved);
   try {
-    const parsed = new URL(resolved);
+    const parsed = new URL(fetchableBaseUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new TypeError(`Unsupported LM Studio protocol: ${parsed.protocol}`);
+    }
     const pathname = normalizeUrlPath(parsed.pathname);
     parsed.pathname = pathname.length > 0 ? pathname : "/";
     parsed.search = "";

--- a/extensions/lmstudio/src/runtime.test.ts
+++ b/extensions/lmstudio/src/runtime.test.ts
@@ -171,6 +171,24 @@ describe("lmstudio-runtime", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("suppresses shell env runtime auth when Authorization is configured", async () => {
+    resolveApiKeyForProviderMock.mockResolvedValueOnce({
+      apiKey: "stale-shell-env-key",
+      source: "shell env: LM_API_TOKEN",
+      mode: "api-key",
+    });
+
+    await expect(
+      resolveLmstudioRuntimeApiKey({
+        config: buildLmstudioConfig({
+          headers: {
+            Authorization: "Bearer proxy-token",
+          },
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("throws when explicit api-key mode cannot resolve any key", async () => {
     resolveApiKeyForProviderMock.mockRejectedValue(
       new Error('No API key found for provider "lmstudio". Auth store: /tmp/auth-profiles.json.'),

--- a/extensions/lmstudio/src/runtime.test.ts
+++ b/extensions/lmstudio/src/runtime.test.ts
@@ -135,6 +135,42 @@ describe("lmstudio-runtime", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("suppresses profile runtime auth when Authorization is configured", async () => {
+    resolveApiKeyForProviderMock.mockResolvedValueOnce({
+      apiKey: "stale-profile-key",
+      source: "profile:lmstudio:default",
+      mode: "api-key",
+    });
+
+    await expect(
+      resolveLmstudioRuntimeApiKey({
+        config: buildLmstudioConfig({
+          headers: {
+            Authorization: "Bearer proxy-token",
+          },
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("suppresses env runtime auth when Authorization is configured", async () => {
+    resolveApiKeyForProviderMock.mockResolvedValueOnce({
+      apiKey: "stale-env-key",
+      source: "env:LM_API_TOKEN",
+      mode: "api-key",
+    });
+
+    await expect(
+      resolveLmstudioRuntimeApiKey({
+        config: buildLmstudioConfig({
+          headers: {
+            Authorization: "Bearer proxy-token",
+          },
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("throws when explicit api-key mode cannot resolve any key", async () => {
     resolveApiKeyForProviderMock.mockRejectedValue(
       new Error('No API key found for provider "lmstudio". Auth store: /tmp/auth-profiles.json.'),

--- a/extensions/lmstudio/src/runtime.ts
+++ b/extensions/lmstudio/src/runtime.ts
@@ -60,6 +60,16 @@ function sanitizeStringHeaders(headers: unknown): Record<string, string> | undef
   return Object.keys(next).length > 0 ? next : undefined;
 }
 
+function shouldSuppressResolvedRuntimeApiKeyForHeaderAuth(
+  source: string | undefined,
+  hasAuthorizationHeader: boolean,
+): boolean {
+  if (!hasAuthorizationHeader || !source) {
+    return false;
+  }
+  return source.startsWith("profile:") || source.startsWith("env:");
+}
+
 export async function resolveLmstudioConfiguredApiKey(params: {
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -228,6 +238,9 @@ export async function resolveLmstudioRuntimeApiKey(params: {
   // Normalize empty/whitespace keys to undefined for callers.
   const resolvedApiKey = resolved.apiKey?.trim();
   if (!resolvedApiKey || resolvedApiKey.length === 0) {
+    return await resolveConfiguredApiKeyOrThrow();
+  }
+  if (shouldSuppressResolvedRuntimeApiKeyForHeaderAuth(resolved.source, hasAuthorizationHeader)) {
     return await resolveConfiguredApiKeyOrThrow();
   }
   if (isNonSecretApiKeyMarker(resolvedApiKey) && resolvedApiKey !== CUSTOM_LOCAL_AUTH_MARKER) {

--- a/extensions/lmstudio/src/runtime.ts
+++ b/extensions/lmstudio/src/runtime.ts
@@ -67,7 +67,7 @@ function shouldSuppressResolvedRuntimeApiKeyForHeaderAuth(
   if (!hasAuthorizationHeader || !source) {
     return false;
   }
-  return source.startsWith("profile:") || source.startsWith("env:");
+  return /^profile:|^(?:shell )?env(?::|$)/.test(source);
 }
 
 export async function resolveLmstudioConfiguredApiKey(params: {


### PR DESCRIPTION
## Summary
- suppress LM Studio runtime profile/env API keys when an `Authorization` header is configured
- normalize bare `host:port` LM Studio base URLs to fetchable `http://` endpoints
- add focused regression tests for both follow-up bugs

## Root cause
The merged LM Studio runtime still accepted profile/env-resolved API keys even when header auth was configured, so stale bearer credentials could override proxy headers. Separately, `new URL("localhost:1234")` was being treated as a custom scheme instead of an HTTP host, so common LM Studio base URL input could normalize to a non-fetchable endpoint.

## Validation
- `PATH="$HOME/.nvm/versions/node/v22.18.0/bin:/Users/termtek/Library/pnpm:$PATH" pnpm exec vitest run extensions/lmstudio/src/runtime.test.ts extensions/lmstudio/src/models.test.ts`
- `PATH="$HOME/.nvm/versions/node/v22.18.0/bin:/Users/termtek/Library/pnpm:$PATH" pnpm tsgo`
- `PATH="$HOME/.nvm/versions/node/v22.18.0/bin:/Users/termtek/Library/pnpm:$PATH" pnpm check`