### PR TITLE
fix(heartbeat): preserve Telegram topic routing for isolated heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Context engines: reject resolved plugin engines whose reported `info.id` does not match their registered slot id, so malformed engines fail fast before id-based runtime branches can misbehave. (#63222) Thanks @fuller-stack-dev.
 - WhatsApp: patch installed Baileys media encryption writes during OpenClaw postinstall so the default npm/install.sh delivery path waits for encrypted media files to finish flushing before readback, avoiding transient `ENOENT` crashes on image sends. (#65896) Thanks @frankekn.
 - Gateway/update: unify service entrypoint resolution around the canonical bundled gateway entrypoint so update, reinstall, and doctor repair stop drifting between stale `dist/entry.js` and current `dist/index.js` paths. (#65984) Thanks @mbelinky.
+
 ## 2026.4.12
 
 ### Changes
@@ -791,7 +792,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/SecretRef: resolve restart token drift checks with merged service/runtime env sources and hard-fail unsupported mutable SecretRef plus OAuth-profile combinations so restart warnings and policy enforcement match runtime behavior. (#58141) Thanks @joshavant.
 - Telegram/outbound chunking: use static markdown chunking when Telegram runtime state is unavailable so long outbound Telegram messages still split correctly after cold starts. (#57816) Thanks @ForestDengHK.
 - Update/Corepack: disable interactive Corepack download prompts during update preflight install unless `COREPACK_ENABLE_DOWNLOAD_PROMPT` is already explicitly set, so `openclaw update` can fetch the repo-pinned pnpm version non-interactively. (#61456) Thanks @p6l-richard.
-- Heartbeat/Telegram topics: keep isolated heartbeat replies on the bound forum topic when `target=last`, instead of dropping them into the group root chat.
+- Heartbeat/Telegram topics: keep isolated heartbeat replies on the bound forum topic when `target=last`, instead of dropping them into the group root chat. (#66035)
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Docs: https://docs.openclaw.ai
 - Context engines: reject resolved plugin engines whose reported `info.id` does not match their registered slot id, so malformed engines fail fast before id-based runtime branches can misbehave. (#63222) Thanks @fuller-stack-dev.
 - WhatsApp: patch installed Baileys media encryption writes during OpenClaw postinstall so the default npm/install.sh delivery path waits for encrypted media files to finish flushing before readback, avoiding transient `ENOENT` crashes on image sends. (#65896) Thanks @frankekn.
 - Gateway/update: unify service entrypoint resolution around the canonical bundled gateway entrypoint so update, reinstall, and doctor repair stop drifting between stale `dist/entry.js` and current `dist/index.js` paths. (#65984) Thanks @mbelinky.
-- Heartbeat/Telegram topics: keep isolated heartbeat replies on the bound forum topic when `target=last`, instead of dropping them into the group root chat. (#66035)
+- Heartbeat/Telegram topics: keep isolated heartbeat replies on the bound forum topic when `target=last`, instead of dropping them into the group root chat. (#66035) Thanks @mbelinky.
 
 ## 2026.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Context engines: reject resolved plugin engines whose reported `info.id` does not match their registered slot id, so malformed engines fail fast before id-based runtime branches can misbehave. (#63222) Thanks @fuller-stack-dev.
 - WhatsApp: patch installed Baileys media encryption writes during OpenClaw postinstall so the default npm/install.sh delivery path waits for encrypted media files to finish flushing before readback, avoiding transient `ENOENT` crashes on image sends. (#65896) Thanks @frankekn.
 - Gateway/update: unify service entrypoint resolution around the canonical bundled gateway entrypoint so update, reinstall, and doctor repair stop drifting between stale `dist/entry.js` and current `dist/index.js` paths. (#65984) Thanks @mbelinky.
+- Heartbeat/Telegram topics: keep isolated heartbeat replies on the bound forum topic when `target=last`, instead of dropping them into the group root chat. (#66035)
 
 ## 2026.4.12
 
@@ -792,7 +793,6 @@ Docs: https://docs.openclaw.ai
 - Gateway/SecretRef: resolve restart token drift checks with merged service/runtime env sources and hard-fail unsupported mutable SecretRef plus OAuth-profile combinations so restart warnings and policy enforcement match runtime behavior. (#58141) Thanks @joshavant.
 - Telegram/outbound chunking: use static markdown chunking when Telegram runtime state is unavailable so long outbound Telegram messages still split correctly after cold starts. (#57816) Thanks @ForestDengHK.
 - Update/Corepack: disable interactive Corepack download prompts during update preflight install unless `COREPACK_ENABLE_DOWNLOAD_PROMPT` is already explicitly set, so `openclaw update` can fetch the repo-pinned pnpm version non-interactively. (#61456) Thanks @p6l-richard.
-- Heartbeat/Telegram topics: keep isolated heartbeat replies on the bound forum topic when `target=last`, instead of dropping them into the group root chat. (#66035)
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -791,6 +791,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/SecretRef: resolve restart token drift checks with merged service/runtime env sources and hard-fail unsupported mutable SecretRef plus OAuth-profile combinations so restart warnings and policy enforcement match runtime behavior. (#58141) Thanks @joshavant.
 - Telegram/outbound chunking: use static markdown chunking when Telegram runtime state is unavailable so long outbound Telegram messages still split correctly after cold starts. (#57816) Thanks @ForestDengHK.
 - Update/Corepack: disable interactive Corepack download prompts during update preflight install unless `COREPACK_ENABLE_DOWNLOAD_PROMPT` is already explicitly set, so `openclaw update` can fetch the repo-pinned pnpm version non-interactively. (#61456) Thanks @p6l-richard.
+- Heartbeat/Telegram topics: keep isolated heartbeat replies on the bound forum topic when `target=last`, instead of dropping them into the group root chat.
 
 ## 2026.4.2
 

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -408,7 +408,6 @@ describe("Ghost reminder bug (issue #13317)", () => {
       expect(options?.messageThreadId).toBeUndefined();
     });
   });
-
   it("keeps exec-event delivery pinned to the original Telegram topic when session route drifts", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg: OpenClawConfig = {
@@ -472,6 +471,72 @@ describe("Ghost reminder bug (issue #13317)", () => {
         "telegram:-1003774691294:topic:47",
         "The review-worker spawn finished successfully.",
         expect.objectContaining({ messageThreadId: 47 }),
+      );
+    });
+  });
+
+  it("keeps Telegram topic routing for isolated scheduled heartbeats", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+              isolatedSession: true,
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            deliveryContext: {
+              channel: "telegram",
+              to: "-100155462274",
+              threadId: 42,
+            },
+            chatType: "group",
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-100155462274",
+      });
+      replySpy.mockResolvedValue({ text: "Topic heartbeat" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        reason: "timer",
+        deps: {
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          SessionKey: `${sessionKey}:heartbeat`,
+          MessageThreadId: 42,
+        }),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "-100155462274",
+        "Topic heartbeat",
+        expect.objectContaining({ messageThreadId: 42 }),
       );
     });
   });

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -498,6 +498,8 @@ describe("Ghost reminder bug (issue #13317)", () => {
           [sessionKey]: {
             sessionId: "sid",
             updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "-100155462274",
             deliveryContext: {
               channel: "telegram",
               to: "-100155462274",
@@ -519,6 +521,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
         agentId: "main",
         reason: "timer",
         deps: {
+          getReplyFromConfig: replySpy,
           telegram: sendTelegram,
         },
       });

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -607,6 +607,74 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.threadId).toBe(1008013);
   });
 
+  it("preserves Telegram topic threadId for heartbeat target=last on topic-bound group sessions", () => {
+    const cfg: OpenClawConfig = {};
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg,
+      entry: {
+        sessionId: "sess-heartbeat-telegram-topic",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "-1001234567890",
+        lastThreadId: 1122,
+        chatType: "group",
+      },
+      heartbeat: {
+        target: "last",
+      },
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("-1001234567890");
+    expect(resolved.threadId).toBe(1122);
+  });
+
+  it("reuses Telegram topic routing when only deliveryContext carries the topic threadId", () => {
+    const cfg: OpenClawConfig = {};
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg,
+      entry: {
+        sessionId: "sess-heartbeat-telegram-topic-context-only",
+        updatedAt: 1,
+        deliveryContext: {
+          channel: "telegram",
+          to: "-1001234567890",
+          threadId: 1122,
+        },
+        chatType: "group",
+      },
+      heartbeat: {
+        target: "last",
+      },
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("-1001234567890");
+    expect(resolved.threadId).toBe(1122);
+  });
+
+  it("does not inherit stale Telegram threadId for direct-chat heartbeat routes", () => {
+    const cfg: OpenClawConfig = {};
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg,
+      entry: {
+        sessionId: "sess-heartbeat-telegram-direct-stale-thread",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "5232990709",
+        lastThreadId: 1122,
+        chatType: "direct",
+      },
+      heartbeat: {
+        target: "last",
+      },
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("5232990709");
+    expect(resolved.threadId).toBeUndefined();
+  });
+
   it("prefers turn-scoped routing over mutable session routing for target=last", () => {
     const resolved = resolveHeartbeatDeliveryTarget({
       cfg: {},

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -49,7 +49,7 @@ export type HeartbeatSenderContext = {
 
 export type { OutboundTargetResolution } from "./targets-resolve-shared.js";
 export { resolveSessionDeliveryTarget, type SessionDeliveryTarget } from "./targets-session.js";
-import { resolveSessionDeliveryTarget } from "./targets-session.js";
+import { resolveSessionDeliveryTarget, type SessionDeliveryTarget } from "./targets-session.js";
 
 // Channel docking: prefer plugin.outbound.resolveTarget + allowFrom to normalize destinations.
 export function resolveOutboundTarget(params: {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -220,12 +220,26 @@ export function resolveHeartbeatDeliveryTarget(params: {
     }
   }
 
+  const inheritedHeartbeatThreadId = shouldReuseHeartbeatTelegramTopicThread({
+    target,
+    heartbeat,
+    turnSource: params.turnSource,
+    entry,
+    resolvedTarget,
+  })
+    ? resolvedTarget.lastThreadId
+    : undefined;
+
   return {
     channel: resolvedTarget.channel,
     to: resolved.to,
     reason,
     accountId: effectiveAccountId,
-    threadId: resolvedTarget.threadId,
+    // Heartbeats normally avoid inheriting session reply-thread IDs, but
+    // Telegram forum-topic sessions encode the topic as part of the
+    // destination identity. Preserve that topic routing when the heartbeat is
+    // still targeting the same group session.
+    threadId: resolvedTarget.threadId ?? inheritedHeartbeatThreadId,
     lastChannel: resolvedTarget.lastChannel,
     lastAccountId: resolvedTarget.lastAccountId,
   };
@@ -283,6 +297,27 @@ function resolveHeartbeatDeliveryChatType(params: {
     channel: params.channel,
     to: params.to,
   });
+}
+
+function shouldReuseHeartbeatTelegramTopicThread(params: {
+  target: HeartbeatTarget;
+  heartbeat?: AgentDefaultsConfig["heartbeat"];
+  turnSource?: DeliveryContext;
+  entry?: SessionEntry;
+  resolvedTarget: SessionDeliveryTarget;
+}): boolean {
+  return (
+    params.resolvedTarget.threadId == null &&
+    params.target === "last" &&
+    !params.heartbeat?.to &&
+    params.turnSource?.threadId == null &&
+    params.resolvedTarget.channel === "telegram" &&
+    params.resolvedTarget.lastChannel === "telegram" &&
+    Boolean(params.resolvedTarget.to) &&
+    Boolean(params.resolvedTarget.lastTo) &&
+    params.resolvedTarget.to === params.resolvedTarget.lastTo &&
+    normalizeChatType(params.entry?.chatType) === "group"
+  );
 }
 
 function resolveHeartbeatSenderId(params: {


### PR DESCRIPTION
## Summary

- Problem: isolated Telegram heartbeats using `target=last` could drop the bound forum-topic `threadId` and send into the group root chat instead.
- Why it matters: topic-bound sessions would leak scheduled heartbeat replies into General, breaking session isolation and reply routing.
- What changed: preserved Telegram topic routing in heartbeat target resolution when the heartbeat is still addressing the same group session, and added focused regressions at the target-resolution seam plus the isolated heartbeat runner path.
- What did NOT change (scope boundary): this does not touch broader delivery-context contamination, cron payload formatting, or dreaming reconciliation/reporting bugs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65693
- Related #65702
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: heartbeat routing intentionally avoided inheriting session reply-thread IDs, but Telegram forum topics encode the topic as part of the destination identity, so `target=last` lost the topic route.
- Missing detection / guardrail: there was no regression test proving isolated scheduled heartbeats preserved Telegram topic routing from stored session delivery context.
- Prior context (`git blame`, prior PR, issue, or refactor if known): adjacent Telegram topic routing fixes already existed for announce and session-spawn paths; the open #65702 attempt targets the isolated-session store, but the actual drop happens earlier in `src/infra/outbound/targets.ts`.
- Why this regressed now: the generic heartbeat rule to avoid stale reply-thread reuse was correct for most channels, but it was too broad for Telegram forum topics.
- If unknown, what was ruled out: ruled out isolated-session creation as the primary seam for #65693 because the topic was already missing before the heartbeat session record mattered.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/outbound/targets.test.ts`, `src/infra/heartbeat-runner.ghost-reminder.test.ts`
- Scenario the test should lock in: a topic-bound Telegram group session with only persisted `deliveryContext.threadId` should keep `messageThreadId` on isolated scheduled heartbeat delivery when `target=last` is used.
- Why this is the smallest reliable guardrail: the bug lives at heartbeat target resolution, but the runner regression proves the real scheduled send path keeps the topic through to Telegram delivery.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Isolated Telegram heartbeat replies stay in the bound forum topic instead of falling back to the group root chat.

## Diagram (if applicable)

```text
Before:
[isolated heartbeat on topic-bound Telegram session] -> [target=last drops threadId] -> [message sent to root group chat]

After:
[isolated heartbeat on topic-bound Telegram session] -> [target=last preserves topic threadId for same group route] -> [message sent to bound forum topic]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (mb-server)
- Runtime/container: local repo worktree
- Model/provider: N/A
- Integration/channel (if any): Telegram forum topics / heartbeat runner
- Relevant config (redacted): `agents.defaults.heartbeat = { every: "5m", target: "last", isolatedSession: true }`

### Steps

1. Persist a Telegram group session with `deliveryContext = { channel: "telegram", to: "-100...", threadId: 42 }` and `chatType: "group"`.
2. Run an isolated scheduled heartbeat with `target=last`.
3. Inspect the resolved delivery target / Telegram send options.

### Expected

- The heartbeat keeps `messageThreadId: 42` and replies in the bound topic.

### Actual

- Before the fix, the heartbeat dropped the topic thread and replied into the group root chat.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted tests for heartbeat target resolution, delivery-context-only persisted shape, direct-chat non-regression, and scheduled isolated heartbeat send path.
- Edge cases checked: direct Telegram chat should not inherit a stale thread ID; explicit turn-scoped thread routing still wins.
- What you did **not** verify: live Telegram delivery against a real forum topic.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: stale or malformed session metadata without `chatType: "group"` will still fail closed and not reuse a topic thread.
  - Mitigation: scope the fix to the confirmed Telegram group-topic route; keep broader metadata-repair behavior out of this PR.
