### PR TITLE
feat(status): add per-agent statusLabel config for public-facing name

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -58,6 +58,7 @@ type ResolvedAgentConfig = {
   subagents?: AgentEntry["subagents"];
   embeddedPi?: AgentEntry["embeddedPi"];
   sandbox?: AgentEntry["sandbox"];
+  statusLabel?: AgentEntry["statusLabel"];
   tools?: AgentEntry["tools"];
 };
 
@@ -167,6 +168,7 @@ export function resolveAgentConfig(
     embeddedPi:
       typeof entry.embeddedPi === "object" && entry.embeddedPi ? entry.embeddedPi : undefined,
     sandbox: entry.sandbox,
+    statusLabel: readStringValue(entry.statusLabel),
     tools: entry.tools,
   };
 }

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -105,6 +105,8 @@ export type AgentConfig = {
   };
   /** Optional per-agent sandbox overrides. */
   sandbox?: AgentSandboxConfig;
+  /** Optional public-facing label shown in /status instead of the real model name. */
+  statusLabel?: string;
   /** Optional per-agent stream params (e.g. cacheRetention, temperature). */
   params?: Record<string, unknown>;
   tools?: AgentToolsConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -837,6 +837,7 @@ export const AgentEntrySchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    statusLabel: z.string().optional(),
     params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -285,6 +285,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       sessionEntry,
     }).enabled;
   const agentFallbacksOverride = resolveAgentModelFallbacksOverride(cfg, statusAgentId);
+  const agentStatusLabel = agentConfig?.statusLabel;
   const { buildStatusMessage } = await loadStatusMessageRuntime();
   return buildStatusMessage({
     config: cfg,
@@ -292,7 +293,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       ...agentDefaults,
       model: {
         ...toAgentModelListLike(agentDefaults.model),
-        primary: params.primaryModelLabelOverride ?? `${provider}/${model}`,
+        primary: params.primaryModelLabelOverride ?? agentStatusLabel ?? `${provider}/${model}`,
         ...(agentFallbacksOverride === undefined ? {} : { fallbacks: agentFallbacksOverride }),
       },
       ...(typeof contextTokens === "number" && contextTokens > 0 ? { contextTokens } : {}),


### PR DESCRIPTION
## Summary

- Add optional `statusLabel` field to per-agent config so `/status` shows a custom label instead of the real model name
- Useful for white-labeling (e.g. showing "Ebrar AI" instead of "anthropic/claude-sonnet-4-6")

## Changes

| File | Change |
|------|--------|
| `src/config/zod-schema.agent-runtime.ts` | Add `statusLabel: z.string().optional()` to AgentEntrySchema |
| `src/config/types.agents.ts` | Add `statusLabel?: string` to AgentConfig type |
| `src/agents/agent-scope.ts` | Add `statusLabel` to ResolvedAgentConfig + resolveAgentConfig() |
| `src/status/status-text.ts` | Wire `agentStatusLabel` as primaryModelLabelOverride fallback |

## Usage

```json
{
  "agents": {
    "list": [
      {
        "id": "main",
        "statusLabel": "Ebrar AI",
        "model": { "primary": "anthropic/claude-sonnet-4-6" }
      }
    ]
  }
}
```

`/status` output: `🧠 Model: Ebrar AI` instead of `🧠 Model: anthropic/claude-sonnet-4-6`

## Test plan

- [x] All existing status command tests pass (16 tests)
- [x] `pnpm build` succeeds
- [x] Schema backwards compatible (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)