### PR TITLE
feat: Add {context} and {contextPercent} template variables for response prefix

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -52,6 +52,7 @@ const createChannelReplyPipeline = vi.hoisted(() =>
     responsePrefix: undefined,
     responsePrefixContextProvider: () => ({ identityName: undefined }),
     onModelSelected: () => undefined,
+    onContextUsage: () => undefined,
   })),
 );
 const wasSentByBot = vi.hoisted(() => vi.fn(() => false));
@@ -194,6 +195,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       responsePrefix: undefined,
       responsePrefixContextProvider: () => ({ identityName: undefined }),
       onModelSelected: () => undefined,
+      onContextUsage: () => undefined,
     });
     wasSentByBot.mockReturnValue(false);
     resolveStorePath.mockReturnValue("/tmp/sessions.json");

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -17,6 +17,14 @@ export type ModelSelectedContext = {
   thinkLevel: string | undefined;
 };
 
+/** Context passed to onContextUsage callback after inference completes. */
+export type ContextUsageContext = {
+  /** Tokens consumed by the last inference call (approximates context-window usage). */
+  tokens?: number;
+  /** Total tokens available in the active model's context window, if known. */
+  contextWindowTokens?: number;
+};
+
 export type TypingPolicy =
   | "auto"
   | "user_message"
