### PR TITLE
fix(cron): guard against missing job.state in start() (#66016)

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -110,6 +110,15 @@ export async function start(state: CronServiceState) {
     await ensureLoaded(state, { skipRecompute: true });
     const jobs = state.store?.jobs ?? [];
     for (const job of jobs) {
+      // Guard against jobs loaded from older store formats that may lack a
+      // `state` field entirely. The rest of the scheduler (isRunnableJob,
+      // isJobDue) already does `if (!job.state) job.state = {}`; mirror it
+      // here so startup does not crash with
+      // `TypeError: Cannot read properties of undefined (reading 'runningAtMs')`
+      // during runMissedJobs → planStartupCatchup. (#66016)
+      if (!job.state) {
+        job.state = {};
+      }
       if (typeof job.state.runningAtMs === "number") {
         state.deps.log.warn(
           { jobId: job.id, runningAtMs: job.state.runningAtMs },


### PR DESCRIPTION
## Summary
The cron \`start()\` routine in \`src/cron/service/ops.ts\` scans \`state.store.jobs\` directly and reads \`job.state.runningAtMs\` without first checking whether \`job.state\` is defined. Jobs loaded from older store formats can lack the \`state\` field entirely, and the scheduler crashes on startup with:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'runningAtMs')
\`\`\`

This is a beta-blocker regression — gateway crash-loops, WebSocket RPC handshake stalls, and \`openclaw cron add/list\` CLI commands hang indefinitely.

Credit to #66016 for a precise root-cause trace including the exact line and a comparison with the correctly-guarded \`isRunnableJob\`/\`isJobDue\` paths.

## Scope of the fix
The downstream catch-up path goes through \`isRunnableJob\`, which already does \`if (!job.state) job.state = {}\` for exactly this reason, so \`collectRunnableJobs\` is safe. Only the unguarded startup scan in \`start()\` crashes.

This PR mirrors the existing \`isRunnableJob\`/\`isJobDue\` defensive init at the crash site — idiomatic to the surrounding code, minimal surface area.

Closes #66016.

## Changes
- \`src/cron/service/ops.ts\` — add \`if (!job.state) { job.state = {}; }\` guard before the \`runningAtMs\` read in the \`start()\` startup loop, with a comment explaining why and pointing at the matching pattern elsewhere

## Test plan
- [x] 4-line fix, all existing tests continue to pass
- [x] Mirrors the documented pattern in \`isRunnableJob\` / \`isJobDue\` — no new contract
- [x] Beta-blocker fix: addresses a hard crash on gateway startup when the cron store contains legacy jobs
- [ ] Ideally this also needs a regression test that loads a job without \`state\` and calls \`start()\` — I can add it in a follow-up if maintainers want

🤖 Generated with [Claude Code](https://claude.com/claude-code)