### PR TITLE
fix(qqbot): add actionable setup guidance to common errors

### DIFF
--- a/extensions/qqbot/src/api.ts
+++ b/extensions/qqbot/src/api.ts
@@ -136,7 +136,9 @@ async function doFetchToken(appId: string, clientSecret: string): Promise<string
   }
 
   if (!data.access_token) {
-    throw new Error(`Failed to get access_token: ${JSON.stringify(data)}`);
+    throw new Error(
+      `Failed to get access_token. Check QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot. API response: ${JSON.stringify(data)}`,
+    );
   }
 
   const expiresAt = Date.now() + (data.expires_in ?? 7200) * 1000;
@@ -242,7 +244,10 @@ export async function apiRequest<T = unknown>(
       throw new Error(`Request timeout[${path}]: exceeded ${timeout}ms`, { cause: err });
     }
     debugError(`[qqbot-api] <<< Network error:`, err);
-    throw new Error(`Network error [${path}]: ${formatErrorMessage(err)}`, { cause: err });
+    throw new Error(
+      `Network error [${path}]: ${formatErrorMessage(err)}. Check connectivity and QQ platform access. See https://docs.openclaw.ai/channels/qqbot`,
+      { cause: err },
+    );
   } finally {
     clearTimeout(timeoutId);
   }

--- a/extensions/qqbot/src/api.ts
+++ b/extensions/qqbot/src/api.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import { QQBOT_SETUP_DOCS_URL } from "./errors.js";
 import { debugLog, debugError } from "./utils/debug-log.js";
 import { sanitizeFileName } from "./utils/platform.js";
 import { computeFileHash, getCachedFileInfo, setCachedFileInfo } from "./utils/upload-cache.js";
@@ -137,7 +138,7 @@ async function doFetchToken(appId: string, clientSecret: string): Promise<string
 
   if (!data.access_token) {
     throw new Error(
-      `Failed to get access_token. Check QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot. API response: ${JSON.stringify(data)}`,
+      `Failed to get access_token. Check QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See ${QQBOT_SETUP_DOCS_URL}. API response: ${JSON.stringify(data)}`,
     );
   }
 
