### PR TITLE
feat(web-fetch): add FxTwitter API fallback for Twitter/X URLs

### DIFF
--- a/src/agents/tools/web-fetch-twitter.test.ts
+++ b/src/agents/tools/web-fetch-twitter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isTwitterStatusUrl, rewriteToFxTwitterApi } from "./web-fetch-twitter.js";
+
+describe("isTwitterStatusUrl", () => {
+  it("matches twitter.com status URLs", () => {
+    expect(isTwitterStatusUrl(new URL("https://twitter.com/elonmusk/status/1234567890"))).toBe(
+      true,
+    );
+  });
+
+  it("matches x.com status URLs", () => {
+    expect(isTwitterStatusUrl(new URL("https://x.com/user/status/9876543210"))).toBe(true);
+  });
+
+  it("matches www.twitter.com", () => {
+    expect(isTwitterStatusUrl(new URL("https://www.twitter.com/user/status/123"))).toBe(true);
+  });
+
+  it("rejects non-status twitter URLs", () => {
+    expect(isTwitterStatusUrl(new URL("https://twitter.com/user"))).toBe(false);
+    expect(isTwitterStatusUrl(new URL("https://twitter.com/explore"))).toBe(false);
+  });
+
+  it("rejects non-twitter URLs", () => {
+    expect(isTwitterStatusUrl(new URL("https://example.com/user/status/123"))).toBe(false);
+  });
+});
+
+describe("rewriteToFxTwitterApi", () => {
+  it("rewrites twitter.com to api.fxtwitter.com", () => {
+    expect(rewriteToFxTwitterApi(new URL("https://twitter.com/user/status/123"))).toBe(
+      "https://api.fxtwitter.com/user/status/123",
+    );
+  });
+
+  it("rewrites x.com to api.fxtwitter.com", () => {
+    expect(rewriteToFxTwitterApi(new URL("https://x.com/user/status/456"))).toBe(
+      "https://api.fxtwitter.com/user/status/456",
+    );
+  });
+
+  it("returns null for non-twitter URLs", () => {
+    expect(rewriteToFxTwitterApi(new URL("https://example.com/user/status/123"))).toBeNull();
+  });
+
+  it("returns null for non-status twitter URLs", () => {
+    expect(rewriteToFxTwitterApi(new URL("https://twitter.com/explore"))).toBeNull();
+  });
+});

--- a/src/agents/tools/web-fetch-twitter.ts
+++ b/src/agents/tools/web-fetch-twitter.ts
@@ -1,0 +1,103 @@
+/**
+ * Twitter/X URL detection and FxTwitter API fallback.
+ *
+ * Twitter/X pages return login walls to non-browser user agents, making
+ * `web_fetch` useless for tweet URLs.  This module rewrites tweet URLs to
+ * the public FxTwitter JSON API (`api.fxtwitter.com`) which returns tweet
+ * content without authentication.
+ */
+
+const TWITTER_HOST_RE = /^(?:www\.)?(?:twitter\.com|x\.com)$/i;
+const TWEET_STATUS_RE = /^\/([A-Za-z0-9_]{1,15})\/status\/(\d+)/;
+
+export function isTwitterStatusUrl(url: URL): boolean {
+  return TWITTER_HOST_RE.test(url.hostname) && TWEET_STATUS_RE.test(url.pathname);
+}
+
+/**
+ * Rewrite a twitter.com / x.com tweet URL to an api.fxtwitter.com URL.
+ * Returns `null` when the URL is not a recognised tweet link.
+ */
+export function rewriteToFxTwitterApi(url: URL): string | null {
+  if (!TWITTER_HOST_RE.test(url.hostname)) {
+    return null;
+  }
+  const match = url.pathname.match(TWEET_STATUS_RE);
+  if (!match) {
+    return null;
+  }
+  const [, user, statusId] = match;
+  return `https://api.fxtwitter.com/${user}/status/${statusId}`;
+}
+
+export type FxTwitterTweet = {
+  text: string;
+  author: { name: string; screen_name: string };
+  created_at: string;
+  media?: { url: string; type: string }[];
+  likes: number;
+  retweets: number;
+  replies: number;
+};
+
+/**
+ * Fetch a tweet via the FxTwitter JSON API.  Returns a formatted markdown
+ * string on success, or `null` on any failure.
+ */
+export async function fetchTweetViaFxTwitter(
+  originalUrl: string,
+  timeoutMs: number = 10_000,
+): Promise<string | null> {
+  let parsed: URL;
+  try {
+    parsed = new URL(originalUrl);
+  } catch {
+    return null;
+  }
+
+  const apiUrl = rewriteToFxTwitterApi(parsed);
+  if (!apiUrl) {
+    return null;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(apiUrl, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    clearTimeout(timer);
+
+    if (!res.ok) {
+      return null;
+    }
+
+    const data = (await res.json()) as { code?: number; tweet?: FxTwitterTweet };
+    if (!data.tweet) {
+      return null;
+    }
+
+    const t = data.tweet;
+    const lines: string[] = [
+      `**${t.author.name}** (@${t.author.screen_name})`,
+      `${t.created_at}`,
+      "",
+      t.text,
+      "",
+      `❤️ ${t.likes}  🔁 ${t.retweets}  💬 ${t.replies}`,
+    ];
+
+    if (t.media?.length) {
+      lines.push("");
+      for (const m of t.media) {
+        lines.push(`[${m.type}: ${m.url}]`);
+      }
+    }
+
+    lines.push("", `Source: ${originalUrl}`);
+    return lines.join("\n");
+  } catch {
+    return null;
+  }
+}

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -24,6 +24,7 @@ import {
   type ExtractMode,
 } from "./web-fetch-utils.js";
 import { fetchWithWebToolsNetworkGuard } from "./web-guarded-fetch.js";
+import { fetchTweetViaFxTwitter, isTwitterStatusUrl } from "./web-fetch-twitter.js";
 import {
   CacheEntry,
   DEFAULT_CACHE_TTL_MINUTES,
@@ -380,6 +381,19 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   }
   if (!["http:", "https:"].includes(parsedUrl.protocol)) {
     throw new Error("Invalid URL: must be http or https");
+  }
+
+  // Twitter/X returns login walls to non-browser clients.  Intercept tweet
+  // URLs and fetch via the public FxTwitter JSON API instead.
+  if (isTwitterStatusUrl(parsedUrl)) {
+    const tweetText = await fetchTweetViaFxTwitter(params.url, (params.timeoutSeconds ?? 10) * 1000);
+    if (tweetText) {
+      const truncated = truncateText(tweetText, params.maxChars);
+      const result = { url: params.url, text: wrapWebContent(truncated.text, "web_fetch"), tookMs: 0 };
+      writeCache(FETCH_CACHE, cacheKey, result, params.cacheTtlMs);
+      return result;
+    }
+    // Fall through to normal fetch if FxTwitter fails.
   }
 
   const start = Date.now();


### PR DESCRIPTION
## Summary

- Detect twitter.com / x.com tweet URLs in `web_fetch` and route them through the public FxTwitter JSON API (`api.fxtwitter.com`)
- Twitter returns login walls to non-browser user agents, making `web_fetch` useless for tweet URLs
- Fail-safe: if FxTwitter is down, falls through to the normal fetch + provider fallback pipeline

Addresses #59872

## Changes

| File | Change |
|------|--------|
| `src/agents/tools/web-fetch-twitter.ts` | New: Twitter URL detection + FxTwitter API fetch + markdown formatter |
| `src/agents/tools/web-fetch-twitter.test.ts` | 9 test cases for URL detection and rewriting |
| `src/agents/tools/web-fetch.ts` | Import + intercept Twitter URLs before normal fetch |

## How it works

1. After URL validation, check if the URL matches `twitter.com/*/status/*` or `x.com/*/status/*`
2. If match: fetch `api.fxtwitter.com/{user}/status/{id}` (JSON API, no auth required)
3. Format response as markdown (author, text, metrics, media links)
4. If FxTwitter fails: fall through to normal fetch pipeline (unchanged behavior)

## Test plan

- [x] 9 unit tests (URL detection, rewriting, edge cases)
- [x] `pnpm build` succeeds
- [x] No import cycle regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)