### PR TITLE
docs(providers): add Bedrock Mantle to provider index pages

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -28,6 +28,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 - [Alibaba Model Studio](/providers/alibaba)
 - [Amazon Bedrock](/providers/bedrock)
+- [Amazon Bedrock Mantle](/providers/bedrock-mantle)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Arcee AI (Trinity models)](/providers/arcee)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -27,6 +27,7 @@ model as `provider/model`.
 - [Alibaba Model Studio](/providers/alibaba)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Amazon Bedrock](/providers/bedrock)
+- [Amazon Bedrock Mantle](/providers/bedrock-mantle)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)
 - [Chutes](/providers/chutes)
 - [ComfyUI](/providers/comfy)


### PR DESCRIPTION
## Summary
- fixes #65863
- add missing Bedrock Mantle entry in provider index docs

## Changes
- `docs/providers/index.md`
- `docs/providers/models.md`
  - add `Amazon Bedrock Mantle` links

## Validation
- `pnpm check:no-conflict-markers`

## Notes
- docs-only update
- local validation passed

Made with [Cursor](https://cursor.com)