@@ -245,7 +246,7 @@ export async function apiRequest<T = unknown>(
     }
     debugError(`[qqbot-api] <<< Network error:`, err);
     throw new Error(
-      `Network error [${path}]: ${formatErrorMessage(err)}. Check connectivity and QQ platform access. See https://docs.openclaw.ai/channels/qqbot`,
+      `Network error [${path}]: ${formatErrorMessage(err)}. Check connectivity and QQ platform access. See ${QQBOT_SETUP_DOCS_URL}`,
       { cause: err },
     );
   } finally {

--- a/extensions/qqbot/src/errors.ts
+++ b/extensions/qqbot/src/errors.ts
@@ -1,0 +1,8 @@
+export const QQBOT_SETUP_DOCS_URL = "https://docs.openclaw.ai/channels/qqbot";
+
+export const QQBOT_CONFIG_MISSING_MESSAGE =
+  "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET (or run `openclaw configure`).";
+
+export function withQQBotSetupDocs(message: string): string {
+  return `${message} See ${QQBOT_SETUP_DOCS_URL}`;
+}

--- a/extensions/qqbot/src/gateway.ts
+++ b/extensions/qqbot/src/gateway.ts
@@ -125,7 +125,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
   const { account, abortSignal, cfg, onReady, onError, log } = ctx;
 
   if (!account.appId || !account.clientSecret) {
-    throw new Error("QQBot not configured (missing appId or clientSecret)");
+    throw new Error(
+      "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
+    );
   }
 
   // Run environment diagnostics during startup.

--- a/extensions/qqbot/src/gateway.ts
+++ b/extensions/qqbot/src/gateway.ts
@@ -18,6 +18,7 @@ import {
   stopBackgroundTokenRefresh,
 } from "./api.js";
 import { formatQQBotAllowFrom } from "./channel-config-shared.js";
+import { QQBOT_CONFIG_MISSING_MESSAGE, withQQBotSetupDocs } from "./errors.js";
 import { formatVoiceText, processAttachments } from "./inbound-attachments.js";
 import { flushKnownUsers, recordKnownUser } from "./known-users.js";
 import { createMessageQueue, type QueuedMessage } from "./message-queue.js";
@@ -125,9 +126,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
   const { account, abortSignal, cfg, onReady, onError, log } = ctx;
 
   if (!account.appId || !account.clientSecret) {
-    throw new Error(
-      "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
-    );
+    throw new Error(withQQBotSetupDocs(QQBOT_CONFIG_MISSING_MESSAGE));
   }
 
   // Run environment diagnostics during startup.

--- a/extensions/qqbot/src/outbound.ts
+++ b/extensions/qqbot/src/outbound.ts
@@ -265,7 +265,9 @@ function buildMediaTarget(
 /** Resolve an authenticated access token for the account. */
 async function getToken(account: ResolvedQQBotAccount): Promise<string> {
   if (!account.appId || !account.clientSecret) {
-    throw new Error("QQBot not configured (missing appId or clientSecret)");
+    throw new Error(
+      "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
+    );
   }
   return getAccessToken(account.appId, account.clientSecret);
 }
@@ -1297,7 +1299,11 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
   }
 
   if (!account.appId || !account.clientSecret) {
-    return { channel: "qqbot", error: "QQBot not configured (missing appId or clientSecret)" };
+    return {
+      channel: "qqbot",
+      error:
+        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
+    };
   }
 
   try {
@@ -1378,7 +1384,8 @@ export async function sendProactiveMessage(
   const timestamp = new Date().toISOString();
 
   if (!account.appId || !account.clientSecret) {
-    const errorMsg = "QQBot not configured (missing appId or clientSecret)";
+    const errorMsg =
+      "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot";
     debugError(`[${timestamp}] [qqbot] sendProactiveMessage: ${errorMsg}`);
     return { channel: "qqbot", error: errorMsg };
   }
@@ -1459,7 +1466,11 @@ export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResu
   const { to, text, replyToId, account, mimeType } = ctx;
 
   if (!account.appId || !account.clientSecret) {
-    return { channel: "qqbot", error: "QQBot not configured (missing appId or clientSecret)" };
+    return {
+      channel: "qqbot",
+      error:
+        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
+    };
   }
   if (!ctx.mediaUrl) {
     return { channel: "qqbot", error: "mediaUrl is required for sendMedia" };

--- a/extensions/qqbot/src/outbound.ts
+++ b/extensions/qqbot/src/outbound.ts
@@ -22,6 +22,7 @@ import {
   sendProactiveC2CMessage,
   sendProactiveGroupMessage,
 } from "./api.js";
+import { QQBOT_CONFIG_MISSING_MESSAGE, withQQBotSetupDocs } from "./errors.js";
 import type { ResolvedQQBotAccount } from "./types.js";
 import {
   audioFileToSilkBase64,
@@ -265,9 +266,7 @@ function buildMediaTarget(
 /** Resolve an authenticated access token for the account. */
 async function getToken(account: ResolvedQQBotAccount): Promise<string> {
   if (!account.appId || !account.clientSecret) {
-    throw new Error(
-      "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
-    );
+    throw new Error(withQQBotSetupDocs(QQBOT_CONFIG_MISSING_MESSAGE));
   }
   return getAccessToken(account.appId, account.clientSecret);
 }
@@ -1301,8 +1300,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
   if (!account.appId || !account.clientSecret) {
     return {
       channel: "qqbot",
-      error:
-        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
+      error: withQQBotSetupDocs(QQBOT_CONFIG_MISSING_MESSAGE),
     };
   }
 
@@ -1384,8 +1382,7 @@ export async function sendProactiveMessage(
   const timestamp = new Date().toISOString();
 
   if (!account.appId || !account.clientSecret) {
-    const errorMsg =
-      "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot";
+    const errorMsg = withQQBotSetupDocs(QQBOT_CONFIG_MISSING_MESSAGE);
     debugError(`[${timestamp}] [qqbot] sendProactiveMessage: ${errorMsg}`);
     return { channel: "qqbot", error: errorMsg };
   }
@@ -1468,8 +1465,7 @@ export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResu
   if (!account.appId || !account.clientSecret) {
     return {
       channel: "qqbot",
-      error:
-        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
+      error: withQQBotSetupDocs(QQBOT_CONFIG_MISSING_MESSAGE),
     };
   }
   if (!ctx.mediaUrl) {

--- a/extensions/qqbot/src/proactive.ts
+++ b/extensions/qqbot/src/proactive.ts
@@ -15,6 +15,7 @@ import {
   sendProactiveGroupMessage,
 } from "./api.js";
 import { resolveDefaultQQBotAccountId, resolveQQBotAccount } from "./config.js";
+import { QQBOT_CONFIG_MISSING_MESSAGE, withQQBotSetupDocs } from "./errors.js";
 import {
   clearKnownUsers as clearKnownUsersImpl,
   getKnownUser as getKnownUserImpl,
@@ -111,8 +112,7 @@ export async function sendProactive(
   if (!account.appId || !account.clientSecret) {
     return {
       success: false,
-      error:
-        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
+      error: withQQBotSetupDocs(QQBOT_CONFIG_MISSING_MESSAGE),
     };
   }
 
@@ -283,8 +283,7 @@ export async function sendProactiveMessageDirect(
   if (!account.appId || !account.clientSecret) {
     return {
       success: false,
-      error:
-        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
+      error: withQQBotSetupDocs(QQBOT_CONFIG_MISSING_MESSAGE),
     };
   }
 

--- a/extensions/qqbot/src/proactive.ts
+++ b/extensions/qqbot/src/proactive.ts
@@ -111,7 +111,8 @@ export async function sendProactive(
   if (!account.appId || !account.clientSecret) {
     return {
       success: false,
-      error: "QQBot not configured (missing appId or clientSecret)",
+      error:
+        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
     };
   }
 
@@ -282,7 +283,8 @@ export async function sendProactiveMessageDirect(
   if (!account.appId || !account.clientSecret) {
     return {
       success: false,
-      error: "QQBot not configured (missing appId or clientSecret)",
+      error:
+        "QQBot not configured. Set QQBOT_APP_ID and QQBOT_CLIENT_SECRET. See https://docs.openclaw.ai/channels/qqbot",
     };
   }
 


### PR DESCRIPTION
## Summary
- fixes #65868
- improve QQBot user-facing setup and network error guidance
- centralize shared error guidance constants to prevent message drift

## Why
Several high-frequency errors were too generic for operator troubleshooting and did not consistently point users to setup guidance.

## Changes
- `extensions/qqbot/src/errors.ts` (new)
  - shared setup docs URL and standardized config-missing message
- `extensions/qqbot/src/api.ts`
  - make token/network errors actionable and docs-linked
- `extensions/qqbot/src/gateway.ts`
- `extensions/qqbot/src/outbound.ts`
- `extensions/qqbot/src/proactive.ts`
  - reuse shared setup guidance for config-missing paths

## Validation
- `pnpm vitest run extensions/qqbot/src/proactive.test.ts extensions/qqbot/src/outbound-deliver.test.ts extensions/qqbot/src/setup.test.ts`

## Notes
- no protocol/transport behavior changes
- local tests passed

Made with [Cursor](https://cursor.com)