### PR TITLE
fix(gateway): point fallback override guidance to valid docs section

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -662,7 +662,7 @@ describe("loadGatewayPlugins", () => {
         }),
       ),
     ).rejects.toThrow(
-      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime and search for: plugins.entries.<id>.subagent.allowModelOverride',
+      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: plugins.entries.<id>.subagent.allowModelOverride',
     );
   });
 

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -662,7 +662,7 @@ describe("loadGatewayPlugins", () => {
         }),
       ),
     ).rejects.toThrow(
-      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: plugins.entries.<id>.subagent.allowModelOverride',
+      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime and search for: plugins.entries.<id>.subagent.allowModelOverride',
     );
   });
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -162,7 +162,7 @@ function authorizeFallbackModelOverride(params: {
       allowed: false,
       reason:
         `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
-        "See https://docs.openclaw.ai/plugins/sdk-runtime and search for: " +
+        "See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: " +
         "plugins.entries.<id>.subagent.allowModelOverride",
     };
   }

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -162,7 +162,7 @@ function authorizeFallbackModelOverride(params: {
       allowed: false,
       reason:
         `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
-        "See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: " +
+        "See https://docs.openclaw.ai/plugins/sdk-runtime and search for: " +
         "plugins.entries.<id>.subagent.allowModelOverride",
     };
   }


### PR DESCRIPTION
## Summary
- fixes #65860
- update fallback override error guidance to point to an existing and specific runtime docs section
- keep test assertion aligned with the runtime message

## Changes
- `src/gateway/server-plugins.ts`
  - docs URL now points to `https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent`
- `src/gateway/server-plugins.test.ts`
  - update expected error string

## Validation
- `pnpm vitest run src/gateway/server-plugins.test.ts`

## Notes
- no behavior changes beyond error guidance text
- local test passed

Made with [Cursor](https://cursor.com)