### PR TITLE
fix(reply): sanitize assistant text in block and final delivery paths

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -1,6 +1,7 @@
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { sanitizeAssistantVisibleText } from "../../shared/text/assistant-visible-text.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   HEARTBEAT_TOKEN,
@@ -97,6 +98,9 @@ export function normalizeReplyPayload(
 
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
+    // Strip reasoning tags and other internal scaffolding that may leak from
+    // certain model providers (e.g. Ollama/Kimi/Qwen `<think>` blocks).
+    text = sanitizeAssistantVisibleText(text);
   }
   if (!hasContent(text)) {
     opts.onSkip?.("empty");

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -110,6 +110,62 @@ describe("createBlockReplyDeliveryHandler", () => {
     });
   });
 
+  it("strips reasoning tags from block reply text before delivery", async () => {
+    const blockReplyPipeline = {
+      enqueue: vi.fn(),
+    } as unknown as BlockReplyPipelineLike;
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply: vi.fn(async () => {}),
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline,
+      directlySentBlockKeys: new Set(),
+    });
+
+    await handler({
+      text: "<think>I need to respond in Turkish</think>\nMerhaba, nasılsınız?",
+    });
+
+    expect(blockReplyPipeline.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Merhaba, nasılsınız?",
+      }),
+    );
+  });
+
+  it("strips nested thinking tags from Ollama/Kimi model output", async () => {
+    const blockReplyPipeline = {
+      enqueue: vi.fn(),
+    } as unknown as BlockReplyPipelineLike;
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply: vi.fn(async () => {}),
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline,
+      directlySentBlockKeys: new Set(),
+    });
+
+    await handler({
+      text: "<thinking>Planning my response carefully</thinking>Here is the answer.",
+    });
+
+    expect(blockReplyPipeline.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Here is the answer.",
+      }),
+    );
+  });
+
   it("parses media directives in block replies before path normalization", () => {
     const normalized = normalizeReplyPayloadDirectives({
       payload: { text: "Result\nMEDIA: ./image.png" },

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -1,5 +1,6 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "../../globals.js";
+import { sanitizeAssistantVisibleText } from "../../shared/text/assistant-visible-text.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { BlockReplyContext, ReplyPayload } from "../types.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
@@ -104,36 +105,41 @@ export function createBlockReplyDeliveryHandler(params: {
       ? await params.normalizeMediaPaths(normalized.payload)
       : normalized.payload;
     const blockPayload = params.applyReplyToMode(mediaNormalizedPayload);
-    const blockHasMedia = resolveSendableOutboundReplyParts(blockPayload).hasMedia;
+    // Strip reasoning tags and other internal scaffolding (e.g. `<think>` blocks
+    // emitted by Ollama/Kimi/Qwen models) before the text reaches end users.
+    const deliveryPayload: ReplyPayload = blockPayload.text
+      ? { ...blockPayload, text: sanitizeAssistantVisibleText(blockPayload.text) }
+      : blockPayload;
+    const blockHasMedia = resolveSendableOutboundReplyParts(deliveryPayload).hasMedia;
 
     // Skip empty payloads unless they have audioAsVoice flag (need to track it).
-    if (!blockPayload.text && !blockHasMedia && !blockPayload.audioAsVoice) {
+    if (!deliveryPayload.text && !blockHasMedia && !deliveryPayload.audioAsVoice) {
       return;
     }
     if (normalized.isSilent && !blockHasMedia) {
       return;
     }
 
-    if (blockPayload.text) {
-      void params.typingSignals.signalTextDelta(blockPayload.text).catch((err) => {
+    if (deliveryPayload.text) {
+      void params.typingSignals.signalTextDelta(deliveryPayload.text).catch((err) => {
         logVerbose(`block reply typing signal failed: ${String(err)}`);
       });
     }
 
     // Use pipeline if available (block streaming enabled), otherwise send directly.
     if (params.blockStreamingEnabled && params.blockReplyPipeline) {
-      params.blockReplyPipeline.enqueue(blockPayload);
+      params.blockReplyPipeline.enqueue(deliveryPayload);
     } else if (params.blockStreamingEnabled) {
       // Send directly when flushing before tool execution (no pipeline but streaming enabled).
       // Track sent key to avoid duplicate in final payloads.
-      params.directlySentBlockKeys.add(createBlockReplyContentKey(blockPayload));
-      await params.onBlockReply(blockPayload);
+      params.directlySentBlockKeys.add(createBlockReplyContentKey(deliveryPayload));
+      await params.onBlockReply(deliveryPayload);
     } else if (blockHasMedia) {
       // When block streaming is disabled, text-only block replies are accumulated into the
       // final response. Media cannot be reconstructed later, so send it immediately and let
       // the assistant's final text arrive through the normal final-reply path.
-      params.directlySentBlockKeys.add(createBlockReplyContentKey(blockPayload));
-      await params.onBlockReply({ ...blockPayload, text: undefined });
+      params.directlySentBlockKeys.add(createBlockReplyContentKey(deliveryPayload));
+      await params.onBlockReply({ ...deliveryPayload, text: undefined });
     }
     // When streaming is disabled entirely, text-only blocks are accumulated in final text.
   };


### PR DESCRIPTION
## Summary

- Wire `sanitizeAssistantVisibleText` ("delivery" profile) into both the **block-reply streaming path** (`reply-delivery.ts`) and the **final-reply normalization path** (`normalize-reply.ts`)
- Models like Ollama Kimi-K2, Qwen, and other reasoning-enabled providers emit `<think>`/`<thinking>` blocks that were leaking into user-visible text because the delivery pipeline only ran `sanitizeUserFacingText` (error formatting) but never the canonical delivery sanitizer
- The existing `sanitizeAssistantVisibleText` function already handles reasoning tags, stray tool-call XML, model special tokens, and memory scaffolding — it just wasn't wired into the delivery pipeline

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/reply/reply-delivery.ts` | Import + apply `sanitizeAssistantVisibleText` to block reply text before pipeline/direct send |
| `src/auto-reply/reply/normalize-reply.ts` | Import + apply `sanitizeAssistantVisibleText` to final reply text after `sanitizeUserFacingText` |
| `src/auto-reply/reply/reply-delivery.test.ts` | 2 new test cases: `<think>` and `<thinking>` tag stripping in block replies |

## How it works

The delivery pipeline currently calls `sanitizeUserFacingText` which handles error formatting, billing/rate-limit messages, and transport errors. However, it does not strip reasoning tags (`<think>`, `<thinking>`, `<thought>`, `<antthinking>`), tool-call XML, model special tokens, or memory scaffolding.

The `sanitizeAssistantVisibleText` function in `src/shared/text/assistant-visible-text.ts` is explicitly designed for delivery-time sanitization (the "delivery" profile). This PR wires it into the two delivery paths that were missing it:

1. **Block streaming path** (`reply-delivery.ts`): After text normalization, directive parsing, and reply-to mode application — right before the text enters the coalescing pipeline or gets sent directly
2. **Final reply path** (`normalize-reply.ts`): After `sanitizeUserFacingText` processes error formatting — before the response prefix is applied

## Test plan

- [x] Existing `reasoning-tags.test.ts` tests pass (100 tests)
- [x] Existing `assistant-visible-text.test.ts` tests pass
- [x] New `reply-delivery.test.ts` tests verify `<think>` and `<thinking>` tag stripping in block replies
- [x] All delivery-related tests pass (106 tests across 5 test files)
- [x] `pnpm build` succeeds
- [x] No import cycle regressions
- [ ] Manual test with Ollama Kimi-K2 model to confirm `<think>` blocks no longer leak to users

🤖 Generated with [Claude Code](https://claude.com/claude-code)