### PR TITLE
fix(nextcloud-talk): align replay test callback contract

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -94,18 +94,19 @@ describe("createNextcloudTalkWebhookServer replay handling", () => {
     stateDir: string;
     accountId?: string;
     handleMessage: (message: NextcloudTalkInboundMessage) => Promise<void>;
-  }) {
+  }): (message: NextcloudTalkInboundMessage) => Promise<void> {
     const replayGuard = createNextcloudTalkReplayGuard({
       stateDir: params.stateDir,
     });
 
-    return async (message: NextcloudTalkInboundMessage) =>
+    return async (message: NextcloudTalkInboundMessage) => {
       await processNextcloudTalkReplayGuardedMessage({
         replayGuard,
         accountId: params.accountId ?? "acct",
         message,
         handleMessage: () => params.handleMessage(message),
       });
+    };
   }
 
   it("acknowledges replayed requests and skips onMessage side effects", async () => {


### PR DESCRIPTION
## Summary
- make the replay-test helper explicitly return `Promise<void>`
- await `processNextcloudTalkReplayGuardedMessage(...)` and discard its internal status string in the test wrapper
- keep the replay assertions unchanged while matching the webhook server `processMessage` contract

## Why
The Nextcloud Talk webhook server expects `processMessage?: (message) => void | Promise<void>`, but the replay test helper was forwarding the replay guard's `"processed" | "duplicate"` status. That widens the `vi.fn()` type and now fails TypeScript in CI.

## Testing
- `PATH="/tmp/pnpm-bin:$PATH" pnpm exec tsc -p extensions/nextcloud-talk/tsconfig.json --noEmit`
- `PATH="/tmp/pnpm-bin:$PATH" node scripts/test-projects.mjs extensions/nextcloud-talk/src/monitor.replay.test.ts`
