### PR TITLE
fix: add local build context to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    build: .
     environment:
       HOME: /home/node
       TERM: xterm-256color


### PR DESCRIPTION
Added \build: .` to the openclaw-gateway service in docker-compose.yml. This resolves the "pull access denied" error for users attempting a pure local deployment (e.g., using `docker compose up --build`), as it currently fails when attempting to pull the nonexistent `openclaw:local` image from remote registries.`

