### PR TITLE
fix(slack): print manifest JSON outside framed note for easy copying

### DIFF
--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -24,6 +24,7 @@ import { inspectSlackAccount } from "./account-inspect.js";
 import { resolveSlackAccount } from "./accounts.js";
 import {
   buildSlackSetupLines,
+  getSlackManifestJson,
   SLACK_CHANNEL as channel,
   isSlackSetupAccountConfigured,
   setSlackChannelAllowlist,
@@ -176,6 +177,16 @@ export function createSlackSetupWizardBase(handlers: {
       lines: buildSlackSetupLines(),
       shouldShow: ({ cfg, accountId }) =>
         !isSlackSetupAccountConfigured(resolveSlackAccount({ cfg, accountId })),
+    },
+    prepare: async ({ cfg, accountId }) => {
+      // Print the manifest JSON outside the framed note so users can
+      // copy-paste it without picking up ASCII box characters (#65751).
+      if (!isSlackSetupAccountConfigured(resolveSlackAccount({ cfg, accountId }))) {
+        const manifest = getSlackManifestJson();
+        console.log("\nSlack App Manifest (copy this JSON):\n");
+        console.log(manifest);
+        console.log();
+      }
     },
     envShortcut: {
       prompt: "SLACK_BOT_TOKEN + SLACK_APP_TOKEN detected. Use env vars?",

--- a/extensions/slack/src/shared.ts
+++ b/extensions/slack/src/shared.ts
@@ -99,7 +99,7 @@ function buildSlackManifest(botName: string) {
 
 export function buildSlackSetupLines(botName = "OpenClaw"): string[] {
   return [
-    "1) Slack API -> Create App -> From scratch or From manifest (with the JSON below)",
+    "1) Slack API -> Create App -> From scratch or From manifest",
     "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
     "3) Install App to workspace to get the xoxb- bot token",
     "4) Enable Event Subscriptions (socket) for message events",
@@ -107,9 +107,17 @@ export function buildSlackSetupLines(botName = "OpenClaw"): string[] {
     "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
     `Docs: ${formatDocsLink("/slack", "slack")}`,
     "",
-    "Manifest (JSON):",
-    buildSlackManifest(botName),
+    "The app manifest JSON will be printed below this box for easy copying.",
   ];
+}
+
+/**
+ * Return the Slack app manifest JSON string for the given bot name.
+ * Consumers can print this outside a framed note so users can copy
+ * the raw JSON without accidentally grabbing ASCII box characters.
+ */
+export function getSlackManifestJson(botName = "OpenClaw"): string {
+  return buildSlackManifest(botName);
 }
 
 export function setSlackChannelAllowlist(


### PR DESCRIPTION
## Summary

The Slack setup wizard (`openclaw channels add` → Slack) displays the app manifest JSON inside a `@clack/prompts` `note()` box. This wraps every line in ASCII box-drawing characters (`│`), making the JSON invalid when users copy it. They have to manually strip pipe characters before pasting into Slack API.

## Root Cause

`buildSlackSetupLines()` returned the manifest JSON as part of the note lines array, which `note()` wraps in a decorative frame:

```
│  {                                                     │
│    "display_information": {                            │
│      "name": "OpenClaw",                               │
```

Copying this gives you `│  {  │` instead of `{`.

## Fix

1. **Remove** the manifest JSON from the intro note lines
2. **Export** a new `getSlackManifestJson()` function from shared.ts
3. **Add** a `prepare()` hook that prints the manifest via `console.log` after the framed note — clean, raw JSON that can be copied directly

**Before:** Manifest trapped inside ASCII box frame → invalid JSON on copy  
**After:** Setup instructions in the box, manifest printed below as clean JSON

## Changes

- `extensions/slack/src/shared.ts`: Split manifest from setup lines, export `getSlackManifestJson()`
- `extensions/slack/src/setup-core.ts`: Add `prepare()` hook to print manifest after the intro note

Fixes #65751