### PR TITLE
fix(amazon-bedrock): add known model context windows to discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Amazon Bedrock: use known context-window metadata for discovered models while keeping the unknown-model fallback conservative, so compaction and overflow handling improve for newer Bedrock models without overstating unlisted model limits. Thanks @wirjo.
 - Providers/Amazon Bedrock Mantle: refresh IAM-backed bearer tokens at runtime instead of baking discovery-time tokens into provider config, so long-lived Mantle sessions keep working after the initial token ages out. Thanks @wirjo.
 - Codex harness: rotate the shared app-server websocket client when the configured bearer token changes, so auth-token refreshes reconnect with the new `Authorization` header instead of reusing a stale socket. (#70328) Thanks @Lucenx9.
 - Telegram/sandbox: keep Telegram bot DMs on per-account sender session keys even when `session.dmScope=main`, so sandbox/tool policy can distinguish Telegram-originated direct chats from the agent main session.

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -433,4 +433,63 @@ describe("bedrock discovery", () => {
     expect(legacyEnabled?.baseUrl).toBe("https://bedrock-runtime.us-west-2.amazonaws.com");
     expect(sendMock).toHaveBeenCalledTimes(4);
   });
+
+  // Ported from #65449 by @alickgithub2 — extended to also cover apac. prefix
+  it("resolves au. and apac. prefixes for regional inference profiles", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [
+          {
+            modelId: "anthropic.claude-sonnet-4-6",
+            modelName: "Claude Sonnet 4.6",
+            providerName: "anthropic",
+            inputModalities: ["TEXT", "IMAGE"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "au.anthropic.claude-sonnet-4-6",
+            inferenceProfileName: "AU Anthropic Claude Sonnet 4.6",
+            inferenceProfileArn:
+              "arn:aws:bedrock:ap-southeast-2::inference-profile/au.anthropic.claude-sonnet-4-6",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [], // no ARNs — forces the prefix-regex fallback
+          },
+          {
+            inferenceProfileId: "apac.anthropic.claude-sonnet-4-6",
+            inferenceProfileName: "APAC Anthropic Claude Sonnet 4.6",
+            inferenceProfileArn:
+              "arn:aws:bedrock:ap-northeast-1::inference-profile/apac.anthropic.claude-sonnet-4-6",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({ region: "ap-southeast-2", clientFactory });
+
+    // Foundation model + 2 regional inference profiles
+    expect(models).toHaveLength(3);
+
+    const auProfile = models.find((m) => m.id === "au.anthropic.claude-sonnet-4-6");
+    expect(auProfile).toMatchObject({
+      id: "au.anthropic.claude-sonnet-4-6",
+      name: "AU Anthropic Claude Sonnet 4.6",
+      input: ["text", "image"],
+    });
+
+    const apacProfile = models.find((m) => m.id === "apac.anthropic.claude-sonnet-4-6");
+    expect(apacProfile).toMatchObject({
+      id: "apac.anthropic.claude-sonnet-4-6",
+      name: "APAC Anthropic Claude Sonnet 4.6",
+      input: ["text", "image"],
+    });
+  });
 });

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -87,7 +87,7 @@ describe("bedrock discovery", () => {
       name: "Claude 3.7 Sonnet",
       reasoning: false,
       input: ["text", "image"],
-      contextWindow: 32000,
+      contextWindow: 200000,
       maxTokens: 4096,
     });
   });

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -104,7 +104,11 @@ describe("bedrock discovery", () => {
   });
 
   it("uses configured defaults for context and max tokens", async () => {
-    mockSingleActiveSummary();
+    mockSingleActiveSummary({
+      modelId: "example.unknown-text-v1:0",
+      modelName: "Example Unknown Text",
+      providerName: "example",
+    });
 
     const models = await discoverBedrockModels({
       region: "us-east-1",
@@ -112,6 +116,38 @@ describe("bedrock discovery", () => {
       clientFactory,
     });
     expect(models[0]).toMatchObject({ contextWindow: 64000, maxTokens: 8192 });
+  });
+
+  it("keeps the conservative fallback for unknown inference profiles", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "jp.example.unknown-text-v1:0",
+            inferenceProfileName: "JP Example Unknown Text",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [
+              {
+                modelArn: "arn:aws:bedrock:ap-northeast-1::foundation-model/example.unknown-text-v1:0",
+              },
+            ],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({ region: "ap-northeast-1", clientFactory });
+
+    expect(models).toHaveLength(1);
+    expect(models[0]).toMatchObject({
+      id: "jp.example.unknown-text-v1:0",
+      contextWindow: 32000,
+      maxTokens: 4096,
+      input: ["text"],
+    });
   });
 
   it("caches results when refreshInterval is enabled", async () => {

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -252,7 +252,7 @@ describe("bedrock discovery", () => {
     expect(usProfile).toMatchObject({
       name: "US Anthropic Claude Sonnet 4.6",
       input: ["text", "image"],
-      contextWindow: 32000,
+      contextWindow: 1000000,
       maxTokens: 4096,
     });
     expect(euProfile).toMatchObject({ input: ["text", "image"] });
@@ -356,7 +356,7 @@ describe("bedrock discovery", () => {
     expect(profile).toMatchObject({
       id: "us.my-prod-profile",
       input: ["text", "image"],
-      contextWindow: 32000,
+      contextWindow: 1000000,
       maxTokens: 4096,
     });
   });

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -150,6 +150,36 @@ describe("bedrock discovery", () => {
     });
   });
 
+  it("normalizes region-prefixed versioned model ids when resolving context windows", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "jp.anthropic.claude-sonnet-4-6-v1:0",
+            inferenceProfileName: "JP Claude Sonnet 4.6",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [
+              {
+                modelArn:
+                  "arn:aws:bedrock:ap-northeast-1::foundation-model/anthropic.claude-sonnet-4-6-v1:0",
+              },
+            ],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({ region: "ap-northeast-1", clientFactory });
+
+    expect(models[0]).toMatchObject({
+      id: "jp.anthropic.claude-sonnet-4-6-v1:0",
+      contextWindow: 1_000_000,
+    });
+  });
+
   it("caches results when refreshInterval is enabled", async () => {
     mockSingleActiveSummary();
 
@@ -394,6 +424,38 @@ describe("bedrock discovery", () => {
       input: ["text", "image"],
       contextWindow: 1000000,
       maxTokens: 4096,
+    });
+  });
+
+  it("uses the resolved base model id for application-profile context fallback", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "us.my-prod-profile",
+            inferenceProfileName: "Prod Claude Profile",
+            status: "ACTIVE",
+            type: "APPLICATION",
+            models: [
+              {
+                modelArn:
+                  "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-6-v1:0",
+              },
+            ],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+
+    expect(models[0]).toMatchObject({
+      id: "us.my-prod-profile",
+      contextWindow: 1_000_000,
+      maxTokens: 4096,
+      input: ["text"],
     });
   });
 

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -21,7 +21,7 @@ import {
 const log = createSubsystemLogger("bedrock-discovery");
 
 const DEFAULT_REFRESH_INTERVAL_SECONDS = 3600;
-const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 4096;
 
 // ---------------------------------------------------------------------------

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -21,8 +21,70 @@ import {
 const log = createSubsystemLogger("bedrock-discovery");
 
 const DEFAULT_REFRESH_INTERVAL_SECONDS = 3600;
-const DEFAULT_CONTEXT_WINDOW = 32000;
+const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 4096;
+
+// ---------------------------------------------------------------------------
+// Known model context windows (Bedrock API does not expose token limits)
+// ---------------------------------------------------------------------------
+
+/**
+ * Bedrock's ListFoundationModels API returns no token limit information.
+ * This map provides correct context window values for known models.
+ * Inference profile prefixes (us., eu., ap., global.) are stripped before lookup.
+ *
+ * Sources: https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
+ *          https://docs.anthropic.com/en/docs/about-claude/models
+ */
+const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
+  // Anthropic Claude
+  "anthropic.claude-opus-4-6-v1": 1_000_000,
+  "anthropic.claude-sonnet-4-6": 1_000_000,
+  "anthropic.claude-sonnet-4-5-20250929-v1:0": 200_000,
+  "anthropic.claude-haiku-4-5-20251001-v1:0": 200_000,
+  // Amazon Nova
+  "amazon.nova-premier-v1:0": 1_000_000,
+  "amazon.nova-pro-v1:0": 300_000,
+  "amazon.nova-lite-v1:0": 300_000,
+  "amazon.nova-micro-v1:0": 128_000,
+  "amazon.nova-2-lite-v1:0": 300_000,
+  // Meta Llama
+  "meta.llama3-3-70b-instruct-v1:0": 128_000,
+  "meta.llama3-2-90b-instruct-v1:0": 128_000,
+  "meta.llama3-2-11b-instruct-v1:0": 128_000,
+  "meta.llama3-2-3b-instruct-v1:0": 128_000,
+  "meta.llama3-2-1b-instruct-v1:0": 128_000,
+  "meta.llama3-1-405b-instruct-v1:0": 128_000,
+  "meta.llama3-1-70b-instruct-v1:0": 128_000,
+  "meta.llama3-1-8b-instruct-v1:0": 128_000,
+  // Mistral
+  "mistral.mistral-large-2407-v1:0": 128_000,
+  "mistral.mistral-small-2402-v1:0": 32_000,
+  // DeepSeek
+  "deepseek.r1-v1:0": 128_000,
+  // Cohere
+  "cohere.command-r-plus-v1:0": 128_000,
+  "cohere.command-r-v1:0": 128_000,
+  // AI21
+  "ai21.jamba-1-5-large-v1:0": 256_000,
+  "ai21.jamba-1-5-mini-v1:0": 256_000,
+};
+
+/**
+ * Resolve the real context window for a Bedrock model ID.
+ * Strips inference profile prefixes (us., eu., ap., global.) before lookup.
+ */
+function resolveKnownContextWindow(modelId: string): number | undefined {
+  if (KNOWN_CONTEXT_WINDOWS[modelId]) {
+    return KNOWN_CONTEXT_WINDOWS[modelId];
+  }
+  // Strip regional inference profile prefix
+  const stripped = modelId.replace(/^(?:us|eu|ap|global)\./, "");
+  if (stripped !== modelId && KNOWN_CONTEXT_WINDOWS[stripped]) {
+    return KNOWN_CONTEXT_WINDOWS[stripped];
+  }
+  return undefined;
+}
 const DEFAULT_COST = {
   input: 0,
   output: 0,
@@ -163,7 +225,7 @@ function toModelDefinition(
     reasoning: inferReasoningSupport(summary),
     input: mapInputModalities(summary),
     cost: DEFAULT_COST,
-    contextWindow: defaults.contextWindow,
+    contextWindow: resolveKnownContextWindow(id) ?? defaults.contextWindow,
     maxTokens: defaults.maxTokens,
   };
 }
@@ -282,7 +344,9 @@ function resolveInferenceProfiles(
       reasoning: baseModel?.reasoning ?? false,
       input: baseModel?.input ?? ["text"],
       cost: baseModel?.cost ?? DEFAULT_COST,
-      contextWindow: baseModel?.contextWindow ?? defaults.contextWindow,
+      contextWindow: baseModel?.contextWindow
+        ?? resolveKnownContextWindow(profile.inferenceProfileId ?? "")
+        ?? defaults.contextWindow,
       maxTokens: baseModel?.maxTokens ?? defaults.maxTokens,
     });
   }

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -29,12 +29,20 @@ const DEFAULT_MAX_TOKENS = 4096;
 // ---------------------------------------------------------------------------
 
 /**
- * Bedrock's ListFoundationModels API returns no token limit information.
- * This map provides correct context window values for known models.
+ * Bedrock's ListFoundationModels and GetFoundationModel APIs return no token
+ * limit information — only model ID, name, modalities, and lifecycle status.
+ * There is currently no Bedrock API to discover context windows or max output
+ * tokens programmatically.
+ *
+ * This map provides correct context window values for known models so that
+ * session management, compaction thresholds, and context overflow detection
+ * work correctly. If AWS adds token metadata to the API in the future, this
+ * table should become a fallback rather than the primary source.
+ *
  * Inference profile prefixes (us., eu., ap., global.) are stripped before lookup.
  *
  * Sources: https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
- *          https://docs.anthropic.com/en/docs/about-claude/models
+ *          https://platform.claude.com/docs/en/about-claude/models
  */
 const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   // Anthropic Claude

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -53,7 +53,6 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   "anthropic.claude-sonnet-4-20250514-v1:0": 200_000,
   "anthropic.claude-opus-4-5-20251101-v1:0": 200_000,
   "anthropic.claude-opus-4-1-20250805-v1:0": 200_000,
