### PR TITLE
chore(labeler): remove dead minimax-portal-auth rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -281,10 +281,6 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/cloudflare-ai-gateway/**"
-"extensions: minimax-portal-auth":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "extensions/minimax-portal-auth/**"
 "extensions: huggingface":
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Summary
- fixes #65861
- remove the stale `extensions: minimax-portal-auth` labeler rule from `.github/labeler.yml`

## Why
The rule targets `extensions/minimax-portal-auth/**`, but that directory does not exist in this repository. The label can never be auto-applied and adds config noise.

## Changes
- `.github/labeler.yml`
  - delete the `extensions: minimax-portal-auth` block

## Validation
- `pnpm check:no-conflict-markers`

## Notes
- config-only cleanup, no runtime behavior changes
- local validation passed before PR creation

Made with [Cursor](https://cursor.com)