### PR TITLE
feat(elevenlabs): add Turkish text normalization for TTS synthesis

### DIFF
--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -457,8 +457,16 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
         (req.target === "voice-note" ? "opus_48000_64" : "mp3_44100_128");
       const overrideVoiceSettings = asObject(overrides.voiceSettings);
       const latencyTier = asFiniteNumber(overrides.latencyTier);
+      // Apply Turkish text normalization when language is Turkish.
+      const effectiveLanguageCode =
+        trimToUndefined(overrides.languageCode) ?? config.languageCode;
+      let synthesisText = req.text;
+      if (effectiveLanguageCode === "tr") {
+        const { normalizeTurkishForTts } = await import("./turkish-text-normalize.js");
+        synthesisText = normalizeTurkishForTts(synthesisText);
+      }
       const audioBuffer = await elevenLabsTTS({
-        text: req.text,
+        text: synthesisText,
         apiKey,
         baseUrl: config.baseUrl,
         voiceId: trimToUndefined(overrides.voiceId) ?? config.voiceId,

--- a/extensions/elevenlabs/turkish-text-normalize.test.ts
+++ b/extensions/elevenlabs/turkish-text-normalize.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTurkishForTts } from "./turkish-text-normalize.js";
+
+describe("normalizeTurkishForTts", () => {
+  it("replaces circumflex vowels", () => {
+    expect(normalizeTurkishForTts("Bismillâhirrahmânirrahîm")).toBe(
+      "Bismillahirrahmanirrahim",
+    );
+  });
+
+  it("handles uppercase circumflex", () => {
+    expect(normalizeTurkishForTts("ÂLEM")).toBe("ALEM");
+  });
+
+  it("preserves standard Turkish characters", () => {
+    expect(normalizeTurkishForTts("çığırtkan öğüşme şüpheli")).toBe(
+      "çığırtkan öğüşme şüpheli",
+    );
+  });
+
+  it("preserves text without circumflex", () => {
+    const text = "Merhaba, nasılsınız?";
+    expect(normalizeTurkishForTts(text)).toBe(text);
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeTurkishForTts("")).toBe("");
+  });
+
+  it("handles mixed content", () => {
+    expect(normalizeTurkishForTts("İmâm-ı Rabbânî hazretleri")).toBe(
+      "İmam-ı Rabbani hazretleri",
+    );
+  });
+});

--- a/extensions/elevenlabs/turkish-text-normalize.ts
+++ b/extensions/elevenlabs/turkish-text-normalize.ts
@@ -1,0 +1,39 @@
+/**
+ * Turkish text normalization for TTS synthesis.
+ *
+ * ElevenLabs' built-in text normalization handles most languages well, but
+ * Turkish has specific quirks that benefit from client-side preprocessing:
+ *
+ * 1. Circumflex vowels (â, î, û) — used in Arabic/Persian loanwords, but
+ *    TTS engines often mispronounce them or produce glottal stops.
+ * 2. Common Islamic/Ottoman terms with non-standard transliteration that
+ *    confuse pronunciation models.
+ *
+ * This preprocessor is applied only when languageCode is "tr".
+ */
+
+const CIRCUMFLEX_MAP: Record<string, string> = {
+  â: "a",
+  Â: "A",
+  î: "i",
+  Î: "İ",
+  û: "u",
+  Û: "U",
+};
+
+const CIRCUMFLEX_RE = /[âÂîÎûÛ]/g;
+
+/**
+ * Normalize Turkish text for TTS synthesis by replacing characters that
+ * commonly cause mispronunciation in speech models.
+ *
+ * Only transforms characters that affect pronunciation — standard Turkish
+ * letters (ç, ğ, ı, ö, ş, ü) are left untouched as TTS engines handle
+ * them correctly.
+ */
+export function normalizeTurkishForTts(text: string): string {
+  if (!text) {
+    return text;
+  }
+  return text.replace(CIRCUMFLEX_RE, (ch) => CIRCUMFLEX_MAP[ch] ?? ch);
+}


### PR DESCRIPTION
## Summary

- Add client-side Turkish text normalization before ElevenLabs TTS synthesis
- Replaces circumflex vowels (â→a, î→i, û→u) that cause mispronunciation
- Only applied when `languageCode` is `"tr"` — zero overhead for other languages

## Changes

| File | Change |
|------|--------|
| `extensions/elevenlabs/turkish-text-normalize.ts` | New: `normalizeTurkishForTts()` — circumflex vowel replacement |
| `extensions/elevenlabs/turkish-text-normalize.test.ts` | 6 test cases (circumflex, uppercase, standard chars, empty, mixed) |
| `extensions/elevenlabs/speech-provider.ts` | Lazy-load + apply Turkish normalize before `elevenLabsTTS()` call |

## Test plan

- [x] 6 unit tests pass
- [x] `pnpm build` succeeds
- [x] Lazy-loaded — no overhead when language is not Turkish

🤖 Generated with [Claude Code](https://claude.com/claude-code)