-  "anthropic.claude-opus-4-20250514-v1:0": 200_000,
   "anthropic.claude-haiku-4-5-20251001-v1:0": 200_000,
   "anthropic.claude-3-5-haiku-20241022-v1:0": 200_000,
   "anthropic.claude-3-haiku-20240307-v1:0": 200_000,
@@ -63,7 +62,14 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   "amazon.nova-lite-v1:0": 300_000,
   "amazon.nova-micro-v1:0": 128_000,
   "amazon.nova-2-lite-v1:0": 300_000,
-  // Meta Llama
+  // MiniMax
+  "minimax.minimax-m2.5": 1_000_000,
+  "minimax.minimax-m2.1": 1_000_000,
+  "minimax.minimax-m2": 1_000_000,
+  // Meta Llama 4
+  "meta.llama4-maverick-17b-instruct-v1:0": 1_000_000,
+  "meta.llama4-scout-17b-instruct-v1:0": 512_000,
+  // Meta Llama 3
   "meta.llama3-3-70b-instruct-v1:0": 128_000,
   "meta.llama3-2-90b-instruct-v1:0": 128_000,
   "meta.llama3-2-11b-instruct-v1:0": 128_000,
@@ -72,12 +78,17 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   "meta.llama3-1-405b-instruct-v1:0": 128_000,
   "meta.llama3-1-70b-instruct-v1:0": 128_000,
   "meta.llama3-1-8b-instruct-v1:0": 128_000,
