### PR TITLE
fix(onboarding): set onboardingScopes for video-only providers runway and alibaba

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ Docs: https://docs.openclaw.ai
 - Providers/MiniMax: register `minimax-portal` for music and video generation,
   preserving OAuth auth and regional MiniMax base URLs across the shared
   `music_generate` and `video_generate` tools. (#63241) Thanks @tars90percent.
+- Providers/onboarding: keep Runway and Alibaba Model Studio out of the
+  text-inference setup picker by scoping their video-generation auth choices to
+  the media setup flow. (#65856) Thanks @Jah-yee.
 - Plugins/Bonjour: stop the gateway from crash-looping on `CIAO PROBING CANCELLED` when the mDNS watchdog cancels a stuck probe. Restores the rejection-handler wiring dropped during the bonjour plugin migration and shares unhandled-rejection state across module instances so plugin-staged copies of `openclaw/plugin-sdk/runtime` register into the same handler set the host consults. Especially affects Docker on macOS, where mDNS probing reliably hits the watchdog. Thanks @troyhitch.
 - Google Meet: report pinned Chrome nodes as offline or missing capabilities in
   setup/join diagnostics, keep inaccessible nodes out of auto-selection, and

--- a/extensions/alibaba/openclaw.plugin.json
+++ b/extensions/alibaba/openclaw.plugin.json
@@ -13,6 +13,7 @@
       "groupId": "alibaba",
       "groupLabel": "Alibaba Model Studio",
       "groupHint": "DashScope / Model Studio API key",
+      "onboardingScopes": ["image-generation"],
       "optionKey": "alibabaModelStudioApiKey",
       "cliFlag": "--alibaba-model-studio-api-key",
       "cliOption": "--alibaba-model-studio-api-key <key>",

--- a/extensions/runway/openclaw.plugin.json
+++ b/extensions/runway/openclaw.plugin.json
@@ -13,6 +13,7 @@
       "groupId": "runway",
       "groupLabel": "Runway",
       "groupHint": "API key",
+      "onboardingScopes": ["image-generation"],
       "optionKey": "runwayApiKey",
       "cliFlag": "--runway-api-key",
       "cliOption": "--runway-api-key <key>",

--- a/src/plugins/contracts/registry.contract.test.ts
+++ b/src/plugins/contracts/registry.contract.test.ts
@@ -104,6 +104,24 @@ describe("plugin contract registry", () => {
     });
   });
 
+  it("keeps video-only provider auth choices out of text onboarding", () => {
+    const registry = loadPluginManifestRegistry({});
+
+    for (const pluginId of ["alibaba", "runway"]) {
+      const plugin = registry.plugins.find(
+        (entry) => entry.origin === "bundled" && entry.id === pluginId,
+      );
+      expect(plugin?.providerAuthChoices).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            provider: pluginId,
+            onboardingScopes: ["image-generation"],
+          }),
+        ]),
+      );
+    }
+  });
+
   it("covers every bundled speech plugin discovered from manifests", () => {
     expectRegistryPluginIds({
       actualPluginIds: pluginRegistrationContractRegistry


### PR DESCRIPTION
## Summary

- **Problem:** `runway` and `alibaba` are video-generation-only providers (no text `providers` key in their manifests, only `contracts.videoGenerationProviders`). Their `providerAuthChoices` do not set `onboardingScopes`, which defaults to `["text-inference"]` per `src/plugins/manifest.ts`. This causes them to appear in the text model onboarding wizard, where they are irrelevant.
- **Why it matters:** Users running `openclaw configure` to set up a text model see Runway and Alibaba Model Studio in the provider list, even though these providers only do video generation. This is confusing and adds noise to the setup flow.
- **What changed:** Added `onboardingScopes: ["image-generation"]` to `providerAuthChoices` in both `extensions/runway/openclaw.plugin.json` and `extensions/alibaba/openclaw.plugin.json`. This matches the pattern used by `fal` and `vydra` (other media-only providers).
- **What did NOT change (scope boundary):** No runtime logic, no new dependencies, no type changes. Only two manifest fields added.

### Audit

| Provider | Has text `providers`? | Video-only contracts? | Had `onboardingScopes`? | Action |
|---|---|---|---|---|
| **runway** | No | Yes | No (defaulted to `text-inference`) | Set `image-generation` |
| **alibaba** | No | Yes | No (defaulted to `text-inference`) | Set `image-generation` |
| fal | No | Yes (image + video) | Yes (`image-generation`) | Already correct |
| vydra | No | Yes (image + video + speech) | Yes (`image-generation`) | Already correct |
| byteplus | **Yes** | Also video | No | Correct (IS a text provider) |
| together | **Yes** | Also video | No | Correct (IS a text provider) |

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65854
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `runway` and `alibaba` were contributed as video-only providers without explicit `onboardingScopes`. The default (`text-inference`) was inherited silently.
- **Missing detection / guardrail:** No automated check validates that providers without text capabilities are not scoped to `text-inference` onboarding.
- **Contributing context:** The `onboardingScopes` field was added after these providers were initially contributed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- **If no new test is added, why not:** This is a manifest metadata fix. The onboarding flow reads `onboardingScopes` from the manifest at runtime; there is no dedicated test for "which providers appear in which wizard" beyond the existing `provider-flow.ts` logic. A manifest-level assertion could be added in a follow-up if desired.

## User-visible / Behavior Changes

1. Runway and Alibaba Model Studio will no longer appear in the text-inference onboarding wizard
2. They will appear in the image-generation wizard instead (alongside fal, vydra)

## Diagram (if applicable)

```text
Before:
[openclaw configure] -> text model wizard -> shows: [..., Runway, Alibaba, ...]

After:
[openclaw configure] -> text model wizard -> shows: [...] (no Runway/Alibaba)
[openclaw configure] -> image/video wizard -> shows: [..., Runway, Alibaba, fal, vydra, ...]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (darwin 25.1.0)
- Runtime/container: Node 22+, pnpm
- Model/provider: runway, alibaba
- Integration/channel: N/A

### Steps

1. Check `extensions/runway/openclaw.plugin.json` for `onboardingScopes: ["image-generation"]`
2. Check `extensions/alibaba/openclaw.plugin.json` for `onboardingScopes: ["image-generation"]`
3. Pre-commit hooks pass

### Expected

- Both manifests correctly scoped; hooks pass

### Actual

- Confirmed

## Evidence

- [x] Trace/log snippets
- Pre-commit hooks (lint + typecheck + format) pass
- Manifest diff review confirms only `onboardingScopes` added

## Human Verification (required)

- **Verified scenarios:** Diff review; confirmed `byteplus` and `together` are NOT changed (they have text `providers` so `text-inference` default is correct)
- **Edge cases checked:** Only providers with no text `providers` key AND only video contracts are changed
- **What you did NOT verify:** Interactive onboarding UI rendering (would need `openclaw configure` flow)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Users who previously found Runway/Alibaba in the text wizard and used that path will now need to look in the image-generation wizard.
  - **Mitigation:** These are video-only providers with no text model support. Appearing in text-inference onboarding was always incorrect. Users can still configure them via `openclaw config set` or env vars regardless of wizard visibility.
