### PR TITLE
fix(reply): harden preferred tmp media allowlist

### DIFF
--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -16,6 +16,9 @@ const waitForEmbeddedPiRunEndMock = vi.fn();
 const enqueueFollowupRunMock = vi.fn();
 const scheduleFollowupDrainMock = vi.fn();
 const refreshQueuedFollowupSessionMock = vi.fn();
+const resolvePreferredOpenClawTmpDirMock = vi.hoisted(() =>
+  vi.fn(() => "/private/tmp/openclaw-test"),
+);
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -46,6 +49,10 @@ vi.mock("./queue.js", () => ({
   scheduleFollowupDrain: scheduleFollowupDrainMock,
 }));
 
+vi.mock("../../infra/tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir: resolvePreferredOpenClawTmpDirMock,
+}));
+
 let runReplyAgent: typeof import("./agent-runner.js").runReplyAgent;
 
 describe("runReplyAgent media path normalization", () => {
@@ -66,6 +73,8 @@ describe("runReplyAgent media path normalization", () => {
     enqueueFollowupRunMock.mockReset();
     scheduleFollowupDrainMock.mockReset();
     refreshQueuedFollowupSessionMock.mockReset();
+    resolvePreferredOpenClawTmpDirMock.mockReset();
+    resolvePreferredOpenClawTmpDirMock.mockReturnValue("/private/tmp/openclaw-test");
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     runWithModelFallbackMock.mockImplementation(
       async ({
@@ -139,6 +148,64 @@ describe("runReplyAgent media path normalization", () => {
     expect(result).toMatchObject({
       mediaUrl: path.join("/tmp/workspace", "out", "generated.png"),
       mediaUrls: [path.join("/tmp/workspace", "out", "generated.png")],
+    });
+  });
+
+  it("keeps final MEDIA replies under the preferred OpenClaw tmp root", async () => {
+    const audioPath = path.join(
+      resolvePreferredOpenClawTmpDirMock(),
+      "tts-q1w2e3",
+      "voice-1713042154000.opus",
+    );
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: `MEDIA:${audioPath}` }],
+      meta: {
+        agentMeta: {
+          sessionId: "session",
+          provider: "anthropic",
+          model: "claude",
+        },
+      },
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "speak",
+      followupRun: createMockFollowupRun({
+        prompt: "speak",
+        run: {
+          agentId: "main",
+          agentDir: "/tmp/agent",
+          messageProvider: "telegram",
+          workspaceDir: "/tmp/workspace",
+        },
+      }) as unknown as FollowupRun,
+      queueKey: "main",
+      resolvedQueue: { mode: "interrupt" } as QueueSettings,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing: createMockTypingController(),
+      sessionCtx: {
+        Provider: "telegram",
+        Surface: "telegram",
+        To: "chat-1",
+        OriginatingTo: "chat-1",
+        AccountId: "default",
+        MessageSid: "msg-1",
+      } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: audioPath,
+      mediaUrls: [audioPath],
     });
   });
 });

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -214,6 +214,40 @@ describe("createReplyMediaPathNormalizer", () => {
     });
   });
 