+  // NVIDIA Nemotron
+  "nvidia.nemotron-super-3-120b": 128_000,
+  "nvidia.nemotron-nano-3-30b": 128_000,
+  "nvidia.nemotron-nano-12b-v2": 128_000,
+  "nvidia.nemotron-nano-9b-v2": 128_000,
   // Mistral
+  "mistral.mistral-large-3-675b-instruct": 128_000,
   "mistral.mistral-large-2407-v1:0": 128_000,
   "mistral.mistral-small-2402-v1:0": 32_000,
   // DeepSeek
   "deepseek.r1-v1:0": 128_000,
-  "deepseek.v3-v1:0": 128_000,
   "deepseek.v3.2": 128_000,
   // Cohere
   "cohere.command-r-plus-v1:0": 128_000,
@@ -89,6 +100,15 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   "google.gemma-3-27b-it": 128_000,
   "google.gemma-3-12b-it": 128_000,
   "google.gemma-3-4b-it": 128_000,
+  // GLM
+  "zai.glm-5": 128_000,
+  "zai.glm-4.7": 128_000,
+  "zai.glm-4.7-flash": 128_000,
+  // Qwen
+  "qwen.qwen3-coder-next": 256_000,
+  "qwen.qwen3-coder-30b-a3b-v1:0": 256_000,
+  "qwen.qwen3-32b-v1:0": 128_000,
+  "qwen.qwen3-vl-235b-a22b": 128_000,
 };
 
 /**

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -21,7 +21,7 @@ import {
 const log = createSubsystemLogger("bedrock-discovery");
 
 const DEFAULT_REFRESH_INTERVAL_SECONDS = 3600;
-const DEFAULT_CONTEXT_WINDOW = 200_000;
+const DEFAULT_CONTEXT_WINDOW = 32_000;
 const DEFAULT_MAX_TOKENS = 4096;
 
 // ---------------------------------------------------------------------------
@@ -46,6 +46,7 @@ const DEFAULT_MAX_TOKENS = 4096;
  */
 const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   // Anthropic Claude
