### PR TITLE
fix(msteams): enforce sender allowlist checks on SSO signin invokes [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(msteams): enforce sender allowlist checks on SSO signin invokes [AI]. (#66033) Thanks @pgondhi987.
 - fix(config): redact sourceConfig and runtimeConfig alias fields in redactConfigSnapshot [AI]. (#66030) Thanks @pgondhi987.
 - Agents/context engines: run opt-in turn maintenance as idle-aware background work so the next foreground turn no longer waits on proactive maintenance. (#65233) thanks @100yenadmin
 

--- a/extensions/msteams/src/monitor-handler.sso.test.ts
+++ b/extensions/msteams/src/monitor-handler.sso.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import type { PluginRuntime } from "../runtime-api.js";
+import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
 import {
   type MSTeamsActivityHandler,
   type MSTeamsMessageHandlerDeps,
@@ -95,7 +95,20 @@ function createSigninInvokeContext(params: {
   value: unknown;
   userAadId?: string;
   userBfId?: string;
+  conversationId?: string;
+  conversationType?: "personal" | "groupChat" | "channel";
+  teamId?: string;
+  channelName?: string;
 }): MSTeamsTurnContext & { sendActivity: ReturnType<typeof vi.fn> } {
+  const conversationType = params.conversationType ?? "personal";
+  const conversationId =
+    params.conversationId ??
+    (conversationType === "personal"
+      ? "19:personal-chat"
+      : conversationType === "channel"
+        ? "19:channel@thread.tacv2"
+        : "19:group@thread.tacv2");
+
   return {
     activity: {
       id: "invoke-1",
@@ -110,10 +123,16 @@ function createSigninInvokeContext(params: {
       },
       recipient: { id: "bot-id", name: "Bot" },
       conversation: {
-        id: "19:personal-chat",
-        conversationType: "personal",
+        id: conversationId,
+        conversationType,
+        tenantId: params.teamId ? "tenant-1" : undefined,
       },
-      channelData: {},
+      channelData: params.teamId
+        ? {
+            team: { id: params.teamId, name: "Team 1" },
+            channel: params.channelName ? { name: params.channelName } : undefined,
+          }
+        : {},
       attachments: [],
       value: params.value,
     },
@@ -148,6 +167,69 @@ function createFakeFetch(handlers: Array<(url: string, init?: unknown) => unknow
     };
   };
   return { fetchImpl, calls };
+}
+
+function createBlockedSigninScenarios() {
+  return [
+    {
+      name: "DM sender outside allowlist",
+      cfg: {
+        channels: {
+          msteams: {
+            dmPolicy: "allowlist",
+            allowFrom: ["owner-aad"],
+          },
+        },
+      } as OpenClawConfig,
+      context: {
+        userAadId: "blocked-dm-aad",
+      },
+      expectedDropLog: "dropping signin invoke (dm sender not allowlisted)",
+    },
+    {
+      name: "channel outside route allowlist",
+      cfg: {
+        channels: {
+          msteams: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["blocked-channel-aad"],
+            teams: {
+              "team-allowlisted": {
+                channels: {
+                  "19:allowlisted@thread.tacv2": { requireMention: false },
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      context: {
+        userAadId: "blocked-channel-aad",
+        conversationType: "channel" as const,
+        conversationId: "19:blocked-channel@thread.tacv2",
+        teamId: "team-blocked",
+        channelName: "General",
+      },
+      expectedDropLog: "dropping signin invoke (not in team/channel allowlist)",
+    },
+    {
+      name: "group sender outside group allowlist",
+      cfg: {
+        channels: {
+          msteams: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["owner-aad"],
+          },
+        },
+      } as OpenClawConfig,
+      context: {
+        userAadId: "blocked-group-aad",
+        conversationType: "groupChat" as const,
+        conversationId: "19:group-chat@thread.v2",
+      },
+      expectedDropLog: "dropping signin invoke (group sender not allowlisted)",
+    },
+  ];
 }
 
 describe("msteams signin invoke value parsers", () => {
@@ -321,6 +403,18 @@ describe("msteams signin invoke handler registration", () => {
     installTestRuntime();
   });
 
+  const blockedSigninScenarios = createBlockedSigninScenarios();
+  const invokeVariants = [
+    {
+      name: "signin/tokenExchange" as const,
+      value: { id: "x", connectionName: "GraphConnection", token: "exchangeable" },
+    },
+    {
+      name: "signin/verifyState" as const,
+      value: { state: "112233" },
+    },
+  ];
+
   it("acks signin invokes even when sso is not configured", async () => {
     const deps = createDepsWithoutSso();
     const { handler, run } = createActivityHandler();
@@ -347,6 +441,56 @@ describe("msteams signin invoke handler registration", () => {
       expect.objectContaining({ name: "signin/tokenExchange" }),
     );
   });
+
+  for (const invoke of invokeVariants) {
+    for (const scenario of blockedSigninScenarios) {
+      it(`does not process ${invoke.name} for ${scenario.name}`, async () => {
+        const { fetchImpl, calls } = createFakeFetch([
+          () => ({
+            ok: true,
+            status: 200,
+            body: {
+              channelId: "msteams",
+              connectionName: "GraphConnection",
+              token: "delegated-graph-token",
+              expiration: "2030-01-01T00:00:00Z",
+            },
+          }),
+        ]);
+        const { sso, tokenStore } = createSsoDeps({ fetchImpl });
+        const deps = createDepsWithoutSso({ cfg: scenario.cfg, sso });
+        const { handler } = createActivityHandler();
+        const registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
+          run: NonNullable<MSTeamsActivityHandler["run"]>;
+        };
+
+        const ctx = createSigninInvokeContext({
+          name: invoke.name,
+          value: invoke.value,
+          ...scenario.context,
+        });
+
+        await registered.run(ctx);
+
+        expect(ctx.sendActivity).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "invokeResponse",
+            value: expect.objectContaining({ status: 200 }),
+          }),
+        );
+        expect(calls).toHaveLength(0);
+        const stored = await tokenStore.get({
+          connectionName: "GraphConnection",
+          userId: scenario.context.userAadId ?? "aad-user-guid",
+        });
+        expect(stored).toBeNull();
+        expect(deps.log.debug).toHaveBeenCalledWith(
+          scenario.expectedDropLog,
+          expect.objectContaining({ name: invoke.name }),
+        );
+      });
+    }
+  }
 
   it("invokes the token exchange handler when sso is configured", async () => {
     const { fetchImpl } = createFakeFetch([

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -56,10 +56,17 @@ function serializeAdaptiveCardActionValue(value: unknown): string | null {
   }
 }
 
-async function isFeedbackInvokeAuthorized(
-  context: MSTeamsTurnContext,
-  deps: MSTeamsMessageHandlerDeps,
-): Promise<boolean> {
+async function isInvokeAuthorized(params: {
+  context: MSTeamsTurnContext;
+  deps: MSTeamsMessageHandlerDeps;
+  deniedLogs: {
+    dm: string;
+    channel: string;
+    group: string;
+  };
+  includeInvokeName?: boolean;
+}): Promise<boolean> {
+  const { context, deps, deniedLogs, includeInvokeName = false } = params;
   const resolved = await resolveMSTeamsSenderAccess({
     cfg: deps.cfg,
     activity: context.activity,
@@ -69,10 +76,13 @@ async function isFeedbackInvokeAuthorized(
     return true;
   }
 
+  const maybeInvokeName = includeInvokeName ? { name: context.activity.name } : undefined;
+
   if (isDirectMessage && resolved.access.decision !== "allow") {
-    deps.log.debug?.("dropping feedback invoke (dm sender not allowlisted)", {
+    deps.log.debug?.(deniedLogs.dm, {
       sender: senderId,
       conversationId,
+      ...maybeInvokeName,
     });
     return false;
   }
@@ -82,18 +92,20 @@ async function isFeedbackInvokeAuthorized(
     resolved.channelGate.allowlistConfigured &&
     !resolved.channelGate.allowed
   ) {
-    deps.log.debug?.("dropping feedback invoke (not in team/channel allowlist)", {
+    deps.log.debug?.(deniedLogs.channel, {
       conversationId,
       teamKey: resolved.channelGate.teamKey ?? "none",
       channelKey: resolved.channelGate.channelKey ?? "none",
+      ...maybeInvokeName,
     });
     return false;
   }
 
   if (!isDirectMessage && !resolved.senderGroupAccess.allowed) {
-    deps.log.debug?.("dropping feedback invoke (group sender not allowlisted)", {
+    deps.log.debug?.(deniedLogs.group, {
       sender: senderId,
       conversationId,
+      ...maybeInvokeName,
     });
     return false;
   }
@@ -101,52 +113,35 @@ async function isFeedbackInvokeAuthorized(
   return true;
 }
 
+async function isFeedbackInvokeAuthorized(
+  context: MSTeamsTurnContext,
+  deps: MSTeamsMessageHandlerDeps,
+): Promise<boolean> {
+  return isInvokeAuthorized({
+    context,
+    deps,
+    deniedLogs: {
+      dm: "dropping feedback invoke (dm sender not allowlisted)",
+      channel: "dropping feedback invoke (not in team/channel allowlist)",
+      group: "dropping feedback invoke (group sender not allowlisted)",
+    },
+  });
+}
+
 async function isSigninInvokeAuthorized(
   context: MSTeamsTurnContext,
   deps: MSTeamsMessageHandlerDeps,
 ): Promise<boolean> {
-  const resolved = await resolveMSTeamsSenderAccess({
-    cfg: deps.cfg,
-    activity: context.activity,
+  return isInvokeAuthorized({
+    context,
+    deps,
+    deniedLogs: {
+      dm: "dropping signin invoke (dm sender not allowlisted)",
+      channel: "dropping signin invoke (not in team/channel allowlist)",
+      group: "dropping signin invoke (group sender not allowlisted)",
+    },
+    includeInvokeName: true,
   });
-  const { msteamsCfg, isDirectMessage, conversationId, senderId } = resolved;
-  if (!msteamsCfg) {
-    return true;
-  }
-
-  if (isDirectMessage && resolved.access.decision !== "allow") {
-    deps.log.debug?.("dropping signin invoke (dm sender not allowlisted)", {
-      sender: senderId,
-      conversationId,
-      name: context.activity.name,
-    });
-    return false;
-  }
-
-  if (
-    !isDirectMessage &&
-    resolved.channelGate.allowlistConfigured &&
-    !resolved.channelGate.allowed
-  ) {
-    deps.log.debug?.("dropping signin invoke (not in team/channel allowlist)", {
-      conversationId,
-      teamKey: resolved.channelGate.teamKey ?? "none",
-      channelKey: resolved.channelGate.channelKey ?? "none",
-      name: context.activity.name,
-    });
-    return false;
-  }
-
-  if (!isDirectMessage && !resolved.senderGroupAccess.allowed) {
-    deps.log.debug?.("dropping signin invoke (group sender not allowlisted)", {
-      sender: senderId,
-      conversationId,
-      name: context.activity.name,
-    });
-    return false;
-  }
-
-  return true;
 }
 
 /**

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -101,6 +101,54 @@ async function isFeedbackInvokeAuthorized(
   return true;
 }
 
+async function isSigninInvokeAuthorized(
+  context: MSTeamsTurnContext,
+  deps: MSTeamsMessageHandlerDeps,
+): Promise<boolean> {
+  const resolved = await resolveMSTeamsSenderAccess({
+    cfg: deps.cfg,
+    activity: context.activity,
+  });
+  const { msteamsCfg, isDirectMessage, conversationId, senderId } = resolved;
+  if (!msteamsCfg) {
+    return true;
+  }
+
+  if (isDirectMessage && resolved.access.decision !== "allow") {
+    deps.log.debug?.("dropping signin invoke (dm sender not allowlisted)", {
+      sender: senderId,
+      conversationId,
+      name: context.activity.name,
+    });
+    return false;
+  }
+
+  if (
+    !isDirectMessage &&
+    resolved.channelGate.allowlistConfigured &&
+    !resolved.channelGate.allowed
+  ) {
+    deps.log.debug?.("dropping signin invoke (not in team/channel allowlist)", {
+      conversationId,
+      teamKey: resolved.channelGate.teamKey ?? "none",
+      channelKey: resolved.channelGate.channelKey ?? "none",
+      name: context.activity.name,
+    });
+    return false;
+  }
+
+  if (!isDirectMessage && !resolved.senderGroupAccess.allowed) {
+    deps.log.debug?.("dropping signin invoke (group sender not allowlisted)", {
+      sender: senderId,
+      conversationId,
+      name: context.activity.name,
+    });
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * Handle fileConsent/invoke activities for large file uploads.
  */
@@ -480,6 +528,10 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
         // Always ack immediately — silently dropping the invoke causes
         // the Teams card UI to report "Something went wrong".
         await ctx.sendActivity({ type: "invokeResponse", value: { status: 200, body: {} } });
+
+        if (!(await isSigninInvokeAuthorized(ctx, deps))) {
+          return;
+        }
 
         if (!deps.sso) {
           deps.log.debug?.("signin invoke received but msteams.sso is not configured", {


### PR DESCRIPTION
## Summary

- **Problem:** The `signin/tokenExchange` and `signin/verifyState` invoke handler in `extensions/msteams/src/monitor-handler.ts` processed SSO token exchange without calling `resolveMSTeamsSenderAccess()`. Senders blocked by DM policy, channel allowlist, or group sender allowlist could complete token exchange and persist a delegated token in `msteams-sso-tokens.json`.
- **Why it matters:** Every other invoke handler in the same file (feedback, adaptive card, file consent) and the main message handler already enforce all three access-control layers before processing. The SSO handler had zero layers — a policy bypass for any operator running `dmPolicy: "allowlist"` or `groupPolicy: "allowlist"`.
- **What changed:** Added `isSigninInvokeAuthorized()` — a new authorization guard that checks DM policy, channel/team gate, and group sender allowlist using `resolveMSTeamsSenderAccess()` before any token exchange work. The check fires after the mandatory 200 ACK (required by Teams to avoid "Something went wrong" UI errors) and before the `sso` config check.
- **What did NOT change:** Token exchange logic, SSO config shape, token store schema, and all authorized sender paths are unchanged. The 200 ACK is still always sent.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** The SSO invoke handler (`monitor-handler.ts` — the `signin/tokenExchange`/`signin/verifyState` block) was written without a `resolveMSTeamsSenderAccess()` call, unlike every other invoke handler in the same file.
- **Missing detection / guardrail:** No unit test exercised the SSO path with a sender whose DM/group/channel policy would deny them.
- **Contributing context:** The SSO handler was introduced in `828ebd43d4`; the feedback-invoke authorization fix (which introduced `isFeedbackInvokeAuthorized`) predates it but the pattern was not carried over.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/msteams/src/monitor-handler.sso.test.ts`
- **Scenario the test should lock in:** `signin/tokenExchange` and `signin/verifyState` invokes from DM-blocked, channel-blocked, and group-blocked senders are each dropped (no fetch calls, no token stored) while still receiving a 200 ACK.
- **Why this is the smallest reliable guardrail:** Directly exercises the three `resolveMSTeamsSenderAccess` paths against the SSO handler with parameterized invite types, verifying both the drop and the absence of side-effects.
- **Existing test that already covers this:** None (gap).
- **If no new test is added, why not:** N/A — tests added in this PR.

## User-visible / Behavior Changes

Unauthorized Teams senders (blocked by DM policy, channel allowlist, or group sender allowlist) will no longer have their `signin/tokenExchange` or `signin/verifyState` invokes processed. They continue to receive a 200 ACK (required by Teams protocol) but no token is exchanged or stored. Authorized senders are unaffected.

## Diagram (if applicable)

```text
Before:
[signin/tokenExchange invoke] -> [200 ACK] -> [handleSigninTokenExchangeInvoke] -> [tokenStore.save]

After:
[signin/tokenExchange invoke] -> [200 ACK] -> [isSigninInvokeAuthorized?]
                                                  No  -> [return, no token stored]
                                                  Yes -> [handleSigninTokenExchangeInvoke] -> [tokenStore.save]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — unauthorized senders can no longer persist delegated tokens via the SSO path.
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- **Risk + mitigation:** The change restricts who can trigger token exchange, matching the existing policy already enforced on all other invoke paths. No new surface is introduced.

## Repro + Verification

### Environment

- OS: Linux (CI / Ubuntu)
- Runtime/container: Node 22 / Bun
- Model/provider: N/A (unit test only)
- Integration/channel: MS Teams (msteams extension)
- Relevant config: `dmPolicy: "allowlist"`, `groupPolicy: "allowlist"`, team/channel allowlist

### Steps

1. Run `pnpm test extensions/msteams/src/monitor-handler.sso.test.ts`
2. Observe new parameterized test cases pass: `does not process signin/tokenExchange for DM sender outside allowlist`, `...channel outside route allowlist`, `...group sender outside group allowlist` (and matching `signin/verifyState` variants).

### Expected

- All 6 new blocked-sender test cases pass.
- `sendActivity` called with `{ type: "invokeResponse", value: { status: 200 } }` (ACK still sent).
- `fetchImpl` called 0 times (no token exchange network call).
- `tokenStore.get(...)` returns `null` (no token persisted).
- `deps.log.debug` called with the expected drop message and `name` field.

### Actual

- All 6 new cases pass; no regressions in existing SSO test suite.

## Evidence

- [x] Failing test/log before + passing after

New tests added in `monitor-handler.sso.test.ts` exercise all three blocked-sender scenarios × two invoke types. Tests confirm both the protocol-level 200 ACK and the absence of side-effects (no HTTP calls, no stored token).

## Human Verification (required)

> This PR was generated by OpenAI Codex and reviewed by an AI reviewer (Claude). No human has manually run or verified the code changes beyond automated test execution.

- **Verified scenarios:** Unit test matrix covers DM-blocked, channel-blocked, and group-blocked senders for both `signin/tokenExchange` and `signin/verifyState`.
- **Edge cases checked:** Authorized senders unaffected (existing tests); ACK always sent before auth check (Teams protocol requirement); `sso` not configured path still works (auth check fires first, but no SSO processing occurs regardless).
- **What you did not verify:** Live Teams bot end-to-end with a real unauthorized sender; behavior under concurrent SSO invoke deduplication.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** The 200 ACK is sent before the authorization check. A future refactor that moves the ACK after the auth check would cause Teams UI errors for blocked senders.
  - **Mitigation:** Code comment at the ACK site explicitly documents this ordering requirement. Pattern is identical to the existing feedback invoke handler.