### PR TITLE
fix(telegram): persist topic-name cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/forum topics: persist learned topic names to the Telegram session sidecar store so agent context can keep using human topic names after a restart instead of relearning from future service metadata.
 - Agents/context engines: run opt-in turn maintenance as idle-aware background work so the next foreground turn no longer waits on proactive maintenance. (#65233) thanks @100yenadmin
 
 - Plugins/status: report the registered context-engine IDs in `plugins inspect` instead of the owning plugin ID, so non-matching engine IDs and multi-engine plugins are classified correctly. (#58766) thanks @zhuisDEV

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -1,4 +1,8 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetTopicNameCacheForTest } from "./topic-name-cache.js";
 const { recordInboundSessionMock } = vi.hoisted(() => ({
   recordInboundSessionMock: vi.fn().mockResolvedValue(undefined),
 }));
@@ -34,10 +38,12 @@ const { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =
 
 beforeEach(() => {
   clearRuntimeConfigSnapshot();
+  resetTopicNameCacheForTest();
 });
 
 afterEach(() => {
   clearRuntimeConfigSnapshot();
+  resetTopicNameCacheForTest();
   recordInboundSessionMock.mockClear();
 });
 
@@ -160,6 +166,52 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
 
     expect(ctx).not.toBeNull();
     expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+  });
+
+  it("reloads topic name from disk after cache reset", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-topic-name-"));
+    const sessionStorePath = path.join(tempDir, "sessions.json");
+    const buildPersistedContext = async (message: Record<string, unknown>) =>
+      await buildTelegramMessageContextForTest({
+        message,
+        options: { forceWasMentioned: true },
+        resolveGroupActivation: () => true,
+        sessionRuntime: {
+          resolveStorePath: () => sessionStorePath,
+        },
+      });
+
+    try {
+      await buildPersistedContext({
+        message_id: 4,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Forum", is_forum: true },
+        date: 1700000003,
+        text: "@bot hello",
+        message_thread_id: 99,
+        from: { id: 42, first_name: "Alice" },
+        reply_to_message: {
+          message_id: 3,
+          forum_topic_created: { name: "Deployments", icon_color: 0x6fb9f0 },
+        },
+      });
+
+      resetTopicNameCacheForTest();
+
+      const ctx = await buildPersistedContext({
+        message_id: 5,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Forum", is_forum: true },
+        date: 1700000004,
+        text: "@bot again",
+        message_thread_id: 99,
+        from: { id: 42, first_name: "Alice" },
+      });
+
+      expect(ctx).not.toBeNull();
+      expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      resetTopicNameCacheForTest();
+    }
   });
 });
 

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -33,7 +33,7 @@ import {
   resolveTelegramReactionVariant,
   resolveTelegramStatusReactionEmojis,
 } from "./status-reaction-variants.js";