+  "anthropic.claude-3-7-sonnet-20250219-v1:0": 200_000,
   "anthropic.claude-opus-4-7": 1_000_000,
   "anthropic.claude-opus-4-6-v1": 1_000_000,
   "anthropic.claude-sonnet-4-6": 1_000_000,
@@ -79,7 +80,7 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   "meta.llama3-1-70b-instruct-v1:0": 128_000,
   "meta.llama3-1-8b-instruct-v1:0": 128_000,
   // NVIDIA Nemotron
-  "nvidia.nemotron-super-3-120b": 128_000,
+  "nvidia.nemotron-super-3-120b": 256_000,
   "nvidia.nemotron-nano-3-30b": 128_000,
   "nvidia.nemotron-nano-12b-v2": 128_000,
   "nvidia.nemotron-nano-9b-v2": 128_000,

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -49,7 +49,9 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   "anthropic.claude-3-7-sonnet-20250219-v1:0": 200_000,
   "anthropic.claude-opus-4-7": 1_000_000,
   "anthropic.claude-opus-4-6-v1": 1_000_000,
+  "anthropic.claude-opus-4-6-v1:0": 1_000_000,
   "anthropic.claude-sonnet-4-6": 1_000_000,
+  "anthropic.claude-sonnet-4-6-v1:0": 1_000_000,
   "anthropic.claude-sonnet-4-5-20250929-v1:0": 200_000,
   "anthropic.claude-sonnet-4-20250514-v1:0": 200_000,
   "anthropic.claude-opus-4-5-20251101-v1:0": 200_000,
