### PR TITLE
docs(minimax): add speech environment override guidance

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -337,6 +337,19 @@ Config lives under `plugins.entries.minimax.config.webSearch.*`.
 See [MiniMax Search](/tools/minimax-search) for full web search configuration and usage.
 </Note>
 
+### Speech environment overrides
+
+MiniMax speech synthesis also supports environment overrides when you do not
+set per-provider config values:
+
+- `MINIMAX_API_HOST`: base URL for MiniMax speech requests.
+- `MINIMAX_TTS_MODEL`: default speech model (fallback default: `speech-2.8-hd`).
+- `MINIMAX_TTS_VOICE_ID`: default voice id (fallback default:
+  `English_expressive_narrator`).
+
+Resolution order is: explicit speech provider config -> environment override ->
+built-in default.
+
 ## Advanced configuration
 
 <AccordionGroup>


### PR DESCRIPTION
## Summary
- fixes #65866
- document MiniMax speech-related environment overrides in provider docs

## Why
The speech provider supports `MINIMAX_TTS_MODEL` and `MINIMAX_TTS_VOICE_ID`, but `docs/providers/minimax.md` did not mention them, making non-default speech setup hard to discover.

## Changes
- `docs/providers/minimax.md`
  - add `Speech environment overrides` section
  - document `MINIMAX_API_HOST`, `MINIMAX_TTS_MODEL`, and `MINIMAX_TTS_VOICE_ID`
  - clarify config resolution order

## Validation
- `pnpm check:no-conflict-markers`

## Notes
- docs-only change
- local validation passed before PR creation

Made with [Cursor](https://cursor.com)