### PR TITLE
fix(codex): materialize synthetic auth in catalog

### DIFF
--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -57,6 +57,31 @@ describe("codex provider", () => {
     });
   });
 
+  it("materializes the catalog apiKey when discovery provides a synthetic auth marker", async () => {
+    const provider = buildCodexProvider();
+
+    const result = await provider.catalog?.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({
+        apiKey: "codex-app-server",
+      }),
+      resolveProviderAuth: () => ({
+        apiKey: undefined,
+        mode: "none",
+        source: "none",
+      }),
+    } as never);
+
+    expect(result).toEqual({
+      provider: expect.objectContaining({
+        auth: "token",
+        apiKey: "codex-app-server",
+        api: "openai-codex-responses",
+      }),
+    });
+  });
+
   it("keeps a static fallback catalog when discovery is disabled", async () => {
     const listModels = vi.fn();
 

--- a/extensions/codex/provider.ts
+++ b/extensions/codex/provider.ts
@@ -39,6 +39,10 @@ type BuildCatalogOptions = {
   env?: NodeJS.ProcessEnv;
   pluginConfig?: unknown;
   listModels?: CodexModelLister;
+  resolveProviderApiKey?: (providerId?: string) => {
+    apiKey: string | undefined;
+    discoveryApiKey?: string;
+  };
 };
 
 const FALLBACK_CODEX_MODELS = [
@@ -81,6 +85,7 @@ export function buildCodexProvider(options: BuildCodexProviderOptions = {}): Pro
           env: ctx.env,
           pluginConfig: options.pluginConfig,
           listModels: options.listModels,
+          resolveProviderApiKey: ctx.resolveProviderApiKey,
         }),
     },
     resolveDynamicModel: (ctx) => resolveCodexDynamicModel(ctx.modelId),
@@ -111,10 +116,12 @@ export async function buildCodexProviderCatalog(
   const models = (discovered.length > 0 ? discovered : FALLBACK_CODEX_MODELS).map(
     codexModelToDefinition,
   );
+  const resolvedApiKey = options.resolveProviderApiKey?.(PROVIDER_ID).apiKey;
   return {
     provider: {
       baseUrl: CODEX_BASE_URL,
       auth: "token",
+      ...(resolvedApiKey ? { apiKey: resolvedApiKey } : {}),
       api: "openai-codex-responses",
       models,
     },

--- a/extensions/codex/provider.ts
+++ b/extensions/codex/provider.ts
@@ -116,7 +116,7 @@ export async function buildCodexProviderCatalog(
   const models = (discovered.length > 0 ? discovered : FALLBACK_CODEX_MODELS).map(
     codexModelToDefinition,
   );
-  const resolvedApiKey = options.resolveProviderApiKey?.(PROVIDER_ID).apiKey;
+  const resolvedApiKey = options.resolveProviderApiKey?.(PROVIDER_ID)?.apiKey;
   return {
     provider: {
       baseUrl: CODEX_BASE_URL,


### PR DESCRIPTION
## Summary

- Problem: the `codex` provider catalog returned a provider with `auth: "token"` and `models`, but without materializing the synthetic auth marker into `apiKey`.
- Why it matters: when that provider is serialized into the PI-facing `models.json`, `@mariozechner/pi-coding-agent` rejects it, which can poison the generated custom model registry and cause unrelated providers to disappear at runtime.
- What changed: the `codex` catalog now consumes the existing discovery-time `resolveProviderApiKey()` hook and writes the resolved synthetic auth marker into the catalog provider config.
- What did NOT change (scope boundary): this does not change the global provider filtering strategy, does not refactor provider discovery broadly, and does not modify unrelated providers such as Bedrock or Volcengine.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64799
- Related https://github.com/openclaw/openclaw/issues/64799
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the `codex` provider plugin declared `resolveSyntheticAuth()`, but its catalog output did not consume the discovery wrapper’s `resolveProviderApiKey()` result, so the synthetic auth marker never got materialized into the provider config written to the PI-facing `models.json`.
- Missing detection / guardrail: there was no provider-level test asserting that the Codex catalog output carries the resolved synthetic auth marker into the returned provider config.
- Contributing context (if known): the plugin discovery framework already supports turning synthetic auth into a non-secret marker via `resolveProviderApiKey()`, but `extensions/codex/provider.ts` bypassed that mechanism and returned a bare `auth: "token"` + `models` provider. That invalid provider shape could poison PI-facing `models.json` and surface as `Unknown model` for unrelated providers such as `volcengine-plan/ark-code-latest` in #64799.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/provider.test.ts`
- Scenario the test should lock in: when discovery provides a synthetic auth marker for `codex`, the catalog output must include that resolved `apiKey` marker in the returned provider config.
- Why this is the smallest reliable guardrail: the bug originates inside the Codex provider catalog output itself, so the narrowest reliable check is a provider-level unit test at that boundary.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- The generated provider config for `codex` now includes the discovery-resolved synthetic auth marker when available.
- This prevents the Codex provider from being serialized into PI-facing `models.json` in an invalid shape.
- Downstream effect: avoids poisoning the custom model registry and reduces the chance of unrelated providers resolving as `Unknown model`, including the Volcengine regression reported in #64799.

## Diagram (if applicable)

```text
Before:
[codex catalog]
  -> [returns auth:"token" + models, no apiKey]
  -> [PI models.json load rejects provider]
  -> [custom model registry can fail]
  -> [unrelated providers may resolve as Unknown model]

After:
[codex catalog]
  -> [uses resolveProviderApiKey("codex")]
  -> [returns auth:"token" + apiKey marker + models]
  -> [PI models.json accepts provider]
  -> [registry remains intact]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout
- Model/provider: `codex`
- Integration/channel (if any): provider discovery / PI-facing `models.json`
- Relevant config (redacted): Codex synthetic auth is provided by the existing plugin discovery wrapper

### Steps

1. Build or run the Codex provider catalog through plugin discovery.
2. Provide a resolved synthetic auth marker through `resolveProviderApiKey("codex")`.
3. Inspect the returned provider config.

### Expected

- The returned `codex` provider config includes the resolved `apiKey` marker.
- The provider is no longer emitted in a PI-invalid `auth: "token"` + `models` + no `apiKey` shape.

### Actual

- Before the fix, the returned catalog provider omitted `apiKey` entirely, even when the discovery layer had already resolved a synthetic auth marker.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added a failing test in `extensions/codex/provider.test.ts` for catalog auth marker materialization.
  - Confirmed the new test fails before the code change.
  - Confirmed the new test passes after the code change.
  - Ran the full `extensions/codex/provider.test.ts` suite successfully.
  - Ran `corepack pnpm tsgo` successfully.
- Edge cases checked:
  - Existing Codex catalog behavior still works for fallback and live discovery paths.
  - Synthetic auth declaration via `resolveSyntheticAuth()` remains unchanged.
- What you did **not** verify:
  - Did not run a full end-to-end gateway repro against a poisoned `models.json` from this branch.
  - Did not rework unrelated provider discovery paths.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: another provider may have a similar bug if it declares synthetic auth but does not materialize discovery-resolved auth in its catalog output.
  - Mitigation: this PR adds a concrete Codex regression test and keeps the fix tightly scoped; similar providers can follow the same pattern if needed.
- Risk: reviewers may expect this PR to solve every PI `models.json` poisoning scenario.
  - Mitigation: this PR intentionally scopes to the Codex root cause only and does not claim a broad provider-discovery refactor.