### PR TITLE
fix(discord): resolve channelId for ACP thread binding from guild channels

### DIFF
--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -644,6 +644,16 @@ export function createThreadBindingManager(
               token: resolveCurrentToken(),
               threadId: conversationId,
             })) ?? undefined;
+          // Fallback: if Discord API resolution failed but conversationId is a guild
+          // channel (possibly with "channel:" prefix), strip the prefix and use it as
+          // channelId for thread creation. This handles ACP spawns where conversationId
+          // is a guild channel ID with no parentConversationId.
+          if (!channelId && conversationId) {
+            const stripped = conversationId.replace(/^channel:/i, "");
+            if (/^\d{17,20}$/.test(stripped)) {
+              channelId = stripped;
+            }
+          }
         }
       } else {
         threadId = conversationId || undefined;


### PR DESCRIPTION
## Problem

ACP sessions spawned with `thread=true` from a Discord guild text channel fail with `thread_binding_invalid: Session binding adapter failed to bind target conversation`.

Reproduced on OpenClaw 2026.4.11 and 2026.4.12. Related: #65313

## Root Cause

When spawning an ACP session with `thread=true`:

1. `prepareAcpThreadBinding()` resolves `conversationId = "channel:1493136670562979980"` (with `channel:` prefix) and `parentConversationId = undefined`
2. Discord adapter's `bind()` is called with `placement = "child"` (create a new thread)
3. Since `parentConversationId` is empty, `channelId` starts as `undefined`
4. `resolveChannelIdForBinding()` is called with `threadId: conversationId` — this queries the Discord API, which may fail or return unexpected results
5. If it fails, `channelId` remains `undefined` and `bindTarget()` returns `null`
6. The `bind()` function returns `null`, causing the spawn to fail with `thread_binding_invalid`

## Fix

Add a fallback in the `placement === "child"` branch: if `resolveChannelIdForBinding()` fails but `conversationId` contains a guild channel identifier (with optional `channel:` prefix), strip the prefix and use the numeric snowflake directly as `channelId` for thread creation.

This is safe because:
- Only runs when `resolveChannelIdForBinding()` has already failed
- Validates the snowflake format (17-20 digit numeric string)
- Only applies to `placement = "child"` (thread creation), not `current`
- The channel ID is already known from the conversation context

## Testing

Verified locally with a Discord bot:
- Before: `sessions_spawn(runtime="acp", thread=true, mode="run")` → `thread_binding_invalid`
- After: Discord thread is created, ACP session streams successfully into the thread

## Changes

- `extensions/discord/src/monitor/thread-bindings.manager.ts`: 10 lines added (1 fallback block with comment)