### PR TITLE
Fix image tool custom provider resolution for models.json

### DIFF
--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -410,16 +410,15 @@ export function resolveModelFromRegistry(params: {
     return model;
   }
 
-  const registry = params.modelRegistry as {
-    getAvailable?: () => unknown[];
-    getAll?: () => unknown[];
-  };
-  const candidates =
-    typeof registry.getAvailable === "function"
-      ? registry.getAvailable()
-      : typeof registry.getAll === "function"
-      ? registry.getAll()
+  const fromAvailable =
+    typeof params.modelRegistry.getAvailable === "function"
+      ? params.modelRegistry.getAvailable()
       : [];
+  const fromAll =
+    typeof params.modelRegistry.getAll === "function"
+      ? params.modelRegistry.getAll()
+      : [];
+  const candidates = [...fromAvailable, ...fromAll];
 
   for (const candidate of candidates) {
     if (!isRecord(candidate)) {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -8,6 +8,7 @@ import {
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
 import { normalizeProviderId } from "../provider-id.js";
+import { isRecord } from "../../utils.js";
 import { ToolInputError, readStringArrayParam, readStringParam } from "./common.js";
 import type { ImageModelConfig } from "./image-tool.helpers.js";
 import {
@@ -396,15 +397,40 @@ export function buildTextToolResult(
 }
 
 export function resolveModelFromRegistry(params: {
-  modelRegistry: { find: (provider: string, modelId: string) => unknown };
+  modelRegistry: {
+    find: (provider: string, modelId: string) => unknown;
+    getAvailable?: () => unknown[];
+    getAll?: () => unknown[];
+  };
   provider: string;
   modelId: string;
 }): Model<Api> {
   const model = params.modelRegistry.find(params.provider, params.modelId) as Model<Api> | null;
-  if (!model) {
-    throw new Error(`Unknown model: ${params.provider}/${params.modelId}`);
+  if (model) {
+    return model;
   }
-  return model;
+
+  const registry = params.modelRegistry as {
+    getAvailable?: () => unknown[];
+    getAll?: () => unknown[];
+  };
+  const candidates =
+    typeof registry.getAvailable === "function"
+      ? registry.getAvailable()
+      : typeof registry.getAll === "function"
+      ? registry.getAll()
+      : [];
+
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+    if (candidate.provider === params.provider && candidate.id === params.modelId) {
+      return candidate as Model<Api>;
+    }
+  }
+
+  throw new Error(`Unknown model: ${params.provider}/${params.modelId}`);
 }
 
 export async function resolveModelRuntimeApiKey(params: {

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -324,4 +324,50 @@ describe("describeImageWithModel", () => {
     );
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
   });
+
+  it("falls back to available registry entries for custom providers", async () => {
+    const findMock = vi.fn(() => null);
+    const getAvailableMock = vi.fn(() => [
+      {
+        provider: "custom-proxy",
+        id: "glm-5v-turbo",
+        input: ["text", "image"],
+        baseUrl: "https://custom-proxy.example.com",
+      },
+    ]);
+    discoverModelsMock.mockReturnValue({
+      find: findMock,
+      getAvailable: getAvailableMock,
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-completions",
+      provider: "custom-proxy",
+      model: "glm-5v-turbo",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "custom provider ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "custom-proxy",
+      model: "glm-5v-turbo",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "custom provider ok",
+      model: "glm-5v-turbo",
+    });
+    expect(findMock).toHaveBeenCalledOnce();
+    expect(getAvailableMock).toHaveBeenCalledOnce();
+    expect(getApiKeyForModelMock).toHaveBeenCalled();
+    expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("custom-proxy", "oauth-test");
+  });
 });

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -8,6 +8,7 @@ import {
 } from "../agents/model-auth.js";
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
+import { resolveModelFromRegistry } from "../agents/tools/media-tool-shared.js";
 import { coerceImageAssistantText } from "../agents/tools/image-tool.helpers.js";
 import type {
   ImageDescriptionRequest,
@@ -49,10 +50,11 @@ async function resolveImageRuntime(params: {
   const authStorage = discoverAuthStorage(params.agentDir);
   const modelRegistry = discoverModels(authStorage, params.agentDir);
   const resolvedRef = normalizeModelRef(params.provider, params.model);
-  const model = modelRegistry.find(resolvedRef.provider, resolvedRef.model) as Model<Api> | null;
-  if (!model) {
-    throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
-  }
+  const model = resolveModelFromRegistry({
+    modelRegistry,
+    provider: resolvedRef.provider,
+    modelId: resolvedRef.model,
+  });
   if (!model.input?.includes("image")) {
     throw new Error(`Model does not support images: ${params.provider}/${params.model}`);
   }


### PR DESCRIPTION
Fix an image tool bug where custom providers defined in models.json were not resolved by the image tool's ModelRegistry lookup. The fix adds a registry fallback for custom providers when find() returns nothing and updates the image tool to use it. Includes a regression test for custom provider model resolution.