### PR TITLE
fix(gateway): save web UI images to disk for non-vision models

### DIFF
--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -5,6 +5,24 @@ import {
   parseMessageWithAttachments,
 } from "./chat-attachments.js";
 
+vi.mock("../media/store.js", () => ({
+  saveMediaBuffer: vi.fn(
+    async (
+      _buf: Buffer,
+      contentType?: string,
+      _subdir?: string,
+      _maxBytes?: number,
+      originalFilename?: string,
+    ) => ({
+      id: originalFilename ?? "mock-id.png",
+      path: `/mock/media/inbound/${originalFilename ?? "mock-id.png"}`,
+      size: _buf?.byteLength ?? 0,
+      contentType,
+    }),
+  ),
+  deleteMediaBuffer: vi.fn(async () => {}),
+}));
+
 const PNG_1x1 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
 
@@ -176,5 +194,80 @@ describe("shared attachment validation", () => {
     } finally {
       fromSpy.mockRestore();
     }
+  });
+});
+
+describe("parseMessageWithAttachments supportsImages: false", () => {
+  it("saves images to disk and injects filesystem path markers", async () => {
+    const { saveMediaBuffer } = await import("../media/store.js");
+    const parsed = await parseMessageWithAttachments(
+      "describe this",
+      [
+        {
+          type: "image",
+          mimeType: "image/png",
+          fileName: "dot.png",
+          content: PNG_1x1,
+        },
+      ],
+      { supportsImages: false, log: { warn: () => {} } },
+    );
+
+    expect(saveMediaBuffer).toHaveBeenCalled();
+    expect(parsed.images).toHaveLength(0);
+    expect(parsed.message).toContain("[media attached:");
+    expect(parsed.message).toContain("/mock/media/inbound/");
+    expect(parsed.message).toContain("(image/png)");
+    expect(parsed.offloadedRefs).toHaveLength(1);
+    expect(parsed.offloadedRefs[0]?.mimeType).toBe("image/png");
+    expect(parsed.imageOrder).toEqual(["offloaded"]);
+  });
+
+  it("does not use media:// URIs in markers", async () => {
+    const parsed = await parseMessageWithAttachments(
+      "see this",
+      [
+        {
+          type: "image",
+          mimeType: "image/png",
+          fileName: "dot.png",
+          content: PNG_1x1,
+        },
+      ],
+      { supportsImages: false, log: { warn: () => {} } },
+    );
+
+    expect(parsed.message).not.toContain("media://");
+  });
+
+  it("handles multiple images", async () => {
+    const parsed = await parseMessageWithAttachments(
+      "what are these",
+      [
+        { type: "image", mimeType: "image/png", fileName: "a.png", content: PNG_1x1 },
+        { type: "image", mimeType: "image/png", fileName: "b.png", content: PNG_1x1 },
+      ],
+      { supportsImages: false, log: { warn: () => {} } },
+    );
+
+    expect(parsed.images).toHaveLength(0);
+    expect(parsed.offloadedRefs).toHaveLength(2);
+    expect(parsed.imageOrder).toEqual(["offloaded", "offloaded"]);
+    const markers = parsed.message.match(/\[media attached:/g);
+    expect(markers).toHaveLength(2);
+  });
+
+  it("still drops non-image payloads", async () => {
+    const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
+    const logs: string[] = [];
+    const parsed = await parseMessageWithAttachments(
+      "x",
+      [{ type: "file", mimeType: "image/png", fileName: "not-image.pdf", content: pdf }],
+      { supportsImages: false, log: { warn: (w) => logs.push(w) } },
+    );
+
+    expect(parsed.images).toHaveLength(0);
+    expect(parsed.offloadedRefs).toHaveLength(0);
+    expect(logs.some((l) => /non-image/i.test(l))).toBe(true);
   });
 });

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -304,17 +304,11 @@ export async function parseMessageWithAttachments(
     return { message, images: [], imageOrder: [], offloadedRefs: [] };
   }
 
-  // For text-only models drop all attachments cleanly. Do not save files or
-  // inject media:// markers that would never be resolved and would leak
-  // internal path references into the model's prompt.
-  if (opts?.supportsImages === false) {
-    if (attachments.length > 0) {
-      log?.warn(
-        `parseMessageWithAttachments: ${attachments.length} attachment(s) dropped — model does not support images`,
-      );
-    }
-    return { message, images: [], imageOrder: [], offloadedRefs: [] };
-  }
+  // When the model does not support native image input, save all images to
+  // disk and inject filesystem-path markers so the model can invoke the
+  // `image` tool.  media:// URIs are NOT used here because the image tool
+  // rejects non-standard URI schemes.
+  const textOnlyMode = opts?.supportsImages === false;
 
   const images: ChatImageContent[] = [];
   const imageOrder: PromptImageOrderEntry[] = [];
@@ -377,10 +371,12 @@ export async function parseMessageWithAttachments(
 
       let isOffloaded = false;
 
-      if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
-        const isSupportedForOffload = SUPPORTED_OFFLOAD_MIMES.has(finalMime);
-
-        if (!isSupportedForOffload) {
+      // In textOnlyMode every image is saved to disk so the model can reference
+      // it by filesystem path (for the `image` tool).  In normal mode only
+      // images exceeding the inline threshold are offloaded.
+      if (textOnlyMode || sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
+        // In normal mode, large unsupported formats cannot be offloaded.
+        if (!textOnlyMode && !SUPPORTED_OFFLOAD_MIMES.has(finalMime)) {
           // Passing this inline would reintroduce the OOM risk this PR prevents.
           throw new Error(
             `attachment ${label}: format ${finalMime} is too large to pass inline ` +
@@ -413,12 +409,22 @@ export async function parseMessageWithAttachments(
           // Track for cleanup if a subsequent attachment fails.
           savedMediaIds.push(savedMedia.id);
 
-          // Opaque URI — compatible with workspaceOnly sandboxes and decouples
-          // the Gateway from the agent's filesystem layout.
-          const mediaRef = `media://inbound/${savedMedia.id}`;
+          // In textOnlyMode use the real filesystem path so the `image` tool
+          // can load the file directly.  In normal mode use an opaque URI that
+          // is compatible with workspaceOnly sandboxes.
+          if (textOnlyMode && !savedMedia.path) {
+            throw new Error(`attachment ${label}: saved to disk but no filesystem path returned`);
+          }
+          const mediaRef = textOnlyMode ? savedMedia.path! : `media://inbound/${savedMedia.id}`;
 
-          updatedMessage += `\n[media attached: ${mediaRef}]`;
-          log?.info?.(`[Gateway] Intercepted large image payload. Saved: ${mediaRef}`);
+          // In textOnlyMode include the MIME type in the marker so the model
+          // has full context (matches the Telegram `[media attached: ...]`
+          // format).  Normal mode keeps the existing marker shape.
+          const marker = textOnlyMode
+            ? `[media attached: ${mediaRef} (${finalMime})]`
+            : `[media attached: ${mediaRef}]`;
+          updatedMessage += `\n${marker}`;
+          log?.info?.(`[Gateway] Intercepted image payload. Saved: ${mediaRef}`);
 
           // Record for transcript metadata — separate from `images` because
           // these are not passed inline to the model.
@@ -445,6 +451,8 @@ export async function parseMessageWithAttachments(
         continue;
       }
 
+      // textOnlyMode images are always offloaded above; this path is only
+      // reached when the model supports native image input.
       images.push({ type: "image", data: b64, mimeType: finalMime });
       imageOrder.push("inline");
     }


### PR DESCRIPTION
Summary

Instead of dropping attachments when the model lacks native image support, save them to disk and inject filesystem-path markers so the model can invoke the image tool.  media:// URIs are replaced with real paths (the image tool rejects non-standard schemes) and a guard throws if saveMediaBuffer fails to return a path.

  - Problem: When images are sent via the web UI to a non-vision model (supportsImages: false), all attachments are silently dropped. The model never knows images were
  attached.
  - Why it matters: Users sending images to text-only models get no feedback and no way for the model to analyze the images via the image tool.
  - What changed: Instead of dropping attachments, images are saved to disk and filesystem-path markers ([media attached: /path (mime)]) are injected into the message so the
   model can invoke the image tool. A guard throws if saveMediaBuffer fails to return a path.
  - What did NOT change: Vision-capable model behavior is untouched. The media:// URI path for normal offloading is unchanged. No new config surface or gateway protocol changes.

  Root Cause (if applicable)

  - Root cause: parseMessageWithAttachments treated supportsImages: false as "discard everything" rather than routing images through the offload-to-disk path that the image
  tool can consume.
  - Missing detection / guardrail: No test coverage for the supportsImages: false path.
  - Contributing context: The original implementation assumed non-vision models could never process images, but the image tool provides an indirect path.

  Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - Unit test
  - Target test or file: src/gateway/chat-attachments.test.ts
  - Scenario the test should lock in: Four new cases under parseMessageWithAttachments supportsImages: false: images saved to disk with filesystem-path markers, no media://
  URIs used, multiple images handled, non-image payloads still dropped.
  - Why this is the smallest reliable guardrail: Directly tests the branching logic in parseMessageWithAttachments without requiring a running gateway.
  - Existing test that already covers this: None — this path was previously untested.

  User-visible / Behavior Changes

  Models without native vision support now receive [media attached: /path/to/file (image/png)] markers when images are attached via the web UI, enabling them to use the
  image tool. Previously, images were silently dropped.

  Diagram

  Before:
  [user sends image to text-only model] -> [attachments dropped] -> [model sees plain text only]

  After:
  [user sends image to text-only model] -> [saved to disk] -> [model sees path marker] -> [model can invoke image tool]

  Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification

  Environment

  - OS: macOS
  - Runtime/container: Node 22+ / Bun
  - Model/provider: Any non-vision model via web UI
  - Integration/channel: Web UI

  Steps

  1. Configure a non-vision model as default
  2. Send a message with an image attachment via the web UI
  3. Observe the model's response

  Expected

  - Model receives [media attached: ...] markers and can invoke the image tool to analyze attachments.

  Human Verification (required)

  - Verified scenarios: Tested via web UI with a non-vision model; images saved to disk and markers injected correctly.
  - Edge cases checked: Multiple images, non-image payloads dropped, missing savedMedia.path guard.

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  Risks and Mitigations

  - Risk: If the image tool is not configured (no vision-capable model has credentials), the model sees path markers it can't act on.
    - Mitigation: Accepted trade-off — the model will indicate it can't view images, which is better than silently dropping attachments. Gating on image tool availability was evaluated and deferred to avoid coupling the gateway to agent-layer tool resolution.