### PR TITLE
fix(gateway): point fallback override guidance to valid docs page

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -662,7 +662,7 @@ describe("loadGatewayPlugins", () => {
         }),
       ),
     ).rejects.toThrow(
-      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: plugins.entries.<id>.subagent.allowModelOverride',
+      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime and search for: plugins.entries.<id>.subagent.allowModelOverride',
     );
   });
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -162,7 +162,7 @@ function authorizeFallbackModelOverride(params: {
       allowed: false,
       reason:
         `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
-        "See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: " +
+        "See https://docs.openclaw.ai/plugins/sdk-runtime and search for: " +
         "plugins.entries.<id>.subagent.allowModelOverride",
     };
   }


### PR DESCRIPTION
## Summary
- fixes #65860
- update fallback override authorization error guidance in `src/gateway/server-plugins.ts` to point at a valid documentation page (`/plugins/sdk-runtime`) instead of a missing anchor
- update the corresponding expectation in `src/gateway/server-plugins.test.ts`

## Why
The previous URL (`/tools/plugin#runtime-helpers`) points to an anchor that does not exist, so users hitting this error could not find the configuration guidance for `plugins.entries.<id>.subagent.allowModelOverride`.

## Changes
- `src/gateway/server-plugins.ts`
  - replace docs URL in the fallback override rejection message
- `src/gateway/server-plugins.test.ts`
  - align assertion string with the updated docs URL

## Validation
- `pnpm vitest run src/gateway/server-plugins.test.ts`

## Notes
- no behavior changes beyond user-facing error guidance text
- no maintainer mention needed per request; local test passed before submission

Made with [Cursor](https://cursor.com)