@@ -117,13 +119,19 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
  * Strips inference profile prefixes (us., eu., ap., global.) before lookup.
  */
 function resolveKnownContextWindow(modelId: string): number | undefined {
-  if (KNOWN_CONTEXT_WINDOWS[modelId] !== undefined) {
-    return KNOWN_CONTEXT_WINDOWS[modelId];
-  }
-  // Strip regional inference profile prefix
   const stripped = modelId.replace(/^(?:us|eu|ap|apac|au|jp|global)\./, "");
-  if (stripped !== modelId && KNOWN_CONTEXT_WINDOWS[stripped] !== undefined) {
-    return KNOWN_CONTEXT_WINDOWS[stripped];
+  const candidates = [modelId, stripped];
+  for (const candidate of candidates) {
+    if (KNOWN_CONTEXT_WINDOWS[candidate] !== undefined) {
+      return KNOWN_CONTEXT_WINDOWS[candidate];
+    }
+    const withoutVersionSuffix = candidate.replace(/:0$/, "");
+    if (
+      withoutVersionSuffix !== candidate &&
+      KNOWN_CONTEXT_WINDOWS[withoutVersionSuffix] !== undefined
+    ) {
+      return KNOWN_CONTEXT_WINDOWS[withoutVersionSuffix];
+    }
   }
   return undefined;
 }
@@ -388,7 +396,7 @@ function resolveInferenceProfiles(
       input: baseModel?.input ?? ["text"],
       cost: baseModel?.cost ?? DEFAULT_COST,
       contextWindow: baseModel?.contextWindow
-        ?? resolveKnownContextWindow(profile.inferenceProfileId ?? "")
+        ?? resolveKnownContextWindow(baseModelId ?? profile.inferenceProfileId ?? "")
         ?? defaults.contextWindow,
       maxTokens: baseModel?.maxTokens ?? defaults.maxTokens,
     });

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -38,10 +38,17 @@ const DEFAULT_MAX_TOKENS = 4096;
  */
 const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   // Anthropic Claude
+  "anthropic.claude-opus-4-7": 1_000_000,
   "anthropic.claude-opus-4-6-v1": 1_000_000,
   "anthropic.claude-sonnet-4-6": 1_000_000,
   "anthropic.claude-sonnet-4-5-20250929-v1:0": 200_000,
+  "anthropic.claude-sonnet-4-20250514-v1:0": 200_000,
+  "anthropic.claude-opus-4-5-20251101-v1:0": 200_000,
+  "anthropic.claude-opus-4-1-20250805-v1:0": 200_000,
+  "anthropic.claude-opus-4-20250514-v1:0": 200_000,
   "anthropic.claude-haiku-4-5-20251001-v1:0": 200_000,
+  "anthropic.claude-3-5-haiku-20241022-v1:0": 200_000,
+  "anthropic.claude-3-haiku-20240307-v1:0": 200_000,
   // Amazon Nova
   "amazon.nova-premier-v1:0": 1_000_000,
   "amazon.nova-pro-v1:0": 300_000,
@@ -62,29 +69,110 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   "mistral.mistral-small-2402-v1:0": 32_000,
   // DeepSeek
   "deepseek.r1-v1:0": 128_000,
+  "deepseek.v3-v1:0": 128_000,
+  "deepseek.v3.2": 128_000,
   // Cohere
   "cohere.command-r-plus-v1:0": 128_000,
   "cohere.command-r-v1:0": 128_000,
   // AI21
   "ai21.jamba-1-5-large-v1:0": 256_000,
   "ai21.jamba-1-5-mini-v1:0": 256_000,
+  // Google Gemma
+  "google.gemma-3-27b-it": 128_000,
+  "google.gemma-3-12b-it": 128_000,
+  "google.gemma-3-4b-it": 128_000,
 };
 
 /**
  * Resolve the real context window for a Bedrock model ID.
  * Strips inference profile prefixes (us., eu., ap., global.) before lookup.
  */
