### PR TITLE
docs(providers): add Bedrock Mantle to provider index pages

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -28,6 +28,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 - [Alibaba Model Studio](/providers/alibaba)
 - [Amazon Bedrock](/providers/bedrock)
+- [Amazon Bedrock Mantle](/providers/bedrock-mantle)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Arcee AI (Trinity models)](/providers/arcee)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -27,6 +27,7 @@ model as `provider/model`.
 - [Alibaba Model Studio](/providers/alibaba)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Amazon Bedrock](/providers/bedrock)
+- [Amazon Bedrock Mantle](/providers/bedrock-mantle)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)
 - [Chutes](/providers/chutes)
 - [ComfyUI](/providers/comfy)


### PR DESCRIPTION
## Summary
- fixes #65863
- add missing `Amazon Bedrock Mantle` links to provider index documents

## Why
`docs/providers/bedrock-mantle.md` already exists as a standalone provider page, but it was missing from both provider index lists, making discovery harder.

## Changes
- `docs/providers/index.md`
  - add `Amazon Bedrock Mantle` under provider docs
- `docs/providers/models.md`
  - add `Amazon Bedrock Mantle` under starter provider list

## Validation
- `pnpm check:no-conflict-markers`

## Notes
- docs-only change
- local validation passed before PR creation

Made with [Cursor](https://cursor.com)