-import { getTopicName, updateTopicName } from "./topic-name-cache.js";
+import { getTopicName, resolveTopicNameCachePath, updateTopicName } from "./topic-name-cache.js";
 
 export type {
   BuildTelegramMessageContextParams,
@@ -148,6 +148,9 @@ export const buildTelegramMessageContext = async ({
   const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
   const replyThreadId = threadSpec.id;
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
+  const topicNameCachePath = resolveTopicNameCachePath(
+    sessionRuntime.resolveStorePath(cfg.session?.store, { agentId: account.accountId }),
+  );
   let topicName: string | undefined;
   if (isForum && resolvedThreadId != null) {
     const ftCreated = msg.forum_topic_created;
@@ -156,32 +159,47 @@ export const buildTelegramMessageContext = async ({
     const ftReopened = msg.forum_topic_reopened;
 
     if (ftCreated?.name) {
-      updateTopicName(chatId, resolvedThreadId, {
-        name: ftCreated.name,
-        iconColor: ftCreated.icon_color,
-        iconCustomEmojiId: ftCreated.icon_custom_emoji_id,
-        closed: false,
-      });
+      updateTopicName(
+        chatId,
+        resolvedThreadId,
+        {
+          name: ftCreated.name,
+          iconColor: ftCreated.icon_color,
+          iconCustomEmojiId: ftCreated.icon_custom_emoji_id,
+          closed: false,
+        },
+        topicNameCachePath,
+      );
     } else if (ftEdited?.name) {
-      updateTopicName(chatId, resolvedThreadId, {
-        name: ftEdited.name,
-        iconCustomEmojiId: ftEdited.icon_custom_emoji_id,
-      });
+      updateTopicName(
+        chatId,
+        resolvedThreadId,
+        {
+          name: ftEdited.name,
+          iconCustomEmojiId: ftEdited.icon_custom_emoji_id,
+        },
+        topicNameCachePath,
+      );
     } else if (ftClosed) {
-      updateTopicName(chatId, resolvedThreadId, { closed: true });
+      updateTopicName(chatId, resolvedThreadId, { closed: true }, topicNameCachePath);
     } else if (ftReopened) {
-      updateTopicName(chatId, resolvedThreadId, { closed: false });
+      updateTopicName(chatId, resolvedThreadId, { closed: false }, topicNameCachePath);
     }
 
-    topicName = getTopicName(chatId, resolvedThreadId);
+    topicName = getTopicName(chatId, resolvedThreadId, topicNameCachePath);
     if (!topicName) {
       const replyFtCreated = msg.reply_to_message?.forum_topic_created;
       if (replyFtCreated?.name) {
-        updateTopicName(chatId, resolvedThreadId, {
-          name: replyFtCreated.name,
-          iconColor: replyFtCreated.icon_color,
-          iconCustomEmojiId: replyFtCreated.icon_custom_emoji_id,
-        });
+        updateTopicName(
+          chatId,
+          resolvedThreadId,
+          {
+            name: replyFtCreated.name,
+            iconColor: replyFtCreated.icon_color,
+            iconCustomEmojiId: replyFtCreated.icon_custom_emoji_id,
+          },
+          topicNameCachePath,
+        );
         topicName = replyFtCreated.name;
       }
     }

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -157,33 +157,26 @@ export const buildTelegramMessageContext = async ({
     const ftEdited = msg.forum_topic_edited;
     const ftClosed = msg.forum_topic_closed;
     const ftReopened = msg.forum_topic_reopened;
-
-    if (ftCreated?.name) {
-      updateTopicName(
-        chatId,
-        resolvedThreadId,
-        {
+    const topicPatch = ftCreated?.name
+      ? {
           name: ftCreated.name,
           iconColor: ftCreated.icon_color,
           iconCustomEmojiId: ftCreated.icon_custom_emoji_id,
           closed: false,
-        },
-        topicNameCachePath,
-      );
-    } else if (ftEdited?.name) {
-      updateTopicName(
-        chatId,
-        resolvedThreadId,
-        {
-          name: ftEdited.name,
-          iconCustomEmojiId: ftEdited.icon_custom_emoji_id,
-        },
-        topicNameCachePath,
-      );
-    } else if (ftClosed) {
-      updateTopicName(chatId, resolvedThreadId, { closed: true }, topicNameCachePath);
-    } else if (ftReopened) {
-      updateTopicName(chatId, resolvedThreadId, { closed: false }, topicNameCachePath);
+        }
+      : ftEdited?.name
+        ? {
+            name: ftEdited.name,
+            iconCustomEmojiId: ftEdited.icon_custom_emoji_id,
+          }
+        : ftClosed
+          ? { closed: true }
+          : ftReopened
+            ? { closed: false }
+            : undefined;
+
+    if (topicPatch) {
+      updateTopicName(chatId, resolvedThreadId, topicPatch, topicNameCachePath);
     }
 
     topicName = getTopicName(chatId, resolvedThreadId, topicNameCachePath);

--- a/extensions/telegram/src/topic-name-cache.test.ts
+++ b/extensions/telegram/src/topic-name-cache.test.ts
@@ -1,8 +1,12 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, beforeEach } from "vitest";
 import {
   clearTopicNameCache,
   getTopicEntry,
   getTopicName,
+  resetTopicNameCacheForTest,
   topicNameCacheSize,
   updateTopicName,
 } from "./topic-name-cache.js";
@@ -10,6 +14,7 @@ import {
 describe("topic-name-cache", () => {
   beforeEach(() => {
     clearTopicNameCache();
+    resetTopicNameCacheForTest();
   });
 
   it("stores and retrieves a topic name", () => {
@@ -90,5 +95,18 @@ describe("topic-name-cache", () => {
     updateTopicName(-100000, 9999, { name: "Newcomer" });
     expect(getTopicName(-100000, 1)).toBe("Active");
     expect(topicNameCacheSize()).toBe(2048);
+  });
+
+  it("reloads persisted entries from disk", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-topic-cache-"));
+    const persistedPath = path.join(tempDir, "topic-names.json");
+    try {
+      updateTopicName(-100123, 42, { name: "Deployments" }, persistedPath);
+      resetTopicNameCacheForTest();
+      expect(getTopicName(-100123, 42, persistedPath)).toBe("Deployments");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      resetTopicNameCacheForTest();
+    }
   });
 });

--- a/extensions/telegram/src/topic-name-cache.ts
+++ b/extensions/telegram/src/topic-name-cache.ts
@@ -1,4 +1,9 @@
+import fs from "node:fs";
+import path from "node:path";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+
 const MAX_ENTRIES = 2_048;
+const TOPIC_NAME_CACHE_STATE_KEY = Symbol.for("openclaw.telegramTopicNameCacheState");
 
 export type TopicEntry = {
   name: string;
@@ -8,34 +13,123 @@ export type TopicEntry = {
   updatedAt: number;
 };
 
-const cache = new Map<string, TopicEntry>();
+type TopicNameStore = Map<string, TopicEntry>;
+
+type TopicNameCacheState = {
+  lastUpdatedAt: number;
+  persistedPath?: string;
+  store?: TopicNameStore;
+};
+
+function getTopicNameCacheState(): TopicNameCacheState {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const existing = globalStore[TOPIC_NAME_CACHE_STATE_KEY] as TopicNameCacheState | undefined;
+  if (existing) {
+    return existing;
+  }
+  const state: TopicNameCacheState = { lastUpdatedAt: 0 };
+  globalStore[TOPIC_NAME_CACHE_STATE_KEY] = state;
+  return state;
+}
+
+function createTopicNameStore(): TopicNameStore {
+  return new Map<string, TopicEntry>();
+}
 
 function cacheKey(chatId: number | string, threadId: number | string): string {
   return `${chatId}:${threadId}`;
 }
 
-function evictOldest(): void {
-  if (cache.size <= MAX_ENTRIES) {
+export function resolveTopicNameCachePath(storePath: string): string {
+  return `${storePath}.telegram-topic-names.json`;
+}
+
+function evictOldest(store: TopicNameStore): void {
+  if (store.size <= MAX_ENTRIES) {
     return;
   }
   let oldestKey: string | undefined;
   let oldestTime = Infinity;
-  for (const [key, entry] of cache) {
+  for (const [key, entry] of store) {
     if (entry.updatedAt < oldestTime) {
       oldestTime = entry.updatedAt;
       oldestKey = key;
     }
   }
   if (oldestKey) {
-    cache.delete(oldestKey);
+    store.delete(oldestKey);
   }
+}
+
+function isTopicEntry(value: unknown): value is TopicEntry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const entry = value as Partial<TopicEntry>;
+  return (
+    typeof entry.name === "string" &&
+    entry.name.length > 0 &&
+    typeof entry.updatedAt === "number" &&
+    Number.isFinite(entry.updatedAt)
+  );
+}
+
+function readPersistedTopicNames(persistedPath: string): TopicNameStore {
+  if (!fs.existsSync(persistedPath)) {
+    return createTopicNameStore();
+  }
+  try {
+    const raw = fs.readFileSync(persistedPath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const entries = Object.entries(parsed)
+      .filter(([, value]) => isTopicEntry(value))
+      .toSorted(([, left], [, right]) => right.updatedAt - left.updatedAt)
+      .slice(0, MAX_ENTRIES);
+    return new Map(entries);
+  } catch (error) {
+    logVerbose(`telegram: failed to read topic-name cache: ${String(error)}`);
+    return createTopicNameStore();
+  }
+}
+
+function getTopicStore(persistedPath?: string): TopicNameStore {
+  const state = getTopicNameCacheState();
+  if (persistedPath && state.persistedPath !== persistedPath) {
+    state.store = readPersistedTopicNames(persistedPath);
+    state.persistedPath = persistedPath;
+    state.lastUpdatedAt = Math.max(0, ...state.store.values().map((entry) => entry.updatedAt));
+  }
+  if (!state.store) {
+    state.store = createTopicNameStore();
+  }
+  return state.store;
+}
+
+function nextUpdatedAt(): number {
+  const state = getTopicNameCacheState();
+  const now = Date.now();
+  state.lastUpdatedAt = now > state.lastUpdatedAt ? now : state.lastUpdatedAt + 1;
+  return state.lastUpdatedAt;
+}
+
+function persistTopicStore(persistedPath: string, store: TopicNameStore): void {
+  if (store.size === 0) {
+    fs.rmSync(persistedPath, { force: true });
+    return;
+  }
+  fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
+  const tempPath = `${persistedPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, JSON.stringify(Object.fromEntries(store)), "utf-8");
+  fs.renameSync(tempPath, persistedPath);
 }
 
 export function updateTopicName(
   chatId: number | string,
   threadId: number | string,
   patch: Partial<Omit<TopicEntry, "updatedAt">>,
+  persistedPath?: string,
 ): void {
+  const cache = getTopicStore(persistedPath);
   const key = cacheKey(chatId, threadId);
   const existing = cache.get(key);
   const merged: TopicEntry = {
@@ -43,22 +137,30 @@ export function updateTopicName(
     iconColor: patch.iconColor ?? existing?.iconColor,
     iconCustomEmojiId: patch.iconCustomEmojiId ?? existing?.iconCustomEmojiId,
     closed: patch.closed ?? existing?.closed,
-    updatedAt: Date.now(),
+    updatedAt: nextUpdatedAt(),
   };
   if (!merged.name) {
     return;
   }
   cache.set(key, merged);
-  evictOldest();
+  evictOldest(cache);
+  if (persistedPath) {
+    try {
+      persistTopicStore(persistedPath, cache);
+    } catch (error) {
+      logVerbose(`telegram: failed to persist topic-name cache: ${String(error)}`);
+    }
+  }
 }
 
 export function getTopicName(
   chatId: number | string,
   threadId: number | string,
+  persistedPath?: string,
 ): string | undefined {
-  const entry = cache.get(cacheKey(chatId, threadId));
+  const entry = getTopicStore(persistedPath).get(cacheKey(chatId, threadId));
   if (entry) {
-    entry.updatedAt = Date.now();
+    entry.updatedAt = nextUpdatedAt();
   }
   return entry?.name;
 }
@@ -66,14 +168,26 @@ export function getTopicName(
 export function getTopicEntry(
   chatId: number | string,
   threadId: number | string,
+  persistedPath?: string,
 ): TopicEntry | undefined {
-  return cache.get(cacheKey(chatId, threadId));
+  return getTopicStore(persistedPath).get(cacheKey(chatId, threadId));
 }
 
-export function clearTopicNameCache(): void {
+export function clearTopicNameCache(persistedPath?: string): void {
+  const cache = getTopicStore(persistedPath);
   cache.clear();
+  if (persistedPath) {
+    fs.rmSync(persistedPath, { force: true });
+  }
 }
 
 export function topicNameCacheSize(): number {
-  return cache.size;
+  return getTopicStore().size;
+}
+
+export function resetTopicNameCacheForTest(): void {
+  const state = getTopicNameCacheState();
+  state.lastUpdatedAt = 0;
+  state.store = undefined;
+  state.persistedPath = undefined;
 }

--- a/extensions/telegram/src/topic-name-cache.ts
+++ b/extensions/telegram/src/topic-name-cache.ts
@@ -18,7 +18,7 @@ type TopicNameStore = Map<string, TopicEntry>;
 type TopicNameCacheState = {
   lastUpdatedAt: number;
   persistedPath?: string;
-  store?: TopicNameStore;
+  store: TopicNameStore;
 };
 
 function getTopicNameCacheState(): TopicNameCacheState {
@@ -27,7 +27,7 @@ function getTopicNameCacheState(): TopicNameCacheState {
   if (existing) {
     return existing;
   }
-  const state: TopicNameCacheState = { lastUpdatedAt: 0 };
+  const state: TopicNameCacheState = { lastUpdatedAt: 0, store: createTopicNameStore() };
   globalStore[TOPIC_NAME_CACHE_STATE_KEY] = state;
   return state;
 }
@@ -98,9 +98,6 @@ function getTopicStore(persistedPath?: string): TopicNameStore {
     state.store = readPersistedTopicNames(persistedPath);
     state.persistedPath = persistedPath;
     state.lastUpdatedAt = Math.max(0, ...state.store.values().map((entry) => entry.updatedAt));
-  }
-  if (!state.store) {
-    state.store = createTopicNameStore();
   }
   return state.store;
 }
@@ -173,12 +170,11 @@ export function getTopicEntry(
   return getTopicStore(persistedPath).get(cacheKey(chatId, threadId));
 }
 
-export function clearTopicNameCache(persistedPath?: string): void {
-  const cache = getTopicStore(persistedPath);
-  cache.clear();
-  if (persistedPath) {
-    fs.rmSync(persistedPath, { force: true });
-  }
+export function clearTopicNameCache(): void {
+  const state = getTopicNameCacheState();
+  state.store.clear();
+  state.persistedPath = undefined;
+  state.lastUpdatedAt = 0;
 }
 
 export function topicNameCacheSize(): number {
@@ -188,6 +184,6 @@ export function topicNameCacheSize(): number {
 export function resetTopicNameCacheForTest(): void {
   const state = getTopicNameCacheState();
   state.lastUpdatedAt = 0;
-  state.store = undefined;
+  state.store = createTopicNameStore();
   state.persistedPath = undefined;
 }


### PR DESCRIPTION
## Summary
- persist learned Telegram forum topic names to a session-sidecar JSON cache
- reload the cache on demand after process restart and keep the existing bounded in-memory path
- cover disk reload behavior in the cache unit test and Telegram context integration test

## Testing
- pnpm exec oxlint extensions/telegram/src/topic-name-cache.ts extensions/telegram/src/bot-message-context.ts extensions/telegram/src/topic-name-cache.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts
- pnpm test extensions/telegram/src/topic-name-cache.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts