### PR TITLE
fix(daemon): ignore setlocal in Windows task parsing

### DIFF
--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -8,6 +8,7 @@ import {
   readScheduledTaskCommand,
   resolveTaskScriptPath,
 } from "./schtasks.js";
+import { quoteCmdScriptArg } from "./cmd-argv.js";
 
 describe("schtasks runtime parsing", () => {
   it.each(["Ready", "Running"])("parses %s status", (status) => {
@@ -243,6 +244,344 @@ describe("readScheduledTaskCommand", () => {
     );
   });
 
+  it("ignores setlocal directives before the real gateway command", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "setlocal enabledelayedexpansion",
+          "set OPENCLAW_PORT=18789",
+          "node gateway.js --verbose",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--verbose"],
+          environment: {
+            OPENCLAW_PORT: "18789",
+          },
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("ignores set lines that do not parse as assignments before the gateway command", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "set /a 1+1",
+          "set DISPLAY_ONLY_VAR",
+          "set OPENCLAW_PORT=18789",
+          "node gateway.js --verbose",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--verbose"],
+          environment: {
+            OPENCLAW_PORT: "18789",
+          },
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("ignores bare setlocal lines", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", "setlocal", "node gateway.js"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("parses the real command when setlocal shares a line with && chaining", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "setlocal enabledelayedexpansion && set OPENCLAW_PORT=18789 && node gateway.js --verbose",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--verbose"],
+          environment: {
+            OPENCLAW_PORT: "18789",
+          },
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("parses the real command when setlocal shares a line with single-pipe chaining", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", "setlocal enabledelayedexpansion | node gateway.js --port 18789"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--port", "18789"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("does not apply set from the left side of a pipe to the parsed gateway command", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", "set OPENCLAW_GATEWAY_PORT=99999 | node gateway.js gateway"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "gateway"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+        expect(result?.environment?.OPENCLAW_GATEWAY_PORT).toBeUndefined();
+      },
+    );
+  });
+
+  it("does not apply set from a right-hand pipe stage to following script lines", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "rem | set OPENCLAW_GATEWAY_PORT=99999",
+          "node gateway.js --port 18789",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--port", "18789"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+        expect(result?.environment?.OPENCLAW_GATEWAY_PORT).toBeUndefined();
+      },
+    );
+  });
+
+  it("applies RHS pipe-stage set before the same stage's command (chained with &&)", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "rem | set OPENCLAW_GATEWAY_PORT=9999 && node gateway.js gateway",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "gateway"],
+          environment: {
+            OPENCLAW_GATEWAY_PORT: "9999",
+          },
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("applies staged RHS env before a pipe-stage command when a second pipe follows (e.g. findstr)", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "rem | set OPENCLAW_GATEWAY_PORT=9999 && node gateway.js gateway | findstr /i running",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "gateway"],
+          environment: {
+            OPENCLAW_GATEWAY_PORT: "9999",
+          },
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("does not apply cd from the left side of a pipe to the parsed gateway command", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ['@echo off', 'cd /d "D:\\PipeLeftOnly" | node gateway.js gateway'],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "gateway"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+        expect(result?.workingDirectory).toBeUndefined();
+      },
+    );
+  });
+
+  it("keeps the gateway launch on the left side of a pipe (e.g. piped to findstr)", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", "node gateway.js --port 18789 | findstr Running"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--port", "18789"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("parses the real command when endlocal shares a line with a fallback command", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", "endlocal || node gateway.js --port 18789"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--port", "18789"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("does not split chained statements inside backslash-escaped quotes", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ['@echo off', 'node gateway.js --flag "a\\"b&c" --port 18789'],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--flag", 'a"b&c', "--port", "18789"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("preserves chained separators inside rendered backslash-plus-quote arguments", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          `node gateway.js --flag ${quoteCmdScriptArg('a\\"b&c')} --port 18789`,
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--flag", 'a\\"b&c', "--port", "18789"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("drops setlocal-scoped assignments after endlocal before the real command", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "setlocal enabledelayedexpansion",
+          "set FOO=bar",
+          "endlocal",
+          "node gateway.js --port 18789",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--port", "18789"],
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("restores outer env assignments after endlocal (shadowed vars)", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "set OPENCLAW_GATEWAY_PORT=18789",
+          "setlocal enabledelayedexpansion",
+          "set OPENCLAW_GATEWAY_PORT=99999",
+          "endlocal",
+          "node gateway.js gateway",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "gateway"],
+          environment: {
+            OPENCLAW_GATEWAY_PORT: "18789",
+          },
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("returns null when script contains only env-scope directives and comments", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", "setlocal", "rem comment", "endlocal"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toBeNull();
+      },
+    );
+  });
+
+  it("preserves working directory and env assignments around setlocal directives", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: [
+          "@echo off",
+          "setlocal enabledelayedexpansion",
+          "cd /d C:\\Projects\\openclaw",
+          "set NODE_ENV=production",
+          "node gateway.js --port 18789",
+        ],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "--port", "18789"],
+          workingDirectory: "C:\\Projects\\openclaw",
+          environment: {
+            NODE_ENV: "production",
+          },
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
   it("parses command with Windows backslash paths", async () => {
     await withScheduledTaskScript(
       {
@@ -330,6 +669,21 @@ describe("readScheduledTaskCommand", () => {
           OC_PERCENT: "%TEMP%",
           OC_BANG: "!token!",
           OC_QUOTE: 'he said "hi"',
+        });
+      },
+    );
+  });
+
+  it("does not split batch chains on `<&` input-handle redirection (#66062)", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", "node gateway.js gateway <&3 --port 18789"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js", "gateway", "<&3", "--port", "18789"],
+          sourcePath: resolveTaskScriptPath(env),
         });
       },
     );

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -108,6 +108,143 @@ function resolveTaskUser(env: GatewayServiceEnv): string | null {
   return username;
 }
 
