### PR TITLE
fix(ci): ignore generated a2ui watch dirt

### DIFF
--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -17,6 +17,8 @@ import {
 import { withTempDir } from "../test-helpers/temp-dir.js";
 
 const ROOT_SRC = "src/index.ts";
+const A2UI_BUNDLE = "src/canvas-host/a2ui/a2ui.bundle.js";
+const A2UI_BUNDLE_HASH = "src/canvas-host/a2ui/.bundle.hash";
 const ROOT_TSCONFIG = "tsconfig.json";
 const ROOT_PACKAGE = "package.json";
 const ROOT_TSDOWN = "tsdown.config.ts";
@@ -1053,6 +1055,39 @@ describe("run-node script", () => {
       expect(requirement).toEqual({
         shouldBuild: true,
         reason: "dirty_watched_tree",
+      });
+    });
+  });
+
+  it("ignores generated a2ui bundle adjunct files when checking dirty watched trees", async () => {
+    await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
+      await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+          [A2UI_BUNDLE]: "export default {};\n",
+          [A2UI_BUNDLE_HASH]: "abc123\n",
+        },
+        buildPaths: [
+          ROOT_SRC,
+          A2UI_BUNDLE,
+          A2UI_BUNDLE_HASH,
+          ROOT_TSCONFIG,
+          ROOT_PACKAGE,
+          DIST_ENTRY,
+          BUILD_STAMP,
+        ],
+      });
+
+      const requirement = resolveBuildRequirement(
+        createBuildRequirementDeps(tmp, {
+          gitHead: "abc123\n",
+          gitStatus: ` M ${A2UI_BUNDLE}\n M ${A2UI_BUNDLE_HASH}\n`,
+        }),
+      );
+
+      expect(requirement).toEqual({
+        shouldBuild: false,
+        reason: "clean",
       });
     });
   });


### PR DESCRIPTION
## Summary
- ignore generated A2UI bundle adjunct files when checking run-node dirty watched trees
- keep real source/config dirt triggering the existing dirty_watched_tree behavior
- add a regression test covering generated A2UI bundle dirt

## Why
- `check-additional` is failing across multiple unrelated PRs in `gateway-watch-regression`
- the current harness builds first, then invalidates itself when generated A2UI bundle files under `src/` appear as watched-tree dirt
- these files are build outputs, not authored source edits, so they should not invalidate the watch regression preflight

## Verification
- `cd /tmp/openclaw-gpt5-fix && node node_modules/vitest/vitest.mjs run src/infra/run-node.test.ts -t 'dirty watched tree|a2ui bundle adjunct'`

## Notes
- normal pre-commit `pnpm check` hit the known `pnpm tsgo` SIGTERM resource issue in this environment
- changed-files lint passed before that, and the targeted regression test passed
