### PR TITLE
docs(zalouser): document profile environment overrides

### DIFF
--- a/docs/channels/zalouser.md
+++ b/docs/channels/zalouser.md
@@ -163,6 +163,15 @@ Accounts map to `zalouser` profiles in OpenClaw state. Example:
 }
 ```
 
+### Profile environment overrides
+
+`zalouser` also supports profile selection through environment variables:
+
+- `ZALOUSER_PROFILE`: preferred profile override for the active account.
+- `ZCA_PROFILE`: fallback profile override used when `ZALOUSER_PROFILE` is not set.
+
+Resolution order is: account config `profile` -> `ZALOUSER_PROFILE` -> `ZCA_PROFILE` -> account id/default.
+
 ## Typing, reactions, and delivery acknowledgements
 
 - OpenClaw sends a typing event before dispatching a reply (best-effort).


### PR DESCRIPTION
## Summary
- fixes #65864
- document `ZALOUSER_PROFILE` and `ZCA_PROFILE` in the Zalo Personal channel docs

## Why
The runtime already reads these environment variables for profile resolution, but users had no discoverable documentation in `docs/channels/zalouser.md`.

## Changes
- `docs/channels/zalouser.md`
  - add a `Profile environment overrides` section under multi-account docs
  - describe both variables and their fallback order

## Validation
- `pnpm check:no-conflict-markers`

## Notes
- docs-only update
- local validation passed before PR creation

Made with [Cursor](https://cursor.com)