### PR TITLE
fix(browser): enforce SSRF policy on snapshot, screenshot, and tab routes [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(browser): enforce SSRF policy on snapshot, screenshot, and tab routes [AI]. (#66040) Thanks @pgondhi987.
 - fix(msteams): enforce sender allowlist checks on SSO signin invokes [AI]. (#66033) Thanks @pgondhi987.
 - fix(config): redact sourceConfig and runtimeConfig alias fields in redactConfigSnapshot [AI]. (#66030) Thanks @pgondhi987.
 - Agents/context engines: run opt-in turn maintenance as idle-aware background work so the next foreground turn no longer waits on proactive maintenance. (#65233) thanks @100yenadmin

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createExistingSessionAgentSharedModule } from "./existing-session.test-support.js";
+import {
+  createExistingSessionAgentSharedModule,
+  existingSessionRouteState,
+} from "./existing-session.test-support.js";
 import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
 
 const chromeMcpMocks = vi.hoisted(() => ({
@@ -37,6 +40,7 @@ vi.mock("./agent.shared.js", () => createExistingSessionAgentSharedModule());
 const DEFAULT_SSRF_POLICY = { allowPrivateNetwork: false } as const;
 
 const { registerBrowserAgentActRoutes } = await import("./agent.act.js");
+const routeState = existingSessionRouteState;
 
 function getActPostHandler(
   ssrfPolicy: { allowPrivateNetwork: false } | null = DEFAULT_SSRF_POLICY,
@@ -65,6 +69,13 @@ describe("existing-session interaction navigation guard", () => {
       fn.mockClear();
     }
     chromeMcpMocks.evaluateChromeMcpScript.mockResolvedValue("https://example.com");
+    routeState.profileCtx.listTabs.mockReset();
+    routeState.profileCtx.listTabs.mockResolvedValue([
+      {
+        targetId: "7",
+        url: "https://example.com",
+      },
+    ]);
   });
 
   afterEach(() => {
@@ -140,6 +151,37 @@ describe("existing-session interaction navigation guard", () => {
     expectNavigationProbeUrls([
       "https://example.com",
       "http://169.254.169.254/latest/meta-data/",
+      "http://169.254.169.254/latest/meta-data/",
+    ]);
+  });
+
+  it("checks URLs for tabs opened during the interaction window", async () => {
+    routeState.profileCtx.listTabs
+      .mockResolvedValueOnce([
+        {
+          targetId: "7",
+          url: "https://example.com",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          targetId: "7",
+          url: "https://example.com",
+        },
+        {
+          targetId: "9",
+          url: "http://169.254.169.254/latest/meta-data/",
+        },
+      ]);
+
+    const response = await runAction({ kind: "click", ref: "btn-1" });
+
+    expect(response.statusCode).toBe(200);
+    expect(chromeMcpMocks.clickChromeMcpElement).toHaveBeenCalledOnce();
+    expectNavigationProbeUrls([
+      "https://example.com",
+      "https://example.com",
+      "https://example.com",
       "http://169.254.169.254/latest/meta-data/",
     ]);
   });
@@ -243,6 +285,7 @@ describe("existing-session interaction navigation guard", () => {
     expect(response.statusCode).toBe(200);
     expect(chromeMcpMocks.pressChromeMcpKey).toHaveBeenCalledOnce();
     expect(chromeMcpMocks.evaluateChromeMcpScript).not.toHaveBeenCalled();
+    expect(routeState.profileCtx.listTabs).not.toHaveBeenCalled();
     expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
   });
 

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -186,6 +186,47 @@ describe("existing-session interaction navigation guard", () => {
     ]);
   });
 
+  it("fails closed when a newly opened tab URL is blocked", async () => {
+    routeState.profileCtx.listTabs
+      .mockResolvedValueOnce([
+        {
+          targetId: "7",
+          url: "https://example.com",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          targetId: "7",
+          url: "https://example.com",
+        },
+        {
+          targetId: "9",
+          url: "http://169.254.169.254/latest/meta-data/",
+        },
+      ]);
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
+      async ({ url }: { url: string }) => {
+        if (url.includes("169.254.169.254")) {
+          throw new Error("blocked new tab");
+        }
+      },
+    );
+
+    const handler = getActPostHandler();
+    const response = createBrowserRouteResponse();
+    const pending =
+      handler?.({ params: {}, query: {}, body: { kind: "click", ref: "btn-1" } }, response.res) ??
+      Promise.resolve();
+    void pending.catch(() => {});
+    const completion = (async () => {
+      await vi.runAllTimersAsync();
+      await pending;
+    })();
+
+    await expect(completion).rejects.toThrow("blocked new tab");
+    expect(chromeMcpMocks.clickChromeMcpElement).toHaveBeenCalledOnce();
+  });
+
   it("fails closed when location probes never return a usable url", async () => {
     chromeMcpMocks.evaluateChromeMcpScript
       .mockResolvedValueOnce("result" as never)

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -17,7 +17,9 @@ const chromeMcpMocks = vi.hoisted(() => ({
 
 const navigationGuardMocks = vi.hoisted(() => ({
   assertBrowserNavigationAllowed: vi.fn(async () => {}),
-  assertBrowserNavigationResultAllowed: vi.fn(async () => {}),
+  assertBrowserNavigationResultAllowed: vi.fn(
+    async (_opts?: { url: string; ssrfPolicy?: unknown }) => {},
+  ),
   withBrowserNavigationPolicy: vi.fn((ssrfPolicy?: unknown) => (ssrfPolicy ? { ssrfPolicy } : {})),
 }));
 
@@ -205,7 +207,8 @@ describe("existing-session interaction navigation guard", () => {
         },
       ]);
     navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
-      async ({ url }: { url: string }) => {
+      async (opts?: { url: string }) => {
+        const url = opts?.url ?? "";
         if (url.includes("169.254.169.254")) {
           throw new Error("blocked new tab");
         }

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -71,15 +71,12 @@ async function assertExistingSessionPostInteractionNavigationAllowed(params: {
   userDataDir?: string;
   targetId: string;
   ssrfPolicy?: BrowserNavigationPolicyOptions["ssrfPolicy"];
-  listTabs?: () => Promise<Array<{ targetId: string; url: string }>>;
-  initialTabTargetIds?: ReadonlySet<string>;
+  listTabs: () => Promise<Array<{ targetId: string; url: string }>>;
+  initialTabTargetIds: ReadonlySet<string>;
 }): Promise<void> {
   const ssrfPolicyOpts = withBrowserNavigationPolicy(params.ssrfPolicy);
   if (!ssrfPolicyOpts.ssrfPolicy) {
     return;
-  }
-  if (!params.listTabs || !params.initialTabTargetIds) {
-    throw new Error("Missing tab-list context for post-interaction navigation verification");
   }
   const listTabs = params.listTabs;
   const initialTabTargetIds = params.initialTabTargetIds;
@@ -392,7 +389,7 @@ export function registerBrowserAgentActRoutes(
         if (isExistingSession) {
           const initialTabTargetIds = withBrowserNavigationPolicy(ssrfPolicy).ssrfPolicy
             ? new Set((await profileCtx.listTabs()).map((currentTab) => currentTab.targetId))
-            : undefined;
+            : new Set<string>();
           const existingSessionNavigationGuard = {
             profileName,
             userDataDir: profileCtx.profile.userDataDir,

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -71,11 +71,31 @@ async function assertExistingSessionPostInteractionNavigationAllowed(params: {
   userDataDir?: string;
   targetId: string;
   ssrfPolicy?: BrowserNavigationPolicyOptions["ssrfPolicy"];
+  listTabs?: () => Promise<Array<{ targetId: string; url: string }>>;
+  initialTabTargetIds?: ReadonlySet<string>;
 }): Promise<void> {
   const ssrfPolicyOpts = withBrowserNavigationPolicy(params.ssrfPolicy);
   if (!ssrfPolicyOpts.ssrfPolicy) {
     return;
   }
+  if (!params.listTabs || !params.initialTabTargetIds) {
+    throw new Error("Missing tab-list context for post-interaction navigation verification");
+  }
+  const listTabs = params.listTabs;
+  const initialTabTargetIds = params.initialTabTargetIds;
+
+  const assertNewTabsAllowed = async () => {
+    const tabs = await listTabs();
+    for (const tab of tabs) {
+      if (initialTabTargetIds.has(tab.targetId)) {
+        continue;
+      }
+      await assertBrowserNavigationResultAllowed({
+        url: tab.url,
+        ...ssrfPolicyOpts,
+      });
+    }
+  };
 
   let lastObservedUrl: string | undefined;
   let sawStableAllowedUrl = false;
@@ -103,6 +123,7 @@ async function assertExistingSessionPostInteractionNavigationAllowed(params: {
   }
 
   if (sawStableAllowedUrl) {
+    await assertNewTabsAllowed();
     return;
   }
 
@@ -122,6 +143,7 @@ async function assertExistingSessionPostInteractionNavigationAllowed(params: {
         ...ssrfPolicyOpts,
       });
       if (followUpUrl === lastObservedUrl) {
+        await assertNewTabsAllowed();
         return;
       }
     } catch {
@@ -368,11 +390,16 @@ export function registerBrowserAgentActRoutes(
         const isExistingSession = getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp;
         const profileName = profileCtx.profile.name;
         if (isExistingSession) {
+          const initialTabTargetIds = withBrowserNavigationPolicy(ssrfPolicy).ssrfPolicy
+            ? new Set((await profileCtx.listTabs()).map((currentTab) => currentTab.targetId))
+            : undefined;
           const existingSessionNavigationGuard = {
             profileName,
             userDataDir: profileCtx.profile.userDataDir,
             targetId: tab.targetId,
             ssrfPolicy,
+            listTabs: () => profileCtx.listTabs(),
+            initialTabTargetIds,
           };
           const unsupportedMessage = getExistingSessionUnsupportedMessage(action);
           if (unsupportedMessage) {

--- a/extensions/browser/src/browser/routes/agent.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/agent.existing-session.test.ts
@@ -21,6 +21,12 @@ const chromeMcpMocks = vi.hoisted(() => ({
   })),
 }));
 
+const navigationGuardMocks = vi.hoisted(() => ({
+  assertBrowserNavigationAllowed: vi.fn(async () => {}),
+  assertBrowserNavigationResultAllowed: vi.fn(async () => {}),
+  withBrowserNavigationPolicy: vi.fn(() => ({})),
+}));
+
 vi.mock("../chrome-mcp.js", () => ({
   clickChromeMcpElement: vi.fn(async () => {}),
   closeChromeMcpTab: vi.fn(async () => {}),
@@ -42,9 +48,9 @@ vi.mock("../cdp.js", () => ({
 }));
 
 vi.mock("../navigation-guard.js", () => ({
-  assertBrowserNavigationAllowed: vi.fn(async () => {}),
-  assertBrowserNavigationResultAllowed: vi.fn(async () => {}),
-  withBrowserNavigationPolicy: vi.fn(() => ({})),
+  assertBrowserNavigationAllowed: navigationGuardMocks.assertBrowserNavigationAllowed,
+  assertBrowserNavigationResultAllowed: navigationGuardMocks.assertBrowserNavigationResultAllowed,
+  withBrowserNavigationPolicy: navigationGuardMocks.withBrowserNavigationPolicy,
 }));
 
 vi.mock("../screenshot.js", () => ({
@@ -99,10 +105,14 @@ function getActPostHandler() {
 describe("existing-session browser routes", () => {
   beforeEach(() => {
     routeState.profileCtx.ensureTabAvailable.mockClear();
+    routeState.profileCtx.listTabs.mockClear();
     chromeMcpMocks.evaluateChromeMcpScript.mockReset();
     chromeMcpMocks.navigateChromeMcpPage.mockClear();
     chromeMcpMocks.takeChromeMcpScreenshot.mockClear();
     chromeMcpMocks.takeChromeMcpSnapshot.mockClear();
+    navigationGuardMocks.assertBrowserNavigationAllowed.mockClear();
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockClear();
+    navigationGuardMocks.withBrowserNavigationPolicy.mockClear();
     chromeMcpMocks.evaluateChromeMcpScript
       .mockResolvedValueOnce({ labels: 1, skipped: 0 } as never)
       .mockResolvedValueOnce(true);
@@ -124,6 +134,9 @@ describe("existing-session browser routes", () => {
     expect(chromeMcpMocks.takeChromeMcpSnapshot).toHaveBeenCalledWith({
       profileName: "chrome-live",
       targetId: "7",
+    });
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).toHaveBeenCalledWith({
+      url: "https://example.com",
     });
     expect(chromeMcpMocks.takeChromeMcpScreenshot).toHaveBeenCalled();
   });
@@ -152,6 +165,9 @@ describe("existing-session browser routes", () => {
       uid: "btn-1",
       fullPage: false,
       format: "jpeg",
+    });
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).toHaveBeenCalledWith({
+      url: "https://example.com",
     });
   });
 

--- a/extensions/browser/src/browser/routes/agent.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/agent.existing-session.test.ts
@@ -24,7 +24,7 @@ const chromeMcpMocks = vi.hoisted(() => ({
 const navigationGuardMocks = vi.hoisted(() => ({
   assertBrowserNavigationAllowed: vi.fn(async () => {}),
   assertBrowserNavigationResultAllowed: vi.fn(async () => {}),
-  withBrowserNavigationPolicy: vi.fn(() => ({})),
+  withBrowserNavigationPolicy: vi.fn((ssrfPolicy?: unknown) => (ssrfPolicy ? { ssrfPolicy } : {})),
 }));
 
 vi.mock("../chrome-mcp.js", () => ({
@@ -72,20 +72,20 @@ vi.mock("./agent.shared.js", () => createExistingSessionAgentSharedModule());
 const { registerBrowserAgentActRoutes } = await import("./agent.act.js");
 const { registerBrowserAgentSnapshotRoutes } = await import("./agent.snapshot.js");
 
-function getSnapshotGetHandler() {
+function getSnapshotGetHandler(ssrfPolicy?: unknown) {
   const { app, getHandlers } = createBrowserRouteApp();
   registerBrowserAgentSnapshotRoutes(app, {
-    state: () => ({ resolved: { ssrfPolicy: undefined } }),
+    state: () => ({ resolved: { ssrfPolicy } }),
   } as never);
   const handler = getHandlers.get("/snapshot");
   expect(handler).toBeTypeOf("function");
   return handler;
 }
 
-function getSnapshotPostHandler() {
+function getSnapshotPostHandler(ssrfPolicy?: unknown) {
   const { app, postHandlers } = createBrowserRouteApp();
   registerBrowserAgentSnapshotRoutes(app, {
-    state: () => ({ resolved: { ssrfPolicy: undefined } }),
+    state: () => ({ resolved: { ssrfPolicy } }),
   } as never);
   const handler = postHandlers.get("/screenshot");
   expect(handler).toBeTypeOf("function");
@@ -135,9 +135,7 @@ describe("existing-session browser routes", () => {
       profileName: "chrome-live",
       targetId: "7",
     });
-    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).toHaveBeenCalledWith({
-      url: "https://example.com",
-    });
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
     expect(chromeMcpMocks.takeChromeMcpScreenshot).toHaveBeenCalled();
   });
 
@@ -166,8 +164,37 @@ describe("existing-session browser routes", () => {
       fullPage: false,
       format: "jpeg",
     });
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
+  });
+
+  it("checks existing-session snapshot URL when SSRF policy is configured", async () => {
+    const handler = getSnapshotGetHandler({ allowPrivateNetwork: false });
+    const response = createBrowserRouteResponse();
+    await handler?.({ params: {}, query: { format: "ai" } }, response.res);
+
+    expect(response.statusCode).toBe(200);
     expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).toHaveBeenCalledWith({
       url: "https://example.com",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+  });
+
+  it("checks existing-session screenshot URL when SSRF policy is configured", async () => {
+    const handler = getSnapshotPostHandler({ allowPrivateNetwork: false });
+    const response = createBrowserRouteResponse();
+    await handler?.(
+      {
+        params: {},
+        query: {},
+        body: { ref: "btn-1", type: "jpeg" },
+      },
+      response.res,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).toHaveBeenCalledWith({
+      url: "https://example.com",
+      ssrfPolicy: { allowPrivateNetwork: false },
     });
   });
 

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -319,10 +319,12 @@ export function registerBrowserAgentSnapshotRoutes(
           if (element) {
             return jsonError(res, 400, EXISTING_SESSION_LIMITS.snapshot.screenshotElement);
           }
-          await assertBrowserNavigationResultAllowed({
-            url: tab.url,
-            ...ssrfPolicyOpts,
-          });
+          if (ssrfPolicyOpts.ssrfPolicy) {
+            await assertBrowserNavigationResultAllowed({
+              url: tab.url,
+              ...ssrfPolicyOpts,
+            });
+          }
           const buffer = await takeChromeMcpScreenshot({
             profileName: profileCtx.profile.name,
             userDataDir: profileCtx.profile.userDataDir,
@@ -405,10 +407,12 @@ export function registerBrowserAgentSnapshotRoutes(
         if (plan.selectorValue || plan.frameSelectorValue) {
           return jsonError(res, 400, EXISTING_SESSION_LIMITS.snapshot.snapshotSelector);
         }
-        await assertBrowserNavigationResultAllowed({
-          url: tab.url,
-          ...ssrfPolicyOpts,
-        });
+        if (ssrfPolicyOpts.ssrfPolicy) {
+          await assertBrowserNavigationResultAllowed({
+            url: tab.url,
+            ...ssrfPolicyOpts,
+          });
+        }
         const snapshot = await takeChromeMcpSnapshot({
           profileName: profileCtx.profile.name,
           userDataDir: profileCtx.profile.userDataDir,

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -315,9 +315,14 @@ export function registerBrowserAgentSnapshotRoutes(
       targetId,
       run: async ({ profileCtx, tab, cdpUrl }) => {
         if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+          const ssrfPolicyOpts = withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy);
           if (element) {
             return jsonError(res, 400, EXISTING_SESSION_LIMITS.snapshot.screenshotElement);
           }
+          await assertBrowserNavigationResultAllowed({
+            url: tab.url,
+            ...ssrfPolicyOpts,
+          });
           const buffer = await takeChromeMcpScreenshot({
             profileName: profileCtx.profile.name,
             userDataDir: profileCtx.profile.userDataDir,
@@ -396,9 +401,14 @@ export function registerBrowserAgentSnapshotRoutes(
         return jsonError(res, 400, "labels/mode=efficient require format=ai");
       }
       if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+        const ssrfPolicyOpts = withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy);
         if (plan.selectorValue || plan.frameSelectorValue) {
           return jsonError(res, 400, EXISTING_SESSION_LIMITS.snapshot.snapshotSelector);
         }
+        await assertBrowserNavigationResultAllowed({
+          url: tab.url,
+          ...ssrfPolicyOpts,
+        });
         const snapshot = await takeChromeMcpSnapshot({
           profileName: profileCtx.profile.name,
           userDataDir: profileCtx.profile.userDataDir,

--- a/extensions/browser/src/browser/routes/existing-session.test-support.ts
+++ b/extensions/browser/src/browser/routes/existing-session.test-support.ts
@@ -7,6 +7,12 @@ export const existingSessionRouteState = {
       driver: "existing-session" as const,
       name: "chrome-live",
     },
+    listTabs: vi.fn(async () => [
+      {
+        targetId: "7",
+        url: "https://example.com",
+      },
+    ]),
     ensureTabAvailable: vi.fn(async () => ({
       targetId: "7",
       url: "https://example.com",

--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -280,6 +280,56 @@ describe("browser tab routes", () => {
     expect(profileCtx.focusTab).not.toHaveBeenCalled();
   });
 
+  it("does not run SSRF result validation for /tabs/focus when policy is not configured", async () => {
+    const profileCtx = createProfileContext({
+      ensureTabAvailable: vi.fn(async () => ({
+        targetId: "T2",
+        title: "Internal",
+        url: "http://169.254.169.254/latest/meta-data/",
+        type: "page",
+      })),
+    });
+
+    const response = await callTabsFocus({
+      profileCtx,
+      body: { targetId: "T2" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(profileCtx.focusTab).toHaveBeenCalledWith("T2");
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
+  });
+
+  it("does not run SSRF result validation for /tabs/action select when policy is not configured", async () => {
+    const profileCtx = createProfileContext({
+      listTabs: vi.fn(async () => [
+        {
+          targetId: "T1",
+          title: "Public",
+          url: "https://example.com",
+          type: "page",
+        },
+        {
+          targetId: "T2",
+          title: "Internal",
+          url: "http://169.254.169.254/latest/meta-data/",
+          type: "page",
+        },
+      ]),
+    });
+
+    const response = await callTabsAction({
+      body: { action: "select", index: 1 },
+      profileCtx,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ ok: true, targetId: "T2" });
+    expect(profileCtx.focusTab).toHaveBeenCalledWith("T2");
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
+  });
+
   it("redacts blocked tab URLs for /tabs/action list", async () => {
     navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
       async (opts?: { url: string }) => {

--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -231,12 +231,14 @@ describe("browser tab routes", () => {
       new Error("blocked"),
     );
     const profileCtx = createProfileContext({
-      ensureTabAvailable: vi.fn(async () => ({
-        targetId: "T2",
-        title: "Internal",
-        url: "http://169.254.169.254/latest/meta-data/",
-        type: "page",
-      })),
+      listTabs: vi.fn(async () => [
+        {
+          targetId: "T2",
+          title: "Internal",
+          url: "http://169.254.169.254/latest/meta-data/",
+          type: "page",
+        },
+      ]),
     });
 
     const response = await callTabsFocus({
@@ -246,6 +248,22 @@ describe("browser tab routes", () => {
     });
 
     expect(response.statusCode).toBe(400);
+    expect(profileCtx.focusTab).not.toHaveBeenCalled();
+  });
+
+  it("does not create a tab for /tabs/focus when target is missing", async () => {
+    const profileCtx = createProfileContext({
+      listTabs: vi.fn(async () => []),
+    });
+
+    const response = await callTabsFocus({
+      profileCtx,
+      body: { targetId: "T404" },
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(profileCtx.ensureTabAvailable).not.toHaveBeenCalled();
     expect(profileCtx.focusTab).not.toHaveBeenCalled();
   });
 
@@ -282,12 +300,14 @@ describe("browser tab routes", () => {
 
   it("does not run SSRF result validation for /tabs/focus when policy is not configured", async () => {
     const profileCtx = createProfileContext({
-      ensureTabAvailable: vi.fn(async () => ({
-        targetId: "T2",
-        title: "Internal",
-        url: "http://169.254.169.254/latest/meta-data/",
-        type: "page",
-      })),
+      listTabs: vi.fn(async () => [
+        {
+          targetId: "T2",
+          title: "Internal",
+          url: "http://169.254.169.254/latest/meta-data/",
+          type: "page",
+        },
+      ]),
     });
 
     const response = await callTabsFocus({
@@ -298,6 +318,7 @@ describe("browser tab routes", () => {
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({ ok: true });
     expect(profileCtx.focusTab).toHaveBeenCalledWith("T2");
+    expect(profileCtx.ensureTabAvailable).not.toHaveBeenCalled();
     expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
   });
 

--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
-import { registerBrowserTabRoutes } from "./tabs.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
+
+const navigationGuardMocks = vi.hoisted(() => ({
+  assertBrowserNavigationAllowed: vi.fn(async () => {}),
+  assertBrowserNavigationResultAllowed: vi.fn(async () => {}),
+  withBrowserNavigationPolicy: vi.fn((ssrfPolicy?: unknown) => (ssrfPolicy ? { ssrfPolicy } : {})),
+}));
+
+vi.mock("../navigation-guard.js", () => navigationGuardMocks);
+
+const { registerBrowserTabRoutes } = await import("./tabs.js");
 
 function createProfileContext(overrides?: Partial<ReturnType<typeof baseProfileContext>>) {
   return {
@@ -44,12 +53,17 @@ function baseProfileContext() {
   };
 }
 
-function createRouteContext(profileCtx: ReturnType<typeof createProfileContext>) {
+function createRouteContext(
+  profileCtx: ReturnType<typeof createProfileContext>,
+  options?: { ssrfPolicy?: unknown },
+) {
   return {
-    state: () => ({ resolved: { ssrfPolicy: undefined } }),
+    state: () => ({ resolved: { ssrfPolicy: options?.ssrfPolicy } }),
     forProfile: () => profileCtx,
     listProfiles: vi.fn(async () => []),
-    mapTabError: vi.fn(() => null),
+    mapTabError: vi.fn((err: unknown) =>
+      err instanceof Error ? { status: 400, message: err.message } : null,
+    ),
     ensureBrowserAvailable: profileCtx.ensureBrowserAvailable,
     ensureTabAvailable: profileCtx.ensureTabAvailable,
     isHttpReachable: profileCtx.isHttpReachable,
@@ -66,9 +80,13 @@ function createRouteContext(profileCtx: ReturnType<typeof createProfileContext>)
 async function callTabsAction(params: {
   body: Record<string, unknown>;
   profileCtx: ReturnType<typeof createProfileContext>;
+  ssrfPolicy?: unknown;
 }) {
   const { app, postHandlers } = createBrowserRouteApp();
-  registerBrowserTabRoutes(app, createRouteContext(params.profileCtx) as never);
+  registerBrowserTabRoutes(
+    app,
+    createRouteContext(params.profileCtx, { ssrfPolicy: params.ssrfPolicy }) as never,
+  );
   const handler = postHandlers.get("/tabs/action");
   expect(handler).toBeTypeOf("function");
 
@@ -77,7 +95,51 @@ async function callTabsAction(params: {
   return response;
 }
 
+async function callTabsList(params: {
+  profileCtx: ReturnType<typeof createProfileContext>;
+  ssrfPolicy?: unknown;
+}) {
+  const { app, getHandlers } = createBrowserRouteApp();
+  registerBrowserTabRoutes(
+    app,
+    createRouteContext(params.profileCtx, { ssrfPolicy: params.ssrfPolicy }) as never,
+  );
+  const handler = getHandlers.get("/tabs");
+  expect(handler).toBeTypeOf("function");
+
+  const response = createBrowserRouteResponse();
+  await handler?.({ params: {}, query: {}, body: {} }, response.res);
+  return response;
+}
+
+async function callTabsFocus(params: {
+  profileCtx: ReturnType<typeof createProfileContext>;
+  body: Record<string, unknown>;
+  ssrfPolicy?: unknown;
+}) {
+  const { app, postHandlers } = createBrowserRouteApp();
+  registerBrowserTabRoutes(
+    app,
+    createRouteContext(params.profileCtx, { ssrfPolicy: params.ssrfPolicy }) as never,
+  );
+  const handler = postHandlers.get("/tabs/focus");
+  expect(handler).toBeTypeOf("function");
+
+  const response = createBrowserRouteResponse();
+  await handler?.({ params: {}, query: {}, body: params.body }, response.res);
+  return response;
+}
+
 describe("browser tab routes", () => {
+  beforeEach(() => {
+    navigationGuardMocks.assertBrowserNavigationAllowed.mockReset();
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockReset();
+    navigationGuardMocks.withBrowserNavigationPolicy.mockReset();
+    navigationGuardMocks.withBrowserNavigationPolicy.mockImplementation((ssrfPolicy?: unknown) =>
+      ssrfPolicy ? { ssrfPolicy } : {},
+    );
+  });
+
   it("returns browser-not-running for close when the browser is not reachable", async () => {
     const profileCtx = createProfileContext({
       isReachable: vi.fn(async () => false),
@@ -108,5 +170,161 @@ describe("browser tab routes", () => {
     expect(response.body).toEqual({ error: "browser not running" });
     expect(profileCtx.listTabs).not.toHaveBeenCalled();
     expect(profileCtx.focusTab).not.toHaveBeenCalled();
+  });
+
+  it("redacts blocked tab URLs from GET /tabs", async () => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
+      async ({ url }: { url: string }) => {
+        if (url.includes("169.254.169.254")) {
+          throw new Error("blocked");
+        }
+      },
+    );
+    const profileCtx = createProfileContext({
+      listTabs: vi.fn(async () => [
+        {
+          targetId: "T1",
+          title: "Public",
+          url: "https://example.com",
+          type: "page",
+        },
+        {
+          targetId: "T2",
+          title: "Internal",
+          url: "http://169.254.169.254/latest/meta-data/",
+          type: "page",
+        },
+      ]),
+    });
+
+    const response = await callTabsList({
+      profileCtx,
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({
+      running: true,
+      tabs: [
+        {
+          targetId: "T1",
+          title: "Public",
+          url: "https://example.com",
+          type: "page",
+        },
+        {
+          targetId: "T2",
+          title: "Internal",
+          url: "",
+          type: "page",
+        },
+      ],
+    });
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).toHaveBeenCalledTimes(2);
+  });
+
+  it("blocks /tabs/focus when target tab URL fails SSRF checks", async () => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockRejectedValueOnce(
+      new Error("blocked"),
+    );
+    const profileCtx = createProfileContext({
+      ensureTabAvailable: vi.fn(async () => ({
+        targetId: "T2",
+        title: "Internal",
+        url: "http://169.254.169.254/latest/meta-data/",
+        type: "page",
+      })),
+    });
+
+    const response = await callTabsFocus({
+      profileCtx,
+      body: { targetId: "T2" },
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(profileCtx.focusTab).not.toHaveBeenCalled();
+  });
+
+  it("blocks /tabs/action select when target tab URL fails SSRF checks", async () => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockRejectedValueOnce(
+      new Error("blocked"),
+    );
+    const profileCtx = createProfileContext({
+      listTabs: vi.fn(async () => [
+        {
+          targetId: "T1",
+          title: "Public",
+          url: "https://example.com",
+          type: "page",
+        },
+        {
+          targetId: "T2",
+          title: "Internal",
+          url: "http://169.254.169.254/latest/meta-data/",
+          type: "page",
+        },
+      ]),
+    });
+
+    const response = await callTabsAction({
+      body: { action: "select", index: 1 },
+      profileCtx,
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(profileCtx.focusTab).not.toHaveBeenCalled();
+  });
+
+  it("redacts blocked tab URLs for /tabs/action list", async () => {
+    navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
+      async ({ url }: { url: string }) => {
+        if (url.includes("10.0.0.5")) {
+          throw new Error("blocked");
+        }
+      },
+    );
+    const profileCtx = createProfileContext({
+      listTabs: vi.fn(async () => [
+        {
+          targetId: "T1",
+          title: "Public",
+          url: "https://example.com",
+          type: "page",
+        },
+        {
+          targetId: "T2",
+          title: "Private Admin",
+          url: "http://10.0.0.5/admin",
+          type: "page",
+        },
+      ]),
+    });
+
+    const response = await callTabsAction({
+      body: { action: "list" },
+      profileCtx,
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({
+      ok: true,
+      tabs: [
+        {
+          targetId: "T1",
+          title: "Public",
+          url: "https://example.com",
+          type: "page",
+        },
+        {
+          targetId: "T2",
+          title: "Private Admin",
+          url: "",
+          type: "page",
+        },
+      ],
+    });
   });
 });

--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -63,9 +63,13 @@ function createRouteContext(
     state: () => ({ resolved: { ssrfPolicy: options?.ssrfPolicy } }),
     forProfile: () => profileCtx,
     listProfiles: vi.fn(async () => []),
-    mapTabError: vi.fn((err: unknown) =>
-      err instanceof Error ? { status: 400, message: err.message } : null,
-    ),
+    mapTabError: vi.fn((err: unknown) => {
+      if (!(err instanceof Error)) {
+        return null;
+      }
+      const status = "status" in err && typeof err.status === "number" ? err.status : 400;
+      return { status, message: err.message };
+    }),
     ensureBrowserAvailable: profileCtx.ensureBrowserAvailable,
     ensureTabAvailable: profileCtx.ensureTabAvailable,
     isHttpReachable: profileCtx.isHttpReachable,
@@ -262,9 +266,37 @@ describe("browser tab routes", () => {
       ssrfPolicy: { allowPrivateNetwork: false },
     });
 
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(404);
     expect(profileCtx.ensureTabAvailable).not.toHaveBeenCalled();
     expect(profileCtx.focusTab).not.toHaveBeenCalled();
+  });
+
+  it("returns conflict for ambiguous target-id prefixes in /tabs/focus", async () => {
+    const profileCtx = createProfileContext({
+      listTabs: vi.fn(async () => [
+        {
+          targetId: "T1abc",
+          title: "Tab 1",
+          url: "https://example.com",
+          type: "page",
+        },
+        {
+          targetId: "T1def",
+          title: "Tab 2",
+          url: "https://example.org",
+          type: "page",
+        },
+      ]),
+    });
+
+    const response = await callTabsFocus({
+      profileCtx,
+      body: { targetId: "T1" },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(profileCtx.focusTab).not.toHaveBeenCalled();
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
   });
 
   it("blocks /tabs/action select when target tab URL fails SSRF checks", async () => {

--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -3,7 +3,9 @@ import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helper
 
 const navigationGuardMocks = vi.hoisted(() => ({
   assertBrowserNavigationAllowed: vi.fn(async () => {}),
-  assertBrowserNavigationResultAllowed: vi.fn(async () => {}),
+  assertBrowserNavigationResultAllowed: vi.fn(
+    async (_opts?: { url: string; ssrfPolicy?: unknown }) => {},
+  ),
   withBrowserNavigationPolicy: vi.fn((ssrfPolicy?: unknown) => (ssrfPolicy ? { ssrfPolicy } : {})),
 }));
 
@@ -174,7 +176,8 @@ describe("browser tab routes", () => {
 
   it("redacts blocked tab URLs from GET /tabs", async () => {
     navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
-      async ({ url }: { url: string }) => {
+      async (opts?: { url: string }) => {
+        const url = opts?.url ?? "";
         if (url.includes("169.254.169.254")) {
           throw new Error("blocked");
         }
@@ -279,7 +282,8 @@ describe("browser tab routes", () => {
 
   it("redacts blocked tab URLs for /tabs/action list", async () => {
     navigationGuardMocks.assertBrowserNavigationResultAllowed.mockImplementation(
-      async ({ url }: { url: string }) => {
+      async (opts?: { url: string }) => {
+        const url = opts?.url ?? "";
         if (url.includes("10.0.0.5")) {
           throw new Error("blocked");
         }

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -1,6 +1,7 @@
 import { BrowserProfileUnavailableError, BrowserTabNotFoundError } from "../errors.js";
 import {
   assertBrowserNavigationAllowed,
+  assertBrowserNavigationResultAllowed,
   withBrowserNavigationPolicy,
 } from "../navigation-guard.js";
 import type { BrowserRouteContext, ProfileContext } from "../server-context.js";
@@ -65,6 +66,34 @@ async function ensureBrowserRunning(profileCtx: ProfileContext, res: BrowserResp
   return true;
 }
 
+async function redactBlockedTabUrls(params: {
+  tabs: Awaited<ReturnType<ProfileContext["listTabs"]>>;
+  ssrfPolicy: ReturnType<BrowserRouteContext["state"]>["resolved"]["ssrfPolicy"];
+}): Promise<Awaited<ReturnType<ProfileContext["listTabs"]>>> {
+  const ssrfPolicyOpts = withBrowserNavigationPolicy(params.ssrfPolicy);
+  if (!ssrfPolicyOpts.ssrfPolicy) {
+    return params.tabs;
+  }
+
+  const redactedTabs: Awaited<ReturnType<ProfileContext["listTabs"]>> = [];
+  for (const tab of params.tabs) {
+    try {
+      await assertBrowserNavigationResultAllowed({
+        url: tab.url,
+        ...ssrfPolicyOpts,
+      });
+      redactedTabs.push(tab);
+    } catch {
+      // Hide blocked URLs while preserving tab identity for safe operations.
+      redactedTabs.push({
+        ...tab,
+        url: "",
+      });
+    }
+  }
+  return redactedTabs;
+}
+
 function resolveIndexedTab(
   tabs: Awaited<ReturnType<ProfileContext["listTabs"]>>,
   index: number | undefined,
@@ -114,7 +143,10 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
         if (!reachable) {
           return res.json({ running: false, tabs: [] as unknown[] });
         }
-        const tabs = await profileCtx.listTabs();
+        const tabs = await redactBlockedTabUrls({
+          tabs: await profileCtx.listTabs(),
+          ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+        });
         res.json({ running: true, tabs });
       },
     });
@@ -154,7 +186,12 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
       ctx,
       targetId,
       mutate: async (profileCtx, id) => {
-        await profileCtx.focusTab(id);
+        const tab = await profileCtx.ensureTabAvailable(id);
+        await assertBrowserNavigationResultAllowed({
+          url: tab.url,
+          ...withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy),
+        });
+        await profileCtx.focusTab(tab.targetId);
       },
     });
   });
@@ -190,7 +227,10 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
           if (!reachable) {
             return res.json({ ok: true, tabs: [] as unknown[] });
           }
-          const tabs = await profileCtx.listTabs();
+          const tabs = await redactBlockedTabUrls({
+            tabs: await profileCtx.listTabs(),
+            ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+          });
           return res.json({ ok: true, tabs });
         }
 
@@ -225,6 +265,10 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
           if (!target) {
             throw new BrowserTabNotFoundError();
           }
+          await assertBrowserNavigationResultAllowed({
+            url: target.url,
+            ...withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy),
+          });
           await profileCtx.focusTab(target.targetId);
           return res.json({ ok: true, targetId: target.targetId });
         }

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -5,6 +5,7 @@ import {
   withBrowserNavigationPolicy,
 } from "../navigation-guard.js";
 import type { BrowserRouteContext, ProfileContext } from "../server-context.js";
+import { resolveTargetIdFromTabs } from "../target-id.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
 import { getProfileContext, jsonError, toNumber, toStringOrEmpty } from "./utils.js";
 
@@ -186,7 +187,15 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
       ctx,
       targetId,
       mutate: async (profileCtx, id) => {
-        const tab = await profileCtx.ensureTabAvailable(id);
+        const tabs = await profileCtx.listTabs();
+        const resolved = resolveTargetIdFromTabs(id, tabs);
+        if (!resolved.ok) {
+          throw new BrowserTabNotFoundError();
+        }
+        const tab = tabs.find((currentTab) => currentTab.targetId === resolved.targetId);
+        if (!tab) {
+          throw new BrowserTabNotFoundError();
+        }
         const ssrfPolicyOpts = withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy);
         if (ssrfPolicyOpts.ssrfPolicy) {
           await assertBrowserNavigationResultAllowed({
@@ -194,7 +203,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
             ...ssrfPolicyOpts,
           });
         }
-        await profileCtx.focusTab(tab.targetId);
+        await profileCtx.focusTab(resolved.targetId);
       },
     });
   });

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -187,10 +187,13 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
       targetId,
       mutate: async (profileCtx, id) => {
         const tab = await profileCtx.ensureTabAvailable(id);
-        await assertBrowserNavigationResultAllowed({
-          url: tab.url,
-          ...withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy),
-        });
+        const ssrfPolicyOpts = withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy);
+        if (ssrfPolicyOpts.ssrfPolicy) {
+          await assertBrowserNavigationResultAllowed({
+            url: tab.url,
+            ...ssrfPolicyOpts,
+          });
+        }
         await profileCtx.focusTab(tab.targetId);
       },
     });
@@ -265,10 +268,13 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
           if (!target) {
             throw new BrowserTabNotFoundError();
           }
-          await assertBrowserNavigationResultAllowed({
-            url: target.url,
-            ...withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy),
-          });
+          const ssrfPolicyOpts = withBrowserNavigationPolicy(ctx.state().resolved.ssrfPolicy);
+          if (ssrfPolicyOpts.ssrfPolicy) {
+            await assertBrowserNavigationResultAllowed({
+              url: target.url,
+              ...ssrfPolicyOpts,
+            });
+          }
           await profileCtx.focusTab(target.targetId);
           return res.json({ ok: true, targetId: target.targetId });
         }

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -1,4 +1,8 @@
-import { BrowserProfileUnavailableError, BrowserTabNotFoundError } from "../errors.js";
+import {
+  BrowserProfileUnavailableError,
+  BrowserTabNotFoundError,
+  BrowserTargetAmbiguousError,
+} from "../errors.js";
 import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationResultAllowed,
@@ -190,6 +194,9 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
         const tabs = await profileCtx.listTabs();
         const resolved = resolveTargetIdFromTabs(id, tabs);
         if (!resolved.ok) {
+          if (resolved.reason === "ambiguous") {
+            throw new BrowserTargetAmbiguousError();
+          }
           throw new BrowserTabNotFoundError();
         }
         const tab = tabs.find((currentTab) => currentTab.targetId === resolved.targetId);


### PR DESCRIPTION
## Summary

- **Problem:** The Chrome MCP snapshot, screenshot, tab-list, and tab-focus routes returned page content and tab URLs without validating them against the configured SSRF policy. A newly-opened internal tab (via `target=\"_blank\"` or `window.open()`) could be enumerated, focused, and fully read by the agent.
- **Why it matters:** Unlike blind SSRF, the agent receives the complete accessibility tree or screenshot buffer of internal pages—cloud metadata endpoints, admin panels, internal APIs—with no SSRF check intervening.
- **What changed:** Added `assertBrowserNavigationResultAllowed` guards on the Chrome MCP screenshot and snapshot paths (behind `if (ssrfPolicyOpts.ssrfPolicy)`); redact blocked tab URLs in `GET /tabs` and `POST /tabs/action list`; gate `POST /tabs/focus` and `POST /tabs/action select` on URL validation; enumerate new tabs opened during an interaction and check their URLs before returning success.
- **What did NOT change:** Non-Chrome-MCP (Playwright/CDP) paths, the `openTab` flow (already guarded), operator-level SSRF policy configuration, and all other browser routes are unaffected.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Integrations
- [x] API / contracts

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The read-side browser routes (`/snapshot`, `/screenshot`, `GET /tabs`, `POST /tabs/focus`) were added without the SSRF result-validation calls that the `openTab` write path already enforced. The post-interaction guard in `agent.act.ts` also only checked the original tab's URL, never detecting tabs opened during the interaction.
- Missing detection / guardrail: No call to `assertBrowserNavigationResultAllowed({ url: tab.url })` before serving snapshot/screenshot content or returning tab URL data.
- Contributing context: The `withRouteTabContext` shared helper resolves the tab but does not apply SSRF checks; each route was expected to apply them individually.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `agent.act.existing-session-navigation-guard.test.ts`, `agent.existing-session.test.ts`, `tabs.test.ts`
- Scenario the test should lock in:
  - Snapshot and screenshot routes call `assertBrowserNavigationResultAllowed` with `tab.url` when SSRF policy is configured.
  - `GET /tabs` and `POST /tabs/action list` redact blocked URLs to `""` rather than exposing them.
  - `POST /tabs/focus` and `POST /tabs/action select` reject tabs whose URLs fail SSRF checks.
  - A newly-opened tab with a blocked URL causes the interaction handler to fail closed.
  - None of the above checks fire when no SSRF policy is configured (no proxy-env regression).
- Why this is the smallest reliable guardrail: Each surface has a direct mock-based unit test that confirms the check is invoked and that errors propagate to the response.
- Existing test that already covers this (if any): None prior to this PR.

## User-visible / Behavior Changes

When an SSRF policy is configured:
- `GET /tabs` and `POST /tabs/action list` now return `url: ""` for any tab whose URL is blocked by the policy (tab identity preserved, URL redacted).
- `POST /tabs/focus` and `POST /tabs/action select` return a 400 error if the target tab's URL is blocked.
- Chrome MCP snapshot and screenshot requests return an error if the current tab URL is blocked.
- Interaction actions (click, key) fail if a new tab opened during the interaction has a blocked URL.

No behavior change when SSRF policy is not configured.

## Diagram (if applicable)

```text
Before (Chrome MCP read paths):
[agent] -> /snapshot or /screenshot -> ensureTabAvailable -> takeChromeMcpSnapshot -> content returned (no SSRF check)
[agent] -> GET /tabs -> listTabs -> res.json({ tabs }) (raw URLs, no filter)
[agent] -> POST /tabs/focus -> focusTab(id) (no URL validation)

After:
[agent] -> /snapshot or /screenshot -> ensureTabAvailable -> assertBrowserNavigationResultAllowed(tab.url) -> takeChromeMcpSnapshot -> content returned
[agent] -> GET /tabs -> listTabs -> redactBlockedTabUrls -> res.json({ tabs }) (blocked URLs become "")
[agent] -> POST /tabs/focus -> ensureTabAvailable -> assertBrowserNavigationResultAllowed(tab.url) -> focusTab
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes — snapshot, screenshot, tab-list, and tab-focus routes now enforce the SSRF policy boundary that was already enforced on the write (openTab) path.
- Risk + mitigation: Operators with SSRF policy configured and a proxy env variable set would previously have had snapshot/screenshot calls pass through unchecked. The new guards are conditioned on `if (ssrfPolicyOpts.ssrfPolicy)`, so they are a no-op when no policy is configured—no regression for proxy-only environments.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu, x86-64)
- Runtime/container: Node 22, Bun
- Model/provider: N/A (unit tests only)
- Integration/channel: Chrome MCP browser profile

### Steps

1. Run `pnpm test extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts`
2. Run `pnpm test extensions/browser/src/browser/routes/agent.existing-session.test.ts`
3. Run `pnpm test extensions/browser/src/browser/routes/tabs.test.ts`

### Expected

- All new tests pass, including: "fails closed when a newly opened tab URL is blocked", "redacts blocked tab URLs from GET /tabs", "blocks /tabs/focus when target tab URL fails SSRF checks", snapshot/screenshot guard assertions.

### Actual

- All tests pass.

## Evidence

- [x] Failing test/log before + passing after (new tests added for each surface; all pass against the patched code)

## Human Verification (required)

- Verified scenarios: All new unit tests pass. `assertBrowserNavigationResultAllowed` is confirmed to be called with the correct tab URL on the Chrome MCP screenshot and snapshot paths. Proxy-env regression confirmed absent via the `if (ssrfPolicyOpts.ssrfPolicy)` guard.
- Edge cases checked: No SSRF policy configured (no-op path); tab with empty URL (handled by `assertBrowserNavigationResultAllowed`'s early-return on empty URLs); new tab opened with blocked URL during interaction (propagates as error).
- What you did **not** verify: Live end-to-end test with a real Chrome MCP profile and a real internal server.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

> **AI-assisted:** This fix was generated by OpenAI Codex and reviewed by Claude. All review findings from the automated review pass were addressed before submission.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Operators with SSRF policy configured may see new 400 errors for snapshot/screenshot/focus operations on tabs with blocked URLs (intended behavior — previously these silently served internal content).
  - Mitigation: Error messages are clear; the behavior matches what the SSRF policy is documented to enforce. No change when policy is not configured.