### PR TITLE
fix(whatsapp): add pairing message locale and credential age warning

### DIFF
--- a/extensions/whatsapp/src/auth-store.ts
+++ b/extensions/whatsapp/src/auth-store.ts
@@ -80,6 +80,17 @@ export async function webAuthExists(authDir: string = resolveDefaultWebAuthDir()
     }
     const raw = await fs.readFile(credsPath, "utf-8");
     JSON.parse(raw);
+    // Warn when credentials are older than 30 days — they may need
+    // re-authentication if the WhatsApp session has expired.
+    const ageDays = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60 * 24);
+    if (ageDays > 30) {
+      const logger = getChildLogger({ module: "web-session" });
+      logger.warn(
+        { credsPath, ageDays: Math.round(ageDays) },
+        "WhatsApp credentials file is %d days old — consider re-authenticating if connection issues occur",
+        Math.round(ageDays),
+      );
+    }
     return true;
   } catch {
     return false;

--- a/src/pairing/pairing-messages.ts
+++ b/src/pairing/pairing-messages.ts
@@ -1,23 +1,51 @@
 import { formatCliCommand } from "../cli/command-format.js";
 import type { PairingChannel } from "./pairing-store.types.js";
 
+type PairingLocaleStrings = {
+  accessNotConfigured: string;
+  pairingCode: string;
+  askOwnerToApprove: string;
+};
+
+const PAIRING_LOCALES: Record<string, PairingLocaleStrings> = {
+  en: {
+    accessNotConfigured: "OpenClaw: access not configured.",
+    pairingCode: "Pairing code:",
+    askOwnerToApprove: "Ask the bot owner to approve with:",
+  },
+  tr: {
+    accessNotConfigured: "OpenClaw: erişim yapılandırılmamış.",
+    pairingCode: "Eşleşme kodu:",
+    askOwnerToApprove: "Bot sahibinden şu komutla onay isteyin:",
+  },
+};
+
+function resolveLocaleStrings(locale?: string): PairingLocaleStrings {
+  if (locale && PAIRING_LOCALES[locale]) {
+    return PAIRING_LOCALES[locale];
+  }
+  return PAIRING_LOCALES.en;
+}
+
 export function buildPairingReply(params: {
   channel: PairingChannel;
   idLine: string;
   code: string;
+  locale?: string;
 }): string {
   const { channel, idLine, code } = params;
+  const strings = resolveLocaleStrings(params.locale);
   const approveCommand = formatCliCommand(`openclaw pairing approve ${channel} ${code}`);
   return [
-    "OpenClaw: access not configured.",
+    strings.accessNotConfigured,
     "",
     idLine,
-    "Pairing code:",
+    strings.pairingCode,
     "```",
     code,
     "```",
     "",
-    "Ask the bot owner to approve with:",
+    strings.askOwnerToApprove,
     formatCliCommand(`openclaw pairing approve ${channel} ${code}`),
     "```",
     approveCommand,


### PR DESCRIPTION
## Summary

- Add locale support to pairing approval messages (Turkish translation included)
- Warn when WhatsApp credential files are older than 30 days

## Changes

| File | Change |
|------|--------|
| `src/pairing/pairing-messages.ts` | Add `locale` parameter + Turkish pairing strings |
| `extensions/whatsapp/src/auth-store.ts` | Add credential mtime check (>30 days → warning log) |

## Test plan

- [x] `pnpm build` succeeds
- [x] Backwards compatible (locale parameter is optional, defaults to English)

🤖 Generated with [Claude Code](https://claude.com/claude-code)