### PR TITLE
fix(cron): promote silent-undefined schedule to error, break spin loop (#66019)

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -99,6 +99,21 @@ vi.mock("../infra/update-check.js", () => ({
 
 vi.mock("../infra/runtime-guard.js", () => ({
   nodeVersionSatisfiesEngine,
+  isAtLeast: (
+    version: { major: number; minor: number; patch: number } | null,
+    minimum: { major: number; minor: number; patch: number },
+  ) => {
+    if (!version) {
+      return false;
+    }
+    if (version.major !== minimum.major) {
+      return version.major > minimum.major;
+    }
+    if (version.minor !== minimum.minor) {
+      return version.minor > minimum.minor;
+    }
+    return version.patch >= minimum.patch;
+  },
   parseSemver: (version: string | null) => {
     if (!version) {
       return null;

--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as schedule from "../schedule.js";
 import type { CronJob, CronStoreFile } from "../types.js";
-import { recomputeNextRuns } from "./jobs.js";
+import { recomputeNextRuns, recomputeNextRunsForMaintenance } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
 
 function createMockState(jobs: CronJob[]): CronServiceState {
@@ -140,6 +141,57 @@ describe("cron schedule error isolation", () => {
     expect(changed).toBe(true);
     expect(job.state.nextRunAtMs).toBeDefined();
     expect(job.state.scheduleErrorCount).toBeUndefined();
+  });
+
+  it("keeps scheduleErrorCount when maintenance cron computation returns undefined", () => {
+    const job = createJob({
+      id: "undefined-next-run",
+      name: "Undefined Next Run",
+      state: { scheduleErrorCount: 1 },
+    });
+    const state = createMockState([job]);
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      const changed = recomputeNextRunsForMaintenance(state);
+
+      expect(changed).toBe(true);
+      expect(job.state.nextRunAtMs).toBeUndefined();
+      expect(job.state.lastError).toContain("schedule computation returned undefined");
+      expect(job.state.scheduleErrorCount).toBe(2);
+      expect(job.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
+  it("auto-disables cron jobs after repeated undefined next-run computations", () => {
+    const job = createJob({
+      id: "undefined-next-run-threshold",
+      name: "Undefined Next Run Threshold",
+      state: { scheduleErrorCount: 2 },
+    });
+    const state = createMockState([job]);
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      const changed = recomputeNextRunsForMaintenance(state);
+
+      expect(changed).toBe(true);
+      expect(job.enabled).toBe(false);
+      expect(job.state.nextRunAtMs).toBeUndefined();
+      expect(job.state.scheduleErrorCount).toBe(3);
+      expect(state.deps.log.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: "undefined-next-run-threshold",
+          name: "Undefined Next Run Threshold",
+          errorCount: 3,
+        }),
+        expect.stringContaining("auto-disabled job"),
+      );
+    } finally {
+      nextRunSpy.mockRestore();
+    }
   });
 
   it("does not modify disabled jobs", () => {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -442,6 +442,13 @@ function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob
   let changed = false;
   try {
     let newNext = computeJobNextRunAtMs(params.job, params.nowMs);
+    if (params.job.schedule.kind === "cron" && newNext === undefined) {
+      return recordScheduleComputeError({
+        state: params.state,
+        job: params.job,
+        err: new Error("schedule computation returned undefined"),
+      });
+    }
     if (
       params.job.schedule.kind !== "at" &&
       params.job.state.lastStatus === "error" &&

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -443,7 +443,6 @@ function recomputeJobNextRunAtMs(params: {
   job: CronJob;
   nowMs: number;
   suppressScheduleComputeError?: boolean;
-  preserveScheduleErrorCount?: boolean;
   recordedScheduleComputeErrorJobIds?: Set<string>;
 }) {
   let changed = false;
@@ -485,7 +484,7 @@ function recomputeJobNextRunAtMs(params: {
       changed = true;
     }
     // Clear schedule error count on successful computation.
-    if (params.job.state.scheduleErrorCount && !params.preserveScheduleErrorCount) {
+    if (params.job.state.scheduleErrorCount) {
       params.job.state.scheduleErrorCount = undefined;
       changed = true;
     }
@@ -505,7 +504,6 @@ export function recomputeNextRuns(
   state: CronServiceState,
   opts?: {
     suppressScheduleComputeErrorJobIds?: ReadonlySet<string>;
-    preserveScheduleErrorCountJobIds?: ReadonlySet<string>;
     recordedScheduleComputeErrorJobIds?: Set<string>;
   },
 ): boolean {
@@ -524,7 +522,6 @@ export function recomputeNextRuns(
           nowMs: now,
           suppressScheduleComputeError:
             opts?.suppressScheduleComputeErrorJobIds?.has(job.id) ?? false,
-          preserveScheduleErrorCount: opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
           recordedScheduleComputeErrorJobIds: opts?.recordedScheduleComputeErrorJobIds,
         })
       ) {
@@ -548,7 +545,6 @@ export function recomputeNextRunsForMaintenance(
     recomputeExpired?: boolean;
     nowMs?: number;
     suppressScheduleComputeErrorJobIds?: ReadonlySet<string>;
-    preserveScheduleErrorCountJobIds?: ReadonlySet<string>;
     recordedScheduleComputeErrorJobIds?: Set<string>;
   },
 ): boolean {
@@ -565,8 +561,6 @@ export function recomputeNextRunsForMaintenance(
             nowMs: now,
             suppressScheduleComputeError:
               opts?.suppressScheduleComputeErrorJobIds?.has(job.id) ?? false,
-            preserveScheduleErrorCount:
-              opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
             recordedScheduleComputeErrorJobIds: opts?.recordedScheduleComputeErrorJobIds,
           })
         ) {
@@ -589,8 +583,6 @@ export function recomputeNextRunsForMaintenance(
               nowMs: now,
               suppressScheduleComputeError:
                 opts?.suppressScheduleComputeErrorJobIds?.has(job.id) ?? false,
-              preserveScheduleErrorCount:
-                opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
               recordedScheduleComputeErrorJobIds: opts?.recordedScheduleComputeErrorJobIds,
             })
           ) {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -512,7 +512,11 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
  */
 export function recomputeNextRunsForMaintenance(
   state: CronServiceState,
-  opts?: { recomputeExpired?: boolean; nowMs?: number },
+  opts?: {
+    recomputeExpired?: boolean;
+    nowMs?: number;
+    skipMissingNextRunJobIds?: ReadonlySet<string>;
+  },
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;
   return walkSchedulableJobs(
@@ -520,6 +524,9 @@ export function recomputeNextRunsForMaintenance(
     ({ job, nowMs: now }) => {
       let changed = false;
       if (!hasScheduledNextRunAtMs(job.state.nextRunAtMs)) {
+        if (opts?.skipMissingNextRunJobIds?.has(job.id)) {
+          return changed;
+        }
         if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
           changed = true;
         }

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -444,6 +444,7 @@ function recomputeJobNextRunAtMs(params: {
   nowMs: number;
   suppressScheduleComputeError?: boolean;
   preserveScheduleErrorCount?: boolean;
+  recordedScheduleComputeErrorJobIds?: Set<string>;
 }) {
   let changed = false;
   try {
@@ -452,6 +453,7 @@ function recomputeJobNextRunAtMs(params: {
       if (params.suppressScheduleComputeError) {
         return changed;
       }
+      params.recordedScheduleComputeErrorJobIds?.add(params.job.id);
       return recordScheduleComputeError({
         state: params.state,
         job: params.job,
@@ -491,6 +493,7 @@ function recomputeJobNextRunAtMs(params: {
     if (params.suppressScheduleComputeError) {
       return changed;
     }
+    params.recordedScheduleComputeErrorJobIds?.add(params.job.id);
     if (recordScheduleComputeError({ state: params.state, job: params.job, err })) {
       changed = true;
     }
@@ -503,6 +506,7 @@ export function recomputeNextRuns(
   opts?: {
     suppressScheduleComputeErrorJobIds?: ReadonlySet<string>;
     preserveScheduleErrorCountJobIds?: ReadonlySet<string>;
+    recordedScheduleComputeErrorJobIds?: Set<string>;
   },
 ): boolean {
   return walkSchedulableJobs(state, ({ job, nowMs: now }) => {
@@ -521,6 +525,7 @@ export function recomputeNextRuns(
           suppressScheduleComputeError:
             opts?.suppressScheduleComputeErrorJobIds?.has(job.id) ?? false,
           preserveScheduleErrorCount: opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
+          recordedScheduleComputeErrorJobIds: opts?.recordedScheduleComputeErrorJobIds,
         })
       ) {
         changed = true;
@@ -544,6 +549,7 @@ export function recomputeNextRunsForMaintenance(
     nowMs?: number;
     suppressScheduleComputeErrorJobIds?: ReadonlySet<string>;
     preserveScheduleErrorCountJobIds?: ReadonlySet<string>;
+    recordedScheduleComputeErrorJobIds?: Set<string>;
   },
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;
@@ -561,6 +567,7 @@ export function recomputeNextRunsForMaintenance(
               opts?.suppressScheduleComputeErrorJobIds?.has(job.id) ?? false,
             preserveScheduleErrorCount:
               opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
+            recordedScheduleComputeErrorJobIds: opts?.recordedScheduleComputeErrorJobIds,
           })
         ) {
           changed = true;
@@ -584,6 +591,7 @@ export function recomputeNextRunsForMaintenance(
                 opts?.suppressScheduleComputeErrorJobIds?.has(job.id) ?? false,
               preserveScheduleErrorCount:
                 opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
+              recordedScheduleComputeErrorJobIds: opts?.recordedScheduleComputeErrorJobIds,
             })
           ) {
             changed = true;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -38,6 +38,12 @@ import type { CronServiceState } from "./state.js";
 const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
 const STAGGER_OFFSET_CACHE_MAX = 4096;
 const staggerOffsetCache = new Map<string, number>();
+/**
+ * Minimum gap between consecutive fires of the same cron job. This prevents
+ * spin-loops when schedule computation lands in the same second as the just
+ * completed run.
+ */
+export const MIN_CRON_REFIRE_GAP_MS = 2_000;
 export const DEFAULT_ERROR_BACKOFF_SCHEDULE_MS = [
   30_000,
   60_000,
@@ -478,6 +484,9 @@ function recomputeJobNextRunAtMs(params: {
       if (newNext !== undefined) {
         newNext = Math.max(newNext, backoffFloor);
       }
+    }
+    if (params.job.schedule.kind === "cron" && newNext !== undefined) {
+      newNext = Math.max(newNext, params.nowMs + MIN_CRON_REFIRE_GAP_MS);
     }
     if (params.job.state.nextRunAtMs !== newNext) {
       params.job.state.nextRunAtMs = newNext;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -438,11 +438,20 @@ function walkSchedulableJobs(
   return changed;
 }
 
-function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob; nowMs: number }) {
+function recomputeJobNextRunAtMs(params: {
+  state: CronServiceState;
+  job: CronJob;
+  nowMs: number;
+  suppressMissingNextRunScheduleError?: boolean;
+  preserveScheduleErrorCount?: boolean;
+}) {
   let changed = false;
   try {
     let newNext = computeJobNextRunAtMs(params.job, params.nowMs);
     if (params.job.schedule.kind === "cron" && newNext === undefined) {
+      if (params.suppressMissingNextRunScheduleError) {
+        return changed;
+      }
       return recordScheduleComputeError({
         state: params.state,
         job: params.job,
@@ -474,7 +483,7 @@ function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob
       changed = true;
     }
     // Clear schedule error count on successful computation.
-    if (params.job.state.scheduleErrorCount) {
+    if (params.job.state.scheduleErrorCount && !params.preserveScheduleErrorCount) {
       params.job.state.scheduleErrorCount = undefined;
       changed = true;
     }
@@ -515,7 +524,8 @@ export function recomputeNextRunsForMaintenance(
   opts?: {
     recomputeExpired?: boolean;
     nowMs?: number;
-    skipMissingNextRunJobIds?: ReadonlySet<string>;
+    suppressMissingNextRunScheduleErrorJobIds?: ReadonlySet<string>;
+    preserveScheduleErrorCountJobIds?: ReadonlySet<string>;
   },
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;
@@ -524,10 +534,17 @@ export function recomputeNextRunsForMaintenance(
     ({ job, nowMs: now }) => {
       let changed = false;
       if (!hasScheduledNextRunAtMs(job.state.nextRunAtMs)) {
-        if (opts?.skipMissingNextRunJobIds?.has(job.id)) {
-          return changed;
-        }
-        if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+        if (
+          recomputeJobNextRunAtMs({
+            state,
+            job,
+            nowMs: now,
+            suppressMissingNextRunScheduleError:
+              opts?.suppressMissingNextRunScheduleErrorJobIds?.has(job.id) ?? false,
+            preserveScheduleErrorCount:
+              opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
+          })
+        ) {
           changed = true;
         }
       } else if (

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -442,14 +442,14 @@ function recomputeJobNextRunAtMs(params: {
   state: CronServiceState;
   job: CronJob;
   nowMs: number;
-  suppressMissingNextRunScheduleError?: boolean;
+  suppressScheduleComputeError?: boolean;
   preserveScheduleErrorCount?: boolean;
 }) {
   let changed = false;
   try {
     let newNext = computeJobNextRunAtMs(params.job, params.nowMs);
     if (params.job.schedule.kind === "cron" && newNext === undefined) {
-      if (params.suppressMissingNextRunScheduleError) {
+      if (params.suppressScheduleComputeError) {
         return changed;
       }
       return recordScheduleComputeError({
@@ -488,6 +488,9 @@ function recomputeJobNextRunAtMs(params: {
       changed = true;
     }
   } catch (err) {
+    if (params.suppressScheduleComputeError) {
+      return changed;
+    }
     if (recordScheduleComputeError({ state: params.state, job: params.job, err })) {
       changed = true;
     }
@@ -495,7 +498,13 @@ function recomputeJobNextRunAtMs(params: {
   return changed;
 }
 
-export function recomputeNextRuns(state: CronServiceState): boolean {
+export function recomputeNextRuns(
+  state: CronServiceState,
+  opts?: {
+    suppressScheduleComputeErrorJobIds?: ReadonlySet<string>;
+    preserveScheduleErrorCountJobIds?: ReadonlySet<string>;
+  },
+): boolean {
   return walkSchedulableJobs(state, ({ job, nowMs: now }) => {
     let changed = false;
     // Only recompute if nextRunAtMs is missing or already past-due.
@@ -504,7 +513,16 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
     const nextRun = job.state.nextRunAtMs;
     const isDueOrMissing = !hasScheduledNextRunAtMs(nextRun) || now >= nextRun;
     if (isDueOrMissing) {
-      if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+      if (
+        recomputeJobNextRunAtMs({
+          state,
+          job,
+          nowMs: now,
+          suppressScheduleComputeError:
+            opts?.suppressScheduleComputeErrorJobIds?.has(job.id) ?? false,
+          preserveScheduleErrorCount: opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
+        })
+      ) {
         changed = true;
       }
     }
@@ -524,7 +542,7 @@ export function recomputeNextRunsForMaintenance(
   opts?: {
     recomputeExpired?: boolean;
     nowMs?: number;
-    suppressMissingNextRunScheduleErrorJobIds?: ReadonlySet<string>;
+    suppressScheduleComputeErrorJobIds?: ReadonlySet<string>;
     preserveScheduleErrorCountJobIds?: ReadonlySet<string>;
   },
 ): boolean {
@@ -539,8 +557,8 @@ export function recomputeNextRunsForMaintenance(
             state,
             job,
             nowMs: now,
-            suppressMissingNextRunScheduleError:
-              opts?.suppressMissingNextRunScheduleErrorJobIds?.has(job.id) ?? false,
+            suppressScheduleComputeError:
+              opts?.suppressScheduleComputeErrorJobIds?.has(job.id) ?? false,
             preserveScheduleErrorCount:
               opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
           })
@@ -557,7 +575,17 @@ export function recomputeNextRunsForMaintenance(
         const lastRun = job.state.lastRunAtMs;
         const alreadyExecutedSlot = isFiniteTimestamp(lastRun) && lastRun >= job.state.nextRunAtMs;
         if (alreadyExecutedSlot) {
-          if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+          if (
+            recomputeJobNextRunAtMs({
+              state,
+              job,
+              nowMs: now,
+              suppressScheduleComputeError:
+                opts?.suppressScheduleComputeErrorJobIds?.has(job.id) ?? false,
+              preserveScheduleErrorCount:
+                opts?.preserveScheduleErrorCountJobIds?.has(job.id) ?? false,
+            })
+          ) {
             changed = true;
           }
         }

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -15,6 +15,7 @@ import {
   setCommandLaneConcurrency,
   waitForActiveTasks,
 } from "../../process/command-queue.js";
+import * as schedule from "../schedule.js";
 import { CommandLane } from "../../process/lanes.js";
 import { enqueueRun, run, start } from "./ops.js";
 import type { CronEvent } from "./state.js";
@@ -226,6 +227,131 @@ describe("cron service ops regressions", () => {
     const staleExecuted = jobs.find((entry) => entry.id === "unrelated-stale-executed");
     expect(unrelated?.state.nextRunAtMs).toBe(dueNextRunAtMs);
     expect((staleExecuted?.state.nextRunAtMs ?? 0) > nowMs).toBe(true);
+  });
+
+  it("does not double-count schedule errors after manual cron.run completion (#66019)", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T17:00:00.000Z");
+    const job = createIsolatedRegressionJob({
+      id: "manual-cron-66019-single-count",
+      name: "manual cron 66019 single count",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "manual target" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [job]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      now = scheduledAt + 25;
+      return { status: "ok" as const, summary: "done" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      const result = await run(state, job.id);
+
+      const updated = state.store?.jobs.find((entry) => entry.id === job.id);
+      expect(result).toEqual({ ok: true, ran: true });
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(updated?.state.scheduleErrorCount).toBe(1);
+      expect(updated?.state.nextRunAtMs).toBeUndefined();
+      expect(updated?.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
+  it("does not double-count pre-existing schedule holes on forced manual cron.run (#66019)", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T17:03:00.000Z");
+    const job = createIsolatedRegressionJob({
+      id: "forced-manual-cron-66019-single-count",
+      name: "forced manual cron 66019 single count",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "manual target" },
+      state: { scheduleErrorCount: 1 },
+    });
+    await writeCronJobs(store.storePath, [job]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      now = scheduledAt + 25;
+      return { status: "ok" as const, summary: "done" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      const result = await run(state, job.id, "force");
+
+      const updated = state.store?.jobs.find((entry) => entry.id === job.id);
+      expect(result).toEqual({ ok: true, ran: true });
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(updated?.state.scheduleErrorCount).toBe(2);
+      expect(updated?.state.nextRunAtMs).toBeUndefined();
+      expect(updated?.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
+  it("does not double-count schedule errors after invalid manual cron.run skip (#66019)", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T17:05:00.000Z");
+    const job = createIsolatedRegressionJob({
+      id: "manual-invalid-cron-66019-single-count",
+      name: "manual invalid cron 66019 single count",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "unsupported main target" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    job.sessionTarget = "main";
+    await writeCronJobs(store.storePath, [job]);
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => scheduledAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(),
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      const result = await run(state, job.id, "force");
+
+      const updated = state.store?.jobs.find((entry) => entry.id === job.id);
+      expect(result).toEqual({ ok: true, ran: false, reason: "invalid-spec" });
+      expect(updated?.state.lastStatus).toBe("skipped");
+      expect(updated?.state.scheduleErrorCount).toBe(1);
+      expect(updated?.state.nextRunAtMs).toBeUndefined();
+      expect(updated?.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
   });
 
   it("applies timeoutSeconds to manual cron.run isolated executions", async () => {

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -15,8 +15,8 @@ import {
   setCommandLaneConcurrency,
   waitForActiveTasks,
 } from "../../process/command-queue.js";
-import * as schedule from "../schedule.js";
 import { CommandLane } from "../../process/lanes.js";
+import * as schedule from "../schedule.js";
 import { enqueueRun, run, start } from "./ops.js";
 import type { CronEvent } from "./state.js";
 import { createCronServiceState } from "./state.js";

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -165,7 +165,7 @@ export async function start(state: CronServiceState) {
     }
   });
 
-  await runMissedJobs(state, {
+  const startupScheduleComputeFailedJobIds = await runMissedJobs(state, {
     skipJobIds: interruptedJobIds.size > 0 ? interruptedJobIds : undefined,
   });
 
@@ -174,7 +174,10 @@ export async function start(state: CronServiceState) {
     // this path runs before the scheduler begins servicing regular timer ticks.
     // Avoid an extra reload/write cycle on startup.
     await ensureLoaded(state, { skipRecompute: true });
-    const changed = recomputeNextRuns(state);
+    const changed = recomputeNextRuns(state, {
+      suppressScheduleComputeErrorJobIds: startupScheduleComputeFailedJobIds,
+      preserveScheduleErrorCountJobIds: startupScheduleComputeFailedJobIds,
+    });
     if (changed) {
       await persist(state);
     }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -446,6 +446,15 @@ type ManualRunPreflightResult =
 
 let nextManualRunId = 1;
 
+function collectNewScheduleComputeFailureJobIds(
+  job: CronJob,
+  scheduleErrorCountBefore: number,
+): ReadonlySet<string> | undefined {
+  return (job.state.scheduleErrorCount ?? 0) > scheduleErrorCountBefore
+    ? new Set([job.id])
+    : undefined;
+}
+
 async function skipInvalidPersistedManualRun(params: {
   state: CronServiceState;
   job: CronJob;
@@ -454,6 +463,7 @@ async function skipInvalidPersistedManualRun(params: {
 }) {
   const endedAt = params.state.deps.nowMs();
   const errorText = normalizeCronRunErrorText(params.error);
+  const scheduleErrorCountBefore = params.job.state.scheduleErrorCount ?? 0;
   const shouldDelete = applyJobResult(
     params.state,
     params.job,
@@ -464,6 +474,10 @@ async function skipInvalidPersistedManualRun(params: {
       endedAt,
     },
     { preserveSchedule: params.mode === "force" },
+  );
+  const suppressScheduleComputeErrorJobIds = collectNewScheduleComputeFailureJobIds(
+    params.job,
+    scheduleErrorCountBefore,
   );
 
   emit(params.state, {
@@ -483,7 +497,10 @@ async function skipInvalidPersistedManualRun(params: {
     emit(params.state, { jobId: params.job.id, action: "removed" });
   }
 
-  recomputeNextRunsForMaintenance(params.state, { recomputeExpired: true });
+  recomputeNextRunsForMaintenance(params.state, {
+    recomputeExpired: true,
+    suppressScheduleComputeErrorJobIds,
+  });
   await persist(params.state);
   armTimer(params.state);
 }
@@ -576,7 +593,9 @@ async function inspectManualRunPreflight(
     // Normalize job tick state (clears stale runningAtMs markers) before
     // checking if already running, so a stale marker from a crashed Phase-1
     // persist does not block manual triggers for up to STUCK_RUN_MS (#17554).
-    recomputeNextRunsForMaintenance(state);
+    recomputeNextRunsForMaintenance(state, {
+      suppressScheduleComputeErrorJobIds: mode === "force" ? new Set([id]) : undefined,
+    });
     const job = findJobOrThrow(state, id);
     try {
       assertSupportedJobSpec(job);
@@ -687,6 +706,7 @@ async function finishPreparedManualRun(
       return;
     }
 
+    const scheduleErrorCountBefore = job.state.scheduleErrorCount ?? 0;
     const shouldDelete = applyJobResult(
       state,
       job,
@@ -698,6 +718,10 @@ async function finishPreparedManualRun(
         endedAt,
       },
       { preserveSchedule: mode === "force" },
+    );
+    const suppressScheduleComputeErrorJobIds = collectNewScheduleComputeFailureJobIds(
+      job,
+      scheduleErrorCountBefore,
     );
 
     emit(state, {
@@ -745,7 +769,10 @@ async function finishPreparedManualRun(
       snapshot: postRunSnapshot,
       removed: postRunRemoved,
     });
-    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+    recomputeNextRunsForMaintenance(state, {
+      recomputeExpired: true,
+      suppressScheduleComputeErrorJobIds,
+    });
     await persist(state);
     armTimer(state);
   });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -176,7 +176,6 @@ export async function start(state: CronServiceState) {
     await ensureLoaded(state, { skipRecompute: true });
     const changed = recomputeNextRuns(state, {
       suppressScheduleComputeErrorJobIds: startupScheduleComputeFailedJobIds,
-      preserveScheduleErrorCountJobIds: startupScheduleComputeFailedJobIds,
     });
     if (changed) {
       await persist(state);

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -15,6 +15,7 @@ import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import * as schedule from "../schedule.js";
 import type { CronJob } from "../types.js";
 import { computeJobNextRunAtMs } from "./jobs.js";
+import { start, stop } from "./ops.js";
 import { createCronServiceState, type CronEvent } from "./state.js";
 import {
   DEFAULT_JOB_TIMEOUT_MS,
@@ -1228,6 +1229,93 @@ describe("cron service timer regressions", () => {
       expect(job?.enabled).toBe(true);
     } finally {
       nextRunSpy.mockRestore();
+    }
+  });
+
+  it("does not double-count thrown schedule errors in the completion maintenance pass (#66019)", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T16:10:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "cron-66019-throw-single-count",
+      name: "cron-66019-throw-single-count",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Invalid/Timezone" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      now = scheduledAt + 25;
+      return { status: "ok" as const, summary: "done" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockImplementation(() => {
+      throw new Error("invalid timezone");
+    });
+
+    try {
+      await onTimer(state);
+
+      const job = state.store?.jobs.find((entry) => entry.id === "cron-66019-throw-single-count");
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(job?.state.scheduleErrorCount).toBe(1);
+      expect(job?.state.nextRunAtMs).toBeUndefined();
+      expect(job?.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
+  it("does not triple-count startup catch-up schedule errors (#66019)", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T16:10:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "cron-66019-startup-single-count",
+      name: "cron-66019-startup-single-count",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      now = scheduledAt + 25;
+      return { status: "ok" as const, summary: "done" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      await start(state);
+
+      const job = state.store?.jobs.find((entry) => entry.id === "cron-66019-startup-single-count");
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(job?.state.scheduleErrorCount).toBe(1);
+      expect(job?.state.nextRunAtMs).toBeUndefined();
+      expect(job?.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+      stop(state);
     }
   });
 

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1319,6 +1319,61 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("suppresses startup follow-up recomputes for maintenance schedule errors (#66019)", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T16:20:00.000Z");
+    const dueJob = createIsolatedRegressionJob({
+      id: "cron-66019-startup-due",
+      name: "cron-66019-startup-due",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    const missingNextRunJob = createIsolatedRegressionJob({
+      id: "cron-66019-startup-maintenance",
+      name: "cron-66019-startup-maintenance",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "pong" },
+      state: {},
+    });
+    await writeCronJobs(store.storePath, [dueJob, missingNextRunJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      now = scheduledAt + 25;
+      return { status: "ok" as const, summary: "done" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      await start(state);
+
+      const due = state.store?.jobs.find((entry) => entry.id === "cron-66019-startup-due");
+      const maintenance = state.store?.jobs.find(
+        (entry) => entry.id === "cron-66019-startup-maintenance",
+      );
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(due?.state.scheduleErrorCount).toBe(1);
+      expect(maintenance?.state.scheduleErrorCount).toBe(1);
+      expect(maintenance?.state.nextRunAtMs).toBeUndefined();
+      expect(maintenance?.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+      stop(state);
+    }
+  });
+
   it("force run preserves 'every' anchor while recording manual lastRunAtMs", () => {
     const nowMs = Date.now();
     const everyMs = 24 * 60 * 60 * 1_000;

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1276,6 +1276,54 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("clears schedule error count when completion maintenance recompute recovers (#66019)", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T16:15:00.000Z");
+    const recoveredNextRunAtMs = scheduledAt + 24 * 60 * 60 * 1_000;
+    const cronJob = createIsolatedRegressionJob({
+      id: "cron-66019-completion-recovered",
+      name: "cron-66019-completion-recovered",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      now = scheduledAt + 25;
+      return { status: "ok" as const, summary: "done" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    let computeCalls = 0;
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockImplementation(() => {
+      computeCalls += 1;
+      return computeCalls === 1 ? undefined : recoveredNextRunAtMs;
+    });
+
+    try {
+      await onTimer(state);
+
+      const job = state.store?.jobs.find((entry) => entry.id === "cron-66019-completion-recovered");
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(computeCalls).toBeGreaterThanOrEqual(2);
+      expect(job?.state.scheduleErrorCount).toBeUndefined();
+      expect(job?.state.nextRunAtMs).toBe(recoveredNextRunAtMs);
+      expect(job?.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
   it("does not triple-count startup catch-up schedule errors (#66019)", async () => {
     const store = timerRegressionFixtures.makeStorePath();
     const scheduledAt = Date.parse("2026-04-13T16:10:00.000Z");
@@ -1312,6 +1360,55 @@ describe("cron service timer regressions", () => {
       expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
       expect(job?.state.scheduleErrorCount).toBe(1);
       expect(job?.state.nextRunAtMs).toBeUndefined();
+      expect(job?.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+      stop(state);
+    }
+  });
+
+  it("clears startup catch-up schedule error count when recompute recovers (#66019)", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T16:15:00.000Z");
+    const recoveredNextRunAtMs = scheduledAt + 24 * 60 * 60 * 1_000;
+    const cronJob = createIsolatedRegressionJob({
+      id: "cron-66019-startup-recovered",
+      name: "cron-66019-startup-recovered",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      now = scheduledAt + 25;
+      return { status: "ok" as const, summary: "done" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    let computeCalls = 0;
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockImplementation(() => {
+      computeCalls += 1;
+      return computeCalls === 1 ? undefined : recoveredNextRunAtMs;
+    });
+
+    try {
+      await start(state);
+
+      const job = state.store?.jobs.find((entry) => entry.id === "cron-66019-startup-recovered");
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(computeCalls).toBeGreaterThanOrEqual(2);
+      expect(job?.state.scheduleErrorCount).toBeUndefined();
+      expect(job?.state.nextRunAtMs).toBe(recoveredNextRunAtMs);
       expect(job?.enabled).toBe(true);
     } finally {
       nextRunSpy.mockRestore();

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -14,7 +14,7 @@ import {
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
 import * as schedule from "../schedule.js";
 import type { CronJob } from "../types.js";
-import { computeJobNextRunAtMs } from "./jobs.js";
+import { MIN_CRON_REFIRE_GAP_MS, computeJobNextRunAtMs } from "./jobs.js";
 import { start, stop } from "./ops.js";
 import { createCronServiceState, type CronEvent } from "./state.js";
 import {
@@ -1279,7 +1279,8 @@ describe("cron service timer regressions", () => {
   it("clears schedule error count when completion maintenance recompute recovers (#66019)", async () => {
     const store = timerRegressionFixtures.makeStorePath();
     const scheduledAt = Date.parse("2026-04-13T16:15:00.000Z");
-    const recoveredNextRunAtMs = scheduledAt + 24 * 60 * 60 * 1_000;
+    const recoveredTooSoonNextRunAtMs = scheduledAt + 1_000;
+    const recoveredRefireFloorMs = scheduledAt + 25 + MIN_CRON_REFIRE_GAP_MS;
     const cronJob = createIsolatedRegressionJob({
       id: "cron-66019-completion-recovered",
       name: "cron-66019-completion-recovered",
@@ -1307,7 +1308,7 @@ describe("cron service timer regressions", () => {
     let computeCalls = 0;
     const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockImplementation(() => {
       computeCalls += 1;
-      return computeCalls === 1 ? undefined : recoveredNextRunAtMs;
+      return computeCalls === 1 ? undefined : recoveredTooSoonNextRunAtMs;
     });
 
     try {
@@ -1317,7 +1318,7 @@ describe("cron service timer regressions", () => {
       expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
       expect(computeCalls).toBeGreaterThanOrEqual(2);
       expect(job?.state.scheduleErrorCount).toBeUndefined();
-      expect(job?.state.nextRunAtMs).toBe(recoveredNextRunAtMs);
+      expect(job?.state.nextRunAtMs).toBe(recoveredRefireFloorMs);
       expect(job?.enabled).toBe(true);
     } finally {
       nextRunSpy.mockRestore();
@@ -1370,7 +1371,8 @@ describe("cron service timer regressions", () => {
   it("clears startup catch-up schedule error count when recompute recovers (#66019)", async () => {
     const store = timerRegressionFixtures.makeStorePath();
     const scheduledAt = Date.parse("2026-04-13T16:15:00.000Z");
-    const recoveredNextRunAtMs = scheduledAt + 24 * 60 * 60 * 1_000;
+    const recoveredTooSoonNextRunAtMs = scheduledAt + 1_000;
+    const recoveredRefireFloorMs = scheduledAt + 25 + MIN_CRON_REFIRE_GAP_MS;
     const cronJob = createIsolatedRegressionJob({
       id: "cron-66019-startup-recovered",
       name: "cron-66019-startup-recovered",
@@ -1398,7 +1400,7 @@ describe("cron service timer regressions", () => {
     let computeCalls = 0;
     const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockImplementation(() => {
       computeCalls += 1;
-      return computeCalls === 1 ? undefined : recoveredNextRunAtMs;
+      return computeCalls === 1 ? undefined : recoveredTooSoonNextRunAtMs;
     });
 
     try {
@@ -1408,7 +1410,7 @@ describe("cron service timer regressions", () => {
       expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
       expect(computeCalls).toBeGreaterThanOrEqual(2);
       expect(job?.state.scheduleErrorCount).toBeUndefined();
-      expect(job?.state.nextRunAtMs).toBe(recoveredNextRunAtMs);
+      expect(job?.state.nextRunAtMs).toBe(recoveredRefireFloorMs);
       expect(job?.enabled).toBe(true);
     } finally {
       nextRunSpy.mockRestore();

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1189,6 +1189,48 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("does not double-count schedule errors in the completion maintenance pass (#66019)", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-04-13T16:00:00.000Z");
+    const cronJob = createIsolatedRegressionJob({
+      id: "cron-66019-single-count",
+      name: "cron-66019-single-count",
+      scheduledAt,
+      schedule: { kind: "cron", expr: "0 7 * * *", tz: "Asia/Shanghai" },
+      payload: { kind: "agentTurn", message: "ping" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await writeCronJobs(store.storePath, [cronJob]);
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn(async () => {
+      now = scheduledAt + 25;
+      return { status: "ok" as const, summary: "done" };
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    const nextRunSpy = vi.spyOn(schedule, "computeNextRunAtMs").mockReturnValue(undefined);
+
+    try {
+      await onTimer(state);
+
+      const job = state.store?.jobs.find((entry) => entry.id === "cron-66019-single-count");
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(job?.state.scheduleErrorCount).toBe(1);
+      expect(job?.state.nextRunAtMs).toBeUndefined();
+      expect(job?.enabled).toBe(true);
+    } finally {
+      nextRunSpy.mockRestore();
+    }
+  });
+
   it("force run preserves 'every' anchor while recording manual lastRunAtMs", () => {
     const nowMs = Date.now();
     const everyMs = 24 * 60 * 60 * 1_000;

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1138,6 +1138,7 @@ describe("cron service timer regressions", () => {
       expect(job.state.runningAtMs).toBeUndefined();
       expect(job.state.lastRunAtMs).toBe(startedAt);
       expect(job.state.lastStatus).toBe("ok");
+      expect(job.state.scheduleErrorCount).toBe(1);
       expect(job.state.nextRunAtMs).toBeUndefined();
       expect(job.enabled).toBe(true);
     } finally {
@@ -1180,6 +1181,7 @@ describe("cron service timer regressions", () => {
       expect(job.state.lastRunAtMs).toBe(startedAt);
       expect(job.state.lastStatus).toBe("error");
       expect(job.state.consecutiveErrors).toBe(1);
+      expect(job.state.scheduleErrorCount).toBe(1);
       expect(job.state.nextRunAtMs).toBeUndefined();
       expect(job.enabled).toBe(true);
     } finally {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -864,7 +864,8 @@ export async function onTimer(state: CronServiceState) {
         // those jobs (advancing nextRunAtMs without execution), causing
         // daily cron schedules to jump 48 h instead of 24 h (#17852).
         recomputeNextRunsForMaintenance(state, {
-          skipMissingNextRunJobIds: scheduleComputeFailedJobIds,
+          suppressMissingNextRunScheduleErrorJobIds: scheduleComputeFailedJobIds,
+          preserveScheduleErrorCountJobIds: scheduleComputeFailedJobIds,
         });
         await persist(state);
       });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1179,6 +1179,7 @@ async function applyStartupCatchupOutcomes(
     recomputeNextRunsForMaintenance(state, {
       suppressScheduleComputeErrorJobIds: scheduleComputeFailedJobIds,
       preserveScheduleErrorCountJobIds: scheduleComputeFailedJobIds,
+      recordedScheduleComputeErrorJobIds: scheduleComputeFailedJobIds,
     });
     await persist(state);
   });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -23,6 +23,7 @@ import type {
 } from "../types.js";
 import {
   DEFAULT_ERROR_BACKOFF_SCHEDULE_MS,
+  MIN_CRON_REFIRE_GAP_MS,
   computeJobPreviousRunAtMs,
   computeJobNextRunAtMs,
   errorBackoffMs,
@@ -49,7 +50,7 @@ const MAX_TIMER_DELAY_MS = 60_000;
  * is intentionally generous (2 s) so it never masks a legitimate schedule
  * but always breaks an infinite re-trigger cycle.  (See #17821)
  */
-const MIN_REFIRE_GAP_MS = 2_000;
+const MIN_REFIRE_GAP_MS = MIN_CRON_REFIRE_GAP_MS;
 
 const DEFAULT_MISSED_JOB_STAGGER_MS = 5_000;
 const DEFAULT_MAX_MISSED_JOBS_PER_RESTART = 5;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -865,7 +865,6 @@ export async function onTimer(state: CronServiceState) {
         // daily cron schedules to jump 48 h instead of 24 h (#17852).
         recomputeNextRunsForMaintenance(state, {
           suppressScheduleComputeErrorJobIds: scheduleComputeFailedJobIds,
-          preserveScheduleErrorCountJobIds: scheduleComputeFailedJobIds,
         });
         await persist(state);
       });
@@ -1178,7 +1177,6 @@ async function applyStartupCatchupOutcomes(
     // instead of being silently advanced.
     recomputeNextRunsForMaintenance(state, {
       suppressScheduleComputeErrorJobIds: scheduleComputeFailedJobIds,
-      preserveScheduleErrorCountJobIds: scheduleComputeFailedJobIds,
       recordedScheduleComputeErrorJobIds: scheduleComputeFailedJobIds,
     });
     await persist(state);

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -511,6 +511,7 @@ export function applyJobResult(
       // Apply exponential backoff for errored jobs to prevent retry storms.
       const backoff = errorBackoffMs(job.state.consecutiveErrors ?? 1);
       let normalNext: number | undefined;
+      let scheduleComputeFailed = false;
       try {
         normalNext =
           opts?.preserveSchedule && job.schedule.kind === "every"
@@ -521,32 +522,51 @@ export function applyJobResult(
         // record the schedule error (auto-disables after repeated failures)
         // and fall back to backoff-only schedule so the state update is not lost.
         recordScheduleComputeError({ state, job, err });
+        scheduleComputeFailed = true;
       }
-      const backoffNext = result.endedAt + backoff;
-      // Use whichever is later: the natural next run or the backoff delay.
-      job.state.nextRunAtMs =
-        job.schedule.kind === "cron"
-          ? resolveCronNextRunWithLowerBound({
-              state,
-              job,
-              naturalNext: normalNext,
-              lowerBoundMs: backoffNext,
-              context: "error_backoff",
-            })
-          : normalNext !== undefined
-            ? Math.max(normalNext, backoffNext)
-            : backoffNext;
-      state.deps.log.info(
-        {
-          jobId: job.id,
-          consecutiveErrors: job.state.consecutiveErrors,
-          backoffMs: backoff,
-          nextRunAtMs: job.state.nextRunAtMs,
-        },
-        "cron: applying error backoff",
-      );
+      // Silent undefined returns (croner nextRun null on tz/ICU edge cases,
+      // staggered cron fall-through) are a schedule failure too — promote
+      // them so we hit the auto-disable path instead of spin-looping on
+      // the backoff delay. (#66019)
+      if (!scheduleComputeFailed && normalNext === undefined) {
+        recordScheduleComputeError({
+          state,
+          job,
+          err: new Error("schedule computation returned undefined"),
+        });
+        scheduleComputeFailed = true;
+      }
+      if (!scheduleComputeFailed) {
+        const backoffNext = result.endedAt + backoff;
+        // Use whichever is later: the natural next run or the backoff delay.
+        job.state.nextRunAtMs =
+          job.schedule.kind === "cron"
+            ? resolveCronNextRunWithLowerBound({
+                state,
+                job,
+                naturalNext: normalNext,
+                lowerBoundMs: backoffNext,
+                context: "error_backoff",
+              })
+            : normalNext !== undefined
+              ? Math.max(normalNext, backoffNext)
+              : backoffNext;
+        state.deps.log.info(
+          {
+            jobId: job.id,
+            consecutiveErrors: job.state.consecutiveErrors,
+            backoffMs: backoff,
+            nextRunAtMs: job.state.nextRunAtMs,
+          },
+          "cron: applying error backoff",
+        );
+      }
+      // When scheduleComputeFailed, recordScheduleComputeError has already
+      // set nextRunAtMs = undefined; leave it alone so the failing job can
+      // be auto-disabled rather than retried.
     } else if (isJobEnabled(job)) {
       let naturalNext: number | undefined;
+      let scheduleComputeFailed = false;
       try {
         naturalNext =
           opts?.preserveSchedule && job.schedule.kind === "every"
@@ -557,8 +577,26 @@ export function applyJobResult(
         // record the schedule error (auto-disables after repeated failures)
         // so a persistent throw doesn't cause a MIN_REFIRE_GAP_MS hot loop.
         recordScheduleComputeError({ state, job, err });
+        scheduleComputeFailed = true;
       }
-      if (job.schedule.kind === "cron") {
+      // Silent undefined returns (croner nextRun null on tz/ICU edge cases,
+      // staggered cron fall-through) are a schedule failure too. Previously
+      // we fell back to MIN_REFIRE_GAP_MS (endedAt + 2s) which re-fired the
+      // job 2s later, succeeded, failed to compute next run, re-fired again,
+      // etc. — a tight spin loop. Promote silent undefined to a schedule
+      // error so we hit the auto-disable path instead. (#66019)
+      if (!scheduleComputeFailed && naturalNext === undefined) {
+        recordScheduleComputeError({
+          state,
+          job,
+          err: new Error("schedule computation returned undefined"),
+        });
+        scheduleComputeFailed = true;
+      }
+      if (scheduleComputeFailed) {
+        // recordScheduleComputeError already set nextRunAtMs = undefined;
+        // leave it alone so the spin loop is broken.
+      } else if (job.schedule.kind === "cron") {
         // Safety net: ensure the next fire is at least MIN_REFIRE_GAP_MS
         // after the current run ended.  Prevents spin-loops when the
         // schedule computation lands in the same second due to

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -620,12 +620,15 @@ export function applyJobResult(
   return shouldDelete;
 }
 
-function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOutcome): void {
+function applyOutcomeToStoredJob(
+  state: CronServiceState,
+  result: TimedCronRunOutcome,
+): { jobId: string; scheduleComputeFailed: boolean } | undefined {
   clearCronJobActive(result.jobId);
   tryFinishCronTaskRun(state, result);
   const store = state.store;
   if (!store) {
-    return;
+    return undefined;
   }
   const jobs = store.jobs;
   const job = jobs.find((entry) => entry.id === result.jobId);
@@ -634,9 +637,10 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
       { jobId: result.jobId },
       "cron: applyOutcomeToStoredJob — job not found after forceReload, result discarded",
     );
-    return;
+    return undefined;
   }
 
+  const scheduleErrorCountBefore = job.state.scheduleErrorCount ?? 0;
   const shouldDelete = applyJobResult(state, job, {
     status: result.status,
     error: result.error,
@@ -644,6 +648,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     startedAt: result.startedAt,
     endedAt: result.endedAt,
   });
+  const scheduleErrorCountAfter = job.state.scheduleErrorCount ?? 0;
 
   emitJobFinished(state, job, result, result.startedAt);
 
@@ -651,6 +656,14 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     store.jobs = jobs.filter((entry) => entry.id !== job.id);
     emit(state, { jobId: job.id, action: "removed" });
   }
+  return {
+    jobId: job.id,
+    scheduleComputeFailed:
+      !shouldDelete &&
+      isJobEnabled(job) &&
+      !hasScheduledNextRunAtMs(job.state.nextRunAtMs) &&
+      scheduleErrorCountAfter > scheduleErrorCountBefore,
+  };
 }
 
 export function armTimer(state: CronServiceState) {
@@ -837,8 +850,12 @@ export async function onTimer(state: CronServiceState) {
     if (completedResults.length > 0) {
       await locked(state, async () => {
         await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+        const scheduleComputeFailedJobIds = new Set<string>();
         for (const result of completedResults) {
-          applyOutcomeToStoredJob(state, result);
+          const applied = applyOutcomeToStoredJob(state, result);
+          if (applied?.scheduleComputeFailed) {
+            scheduleComputeFailedJobIds.add(applied.jobId);
+          }
         }
 
         // Use maintenance-only recompute to avoid advancing past-due
@@ -846,7 +863,9 @@ export async function onTimer(state: CronServiceState) {
         // locked block.  The full recomputeNextRuns would silently skip
         // those jobs (advancing nextRunAtMs without execution), causing
         // daily cron schedules to jump 48 h instead of 24 h (#17852).
-        recomputeNextRunsForMaintenance(state);
+        recomputeNextRunsForMaintenance(state, {
+          skipMissingNextRunJobIds: scheduleComputeFailedJobIds,
+        });
         await persist(state);
       });
     }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -864,7 +864,7 @@ export async function onTimer(state: CronServiceState) {
         // those jobs (advancing nextRunAtMs without execution), causing
         // daily cron schedules to jump 48 h instead of 24 h (#17852).
         recomputeNextRunsForMaintenance(state, {
-          suppressMissingNextRunScheduleErrorJobIds: scheduleComputeFailedJobIds,
+          suppressScheduleComputeErrorJobIds: scheduleComputeFailedJobIds,
           preserveScheduleErrorCountJobIds: scheduleComputeFailedJobIds,
         });
         await persist(state);
@@ -1020,14 +1020,14 @@ function collectRunnableJobs(
 export async function runMissedJobs(
   state: CronServiceState,
   opts?: { skipJobIds?: ReadonlySet<string> },
-) {
+): Promise<ReadonlySet<string>> {
   const plan = await planStartupCatchup(state, opts);
   if (plan.candidates.length === 0 && plan.deferredJobIds.length === 0) {
-    return;
+    return new Set();
   }
 
   const outcomes = await executeStartupCatchupPlan(state, plan);
-  await applyStartupCatchupOutcomes(state, plan, outcomes);
+  return await applyStartupCatchupOutcomes(state, plan, outcomes);
 }
 
 async function planStartupCatchup(
@@ -1142,8 +1142,9 @@ async function applyStartupCatchupOutcomes(
   state: CronServiceState,
   plan: StartupCatchupPlan,
   outcomes: TimedCronRunOutcome[],
-): Promise<void> {
+): Promise<ReadonlySet<string>> {
   const staggerMs = Math.max(0, state.deps.missedJobStaggerMs ?? DEFAULT_MISSED_JOB_STAGGER_MS);
+  const scheduleComputeFailedJobIds = new Set<string>();
   await locked(state, async () => {
     // Startup catch-up runs during service bootstrap, before the timer loop is
     // armed. Reuse the in-memory store instead of forcing a second reload.
@@ -1153,7 +1154,10 @@ async function applyStartupCatchupOutcomes(
     }
 
     for (const result of outcomes) {
-      applyOutcomeToStoredJob(state, result);
+      const applied = applyOutcomeToStoredJob(state, result);
+      if (applied?.scheduleComputeFailed) {
+        scheduleComputeFailedJobIds.add(applied.jobId);
+      }
     }
 
     if (plan.deferredJobIds.length > 0) {
@@ -1172,9 +1176,13 @@ async function applyStartupCatchupOutcomes(
     // Preserve any new past-due nextRunAtMs values that became due while
     // startup catch-up was running. They should execute on a future tick
     // instead of being silently advanced.
-    recomputeNextRunsForMaintenance(state);
+    recomputeNextRunsForMaintenance(state, {
+      suppressScheduleComputeErrorJobIds: scheduleComputeFailedJobIds,
+      preserveScheduleErrorCountJobIds: scheduleComputeFailedJobIds,
+    });
     await persist(state);
   });
+  return scheduleComputeFailedJobIds;
 }
 
 export async function runDueJobs(state: CronServiceState) {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -6,6 +6,7 @@ import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../plugins/runtime-sidecar-paths.
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { pathExists } from "../utils.js";
+import { NPM_UPDATE_COMPAT_SIDECARS } from "./npm-update-compat-sidecars.js";
 import { writePackageDistInventory } from "./package-dist-inventory.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import { runGatewayUpdate } from "./update-runner.js";
@@ -261,6 +262,11 @@ describe("runGatewayUpdate", () => {
       const absolutePath = path.join(pkgRoot, relativePath);
       await fs.mkdir(path.dirname(absolutePath), { recursive: true });
       await fs.writeFile(absolutePath, "export {};\n", "utf-8");
+    }
+    for (const sidecar of NPM_UPDATE_COMPAT_SIDECARS) {
+      const absolutePath = path.join(pkgRoot, sidecar.path);
+      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+      await fs.writeFile(absolutePath, sidecar.content, "utf-8");
     }
   }
 


### PR DESCRIPTION
## Summary
\`applyJobResult\` in \`src/cron/service/timer.ts\` conflated two semantics on \`MIN_REFIRE_GAP_MS\`:

1. **Lower bound** for the next cron fire (the #17821 fix — protects against "next run lands in the same second as the run that just finished").
2. **Fallback value** for when \`computeJobNextRunAtMs\` returns \`undefined\`.

The second usage caused a spin loop: \`computeNextRunAtMs\` and the 4-attempt staggered loop in \`src/cron/schedule.ts\` can **silently return \`undefined\`** when croner's \`cron.nextRun()\` returns \`null\` on certain tz/ICU edge cases. When that happened, \`nextRunAtMs\` got pinned to \`endedAt + 2s\`, the job re-fired 2s later, computation silently failed again, and the scheduler tight-looped.

The throw path had the same structural issue: \`recordScheduleComputeError\` set \`nextRunAtMs = undefined\`, but the subsequent unconditional assignment in the same branch **overwrote** it back to \`minNext\`, defeating the intended auto-disable.

Credit to #66019 for a precise root-cause trace through \`computeNextRunAtMs\`, \`computeStaggeredCronNextRunAtMs\`, and both branches of \`applyJobResult\`.

Closes #66019.

## Fix
- Track schedule-compute failure via a local \`scheduleComputeFailed\` flag.
- Treat silent \`undefined\` returns as a schedule error by calling \`recordScheduleComputeError\` with a synthetic \`Error("schedule computation returned undefined")\` — matches the existing throw-path behavior (increments \`scheduleErrorCount\`, sets \`nextRunAtMs = undefined\`, auto-disables after \`MAX_SCHEDULE_ERRORS = 3\`).
- Skip the \`minNext\`/\`backoffNext\` fallback assignment when the compute failed, so the auto-disable state is preserved.

Same fix applied to both the cron success branch and the error-backoff branch — the reporter identified both as structurally affected.

## Changes
- \`src/cron/service/timer.ts\` — promote silent undefined to schedule error in both branches of \`applyJobResult\`

## Test plan
- [x] Mirrors the existing throw-path semantics via \`recordScheduleComputeError\` — no new auto-disable logic
- [x] Preserves the #17821 \`MIN_REFIRE_GAP_MS\` safety net on the normal path (only skipped when compute failed)
- [x] Existing \`timer.regression.test.ts\` tests (\`spin-loop-17821\`, \`spin-gap-17821\`) continue to cover the "same-second" case
- [ ] Ideally needs a new regression test for the silent-undefined path — happy to add in a follow-up once the approach is confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)