-function resolveKnownContextWindow(modelId: string): number | undefined {
-  if (KNOWN_CONTEXT_WINDOWS[modelId]) {
-    return KNOWN_CONTEXT_WINDOWS[modelId];
+/**
+ * Known max output tokens for Bedrock models.
+ *
+ * These values balance response quality against Bedrock's token quota burndown:
+ * at request start, Bedrock reserves input_tokens + max_tokens from your TPM
+ * quota. For Claude 3.7+ models, output tokens burn at 5x rate. Setting
+ * max_tokens too high wastes quota capacity and reduces concurrent throughput;
+ * setting too low truncates responses.
+ *
+ * Values here are intentionally conservative — pi's buildBaseOptions caps at
+ * 32K anyway, and thinking budget is added separately by adjustMaxTokensForThinking.
+ *
+ * Sources: https://docs.aws.amazon.com/bedrock/latest/userguide/quotas-token-burndown.html
+ *          https://platform.claude.com/docs/en/about-claude/models/overview
+ */
+const KNOWN_MAX_TOKENS: Record<string, number> = {
+  // Anthropic Claude — conservative to avoid quota burndown waste.
+  // Actual limits: Opus 4.7 = 128K, Sonnet/Opus 4.6 = 64K, older = 64K.
+  // Thinking budget is added on top by the runtime, not counted here.
+  "anthropic.claude-opus-4-7": 16_384,
+  "anthropic.claude-opus-4-6-v1": 16_384,
+  "anthropic.claude-sonnet-4-6": 16_384,
+  "anthropic.claude-sonnet-4-5-20250929-v1:0": 8_192,
+  "anthropic.claude-sonnet-4-20250514-v1:0": 8_192,
+  "anthropic.claude-opus-4-5-20251101-v1:0": 8_192,
+  "anthropic.claude-opus-4-1-20250805-v1:0": 8_192,
+  "anthropic.claude-opus-4-20250514-v1:0": 8_192,
+  "anthropic.claude-haiku-4-5-20251001-v1:0": 8_192,
+  "anthropic.claude-3-5-haiku-20241022-v1:0": 4_096,
+  "anthropic.claude-3-haiku-20240307-v1:0": 4_096,
+  // Amazon Nova — max output is 5K for all Nova text models
+  "amazon.nova-premier-v1:0": 5_120,
+  "amazon.nova-pro-v1:0": 5_120,
+  "amazon.nova-lite-v1:0": 5_120,
+  "amazon.nova-micro-v1:0": 5_120,
+  "amazon.nova-2-lite-v1:0": 5_120,
+  // Meta Llama — varies by model, 4K-128K
+  "meta.llama3-3-70b-instruct-v1:0": 8_192,
+  "meta.llama3-2-90b-instruct-v1:0": 4_096,
+  "meta.llama3-2-11b-instruct-v1:0": 4_096,
+  "meta.llama3-2-3b-instruct-v1:0": 4_096,
+  "meta.llama3-2-1b-instruct-v1:0": 4_096,
+  "meta.llama3-1-405b-instruct-v1:0": 8_192,
+  "meta.llama3-1-70b-instruct-v1:0": 8_192,
+  "meta.llama3-1-8b-instruct-v1:0": 4_096,
+  // DeepSeek
+  "deepseek.r1-v1:0": 16_384,
+  "deepseek.v3-v1:0": 8_192,
+  "deepseek.v3.2": 8_192,
+  // AI21 Jamba
+  "ai21.jamba-1-5-large-v1:0": 4_096,
+  "ai21.jamba-1-5-mini-v1:0": 4_096,
+};
+
+/**
+ * Resolve a known value from a lookup table, stripping inference profile prefixes.
+ * Used for both context windows and max tokens.
+ */
+function resolveKnownValue(modelId: string, table: Record<string, number>): number | undefined {
+  if (table[modelId] !== undefined) {
+    return table[modelId];
   }
   // Strip regional inference profile prefix
   const stripped = modelId.replace(/^(?:us|eu|ap|global)\./, "");
-  if (stripped !== modelId && KNOWN_CONTEXT_WINDOWS[stripped]) {
-    return KNOWN_CONTEXT_WINDOWS[stripped];
+  if (stripped !== modelId && table[stripped] !== undefined) {
+    return table[stripped];
   }
   return undefined;
 }
+
+/**
+ * Resolve the real context window for a Bedrock model ID.
+ * Strips inference profile prefixes (us., eu., ap., global.) before lookup.
+ */
+function resolveKnownContextWindow(modelId: string): number | undefined {
+  return resolveKnownValue(modelId, KNOWN_CONTEXT_WINDOWS);
+}
+
+/**
+ * Resolve the recommended max output tokens for a Bedrock model ID.
+ * Returns values optimized for Bedrock's quota burndown mechanism.
+ */
+function resolveKnownMaxTokens(modelId: string): number | undefined {
+  return resolveKnownValue(modelId, KNOWN_MAX_TOKENS);
+}
+
 const DEFAULT_COST = {
   input: 0,
   output: 0,
@@ -226,7 +314,7 @@ function toModelDefinition(
     input: mapInputModalities(summary),
     cost: DEFAULT_COST,
     contextWindow: resolveKnownContextWindow(id) ?? defaults.contextWindow,
-    maxTokens: defaults.maxTokens,
+    maxTokens: resolveKnownMaxTokens(id) ?? defaults.maxTokens,
   };
 }
 
@@ -347,7 +435,9 @@ function resolveInferenceProfiles(
       contextWindow: baseModel?.contextWindow
         ?? resolveKnownContextWindow(profile.inferenceProfileId ?? "")
         ?? defaults.contextWindow,
-      maxTokens: baseModel?.maxTokens ?? defaults.maxTokens,
+      maxTokens: baseModel?.maxTokens
+        ?? resolveKnownMaxTokens(profile.inferenceProfileId ?? "")
+        ?? defaults.maxTokens,
     });
   }
   return discovered;

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -87,90 +87,16 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
  * Resolve the real context window for a Bedrock model ID.
  * Strips inference profile prefixes (us., eu., ap., global.) before lookup.
  */
-/**
- * Known max output tokens for Bedrock models.
- *
- * These values balance response quality against Bedrock's token quota burndown:
- * at request start, Bedrock reserves input_tokens + max_tokens from your TPM
- * quota. For Claude 3.7+ models, output tokens burn at 5x rate. Setting
- * max_tokens too high wastes quota capacity and reduces concurrent throughput;
- * setting too low truncates responses.
- *
- * Values here are intentionally conservative — pi's buildBaseOptions caps at
- * 32K anyway, and thinking budget is added separately by adjustMaxTokensForThinking.
- *
- * Sources: https://docs.aws.amazon.com/bedrock/latest/userguide/quotas-token-burndown.html
- *          https://platform.claude.com/docs/en/about-claude/models/overview
- */
-const KNOWN_MAX_TOKENS: Record<string, number> = {
-  // Anthropic Claude — conservative to avoid quota burndown waste.
-  // Actual limits: Opus 4.7 = 128K, Sonnet/Opus 4.6 = 64K, older = 64K.
-  // Thinking budget is added on top by the runtime, not counted here.
-  "anthropic.claude-opus-4-7": 16_384,
-  "anthropic.claude-opus-4-6-v1": 16_384,
-  "anthropic.claude-sonnet-4-6": 16_384,
-  "anthropic.claude-sonnet-4-5-20250929-v1:0": 8_192,
-  "anthropic.claude-sonnet-4-20250514-v1:0": 8_192,
-  "anthropic.claude-opus-4-5-20251101-v1:0": 8_192,
-  "anthropic.claude-opus-4-1-20250805-v1:0": 8_192,
-  "anthropic.claude-opus-4-20250514-v1:0": 8_192,
-  "anthropic.claude-haiku-4-5-20251001-v1:0": 8_192,
-  "anthropic.claude-3-5-haiku-20241022-v1:0": 4_096,
-  "anthropic.claude-3-haiku-20240307-v1:0": 4_096,
-  // Amazon Nova — max output is 5K for all Nova text models
-  "amazon.nova-premier-v1:0": 5_120,
-  "amazon.nova-pro-v1:0": 5_120,
-  "amazon.nova-lite-v1:0": 5_120,
-  "amazon.nova-micro-v1:0": 5_120,
-  "amazon.nova-2-lite-v1:0": 5_120,
-  // Meta Llama — varies by model, 4K-128K
-  "meta.llama3-3-70b-instruct-v1:0": 8_192,
-  "meta.llama3-2-90b-instruct-v1:0": 4_096,
-  "meta.llama3-2-11b-instruct-v1:0": 4_096,
-  "meta.llama3-2-3b-instruct-v1:0": 4_096,
-  "meta.llama3-2-1b-instruct-v1:0": 4_096,
-  "meta.llama3-1-405b-instruct-v1:0": 8_192,
-  "meta.llama3-1-70b-instruct-v1:0": 8_192,
-  "meta.llama3-1-8b-instruct-v1:0": 4_096,
-  // DeepSeek
-  "deepseek.r1-v1:0": 16_384,
-  "deepseek.v3-v1:0": 8_192,
-  "deepseek.v3.2": 8_192,
-  // AI21 Jamba
-  "ai21.jamba-1-5-large-v1:0": 4_096,
-  "ai21.jamba-1-5-mini-v1:0": 4_096,
-};
-
-/**
- * Resolve a known value from a lookup table, stripping inference profile prefixes.
- * Used for both context windows and max tokens.
- */
-function resolveKnownValue(modelId: string, table: Record<string, number>): number | undefined {
-  if (table[modelId] !== undefined) {
-    return table[modelId];
+function resolveKnownContextWindow(modelId: string): number | undefined {
+  if (KNOWN_CONTEXT_WINDOWS[modelId] !== undefined) {
+    return KNOWN_CONTEXT_WINDOWS[modelId];
   }
   // Strip regional inference profile prefix
   const stripped = modelId.replace(/^(?:us|eu|ap|global)\./, "");
-  if (stripped !== modelId && table[stripped] !== undefined) {
-    return table[stripped];
+  if (stripped !== modelId && KNOWN_CONTEXT_WINDOWS[stripped] !== undefined) {
+    return KNOWN_CONTEXT_WINDOWS[stripped];
   }
   return undefined;
-}
-
-/**
- * Resolve the real context window for a Bedrock model ID.
- * Strips inference profile prefixes (us., eu., ap., global.) before lookup.
- */
-function resolveKnownContextWindow(modelId: string): number | undefined {
-  return resolveKnownValue(modelId, KNOWN_CONTEXT_WINDOWS);
-}
-
-/**
- * Resolve the recommended max output tokens for a Bedrock model ID.
- * Returns values optimized for Bedrock's quota burndown mechanism.
- */
-function resolveKnownMaxTokens(modelId: string): number | undefined {
-  return resolveKnownValue(modelId, KNOWN_MAX_TOKENS);
 }
 
 const DEFAULT_COST = {
@@ -314,7 +240,7 @@ function toModelDefinition(
     input: mapInputModalities(summary),
     cost: DEFAULT_COST,
     contextWindow: resolveKnownContextWindow(id) ?? defaults.contextWindow,
-    maxTokens: resolveKnownMaxTokens(id) ?? defaults.maxTokens,
+    maxTokens: defaults.maxTokens,
   };
 }
 
@@ -435,9 +361,7 @@ function resolveInferenceProfiles(
       contextWindow: baseModel?.contextWindow
         ?? resolveKnownContextWindow(profile.inferenceProfileId ?? "")
         ?? defaults.contextWindow,
-      maxTokens: baseModel?.maxTokens
-        ?? resolveKnownMaxTokens(profile.inferenceProfileId ?? "")
-        ?? defaults.maxTokens,
+      maxTokens: baseModel?.maxTokens ?? defaults.maxTokens,
     });
   }
   return discovered;

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -100,7 +100,7 @@ function resolveKnownContextWindow(modelId: string): number | undefined {
     return KNOWN_CONTEXT_WINDOWS[modelId];
   }
   // Strip regional inference profile prefix
-  const stripped = modelId.replace(/^(?:us|eu|ap|global)\./, "");
+  const stripped = modelId.replace(/^(?:us|eu|ap|apac|au|jp|global)\./, "");
   if (stripped !== modelId && KNOWN_CONTEXT_WINDOWS[stripped] !== undefined) {
     return KNOWN_CONTEXT_WINDOWS[stripped];
   }
@@ -276,7 +276,7 @@ function resolveBaseModelId(profile: InferenceProfileSummary): string | undefine
   }
   if (profile.type === "SYSTEM_DEFINED") {
     const id = profile.inferenceProfileId ?? "";
-    const prefixMatch = /^(?:us|eu|ap|jp|global)\.(.+)$/i.exec(id);
+    const prefixMatch = /^(?:us|eu|ap|apac|au|jp|global)\.(.+)$/i.exec(id);
     if (prefixMatch) {
       return prefixMatch[1];
     }


### PR DESCRIPTION
## Problem

Bedrock's `ListFoundationModels` API does not expose token limits. Discovery hardcodes `contextWindow: 32000` for every model — including Claude (1M), Nova (300K), and Llama (128K). This causes:

- **Premature "Context limit exceeded" errors** on first or second message
- **Unnecessary session resets** — users can't hold conversations
- **Wrong compaction thresholds** — compaction triggers at 32K instead of the real limit
- The `source: "model"` classification means the warning system doesn't fire (#64919)

Affects every Bedrock user relying on auto-discovery (the default). Reported in #64250 (8+ affected users across Bedrock, Minimax, Doubao, GLM).

## Fix

Adds a lookup table of known context windows for Bedrock models. Discovery checks the table before falling back to the default.

```
Claude Opus 4.6 / Sonnet 4.6  → 1,000,000
Nova Premier                   → 1,000,000
Nova Pro / Lite / 2 Lite       →   300,000
AI21 Jamba 1.5                 →   256,000
Claude Sonnet 4.5 / Haiku 4.5 →   200,000
Nova Micro, Llama 3.x, Mistral Large, DeepSeek R1, Cohere Command R → 128,000
Mistral Small                  →    32,000
```

Inference profile prefixes (`us.`, `eu.`, `ap.`, `global.`) are stripped before lookup, so `us.anthropic.claude-opus-4-6-v1` correctly resolves to 1M.

Also raises the default fallback from 32K to 128K for unknown models.

## Changes

| File | Change |
|------|--------|
| `extensions/amazon-bedrock/discovery.ts` | +67/-3 — add `KNOWN_CONTEXT_WINDOWS` map + `resolveKnownContextWindow()`, update `toModelDefinition` and inference profile resolution |

Single file, no type system changes, no cross-cutting impact.

## Relationship to #65030

This PR is **complementary** to #65030 (provenance flag by @mobilinkd):

- **This PR** answers "what's the right value?" — provides correct context windows for known models so sessions work immediately
- **#65030** answers "how do we know the value is wrong?" — adds a warning when falling back to the default for unknown models

Both can merge independently. Together they cover known models (correct values) and unknown models (warning + fallback). Recommend merging this first since it immediately fixes broken sessions.

Fixes #64919
Related: #64250