### PR TITLE
fix(discord): narrow batched replay and message ids

### DIFF
--- a/extensions/discord/src/monitor/inbound-dedupe.ts
+++ b/extensions/discord/src/monitor/inbound-dedupe.ts
@@ -69,5 +69,12 @@ export function releaseDiscordInboundReplay(params: {
 function normalizeDiscordInboundReplayKeys(
   replayKeys?: readonly (string | null | undefined)[],
 ): string[] {
-  return [...new Set((replayKeys ?? []).map((replayKey) => replayKey?.trim()).filter(Boolean))];
+  return [
+    ...new Set(
+      (replayKeys ?? []).flatMap((replayKey) => {
+        const normalizedReplayKey = replayKey?.trim();
+        return normalizedReplayKey ? [normalizedReplayKey] : [];
+      }),
+    ),
+  ];
 }

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -114,7 +114,7 @@ export function createDiscordMessageHandler(
       if (!last) {
         return;
       }
-      const replayKeys = entries.map((entry) => entry.replayKey).filter(Boolean);
+      const replayKeys = entries.flatMap((entry) => (entry.replayKey ? [entry.replayKey] : []));
       const abortSignal = last.abortSignal;
       if (abortSignal?.aborted) {
         releaseDiscordInboundReplay({
@@ -143,10 +143,12 @@ export function createDiscordMessageHandler(
           return;
         }
         const combinedBaseText = entries
-          .map((entry) =>
-            resolveDiscordMessageText(entry.data.message, { includeForwarded: false }),
-          )
-          .filter(Boolean)
+          .flatMap((entry) => {
+            const baseText = resolveDiscordMessageText(entry.data.message, {
+              includeForwarded: false,
+            });
+            return baseText ? [baseText] : [];
+          })
           .join("\n");
         const syntheticMessage = {
           ...last.data.message,
@@ -177,7 +179,10 @@ export function createDiscordMessageHandler(
         }
         applyImplicitReplyBatchGate(ctx, params.replyToMode, true);
         if (entries.length > 1) {
-          const ids = entries.map((entry) => entry.data.message?.id).filter(Boolean) as string[];
+          const ids = entries.flatMap((entry) => {
+            const messageId = entry.data.message?.id?.trim();
+            return messageId ? [messageId] : [];
+          });
           if (ids.length > 0) {
             const ctxBatch = ctx as typeof ctx & {
               MessageSids?: string[];


### PR DESCRIPTION
## Summary
- narrow replay key batching to concrete strings before passing them into the inbound job and replay guard
- narrow synthesized message text and batched message ids without relying on `filter(Boolean)` casts
- keep the existing debounce and replay behavior while satisfying the package-boundary TypeScript checks

## Why
The Discord monitor was building batched replay key and message id arrays from optional values. Recent TypeScript tightening no longer accepts `filter(Boolean)` here as sufficient narrowing, which breaks the extension package-boundary compile in CI even though runtime behavior is unchanged.

## Testing
- `PATH="/tmp/pnpm-bin:$PATH" pnpm exec tsc -p extensions/discord/tsconfig.json --noEmit`
- `PATH="/tmp/pnpm-bin:$PATH" node scripts/test-projects.mjs extensions/discord/src/monitor/message-handler.queue.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/discord/src/monitor/message-handler.bot-self-filter.test.ts`
- `PATH="/tmp/pnpm-bin:$PATH" pnpm test:extensions:package-boundary` (now progresses past `discord`; current failure moves to unrelated `whatsapp` errors)
