### PR TITLE
fix(openai): improve debuggability of codex cli auth file reading

### DIFF
--- a/extensions/openai/openai-codex-cli-auth.ts
+++ b/extensions/openai/openai-codex-cli-auth.ts
@@ -44,8 +44,8 @@ function readCodexCliAuthFile(env: NodeJS.ProcessEnv): CodexCliAuthFile | null {
     return parsed && typeof parsed === "object" ? (parsed as CodexCliAuthFile) : null;
   } catch (error) {
     if (error instanceof Error) {
-      const code = 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
-      if (code === 'ENOENT') {
+      const code = "code" in error ? (error as NodeJS.ErrnoException).code : undefined;
+      if (code === "ENOENT") {
         return null;
       }
       console.debug(`[openai-codex-cli-auth] Failed to read auth file: ${error.message}`);

--- a/extensions/openai/openai-codex-cli-auth.ts
+++ b/extensions/openai/openai-codex-cli-auth.ts
@@ -42,7 +42,16 @@ function readCodexCliAuthFile(env: NodeJS.ProcessEnv): CodexCliAuthFile | null {
     const raw = fs.readFileSync(authPath, "utf8");
     const parsed = JSON.parse(raw);
     return parsed && typeof parsed === "object" ? (parsed as CodexCliAuthFile) : null;
-  } catch {
+  } catch (error) {
+    if (error instanceof Error) {
+      const code = 'code' in error ? (error as NodeJS.ErrnoException).code : undefined;
+      if (code === 'ENOENT') {
+        return null;
+      }
+      console.debug(`[openai-codex-cli-auth] Failed to read auth file: ${error.message}`);
+    } else {
+      console.debug(`[openai-codex-cli-auth] Failed to read auth file: ${String(error)}`);
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- **Problem**: `readCodexCliAuthFile` used an empty catch block that swallowed all errors, making debugging impossible when auth file reading failed for non-ENOENT reasons.
- **Why it matters**: Silent failures hide real issues (e.g., permission errors, malformed JSON) and slow down troubleshooting for both users and maintainers.
- **What changed**: Added selective error logging:
  - Still silently returns `null` for `ENOENT` (file not found) to preserve existing behavior
  - Logs all other errors with `console.debug` for debuggability
- **What did NOT change (scope boundary)**:
  - Core functionality (still returns `null` on any failure)
  - User-visible behavior (no breaking changes)
  - File not found handling (still silent for `ENOENT`)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (OpenAI extension)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (if applicable, else remove)
- Related # (if applicable, else remove)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause**: Empty catch block in `readCodexCliAuthFile` swallowed all exceptions without distinction.
- **Missing detection / guardrail**: No logging for non-ENOENT failures.
- **Contributing context (if known)**: N/A

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this**:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file**: `extensions/openai/openai-codex-cli-auth.test.ts` (if exists)
- **Scenario the test should lock in**:
  - File not found (`ENOENT`): returns `null`, no log
  - Permission denied (`EACCES`): returns `null`, logs debug message
  - Malformed JSON: returns `null`, logs debug message
- **Why this is the smallest reliable guardrail**: Directly tests the error handling logic without external dependencies.
- **Existing test that already covers this (if any)**: N/A
- **If no new test is added, why not**: This is a minimal debuggability improvement with no behavior changes; existing coverage for core functionality is sufficient.

## User-visible / Behavior Changes

None. This change preserves all existing behavior while adding debug logging for non-ENOENT failures.

## Diagram (if applicable)

```text
Before:
[read auth file] -> [any error] -> [silent return null] (impossible to debug)

After:
[read auth file] -> [ENOENT?] -> [yes] -> [silent return null] (preserve existing)
                    [no] -> [log debug message] -> [return null] (improved debuggability)