### PR TITLE
fix(cron): guard legacy jobs without state on startup

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -157,6 +157,42 @@ describe("CronService restart catch-up", () => {
       },
     );
   });
+
+  it("starts cleanly when a persisted job is missing its state object (#66016)", async () => {
+    const dueAt = Date.parse("2025-12-13T15:00:00.000Z");
+
+    await withRestartedCron(
+      [
+        {
+          id: "restart-missing-state",
+          name: "legacy missing state",
+          enabled: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-12T15:00:00.000Z"),
+          schedule: { kind: "every", everyMs: 60_000, anchorMs: dueAt - 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "recover missing state" },
+        },
+      ],
+      async ({ cron, enqueueSystemEvent, requestHeartbeatNow }) => {
+        expect(enqueueSystemEvent).not.toHaveBeenCalled();
+        expect(requestHeartbeatNow).not.toHaveBeenCalled();
+
+        const listedJobs = await cron.list({ includeDisabled: true });
+        const updated = listedJobs.find((job) => job.id === "restart-missing-state");
+        expect(updated?.state).toEqual(
+          expect.objectContaining({
+            nextRunAtMs: expect.any(Number),
+          }),
+        );
+        expect(updated?.state.nextRunAtMs).toBeGreaterThanOrEqual(
+          Date.parse("2025-12-13T17:00:00.000Z"),
+        );
+      },
+    );
+  });
+
   it("replays the most recent missed cron slot after restart when nextRunAtMs already advanced", async () => {
     vi.setSystemTime(new Date("2025-12-13T04:02:00.000Z"));
     await withRestartedCron(

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -110,6 +110,9 @@ export async function start(state: CronServiceState) {
     await ensureLoaded(state, { skipRecompute: true });
     const jobs = state.store?.jobs ?? [];
     for (const job of jobs) {
+      if (!job.state) {
+        job.state = {};
+      }
       if (typeof job.state.runningAtMs === "number") {
         state.deps.log.warn(
           { jobId: job.id, runningAtMs: job.state.runningAtMs },


### PR DESCRIPTION
## Summary

- Problem: cron startup assumed every persisted job already had a state object and crashed on legacy or damaged entries missing that field
- Why it matters: gateway startup could fail before cron recovery logic ran, which blocks CLI and scheduled jobs for affected installs
- What changed: normalize missing job.state objects during cron startup before stale running-marker cleanup, and add a restart regression test for stores missing state
- What did NOT change (scope boundary): catch-up behavior still depends on persisted scheduling metadata; this PR only hardens startup against malformed legacy job records

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66016
- Related #60495
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: cron startup dereferenced job.state.runningAtMs before normalizing legacy store entries that omitted state entirely
- Missing detection / guardrail: startup had no regression test covering persisted jobs without a state object even though later cron paths already normalize it
- Contributing context (if known): older or externally modified cron stores can contain jobs without state metadata

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: src/cron/service.restart-catchup.test.ts
- Scenario the test should lock in: cron.start() should not crash when a persisted recurring job omits state and should recompute a safe nextRunAtMs
- Why this is the smallest reliable guardrail: it exercises the exact startup path that previously dereferenced job.state before any later normalization ran
- Existing test that already covers this (if any): restart catch-up tests cover stale running markers but not missing state
- If no new test is added, why not:

## User-visible / Behavior Changes

- Gateway startup no longer crashes when cron store entries are missing state metadata.

## Diagram (if applicable)

```text
Before:
[cron start] -> [job missing state] -> [job.state.runningAtMs access] -> [TypeError / startup failure]

After:
[cron start] -> [missing state normalized to {}] -> [stale-marker cleanup + schedule recompute] -> [startup continues]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm/vitest
- Model/provider: N/A
- Integration/channel (if any): cron service
- Relevant config (redacted): cronEnabled=true, persisted job missing state

### Steps

1. Persist a cron job record without a state object.
2. Start the cron service.
3. Observe startup behavior.

### Expected

- Cron startup completes and the job is normalized instead of crashing.

### Actual

- Before this fix, startup could throw while reading job.state.runningAtMs.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted vitest run for src/cron/service.restart-catchup.test.ts and src/cron/service/ops.test.ts
- Edge cases checked: persisted recurring job missing state metadata during startup
- What you did **not** verify: full repo-wide pnpm check/test lanes and live Docker reproduction

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: silently normalizing malformed state could mask deeper store corruption
  - Mitigation: the change only creates the same empty state shape that other cron paths already expect, and the regression test locks that startup behavior in

AI-assisted: Yes (Codex). Testing: targeted vitest coverage listed above. I attempted codex review --base origin/main, but the local Codex CLI is currently rate-limited.
