### PR TITLE
fix(mcp): widen shutdown test mock signatures

### DIFF
--- a/src/mcp/channel-server.shutdown-unhandled-rejection.test.ts
+++ b/src/mcp/channel-server.shutdown-unhandled-rejection.test.ts
@@ -4,7 +4,7 @@ const transportState = vi.hoisted(() => ({
   lastTransport: null as { onclose?: (() => void) | undefined } | null,
 }));
 const serverState = vi.hoisted(() => ({
-  connect: vi.fn(async () => {}),
+  connect: vi.fn(async (_transport: unknown) => {}),
   close: vi.fn(async () => {}),
 }));
 const bridgeState = vi.hoisted(() => ({
@@ -13,7 +13,7 @@ const bridgeState = vi.hoisted(() => ({
     throw new Error("close boom");
   }),
   setServer: vi.fn(),
-  handleClaudePermissionRequest: vi.fn(async () => {}),
+  handleClaudePermissionRequest: vi.fn(async (_payload: unknown) => {}),
 }));
 
 vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({


### PR DESCRIPTION
## Summary
- widen the mocked MCP server `connect` signature to accept the transport argument used by the test subject
- widen the mocked bridge permission handler signature to accept the payload argument passed by the server
- keep shutdown behavior assertions unchanged while matching the mocked call sites

## Why
`vi.fn(async () => {})` now infers zero-argument mocks here, but the shutdown test forwards one argument into both mocks. That causes TypeScript to flag `Expected 0 arguments, but got 1` in CI.

## Testing
- `PATH="/tmp/pnpm-bin:$PATH" node scripts/test-projects.mjs src/mcp/channel-server.shutdown-unhandled-rejection.test.ts`
- `PATH="/tmp/pnpm-bin:$PATH" pnpm exec tsc -p tsconfig.json --noEmit --pretty false 2>&1 | rg -n "channel-server.shutdown-unhandled-rejection"` (no output)
