### PR TITLE
fix: align timestampOptsFromConfig test with resolveUserTimezone UTC fallback

### DIFF
--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -339,7 +339,7 @@ describe("timestampOptsFromConfig", () => {
     {
       name: "falls back gracefully with empty config",
       cfg: {} as any,
-      expected: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      expected: Intl.DateTimeFormat().resolvedOptions().timeZone?.trim() || "UTC",
     },
   ])("$name", ({ cfg, expected }) => {
     expect(timestampOptsFromConfig(cfg).timezone).toBe(expected);


### PR DESCRIPTION
## Summary

Auto-detected and fixed test failure from full test suite run.

### Issue Found and Fixed

**1 test failure in `src/gateway/server-methods/server-methods.test.ts`**

- **Test**: `timestampOptsFromConfig > falls back gracefully with empty config`
- **Root cause**: The test expected `Intl.DateTimeFormat().resolvedOptions().timeZone` as the fallback value for empty config, but `resolveUserTimezone()` in `src/agents/date-time.ts` applies an additional `|| "UTC"` fallback when the host timezone is undefined/empty. In environments where `Intl.DateTimeFormat().resolvedOptions().timeZone` returns `undefined`, the source code correctly falls back to `"UTC"`, but the test expected `undefined`.
- **Fix**: Updated the test expected value to `Intl.DateTimeFormat().resolvedOptions().timeZone?.trim() || "UTC"` to match the actual `resolveUserTimezone` behavior.

### Verification

- `pnpm check` passes (lint + type-check + all custom checks)
- All 68 tests in `server-methods.test.ts` pass
- Pre-commit hooks pass
