### PR TITLE
fix(bluebubbles): accept updated-message events carrying attachments

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -248,11 +248,22 @@ export async function handleBlueBubblesWebhookRequest(
         return true;
       }
       const reaction = normalizeWebhookReaction(payload);
+      // Allow updated-message events through when they carry attachments.
+      // BB fires new-message (text only), then updated-message ~2-3s later once
+      // attachment data is ready. Without this, inbound images/PDFs/files are
+      // silently dropped. Only check data.attachments (not root payload.attachments)
+      // -- normalizeWebhookMessage requires a message container
+      // (payload.data/message/payload/event); root-only attachment payloads would
+      // pass the filter but fail normalization.
+      const dataAttachments = (asRecord(asRecord(payload)?.data) as Record<string, unknown> | undefined)?.attachments;
+      const isAttachmentUpdate =
+        eventType === "updated-message" && Array.isArray(dataAttachments) && dataAttachments.length > 0;
       if (
         (eventType === "updated-message" ||
           eventType === "message-reaction" ||
           eventType === "reaction") &&
-        !reaction
+        !reaction &&
+        !isAttachmentUpdate
       ) {
         res.statusCode = 200;
         res.end("ok");
@@ -265,7 +276,13 @@ export async function handleBlueBubblesWebhookRequest(
         }
         return true;
       }
-      const message = reaction ? null : normalizeWebhookMessage(payload);
+      let message = reaction ? null : normalizeWebhookMessage(payload);
+      // Strip text from attachment updates to prevent duplicate delivery.
+      // The text was already dispatched via new-message; the debounce window (500ms)
+      // is shorter than the updated-message delay (~2-3s) so they won't coalesce.
+      if (message && isAttachmentUpdate) {
+        message = { ...message, text: "" };
+      }
       if (!message && !reaction) {
         res.statusCode = 400;
         res.end("invalid payload");


### PR DESCRIPTION
## Summary

BlueBubbles fires `new-message` first (text only), then `updated-message` ~2-3s later once attachment data is ready. The webhook filter unconditionally discards `updated-message` events that are not reactions, silently dropping all inbound images, PDFs, and files.

This lets `updated-message` events through when `data.attachments` is non-empty, and strips the text body to prevent duplicate delivery (the text was already dispatched via `new-message` and the 500ms debounce window is too short to coalesce the ~2-3s delayed update).

Supersedes #63983 which had several issues flagged in review:
- Boolean-named variable assigned an array
- Checked root `payload.attachments` which could pass the filter but fail `normalizeWebhookMessage`
- No deduplication guard for text+attachment sends

## Changes

- `extensions/bluebubbles/src/monitor.ts`:
  - Detect attachment-bearing `updated-message` via `data.attachments` (not root payload)
  - Pass these events through the event type filter
  - Strip text body to prevent duplicate delivery (text already processed via `new-message`)

## Test plan

- [ ] Send an image via iMessage to a BB-connected agent — confirm the image is received and processed
- [ ] Send text + image in the same iMessage — confirm no duplicate text delivery
- [ ] Verify `updated-message` events without attachments are still filtered out
- [ ] Verify reactions still work normally