### PR TITLE
fix(skills): pin targetDir by inode identity to close TOCTOU window during download and extraction [AI-assisted]

### DIFF
--- a/src/agents/skills-install-download.ts
+++ b/src/agents/skills-install-download.ts
@@ -6,6 +6,7 @@ import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { isWindowsDrivePath } from "../infra/archive-path.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { sameFileIdentity } from "../infra/file-identity.js";
 import { writeFileFromPathWithinRoot } from "../infra/fs-safe.js";
 import { assertCanonicalPathWithinBase } from "../infra/install-safe-path.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
@@ -22,22 +23,88 @@ function isNodeReadableStream(value: unknown): value is NodeJS.ReadableStream {
   return Boolean(value && typeof (value as NodeJS.ReadableStream).pipe === "function");
 }
 
-function resolveDownloadTargetDir(entry: SkillEntry, spec: SkillInstallSpec): string {
-  const safeRoot = resolveSkillToolsRootDir(entry);
-  const raw = spec.targetDir?.trim();
+type PinnedDirectory = {
+  canonicalPath: string;
+  identity: {
+    dev: number | bigint;
+    ino: number | bigint;
+  };
+};
+
+async function pinCanonicalDirectory(params: {
+  baseDir: string;
+  candidatePath: string;
+  boundaryLabel: string;
+}): Promise<PinnedDirectory> {
+  await assertCanonicalPathWithinBase({
+    baseDir: params.baseDir,
+    candidatePath: params.candidatePath,
+    boundaryLabel: params.boundaryLabel,
+  });
+  const canonicalPath = await fs.promises.realpath(params.candidatePath);
+  await assertCanonicalPathWithinBase({
+    baseDir: params.baseDir,
+    candidatePath: canonicalPath,
+    boundaryLabel: params.boundaryLabel,
+  });
+
+  const stat = await fs.promises.lstat(canonicalPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Invalid ${params.boundaryLabel}: directory must be real and non-symlinked`);
+  }
+  return {
+    canonicalPath,
+    identity: {
+      dev: stat.dev,
+      ino: stat.ino,
+    },
+  };
+}
+
+async function assertPinnedDirectoryUnchanged(params: {
+  baseDir: string;
+  pinnedDir: PinnedDirectory;
+  boundaryLabel: string;
+}): Promise<void> {
+  try {
+    await assertCanonicalPathWithinBase({
+      baseDir: params.baseDir,
+      candidatePath: params.pinnedDir.canonicalPath,
+      boundaryLabel: params.boundaryLabel,
+    });
+  } catch {
+    throw new Error(`Invalid ${params.boundaryLabel}: directory changed during install`);
+  }
+
+  let current: Awaited<ReturnType<typeof fs.promises.lstat>>;
+  try {
+    current = await fs.promises.lstat(params.pinnedDir.canonicalPath);
+  } catch {
+    throw new Error(`Invalid ${params.boundaryLabel}: directory changed during install`);
+  }
+  if (!current.isDirectory() || current.isSymbolicLink()) {
+    throw new Error(`Invalid ${params.boundaryLabel}: directory changed during install`);
+  }
+  if (!sameFileIdentity(current, params.pinnedDir.identity)) {
+    throw new Error(`Invalid ${params.boundaryLabel}: directory changed during install`);
+  }
+}
+
+function resolveDownloadTargetDir(params: { safeRoot: string; spec: SkillInstallSpec }): string {
+  const raw = params.spec.targetDir?.trim();
   if (!raw) {
-    return safeRoot;
+    return params.safeRoot;
   }
 
   // Treat non-absolute paths as relative to the per-skill tools root.
   const resolved =
     raw.startsWith("~") || path.isAbsolute(raw) || isWindowsDrivePath(raw)
       ? resolveUserPath(raw)
-      : path.resolve(safeRoot, raw);
+      : path.resolve(params.safeRoot, raw);
 
-  if (!isWithinDir(safeRoot, resolved)) {
+  if (!isWithinDir(params.safeRoot, resolved)) {
     throw new Error(
-      `Refusing to install outside the skill tools directory. targetDir="${raw}" resolves to "${resolved}". Allowed root: "${safeRoot}".`,
+      `Refusing to install outside the skill tools directory. targetDir="${raw}" resolves to "${resolved}". Allowed root: "${params.safeRoot}".`,
     );
   }
   return resolved;
@@ -69,6 +136,8 @@ async function downloadFile(params: {
   rootDir: string;
   relativePath: string;
   timeoutMs: number;
+  beforeFinalCopy?: () => Promise<void>;
+  afterFinalCopy?: () => Promise<void>;
 }): Promise<{ bytes: number }> {
   const destPath = path.resolve(params.rootDir, params.relativePath);
   const stagingDir = path.join(params.rootDir, ".openclaw-download-staging");
@@ -93,11 +162,17 @@ async function downloadFile(params: {
       ? body
       : Readable.fromWeb(body as NodeReadableStream);
     await pipeline(readable, file);
+    if (params.beforeFinalCopy) {
+      await params.beforeFinalCopy();
+    }
     await writeFileFromPathWithinRoot({
       rootDir: params.rootDir,
       relativePath: params.relativePath,
       sourcePath: tempPath,
     });
+    if (params.afterFinalCopy) {
+      await params.afterFinalCopy();
+    }
     const stat = await fs.promises.stat(destPath);
     return { bytes: stat.size };
   } finally {
@@ -137,28 +212,39 @@ export async function installDownloadSpec(params: {
 
   let canonicalSafeRoot = "";
   let targetDir = "";
+  let pinnedTargetDir: PinnedDirectory | undefined;
   try {
     await ensureDir(safeRoot);
-    await assertCanonicalPathWithinBase({
+    const pinnedSafeRoot = await pinCanonicalDirectory({
       baseDir: safeRoot,
       candidatePath: safeRoot,
       boundaryLabel: "skill tools directory",
     });
-    canonicalSafeRoot = await fs.promises.realpath(safeRoot);
+    canonicalSafeRoot = pinnedSafeRoot.canonicalPath;
 
-    const requestedTargetDir = resolveDownloadTargetDir(entry, spec);
+    const requestedTargetDir = resolveDownloadTargetDir({ safeRoot: canonicalSafeRoot, spec });
     await ensureDir(requestedTargetDir);
-    await assertCanonicalPathWithinBase({
-      baseDir: safeRoot,
+    pinnedTargetDir = await pinCanonicalDirectory({
+      baseDir: canonicalSafeRoot,
       candidatePath: requestedTargetDir,
       boundaryLabel: "skill tools directory",
     });
-    const targetRelativePath = path.relative(safeRoot, requestedTargetDir);
-    targetDir = path.join(canonicalSafeRoot, targetRelativePath);
+    targetDir = pinnedTargetDir.canonicalPath;
   } catch (err) {
     const message = formatErrorMessage(err);
     return { ok: false, message, stdout: "", stderr: message, code: null };
   }
+
+  const assertTargetDirStillPinned = async (): Promise<void> => {
+    if (!pinnedTargetDir) {
+      throw new Error("invalid download target directory");
+    }
+    await assertPinnedDirectoryUnchanged({
+      baseDir: canonicalSafeRoot,
+      pinnedDir: pinnedTargetDir,
+      boundaryLabel: "skill tools directory",
+    });
+  };
 
   const archivePath = path.join(targetDir, filename);
   const archiveRelativePath = path.relative(canonicalSafeRoot, archivePath);
@@ -178,11 +264,14 @@ export async function installDownloadSpec(params: {
   }
   let downloaded = 0;
   try {
+    await assertTargetDirStillPinned();
     const result = await downloadFile({
       url,
       rootDir: canonicalSafeRoot,
       relativePath: archiveRelativePath,
       timeoutMs,
+      beforeFinalCopy: assertTargetDirStillPinned,
+      afterFinalCopy: assertTargetDirStillPinned,
     });
     downloaded = result.bytes;
   } catch (err) {
@@ -213,11 +302,7 @@ export async function installDownloadSpec(params: {
   }
 
   try {
-    await assertCanonicalPathWithinBase({
-      baseDir: canonicalSafeRoot,
-      candidatePath: targetDir,
-      boundaryLabel: "skill tools directory",
-    });
+    await assertTargetDirStillPinned();
   } catch (err) {
     const message = formatErrorMessage(err);
     return { ok: false, message, stdout: "", stderr: message, code: null };
@@ -229,6 +314,7 @@ export async function installDownloadSpec(params: {
     targetDir,
     stripComponents: spec.stripComponents,
     timeoutMs,
+    validateTargetDir: assertTargetDirStillPinned,
   });
   const success = extractResult.code === 0;
   return {

--- a/src/agents/skills-install-download.ts
+++ b/src/agents/skills-install-download.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -147,14 +148,8 @@ async function downloadFile(params: {
   };
 
   const destPath = path.resolve(params.rootDir, params.relativePath);
-  const stagingDir = path.join(params.rootDir, ".openclaw-download-staging");
+  const stagingDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-download-"));
   await runBeforeTempWrite();
-  await ensureDir(stagingDir);
-  await assertCanonicalPathWithinBase({
-    baseDir: params.rootDir,
-    candidatePath: stagingDir,
-    boundaryLabel: "skill tools directory",
-  });
   const tempPath = path.join(stagingDir, `${randomUUID()}.tmp`);
   const { response, release } = await fetchWithSsrFGuard({
     url: params.url,
@@ -186,6 +181,7 @@ async function downloadFile(params: {
     return { bytes: stat.size };
   } finally {
     await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
+    await fs.promises.rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
     await release();
   }
 }

--- a/src/agents/skills-install-download.ts
+++ b/src/agents/skills-install-download.ts
@@ -149,13 +149,17 @@ async function downloadFile(params: {
 
   const destPath = path.resolve(params.rootDir, params.relativePath);
   const stagingDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-download-"));
-  await runBeforeTempWrite();
   const tempPath = path.join(stagingDir, `${randomUUID()}.tmp`);
-  const { response, release } = await fetchWithSsrFGuard({
-    url: params.url,
-    timeoutMs: Math.max(1_000, params.timeoutMs),
-  });
+  let release: (() => Promise<void>) | undefined;
   try {
+    await runBeforeTempWrite();
+    const fetched = await fetchWithSsrFGuard({
+      url: params.url,
+      timeoutMs: Math.max(1_000, params.timeoutMs),
+    });
+    release = fetched.release;
+    const { response } = fetched;
+
     if (!response.ok || !response.body) {
       throw new Error(`Download failed (${response.status} ${response.statusText})`);
     }
@@ -182,7 +186,9 @@ async function downloadFile(params: {
   } finally {
     await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
     await fs.promises.rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
-    await release();
+    if (release) {
+      await release();
+    }
   }
 }
 

--- a/src/agents/skills-install-download.ts
+++ b/src/agents/skills-install-download.ts
@@ -136,11 +136,19 @@ async function downloadFile(params: {
   rootDir: string;
   relativePath: string;
   timeoutMs: number;
+  beforeTempWrite?: () => Promise<void>;
   beforeFinalCopy?: () => Promise<void>;
   afterFinalCopy?: () => Promise<void>;
 }): Promise<{ bytes: number }> {
+  const runBeforeTempWrite = async (): Promise<void> => {
+    if (params.beforeTempWrite) {
+      await params.beforeTempWrite();
+    }
+  };
+
   const destPath = path.resolve(params.rootDir, params.relativePath);
   const stagingDir = path.join(params.rootDir, ".openclaw-download-staging");
+  await runBeforeTempWrite();
   await ensureDir(stagingDir);
   await assertCanonicalPathWithinBase({
     baseDir: params.rootDir,
@@ -156,6 +164,7 @@ async function downloadFile(params: {
     if (!response.ok || !response.body) {
       throw new Error(`Download failed (${response.status} ${response.statusText})`);
     }
+    await runBeforeTempWrite();
     const file = fs.createWriteStream(tempPath);
     const body = response.body as unknown;
     const readable = isNodeReadableStream(body)
@@ -270,6 +279,7 @@ export async function installDownloadSpec(params: {
       rootDir: canonicalSafeRoot,
       relativePath: archiveRelativePath,
       timeoutMs,
+      beforeTempWrite: assertTargetDirStillPinned,
       beforeFinalCopy: assertTargetDirStillPinned,
       afterFinalCopy: assertTargetDirStillPinned,
     });

--- a/src/agents/skills-install-extract.ts
+++ b/src/agents/skills-install-extract.ts
@@ -136,6 +136,7 @@ async function extractTarBz2WithStaging(params: {
         sourceDir: stagingDir,
         destinationDir: params.destinationRealDir,
         destinationRealDir: params.destinationRealDir,
+        beforeEachDestinationWrite: params.beforeMerge,
       });
       return extractResult;
     },

--- a/src/agents/skills-install-extract.ts
+++ b/src/agents/skills-install-extract.ts
@@ -113,6 +113,7 @@ async function extractTarBz2WithStaging(params: {
   destinationRealDir: string;
   stripComponents: number;
   timeoutMs: number;
+  beforeMerge?: () => Promise<void>;
 }): Promise<ArchiveExtractResult> {
   return await withStagedArchiveDestination({
     destinationRealDir: params.destinationRealDir,
@@ -127,6 +128,9 @@ async function extractTarBz2WithStaging(params: {
       );
       if (extractResult.code !== 0) {
         return extractResult;
+      }
+      if (params.beforeMerge) {
+        await params.beforeMerge();
       }
       await mergeExtractedTreeIntoDestination({
         sourceDir: stagingDir,
@@ -144,14 +148,20 @@ export async function extractArchive(params: {
   targetDir: string;
   stripComponents?: number;
   timeoutMs: number;
+  validateTargetDir?: () => Promise<void>;
 }): Promise<ArchiveExtractResult> {
-  const { archivePath, archiveType, targetDir, stripComponents, timeoutMs } = params;
+  const { archivePath, archiveType, targetDir, stripComponents, timeoutMs, validateTargetDir } =
+    params;
   const strip =
     typeof stripComponents === "number" && Number.isFinite(stripComponents)
       ? Math.max(0, Math.floor(stripComponents))
       : 0;
 
   try {
+    if (validateTargetDir) {
+      await validateTargetDir();
+    }
+
     if (archiveType === "zip") {
       await extractArchiveSafe({
         archivePath,
@@ -223,6 +233,7 @@ export async function extractArchive(params: {
         destinationRealDir,
         stripComponents: strip,
         timeoutMs,
+        beforeMerge: validateTargetDir,
       });
     }
 

--- a/src/agents/skills-install-extract.ts
+++ b/src/agents/skills-install-extract.ts
@@ -113,11 +113,18 @@ async function extractTarBz2WithStaging(params: {
   destinationRealDir: string;
   stripComponents: number;
   timeoutMs: number;
-  beforeMerge?: () => Promise<void>;
+  validateDestination?: () => Promise<void>;
 }): Promise<ArchiveExtractResult> {
+  if (params.validateDestination) {
+    await params.validateDestination();
+  }
+
   return await withStagedArchiveDestination({
     destinationRealDir: params.destinationRealDir,
     run: async (stagingDir) => {
+      if (params.validateDestination) {
+        await params.validateDestination();
+      }
       const extractResult = await runCommandWithTimeout(
         buildTarExtractArgv({
           archivePath: params.archivePath,
@@ -129,14 +136,11 @@ async function extractTarBz2WithStaging(params: {
       if (extractResult.code !== 0) {
         return extractResult;
       }
-      if (params.beforeMerge) {
-        await params.beforeMerge();
-      }
       await mergeExtractedTreeIntoDestination({
         sourceDir: stagingDir,
         destinationDir: params.destinationRealDir,
         destinationRealDir: params.destinationRealDir,
-        beforeEachDestinationWrite: params.beforeMerge,
+        beforeEachDestinationWrite: params.validateDestination,
       });
       return extractResult;
     },
@@ -236,7 +240,7 @@ export async function extractArchive(params: {
         destinationRealDir,
         stripComponents: strip,
         timeoutMs,
-        beforeMerge: validateTargetDir,
+        validateDestination: validateTargetDir,
       });
     }
 

--- a/src/agents/skills-install-extract.ts
+++ b/src/agents/skills-install-extract.ts
@@ -169,6 +169,7 @@ export async function extractArchive(params: {
         timeoutMs,
         kind: "zip",
         stripComponents: strip,
+        beforeWriteToDestination: validateTargetDir,
       });
       return { stdout: "", stderr: "", code: 0 };
     }
@@ -181,6 +182,7 @@ export async function extractArchive(params: {
         kind: "tar",
         stripComponents: strip,
         tarGzip: true,
+        beforeWriteToDestination: validateTargetDir,
       });
       return { stdout: "", stderr: "", code: 0 };
     }

--- a/src/agents/skills-install.download.test.ts
+++ b/src/agents/skills-install.download.test.ts
@@ -521,6 +521,50 @@ describe("installDownloadSpec extraction safety (tar.bz2)", () => {
     expect(extractionAttempted).toBe(false);
   });
 
+  it.runIf(process.platform !== "win32")(
+    "fails closed when targetDir is replaced between tar.bz2 extract and merge",
+    async () => {
+      const entry = buildEntry("tbz2-before-merge-rebind");
+      const targetDir = path.join(resolveSkillToolsRootDir(entry), "target");
+
+      mockArchiveResponse(new Uint8Array([1, 2, 3]));
+
+      runCommandWithTimeoutMock.mockImplementation(async (...argv: unknown[]) => {
+        const cmd = (argv[0] ?? []) as string[];
+        if (cmd[0] === "tar" && cmd[1] === "tf") {
+          return runCommandResult({ stdout: "package/hello.txt\n" });
+        }
+        if (cmd[0] === "tar" && cmd[1] === "tvf") {
+          return runCommandResult({
+            stdout: "-rw-r--r--  0 0 0 0 Jan  1 00:00 package/hello.txt\n",
+          });
+        }
+        if (cmd[0] === "tar" && cmd[1] === "xf") {
+          const stagingDir = cmd[cmd.indexOf("-C") + 1] ?? "";
+          await fs.mkdir(path.join(stagingDir, "package"), { recursive: true });
+          await fs.writeFile(path.join(stagingDir, "package", "hello.txt"), "hi", "utf-8");
+
+          const reboundTargetDir = `${targetDir}-rebound`;
+          await fs.rename(targetDir, reboundTargetDir);
+          await fs.mkdir(targetDir, { recursive: true });
+          return runCommandResult({ stdout: "ok" });
+        }
+        return runCommandResult();
+      });
+
+      const result = await installDownloadSkill({
+        name: "tbz2-before-merge-rebind",
+        url: "https://example.invalid/good.tbz2",
+        archive: "tar.bz2",
+        targetDir,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.stderr.toLowerCase()).toContain("directory changed during install");
+      expect(await fileExists(path.join(targetDir, "package", "hello.txt"))).toBe(false);
+    },
+  );
+
   it("rejects tar.bz2 entries that traverse pre-existing targetDir symlinks", async () => {
     const entry = buildEntry("tbz2-targetdir-symlink");
     const targetDir = path.join(resolveSkillToolsRootDir(entry), "target");

--- a/src/agents/skills-install.download.test.ts
+++ b/src/agents/skills-install.download.test.ts
@@ -305,6 +305,52 @@ describe("installDownloadSpec extraction safety", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "fails closed before streaming when default targetDir root is rebound during download",
+    async () => {
+      const entry = buildEntry("base-rebind-default-target");
+      const safeRoot = resolveSkillToolsRootDir(entry);
+      const outsideRoot = path.join(workspaceDir, "outside-root-default-target");
+      await fs.mkdir(path.join(outsideRoot, ".openclaw-download-staging"), { recursive: true });
+
+      let streamPulls = 0;
+      fetchWithSsrFGuardMock.mockImplementation(async () => {
+        const reboundRoot = `${safeRoot}-rebound`;
+        await fs.rename(safeRoot, reboundRoot);
+        await fs.symlink(outsideRoot, safeRoot);
+        return {
+          response: new Response(
+            new ReadableStream({
+              pull(controller) {
+                streamPulls += 1;
+                controller.enqueue(new Uint8Array(Buffer.from("payload")));
+                controller.close();
+              },
+            }),
+            { status: 200 },
+          ),
+          release: async () => undefined,
+        };
+      });
+
+      const result = await installDownloadSpec({
+        entry,
+        spec: {
+          kind: "download",
+          id: "dl",
+          url: "https://example.invalid/payload.bin",
+          extract: false,
+        },
+        timeoutMs: 30_000,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.stderr.toLowerCase()).toContain("directory changed during install");
+      expect(streamPulls).toBe(0);
+      expect(await fileExists(path.join(outsideRoot, "payload.bin"))).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "fails closed when targetDir is replaced with a different directory inode during download",
     async () => {
       const entry = buildEntry("targetdir-inode-rebind");

--- a/src/agents/skills-install.download.test.ts
+++ b/src/agents/skills-install.download.test.ts
@@ -522,6 +522,48 @@ describe("installDownloadSpec extraction safety (tar.bz2)", () => {
   });
 
   it.runIf(process.platform !== "win32")(
+    "fails closed when targetDir is replaced before tar.bz2 staging extraction",
+    async () => {
+      const entry = buildEntry("tbz2-pre-stage-rebind");
+      const targetDir = path.join(resolveSkillToolsRootDir(entry), "target");
+      let extractionAttempted = false;
+
+      mockArchiveResponse(new Uint8Array([1, 2, 3]));
+
+      runCommandWithTimeoutMock.mockImplementation(async (...argv: unknown[]) => {
+        const cmd = (argv[0] ?? []) as string[];
+        if (cmd[0] === "tar" && cmd[1] === "tf") {
+          return runCommandResult({ stdout: "package/hello.txt\n" });
+        }
+        if (cmd[0] === "tar" && cmd[1] === "tvf") {
+          const reboundTargetDir = `${targetDir}-rebound`;
+          await fs.rename(targetDir, reboundTargetDir);
+          await fs.mkdir(targetDir, { recursive: true });
+          return runCommandResult({
+            stdout: "-rw-r--r--  0 0 0 0 Jan  1 00:00 package/hello.txt\n",
+          });
+        }
+        if (cmd[0] === "tar" && cmd[1] === "xf") {
+          extractionAttempted = true;
+          return runCommandResult({ stdout: "ok" });
+        }
+        return runCommandResult();
+      });
+
+      const result = await installDownloadSkill({
+        name: "tbz2-pre-stage-rebind",
+        url: "https://example.invalid/good.tbz2",
+        archive: "tar.bz2",
+        targetDir,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.stderr.toLowerCase()).toContain("directory changed during install");
+      expect(extractionAttempted).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "fails closed when targetDir is replaced between tar.bz2 extract and merge",
     async () => {
       const entry = buildEntry("tbz2-before-merge-rebind");

--- a/src/agents/skills-install.download.test.ts
+++ b/src/agents/skills-install.download.test.ts
@@ -303,6 +303,90 @@ describe("installDownloadSpec extraction safety", () => {
       expect(await fileExists(path.join(outsideRoot, "runtime", "payload.bin"))).toBe(false);
     },
   );
+
+  it.runIf(process.platform !== "win32")(
+    "fails closed when targetDir is replaced with a different directory inode during download",
+    async () => {
+      const entry = buildEntry("targetdir-inode-rebind");
+      const targetDir = path.join(resolveSkillToolsRootDir(entry), "runtime");
+      await fs.mkdir(targetDir, { recursive: true });
+
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(
+          new ReadableStream({
+            async start(controller) {
+              controller.enqueue(new Uint8Array(Buffer.from("payload")));
+              const reboundTargetDir = `${targetDir}-rebound`;
+              await fs.rename(targetDir, reboundTargetDir);
+              await fs.mkdir(targetDir, { recursive: true });
+              controller.close();
+            },
+          }),
+          { status: 200 },
+        ),
+        release: async () => undefined,
+      });
+
+      const result = await installDownloadSpec({
+        entry,
+        spec: {
+          kind: "download",
+          id: "dl",
+          url: "https://example.invalid/payload.bin",
+          extract: false,
+          targetDir: "runtime",
+        },
+        timeoutMs: 30_000,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.stderr.toLowerCase()).toContain("directory changed during install");
+      expect(await fileExists(path.join(targetDir, "payload.bin"))).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "fails closed when targetDir is rebound to a symlink before the final copy",
+    async () => {
+      const entry = buildEntry("targetdir-symlink-rebind");
+      const targetDir = path.join(resolveSkillToolsRootDir(entry), "runtime");
+      const outsideRoot = path.join(workspaceDir, "targetdir-symlink-outside");
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.mkdir(outsideRoot, { recursive: true });
+
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(
+          new ReadableStream({
+            async start(controller) {
+              controller.enqueue(new Uint8Array(Buffer.from("payload")));
+              const reboundTargetDir = `${targetDir}-rebound`;
+              await fs.rename(targetDir, reboundTargetDir);
+              await fs.symlink(outsideRoot, targetDir);
+              controller.close();
+            },
+          }),
+          { status: 200 },
+        ),
+        release: async () => undefined,
+      });
+
+      const result = await installDownloadSpec({
+        entry,
+        spec: {
+          kind: "download",
+          id: "dl",
+          url: "https://example.invalid/payload.bin",
+          extract: false,
+          targetDir: "runtime",
+        },
+        timeoutMs: 30_000,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.stderr.toLowerCase()).toContain("directory changed during install");
+      expect(await fileExists(path.join(outsideRoot, "payload.bin"))).toBe(false);
+    },
+  );
 });
 
 describe("installDownloadSpec extraction safety (tar.bz2)", () => {

--- a/src/infra/archive-staging.test.ts
+++ b/src/infra/archive-staging.test.ts
@@ -10,6 +10,7 @@ import {
   prepareArchiveOutputPath,
   withStagedArchiveDestination,
 } from "./archive-staging.js";
+import { sameFileIdentity } from "./file-identity.js";
 
 const directorySymlinkType = process.platform === "win32" ? "junction" : undefined;
 
@@ -159,6 +160,46 @@ describe("archive-staging helpers", () => {
         ).rejects.toMatchObject({
           code: "destination-symlink-traversal",
         } satisfies Partial<ArchiveSecurityError>);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "re-validates destination identity during merge writes",
+    async () => {
+      await withTempDir({ prefix: "openclaw-archive-staging-" }, async (rootDir) => {
+        const sourceDir = path.join(rootDir, "source");
+        const sourceNestedDir = path.join(sourceDir, "package");
+        const destDir = path.join(rootDir, "dest");
+        await fs.mkdir(sourceNestedDir, { recursive: true });
+        await fs.mkdir(destDir, { recursive: true });
+        await fs.writeFile(path.join(sourceNestedDir, "payload.txt"), "hi", "utf8");
+
+        const destinationRealDir = await prepareArchiveDestinationDir(destDir);
+        const pinnedDest = await fs.lstat(destDir);
+        let callbackCalls = 0;
+
+        await expect(
+          mergeExtractedTreeIntoDestination({
+            sourceDir,
+            destinationDir: destDir,
+            destinationRealDir,
+            beforeEachDestinationWrite: async () => {
+              callbackCalls += 1;
+              if (callbackCalls === 2) {
+                const reboundDir = `${destDir}-rebound`;
+                await fs.rename(destDir, reboundDir);
+                await fs.mkdir(destDir, { recursive: true });
+              }
+              const currentDest = await fs.lstat(destDir);
+              if (!sameFileIdentity(currentDest, pinnedDest)) {
+                throw new Error("destination directory changed during merge");
+              }
+            },
+          }),
+        ).rejects.toThrow("destination directory changed during merge");
+
+        expect(callbackCalls).toBeGreaterThanOrEqual(2);
       });
     },
   );

--- a/src/infra/archive-staging.ts
+++ b/src/infra/archive-staging.ts
@@ -150,7 +150,14 @@ export async function mergeExtractedTreeIntoDestination(params: {
   sourceDir: string;
   destinationDir: string;
   destinationRealDir: string;
+  beforeEachDestinationWrite?: () => Promise<void>;
 }): Promise<void> {
+  const runBeforeEachDestinationWrite = async (): Promise<void> => {
+    if (params.beforeEachDestinationWrite) {
+      await params.beforeEachDestinationWrite();
+    }
+  };
+
   const walk = async (currentSourceDir: string): Promise<void> => {
     const entries = await fs.readdir(currentSourceDir, { withFileTypes: true });
     for (const entry of entries) {
@@ -165,6 +172,7 @@ export async function mergeExtractedTreeIntoDestination(params: {
       }
 
       if (sourceStat.isDirectory()) {
+        await runBeforeEachDestinationWrite();
         await prepareArchiveOutputPath({
           destinationDir: params.destinationDir,
           destinationRealDir: params.destinationRealDir,
@@ -174,6 +182,7 @@ export async function mergeExtractedTreeIntoDestination(params: {
           isDirectory: true,
         });
         await walk(sourcePath);
+        await runBeforeEachDestinationWrite();
         await applyStagedEntryMode({
           destinationRealDir: params.destinationRealDir,
           relPath,
@@ -187,6 +196,7 @@ export async function mergeExtractedTreeIntoDestination(params: {
         throw new Error(`archive staging contains unsupported entry: ${originalPath}`);
       }
 
+      await runBeforeEachDestinationWrite();
       await prepareArchiveOutputPath({
         destinationDir: params.destinationDir,
         destinationRealDir: params.destinationRealDir,
@@ -195,12 +205,14 @@ export async function mergeExtractedTreeIntoDestination(params: {
         originalPath,
         isDirectory: false,
       });
+      await runBeforeEachDestinationWrite();
       await copyFileWithinRoot({
         sourcePath,
         rootDir: params.destinationRealDir,
         relativePath: relPath,
         mkdir: true,
       });
+      await runBeforeEachDestinationWrite();
       await applyStagedEntryMode({
         destinationRealDir: params.destinationRealDir,
         relPath,

--- a/src/infra/archive.test.ts
+++ b/src/infra/archive.test.ts
@@ -420,9 +420,11 @@ describe("archive utils", () => {
           timeoutMs: ARCHIVE_EXTRACT_TIMEOUT_MS,
           beforeWriteToDestination: async () => {
             callbackCalls += 1;
-            const reboundDir = `${extractDir}-rebound`;
-            await fs.rename(extractDir, reboundDir);
-            await fs.mkdir(extractDir, { recursive: true });
+            if (callbackCalls === 2) {
+              const reboundDir = `${extractDir}-rebound`;
+              await fs.rename(extractDir, reboundDir);
+              await fs.mkdir(extractDir, { recursive: true });
+            }
             const current = await fs.lstat(extractDir);
             if (!sameFileIdentity(current, pinned)) {
               throw new Error("destination directory changed during extract");
@@ -431,7 +433,7 @@ describe("archive utils", () => {
         }),
       ).rejects.toThrow("destination directory changed during extract");
 
-      expect(callbackCalls).toBe(1);
+      expect(callbackCalls).toBeGreaterThanOrEqual(2);
       await expectPathMissing(path.join(extractDir, "package", "hello.txt"));
     });
   });

--- a/src/infra/archive.test.ts
+++ b/src/infra/archive.test.ts
@@ -375,26 +375,20 @@ describe("archive utils", () => {
         content: "hi",
       });
 
-      const tarExtractSpy = vi.spyOn(tar, "x");
       let callbackCalls = 0;
-      try {
-        await expect(
-          extractArchive({
-            archivePath,
-            destDir: extractDir,
-            timeoutMs: ARCHIVE_EXTRACT_TIMEOUT_MS,
-            beforeWriteToDestination: async () => {
-              callbackCalls += 1;
-              throw new Error("destination directory changed during extract");
-            },
-          }),
-        ).rejects.toThrow("destination directory changed during extract");
-      } finally {
-        tarExtractSpy.mockRestore();
-      }
+      await expect(
+        extractArchive({
+          archivePath,
+          destDir: extractDir,
+          timeoutMs: ARCHIVE_EXTRACT_TIMEOUT_MS,
+          beforeWriteToDestination: async () => {
+            callbackCalls += 1;
+            throw new Error("destination directory changed during extract");
+          },
+        }),
+      ).rejects.toThrow("destination directory changed during extract");
 
       expect(callbackCalls).toBe(1);
-      expect(tarExtractSpy).not.toHaveBeenCalled();
       await expectPathMissing(path.join(extractDir, "package", "hello.txt"));
     });
   });

--- a/src/infra/archive.test.ts
+++ b/src/infra/archive.test.ts
@@ -7,6 +7,7 @@ import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withRealpathSymlinkRebindRace } from "../test-utils/symlink-rebind-race.js";
 import type { ArchiveSecurityError } from "./archive.js";
 import { extractArchive, resolvePackedRootDir } from "./archive.js";
+import { sameFileIdentity } from "./file-identity.js";
 
 const fixtureRootTracker = createSuiteTempRootTracker({ prefix: "openclaw-archive-" });
 const directorySymlinkType = process.platform === "win32" ? "junction" : undefined;
@@ -361,6 +362,77 @@ describe("archive utils", () => {
           timeoutMs: ARCHIVE_EXTRACT_TIMEOUT_MS,
         }),
       ).rejects.toThrow(/absolute|drive path|escapes destination/i);
+    });
+  });
+
+  it("runs beforeWriteToDestination on zip extracts and blocks destination rebinds", async () => {
+    await withArchiveCase("zip", async ({ archivePath, extractDir }) => {
+      const zip = new JSZip();
+      zip.file("package/one.txt", "one");
+      zip.file("package/two.txt", "two");
+      await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+
+      const pinned = await fs.lstat(extractDir);
+      let callbackCalls = 0;
+
+      await expect(
+        extractArchive({
+          archivePath,
+          destDir: extractDir,
+          timeoutMs: ARCHIVE_EXTRACT_TIMEOUT_MS,
+          beforeWriteToDestination: async () => {
+            callbackCalls += 1;
+            if (callbackCalls === 2) {
+              const reboundDir = `${extractDir}-rebound`;
+              await fs.rename(extractDir, reboundDir);
+              await fs.mkdir(extractDir, { recursive: true });
+            }
+            const current = await fs.lstat(extractDir);
+            if (!sameFileIdentity(current, pinned)) {
+              throw new Error("destination directory changed during extract");
+            }
+          },
+        }),
+      ).rejects.toThrow("destination directory changed during extract");
+
+      expect(callbackCalls).toBeGreaterThanOrEqual(2);
+      await expectPathMissing(path.join(extractDir, "package", "two.txt"));
+    });
+  });
+
+  it("runs beforeWriteToDestination on tar extracts and blocks destination rebinds", async () => {
+    await withArchiveCase("tar", async ({ workDir, archivePath, extractDir }) => {
+      await writePackageArchive({
+        ext: "tar",
+        workDir,
+        archivePath,
+        fileName: "hello.txt",
+        content: "hi",
+      });
+
+      const pinned = await fs.lstat(extractDir);
+      let callbackCalls = 0;
+
+      await expect(
+        extractArchive({
+          archivePath,
+          destDir: extractDir,
+          timeoutMs: ARCHIVE_EXTRACT_TIMEOUT_MS,
+          beforeWriteToDestination: async () => {
+            callbackCalls += 1;
+            const reboundDir = `${extractDir}-rebound`;
+            await fs.rename(extractDir, reboundDir);
+            await fs.mkdir(extractDir, { recursive: true });
+            const current = await fs.lstat(extractDir);
+            if (!sameFileIdentity(current, pinned)) {
+              throw new Error("destination directory changed during extract");
+            }
+          },
+        }),
+      ).rejects.toThrow("destination directory changed during extract");
+
+      expect(callbackCalls).toBe(1);
+      await expectPathMissing(path.join(extractDir, "package", "hello.txt"));
     });
   });
 });

--- a/src/infra/archive.test.ts
+++ b/src/infra/archive.test.ts
@@ -365,6 +365,40 @@ describe("archive utils", () => {
     });
   });
 
+  it("runs beforeWriteToDestination before tar staging extraction", async () => {
+    await withArchiveCase("tar", async ({ workDir, archivePath, extractDir }) => {
+      await writePackageArchive({
+        ext: "tar",
+        workDir,
+        archivePath,
+        fileName: "hello.txt",
+        content: "hi",
+      });
+
+      const tarExtractSpy = vi.spyOn(tar, "x");
+      let callbackCalls = 0;
+      try {
+        await expect(
+          extractArchive({
+            archivePath,
+            destDir: extractDir,
+            timeoutMs: ARCHIVE_EXTRACT_TIMEOUT_MS,
+            beforeWriteToDestination: async () => {
+              callbackCalls += 1;
+              throw new Error("destination directory changed during extract");
+            },
+          }),
+        ).rejects.toThrow("destination directory changed during extract");
+      } finally {
+        tarExtractSpy.mockRestore();
+      }
+
+      expect(callbackCalls).toBe(1);
+      expect(tarExtractSpy).not.toHaveBeenCalled();
+      await expectPathMissing(path.join(extractDir, "package", "hello.txt"));
+    });
+  });
+
   it("runs beforeWriteToDestination on zip extracts and blocks destination rebinds", async () => {
     await withArchiveCase("zip", async ({ archivePath, extractDir }) => {
       const zip = new JSZip();

--- a/src/infra/archive.ts
+++ b/src/infra/archive.ts
@@ -634,13 +634,11 @@ export async function extractArchive(params: {
                 }
               },
             });
-            if (params.beforeWriteToDestination) {
-              await params.beforeWriteToDestination();
-            }
             await mergeExtractedTreeIntoDestination({
               sourceDir: stagingDir,
               destinationDir: destinationRealDir,
               destinationRealDir,
+              beforeEachDestinationWrite: params.beforeWriteToDestination,
             });
           },
         });

--- a/src/infra/archive.ts
+++ b/src/infra/archive.ts
@@ -457,6 +457,7 @@ async function extractZip(params: {
   destDir: string;
   stripComponents?: number;
   limits?: ArchiveExtractLimits;
+  beforeWriteToDestination?: () => Promise<void>;
 }): Promise<void> {
   const limits = resolveExtractLimits(params.limits);
   const destinationRealDir = await prepareArchiveDestinationDir(params.destDir);
@@ -482,6 +483,9 @@ async function extractZip(params: {
     });
     if (!output) {
       continue;
+    }
+    if (params.beforeWriteToDestination) {
+      await params.beforeWriteToDestination();
     }
 
     await prepareZipOutputPath({
@@ -581,6 +585,7 @@ export async function extractArchive(params: {
   tarGzip?: boolean;
   limits?: ArchiveExtractLimits;
   logger?: ArchiveLogger;
+  beforeWriteToDestination?: () => Promise<void>;
 }): Promise<void> {
   const kind = params.kind ?? resolveArchiveKind(params.archivePath);
   if (!kind) {
@@ -629,6 +634,9 @@ export async function extractArchive(params: {
                 }
               },
             });
+            if (params.beforeWriteToDestination) {
+              await params.beforeWriteToDestination();
+            }
             await mergeExtractedTreeIntoDestination({
               sourceDir: stagingDir,
               destinationDir: destinationRealDir,
@@ -649,6 +657,7 @@ export async function extractArchive(params: {
       destDir: params.destDir,
       stripComponents: params.stripComponents,
       limits: params.limits,
+      beforeWriteToDestination: params.beforeWriteToDestination,
     }),
     params.timeoutMs,
     label,

--- a/src/infra/archive.ts
+++ b/src/infra/archive.ts
@@ -603,9 +603,15 @@ export async function extractArchive(params: {
         }
 
         const destinationRealDir = await prepareArchiveDestinationDir(params.destDir);
+        if (params.beforeWriteToDestination) {
+          await params.beforeWriteToDestination();
+        }
         await withStagedArchiveDestination({
           destinationRealDir,
           run: async (stagingDir) => {
+            if (params.beforeWriteToDestination) {
+              await params.beforeWriteToDestination();
+            }
             const checkTarEntrySafety = createTarEntryPreflightChecker({
               rootDir: destinationRealDir,
               stripComponents: params.stripComponents,


### PR DESCRIPTION
## Summary

- **Problem:** `skills-install-download.ts` validated `targetDir` against `safeRoot` using path-containment checks only, leaving a TOCTOU window. Between validation and file write, a subdirectory could be atomically replaced (renamed away and recreated with a symlink, or recreated as a new directory inode) allowing writes to escape the intended root.
- **Why it matters:** A malicious or compromised skill package could exploit this race to write files to arbitrary filesystem locations during install, including overwriting sensitive paths.
- **What changed:** Introduced `PinnedDirectory` (captures `dev`+`ino` at validation time) and `assertPinnedDirectoryUnchanged` to re-verify identity at every critical point: before download, before final file copy, after final file copy, before extraction, and (for tar.bz2) before merge into destination. Added `beforeWriteToDestination` callback to `extractArchive`/`extractZip` in `src/infra/archive.ts` so zip and tar.gz extractions also receive per-write or pre-merge inode-pinned checks.
- **What did NOT change:** No changes to public APIs, plugin SDK, config schema, or behavior visible to end users. The fix is scoped entirely to the install download/extract path.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `targetDir` was validated once via path-containment check (`assertCanonicalPathWithinBase`) but not pinned by filesystem identity. An atomic directory swap (rename + recreate) between validation and use passes path checks but writes to a different inode.
- Missing detection / guardrail: No inode identity check after initial validation; no re-check before each write step.
- Contributing context (if known): Multi-step download-then-extract flow has multiple async yield points, each a potential race window.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/agents/skills-install.download.test.ts`, `src/infra/archive.test.ts`
- Scenario the test should lock in: Directory inode rebind during download stream (different inode), symlink rebind before final copy, and directory swap between tar.bz2 extract and merge all return `ok: false` with `"directory changed during install"` and do not write to the rebound location.
- Why this is the smallest reliable guardrail: Tests directly inject the race (rename + recreate / symlink) inside the stream/command mock so timing is deterministic, not flaky.
- Existing test that already covered this (if any): None — this attack vector had no prior regression coverage.

## User-visible / Behavior Changes

None. Failed installs already returned an error result; they now fail with a more specific message.

## Diagram (if applicable)

```text
Before (vulnerable):
[validate targetDir path] -> [async download/extract] -> [write to targetDir path]
                              ^ race window: dir can be swapped here

After (fixed):
[pin targetDir inode] -> [check inode] -> [download] -> [check inode] -> [copy] -> [check inode] -> [extract w/ per-step check]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime/container: Node 22 / Bun

### Steps

1. Run scoped tests: `pnpm test src/agents/skills-install.download.test.ts`
2. Run archive tests: `pnpm test src/infra/archive.test.ts`

### Expected

- All new tests pass; inode rebind and symlink rebind cases return `ok: false`

### Actual

- All new tests pass

## Evidence

- [x] Failing test/log before + passing after — new tests added that directly simulate the race condition

## Human Verification (required)

- Verified scenarios: Inode rebind during stream, symlink rebind before final copy, tar.bz2 directory swap before merge
- Edge cases checked: `afterFinalCopy` check fires post-write (belt-and-suspenders); `writeFileFromPathWithinRoot` also has its own `assertNoPathAliasEscape` guard
- What you did **not** verify: Windows (inode pinning is explicitly not supported on Windows — tests are skipped on `win32`; `sameFileIdentity` documents the `dev=0` limitation)

> **Note:** This fix was generated by AI (Codex) and reviewed by Claude. All source file changes are AI-assisted.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Per-entry callback in zip extraction adds one `lstat` call per archive entry, scaling linearly with entry count.
  - Mitigation: `lstat` is extremely cheap; no user-visible latency impact expected for typical skill archives.