### PR TITLE
fix: respect models.mode 'replace' in UI model catalog

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -379,8 +379,8 @@ describe("loadModelCatalog", () => {
 
   it("filters catalog to configured providers when models.mode is 'replace'", async () => {
     mockPiDiscoveryModels([
-      { id: "gpt-4.1", provider: "openai", name: "GPT-4.1" },
-      { id: "claude-sonnet-4", provider: "anthropic", name: "Claude Sonnet 4" },
+      { id: "gpt-5.4", provider: "openai", name: "GPT-5.4" },
+      { id: "claude-sonnet-4-6", provider: "anthropic", name: "Claude Sonnet 4.6" },
       { id: "gemini-3-pro", provider: "google", name: "Gemini 3 Pro" },
     ]);
 
@@ -392,8 +392,8 @@ describe("loadModelCatalog", () => {
             baseUrl: "https://api.anthropic.com",
             models: [
               {
-                id: "claude-sonnet-4",
-                name: "Claude Sonnet 4",
+                id: "claude-sonnet-4-6",
+                name: "Claude Sonnet 4.6",
                 reasoning: true,
                 input: ["text"],
                 cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -410,7 +410,7 @@ describe("loadModelCatalog", () => {
 
     // Only anthropic models should survive.
     expect(result).toContainEqual(
-      expect.objectContaining({ provider: "anthropic", id: "claude-sonnet-4" }),
+      expect.objectContaining({ provider: "anthropic", id: "claude-sonnet-4-6" }),
     );
     expect(result).not.toContainEqual(expect.objectContaining({ provider: "openai" }));
     expect(result).not.toContainEqual(expect.objectContaining({ provider: "google" }));
@@ -418,8 +418,8 @@ describe("loadModelCatalog", () => {
 
   it("returns full catalog when models.mode is 'merge'", async () => {
     mockPiDiscoveryModels([
-      { id: "gpt-4.1", provider: "openai", name: "GPT-4.1" },
-      { id: "claude-sonnet-4", provider: "anthropic", name: "Claude Sonnet 4" },
+      { id: "gpt-5.4", provider: "openai", name: "GPT-5.4" },
+      { id: "claude-sonnet-4-6", provider: "anthropic", name: "Claude Sonnet 4.6" },
     ]);
 
     const cfg = {
@@ -430,8 +430,8 @@ describe("loadModelCatalog", () => {
             baseUrl: "https://api.anthropic.com",
             models: [
               {
-                id: "claude-sonnet-4",
-                name: "Claude Sonnet 4",
+                id: "claude-sonnet-4-6",
+                name: "Claude Sonnet 4.6",
                 reasoning: true,
                 input: ["text"],
                 cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -448,9 +448,9 @@ describe("loadModelCatalog", () => {
 
     // Both providers should be present in merge mode.
     expect(result).toContainEqual(
-      expect.objectContaining({ provider: "anthropic", id: "claude-sonnet-4" }),
+      expect.objectContaining({ provider: "anthropic", id: "claude-sonnet-4-6" }),
     );
-    expect(result).toContainEqual(expect.objectContaining({ provider: "openai", id: "gpt-4.1" }));
+    expect(result).toContainEqual(expect.objectContaining({ provider: "openai", id: "gpt-5.4" }));
   });
 
   it("matches models across canonical provider aliases", () => {

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -377,6 +377,82 @@ describe("loadModelCatalog", () => {
     expect(matches[0]?.name).toBe("Kilo Auto");
   });
 
+  it("filters catalog to configured providers when models.mode is 'replace'", async () => {
+    mockPiDiscoveryModels([
+      { id: "gpt-4.1", provider: "openai", name: "GPT-4.1" },
+      { id: "claude-sonnet-4", provider: "anthropic", name: "Claude Sonnet 4" },
+      { id: "gemini-3-pro", provider: "google", name: "Gemini 3 Pro" },
+    ]);
+
+    const cfg = {
+      models: {
+        mode: "replace" as const,
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com",
+            models: [
+              {
+                id: "claude-sonnet-4",
+                name: "Claude Sonnet 4",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await loadModelCatalog({ config: cfg });
+
+    // Only anthropic models should survive.
+    expect(result).toContainEqual(
+      expect.objectContaining({ provider: "anthropic", id: "claude-sonnet-4" }),
+    );
+    expect(result).not.toContainEqual(expect.objectContaining({ provider: "openai" }));
+    expect(result).not.toContainEqual(expect.objectContaining({ provider: "google" }));
+  });
+
+  it("returns full catalog when models.mode is 'merge'", async () => {
+    mockPiDiscoveryModels([
+      { id: "gpt-4.1", provider: "openai", name: "GPT-4.1" },
+      { id: "claude-sonnet-4", provider: "anthropic", name: "Claude Sonnet 4" },
+    ]);
+
+    const cfg = {
+      models: {
+        mode: "merge" as const,
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com",
+            models: [
+              {
+                id: "claude-sonnet-4",
+                name: "Claude Sonnet 4",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 200000,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await loadModelCatalog({ config: cfg });
+
+    // Both providers should be present in merge mode.
+    expect(result).toContainEqual(
+      expect.objectContaining({ provider: "anthropic", id: "claude-sonnet-4" }),
+    );
+    expect(result).toContainEqual(expect.objectContaining({ provider: "openai", id: "gpt-4.1" }));
+  });
+
   it("matches models across canonical provider aliases", () => {
     expect(
       findModelInCatalog([{ provider: "z.ai", id: "glm-5", name: "GLM-5" }], "z-ai", "glm-5"),

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -176,6 +176,26 @@ export async function loadModelCatalog(params?: {
       }
       logStage("plugin-models-merged", `entries=${models.length}`);
 
+      // When models.mode is "replace", the user expects ONLY models from their
+      // explicitly configured providers to appear in the catalog (and the UI
+      // model-selector dropdown).  Filter out any built-in registry entries
+      // whose provider is not listed in cfg.models.providers.
+      if (cfg.models?.mode === "replace") {
+        const configuredProviders = cfg.models?.providers;
+        if (configuredProviders && typeof configuredProviders === "object") {
+          const allowedProviders = new Set(
+            Object.keys(configuredProviders).map((p) => normalizeProviderId(p)),
+          );
+          // Walk backwards so splice indices stay valid.
+          for (let i = models.length - 1; i >= 0; i--) {
+            if (!allowedProviders.has(normalizeProviderId(models[i].provider))) {
+              models.splice(i, 1);
+            }
+          }
+          logStage("replace-mode-filtered", `entries=${models.length}`);
+        }
+      }
+
       if (models.length === 0) {
         // If we found nothing, don't cache this result so we can try again.
         modelCatalogPromise = null;


### PR DESCRIPTION
## Summary

- **Bug**: When `models.mode` is set to `"replace"` in the OpenClaw config, the gateway runtime correctly restricts inference to user-configured providers only. However, the Control UI model-selector dropdown still displayed the full 833-model built-in catalog because `loadModelCatalog()` unconditionally loaded every model from the built-in `ModelRegistry`, ignoring the mode setting.
- **Fix**: After merging plugin/discovery models, `loadModelCatalog()` now checks `cfg.models.mode`. When mode is `"replace"`, the catalog is filtered to keep only models whose provider appears in `cfg.models.providers`. Provider matching uses `normalizeProviderId()` so that aliases (e.g. `anthropic` vs `anthropic-ai`) are handled correctly. The `"merge"` mode (default) is unaffected and continues to return the full catalog.
- **Files changed**: `src/agents/model-catalog.ts` (filtering logic), `src/agents/model-catalog.test.ts` (two new test cases covering replace and merge modes).

## Test plan

- [x] New unit test: `"filters catalog to configured providers when models.mode is 'replace'"` -- verifies that only the configured provider's models survive and other providers are excluded.
- [x] New unit test: `"returns full catalog when models.mode is 'merge'"` -- verifies merge mode returns models from all providers (no regression).
- [ ] Manual: set `models.mode: "replace"` with a single provider in config, open the Control UI model dropdown, and confirm only that provider's models appear.
- [ ] Manual: set `models.mode: "merge"` (or omit it) and confirm the full catalog is still shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)