### PR TITLE
feat(exa): add secretRef support for web search API key

### DIFF
--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -47,6 +47,7 @@ Scope intent:
 - `plugins.entries.moonshot.config.webSearch.apiKey`
 - `plugins.entries.perplexity.config.webSearch.apiKey`
 - `plugins.entries.firecrawl.config.webSearch.apiKey`
+- `plugins.entries.exa.config.webSearch.apiKey`
 - `plugins.entries.minimax.config.webSearch.apiKey`
 - `plugins.entries.tavily.config.webSearch.apiKey`
 - `tools.web.search.apiKey`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -527,6 +527,13 @@
       "optIn": true
     },
     {
+      "id": "plugins.entries.exa.config.webSearch.apiKey",
+      "configFile": "openclaw.json",
+      "path": "plugins.entries.exa.config.webSearch.apiKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "plugins.entries.firecrawl.config.webSearch.apiKey",
       "configFile": "openclaw.json",
       "path": "plugins.entries.firecrawl.config.webSearch.apiKey",

--- a/extensions/exa/web-search-contract-api.ts
+++ b/extensions/exa/web-search-contract-api.ts
@@ -1,0 +1,29 @@
+import {
+  createWebSearchProviderContractFields,
+  type WebSearchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-search-contract";
+
+export function createExaWebSearchProvider(): WebSearchProviderPlugin {
+  const credentialPath = "plugins.entries.exa.config.webSearch.apiKey";
+
+  return {
+    id: "exa",
+    label: "Exa Search",
+    hint: "Neural + keyword search with date filters and content extraction",
+    onboardingScopes: ["text-inference"],
+    credentialLabel: "Exa API key",
+    envVars: ["EXA_API_KEY"],
+    placeholder: "exa-...",
+    signupUrl: "https://exa.ai/",
+    docsUrl: "https://docs.openclaw.ai/tools/web",
+    autoDetectOrder: 65,
+    credentialPath,
+    ...createWebSearchProviderContractFields({
+      credentialPath,
+      searchCredential: { type: "scoped", scopeId: "exa" },
+      configuredCredential: { pluginId: "exa" },
+      selectionPluginId: "exa",
+    }),
+    createTool: () => null,
+  };
+}

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -35,6 +35,7 @@ const STATIC_AGENT_RUNTIME_BASE_TARGET_IDS = [
   "plugins.entries.moonshot.config.webSearch.apiKey",
   "plugins.entries.perplexity.config.webSearch.apiKey",
   "plugins.entries.firecrawl.config.webSearch.apiKey",
+  "plugins.entries.exa.config.webSearch.apiKey",
   "plugins.entries.firecrawl.config.webFetch.apiKey",
   "plugins.entries.tavily.config.webSearch.apiKey",
   "plugins.entries.minimax.config.webSearch.apiKey",

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -359,6 +359,17 @@ const CORE_SECRET_TARGET_REGISTRY: SecretTargetRegistryEntry[] = [
     includeInAudit: true,
   },
   {
+    id: "plugins.entries.exa.config.webSearch.apiKey",
+    targetType: "plugins.entries.exa.config.webSearch.apiKey",
+    configFile: "openclaw.json",
+    pathPattern: "plugins.entries.exa.config.webSearch.apiKey",
+    secretShape: SECRET_INPUT_SHAPE,
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
     id: "plugins.entries.google.config.webSearch.apiKey",
     targetType: "plugins.entries.google.config.webSearch.apiKey",
     configFile: "openclaw.json",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Exa already supports `plugins.entries.exa.config.webSearch.apiKey` at runtime, but the secret target registry and bundled public contract did not expose that path.
- Why it matters: users could not supply the Exa web search API key through secretRef-aware flows the way they can for other bundled web search providers.
- What changed: added the Exa web-search contract artifact, registered the Exa API-key secret target for planning/configure/audit flows, and regenerated the secretRef credential matrix/docs.
- What did NOT change (scope boundary): Exa request execution, provider selection behavior, and network calls are unchanged.
- AI-assisted: Yes, built with Codex. Testing: lightly tested locally with focused contract/registry coverage.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65791
- Related #65791
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the Exa provider declared its runtime `credentialPath`, but the bundled public contract surface and the core secret target registry did not publish that path.
- Missing detection / guardrail: generic registry/docs checks existed, but Exa had never been wired into those secretRef surfaces.
- Contributing context (if known): parity drift versus other bundled web search providers.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file:
  - `extensions/exa/src/exa-web-search-provider.test.ts`
  - `src/plugins/contracts/web-search-provider.exa.contract.test.ts`
  - `src/plugins/contracts/plugin-registration.exa.contract.test.ts`
  - `src/secrets/target-registry.docs.test.ts`
  - `src/secrets/exec-secret-ref-id-parity.test.ts`
  - `src/cli/command-secret-targets.test.ts`
- Scenario the test should lock in: Exa publishes a bundled web-search contract surface and its API-key path appears in secretRef discovery/docs and agent-runtime target selection.
- Why this is the smallest reliable guardrail: these suites already exercise the shared registry, docs generation, and bundled plugin contract loading paths used by every provider.
- Existing test that already covers this (if any): the files above once the Exa secret target is registered.
- If no new test is added, why not: existing generic coverage already fails when this surface is missing and passes once it is wired correctly.

## User-visible / Behavior Changes

- `plugins.entries.exa.config.webSearch.apiKey` now participates in secretRef-aware config flows and appears in the generated secretRef credential documentation.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this adds Exa's existing API-key path to the same secretRef plumbing already used by other bundled web-search providers. Resolution still goes through the existing secret-input validation, registry, and audit/configure paths.

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: Node `v25.7.0`, pnpm `10.32.1`
- Model/provider: N/A
- Integration/channel (if any): Exa bundled web search provider
- Relevant config (redacted): `plugins.entries.exa.config.webSearch.apiKey`

### Steps

1. Generate the secretRef credential matrix from the current registry.
2. Inspect the bundled Exa web-search contract + agent-runtime secret target list.
3. Run the focused Exa contract/registry Vitest suite.

### Expected

- Exa's API-key path is present in the generated matrix and agent-runtime target set.
- Bundled Exa contract loading succeeds.
- Focused tests pass.

### Actual

- Verified all three locally.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: regenerated `docs/reference/secretref-user-supplied-credentials-matrix.json`; confirmed `plugins.entries.exa.config.webSearch.apiKey` is present in both `buildSecretRefCredentialMatrix()` and `getAgentRuntimeCommandSecretTargetIds()`; ran the focused Vitest suite listed above.
- Edge cases checked: ensured the docs generator output is stable and the Exa surface loads through the bundled contract path instead of runtime-only registration.
- What you did **not** verify: full `pnpm build && pnpm check && pnpm test` across the entire monorepo.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: secretRef/documentation parity could drift again if Exa's credential path changes in only one layer.
  - Mitigation: this wires Exa into the shared bundled contract surface and shared secret registry, and the existing registry/docs test suite now exercises that path.
