### PR TITLE
fix: update Brave Search docsUrl to canonical /tools/brave-search path

### DIFF
--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -122,7 +122,7 @@ export function createBraveWebSearchProvider(): WebSearchProviderPlugin {
     envVars: ["BRAVE_API_KEY"],
     placeholder: "BSA...",
     signupUrl: "https://brave.com/search/api/",
-    docsUrl: "https://docs.openclaw.ai/brave-search",
+    docsUrl: "https://docs.openclaw.ai/tools/brave-search",
     autoDetectOrder: 10,
     credentialPath: "plugins.entries.brave.config.webSearch.apiKey",
     inactiveSecretPaths: ["plugins.entries.brave.config.webSearch.apiKey"],

--- a/extensions/brave/web-search-contract-api.ts
+++ b/extensions/brave/web-search-contract-api.ts
@@ -15,7 +15,7 @@ export function createBraveWebSearchProvider(): WebSearchProviderPlugin {
     envVars: ["BRAVE_API_KEY"],
     placeholder: "BSA...",
     signupUrl: "https://brave.com/search/api/",
-    docsUrl: "https://docs.openclaw.ai/brave-search",
+    docsUrl: "https://docs.openclaw.ai/tools/brave-search",
     autoDetectOrder: 10,
     credentialPath,
     ...createWebSearchProviderContractFields({


### PR DESCRIPTION
## Problem

The `docsUrl` field in both Brave Search provider files points to the legacy path `/brave-search` instead of the canonical `/tools/brave-search`.

While a redirect exists in `docs.json`, the code should reference the canonical URL directly.

## Changes

- `extensions/brave/web-search-contract-api.ts`: Updated `docsUrl`
- `extensions/brave/src/brave-web-search-provider.ts`: Updated `docsUrl`

Both changed from `https://docs.openclaw.ai/brave-search` to `https://docs.openclaw.ai/tools/brave-search`.

Closes #65870
