### PR TITLE
fix(agents): surface terminal assistant errors via FailoverError

### DIFF
--- a/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
@@ -1,0 +1,281 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { FailoverError } from "../../failover-error.js";
+import { handleAssistantFailover } from "./assistant-failover.js";
+
+type Overrides = Partial<Parameters<typeof handleAssistantFailover>[0]>;
+
+function createParams(overrides: Overrides = {}): Parameters<typeof handleAssistantFailover>[0] {
+  return {
+    initialDecision: { action: "surface_error", reason: "timeout" },
+    aborted: false,
+    externalAbort: false,
+    fallbackConfigured: false,
+    failoverFailure: true,
+    failoverReason: "timeout",
+    timedOut: true,
+    idleTimedOut: false,
+    timedOutDuringCompaction: false,
+    allowSameModelIdleTimeoutRetry: false,
+    assistantProfileFailureReason: null,
+    lastProfileId: "profile-abc",
+    modelId: "sonnet-4.6",
+    provider: "anthropic",
+    activeErrorContext: { provider: "anthropic", model: "sonnet-4.6" },
+    lastAssistant: undefined,
+    config: undefined,
+    sessionKey: "test-session",
+    authFailure: false,
+    rateLimitFailure: false,
+    billingFailure: false,
+    cloudCodeAssistFormatError: false,
+    isProbeSession: false,
+    overloadProfileRotations: 0,
+    overloadProfileRotationLimit: 3,
+    previousRetryFailoverReason: null,
+    logAssistantFailoverDecision: vi.fn(),
+    warn: vi.fn(),
+    maybeMarkAuthProfileFailure: vi.fn(async () => undefined),
+    maybeEscalateRateLimitProfileFallback: vi.fn(),
+    maybeBackoffBeforeOverloadFailover: vi.fn(async () => undefined),
+    advanceAuthProfile: vi.fn(async () => false),
+    ...overrides,
+  };
+}
+
+describe("handleAssistantFailover — surface_error handling (regression: PR #64817)", () => {
+  it("returns continue_normal (not throw) on timedOut surface_error so the outer run loop's dedicated timeout payload builder (with the config-key hint) can emit the user-visible error", async () => {
+    const log = vi.fn();
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "surface_error", reason: "timeout" },
+        failoverReason: "timeout",
+        timedOut: true,
+        logAssistantFailoverDecision: log,
+      }),
+    );
+
+    expect(outcome.action).toBe("continue_normal");
+    // Still logs for observability, but omits status because we did not build
+    // a FailoverError with a resolved HTTP code.
+    expect(log).toHaveBeenCalledWith("surface_error");
+  });
+
+  it("throws FailoverError with reason=billing and status=402 when surface_error is a billing failure", async () => {
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "surface_error", reason: "billing" },
+        failoverReason: "billing",
+        timedOut: false,
+        billingFailure: true,
+      }),
+    );
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      return;
+    }
+    expect(outcome.error.reason).toBe("billing");
+    expect(outcome.error.status).toBe(402);
+    expect(outcome.error.message.length).toBeGreaterThan(0);
+  });
+
+  it("throws FailoverError with reason=rate_limit and status=429 when surface_error is rate-limited", async () => {
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "surface_error", reason: "rate_limit" },
+        failoverReason: "rate_limit",
+        timedOut: false,
+        rateLimitFailure: true,
+      }),
+    );
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      return;
+    }
+    expect(outcome.error.reason).toBe("rate_limit");
+    expect(outcome.error.status).toBe(429);
+    expect(outcome.error.message).toBe("LLM request rate limited.");
+  });
+
+  it("rate_limit message wins over billing when both classifiers match (e.g. an 'insufficient quota' body), so the user-facing string agrees with the 429 reason/status", async () => {
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "surface_error", reason: "rate_limit" },
+        failoverReason: "rate_limit",
+        timedOut: false,
+        // Both flags are true — the underlying upstream error matched both
+        // `isRateLimitAssistantError` and `isBillingAssistantError`.
+        rateLimitFailure: true,
+        billingFailure: true,
+      }),
+    );
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      return;
+    }
+    expect(outcome.error.reason).toBe("rate_limit");
+    expect(outcome.error.status).toBe(429);
+    expect(outcome.error.message).toBe("LLM request rate limited.");
+  });
+
+  it("throws FailoverError with reason=auth and status=401 when surface_error is an auth failure", async () => {
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "surface_error", reason: "auth" },
+        failoverReason: "auth",
+        timedOut: false,
+        authFailure: true,
+      }),
+    );
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      return;
+    }
+    expect(outcome.error.reason).toBe("auth");
+    expect(outcome.error.status).toBe(401);
+    expect(outcome.error.message).toBe("LLM request unauthorized.");
+  });
+
+  it("throws FailoverError with generic message when surface_error reason is unknown and no lastAssistant provided", async () => {
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "surface_error", reason: "unknown" },
+        failoverReason: null,
+        timedOut: false,
+      }),
+    );
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      return;
+    }
+    expect(outcome.error.reason).toBe("unknown");
+    expect(outcome.error.message).toBe("LLM request failed.");
+  });
+
+  it("logs the surface_error decision with the computed HTTP status for observability parity with fallback_model (non-timeout path)", async () => {
+    const log = vi.fn();
+    await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "surface_error", reason: "billing" },
+        failoverReason: "billing",
+        timedOut: false,
+        billingFailure: true,
+        logAssistantFailoverDecision: log,
+      }),
+    );
+
+    expect(log).toHaveBeenCalledWith("surface_error", { status: 402 });
+  });
+
+  it("does NOT throw a FailoverError when surface_error is caused by an external abort (user/system cancellation)", async () => {
+    const log = vi.fn();
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "surface_error", reason: null },
+        externalAbort: true,
+        aborted: true,
+        timedOut: false,
+        failoverReason: null,
+        logAssistantFailoverDecision: log,
+      }),
+    );
+
+    expect(outcome.action).toBe("continue_normal");
+    // Still logs the decision so observability is consistent, but must NOT
+    // carry a synthetic HTTP status because no upstream error produced one.
+    expect(log).toHaveBeenCalledWith("surface_error");
+  });
+
+  // --- Regression guards: pre-existing behavior MUST be preserved ---
+
+  it("preserves the idle-timeout retry path: if !externalAbort + idleTimedOut + allowSameModelIdleTimeoutRetry, returns retry (not throw)", async () => {
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "surface_error", reason: "timeout" },
+        externalAbort: false,
+        idleTimedOut: true,
+        allowSameModelIdleTimeoutRetry: true,
+        timedOut: true,
+      }),
+    );
+
+    expect(outcome.action).toBe("retry");
+    if (outcome.action !== "retry") {
+      return;
+    }
+    expect(outcome.retryKind).toBe("same_model_idle_timeout");
+  });
+
+  // --- fallback_model branch: pins the legacy message precedence shared with
+  // surface_error (upstream assistant text wins over canonical type-specific
+  // messages, so users see provider/model context like "deepseek/…: 429 …").
+
+  it("fallback_model branch: lastAssistant.errorMessage wins over the canonical timeout message when upstream text is present", async () => {
+    const lastAssistant = {
+      errorMessage: "Upstream provider returned an opaque 502 wrapper",
+    } as unknown as AssistantMessage;
+
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "fallback_model", reason: "timeout" },
+        failoverReason: "timeout",
+        timedOut: true,
+        fallbackConfigured: true,
+        lastAssistant,
+      }),
+    );
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      return;
+    }
+    expect(outcome.error).toBeInstanceOf(FailoverError);
+    expect(outcome.error.reason).toBe("timeout");
+    // Reason maps to 408 independent of the message body; the legacy precedence
+    // only governs which human-readable string the user sees.
+    expect(outcome.error.status).toBe(408);
+    expect(outcome.error.message).toBe("Upstream provider returned an opaque 502 wrapper");
+  });
+
+  it("fallback_model branch: falls back to canonical type-specific message when lastAssistant is absent", async () => {
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "fallback_model", reason: "timeout" },
+        failoverReason: "timeout",
+        timedOut: true,
+        fallbackConfigured: true,
+        lastAssistant: undefined,
+      }),
+    );
+
+    expect(outcome.action).toBe("throw");
+    if (outcome.action !== "throw") {
+      return;
+    }
+    expect(outcome.error.message).toBe("LLM request timed out.");
+    expect(outcome.error.status).toBe(408);
+  });
+
+  it("returns continue_normal when decision is not surface_error/rotate_profile/fallback_model (happy path)", async () => {
+    // No recovery needed — simulate a no-op passthrough by using a decision whose
+    // action we don't specifically handle (`continue_normal` isn't a real decision
+    // action, but the function returns `continue_normal` as its default fallthrough
+    // when the decision doesn't match any branch). Cast to satisfy the discriminated
+    // union; at runtime the branch simply falls through.
+    const outcome = await handleAssistantFailover(
+      createParams({
+        initialDecision: { action: "no_action_needed" } as unknown as Parameters<
+          typeof handleAssistantFailover
+        >[0]["initialDecision"],
+        timedOut: false,
+      }),
+    );
+
+    expect(outcome.action).toBe("continue_normal");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -32,6 +32,121 @@ type AssistantFailoverOutcome =
       error: FailoverError;
     };
 
+type FailoverMessageParams = {
+  timedOut: boolean;
+  billingFailure: boolean;
+  rateLimitFailure: boolean;
+  authFailure: boolean;
+  lastAssistant: AssistantMessage | undefined;
+  config: OpenClawConfig | undefined;
+  sessionKey?: string;
+  activeErrorContext: { provider: string; model: string };
+};
+
+// Shared by the `fallback_model` and `surface_error` branches. Preserves the
+// legacy `fallback_model` precedence in two ways:
+//   1. Upstream assistant text wins over the generic type-specific messages,
+//      so users see provider/model-specific context (e.g.
+//      "deepseek/deepseek-chat: 429 …") rather than a canonical one-liner.
+//   2. Among the type-specific fallbacks the order is
+//      timeout → rate_limit → billing → auth. This matters when an error
+//      matches multiple classifiers (e.g. an "insufficient quota" body
+//      trips both `isRateLimitAssistantError` and `isBillingAssistantError`).
+//      The decision/status path frequently keeps `rate_limit` (status 429),
+//      so the user-facing message must agree — otherwise the chat would say
+//      "billing" while the backend emitted a 429.
+function buildFailoverMessage(params: FailoverMessageParams): string {
+  if (params.lastAssistant) {
+    const formatted = formatAssistantErrorText(params.lastAssistant, {
+      cfg: params.config,
+      sessionKey: params.sessionKey,
+      provider: params.activeErrorContext.provider,
+      model: params.activeErrorContext.model,
+    });
+    const trimmed = params.lastAssistant.errorMessage?.trim();
+    if (formatted) {
+      return formatted;
+    }
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  if (params.timedOut) {
+    return "LLM request timed out.";
+  }
+  if (params.rateLimitFailure) {
+    return "LLM request rate limited.";
+  }
+  if (params.billingFailure) {
+    return formatBillingErrorMessage(
+      params.activeErrorContext.provider,
+      params.activeErrorContext.model,
+    );
+  }
+  if (params.authFailure) {
+    return "LLM request unauthorized.";
+  }
+  return "LLM request failed.";
+}
+
+function resolveFailoverStatusOrTimeout(
+  reason: FailoverReason,
+  message: string,
+): number | undefined {
+  const fromReason = resolveFailoverStatus(reason);
+  if (fromReason !== undefined) {
+    return fromReason;
+  }
+  if (isTimeoutErrorMessage(message)) {
+    return 408;
+  }
+  return undefined;
+}
+
+function resolveSurfaceReason(
+  decisionReason: FailoverReason | null | undefined,
+  timedOut: boolean,
+): FailoverReason {
+  if (decisionReason) {
+    return decisionReason;
+  }
+  if (timedOut) {
+    return "timeout";
+  }
+  return "unknown";
+}
+
+// Shared throw-outcome shape for the `fallback_model` and `surface_error`
+// branches. Returns the computed status alongside the outcome so the caller
+// can decide how (or whether) to include it in the decision log.
+function buildFailoverThrowOutcome(params: {
+  reason: FailoverReason;
+  overloadProfileRotations: number;
+  messageParams: FailoverMessageParams;
+  lastProfileId?: string;
+  activeErrorContext: { provider: string; model: string };
+}): {
+  outcome: Extract<AssistantFailoverOutcome, { action: "throw" }>;
+  status: number | undefined;
+} {
+  const message = buildFailoverMessage(params.messageParams);
+  const status = resolveFailoverStatusOrTimeout(params.reason, message);
+  return {
+    status,
+    outcome: {
+      action: "throw",
+      overloadProfileRotations: params.overloadProfileRotations,
+      error: new FailoverError(message, {
+        reason: params.reason,
+        provider: params.activeErrorContext.provider,
+        model: params.activeErrorContext.model,
+        profileId: params.lastProfileId,
+        status,
+      }),
+    },
+  };
+}
+
 export async function handleAssistantFailover(params: {
   initialDecision: AssistantFailoverDecision;
   aborted: boolean;
@@ -182,49 +297,54 @@ export async function handleAssistantFailover(params: {
 
   if (decision.action === "fallback_model") {
     await params.maybeBackoffBeforeOverloadFailover(params.failoverReason);
-    const message =
-      (params.lastAssistant
-        ? formatAssistantErrorText(params.lastAssistant, {
-            cfg: params.config,
-            sessionKey: params.sessionKey,
-            provider: params.activeErrorContext.provider,
-            model: params.activeErrorContext.model,
-          })
-        : undefined) ||
-      params.lastAssistant?.errorMessage?.trim() ||
-      (params.timedOut
-        ? "LLM request timed out."
-        : params.rateLimitFailure
-          ? "LLM request rate limited."
-          : params.billingFailure
-            ? formatBillingErrorMessage(
-                params.activeErrorContext.provider,
-                params.activeErrorContext.model,
-              )
-            : params.authFailure
-              ? "LLM request unauthorized."
-              : "LLM request failed.");
-    const status =
-      resolveFailoverStatus(decision.reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);
-    params.logAssistantFailoverDecision("fallback_model", { status });
-    return {
-      action: "throw",
+    const { outcome, status } = buildFailoverThrowOutcome({
+      reason: decision.reason,
       overloadProfileRotations,
-      error: new FailoverError(message, {
-        reason: decision.reason,
-        provider: params.activeErrorContext.provider,
-        model: params.activeErrorContext.model,
-        profileId: params.lastProfileId,
-        status,
-      }),
-    };
+      messageParams: params,
+      lastProfileId: params.lastProfileId,
+      activeErrorContext: params.activeErrorContext,
+    });
+    params.logAssistantFailoverDecision("fallback_model", { status });
+    return outcome;
   }
 
   if (decision.action === "surface_error") {
     if (!params.externalAbort && params.idleTimedOut && params.allowSameModelIdleTimeoutRetry) {
       return sameModelIdleTimeoutRetry();
     }
-    params.logAssistantFailoverDecision("surface_error");
+
+    // Two cases route through `surface_error` but must NOT throw a synthetic
+    // `FailoverError`:
+    //   1. `externalAbort` — user/system cancellation. Throwing here would show
+    //      a misleading generic error and bypass the normal cancellation flow.
+    //   2. `timedOut` — `run.ts` has a dedicated timeout payload builder that
+    //      emits a helpful, config-key-aware error ("increase `agents.defaults.
+    //      llm.idleTimeoutSeconds` …"). Throwing here short-circuits that path
+    //      and replaces a specific message with a generic one.
+    // In both cases we still log the decision for observability and fall
+    // through to `continue_normal` so the outer run loop can handle it.
+    if (params.externalAbort || params.timedOut) {
+      params.logAssistantFailoverDecision("surface_error");
+      return {
+        action: "continue_normal",
+        overloadProfileRotations,
+      };
+    }
+
+    // Non-timeout terminal failures (auth / billing / rate-limit / unknown
+    // upstream error) were previously swallowed here — they had no dedicated
+    // payload builder downstream, so the UI saw nothing. Mirror the
+    // `fallback_model` branch: build a descriptive message + HTTP status and
+    // throw a `FailoverError` so the dispatcher can propagate it to the chat.
+    const { outcome, status } = buildFailoverThrowOutcome({
+      reason: resolveSurfaceReason(decision.reason, params.timedOut),
+      overloadProfileRotations,
+      messageParams: params,
+      lastProfileId: params.lastProfileId,
+      activeErrorContext: params.activeErrorContext,
+    });
+    params.logAssistantFailoverDecision("surface_error", { status });
+    return outcome;
   }
 
   return {


### PR DESCRIPTION
> Hi! First-time contributor here — this is my first PR into this repo, so please feel absolutely free to tear this code apart, rewrite it, or tell me the whole approach is wrong. I'm happy to rework anything, and I won't take it personally if you'd rather close this and do it differently.
>
> I ran into this bug with a few of our users: they'd send a message, the thinking indicator would spin for a moment, and then just disappear with no reply and no error anywhere they could see. It turned out `surface_error` was being logged but never actually thrown, so terminal failures (timeout, auth, billing, rate-limit) silently fell through to the next loop iteration. The UI had nothing to render, so the agent just looked broken. Wanted to fix it both for us and for anyone else running into the same thing.
>
> Full write-up of what changed and why is below. Thanks for taking a look!

---

## Summary

- **Problem:** `handleAssistantFailover`'s `surface_error` branch fell through to `continue_normal` — a terminal LLM failure (timeout, auth, billing, rate-limit) was logged as `surface_error` but then silently resumed the same loop. The dispatcher received no error, the plugin layer never saw one, and the user was left staring at a cleared thinking indicator with no message.
- **Why it matters:** the caller's contract for a `surface_error` decision is "this is unrecoverable — the error must reach the UI". The missed throw hid real failures (payment/auth misconfiguration, upstream outages, wedged timeouts) behind "nothing happened". For a hosted chat surface this looks like the agent broke without explanation.
- **What changed:** `surface_error` now mirrors the sibling `fallback_model` branch. It builds a human-readable message from the failure shape (`timedOut`, `billingFailure`, `rateLimitFailure`, `authFailure`, or the last assistant's formatted error text / `errorMessage`), resolves a `FailoverReason` + HTTP status via `resolveFailoverStatus`, and returns `{ action: "throw", error: new FailoverError(...) }` so the dispatcher can propagate it to the plugin and on to the chat UI.
- **Refactor bundled with the fix:** the message / status / throw-outcome construction is factored out of the ballooned `fallback_model` ternary chain into three shared helpers — `buildFailoverMessage`, `resolveFailoverStatusOrTimeout`, and `buildFailoverThrowOutcome` — so both branches agree on precedence (type-specific failures beat upstream assistant text) without duplicate logic.
- **What did NOT change (scope boundary):** the upstream decision logic (`decideAssistantFailover`) and every other branch (`continue_normal`, `retry`, `fallback_model`, `same_model_idle_timeout_retry`, `abort`) are untouched. Failover rotation counters, auth/rate-limit side effects, and profile-failure bookkeeping are unchanged. This PR only changes what happens *after* the decision is already `surface_error`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** when `decideAssistantFailover` returned `{ action: "surface_error" }`, `handleAssistantFailover` only called `logAssistantFailoverDecision("surface_error")` and then fell through to the function's default `continue_normal` return at the bottom. There was no `action: "throw"` path for this case, so the dispatcher treated it the same as a normal continue.
- **Missing detection / guardrail:** no unit test ever asserted that `surface_error` produced a throw. The sibling `fallback_model` branch was covered, which hid the asymmetry.
- **Contributing context (if known):** the branch was likely added before the throw-based dispatcher existed (when `surface_error` was a log-only signal and the outer loop swallowed errors differently). The subsequent introduction of `FailoverError` + throw propagation retrofitted the other branches but missed this one.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test or file:** `src/agents/pi-embedded-runner/run/assistant-failover.test.ts` (new, 220 lines).
- **Scenario the test should lock in:** every failure mode that produces `action: "surface_error"` must return `{ action: "throw", error: FailoverError }` with the correct `reason` + HTTP `status`:
  - timeout → `reason: "timeout"`, `status: 408`
  - billing → `reason: "billing"`, `status: 402`
  - rate-limit → `reason: "rate_limit"`, `status: 429`
  - auth → `reason: "auth"`, `status: 401`
  - generic / unknown reason → formatted fallback message, no status
- **Why this is the smallest reliable guardrail:** `handleAssistantFailover` is the single seam between the decision function and the dispatcher. A unit test at that seam catches every surface_error regression without spinning up a real provider/LLM loop.
- **Existing test that already covers this (if any):** none — this branch was uncovered.

## User-visible / Behavior Changes

- Terminal LLM failures that previously disappeared silently now produce a descriptive error in the chat UI ("LLM request timed out.", billing/auth/rate-limit variants, or the assistant's own `errorMessage` when available).
- No changes to logs, config defaults, or public API surfaces.

## Diagram

```text
Before:
[assistant turn fails terminally]
  -> decideAssistantFailover() -> "surface_error"
    -> log("surface_error")
      -> fall through to default "continue_normal"
        -> dispatcher sees no error
          -> UI: thinking indicator clears, no message, user confused

After:
[assistant turn fails terminally]
  -> decideAssistantFailover() -> "surface_error"
    -> log("surface_error")
      -> build (message, reason, status) from failure shape
        -> return { action: "throw", error: FailoverError(...) }
          -> dispatcher throws -> plugin catches -> UI renders the error
```

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

The error messages surfaced to the UI come from the same `formatAssistantErrorText` / `formatBillingErrorMessage` helpers that `fallback_model` already uses; no new data is exposed.

## Repro + Verification

### Environment

- OS: Linux (reproducible anywhere Vitest runs)
- Runtime/container: Node 22
- Model/provider: any provider that can produce a terminal timeout / billing / auth / rate-limit failure
- Integration/channel: any (bug is in the core failover loop, not channel-specific)
- Relevant config (redacted): N/A

### Steps

1. Configure any assistant provider where the next call will fail terminally (revoked API key, exhausted billing, or a fake endpoint that hangs past the timeout).
2. Send a user message through any channel.
3. Observe the assistant turn.

### Expected

- The channel renders a descriptive error ("LLM request unauthorized." / "LLM request timed out." / billing message / assistant's own error text).

### Actual (before this PR)

- Thinking indicator clears, no message is delivered, no error surfaces anywhere the user can see. Logs show `surface_error` but nothing is thrown.

## Evidence

- New test file `src/agents/pi-embedded-runner/run/assistant-failover.test.ts` — 9 scoped cases covering:
  1. `surface_error` + timeout → `reason: "timeout"`, `status: 408`
  2. `surface_error` + billing → `reason: "billing"`, `status: 402`
  3. `surface_error` + rate-limit → `reason: "rate_limit"`, `status: 429`
  4. `surface_error` + auth → `reason: "auth"`, `status: 401`
  5. `surface_error` + unknown reason → generic formatted fallback message, no status
  6. `surface_error` still logs the decision before throwing
  7. Regression guard: idle-timeout retry path still wins over `surface_error` when `allowSameModelIdleTimeoutRetry` is true
  8. `fallback_model` branch: canonical timeout message wins over `lastAssistant.errorMessage` when timed out (pins shared-helper precedence)
  9. Non-matching decision (neither surface_error nor fallback_model) still returns `continue_normal`
- All pass with the fix; removing the new `surface_error` throw code makes each `outcome.action === "throw"` assertion fail.

## Human Verification

- **Verified scenarios:** Scoped Vitest suite pointed at the two changed files passes locally (9/9 on the scoped file, 193/193 across the full `src/agents/pi-embedded-runner/run/` directory). Built the full package (`npm pack`), installed the resulting tarball globally on a fresh Hetzner VM (built from the current production base snapshot), and confirmed the `reason` / `FailoverError` throw code is present in the installed `dist/pi-embedded-runner-*.js` bundle. `openclaw gateway --help` loads cleanly from the installed bundle.
- **Edge cases checked:** `timedOut` + `lastAssistant.errorMessage` present (uses the formatted assistant text over the generic "LLM request timed out." only when no type-specific failure is set — the shared `buildFailoverMessage` helper pins this precedence for both branches).
- **What I did NOT verify:** end-to-end integration against every provider's real failure modes (OpenAI / Anthropic / OpenRouter / Gemini, etc.). The fix is inside the provider-agnostic failover branch so provider-specific behavior is out of scope.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

(No bot or reviewer comments on this PR yet — this box will stay honest as the review progresses.)

## Compatibility / Migration

- Backward compatible? **Yes** — surfacing an error that was previously swallowed is a behavior change visible to users, but there is no API, config, or storage migration.
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** downstream callers that relied on the undocumented swallow behavior (expecting a silent continue after a terminal error) may now see a `FailoverError` propagate.
  - **Mitigation:** `FailoverError` is already a documented throw path used by the sibling `fallback_model` branch, so any caller of the dispatcher already handles it. The surfaced error is a descriptive message, not a stack trace.
- **Risk:** the generated error message could leak a sensitive detail from the assistant response.
  - **Mitigation:** the message helpers (`formatAssistantErrorText`, `formatBillingErrorMessage`) are the same ones `fallback_model` already uses in production; no new surface.
