### PR TITLE
fix(agent): stop model fallback on session lock contention

### DIFF
--- a/src/agents/model-fallback.session-lock.test.ts
+++ b/src/agents/model-fallback.session-lock.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { runWithModelFallback } from "./model-fallback.js";
+
+describe("runWithModelFallback session lock contention", () => {
+  it("rethrows session file lock errors without trying fallback candidates", async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("session file locked (timeout 10000ms): pid=41991 /tmp/test-session.jsonl.lock"),
+      )
+      .mockResolvedValueOnce("should-not-run");
+
+    await expect(
+      runWithModelFallback({
+        cfg: undefined,
+        provider: "openai-codex",
+        model: "gpt-5.4",
+        fallbacksOverride: ["ollama/qwen3.5:35b"],
+        run,
+      }),
+    ).rejects.toThrow(/session file locked/);
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -96,6 +96,13 @@ function shouldRethrowAbort(err: unknown): boolean {
   return isFallbackAbortError(err) && !isTimeoutError(err);
 }
 
+function isSessionWriteLockError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    /session file locked \(timeout \d+ms\): .*\.jsonl\.lock/.test(err.message)
+  );
+}
+
 function createModelCandidateCollector(allowlist: Set<string> | null | undefined): {
   candidates: ModelCandidate[];
   addExplicitCandidate: (candidate: ModelCandidate) => void;
@@ -773,6 +780,9 @@ export async function runWithModelFallback<T>(params: {
       // throw, rethrow it immediately rather than trying a different model
       // that may have a smaller context window and fail worse.
       const errMessage = err instanceof Error ? err.message : String(err);
+      if (isSessionWriteLockError(err)) {
+        throw err;
+      }
       if (isLikelyContextOverflowError(errMessage)) {
         throw err;
       }


### PR DESCRIPTION
## Summary

- When a second local OpenClaw run overlaps an already-running Blueprint session, the session-file write lock times out. Previously, `runWithModelFallback` treated this as a model candidate failure and cycled through every fallback model before emitting a misleading `FallbackSummaryError: All models failed`.
- This patch detects the session-write-lock error by message and rethrows it immediately, skipping fallback candidates entirely.
- Adds a focused unit test confirming the rethrow and single-invocation behavior.

## Changed files

- `src/agents/model-fallback.ts` - add `isSessionWriteLockError` guard; rethrow before fallback loop
- `src/agents/model-fallback.session-lock.test.ts` - new test

## Test plan

- [x] Unit test passes (`vitest run src/agents/model-fallback.session-lock.test.ts`)
- [x] Post-commit overlap repro confirmed: second run now surfaces `FailoverError: session file locked ...` directly, with zero `candidate_failed` or `FallbackSummaryError` output
- [ ] CI passes

## Follow-up (not blocking)

- Introduce a dedicated `SessionFileLockedError` class in `src/agents/session-write-lock.ts` instead of regex-matching the message string
- Map it to a clearer end-user CLI error than generic `FailoverError`