### PR TITLE
fix(slack): render inbound user mentions in message bodies

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -14,6 +14,52 @@ export type SlackResolvedMessageContent = {
   effectiveDirectMedia: SlackMediaResult[] | null;
 };
 
+const SLACK_USER_MENTION_TOKEN_RE = /<@([A-Z0-9]+)(?:\|([^>]+))?>/gi;
+
+async function normalizeSlackInboundMentions(
+  text: string,
+  resolveUserName?: (userId: string) => Promise<{ name?: string }>,
+): Promise<string> {
+  if (!text.includes("<@")) {
+    return text;
+  }
+
+  const matches = [...text.matchAll(SLACK_USER_MENTION_TOKEN_RE)];
+  if (matches.length === 0) {
+    return text;
+  }
+
+  const resolvedNames = new Map<string, string | null>();
+  if (resolveUserName) {
+    const uniqueIds = [...new Set(matches.map((match) => match[1] ?? "").filter(Boolean))];
+    await Promise.all(
+      uniqueIds.map(async (userId) => {
+        try {
+          const resolved = normalizeOptionalString((await resolveUserName(userId))?.name);
+          resolvedNames.set(userId, resolved ?? null);
+        } catch {
+          resolvedNames.set(userId, null);
+        }
+      }),
+    );
+  }
+
+  return text.replaceAll(
+    SLACK_USER_MENTION_TOKEN_RE,
+    (token, userId: string, inlineLabel: string | undefined) => {
+      const resolvedName = normalizeOptionalString(resolvedNames.get(userId) ?? undefined);
+      if (resolvedName) {
+        return `@${resolvedName}`;
+      }
+      const normalizedInlineLabel = normalizeOptionalString(inlineLabel);
+      if (normalizedInlineLabel) {
+        return `@${normalizedInlineLabel}`;
+      }
+      return token;
+    },
+  );
+}
+
 function filterInheritedParentFiles(params: {
   files: SlackFile[] | undefined;
   isThreadReply: boolean;
@@ -43,6 +89,7 @@ export async function resolveSlackMessageContent(params: {
   isBotMessage: boolean;
   botToken: string;
   mediaMaxBytes: number;
+  resolveUserName?: (userId: string) => Promise<{ name?: string }>;
 }): Promise<SlackResolvedMessageContent | null> {
   const ownFiles = filterInheritedParentFiles({
     files: params.message.files,
@@ -105,7 +152,7 @@ export async function resolveSlackMessageContent(params: {
   }
 
   return {
-    rawBody,
+    rawBody: await normalizeSlackInboundMentions(rawBody, params.resolveUserName),
     effectiveDirectMedia,
   };
 }

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -14,7 +14,7 @@ export type SlackResolvedMessageContent = {
   effectiveDirectMedia: SlackMediaResult[] | null;
 };
 
-const SLACK_USER_MENTION_TOKEN_RE = /<@([A-Z0-9]+)(?:\|([^>]+))?>/gi;
+const SLACK_USER_MENTION_TOKEN_RE = /<@([A-Z0-9]+)(?:\|([^>]+))?>/g;
 
 async function normalizeSlackInboundMentions(
   text: string,

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -18,7 +18,10 @@ const SLACK_USER_MENTION_TOKEN_RE = /<@([A-Z0-9]+)(?:\|([^>]+))?>/gi;
 
 async function normalizeSlackInboundMentions(
   text: string,
-  resolveUserName?: (userId: string) => Promise<{ name?: string }>,
+  params?: {
+    botUserId?: string;
+    resolveUserName?: (userId: string) => Promise<{ name?: string }>;
+  },
 ): Promise<string> {
   if (!text.includes("<@")) {
     return text;
@@ -29,9 +32,17 @@ async function normalizeSlackInboundMentions(
     return text;
   }
 
+  const botUserId = normalizeOptionalString(params?.botUserId);
+  const resolveUserName = params?.resolveUserName;
   const resolvedNames = new Map<string, string | null>();
   if (resolveUserName) {
-    const uniqueIds = [...new Set(matches.map((match) => match[1] ?? "").filter(Boolean))];
+    const uniqueIds = [
+      ...new Set(
+        matches
+          .map((match) => match[1] ?? "")
+          .filter((userId) => Boolean(userId) && normalizeOptionalString(userId) !== botUserId),
+      ),
+    ];
     await Promise.all(
       uniqueIds.map(async (userId) => {
         try {
@@ -47,6 +58,9 @@ async function normalizeSlackInboundMentions(
   return text.replaceAll(
     SLACK_USER_MENTION_TOKEN_RE,
     (token, userId: string, inlineLabel: string | undefined) => {
+      if (normalizeOptionalString(userId) === botUserId) {
+        return token;
+      }
       const resolvedName = normalizeOptionalString(resolvedNames.get(userId) ?? undefined);
       if (resolvedName) {
         return `@${resolvedName}`;
@@ -62,13 +76,16 @@ async function normalizeSlackInboundMentions(
 
 async function normalizeOptionalSlackInboundText(
   text: string | undefined,
-  resolveUserName?: (userId: string) => Promise<{ name?: string }>,
+  params?: {
+    botUserId?: string;
+    resolveUserName?: (userId: string) => Promise<{ name?: string }>;
+  },
 ): Promise<string | undefined> {
   const normalizedText = normalizeOptionalString(text);
   if (!normalizedText) {
     return undefined;
   }
-  return await normalizeSlackInboundMentions(normalizedText, resolveUserName);
+  return await normalizeSlackInboundMentions(normalizedText, params);
 }
 
 function filterInheritedParentFiles(params: {
@@ -99,6 +116,7 @@ export async function resolveSlackMessageContent(params: {
   threadStarter: SlackThreadStarter | null;
   isBotMessage: boolean;
   botToken: string;
+  botUserId?: string;
   mediaMaxBytes: number;
   resolveUserName?: (userId: string) => Promise<{ name?: string }>;
 }): Promise<SlackResolvedMessageContent | null> {
@@ -150,15 +168,24 @@ export async function resolveSlackMessageContent(params: {
 
   const normalizedMessageText = await normalizeOptionalSlackInboundText(
     params.message.text,
-    params.resolveUserName,
+    {
+      botUserId: params.botUserId,
+      resolveUserName: params.resolveUserName,
+    },
   );
   const normalizedAttachmentText = await normalizeOptionalSlackInboundText(
     attachmentContent?.text,
-    params.resolveUserName,
+    {
+      botUserId: params.botUserId,
+      resolveUserName: params.resolveUserName,
+    },
   );
   const normalizedBotAttachmentText = await normalizeOptionalSlackInboundText(
     botAttachmentText,
-    params.resolveUserName,
+    {
+      botUserId: params.botUserId,
+      resolveUserName: params.resolveUserName,
+    },
   );
 
   const rawBody =

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -60,6 +60,17 @@ async function normalizeSlackInboundMentions(
   );
 }
 
+async function normalizeOptionalSlackInboundText(
+  text: string | undefined,
+  resolveUserName?: (userId: string) => Promise<{ name?: string }>,
+): Promise<string | undefined> {
+  const normalizedText = normalizeOptionalString(text);
+  if (!normalizedText) {
+    return undefined;
+  }
+  return await normalizeSlackInboundMentions(normalizedText, resolveUserName);
+}
+
 function filterInheritedParentFiles(params: {
   files: SlackFile[] | undefined;
   isThreadReply: boolean;
@@ -137,11 +148,24 @@ export async function resolveSlackMessageContent(params: {
           .join("\n")
       : undefined;
 
+  const normalizedMessageText = await normalizeOptionalSlackInboundText(
+    params.message.text,
+    params.resolveUserName,
+  );
+  const normalizedAttachmentText = await normalizeOptionalSlackInboundText(
+    attachmentContent?.text,
+    params.resolveUserName,
+  );
+  const normalizedBotAttachmentText = await normalizeOptionalSlackInboundText(
+    botAttachmentText,
+    params.resolveUserName,
+  );
+
   const rawBody =
     [
-      normalizeOptionalString(params.message.text),
-      attachmentContent?.text,
-      botAttachmentText,
+      normalizedMessageText,
+      normalizedAttachmentText,
+      normalizedBotAttachmentText,
       mediaPlaceholder,
       fileOnlyPlaceholder,
     ]
@@ -152,7 +176,7 @@ export async function resolveSlackMessageContent(params: {
   }
 
   return {
-    rawBody: await normalizeSlackInboundMentions(rawBody, params.resolveUserName),
+    rawBody,
     effectiveDirectMedia,
   };
 }

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -236,6 +236,28 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.RawBody).toContain("[Forwarded message from Bob]\nForwarded hello");
   });
 
+  it("renders inbound Slack user mentions to readable names in RawBody and BodyForAgent", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+    });
+    slackCtx.resolveUserName = async (userId) =>
+      ({ name: userId === "U2" ? "Bek" : userId === "U3" ? "Ava" : undefined }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      defaultAccount,
+      createSlackMessage({
+        text: "hi <@U2> and <@U3|fallback-name> and <@U4>",
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toBe("hi @Bek and @Ava and <@U4>");
+    expect(prepared!.ctxPayload.BodyForAgent).toBe("hi @Bek and @Ava and <@U4>");
+  });
+
   it("ignores non-forward attachments when no direct text/files are present", async () => {
     const prepared = await prepareWithDefaultCtx(
       createSlackMessage({

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -258,6 +258,29 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.BodyForAgent).toBe("hi @Bek and @Ava and <@U4>");
   });
 
+  it("keeps bot mentions unchanged while normalizing user mentions", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+    });
+    slackCtx.botUserId = "BOT";
+    slackCtx.resolveUserName = async (userId) =>
+      ({ name: userId === "U2" ? "Bek" : userId === "BOT" ? "OpenClaw" : undefined }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      defaultAccount,
+      createSlackMessage({
+        text: "<@BOT> hi <@U2>",
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toBe("<@BOT> hi @Bek");
+    expect(prepared!.ctxPayload.BodyForAgent).toBe("<@BOT> hi @Bek");
+  });
+
   it("keeps generated file placeholders unchanged while normalizing user-authored text", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -258,6 +258,28 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.BodyForAgent).toBe("hi @Bek and @Ava and <@U4>");
   });
 
+  it("keeps generated file placeholders unchanged while normalizing user-authored text", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+    });
+    slackCtx.resolveUserName = async (userId) =>
+      ({ name: userId === "U2" ? "Bek" : userId === "U3" ? "Ava" : undefined }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      defaultAccount,
+      createSlackMessage({
+        text: "hi <@U2>",
+        files: [{ name: "<@U3>.png" }],
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toBe("hi @Bek\n[Slack file: <@U3>.png]");
+  });
+
   it("ignores non-forward attachments when no direct text/files are present", async () => {
     const prepared = await prepareWithDefaultCtx(
       createSlackMessage({

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -8,6 +8,7 @@ import { expectChannelInboundContextContract as expectInboundContextContract } f
 import type { ResolvedSlackAccount } from "../../accounts.js";
 import type { SlackMessageEvent } from "../../types.js";
 import type { SlackMonitorContext } from "../context.js";
+import { resolveSlackMessageContent } from "./prepare-content.js";
 import { prepareSlackMessage } from "./prepare.js";
 import {
   createInboundSlackTestContext,
@@ -259,26 +260,21 @@ describe("slack prepareSlackMessage inbound contract", () => {
   });
 
   it("skips mention resolution when the message contains no Slack mentions", async () => {
-    const slackCtx = createReplyToAllSlackCtx({
-      defaultRequireMention: false,
-      asChannel: true,
-    });
     const resolveUserName = vi.fn(async () => ({ name: "Bek" }) as any);
-    slackCtx.resolveUserName = resolveUserName;
-
-    const prepared = await prepareMessageWith(
-      slackCtx,
-      defaultAccount,
-      createSlackMessage({
-        channel: "C123",
-        channel_type: "channel",
+    const resolved = await resolveSlackMessageContent({
+      message: createSlackMessage({
         text: "hi there",
       }),
-    );
+      isThreadReply: false,
+      threadStarter: null,
+      isBotMessage: false,
+      botToken: "token",
+      mediaMaxBytes: 1024,
+      resolveUserName,
+    });
 
-    expect(prepared).toBeTruthy();
-    expect(prepared!.ctxPayload.RawBody).toBe("hi there");
-    expect(prepared!.ctxPayload.BodyForAgent).toBe("hi there");
+    expect(resolved).toBeTruthy();
+    expect(resolved!.rawBody).toBe("hi there");
     expect(resolveUserName).not.toHaveBeenCalled();
   });
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -258,6 +258,55 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.BodyForAgent).toBe("hi @Bek and @Ava and <@U4>");
   });
 
+  it("skips mention resolution when the message contains no Slack mentions", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+    });
+    const resolveUserName = vi.fn(async () => ({ name: "Bek" }) as any);
+    slackCtx.resolveUserName = resolveUserName;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      defaultAccount,
+      createSlackMessage({
+        text: "hi there",
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toBe("hi there");
+    expect(prepared!.ctxPayload.BodyForAgent).toBe("hi there");
+    expect(resolveUserName).not.toHaveBeenCalled();
+  });
+
+  it("keeps other mentions resolvable when one user lookup fails", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+    });
+    slackCtx.resolveUserName = async (userId) => {
+      if (userId === "U2") {
+        throw new Error("lookup failed");
+      }
+      return ({ name: userId === "U3" ? "Ava" : undefined }) as any;
+    };
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      defaultAccount,
+      createSlackMessage({
+        text: "hi <@U2|bek-fallback> and <@U3> and <@U4>",
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toBe("hi @bek-fallback and @Ava and <@U4>");
+    expect(prepared!.ctxPayload.BodyForAgent).toBe("hi @bek-fallback and @Ava and <@U4>");
+  });
+
   it("keeps bot mentions unchanged while normalizing user mentions", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -259,10 +259,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
   });
 
   it("skips mention resolution when the message contains no Slack mentions", async () => {
-    const slackCtx = createInboundSlackCtx({
-      cfg: {
-        channels: { slack: { enabled: true } },
-      } as OpenClawConfig,
+    const slackCtx = createReplyToAllSlackCtx({
+      defaultRequireMention: false,
+      asChannel: true,
     });
     const resolveUserName = vi.fn(async () => ({ name: "Bek" }) as any);
     slackCtx.resolveUserName = resolveUserName;
@@ -271,6 +270,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
       slackCtx,
       defaultAccount,
       createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
         text: "hi there",
       }),
     );

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -555,6 +555,7 @@ export async function prepareSlackMessage(params: {
     threadStarter,
     isBotMessage,
     botToken: ctx.botToken,
+    botUserId: ctx.botUserId,
     mediaMaxBytes: ctx.mediaMaxBytes,
     resolveUserName: ctx.resolveUserName,
   });

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -556,6 +556,7 @@ export async function prepareSlackMessage(params: {
     isBotMessage,
     botToken: ctx.botToken,
     mediaMaxBytes: ctx.mediaMaxBytes,
+    resolveUserName: ctx.resolveUserName,
   });
   if (!resolvedMessageContent) {
     return null;


### PR DESCRIPTION
## Summary

This fixes Slack inbound message normalization so user mention tokens like `<@U123>` no longer leak into `RawBody` / `BodyForAgent` when a readable name can be resolved.

Changes:
- normalize inbound Slack user mentions during message-content preparation
- prefer resolved Slack display names
- fall back to inline mention labels when available
- preserve unresolved mentions as-is
- add regression coverage for inbound mention rendering

## Why

Today inbound Slack bodies can preserve raw mention IDs even though sender names are already humanized elsewhere. That makes agent-facing content and debugging harder to read.

## Testing

Added regression coverage in:
- `extensions/slack/src/monitor/message-handler/prepare.test.ts`

Local note:
- `git diff --check` is clean
- I was not able to complete the full local vitest run because local dependency installation was incomplete on this machine, so I’m relying on CI for full validation

## AI assistance disclosure

This PR was prepared with AI assistance, and I reviewed and edited the final code and test changes before submission.