+type BatchScriptLine =
+  | { kind: "empty" }
+  | { kind: "echo" }
+  | { kind: "comment" }
+  | { kind: "env_scope" }
+  | { kind: "setlocal" }
+  | { kind: "endlocal" }
+  | { kind: "env_assignment"; key: string; value: string }
+  | { kind: "working_directory"; path: string }
+  | { kind: "command"; raw: string };
+
+function restoreEnvironmentSnapshot(
+  target: Record<string, string>,
+  snapshot: Record<string, string>,
+): void {
+  for (const key of Object.keys(target)) {
+    if (!(key in snapshot)) {
+      delete target[key];
+    }
+  }
+  for (const [key, value] of Object.entries(snapshot)) {
+    target[key] = value;
+  }
+}
+
+type BatchStatementSplit = {
+  statement: string;
+  remainder: string;
+  /** True when split at a single `|` (CMD pipe). LHS side effects do not apply to the RHS command. */
+  usedSinglePipe: boolean;
+};
+
+function isBackslashEscapedQuote(value: string, index: number): boolean {
+  return index > 0 && value[index - 1] === "\\";
+}
+
+function splitFirstBatchStatement(rawLine: string): BatchStatementSplit {
+  let inQuotes = false;
+  let escaped = false;
+  for (let index = 0; index < rawLine.length; index += 1) {
+    const current = rawLine[index];
+    if (!current) {
+      continue;
+    }
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (current === "^") {
+      escaped = true;
+      continue;
+    }
+    if (current === '"' && !isBackslashEscapedQuote(rawLine, index)) {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (inQuotes) {
+      continue;
+    }
+
+    const next = rawLine[index + 1] ?? "";
+    if ((current === "&" && next === "&") || (current === "|" && next === "|")) {
+      return {
+        statement: rawLine.slice(0, index).trim(),
+        remainder: rawLine.slice(index + 2).trim(),
+        usedSinglePipe: false,
+      };
+    }
+    // Single `|` is CMD pipe; split so prologue directives (setlocal, set, …) do not
+    // hide the real command on the same line (e.g. `setlocal … | node gateway.js`).
+    if (current === "|") {
+      return {
+        statement: rawLine.slice(0, index).trim(),
+        remainder: rawLine.slice(index + 1).trim(),
+        usedSinglePipe: true,
+      };
+    }
+    if (current === "&") {
+      const prev = index > 0 ? rawLine[index - 1] : "";
+      // `2>&1`-style merges use `&` after `>`; `<&3` input-handle redirection uses `&` after `<`.
+      // Those are not CMD chain separators (unquoted `&` / `&&`).
+      if (prev !== ">" && prev !== "<") {
+        return {
+          statement: rawLine.slice(0, index).trim(),
+          remainder: rawLine.slice(index + 1).trim(),
+          usedSinglePipe: false,
+        };
+      }
+    }
+  }
+  return {
+    statement: rawLine.trim(),
+    remainder: "",
+    usedSinglePipe: false,
+  };
+}
+
+function classifyBatchScriptLine(rawLine: string): BatchScriptLine {
+  const line = rawLine.trim();
+  if (!line) {
+    return { kind: "empty" };
+  }
+
+  const lower = normalizeLowercaseStringOrEmpty(line);
+  if (line.startsWith("@echo")) {
+    return { kind: "echo" };
+  }
+  if (lower === "rem" || lower.startsWith("rem ")) {
+    return { kind: "comment" };
+  }
+  if (lower === "setlocal" || lower.startsWith("setlocal ")) {
+    return { kind: "setlocal" };
+  }
+  if (lower === "endlocal" || lower.startsWith("endlocal ")) {
+    return { kind: "endlocal" };
+  }
+  if (lower.startsWith("set ")) {
+    const assignment = parseCmdSetAssignment(line.slice(4));
+    if (assignment) {
+      return {
+        kind: "env_assignment",
+        key: assignment.key,
+        value: assignment.value,
+      };
+    }
+    // Non-assignment SET forms (set /a, set /p, bare `set VAR`, etc.): skip like the pre-refactor loop.
+    return { kind: "env_scope" };
+  }
+  if (lower.startsWith("cd /d ")) {
+    return {
+      kind: "working_directory",
+      path: line.slice("cd /d ".length).trim().replace(/^"|"$/g, ""),
+    };
+  }
+  return { kind: "command", raw: line };
+}
+
 export async function readScheduledTaskCommand(
   env: GatewayServiceEnv,
 ): Promise<GatewayServiceCommandConfig | null> {
@@ -117,31 +254,114 @@ export async function readScheduledTaskCommand(
     let workingDirectory = "";
     let commandLine = "";
     const environment: Record<string, string> = {};
+    const setlocalStack: Array<Record<string, string>> = [];
     for (const rawLine of content.split(/\r?\n/)) {
-      const line = rawLine.trim();
-      if (!line) {
-        continue;
-      }
-      const lower = normalizeLowercaseStringOrEmpty(line);
-      if (line.startsWith("@echo")) {
-        continue;
-      }
-      if (lower.startsWith("rem ")) {
-        continue;
-      }
-      if (lower.startsWith("set ")) {
-        const assignment = parseCmdSetAssignment(line.slice(4));
-        if (assignment) {
-          environment[assignment.key] = assignment.value;
+      let remainder = rawLine;
+      // Mutations after a pipe (`a | b`) belong to stage-local contexts; accumulate RHS
+      // setup (`set … && node …`) into `pipeRhsStaging` and merge only when we take a
+      // command from that RHS. Discard staging if the line ends without a command so
+      // `rem | set VAR=1` cannot leak VAR to the next physical line.
+      let pipeRhsStaging: {
+        environment: Record<string, string>;
+        workingDirectory: string;
+        setlocalStack: Array<Record<string, string>>;
+      } | null = null;
+
+      while (remainder.trim()) {
+        const split = splitFirstBatchStatement(remainder);
+        remainder = split.remainder;
+        const lhsPipeStage =
+          split.usedSinglePipe && split.remainder.trim() !== "";
+        const parsedLine = classifyBatchScriptLine(split.statement);
+
+        if (parsedLine.kind === "command") {
+          if (lhsPipeStage) {
+            // Runnable command on the LHS of a later `|` (e.g. `… && node … | findstr`):
+            // still merge any `set`/`cd` setup that ran earlier in the same stage before this
+            // command (e.g. `rem | set PORT=1 && node g.js | findstr`).
+            if (pipeRhsStaging) {
+              Object.assign(environment, pipeRhsStaging.environment);
+              if (pipeRhsStaging.workingDirectory) {
+                workingDirectory = pipeRhsStaging.workingDirectory;
+              }
+            }
+            commandLine = parsedLine.raw;
+            break;
+          }
+          if (pipeRhsStaging) {
+            Object.assign(environment, pipeRhsStaging.environment);
+            if (pipeRhsStaging.workingDirectory) {
+              workingDirectory = pipeRhsStaging.workingDirectory;
+            }
+          }
+          commandLine = parsedLine.raw;
+          break;
         }
-        continue;
+
+        if (lhsPipeStage) {
+          pipeRhsStaging ??= {
+            environment: {},
+            workingDirectory: "",
+            setlocalStack: [],
+          };
+        }
+
+        const suppressMutationEffects = lhsPipeStage;
+        switch (parsedLine.kind) {
+          case "empty":
+          case "echo":
+          case "comment":
+          case "env_scope":
+            continue;
+          case "setlocal":
+            if (!suppressMutationEffects) {
+              if (pipeRhsStaging) {
+                pipeRhsStaging.setlocalStack.push({ ...pipeRhsStaging.environment });
+              } else {
+                setlocalStack.push({ ...environment });
+              }
+            }
+            continue;
+          case "endlocal": {
+            if (suppressMutationEffects) {
+              continue;
+            }
+            if (pipeRhsStaging) {
+              const snapshot = pipeRhsStaging.setlocalStack.pop();
+              if (snapshot) {
+                restoreEnvironmentSnapshot(pipeRhsStaging.environment, snapshot);
+              }
+            } else {
+              const snapshot = setlocalStack.pop();
+              if (snapshot) {
+                restoreEnvironmentSnapshot(environment, snapshot);
+              }
+            }
+            continue;
+          }
+          case "env_assignment":
+            if (!suppressMutationEffects) {
+              if (pipeRhsStaging) {
+                pipeRhsStaging.environment[parsedLine.key] = parsedLine.value;
+              } else {
+                environment[parsedLine.key] = parsedLine.value;
+              }
+            }
+            continue;
+          case "working_directory":
+            if (!suppressMutationEffects) {
+              if (pipeRhsStaging) {
+                pipeRhsStaging.workingDirectory = parsedLine.path;
+              } else {
+                workingDirectory = parsedLine.path;
+              }
+            }
+            continue;
+        }
       }
-      if (lower.startsWith("cd /d ")) {
-        workingDirectory = line.slice("cd /d ".length).trim().replace(/^"|"$/g, "");
-        continue;
+      if (commandLine) {
+        break;
       }
-      commandLine = line;
-      break;
     }
     if (!commandLine) {
       return null;


### PR DESCRIPTION
## Summary
- Problem: `openclaw gateway status` on Windows could flag a healthy Scheduled Task as missing the `gateway` subcommand when the generated task script contained batch prologue directives like `setlocal` before the real command.
- Why it matters: this produced a false-positive service audit warning in `gateway status` / `doctor`, making valid Windows installs look broken.
- What changed: `readScheduledTaskCommand()` now classifies `setlocal` / `endlocal` batch directives explicitly, keeps skipping unsupported `set` forms, and now continues through same-line chained prologue statements before capturing the real gateway command.
- What did NOT change (scope boundary): this PR does not change task installation, task execution, or Windows runtime control flow outside command-line parsing.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #53474
- Related #49126
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: the Windows task-script scanner treated each line as a single batch statement and skipped only `set ` assignments, so `setlocal` / `endlocal` could be misread as the runnable command and same-line chained prologue directives could hide the real gateway command.
- Missing detection / guardrail: there was no regression coverage for Windows task scripts that include batch prologue directives before the real `gateway` command.
- Contributing context (if known): the installed/inspected script format is batch syntax, but the parser only handled the simplest one-statement-per-line subset.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/daemon/schtasks.test.ts`
- Scenario the test should lock in: ignore `setlocal` / `endlocal`, ignore unsupported `set` forms, and continue through `&` / `&&` / `||` chained batch prologue statements until the real gateway command is found.
- Why this is the smallest reliable guardrail: the bug is isolated to `readScheduledTaskCommand()` batch parsing, so focused unit coverage exercises the exact failing path without needing real Windows task registration.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- `openclaw gateway status` / `openclaw doctor` no longer report a false-positive Windows service audit warning when the inspected task script uses `setlocal` / `endlocal` prologue directives before the real gateway command.

## Diagram (if applicable)
```text
Before:
[gateway status] -> [scan gateway.cmd] -> [treat setlocal/prologue as command] -> [false audit warning]

After:
[gateway status] -> [scan gateway.cmd] -> [skip/unwrap batch prologue directives] -> [parse real gateway command] -> [correct audit result]
```

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: Windows 10 (native)
- Runtime/container: Node.js 24 / Vitest daemon project
- Model/provider: N/A
- Integration/channel (if any): Windows Scheduled Task gateway runtime
- Relevant config (redacted): default Windows gateway task script under `%USERPROFILE%\\.openclaw\\gateway.cmd`

### Steps
1. Install or inspect a Windows gateway task script whose batch prologue includes `setlocal` / `endlocal` before the real gateway command.
2. Run `openclaw gateway status` or call `readScheduledTaskCommand()` through the daemon tests.
3. Observe which command line gets parsed.

### Expected
- The parser skips batch prologue directives and returns the real gateway command line.

### Actual
- Before this fix, `setlocal` could be treated as the runnable command and chained prologue directives could prevent the real gateway command from being found.

## Evidence
- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
- Verified scenarios:
  - `pnpm test src/daemon/schtasks.test.ts`
  - `pnpm test src/daemon/schtasks.install.test.ts src/daemon/schtasks.stop.test.ts`
  - reviewed the exact issue root cause in `src/daemon/schtasks.ts` against issue #53474 and the Windows tracker entry in #49126
- Edge cases checked:
  - unsupported `set` forms like `set /a ...` and bare `set VAR`
  - bare `setlocal`
  - `endlocal`
  - same-line chained `setlocal ... && ...` and `endlocal || ...`
- What you did **not** verify:
  - `pnpm check` still stalled locally after `pnpm check:madge-import-cycles` with no further output, matching the behavior already noted on this PR

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations
- Risk: widening parsing to same-line batch chains could accidentally split command text on command separators that are part of shell syntax rather than batch prologues.
  - Mitigation: split only on unquoted / unescaped `&`, `&&`, and `||`, keep `2>&1`-style redirections intact, and lock behavior with focused regression tests.