### PR TITLE
feat(plugins): pass attachment metadata to before_model_resolve hook

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -264,7 +264,7 @@ export async function runEmbeddedPiAgent(
 
       const attachments = (params.images ?? []).map((img) => ({
         kind: "image" as const,
-        mimeType: img.media_type,
+        mimeType: img.mimeType,
       }));
 
       const hookSelection = await resolveHookModelSelection({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -262,8 +262,14 @@ export async function runEmbeddedPiAgent(
         channelId: params.messageChannel ?? params.messageProvider ?? undefined,
       };
 
+      const attachments = (params.images ?? []).map((img) => ({
+        kind: "image" as const,
+        mimeType: img.media_type,
+      }));
+
       const hookSelection = await resolveHookModelSelection({
         prompt: params.prompt,
+        attachments: attachments.length > 0 ? attachments : undefined,
         provider,
         modelId,
         hookRunner,

--- a/src/agents/pi-embedded-runner/run/setup.ts
+++ b/src/agents/pi-embedded-runner/run/setup.ts
@@ -26,7 +26,7 @@ type HookContext = {
 type HookRunnerLike = {
   hasHooks(hookName: string): boolean;
   runBeforeModelResolve(
-    input: { prompt: string },
+    input: { prompt: string; attachments?: { kind: string; mimeType?: string }[] },
     context: HookContext,
   ): Promise<{ providerOverride?: string; modelOverride?: string } | undefined>;
   runBeforeAgentStart(
@@ -37,6 +37,7 @@ type HookRunnerLike = {
 
 export async function resolveHookModelSelection(params: {
   prompt: string;
+  attachments?: { kind: string; mimeType?: string }[];
   provider: string;
   modelId: string;
   hookRunner?: HookRunnerLike | null;
@@ -56,7 +57,7 @@ export async function resolveHookModelSelection(params: {
   if (hookRunner?.hasHooks("before_model_resolve")) {
     try {
       modelResolveOverride = await hookRunner.runBeforeModelResolve(
-        { prompt: params.prompt },
+        { prompt: params.prompt, attachments: params.attachments },
         params.hookContext,
       );
     } catch (hookErr) {

--- a/src/plugins/hook-before-agent-start.types.ts
+++ b/src/plugins/hook-before-agent-start.types.ts
@@ -1,7 +1,14 @@
 // before_model_resolve hook
+export type PluginHookBeforeModelResolveAttachment = {
+  kind: "image" | "video" | "audio" | "document" | "other";
+  mimeType?: string;
+};
+
 export type PluginHookBeforeModelResolveEvent = {
   /** User prompt for this run. No session messages are available yet in this phase. */
   prompt: string;
+  /** Attachment metadata for file-aware model routing. */
+  attachments?: PluginHookBeforeModelResolveAttachment[];
 };
 
 export type PluginHookBeforeModelResolveResult = {


### PR DESCRIPTION
## Summary

- Add optional `attachments` field to `PluginHookBeforeModelResolveEvent` so plugins can inspect file metadata (kind + mimeType) during model resolution
- Thread `params.images` through `resolveHookModelSelection` as attachment hints
- Introduce `PluginHookBeforeModelResolveAttachment` type (`kind: "image" | "video" | "audio" | "document" | "other"`, `mimeType?: string`)

## Motivation

Plugins that implement cost-aware model routing (e.g. routing image-heavy messages to Gemini Flash instead of Sonnet) currently cannot inspect whether the user message contains attachments. The `before_model_resolve` hook only receives `{ prompt: string }`, so file-type-based routing is impossible.

This is a minimal, backwards-compatible change: `attachments` is optional, and existing plugins continue to work without modification.

## Changes

| File | Change |
|------|--------|
| `src/plugins/hook-before-agent-start.types.ts` | Add `PluginHookBeforeModelResolveAttachment` type and optional `attachments` field |
| `src/agents/pi-embedded-runner/run/setup.ts` | Accept and forward `attachments` in `resolveHookModelSelection` |
| `src/agents/pi-embedded-runner/run.ts` | Build attachment metadata from `params.images` and pass to hook |

> Supersedes #65831 (submitted from wrong fork account).

## Test plan

- [ ] Existing plugin tests pass (no breaking changes — field is optional)
- [ ] Plugin receiving `attachments` can read kind/mimeType correctly
- [ ] When no images are present, `attachments` is `undefined` (not empty array)