### PR TITLE
Fallback ACP metadata lookup for thread aliases

### DIFF
--- a/src/acp/runtime/session-meta.test.ts
+++ b/src/acp/runtime/session-meta.test.ts
@@ -19,14 +19,67 @@ vi.mock("../../config/sessions/targets.js", () => ({
     hoisted.resolveAllAgentSessionStoreTargetsMock(cfg, opts),
 }));
 let listAcpSessionEntries: typeof import("./session-meta.js").listAcpSessionEntries;
+let readAcpSessionEntry: typeof import("./session-meta.js").readAcpSessionEntry;
 
-describe("listAcpSessionEntries", () => {
+describe("session-meta", () => {
   beforeAll(async () => {
-    ({ listAcpSessionEntries } = await import("./session-meta.js"));
+    ({ listAcpSessionEntries, readAcpSessionEntry } = await import("./session-meta.js"));
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("falls back from thread-scoped ACP aliases to the base ACP session entry", () => {
+    const cfg = {
+      session: {
+        store: "/custom/sessions/{agentId}.json",
+      },
+    } as OpenClawConfig;
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:codex:acp:base-session": {
+        sessionId: "session-1",
+        updatedAt: 123,
+        acp: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "acpx:v2:example",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: 123,
+        },
+      },
+      "agent:codex:acp:base-session:thread:7657523082:4403": {
+        sessionId: "session-2",
+        updatedAt: 124,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:7657523082",
+          accountId: "default",
+          threadId: "4403",
+        },
+      },
+    });
+
+    const entry = readAcpSessionEntry({
+      cfg,
+      sessionKey: "agent:codex:acp:base-session:thread:7657523082:4403",
+    });
+
+    expect(hoisted.loadSessionStoreMock).toHaveBeenCalledWith("/custom/sessions/codex.json");
+    expect(entry).toEqual(
+      expect.objectContaining({
+        cfg,
+        storePath: "/custom/sessions/codex.json",
+        sessionKey: "agent:codex:acp:base-session:thread:7657523082:4403",
+        storeSessionKey: "agent:codex:acp:base-session",
+        acp: expect.objectContaining({
+          agent: "codex",
+          backend: "acpx",
+          runtimeSessionName: "acpx:v2:example",
+        }),
+      }),
+    );
   });
 
   it("reads ACP sessions from resolved configured store targets", async () => {

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -82,15 +82,29 @@ export function readAcpSessionEntry(params: {
     storeReadFailed = true;
     store = {};
   }
-  const storeSessionKey = resolveStoreSessionKey(store, sessionKey);
-  const entry = store[storeSessionKey];
+  let storeSessionKey = resolveStoreSessionKey(store, sessionKey);
+  let entry = store[storeSessionKey];
+  let acp = entry?.acp;
+  if (!acp) {
+    const threadMarker = sessionKey.indexOf(":thread:");
+    if (threadMarker > 0) {
+      const baseSessionKey = sessionKey.slice(0, threadMarker);
+      const fallbackStoreSessionKey = resolveStoreSessionKey(store, baseSessionKey);
+      const fallbackEntry = store[fallbackStoreSessionKey];
+      if (fallbackEntry?.acp) {
+        storeSessionKey = fallbackStoreSessionKey;
+        entry = fallbackEntry;
+        acp = fallbackEntry.acp;
+      }
+    }
+  }
   return {
     cfg,
     storePath,
     sessionKey,
     storeSessionKey,
     entry,
-    acp: entry?.acp,
+    acp,
     storeReadFailed,
   };
 }


### PR DESCRIPTION
## Summary
- fall back from thread-scoped ACP session aliases to the base ACP session entry when the alias record has no `acp` metadata
- preserve the original thread-scoped session key in the returned metadata lookup result while reusing the base ACP metadata
- add a regression test covering Telegram-style `:thread:` ACP aliases

## Problem
Thread-bound ACP spawns can create a base session entry like `agent:codex:acp:<id>` with ACP metadata plus a thread alias entry like `agent:codex:acp:<id>:thread:<chat>:<topic>` that only carries delivery context. On the next inbound message, `readAcpSessionEntry()` resolves the thread alias directly, sees no `acp` block, and the ACP manager reports `ACP metadata is missing` even though the base session is valid.

## Testing
- corepack pnpm test src/acp/runtime/session-meta.test.ts