### PR TITLE
fix(onboarding): include DuckDuckGo web search in setup wizard

### DIFF
--- a/extensions/duckduckgo/src/ddg-search-provider.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.ts
@@ -39,6 +39,7 @@ export function createDuckDuckGoWebSearchProvider(): WebSearchProviderPlugin {
     label: "DuckDuckGo Search (experimental)",
     hint: "Free web search fallback with no API key required",
     requiresCredential: false,
+    onboardingScopes: ["text-inference"],
     envVars: [],
     placeholder: "(no key needed)",
     signupUrl: "https://duckduckgo.com/",

--- a/extensions/duckduckgo/web-search-contract-api.ts
+++ b/extensions/duckduckgo/web-search-contract-api.ts
@@ -9,6 +9,7 @@ export function createDuckDuckGoWebSearchProvider(): WebSearchProviderPlugin {
     label: "DuckDuckGo Search (experimental)",
     hint: "Free web search fallback with no API key required",
     requiresCredential: false,
+    onboardingScopes: ["text-inference"],
     envVars: [],
     placeholder: "(no key needed)",
     signupUrl: "https://duckduckgo.com/",


### PR DESCRIPTION
## Summary
- fixes #65862
- include DuckDuckGo in setup by adding `onboardingScopes: [\"text-inference\"]`

## Changes
- `extensions/duckduckgo/src/ddg-search-provider.ts`
- `extensions/duckduckgo/web-search-contract-api.ts`
  - add onboarding scope metadata in runtime + contract definitions

## Validation
- `pnpm vitest run src/plugins/contracts/bundled-web-search.duckduckgo.contract.test.ts src/plugins/contracts/web-search-provider.duckduckgo.contract.test.ts src/plugins/contracts/plugin-registration.duckduckgo.contract.test.ts`

## Notes
- metadata-only change
- local tests passed

Made with [Cursor](https://cursor.com)