### PR TITLE
fix(security): add npm overrides for vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1486,8 +1486,26 @@
     "music-metadata": "^11.12.3"
   },
   "overrides": {
+    "@anthropic-ai/sdk": "0.81.0",
     "axios": "1.15.0",
-    "follow-redirects": "1.16.0"
+    "basic-ftp": "5.2.2",
+    "defu": "6.1.5",
+    "fast-xml-parser": "5.5.7",
+    "file-type": "22.0.1",
+    "form-data": "2.5.4",
+    "follow-redirects": "1.16.0",
+    "hono": "4.12.12",
+    "@hono/node-server": "1.19.13",
+    "minimatch": "10.2.4",
+    "path-to-regexp": "8.4.0",
+    "qs": "6.14.2",
+    "request": "npm:@cypress/request@3.0.10",
+    "request-promise": "npm:@cypress/request-promise@5.0.0",
+    "@sinclair/typebox": "0.34.49",
+    "tar": "7.5.13",
+    "tough-cookie": "4.1.3",
+    "yauzl": "3.2.1",
+    "node-domexception": "npm:@nolyfill/domexception@1.0.29"
   },
   "engines": {
     "node": ">=22.14.0"


### PR DESCRIPTION
## Summary

Fix npm security audit warnings by adding npm overrides to package.json.

## Problem
Installing OpenClaw via npm shows security warnings for deprecated packages with known vulnerabilities (issue #65079).

## Root Cause
The project had security overrides in pnpm-lock.yaml, but npm does not read pnpm-lock.yaml. npm users were still getting vulnerable transitive dependencies.

## Solution
Add the same security overrides to package.json overrides field so both npm and pnpm users get patched dependencies.

## Changes
Updated package.json overrides to include 18 security patches that were previously only in pnpm-lock.yaml.

Fixes #65079