### PR TITLE
fix(brave): use canonical tools docs URL in provider metadata

### DIFF
--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -122,7 +122,7 @@ export function createBraveWebSearchProvider(): WebSearchProviderPlugin {
     envVars: ["BRAVE_API_KEY"],
     placeholder: "BSA...",
     signupUrl: "https://brave.com/search/api/",
-    docsUrl: "https://docs.openclaw.ai/brave-search",
+    docsUrl: "https://docs.openclaw.ai/tools/brave-search",
     autoDetectOrder: 10,
     credentialPath: "plugins.entries.brave.config.webSearch.apiKey",
     inactiveSecretPaths: ["plugins.entries.brave.config.webSearch.apiKey"],

--- a/extensions/brave/web-search-contract-api.ts
+++ b/extensions/brave/web-search-contract-api.ts
@@ -15,7 +15,7 @@ export function createBraveWebSearchProvider(): WebSearchProviderPlugin {
     envVars: ["BRAVE_API_KEY"],
     placeholder: "BSA...",
     signupUrl: "https://brave.com/search/api/",
-    docsUrl: "https://docs.openclaw.ai/brave-search",
+    docsUrl: "https://docs.openclaw.ai/tools/brave-search",
     autoDetectOrder: 10,
     credentialPath,
     ...createWebSearchProviderContractFields({


### PR DESCRIPTION
## Summary
- fixes #65870
- switch Brave provider metadata docs URL from legacy path to canonical tools path

## Changes
- `extensions/brave/src/brave-web-search-provider.ts`
- `extensions/brave/web-search-contract-api.ts`
  - set `docsUrl` to `https://docs.openclaw.ai/tools/brave-search`

## Validation
- `pnpm vitest run src/plugins/contracts/bundled-web-search.brave.contract.test.ts src/plugins/contracts/web-search-provider.brave.contract.test.ts src/plugins/contracts/plugin-registration.brave.contract.test.ts`

## Notes
- metadata-only change
- local tests passed

Made with [Cursor](https://cursor.com)