### PR TITLE
fix(build): pin subagent-registry.runtime as stable entry (#66096)

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -147,6 +147,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
+    "agents/subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",
     "plugins/provider-discovery.runtime": "src/plugins/provider-discovery.runtime.ts",


### PR DESCRIPTION
## Summary
\`openclaw@2026.4.12\` ships without \`dist/subagent-registry.runtime.js\`, but the built \`src/agents/subagent-registry.ts\` still does \`import("./subagent-registry.runtime.js")\` at runtime. Subagent cleanup then fails with \`ERR_MODULE_NOT_FOUND\` on every run (#66096):

\`\`\`
Cannot find module '.../dist/subagent-registry.runtime.js' imported
from '.../dist/subagent-registry-CflSFWBm.js'
\`\`\`

\`tsdown.config.ts\` already maintains an explicit allowlist of lazy runtime boundaries that must be emitted on stable filenames so the downstream \`writeStableRootRuntimeAliases\` postbuild step (in \`scripts/runtime-postbuild.mjs\`) can generate the \`*.runtime.js\` re-export shim. The \`subagent-registry\` runtime was missing from that list, so tsdown folded it into an adjacent hashed chunk (\`subagent-registry-<hash>.js\`) and the shim generator had nothing matching \`<base>.runtime-<hash>.js\` to alias from.

This PR adds \`agents/subagent-registry.runtime\` to the entries block alongside the other \`agents/*.runtime\` boundaries (\`auth-profiles\`, \`model-catalog\`, \`models-config\`, etc.) so the built tree contains both \`dist/agents/subagent-registry.runtime-<hash>.js\` and \`dist/subagent-registry.runtime.js\` going forward.

This matches the pattern used for the previous missing-runtime fixes referenced in the issue: #65561, #65735, #65962.

Closes #66096.

## Changes
- \`tsdown.config.ts\` — add \`"agents/subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts"\` to \`buildCoreDistEntries()\` alphabetically next to the other \`agents/\` runtime entries (1-line insertion)

## Test plan
- [x] Mirrors the existing pattern for \`auth-profiles.runtime\`, \`model-catalog.runtime\`, \`models-config.runtime\`, which all currently ship correctly
- [x] Source file \`src/agents/subagent-registry.runtime.ts\` already exists
- [x] The only runtime caller (\`src/agents/subagent-registry.ts:121\`) uses the \`./subagent-registry.runtime.js\` relative path which the stable-alias postbuild step resolves
- [ ] A CI build-smoke that greps \`dist/\` for \`subagent-registry.runtime.js\` would catch similar regressions — can be a follow-up, not included here to keep the diff minimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)