### PR TITLE
docs: add Bedrock Mantle provider to index and models pages

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -28,6 +28,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 - [Alibaba Model Studio](/providers/alibaba)
 - [Amazon Bedrock](/providers/bedrock)
+- [Amazon Bedrock Mantle](/providers/bedrock-mantle)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Arcee AI (Trinity models)](/providers/arcee)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -27,6 +27,7 @@ model as `provider/model`.
 - [Alibaba Model Studio](/providers/alibaba)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Amazon Bedrock](/providers/bedrock)
+- [Amazon Bedrock Mantle](/providers/bedrock-mantle)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)
 - [Chutes](/providers/chutes)
 - [ComfyUI](/providers/comfy)


### PR DESCRIPTION
## Problem

`docs/providers/index.md` and `docs/providers/models.md` list all supported providers but omit the existing `docs/providers/bedrock-mantle.md` page (Amazon Bedrock Mantle — a distinct provider from standard Bedrock Converse).

## Changes

- `docs/providers/index.md`: Added `[Amazon Bedrock Mantle](/providers/bedrock-mantle)` entry after Amazon Bedrock
- `docs/providers/models.md`: Added the same entry

Closes #65863
