### PR TITLE
fix(whatsapp): narrow inbound dedupe keys

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -131,7 +131,14 @@ export async function attachWebInboxToSocket(
     entries: QueuedInboundMessage[],
     error?: unknown,
   ): Promise<void> => {
-    const dedupeKeys = [...new Set(entries.map((entry) => entry.dedupeKey).filter(Boolean))];
+    const dedupeKeys = [
+      ...new Set(
+        entries.flatMap((entry) => {
+          const dedupeKey = entry.dedupeKey?.trim();
+          return dedupeKey ? [dedupeKey] : [];
+        }),
+      ),
+    ];
     if (dedupeKeys.length === 0) {
       return;
     }


### PR DESCRIPTION
## Summary
- narrow inbound dedupe keys to concrete strings before commit/release operations
- stop relying on `filter(Boolean)` for TypeScript narrowing in the inbound monitor
- preserve existing dedupe behavior by trimming, dropping empty values, and deduplicating keys

## Why
The WhatsApp inbound monitor builds batched dedupe keys from optional per-message values. Recent TypeScript tightening no longer treats `filter(Boolean)` as sufficient narrowing here, which breaks the package-boundary compile for the extension.

## Testing
- `PATH="/tmp/pnpm-bin:$PATH" pnpm exec tsc -p extensions/whatsapp/tsconfig.json --noEmit`
- `PATH="/tmp/pnpm-bin:$PATH" node scripts/test-projects.mjs extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts`
