### PR TITLE
fix(telegram): persist topic-name cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Slack/interactions: apply the configured global `allowFrom` owner allowlist to channel block-action and modal interactive events, require an expected sender id for cross-verification, and reject ambiguous channel types so interactive triggers can no longer bypass the documented allowlist intent in channels without a `users` list. Open-by-default behavior is preserved when no allowlists are configured. (#66028) Thanks @eleqtrizit.
 - Media-understanding/attachments: fail closed when a local attachment path cannot be canonically resolved via `realpath`, so a `realpath` error can no longer downgrade the canonical-roots allowlist check to a non-canonical comparison; attachments that also have a URL still fall back to the network fetch path. (#66022) Thanks @eleqtrizit.
 - Agents/gateway-tool: reject `config.patch` and `config.apply` calls from the model-facing gateway tool when they would newly enable any flag enumerated by `openclaw security audit` (for example `dangerouslyDisableDeviceAuth`, `allowInsecureAuth`, `dangerouslyAllowHostHeaderOriginFallback`, `hooks.gmail.allowUnsafeExternalContent`, `tools.exec.applyPatch.workspaceOnly: false`); already-enabled flags pass through unchanged so non-dangerous edits in the same patch still apply, and direct authenticated operator RPC behavior is unchanged. (#62006) Thanks @eleqtrizit.
+- Telegram/forum topics: persist learned topic names to the Telegram session sidecar store so agent context can keep using human topic names after a restart instead of relearning from future service metadata. (#66107) Thanks @obviyus.
 
 ## 2026.4.14-beta.1
 
@@ -55,7 +56,6 @@ Docs: https://docs.openclaw.ai
 - Outbound/relay-status: suppress internal relay-status placeholder payloads (`No channel reply.`, `Replied in-thread.`, `Replied in #...`, wiki-update status variants ending in `No channel reply.`) before channel delivery so internal housekeeping text does not leak to users.
 - Slack/doctor: add a dedicated doctor-contract sidecar so config warmup paths such as `openclaw cron` no longer fall back to Slack's broader contract surface, which could trigger Slack-related config-read crashes on affected setups. (#63192) Thanks @shhtheonlyperson.
 - Hooks/session-memory: pass the resolved agent workspace into gateway `/new` and `/reset` session-memory hooks so reset snapshots stay scoped to the right agent workspace instead of leaking into the default workspace. (#64735) Thanks @suboss87 and @vincentkoc.
-- Telegram/forum topics: persist learned topic names to the Telegram session sidecar store so agent context can keep using human topic names after a restart instead of relearning from future service metadata. (#66107) Thanks @obviyus.
 
 ## 2026.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Outbound/relay-status: suppress internal relay-status placeholder payloads (`No channel reply.`, `Replied in-thread.`, `Replied in #...`, wiki-update status variants ending in `No channel reply.`) before channel delivery so internal housekeeping text does not leak to users.
 - Slack/doctor: add a dedicated doctor-contract sidecar so config warmup paths such as `openclaw cron` no longer fall back to Slack's broader contract surface, which could trigger Slack-related config-read crashes on affected setups. (#63192) Thanks @shhtheonlyperson.
 - Hooks/session-memory: pass the resolved agent workspace into gateway `/new` and `/reset` session-memory hooks so reset snapshots stay scoped to the right agent workspace instead of leaking into the default workspace. (#64735) Thanks @suboss87 and @vincentkoc.
+- Telegram/forum topics: persist learned topic names to the Telegram session sidecar store so agent context can keep using human topic names after a restart instead of relearning from future service metadata. (#66107) Thanks @obviyus.
 
 ## 2026.4.12
 

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -168,6 +168,29 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
     expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
   });
 
+  it("handles forum messages without session runtime overrides", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 3,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Forum", is_forum: true },
+        date: 1700000002,
+        text: "@bot hello",
+        message_thread_id: 99,
+        from: { id: 42, first_name: "Alice" },
+        reply_to_message: {
+          message_id: 2,
+          forum_topic_created: { name: "Deployments", icon_color: 0x6fb9f0 },
+        },
+      },
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+      sessionRuntime: null,
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+  });
+
   it("reloads topic name from disk after cache reset", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-topic-name-"));
     const sessionStorePath = path.join(tempDir, "sessions.json");

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -1,4 +1,8 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetTopicNameCacheForTest } from "./topic-name-cache.js";
 const { recordInboundSessionMock } = vi.hoisted(() => ({
   recordInboundSessionMock: vi.fn().mockResolvedValue(undefined),
 }));
@@ -34,10 +38,12 @@ const { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =
 
 beforeEach(() => {
   clearRuntimeConfigSnapshot();
+  resetTopicNameCacheForTest();
 });
 
 afterEach(() => {
   clearRuntimeConfigSnapshot();
+  resetTopicNameCacheForTest();
   recordInboundSessionMock.mockClear();
 });
 
@@ -160,6 +166,52 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
 
     expect(ctx).not.toBeNull();
     expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+  });
+
+  it("reloads topic name from disk after cache reset", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-topic-name-"));
+    const sessionStorePath = path.join(tempDir, "sessions.json");
+    const buildPersistedContext = async (message: Record<string, unknown>) =>
+      await buildTelegramMessageContextForTest({
+        message,
+        options: { forceWasMentioned: true },
+        resolveGroupActivation: () => true,
+        sessionRuntime: {
+          resolveStorePath: () => sessionStorePath,
+        },
+      });
+
+    try {
+      await buildPersistedContext({
+        message_id: 4,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Forum", is_forum: true },
+        date: 1700000003,
+        text: "@bot hello",
+        message_thread_id: 99,
+        from: { id: 42, first_name: "Alice" },
+        reply_to_message: {
+          message_id: 3,
+          forum_topic_created: { name: "Deployments", icon_color: 0x6fb9f0 },
+        },
+      });
+
+      resetTopicNameCacheForTest();
+
+      const ctx = await buildPersistedContext({
+        message_id: 5,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Forum", is_forum: true },
+        date: 1700000004,
+        text: "@bot again",
+        message_thread_id: 99,
+        from: { id: 42, first_name: "Alice" },
+      });
+
+      expect(ctx).not.toBeNull();
+      expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      resetTopicNameCacheForTest();
+    }
   });
 });
 

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -3,8 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetTopicNameCacheForTest } from "./topic-name-cache.js";
-const { recordInboundSessionMock } = vi.hoisted(() => ({
+const { recordInboundSessionMock, resolveStorePathMock } = vi.hoisted(() => ({
   recordInboundSessionMock: vi.fn().mockResolvedValue(undefined),
+  resolveStorePathMock: vi.fn(() => "/tmp/openclaw-session-store.json"),
 }));
 
 vi.mock("./bot-message-context.session.runtime.js", async () => {
@@ -14,6 +15,7 @@ vi.mock("./bot-message-context.session.runtime.js", async () => {
   return {
     ...actual,
     recordInboundSession: (...args: unknown[]) => recordInboundSessionMock(...args),
+    resolveStorePath: (...args: unknown[]) => resolveStorePathMock(...args),
   };
 });
 
@@ -45,6 +47,8 @@ afterEach(() => {
   clearRuntimeConfigSnapshot();
   resetTopicNameCacheForTest();
   recordInboundSessionMock.mockClear();
+  resolveStorePathMock.mockReset();
+  resolveStorePathMock.mockReturnValue("/tmp/openclaw-session-store.json");
 });
 
 describe("buildTelegramMessageContext dm thread sessions", () => {
@@ -227,6 +231,54 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
         text: "@bot again",
         message_thread_id: 99,
         from: { id: 42, first_name: "Alice" },
+      });
+
+      expect(ctx).not.toBeNull();
+      expect(ctx?.ctxPayload?.TopicName).toBe("Deployments");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      resetTopicNameCacheForTest();
+    }
+  });
+
+  it("persists topic names through the default session runtime path", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-topic-name-"));
+    const sessionStorePath = path.join(tempDir, "sessions.json");
+    resolveStorePathMock.mockReturnValue(sessionStorePath);
+
+    try {
+      await buildTelegramMessageContextForTest({
+        message: {
+          message_id: 6,
+          chat: { id: -1001234567890, type: "supergroup", title: "Test Forum", is_forum: true },
+          date: 1700000005,
+          text: "@bot hello",
+          message_thread_id: 99,
+          from: { id: 42, first_name: "Alice" },
+          reply_to_message: {
+            message_id: 5,
+            forum_topic_created: { name: "Deployments", icon_color: 0x6fb9f0 },
+          },
+        },
+        options: { forceWasMentioned: true },
+        resolveGroupActivation: () => true,
+        sessionRuntime: null,
+      });
+
+      resetTopicNameCacheForTest();
+
+      const ctx = await buildTelegramMessageContextForTest({
+        message: {
+          message_id: 7,
+          chat: { id: -1001234567890, type: "supergroup", title: "Test Forum", is_forum: true },
+          date: 1700000006,
+          text: "@bot again",
+          message_thread_id: 99,
+          from: { id: 42, first_name: "Alice" },
+        },
+        options: { forceWasMentioned: true },
+        resolveGroupActivation: () => true,
+        sessionRuntime: null,
       });
 
       expect(ctx).not.toBeNull();

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -76,6 +76,17 @@ async function loadTelegramMessageContextSessionRuntime(
   };
 }
 
+export async function resolveTelegramMessageContextStorePath(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionRuntime?: TelegramMessageContextSessionRuntimeOverrides;
+}): Promise<string> {
+  const sessionRuntime = await loadTelegramMessageContextSessionRuntime(params.sessionRuntime);
+  return sessionRuntime.resolveStorePath(params.cfg.session?.store, {
+    agentId: params.agentId,
+  });
+}
+
 export async function buildTelegramInboundContextPayload(params: {
   cfg: OpenClawConfig;
   primaryCtx: TelegramContext;
@@ -232,8 +243,10 @@ export async function buildTelegramInboundContextPayload(params: {
     ? (groupLabel ?? `group:${chatId}`)
     : buildSenderLabel(msg, senderId || chatId);
   const sessionRuntime = await loadTelegramMessageContextSessionRuntime(sessionRuntimeOverride);
-  const storePath = sessionRuntime.resolveStorePath(cfg.session?.store, {
+  const storePath = await resolveTelegramMessageContextStorePath({
+    cfg,
     agentId: route.agentId,
+    sessionRuntime: sessionRuntimeOverride,
   });
   const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
   const previousTimestamp = sessionRuntime.readSessionUpdatedAt({

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -36,7 +36,7 @@ type BuildTelegramMessageContextForTestParams = {
   cfg?: Record<string, unknown>;
   accountId?: string;
   runtime?: BuildTelegramMessageContextParams["runtime"];
-  sessionRuntime?: BuildTelegramMessageContextParams["sessionRuntime"];
+  sessionRuntime?: BuildTelegramMessageContextParams["sessionRuntime"] | null;
   resolveGroupActivation?: BuildTelegramMessageContextParams["resolveGroupActivation"];
   resolveGroupRequireMention?: BuildTelegramMessageContextParams["resolveGroupRequireMention"];
   resolveTelegramGroupConfig?: BuildTelegramMessageContextParams["resolveTelegramGroupConfig"];
@@ -59,6 +59,13 @@ export async function buildTelegramMessageContextForTest(
 > {
   const { vi } = await loadVitestModule();
   const buildTelegramMessageContext = await loadBuildTelegramMessageContext();
+  const sessionRuntime =
+    params.sessionRuntime === null
+      ? undefined
+      : {
+          ...telegramMessageContextSessionRuntimeForTest,
+          ...params.sessionRuntime,
+        };
   return await buildTelegramMessageContext({
     primaryCtx: {
       message: {
@@ -85,10 +92,7 @@ export async function buildTelegramMessageContextForTest(
       recordChannelActivity: () => undefined,
       ...params.runtime,
     },
-    sessionRuntime: {
-      ...telegramMessageContextSessionRuntimeForTest,
-      ...params.sessionRuntime,
-    },
+    sessionRuntime,
     account: { accountId: params.accountId ?? "default" } as never,
     historyLimit: 0,
     groupHistories: new Map(),

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -11,7 +11,10 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { firstDefined, normalizeAllowFrom, normalizeDmAllowFromWithStore } from "./bot-access.js";
 import { resolveTelegramInboundBody } from "./bot-message-context.body.js";
-import { buildTelegramInboundContextPayload } from "./bot-message-context.session.js";
+import {
+  buildTelegramInboundContextPayload,
+  resolveTelegramMessageContextStorePath,
+} from "./bot-message-context.session.js";
 import type { BuildTelegramMessageContextParams } from "./bot-message-context.types.js";
 import {
   buildTypingThreadParams,
@@ -149,11 +152,13 @@ export const buildTelegramMessageContext = async ({
   const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
   const replyThreadId = threadSpec.id;
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
-  const topicNameCachePath = sessionRuntime?.resolveStorePath
-    ? resolveTopicNameCachePath(
-        sessionRuntime.resolveStorePath(cfg.session?.store, { agentId: account.accountId }),
-      )
-    : undefined;
+  const topicNameCachePath = resolveTopicNameCachePath(
+    await resolveTelegramMessageContextStorePath({
+      cfg,
+      agentId: account.accountId,
+      sessionRuntime,
+    }),
+  );
   let topicName: string | undefined;
   if (isForum && resolvedThreadId != null) {
     const ftCreated = msg.forum_topic_created;

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -34,7 +34,7 @@ import {
   resolveTelegramReactionVariant,
   resolveTelegramStatusReactionEmojis,
 } from "./status-reaction-variants.js";
-import { getTopicName, updateTopicName } from "./topic-name-cache.js";
+import { getTopicName, resolveTopicNameCachePath, updateTopicName } from "./topic-name-cache.js";
 
 export type {
   BuildTelegramMessageContextParams,
@@ -149,40 +149,51 @@ export const buildTelegramMessageContext = async ({
   const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
   const replyThreadId = threadSpec.id;
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
+  const topicNameCachePath = resolveTopicNameCachePath(
+    sessionRuntime.resolveStorePath(cfg.session?.store, { agentId: account.accountId }),
+  );
   let topicName: string | undefined;
   if (isForum && resolvedThreadId != null) {
     const ftCreated = msg.forum_topic_created;
     const ftEdited = msg.forum_topic_edited;
     const ftClosed = msg.forum_topic_closed;
     const ftReopened = msg.forum_topic_reopened;
+    const topicPatch = ftCreated?.name
+      ? {
+          name: ftCreated.name,
+          iconColor: ftCreated.icon_color,
+          iconCustomEmojiId: ftCreated.icon_custom_emoji_id,
+          closed: false,
+        }
+      : ftEdited?.name
+        ? {
+            name: ftEdited.name,
+            iconCustomEmojiId: ftEdited.icon_custom_emoji_id,
+          }
+        : ftClosed
+          ? { closed: true }
+          : ftReopened
+            ? { closed: false }
+            : undefined;
 
-    if (ftCreated?.name) {
-      updateTopicName(chatId, resolvedThreadId, {
-        name: ftCreated.name,
-        iconColor: ftCreated.icon_color,
-        iconCustomEmojiId: ftCreated.icon_custom_emoji_id,
-        closed: false,
-      });
-    } else if (ftEdited?.name) {
-      updateTopicName(chatId, resolvedThreadId, {
-        name: ftEdited.name,
-        iconCustomEmojiId: ftEdited.icon_custom_emoji_id,
-      });
-    } else if (ftClosed) {
-      updateTopicName(chatId, resolvedThreadId, { closed: true });
-    } else if (ftReopened) {
-      updateTopicName(chatId, resolvedThreadId, { closed: false });
+    if (topicPatch) {
+      updateTopicName(chatId, resolvedThreadId, topicPatch, topicNameCachePath);
     }
 
-    topicName = getTopicName(chatId, resolvedThreadId);
+    topicName = getTopicName(chatId, resolvedThreadId, topicNameCachePath);
     if (!topicName) {
       const replyFtCreated = msg.reply_to_message?.forum_topic_created;
       if (replyFtCreated?.name) {
-        updateTopicName(chatId, resolvedThreadId, {
-          name: replyFtCreated.name,
-          iconColor: replyFtCreated.icon_color,
-          iconCustomEmojiId: replyFtCreated.icon_custom_emoji_id,
-        });
+        updateTopicName(
+          chatId,
+          resolvedThreadId,
+          {
+            name: replyFtCreated.name,
+            iconColor: replyFtCreated.icon_color,
+            iconCustomEmojiId: replyFtCreated.icon_custom_emoji_id,
+          },
+          topicNameCachePath,
+        );
         topicName = replyFtCreated.name;
       }
     }

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -149,9 +149,11 @@ export const buildTelegramMessageContext = async ({
   const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
   const replyThreadId = threadSpec.id;
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
-  const topicNameCachePath = resolveTopicNameCachePath(
-    sessionRuntime.resolveStorePath(cfg.session?.store, { agentId: account.accountId }),
-  );
+  const topicNameCachePath = sessionRuntime?.resolveStorePath
+    ? resolveTopicNameCachePath(
+        sessionRuntime.resolveStorePath(cfg.session?.store, { agentId: account.accountId }),
+      )
+    : undefined;
   let topicName: string | undefined;
   if (isForum && resolvedThreadId != null) {
     const ftCreated = msg.forum_topic_created;

--- a/extensions/telegram/src/topic-name-cache.test.ts
+++ b/extensions/telegram/src/topic-name-cache.test.ts
@@ -1,20 +1,21 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import syncFs from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearTopicNameCache,
   getTopicEntry,
   getTopicName,
+  resetTopicNameCacheForTest,
   topicNameCacheSize,
   updateTopicName,
 } from "./topic-name-cache.js";
 
 describe("topic-name-cache", () => {
   beforeEach(() => {
-    vi.useRealTimers();
     clearTopicNameCache();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
+    resetTopicNameCacheForTest();
   });
 
   it("stores and retrieves a topic name", () => {
@@ -63,11 +64,9 @@ describe("topic-name-cache", () => {
   });
 
   it("updates timestamps on write", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T22:00:00.000Z"));
     updateTopicName(-100123, 42, { name: "A" });
     const t1 = getTopicEntry(-100123, 42)?.updatedAt ?? 0;
-    await vi.advanceTimersByTimeAsync(10);
+    await new Promise((r) => setTimeout(r, 10));
     updateTopicName(-100123, 42, { name: "B" });
     const t2 = getTopicEntry(-100123, 42)?.updatedAt ?? 0;
     expect(t2).toBeGreaterThan(t1);
@@ -88,10 +87,8 @@ describe("topic-name-cache", () => {
   });
 
   it("refreshes recency on read so active topics survive eviction", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T22:00:00.000Z"));
     updateTopicName(-100000, 1, { name: "Active" });
-    await vi.advanceTimersByTimeAsync(10);
+    await new Promise((r) => setTimeout(r, 10));
     for (let i = 2; i <= 2048; i++) {
       updateTopicName(-100000, i, { name: `Topic ${i}` });
     }
@@ -99,5 +96,38 @@ describe("topic-name-cache", () => {
     updateTopicName(-100000, 9999, { name: "Newcomer" });
     expect(getTopicName(-100000, 1)).toBe("Active");
     expect(topicNameCacheSize()).toBe(2048);
+  });
+
+  it("reloads persisted entries from disk", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-topic-cache-"));
+    const persistedPath = path.join(tempDir, "topic-names.json");
+    try {
+      updateTopicName(-100123, 42, { name: "Deployments" }, persistedPath);
+      resetTopicNameCacheForTest();
+      expect(getTopicName(-100123, 42, persistedPath)).toBe("Deployments");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      resetTopicNameCacheForTest();
+    }
+  });
+
+  it("keeps separate in-memory stores for separate persisted paths", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-topic-cache-"));
+    const firstPath = path.join(tempDir, "first-topic-names.json");
+    const secondPath = path.join(tempDir, "second-topic-names.json");
+    try {
+      updateTopicName(-100123, 42, { name: "Deployments" }, firstPath);
+      updateTopicName(-200456, 84, { name: "Incidents" }, secondPath);
+
+      const readFileSpy = vi.spyOn(syncFs, "readFileSync");
+
+      expect(getTopicName(-100123, 42, firstPath)).toBe("Deployments");
+      expect(getTopicName(-200456, 84, secondPath)).toBe("Incidents");
+      expect(readFileSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.restoreAllMocks();
+      await fs.rm(tempDir, { recursive: true, force: true });
+      resetTopicNameCacheForTest();
+    }
   });
 });

--- a/extensions/telegram/src/topic-name-cache.ts
+++ b/extensions/telegram/src/topic-name-cache.ts
@@ -1,4 +1,10 @@
+import fs from "node:fs";
+import path from "node:path";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+
 const MAX_ENTRIES = 2_048;
+const TOPIC_NAME_CACHE_STATE_KEY = Symbol.for("openclaw.telegramTopicNameCacheState");
+const DEFAULT_TOPIC_NAME_CACHE_KEY = "__default__";
 
 export type TopicEntry = {
   name: string;
@@ -8,27 +14,151 @@ export type TopicEntry = {
   updatedAt: number;
 };
 
-const cache = new Map<string, TopicEntry>();
+type TopicNameStore = Map<string, TopicEntry>;
+
+type TopicNameStoreState = {
+  lastUpdatedAt: number;
+  store: TopicNameStore;
+};
+
+type TopicNameCacheState = {
+  stores: Map<string, TopicNameStoreState>;
+};
+
+function createTopicNameStore(): TopicNameStore {
+  return new Map<string, TopicEntry>();
+}
+
+function createTopicNameStoreState(): TopicNameStoreState {
+  return {
+    lastUpdatedAt: 0,
+    store: createTopicNameStore(),
+  };
+}
+
+function getTopicNameCacheState(): TopicNameCacheState {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const existing = globalStore[TOPIC_NAME_CACHE_STATE_KEY] as TopicNameCacheState | undefined;
+  if (existing) {
+    return existing;
+  }
+  const state: TopicNameCacheState = { stores: new Map() };
+  globalStore[TOPIC_NAME_CACHE_STATE_KEY] = state;
+  return state;
+}
 
 function cacheKey(chatId: number | string, threadId: number | string): string {
   return `${chatId}:${threadId}`;
 }
 
-function evictOldest(): void {
-  while (cache.size > MAX_ENTRIES) {
-    const oldestKey = cache.keys().next().value;
-    if (!oldestKey) {
-      return;
-    }
-    cache.delete(oldestKey);
+export function resolveTopicNameCachePath(storePath: string): string {
+  return `${storePath}.telegram-topic-names.json`;
+}
+
+function evictOldest(store: TopicNameStore): void {
+  if (store.size <= MAX_ENTRIES) {
+    return;
   }
+  let oldestKey: string | undefined;
+  let oldestTime = Infinity;
+  for (const [key, entry] of store) {
+    if (entry.updatedAt < oldestTime) {
+      oldestTime = entry.updatedAt;
+      oldestKey = key;
+    }
+  }
+  if (oldestKey) {
+    store.delete(oldestKey);
+  }
+}
+
+function isTopicEntry(value: unknown): value is TopicEntry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const entry = value as Partial<TopicEntry>;
+  return (
+    typeof entry.name === "string" &&
+    entry.name.length > 0 &&
+    typeof entry.updatedAt === "number" &&
+    Number.isFinite(entry.updatedAt)
+  );
+}
+
+function readPersistedTopicNames(persistedPath: string): TopicNameStore {
+  if (!fs.existsSync(persistedPath)) {
+    return createTopicNameStore();
+  }
+  try {
+    const raw = fs.readFileSync(persistedPath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const entries = Object.entries(parsed)
+      .filter((entry): entry is [string, TopicEntry] => isTopicEntry(entry[1]))
+      .toSorted(([, left], [, right]) => right.updatedAt - left.updatedAt)
+      .slice(0, MAX_ENTRIES);
+    return new Map(entries);
+  } catch (error) {
+    logVerbose(`telegram: failed to read topic-name cache: ${String(error)}`);
+    return createTopicNameStore();
+  }
+}
+
+function getTopicStoreState(persistedPath?: string): TopicNameStoreState {
+  const state = getTopicNameCacheState();
+  const stateKey = persistedPath ?? DEFAULT_TOPIC_NAME_CACHE_KEY;
+  const existing = state.stores.get(stateKey);
+  if (existing) {
+    return existing;
+  }
+  const next = persistedPath
+    ? {
+        lastUpdatedAt: 0,
+        store: readPersistedTopicNames(persistedPath),
+      }
+    : createTopicNameStoreState();
+  next.lastUpdatedAt = Math.max(0, ...next.store.values().map((entry) => entry.updatedAt));
+  state.stores.set(stateKey, next);
+  return next;
+}
+
+function getTopicStore(persistedPath?: string): TopicNameStore {
+  return getTopicStoreState(persistedPath).store;
+}
+
+function nextUpdatedAt(persistedPath?: string): number {
+  const state = getTopicStoreState(persistedPath);
+  const now = Date.now();
+  state.lastUpdatedAt = now > state.lastUpdatedAt ? now : state.lastUpdatedAt + 1;
+  return state.lastUpdatedAt;
+}
+
+function removeTopicStore(persistedPath?: string): void {
+  const state = getTopicNameCacheState();
+  const stateKey = persistedPath ?? DEFAULT_TOPIC_NAME_CACHE_KEY;
+  if (persistedPath) {
+    fs.rmSync(persistedPath, { force: true });
+  }
+  state.stores.delete(stateKey);
+}
+
+function persistTopicStore(persistedPath: string, store: TopicNameStore): void {
+  if (store.size === 0) {
+    fs.rmSync(persistedPath, { force: true });
+    return;
+  }
+  fs.mkdirSync(path.dirname(persistedPath), { recursive: true });
+  const tempPath = `${persistedPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, JSON.stringify(Object.fromEntries(store)), "utf-8");
+  fs.renameSync(tempPath, persistedPath);
 }
 
 export function updateTopicName(
   chatId: number | string,
   threadId: number | string,
   patch: Partial<Omit<TopicEntry, "updatedAt">>,
+  persistedPath?: string,
 ): void {
+  const cache = getTopicStore(persistedPath);
   const key = cacheKey(chatId, threadId);
   const existing = cache.get(key);
   const merged: TopicEntry = {
@@ -36,45 +166,53 @@ export function updateTopicName(
     iconColor: patch.iconColor ?? existing?.iconColor,
     iconCustomEmojiId: patch.iconCustomEmojiId ?? existing?.iconCustomEmojiId,
     closed: patch.closed ?? existing?.closed,
-    updatedAt: Date.now(),
+    updatedAt: nextUpdatedAt(persistedPath),
   };
   if (!merged.name) {
     return;
   }
-  cache.delete(key);
   cache.set(key, merged);
-  evictOldest();
+  evictOldest(cache);
+  if (persistedPath) {
+    try {
+      persistTopicStore(persistedPath, cache);
+    } catch (error) {
+      logVerbose(`telegram: failed to persist topic-name cache: ${String(error)}`);
+    }
+  }
 }
 
 export function getTopicName(
   chatId: number | string,
   threadId: number | string,
+  persistedPath?: string,
 ): string | undefined {
-  const key = cacheKey(chatId, threadId);
-  const entry = cache.get(key);
+  const entry = getTopicStore(persistedPath).get(cacheKey(chatId, threadId));
   if (entry) {
-    const refreshedEntry: TopicEntry = {
-      ...entry,
-      updatedAt: Date.now(),
-    };
-    cache.delete(key);
-    cache.set(key, refreshedEntry);
-    return refreshedEntry.name;
+    entry.updatedAt = nextUpdatedAt(persistedPath);
   }
-  return undefined;
+  return entry?.name;
 }
 
 export function getTopicEntry(
   chatId: number | string,
   threadId: number | string,
+  persistedPath?: string,
 ): TopicEntry | undefined {
-  return cache.get(cacheKey(chatId, threadId));
+  return getTopicStore(persistedPath).get(cacheKey(chatId, threadId));
 }
 
 export function clearTopicNameCache(): void {
-  cache.clear();
+  const state = getTopicNameCacheState();
+  for (const stateKey of state.stores.keys()) {
+    removeTopicStore(stateKey === DEFAULT_TOPIC_NAME_CACHE_KEY ? undefined : stateKey);
+  }
 }
 
 export function topicNameCacheSize(): number {
-  return cache.size;
+  return getTopicStore().size;
+}
+
+export function resetTopicNameCacheForTest(): void {
+  getTopicNameCacheState().stores.clear();
 }


### PR DESCRIPTION
## Summary
- persist learned Telegram forum topic names to a session-sidecar JSON cache
- reload the cache on demand after restart while keeping the bounded in-memory path
- add cache reload tests and note the user-visible fix in the changelog

## Commits
- fix(telegram): persist topic-name cache
- test(telegram): cover topic-name cache reload
- docs(changelog): note telegram topic-name persistence

## Testing
- pnpm exec oxlint extensions/telegram/src/topic-name-cache.ts extensions/telegram/src/bot-message-context.ts extensions/telegram/src/topic-name-cache.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts
- pnpm test extensions/telegram/src/topic-name-cache.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts