### PR TITLE
fix(ci): resolve existing tsgo type errors

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -154,11 +154,12 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
         throw new NextcloudTalkRetryableWebhookError("transient nextcloud failure");
       }
     });
+    const replayAwareProcessMessage = createReplayAwareProcessMessage({
+      stateDir,
+      handleMessage,
+    });
     const processMessage = vi.fn(async (message: NextcloudTalkInboundMessage) => {
-      await createReplayAwareProcessMessage({
-        stateDir,
-        handleMessage,
-      })(message);
+      await replayAwareProcessMessage(message);
     });
     const harness = await startWebhookServer({
       path: "/nextcloud-replay-process",
@@ -196,11 +197,12 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
       visibleSideEffect();
       throw new Error("post-send failure");
     });
+    const replayAwareProcessMessage = createReplayAwareProcessMessage({
+      stateDir,
+      handleMessage,
+    });
     const processMessage = vi.fn(async (message: NextcloudTalkInboundMessage) => {
-      await createReplayAwareProcessMessage({
-        stateDir,
-        handleMessage,
-      })(message);
+      await replayAwareProcessMessage(message);
     });
     const harness = await startWebhookServer({
       path: "/nextcloud-replay-post-send",

--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -154,12 +154,12 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
         throw new NextcloudTalkRetryableWebhookError("transient nextcloud failure");
       }
     });
-    const processMessage = vi.fn(
-      createReplayAwareProcessMessage({
+    const processMessage = vi.fn(async (message: NextcloudTalkInboundMessage) => {
+      await createReplayAwareProcessMessage({
         stateDir,
         handleMessage,
-      }),
-    );
+      })(message);
+    });
     const harness = await startWebhookServer({
       path: "/nextcloud-replay-process",
       processMessage,
@@ -196,12 +196,12 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
       visibleSideEffect();
       throw new Error("post-send failure");
     });
-    const processMessage = vi.fn(
-      createReplayAwareProcessMessage({
+    const processMessage = vi.fn(async (message: NextcloudTalkInboundMessage) => {
+      await createReplayAwareProcessMessage({
         stateDir,
         handleMessage,
-      }),
-    );
+      })(message);
+    });
     const harness = await startWebhookServer({
       path: "/nextcloud-replay-post-send",
       processMessage,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -157,7 +157,10 @@ export async function attachWebInboxToSocket(
       if (!senderKey) {
         return null;
       }
-      const conversationKey = msg.chatType === "group" ? msg.chatId : msg.from;
+      const conversationKey = msg.chatType === "group" ? (msg.chatId ?? msg.from) : msg.from;
+      if (!conversationKey) {
+        return null;
+      }
       return `${msg.accountId}:${conversationKey}:${senderKey}`;
     },
     shouldDebounce: options.shouldDebounce,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -500,6 +500,10 @@ export async function runSetupWizard(
     });
   }
 
+  if (!authChoice) {
+    throw new Error("Missing auth choice.");
+  }
+
   if (authChoice === "custom-api-key") {
     const { promptCustomApiConfig } = await import("../commands/onboard-custom.js");
     const customResult = await promptCustomApiConfig({


### PR DESCRIPTION
## Summary

This PR addresses a small set of existing TypeScript type errors currently surfacing in CI on `main`.

The changes are limited to:
- `extensions/nextcloud-talk/src/monitor.replay.test.ts`
- `extensions/whatsapp/src/inbound/monitor.ts`
- `src/wizard/setup.ts`

The issue was originally reported against OpenClaw 2026.4.11, but this PR targets current `main`. The CI failure discussed in the earlier memory-wiki work was unrelated to that diff and came from these pre-existing type errors instead.

## What changed

- wrap the Nextcloud Talk replay message handler so the test mock matches the expected `void | Promise<void>` signature
- narrow the WhatsApp conversation key before using it in the debounce key
- narrow the setup wizard auth choice before passing it into auth/model selection helpers

## Notes

This PR keeps the fix intentionally small and localized. It does not change the broader behavior of those subsystems.