### PR TITLE
fix(cron): normalize missing persisted job state

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -73,6 +73,24 @@ describe("printCronList", () => {
     expect(logs.some((line) => line.includes("isolated"))).toBe(true);
   });
 
+  it("handles jobs with missing runtime state (#65916)", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const missingState = createBaseJob({
+      id: "missing-state",
+      sessionTarget: "main",
+    });
+    delete (missingState as unknown as { state?: unknown }).state;
+    const nullState = createBaseJob({
+      id: "null-state",
+      sessionTarget: "main",
+      state: null as unknown as CronJob["state"],
+    });
+
+    expect(() => printCronList([missingState, nullState], runtime)).not.toThrow();
+    expect(logs.some((line) => line.includes("missing-state"))).toBe(true);
+    expect(logs.some((line) => line.includes("null-state"))).toBe(true);
+  });
+
   it("shows stagger label for cron schedules", () => {
     const { logs, runtime } = createRuntimeLogCapture();
     const job = createBaseJob({

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -1,4 +1,5 @@
 import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { ensureCronJobState } from "../../cron/job-state.js";
 import { parseAbsoluteTimeMs } from "../../cron/parse.js";
 import { resolveCronStaggerMs } from "../../cron/stagger.js";
 import type { CronJob, CronSchedule } from "../../cron/types.js";
@@ -218,10 +219,11 @@ const formatStatus = (job: CronJob) => {
   if (!job.enabled) {
     return "disabled";
   }
-  if (job.state.runningAtMs) {
+  const jobState = ensureCronJobState(job);
+  if (jobState.runningAtMs) {
     return "running";
   }
-  return job.state.lastStatus ?? "idle";
+  return jobState.lastStatus ?? "idle";
 };
 
 export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRuntime) {
@@ -247,6 +249,7 @@ export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRunt
   const now = Date.now();
 
   for (const job of jobs) {
+    const jobState = ensureCronJobState(job);
     const idLabel = pad(job.id, CRON_ID_PAD);
     const nameLabel = pad(truncate(job.name, CRON_NAME_PAD), CRON_NAME_PAD);
     const scheduleLabel = pad(
@@ -254,10 +257,10 @@ export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRunt
       CRON_SCHEDULE_PAD,
     );
     const nextLabel = pad(
-      job.enabled ? formatRelative(job.state.nextRunAtMs, now) : "-",
+      job.enabled ? formatRelative(jobState.nextRunAtMs, now) : "-",
       CRON_NEXT_PAD,
     );
-    const lastLabel = pad(formatRelative(job.state.lastRunAtMs, now), CRON_LAST_PAD);
+    const lastLabel = pad(formatRelative(jobState.lastRunAtMs, now), CRON_LAST_PAD);
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);

--- a/src/cron/job-state.ts
+++ b/src/cron/job-state.ts
@@ -4,6 +4,7 @@ type CronJobStateContainer = {
   state?: unknown;
 };
 
+/** Mutates job.state in place when persisted runtime state is missing or invalid. */
 export function ensureCronJobState(job: CronJobStateContainer): CronJobState {
   const state = job.state;
   if (!state || typeof state !== "object" || Array.isArray(state)) {

--- a/src/cron/job-state.ts
+++ b/src/cron/job-state.ts
@@ -1,0 +1,15 @@
+import type { CronJobState } from "./types.js";
+
+type CronJobStateContainer = {
+  state?: unknown;
+};
+
+export function ensureCronJobState(job: CronJobStateContainer): CronJobState {
+  const state = job.state;
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
+    const emptyState: CronJobState = {};
+    job.state = emptyState;
+    return emptyState;
+  }
+  return state as CronJobState;
+}

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -102,6 +102,50 @@ describe("Cron issue regressions", () => {
     cron.stop();
   });
 
+  it("#65916 starts with persisted jobs missing runtime state", async () => {
+    const store = cronIssueRegressionFixtures.makeStorePath();
+    const now = Date.now();
+    const baseJob = {
+      name: "missing runtime state",
+      enabled: true,
+      createdAtMs: now,
+      updatedAtMs: now,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    };
+    await writeCronStoreSnapshot(store.storePath, [
+      {
+        id: "missing-state",
+        ...baseJob,
+      },
+      {
+        id: "null-state",
+        ...baseJob,
+        state: null,
+      },
+    ]);
+
+    const cron = await startCronForStore({
+      storePath: store.storePath,
+      cronEnabled: true,
+    });
+
+    const jobs = await cron.list({ includeDisabled: true });
+    expect(jobs).toHaveLength(2);
+    expect(jobs.every((job) => typeof job.state.nextRunAtMs === "number")).toBe(true);
+
+    const persisted = JSON.parse(await fs.readFile(store.storePath, "utf8")) as {
+      jobs: Array<{ id: string; state?: { nextRunAtMs?: number } | null }>;
+    };
+    expect(
+      persisted.jobs.every((job) => job.state && typeof job.state.nextRunAtMs === "number"),
+    ).toBe(true);
+
+    cron.stop();
+  });
+
   it("does not rewrite unchanged stores during startup", async () => {
     const store = cronIssueRegressionFixtures.makeStorePath();
     const scheduledAt = Date.parse("2026-02-06T11:00:00.000Z");

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString,
   normalizeOptionalThreadValue,
 } from "../../shared/string-coerce.js";
+import { ensureCronJobState } from "../job-state.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import {
   coerceFiniteScheduleNumber,
@@ -360,8 +361,9 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
   const { state, job, nowMs } = params;
   let changed = false;
 
-  if (!job.state) {
-    job.state = {};
+  const previousState = job.state;
+  const jobState = ensureCronJobState(job);
+  if (previousState !== jobState) {
     changed = true;
   }
 
@@ -380,29 +382,29 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
   }
 
   if (!isJobEnabled(job)) {
-    if (job.state.nextRunAtMs !== undefined) {
-      job.state.nextRunAtMs = undefined;
+    if (jobState.nextRunAtMs !== undefined) {
+      jobState.nextRunAtMs = undefined;
       changed = true;
     }
-    if (job.state.runningAtMs !== undefined) {
-      job.state.runningAtMs = undefined;
+    if (jobState.runningAtMs !== undefined) {
+      jobState.runningAtMs = undefined;
       changed = true;
     }
     return { changed, skip: true };
   }
 
-  if (!hasScheduledNextRunAtMs(job.state.nextRunAtMs) && job.state.nextRunAtMs !== undefined) {
-    job.state.nextRunAtMs = undefined;
+  if (!hasScheduledNextRunAtMs(jobState.nextRunAtMs) && jobState.nextRunAtMs !== undefined) {
+    jobState.nextRunAtMs = undefined;
     changed = true;
   }
 
-  const runningAt = job.state.runningAtMs;
+  const runningAt = jobState.runningAtMs;
   if (typeof runningAt === "number" && nowMs - runningAt > STUCK_RUN_MS) {
     state.deps.log.warn(
       { jobId: job.id, runningAtMs: runningAt },
       "cron: clearing stuck running marker",
     );
-    job.state.runningAtMs = undefined;
+    jobState.runningAtMs = undefined;
     changed = true;
   }
 
@@ -868,10 +870,8 @@ function mergeCronFailureAlert(
 }
 
 export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean }) {
-  if (!job.state) {
-    job.state = {};
-  }
-  if (typeof job.state.runningAtMs === "number") {
+  const jobState = ensureCronJobState(job);
+  if (typeof jobState.runningAtMs === "number") {
     return false;
   }
   if (opts.forced) {
@@ -879,8 +879,8 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
   }
   return (
     isJobEnabled(job) &&
-    hasScheduledNextRunAtMs(job.state.nextRunAtMs) &&
-    nowMs >= job.state.nextRunAtMs
+    hasScheduledNextRunAtMs(jobState.nextRunAtMs) &&
+    nowMs >= jobState.nextRunAtMs
   );
 }
 

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { ensureCronJobState } from "../job-state.js";
 import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { normalizeCronJobInput } from "../normalize.js";
 import { isInvalidCronSessionTargetIdError } from "../session-target.js";
@@ -55,6 +56,7 @@ export async function ensureLoaded(
     const hydrated =
       normalized && typeof normalized === "object" ? (normalized as unknown as CronJob) : job;
     jobs[index] = hydrated;
+    ensureCronJobState(hydrated);
     if (legacyJobIdIssue) {
       const resolvedId = typeof hydrated.id === "string" ? hydrated.id : undefined;
       state.deps.log.warn(

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -11,6 +11,7 @@ import {
 import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
 import { resolveCronDeliveryPlan } from "../delivery-plan.js";
 import { createCronExecutionId } from "../run-id.js";
+import { ensureCronJobState } from "../job-state.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
 import type {
   CronDeliveryStatus,
@@ -855,26 +856,24 @@ function isRunnableJob(params: {
   allowCronMissedRunByLastRun?: boolean;
 }): boolean {
   const { job, nowMs } = params;
-  if (!job.state) {
-    job.state = {};
-  }
+  const jobState = ensureCronJobState(job);
   if (!isJobEnabled(job)) {
     return false;
   }
   if (params.skipJobIds?.has(job.id)) {
     return false;
   }
-  if (typeof job.state.runningAtMs === "number") {
+  if (typeof jobState.runningAtMs === "number") {
     return false;
   }
-  if (params.skipAtIfAlreadyRan && job.schedule.kind === "at" && job.state.lastStatus) {
+  if (params.skipAtIfAlreadyRan && job.schedule.kind === "at" && jobState.lastStatus) {
     // One-shot with terminal status: skip unless it's a transient-error retry.
     // Retries have nextRunAtMs > lastRunAtMs (scheduled after the failed run) (#24355).
     // ok/skipped or error-without-retry always skip (#13845).
-    const lastRun = job.state.lastRunAtMs;
-    const nextRun = job.state.nextRunAtMs;
+    const lastRun = jobState.lastRunAtMs;
+    const nextRun = jobState.nextRunAtMs;
     if (
-      job.state.lastStatus === "error" &&
+      jobState.lastStatus === "error" &&
       isJobEnabled(job) &&
       typeof nextRun === "number" &&
       typeof lastRun === "number" &&
@@ -884,7 +883,7 @@ function isRunnableJob(params: {
     }
     return false;
   }
-  const next = job.state.nextRunAtMs;
+  const next = jobState.nextRunAtMs;
   if (hasScheduledNextRunAtMs(next) && nowMs >= next) {
     return true;
   }
@@ -1312,12 +1311,10 @@ export async function executeJob(
   _nowMs: number,
   _opts: { forced: boolean },
 ) {
-  if (!job.state) {
-    job.state = {};
-  }
+  const jobState = ensureCronJobState(job);
   const startedAt = state.deps.nowMs();
-  job.state.runningAtMs = startedAt;
-  job.state.lastError = undefined;
+  jobState.runningAtMs = startedAt;
+  jobState.lastError = undefined;
   markCronJobActive(job.id);
   emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
 


### PR DESCRIPTION
Closes #65916
Closes #66016

## Summary

- Problem: persisted cron jobs with missing `state` or `state: null` crash `cron.start()` while reading `job.state.runningAtMs`.
- Why it matters: one malformed restored/programmatic job can prevent the entire cron scheduler from starting.
- What changed: cron job hydration now normalizes invalid runtime state to `{}` before service startup logic runs, and CLI list rendering uses the same state guard.
- What did NOT change (scope boundary): this does not change cron schedule semantics, job payloads, delivery behavior, or doctor migration policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65916
- Closes #66016
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `loadCronStore()` accepts persisted JSON and `ensureLoaded()` hydrates entries as `CronJob`, but it did not restore the required runtime `state` object when the on-disk job omitted it or set it to `null`.
- Missing detection / guardrail: startup regression coverage only covered legacy jobs with `state: {}`, not malformed/missing runtime state.
- Contributing context (if known): doctor already repairs invalid cron `state` on disk, but runtime startup still needed to be resilient before users run doctor.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/cron/service.issue-regressions.test.ts`
  - `src/cli/cron-cli/shared.test.ts`
- Scenario the test should lock in: persisted jobs with missing `state` and `state: null` should not crash cron startup or cron list rendering.
- Why this is the smallest reliable guardrail: the service regression test exercises the persisted store hydration path that previously crashed `cron.start()`, and the CLI test covers the adjacent direct rendering path.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Cron startup now tolerates restored or programmatically-created jobs that omit runtime `state` or contain `state: null`; the scheduler starts and recomputes runtime state instead of failing the whole cron service.

## Diagram (if applicable)

```text
Before:
[jobs.json has job without state] -> [cron.start()] -> [job.state.runningAtMs crash]

After:
[jobs.json has job without state] -> [hydrate job state as {}] -> [cron.start()] -> [scheduler runs]
```
## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node / pnpm
- Model/provider: N/A
- Integration/channel (if any): cron scheduler
- Relevant config (redacted): temporary cron store with one job missing `state` and one job using `state: null`

### Steps

1. Write a `jobs.json` with a valid cron job that omits `state`.
2. Write a second job with `state: null`.
3. Start `CronService` against that store.

### Expected

- `cron.start()` succeeds.
- Runtime state is initialized and `nextRunAtMs` is recomputed.
- CLI list rendering does not throw on missing/null state.

### Actual

- Before this fix: startup threw `TypeError: Cannot read properties of undefined/null (reading 'runningAtMs')`.
- After this fix: startup succeeds for both missing and null state cases.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/cron/service.issue-regressions.test.ts src/cli/cron-cli/shared.test.ts`
  - A direct `node --import tsx --eval ...` repro confirmed `state: null` and missing `state` both start successfully.
  - `./node_modules/.bin/oxfmt --check src/cron/job-state.ts src/cron/service/store.ts src/cron/service/jobs.ts src/cron/service/timer.ts src/cli/cron-cli/shared.ts src/cron/service.issue-regressions.test.ts src/cli/cron-cli/shared.test.ts`
  - `git diff --check`
- Edge cases checked:
  - Missing `state`
  - `state: null`
  - CLI list rendering with missing/null state
- What you did **not** verify:
  - Full `pnpm format:check`, because it currently fails on unrelated pre-existing formatting issues in untouched files.
  - Full `pnpm tsgo`, because it currently fails on unrelated Discord monitor `firstHeartbeatTimeout` type errors in untouched files.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: normalizing invalid runtime state could hide malformed persisted cron entries.
  - Mitigation: this only restores the runtime-only `state` object that cron already treats as mutable/recomputable; existing doctor repair remains the path for canonical on-disk cleanup.