+  it("accepts valid TTS media after the preferred tmp root changes", async () => {
+    resolvePreferredOpenClawTmpDir
+      .mockReturnValueOnce("/private/tmp/openclaw-501")
+      .mockReturnValueOnce("/private/tmp/openclaw-777");
+    saveMediaSource
+      .mockResolvedValueOnce({
+        path: "/Users/peter/.openclaw/media/outbound/tts-voice-a.opus",
+      })
+      .mockResolvedValueOnce({
+        path: "/Users/peter/.openclaw/media/outbound/tts-voice-b.opus",
+      });
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const first = await normalize({
+      mediaUrls: ["/private/tmp/openclaw-501/tts-a1b2c3/voice-1713042154000.opus"],
+    });
+    const second = await normalize({
+      mediaUrls: ["/private/tmp/openclaw-777/tts-z9y8x7/voice-1713042155000.opus"],
+    });
+
+    expect(first).toMatchObject({
+      mediaUrl: "/Users/peter/.openclaw/media/outbound/tts-voice-a.opus",
+      mediaUrls: ["/Users/peter/.openclaw/media/outbound/tts-voice-a.opus"],
+    });
+    expect(second).toMatchObject({
+      mediaUrl: "/Users/peter/.openclaw/media/outbound/tts-voice-b.opus",
+      mediaUrls: ["/Users/peter/.openclaw/media/outbound/tts-voice-b.opus"],
+    });
+  });
+
   it("falls back to the original preferred tmp path when persisting TTS media fails", async () => {
     const tmpVoicePath = path.join(
       "/private/tmp/openclaw-501",
@@ -235,6 +269,25 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrl: tmpVoicePath,
       mediaUrls: [tmpVoicePath],
     });
+  });
+
+  it("keeps non-media temp artifacts under the preferred tmp root blocked", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/private/tmp/openclaw-501/openclaw-cli-system-prompt-123/prompt.txt"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+    expect(resolvePreferredOpenClawTmpDir).not.toHaveBeenCalled();
+    expect(saveMediaSource).not.toHaveBeenCalled();
   });
 
   it("drops host tmp paths outside the preferred OpenClaw temp directory", async () => {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -20,7 +20,6 @@ const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT_RE = /\.\w{1,10}$/;
 const AGENT_STATE_MEDIA_DIRNAME = path.join(".openclaw", "media");
 const MANAGED_GLOBAL_MEDIA_SUBDIRS = new Set(["outbound"]);
-let cachedPreferredTmpRoot: string | null | undefined;
 
 function isPathInside(root: string, candidate: string): boolean {
   const relative = path.relative(path.resolve(root), path.resolve(candidate));
@@ -37,41 +36,58 @@ function isManagedGlobalReplyMediaPath(candidate: string): boolean {
   return MANAGED_GLOBAL_MEDIA_SUBDIRS.has(firstSegment) || firstSegment.startsWith("tool-");
 }
 
-function resolvePreferredReplyMediaTmpRoot(): string | undefined {
-  if (cachedPreferredTmpRoot !== undefined) {
-    return cachedPreferredTmpRoot ?? undefined;
-  }
-  try {
-    cachedPreferredTmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
-  } catch {
-    cachedPreferredTmpRoot = null;
-  }
-  return cachedPreferredTmpRoot ?? undefined;
-}
-
-function buildVolatileReplyMediaRoots(params: {
+function buildAgentStateMediaRoots(params: {
   workspaceDir: string;
   sandboxRoot?: string;
 }): string[] {
-  const roots = [params.workspaceDir, params.sandboxRoot]
+  return [params.workspaceDir, params.sandboxRoot]
     .filter((root): root is string => Boolean(root))
     .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
-  const preferredTmpRoot = resolvePreferredReplyMediaTmpRoot();
-  if (preferredTmpRoot) {
-    roots.push(preferredTmpRoot);
-  }
-  return roots;
 }
 
-function isAllowedAbsoluteReplyMediaPath(params: {
-  candidate: string;
-  workspaceDir: string;
-  sandboxRoot?: string;
-}): boolean {
-  if (isManagedGlobalReplyMediaPath(params.candidate)) {
-    return true;
+function hasPreferredOpenClawTtsReplyMediaShape(candidate: string): boolean {
+  const resolvedCandidate = path.resolve(candidate);
+  const fileName = path.basename(resolvedCandidate);
+  if (!fileName.startsWith("voice-")) {
+    return false;
   }
-  return buildVolatileReplyMediaRoots(params).some((root) => isPathInside(root, params.candidate));
+  const parentDirName = path.basename(path.dirname(resolvedCandidate));
+  return parentDirName.startsWith("tts-");
+}
+
+function isPreferredOpenClawTtsReplyMediaPath(
+  candidate: string,
+  preferredTmpRoot: string,
+): boolean {
+  if (!hasPreferredOpenClawTtsReplyMediaShape(candidate)) {
+    return false;
+  }
+  const resolvedCandidate = path.resolve(candidate);
+  const relative = path.relative(preferredTmpRoot, resolvedCandidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return false;
+  }
+  const segments = relative.split(path.sep).filter(Boolean);
+  if (segments.length !== 2) {
+    return false;
+  }
+  // Keep this narrow: the preferred tmp root also stores non-media artifacts.
+  return segments[0]?.startsWith("tts-") && segments[1]?.startsWith("voice-");
+}
+
+function resolvePreferredOpenClawTtsReplyMediaRoot(candidate: string): string | undefined {
+  if (!hasPreferredOpenClawTtsReplyMediaShape(candidate)) {
+    return undefined;
+  }
+  let preferredTmpRoot: string;
+  try {
+    preferredTmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
+  } catch {
+    return undefined;
+  }
+  return isPreferredOpenClawTtsReplyMediaPath(candidate, preferredTmpRoot)
+    ? preferredTmpRoot
+    : undefined;
 }
 
 function isLikelyLocalMediaSource(media: string): boolean {
@@ -107,6 +123,7 @@ export function createReplyMediaPathNormalizer(params: {
   const configuredMediaMaxBytes = resolveConfiguredMediaMaxBytes(params.cfg);
   let sandboxRootPromise: Promise<string | undefined> | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
+  const preferredTtsTmpRootByMedia = new Map<string, string>();
 
   const resolveSandboxRoot = async (): Promise<string | undefined> => {
     if (!sandboxRootPromise) {
@@ -119,16 +136,49 @@ export function createReplyMediaPathNormalizer(params: {
     return await sandboxRootPromise;
   };
 
+  const isVolatileReplyMediaPath = (input: {
+    candidate: string;
+    sandboxRoot?: string;
+  }): boolean => {
+    const volatileRoots = buildAgentStateMediaRoots({
+      workspaceDir: params.workspaceDir,
+      sandboxRoot: input.sandboxRoot,
+    });
+    if (volatileRoots.some((root) => isPathInside(root, input.candidate))) {
+      return true;
+    }
+    const cachedPreferredTmpRoot = preferredTtsTmpRootByMedia.get(input.candidate);
+    if (
+      cachedPreferredTmpRoot &&
+      isPreferredOpenClawTtsReplyMediaPath(input.candidate, cachedPreferredTmpRoot)
+    ) {
+      return true;
+    }
+    preferredTtsTmpRootByMedia.delete(input.candidate);
+    const preferredTmpRoot = resolvePreferredOpenClawTtsReplyMediaRoot(input.candidate);
+    if (!preferredTmpRoot) {
+      return false;
+    }
+    preferredTtsTmpRootByMedia.set(input.candidate, preferredTmpRoot);
+    return true;
+  };
+
+  const isAllowedAbsoluteReplyMediaPath = (input: {
+    candidate: string;
+    sandboxRoot?: string;
+  }): boolean => isManagedGlobalReplyMediaPath(input.candidate) || isVolatileReplyMediaPath(input);
+
   const persistVolatileReplyMedia = async (media: string): Promise<string> => {
     if (!path.isAbsolute(media)) {
       return media;
     }
     const sandboxRoot = await resolveSandboxRoot();
-    const volatileRoots = buildVolatileReplyMediaRoots({
-      workspaceDir: params.workspaceDir,
-      sandboxRoot,
-    });
-    if (!volatileRoots.some((root) => isPathInside(root, media))) {
+    if (
+      !isVolatileReplyMediaPath({
+        candidate: media,
+        sandboxRoot,
+      })
+    ) {
       return media;
     }
     const cached = persistedMediaBySource.get(media);
@@ -179,7 +229,6 @@ export function createReplyMediaPathNormalizer(params: {
         if (
           isAllowedAbsoluteReplyMediaPath({
             candidate: media,
-            workspaceDir: params.workspaceDir,
             sandboxRoot,
           })
         ) {
@@ -205,7 +254,6 @@ export function createReplyMediaPathNormalizer(params: {
     if (
       isAllowedAbsoluteReplyMediaPath({
         candidate: media,
-        workspaceDir: params.workspaceDir,
         sandboxRoot,
       })
     ) {


### PR DESCRIPTION
## Summary

Follow-up hardening on top of #63511, which already restored TTS reply delivery from the preferred OpenClaw tmp root.

- keep the functional TTS tmp-root delivery path merged in #63511
- narrow reply-media allowlisting and persistence to managed TTS artifacts shaped like `tts-*/voice-*` instead of trusting the whole preferred tmp root
- re-resolve the preferred tmp root for new candidates while keeping a per-media cache inside one normalization pass so a valid artifact is handled consistently
- add regression coverage for dynamic tmp-root changes, blocked non-media tmp artifacts, and a hermetic agent-runner seam test

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #65964
- Follow-up to #63511
- Related #64539
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: #63511 correctly restored TTS delivery by trusting the preferred OpenClaw tmp root, but that root also stores non-media artifacts and should not be trusted wholesale when only managed TTS artifacts need to pass.
- Missing detection / guardrail: reply-media tests did not lock in a negative case for non-media temp artifacts under the preferred tmp root, a dynamic tmp-root change case, or a hermetic agent-runner seam for preferred-tmp TTS media.
- Contributing context (if known): the preferred tmp root can move between fallback and preferred locations during a long-lived process, so this follow-up must avoid pinning the first successful root forever while still handling one candidate consistently inside a normalization pass.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/reply-media-paths.test.ts`, `src/auto-reply/reply/agent-runner.media-paths.test.ts`
- Scenario the test should lock in: managed TTS temp artifacts under `tts-*/voice-*` survive normalization and persistence, unrelated temp artifacts under the same root remain blocked, and valid artifacts still work after the preferred tmp root changes.
- Why this is the smallest reliable guardrail: the change is in shared reply-media normalization, and the agent-runner seam confirms the final `MEDIA:` reply path survives the real pipeline without touching the real tmp-dir helper.
- Existing test that already covers this (if any): #63511 added broad tmp-root coverage, but not the narrowed trust boundary or dynamic-root follow-up cases.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- TTS-generated voice replies under `tts-*/voice-*` still deliver.
- Unrelated files under the preferred OpenClaw tmp root stay blocked instead of being treated as valid reply media.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source tree rebased onto current `main`
- Model/provider: N/A for the path-normalization follow-up itself
- Integration/channel (if any): reply-media normalizer and agent-runner seam
- Relevant config (redacted): existing Telegram direct-chat setup was used for earlier narrow-path smoke before the rebase

### Steps

1. Route preferred-tmp TTS artifacts shaped like `tts-*/voice-*` through the shared reply-media normalizer.
2. Verify they remain allowed and persistable.
3. Verify unrelated artifacts under the same preferred tmp root are still dropped.
4. Verify a later valid artifact still works after the preferred tmp root changes.

### Expected

- Managed TTS temp media survives normalization and persistence.
- Unrelated preferred-tmp artifacts stay blocked.

### Actual

- Targeted tests passed on the rebased follow-up branch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test src/auto-reply/reply/reply-media-paths.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts` on the rebased branch.
- Edge cases checked: preferred-tmp TTS media still persists, unrelated temp artifacts remain blocked, dynamic preferred tmp-root changes work, and the agent-runner seam is hermetic.
- What you did **not** verify: a fresh post-rebase live Telegram smoke on this exact commit.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a valid TTS artifact could be checked against two different tmp roots inside one normalization pass if the resolver changes between calls.
  - Mitigation: the normalizer now memoizes the resolved tmp root per media candidate within the pass while still re-resolving for new candidates over the lifetime of the process.
- Risk: reviewers may compare this against the already-merged broad fix and think the branch is stale.
  - Mitigation: this PR is now explicitly framed as a hardening follow-up on top of #63511 rather than a parallel replacement.
