### PR TITLE
chore(labeler): remove dead minimax-portal-auth rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -281,10 +281,6 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/cloudflare-ai-gateway/**"
-"extensions: minimax-portal-auth":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "extensions/minimax-portal-auth/**"
 "extensions: huggingface":
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Summary
- fixes #65861
- remove stale labeler rule targeting a non-existent extension path

## Changes
- `.github/labeler.yml`
  - remove `extensions: minimax-portal-auth` block

## Validation
- `pnpm check:no-conflict-markers`

## Notes
- config-only cleanup
- local validation passed

Made with [Cursor](https://cursor.com)