### PR TITLE
fix: skip invalid PI custom model providers

### DIFF
--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -98,6 +98,19 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function filterProvidersUnsupportedByPiModelsJson(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  return Object.fromEntries(
+    Object.entries(providers).filter(([, provider]) => {
+      if (!provider.models?.length) {
+        return true;
+      }
+      return Boolean(provider.baseUrl && provider.apiKey);
+    }),
+  );
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -144,7 +157,9 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? mergedProviders;
-  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const finalProviders = filterProvidersUnsupportedByPiModelsJson(
+    applyNativeStreamingUsageCompat(secretEnforcedProviders),
+  );
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -7,6 +7,23 @@ import {
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
 import { createProviderAuthResolver } from "./models-config.providers.secrets.js";
 
+function makeModelDefinition(id: string) {
+  return {
+    id,
+    name: id,
+    reasoning: true,
+    input: ["text"] as Array<"text" | "image">,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: 128000,
+    maxTokens: 8192,
+  };
+}
+
 vi.mock("./models-config.providers.js", () => ({
   applyNativeStreamingUsageCompat: (providers: unknown) => providers,
   enforceSourceManagedProviderSecrets: ({ providers }: { providers: unknown }) => providers,
@@ -122,6 +139,49 @@ describe("models-config", () => {
         2,
       )}\n`,
     });
+  });
+
+  it("filters runtime-only providers that would invalidate PI custom models", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: { models: { providers: {} } },
+        agentDir: "/tmp/openclaw-agent",
+        env: {} as NodeJS.ProcessEnv,
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          volcengine: {
+            baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+            api: "openai-completions",
+            apiKey: "VOLCANO_ENGINE_API_KEY",
+            models: [makeModelDefinition("deepseek-v3-2-251201")],
+          },
+          "volcengine-plan": {
+            baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+            api: "openai-completions",
+            apiKey: "VOLCANO_ENGINE_API_KEY",
+            models: [makeModelDefinition("ark-code-latest")],
+          },
+          codex: {
+            baseUrl: "https://chatgpt.com/backend-api",
+            api: "openai-codex-responses",
+            models: [makeModelDefinition("gpt-5-codex")],
+          },
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    const providers =
+      plan.action === "write"
+        ? (JSON.parse(plan.contents) as { providers: Record<string, ProviderConfig> }).providers
+        : {};
+
+    expect(providers["volcengine"]).toBeDefined();
+    expect(providers["volcengine-plan"]).toBeDefined();
+    expect(providers["codex"]).toBeUndefined();
   });
 
   it("uses tokenRef env var when github-copilot profile omits plaintext token", () => {


### PR DESCRIPTION
## Summary

- Problem: `volcengine-plan/ark-code-latest` could fail at runtime with `Unknown model` because the generated PI-facing `models.json` included an invalid `codex` provider entry.
- Why it matters: once PI rejected the generated `models.json`, valid providers such as `volcengine` and `volcengine-plan` were also dropped from the runtime registry, blocking normal chat replies.
- What changed: filtered out generated providers that define custom `models` but do not satisfy PI `models.json` requirements (`baseUrl` + `apiKey`), and added regression coverage for this case.
- What did NOT change (scope boundary): did not change user-facing Volcengine config/auth flow, did not change PI runtime behavior, and did not change non-PI provider generation outside the generated `models.json` guardrail.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64799
- Related #64799
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the generated `~/.openclaw/agents/<agent>/agent/models.json` could include a `codex` provider with `models` and `api: "openai-codex-responses"` but without `apiKey`. `@mariozechner/pi-coding-agent` rejects custom-model providers in that shape, so loading the generated file failed and valid providers such as `volcengine` / `volcengine-plan` never entered the runtime registry.
- Missing detection / guardrail: there was no validation/filtering step preventing PI-incompatible generated providers from being written into the PI-facing `models.json`.
- Contributing context (if known): this surfaced after Codex-related provider generation changes in `2026.4.10`, where runtime-only / synthetic-auth provider data could end up in a file consumed by PI’s stricter custom-model loader.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts`
- Scenario the test should lock in: when implicit/generated providers include valid `volcengine` / `volcengine-plan` entries plus a runtime-only `codex` entry with `models` but no `apiKey`, the generated PI-facing `models.json` must keep the valid providers and exclude `codex`.
- Why this is the smallest reliable guardrail: the bug is caused at generation time, before runtime model lookup; the narrowest reliable protection is a generation-layer test that asserts the bad provider never enters the PI-facing file.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `volcengine-plan/ark-code-latest` no longer fails with `Unknown model` due to invalid generated provider entries poisoning PI `models.json`.
- Valid `volcengine` and `volcengine-plan` custom providers remain available in runtime model resolution even when runtime-only generated providers exist.
- No intended change to user config syntax, auth setup, or documented Volcengine model refs.

## Diagram (if applicable)

```text
Before:
[generated providers]
  -> [models.json includes codex with models but no apiKey]
  -> [PI rejects entire models.json]
  -> [volcengine-plan missing from registry]
  -> [Unknown model]

After:
[generated providers]
  -> [filter PI-incompatible providers before writing models.json]
  -> [PI loads models.json successfully]
  -> [volcengine-plan present in registry]
  -> [probe/chat succeeds]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: Node-based OpenClaw CLI + local macOS app/gateway
- Model/provider: `volcengine-plan/ark-code-latest`, `volcengine/deepseek-v3-2-251201`
- Integration/channel (if any): local gateway
- Relevant config (redacted): `VOLCANO_ENGINE_API_KEY` configured; default model set to `volcengine-plan/ark-code-latest`

### Steps

1. Install/use OpenClaw `2026.4.10` and configure local gateway + Volcengine auth.
2. Set default model to `volcengine-plan/ark-code-latest`.
3. Run `openclaw models status --agent main --probe` or try to chat.

### Expected

- `volcengine-plan/ark-code-latest` is accepted and resolves normally.
- Probe shows `ok` for both `volcengine` and `volcengine-plan`.

### Actual

- Runtime fails with `Unknown model: volcengine-plan/ark-code-latest`.
- PI registry rejects generated `models.json` because the generated `codex` provider defines `models` without `apiKey`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced the registry failure path and confirmed PI error: `Provider codex: "apiKey" is required when defining custom models.`
  - Confirmed that in the broken case `volcengine` / `volcengine-plan` disappear from the runtime registry.
  - Verified targeted regression test passes.
  - Verified `src/agents/pi-embedded-runner/model.test.ts` passes.
  - Verified full build passes.
  - Verified `openclaw models status --agent main --probe` returns:
    - `volcengine/deepseek-v3-2-251201 -> ok`
    - `volcengine-plan/ark-code-latest -> ok`
- Edge cases checked:
  - Valid generated providers with `models` + `apiKey` are preserved.
  - Invalid runtime-only provider with `models` but no `apiKey` is excluded.
- What you did **not** verify:
  - Did not add a full end-to-end macOS app regression test covering every provider generation path.
  - Did not validate unrelated provider families beyond the minimal PI-facing guardrail scenario.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: filtering generated providers too aggressively could exclude a provider that PI can actually load.
  - Mitigation: the guardrail only excludes providers that define custom `models` but are missing PI-required fields (`baseUrl` and `apiKey`), and regression coverage asserts valid providers remain.
- Risk: the issue could reappear through another provider shape not covered by this exact test.
  - Mitigation: the fix is generation-layer and generic for PI-incompatible custom-model providers, not hardcoded only to `codex`.