### PR TITLE
fix(feishu): add wait-timeout support to lifecycle helper

### DIFF
--- a/extensions/feishu/src/test-support/lifecycle-test-support.ts
+++ b/extensions/feishu/src/test-support/lifecycle-test-support.ts
@@ -374,18 +374,28 @@ export async function expectFeishuReplyPipelineDedupedAfterPostSendFailure(param
   event: unknown;
   dispatchReplyFromConfigMock: ReturnType<typeof vi.fn>;
   runtimeErrorMock: ReturnType<typeof vi.fn>;
+  waitTimeoutMs?: number;
 }) {
+  const waitTimeoutMs = params.waitTimeoutMs ?? FEISHU_LIFECYCLE_WAIT_TIMEOUT_MS;
   await replayFeishuLifecycleEvent({
     handler: params.handler,
     event: params.event,
-    waitForFirst: () => {
-      expect(params.dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
-      expect(params.runtimeErrorMock).toHaveBeenCalledTimes(1);
-    },
-    waitForSecond: () => {
-      expect(params.dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
-      expect(params.runtimeErrorMock).toHaveBeenCalledTimes(1);
-    },
+    waitForFirst: () =>
+      vi.waitFor(
+        () => {
+          expect(params.dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+          expect(params.runtimeErrorMock).toHaveBeenCalledTimes(1);
+        },
+        waitTimeoutMs == null ? undefined : { timeout: waitTimeoutMs },
+      ),
+    waitForSecond: () =>
+      vi.waitFor(
+        () => {
+          expect(params.dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+          expect(params.runtimeErrorMock).toHaveBeenCalledTimes(1);
+        },
+        waitTimeoutMs == null ? undefined : { timeout: waitTimeoutMs },
+      ),
   });
 }
 


### PR DESCRIPTION
## Summary
- add optional `waitTimeoutMs` support to the Feishu post-send-failure lifecycle helper
- use the same `vi.waitFor(..., { timeout })` pattern already used by the replay helper
- keep lifecycle assertions stable for slower environments without changing production behavior

## Why
The Feishu lifecycle tests already pass `waitTimeoutMs` at several call sites, but `expectFeishuReplyPipelineDedupedAfterPostSendFailure` no longer accepted that field in its helper params. That mismatch now trips TypeScript in CI.

## Testing
- `PATH="/tmp/pnpm-bin:$PATH" node scripts/test-projects.mjs extensions/feishu/src/monitor.bot-menu.lifecycle.test.ts extensions/feishu/src/monitor.card-action.lifecycle.test.ts extensions/feishu/src/monitor.reply-once.lifecycle.test.ts`
