### PR TITLE
feat(docs): add Hostinger installation guide and link in VPS document…

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -976,6 +976,7 @@
                   "install/fly",
                   "install/gcp",
                   "install/hetzner",
+                  "install/hostinger",
                   "install/kubernetes",
                   "vps",
                   "install/macos-vm",

--- a/docs/install/hostinger.md
+++ b/docs/install/hostinger.md
@@ -1,0 +1,85 @@
+---
+summary: "Host OpenClaw on Hostinger"
+read_when:
+  - Setting up OpenClaw on Hostinger
+  - Looking for a managed VPS for OpenClaw
+  - Using Hostinger 1-Click OpenClaw
+title: "Hostinger"
+---
+
+# Hostinger
+
+Run a persistent OpenClaw Gateway on [Hostinger](https://www.hostinger.com/openclaw) via a **1-Click** managed deployment or a **VPS** install.
+
+## Prerequisites
+
+- Hostinger account ([signup](https://www.hostinger.com/openclaw))
+- About 5-10 minutes
+
+## Option A: 1-Click OpenClaw
+
+The fastest way to get started. Hostinger handles infrastructure, Docker, and automatic updates.
+
+<Steps>
+  <Step title="Purchase and launch">
+    1. From the [Hostinger OpenClaw page](https://www.hostinger.com/openclaw), choose a Managed OpenClaw plan and complete checkout.
+
+    <Note>
+    During checkout you can select **Ready-to-Use AI** credits that are pre-purchased and integrated instantly inside OpenClaw -- no external accounts or API keys from other providers needed. You can start chatting right away. Alternatively, provide your own key from Anthropic, OpenAI, Google Gemini, or xAI during setup.
+    </Note>
+  </Step>
+
+  <Step title="Select a messaging channel">
+    Choose one or more channels to connect:
+
+    - **WhatsApp** -- scan the QR code shown in the setup wizard.
+    - **Telegram** -- paste the bot token from [BotFather](https://t.me/BotFather).
+  </Step>
+
+  <Step title="Complete installation">
+    Click **Finish** to deploy the instance. Once ready, access the OpenClaw dashboard from **OpenClaw Overview** in hPanel.
+  </Step>
+
+</Steps>
+
+## Option B: OpenClaw on VPS
+
+More control over your server. Hostinger deploys OpenClaw via Docker on your VPS and you manage it through the **Docker Manager** in hPanel.
+
+<Steps>
+  <Step title="Purchase a VPS">
+    1. From the [Hostinger OpenClaw page](https://www.hostinger.com/openclaw), choose an OpenClaw on VPS plan and complete checkout.
+
+    <Note>
+    You can select **Ready-to-Use AI** credits during checkout -- these are pre-purchased and integrated instantly inside OpenClaw, so you can start chatting without any external accounts or API keys from other providers.
+    </Note>
+  </Step>
+
+  <Step title="Configure OpenClaw">
+    Once the VPS is provisioned, fill in the configuration fields:
+
+    - **Gateway token** -- auto-generated; save it for later use.
+    - **WhatsApp number** -- your number with country code (optional).
+    - **Telegram bot token** -- from [BotFather](https://t.me/BotFather) (optional).
+    - **API keys** -- only needed if you did not select Ready-to-Use AI credits during checkout.
+  </Step>
+
+  <Step title="Start OpenClaw">
+    Click **Deploy**. Once running, open the OpenClaw dashboard from the hPanel by clicking on **Open**.
+  </Step>
+
+</Steps>
+
+Logs, restarts, and updates are managed directly from the Docker Manager interface in hPanel. To update, press on **Update** in Docker Manager and that will pull the latest image.
+
+## Verify your setup
+
+Send "Hi" to your assistant on the channel you connected. OpenClaw will reply and walk you through initial preferences.
+
+## Troubleshooting
+
+**Dashboard not loading** -- Wait a few minutes for the container to finish provisioning. Check the Docker Manager logs in hPanel.
+
+**Docker container keeps restarting** -- Open Docker Manager logs and look for configuration errors (missing tokens, invalid API keys).
+
+**Telegram bot not responding** -- Send your pairing code message from Telegram directly as a message inside your OpenClaw chat to complete the connection.

--- a/docs/install/hostinger.md
+++ b/docs/install/hostinger.md
@@ -27,6 +27,7 @@ The fastest way to get started. Hostinger handles infrastructure, Docker, and au
     <Note>
     During checkout you can select **Ready-to-Use AI** credits that are pre-purchased and integrated instantly inside OpenClaw -- no external accounts or API keys from other providers needed. You can start chatting right away. Alternatively, provide your own key from Anthropic, OpenAI, Google Gemini, or xAI during setup.
     </Note>
+
   </Step>
 
   <Step title="Select a messaging channel">
@@ -34,6 +35,7 @@ The fastest way to get started. Hostinger handles infrastructure, Docker, and au
 
     - **WhatsApp** -- scan the QR code shown in the setup wizard.
     - **Telegram** -- paste the bot token from [BotFather](https://t.me/BotFather).
+
   </Step>
 
   <Step title="Complete installation">
@@ -53,6 +55,7 @@ More control over your server. Hostinger deploys OpenClaw via Docker on your VPS
     <Note>
     You can select **Ready-to-Use AI** credits during checkout -- these are pre-purchased and integrated instantly inside OpenClaw, so you can start chatting without any external accounts or API keys from other providers.
     </Note>
+
   </Step>
 
   <Step title="Configure OpenClaw">
@@ -62,6 +65,7 @@ More control over your server. Hostinger deploys OpenClaw via Docker on your VPS
     - **WhatsApp number** -- your number with country code (optional).
     - **Telegram bot token** -- from [BotFather](https://t.me/BotFather) (optional).
     - **API keys** -- only needed if you did not select Ready-to-Use AI credits during checkout.
+
   </Step>
 
   <Step title="Start OpenClaw">

--- a/docs/install/hostinger.md
+++ b/docs/install/hostinger.md
@@ -87,3 +87,8 @@ Send "Hi" to your assistant on the channel you connected. OpenClaw will reply an
 **Docker container keeps restarting** -- Open Docker Manager logs and look for configuration errors (missing tokens, invalid API keys).
 
 **Telegram bot not responding** -- Send your pairing code message from Telegram directly as a message inside your OpenClaw chat to complete the connection.
+
+## Next steps
+
+- [Channels](/channels) -- connect Telegram, WhatsApp, Discord, and more
+- [Gateway configuration](/gateway/configuration) -- all config optionss

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -23,6 +23,7 @@ tuning that applies everywhere.
   <Card title="Oracle Cloud" href="/install/oracle">Always Free ARM tier</Card>
   <Card title="Fly.io" href="/install/fly">Fly Machines</Card>
   <Card title="Hetzner" href="/install/hetzner">Docker on Hetzner VPS</Card>
+  <Card title="Hostinger" href="/install/hostinger">VPS with one-click setup</Card>
   <Card title="GCP" href="/install/gcp">Compute Engine</Card>
   <Card title="Azure" href="/install/azure">Linux VM</Card>
   <Card title="exe.dev" href="/install/exe-dev">VM with HTTPS proxy</Card>


### PR DESCRIPTION
## Summary

- Problem: No installation guide exists for Hostinger, despite it being a supported hosting provider with both managed and VPS deployment options.
- Why it matters: Users choosing Hostinger have no official docs to follow, and the VPS provider picker page does not list it.
- What changed: Added `docs/install/hostinger.md` covering 1-Click managed and VPS (Docker Manager) install paths, added Hostinger to the navigation in `docs/docs.json`, and added a Hostinger card to the VPS provider picker in `docs/vps.md`.
- What did NOT change (scope boundary): No code, config, or runtime changes. Existing install guides untouched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- New docs page at `/install/hostinger` with two install paths (1-Click managed and VPS with Docker Manager).
- Hostinger appears in the Install > Hosting sidebar navigation.
- Hostinger card added to the Linux Server VPS provider picker page.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: N/A (docs only)

### Steps

1. Open docs site locally or preview the Mintlify build.
2. Navigate to Install > Hosting in the sidebar.
3. Confirm "Hostinger" appears between Hetzner and Kubernetes.
4. Open the Hostinger page and verify both Option A and Option B render correctly.
5. Navigate to the Linux Server (vps) page and confirm the Hostinger card appears.

### Expected

- Hostinger page renders with correct structure, links, and Mintlify components.
- Navigation and provider picker include Hostinger in alphabetical order.

### Actual

- As expected.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Docs-only change; visual verification via Mintlify preview.

## Human Verification (required)

- Verified scenarios: Page structure matches digitalocean.md pattern, internal links are root-relative without `.md` suffix, alphabetical ordering in nav and provider picker.
- Edge cases checked: Frontmatter fields (`summary`, `read_when`, `title`) present and consistent.
- What you did **not** verify: Live Mintlify build rendering, i18n glossary impact.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.