@@ -137,6 +145,9 @@ export type GetReplyOptions = {
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;
+  /** Called once inference usage data is available.
+   * Use this to populate `{context}`/`{contextPercent}` in responsePrefix templates. */
+  onContextUsage?: (ctx: ContextUsageContext) => void;
   disableBlockStreaming?: boolean;
   /** Timeout for block reply delivery (ms). */
   blockReplyTimeoutMs?: number;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -11,6 +11,7 @@ import {
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
+import { resolveContextWindowInfo } from "../../agents/context-window-guard.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { runWithModelFallback, isFallbackSummaryError } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -1239,6 +1240,31 @@ export async function runAgentTurnWithFallback(params: {
       runResult = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
       fallbackModel = fallbackResult.model;
+
+      // Surface token usage so responsePrefix templates can interpolate
+      // `{context}` / `{contextPercent}`. lastCallUsage reflects the final
+      // API call's context size (not the accumulated tool-loop usage).
+      const lastCallUsage = runResult?.meta?.agentMeta?.lastCallUsage;
+      if (lastCallUsage && params.opts?.onContextUsage) {
+        const tokens =
+          typeof lastCallUsage.total === "number" && lastCallUsage.total > 0
+            ? lastCallUsage.total
+            : (lastCallUsage.input ?? 0) +
+              (lastCallUsage.cacheRead ?? 0) +
+              (lastCallUsage.cacheWrite ?? 0);
+        const contextWindowInfo = resolveContextWindowInfo({
+          cfg: runtimeConfig,
+          provider: fallbackProvider ?? "",
+          modelId: fallbackModel ?? "",
+          defaultTokens: 0,
+        });
+        const contextWindowTokens =
+          contextWindowInfo.source === "default" ? undefined : contextWindowInfo.tokens;
+        params.opts.onContextUsage({
+          tokens: tokens > 0 ? tokens : undefined,
+          contextWindowTokens,
+        });
+      }
       fallbackAttempts = Array.isArray(fallbackResult.attempts)
         ? fallbackResult.attempts.map((attempt) => ({
             provider: attempt.provider,

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -527,6 +527,18 @@ describe("resolveResponsePrefixTemplate", () => {
         expected: "[OpenClaw]",
       },
       {
+        name: "context",
+        template: "ctx:{context}",
+        values: { context: "15k" },
+        expected: "ctx:15k",
+      },
+      {
+        name: "contextPercent",
+        template: "usage:{contextPercent}%",
+        values: { contextPercent: "75" },
+        expected: "usage:75%",
+      },
+      {
         name: "case-insensitive variables",
         template: "[{MODEL} | {ThinkingLevel}]",
         values: { model: "gpt-5.4", thinkingLevel: "low" },

--- a/src/auto-reply/reply/response-prefix-template.ts
+++ b/src/auto-reply/reply/response-prefix-template.ts
@@ -18,6 +18,10 @@ export type ResponsePrefixContext = {
   thinkingLevel?: string;
   /** Agent identity name */
   identityName?: string;
+  /** Context window usage in tokens (e.g., "15k" or "15000") */
+  context?: string;
+  /** Context usage as percentage (e.g., "75" for 75%) */
+  contextPercent?: string;
 };
 
 // Regex pattern for template variables: {variableName} or {variable.name}
@@ -61,6 +65,10 @@ export function resolveResponsePrefixTemplate(
       case "identity.name":
       case "identityname":
         return context.identityName ?? match;
+      case "context":
+        return context.context ?? match;
+      case "contextpercent":
+        return context.contextPercent ?? match;
       default:
         // Leave unrecognized variables as-is
         return match;

--- a/src/channels/reply-prefix.test.ts
+++ b/src/channels/reply-prefix.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createReplyPrefixContext } from "./reply-prefix.js";
+
+function makeBundle() {
+  const cfg = {
+    messages: { responsePrefix: "[{model} ctx:{context} {contextPercent}%]" },
+  } as OpenClawConfig;
+  return createReplyPrefixContext({ cfg, agentId: "default" });
+}
+
+describe("reply-prefix onContextUsage", () => {
+  it("populates context and contextPercent from token usage", () => {
+    const bundle = makeBundle();
+    bundle.onModelSelected({ provider: "anthropic", model: "claude-opus-4-6", thinkLevel: "high" });
+    bundle.onContextUsage({ tokens: 15_000, contextWindowTokens: 200_000 });
+
+    const ctx = bundle.responsePrefixContextProvider();
+    expect(ctx.context).toBe("15k");
+    expect(ctx.contextPercent).toBe("8");
+    expect(ctx.model).toBe("claude-opus-4-6");
+  });
+
+  it("sets context but omits contextPercent when window is unknown", () => {
+    const bundle = makeBundle();
+    bundle.onContextUsage({ tokens: 42_000 });
+    const ctx = bundle.responsePrefixContextProvider();
+    expect(ctx.context).toBe("42k");
+    expect(ctx.contextPercent).toBeUndefined();
+  });
+
+  it("ignores invalid token counts", () => {
+    const bundle = makeBundle();
+    bundle.onContextUsage({ tokens: -1, contextWindowTokens: 200_000 });
+    const ctx = bundle.responsePrefixContextProvider();
+    expect(ctx.context).toBeUndefined();
+    expect(ctx.contextPercent).toBeUndefined();
+  });
+
+  it("clamps contextPercent to 100 for over-budget usage", () => {
+    const bundle = makeBundle();
+    bundle.onContextUsage({ tokens: 500_000, contextWindowTokens: 200_000 });
+    const ctx = bundle.responsePrefixContextProvider();
+    expect(ctx.contextPercent).toBe("100");
+  });
+});

--- a/src/channels/reply-prefix.ts
+++ b/src/channels/reply-prefix.ts
@@ -6,19 +6,22 @@ import {
 } from "../auto-reply/reply/response-prefix-template.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { formatTokenCount } from "../utils/usage-format.js";
 
 type ModelSelectionContext = Parameters<NonNullable<GetReplyOptions["onModelSelected"]>>[0];
+type ContextUsageInput = Parameters<NonNullable<GetReplyOptions["onContextUsage"]>>[0];
 
 export type ReplyPrefixContextBundle = {
   prefixContext: ResponsePrefixContext;
   responsePrefix?: string;
   responsePrefixContextProvider: () => ResponsePrefixContext;
   onModelSelected: (ctx: ModelSelectionContext) => void;
+  onContextUsage: (ctx: ContextUsageInput) => void;
 };
 
 export type ReplyPrefixOptions = Pick<
   ReplyPrefixContextBundle,
-  "responsePrefix" | "responsePrefixContextProvider" | "onModelSelected"
+  "responsePrefix" | "responsePrefixContextProvider" | "onModelSelected" | "onContextUsage"
 >;
 
 export function createReplyPrefixContext(params: {
@@ -40,6 +43,21 @@ export function createReplyPrefixContext(params: {
     prefixContext.thinkingLevel = ctx.thinkLevel ?? "off";
   };
 
+  const onContextUsage = (ctx: ContextUsageInput) => {
+    const tokens =
+      typeof ctx.tokens === "number" && Number.isFinite(ctx.tokens) && ctx.tokens >= 0
+        ? ctx.tokens
+        : undefined;
+    if (tokens === undefined) {
+      return;
+    }
+    prefixContext.context = formatTokenCount(tokens);
+    const window = ctx.contextWindowTokens;
+    if (typeof window === "number" && Number.isFinite(window) && window > 0) {
+      prefixContext.contextPercent = String(Math.min(100, Math.round((tokens / window) * 100)));
+    }
+  };
+
   return {
     prefixContext,
     responsePrefix: resolveEffectiveMessagesConfig(cfg, agentId, {
@@ -48,6 +66,7 @@ export function createReplyPrefixContext(params: {
     }).responsePrefix,
     responsePrefixContextProvider: () => prefixContext,
     onModelSelected,
+    onContextUsage,
   };
 }
 
@@ -57,11 +76,12 @@ export function createReplyPrefixOptions(params: {
   channel?: string;
   accountId?: string;
 }): ReplyPrefixOptions {
-  const { responsePrefix, responsePrefixContextProvider, onModelSelected } =
+  const { responsePrefix, responsePrefixContextProvider, onModelSelected, onContextUsage } =
     createReplyPrefixContext(params);
   return {
     responsePrefix,
     responsePrefixContextProvider,
     onModelSelected,
+    onContextUsage,
   };
 }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2007,7 +2007,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         GatewayClientScopes: client?.connect?.scopes ?? [],
       };
 
-      const { onModelSelected, ...replyPipeline } = createChannelReplyPipeline({
+      const { onModelSelected, onContextUsage, ...replyPipeline } = createChannelReplyPipeline({
         cfg,
         agentId,
         channel: INTERNAL_MESSAGE_CHANNEL,
@@ -2170,6 +2170,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             }
           },
           onModelSelected,
+          onContextUsage,
         },
       })
         .then(async () => {

--- a/src/plugin-sdk/inbound-reply-dispatch.ts
+++ b/src/plugin-sdk/inbound-reply-dispatch.ts
@@ -13,7 +13,7 @@ import { createNormalizedOutboundDeliverer, type OutboundReplyPayload } from "./
 
 type ReplyOptionsWithoutModelSelected = Omit<
   Omit<GetReplyOptions, "onToolResult" | "onBlockReply">,
-  "onModelSelected"
+  "onModelSelected" | "onContextUsage"
 >;
 type RecordInboundSessionFn = typeof import("../channels/session.js").recordInboundSession;
 
@@ -124,7 +124,7 @@ export async function recordInboundSessionAndDispatchReply(params: {
     onRecordError: params.onRecordError,
   });
 
-  const { onModelSelected, ...replyPipeline } = createChannelReplyPipeline({
+  const { onModelSelected, onContextUsage, ...replyPipeline } = createChannelReplyPipeline({
     cfg: params.cfg,
     agentId: params.agentId,
     channel: params.channel,
@@ -143,6 +143,7 @@ export async function recordInboundSessionAndDispatchReply(params: {
     replyOptions: {
       ...params.replyOptions,
       onModelSelected,
+      onContextUsage,
     },
   });
 }


### PR DESCRIPTION
Fixes #1920

This PR adds support for two new template variables in response prefix templates:

- `{context}`: Shows context window usage in tokens (e.g., "15k" or "15000")
- `{contextPercent}`: Shows context usage as a percentage (e.g., "75" for 75%)

## Changes Made

- Added `context` and `contextPercent` fields to `ResponsePrefixContext` type
- Implemented template resolution for both new variables in `resolveResponsePrefixTemplate`
- Added comprehensive test cases covering both variables
- Both variables gracefully fall back to the original template if values are not provided

## Testing

Added test cases that verify:
- `{context}` resolves to the provided context value
- `{contextPercent}` resolves to the provided percentage value
- Templates work correctly with the new variables

## Example Usage

With this change, users can now use templates like:
- `"Context: {context} ({contextPercent}% used)"`
- `"[{contextPercent}%] Your response:"`
- `"Memory: {context}"`