### PR TITLE
fix(active-memory): expose /active_memory Telegram alias (#65985)

### DIFF
--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1879,6 +1879,11 @@ export default definePluginEntry({
     };
     api.registerCommand({
       name: "active-memory",
+      // Telegram's BotFather command registration only accepts
+      // `^[a-z0-9_]+$` names, so expose an underscore alias for the
+      // Telegram native surface. Other surfaces keep the canonical
+      // hyphen form. (#65985)
+      nativeNames: { telegram: "active_memory" },
       description: "Enable, disable, or inspect Active Memory for this session.",
       acceptsArgs: true,
       handler: async (ctx) => {


### PR DESCRIPTION
## Summary
Telegram's BotFather command registration only accepts command names matching \`^[a-z0-9_]+$\`, so the canonical \`/active-memory\` slash command cannot be registered in BotFather as-is (#65985). Users end up with a mismatch: chat runtime uses \`/active-memory\`, BotFather accepts \`/active_memory\`, and the two surfaces disagree.

The plugin command contract already supports this exact case: \`OpenClawPluginCommandDefinition.nativeNames\` accepts a per-native-surface override (e.g. \`{ telegram: 'pair', discord: 'pair' }\` is already used elsewhere per \`src/plugins/stage-bundled-plugin-runtime.test.ts:202\`). This PR just adds \`nativeNames: { telegram: "active_memory" }\` to the active-memory command registration so Telegram sees the underscore form while Discord/web/other surfaces keep the canonical hyphen form.

Closes #65985.

## Changes
- \`extensions/active-memory/index.ts\` — add \`nativeNames: { telegram: "active_memory" }\` to the \`api.registerCommand\` call, with a 4-line comment explaining why

## Test plan
- [x] Uses an existing, documented SDK field (\`nativeNames\`) — no contract changes
- [x] Non-Telegram surfaces unaffected (no \`default\` override provided)
- [x] Other tests using the same pattern already exist (see \`src/plugins/commands.test.ts\` for \`nativeNames\` coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)