### PR TITLE
fix(doctor): avoid false gateway entrypoint mismatches for dist aliases

### DIFF
--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -381,9 +381,25 @@ describe("maybeRepairGatewayServiceConfig", () => {
     expect(mocks.install).toHaveBeenCalledTimes(1);
   });
 
-  it("repairs entrypoint mismatch in non-interactive fix mode", async () => {
+  it("does not flag entrypoint mismatch when the dist directory matches but entrypoint aliases differ", async () => {
     setupGatewayEntrypointRepairScenario({
       currentEntrypoint: "/Users/test/Library/npm/node_modules/openclaw/dist/entry.js",
+      installEntrypoint: "/Users/test/Library/npm/node_modules/openclaw/dist/index.js",
+    });
+
+    await runRepair({ gateway: {} });
+
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("Gateway service entrypoint does not match the current install."),
+      "Gateway service config",
+    );
+    expect(mocks.stage).not.toHaveBeenCalled();
+    expect(mocks.install).not.toHaveBeenCalled();
+  });
+
+  it("repairs entrypoint mismatch in non-interactive fix mode when the install root changed", async () => {
+    setupGatewayEntrypointRepairScenario({
+      currentEntrypoint: "/Users/test/Library/npm/node_modules/openclaw-legacy/dist/entry.js",
       installEntrypoint: "/Users/test/Library/npm/node_modules/openclaw/dist/index.js",
       installWorkingDirectory: "/tmp",
     });
@@ -401,9 +417,9 @@ describe("maybeRepairGatewayServiceConfig", () => {
     expect(mocks.install).toHaveBeenCalledTimes(1);
   });
 
-  it("stages service config repairs during non-interactive update repairs", async () => {
+  it("stages service config repairs during non-interactive update repairs when the install root changed", async () => {
     setupGatewayEntrypointRepairScenario({
-      currentEntrypoint: "/Users/test/Library/npm/node_modules/openclaw/dist/entry.js",
+      currentEntrypoint: "/Users/test/Library/npm/node_modules/openclaw-legacy/dist/entry.js",
       installEntrypoint: "/Users/test/Library/npm/node_modules/openclaw/dist/index.js",
       installWorkingDirectory: "/tmp",
     });

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { writeConfigFile, type OpenClawConfig } from "../config/config.js";
 import { resolveGatewayPort, resolveIsNixMode } from "../config/paths.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { areEquivalentGatewayDistEntrypoints } from "../daemon/gateway-entrypoint.js";
 import {
   findExtraGatewayServices,
   renderGatewayServiceCleanupHints,
@@ -285,11 +286,15 @@ export async function maybeRepairGatewayServiceConfig(
   const normalizedCurrentEntrypoint = currentEntrypoint
     ? await normalizeExecutablePath(currentEntrypoint)
     : null;
-  if (
+  const entrypointsMatch =
     normalizedExpectedEntrypoint &&
     normalizedCurrentEntrypoint &&
-    normalizedExpectedEntrypoint !== normalizedCurrentEntrypoint
-  ) {
+    (normalizedExpectedEntrypoint === normalizedCurrentEntrypoint ||
+      areEquivalentGatewayDistEntrypoints(
+        normalizedCurrentEntrypoint,
+        normalizedExpectedEntrypoint,
+      ));
+  if (normalizedExpectedEntrypoint && normalizedCurrentEntrypoint && !entrypointsMatch) {
     audit.issues.push({
       code: SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
       message: "Gateway service entrypoint does not match the current install.",

--- a/src/daemon/gateway-entrypoint.ts
+++ b/src/daemon/gateway-entrypoint.ts
@@ -7,6 +7,7 @@ const GATEWAY_DIST_ENTRYPOINT_BASENAMES = [
   "entry.js",
   "entry.mjs",
 ] as const;
+const GATEWAY_DIST_ENTRYPOINT_BASENAME_SET = new Set<string>(GATEWAY_DIST_ENTRYPOINT_BASENAMES);
 
 export function isGatewayDistEntrypointPath(inputPath: string): boolean {
   return /[/\\]dist[/\\].+\.(cjs|js|mjs)$/.test(inputPath);
@@ -42,6 +43,32 @@ export function buildGatewayDistEntrypointCandidates(...inputs: string[]): strin
     }
   }
   return candidates;
+}
+
+export function areEquivalentGatewayDistEntrypoints(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): boolean {
+  if (!left || !right) {
+    return false;
+  }
+  if (left === right) {
+    return true;
+  }
+  if (!isGatewayDistEntrypointPath(left) || !isGatewayDistEntrypointPath(right)) {
+    return false;
+  }
+
+  const leftBasename = path.basename(left);
+  const rightBasename = path.basename(right);
+  if (
+    !GATEWAY_DIST_ENTRYPOINT_BASENAME_SET.has(leftBasename) ||
+    !GATEWAY_DIST_ENTRYPOINT_BASENAME_SET.has(rightBasename)
+  ) {
+    return false;
+  }
+
+  return path.dirname(left) === path.dirname(right);
 }
 
 export async function findFirstAccessibleGatewayEntrypoint(


### PR DESCRIPTION
## Summary
- treat `dist/entry.js` and `dist/index.js` as equivalent when they resolve to the same `dist/` directory
- keep repair prompts for actual install-root changes
- add regression coverage for the alias case

## Why
The packaged CLI still boots via `openclaw.mjs -> dist/entry.js`, while doctor/install logic can compute `dist/index.js` as the expected gateway entrypoint. On installs where both files exist in the same package root, doctor can incorrectly suggest a gateway service repair even though the service already matches the current install.

## Testing
- `PATH="/tmp/pnpm-bin:$PATH" node scripts/test-projects.mjs src/commands/doctor-gateway-services.test.ts src/cli/update-cli/update-command.test.ts src/daemon/program-args.test.ts`