### PR TITLE
fix(bluebubbles): route fetchImpl through bundled undici fetch on Node 24+

### DIFF
--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithRuntimeDispatcher } from "openclaw/plugin-sdk/infra-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -19,7 +20,6 @@ import { getBlueBubblesRuntime, warnBlueBubbles } from "./runtime.js";
 import { extractBlueBubblesMessageId, resolveBlueBubblesSendTarget } from "./send-helpers.js";
 import { createChatForHandle, resolveChatGuidForTarget } from "./send.js";
 import {
-  blueBubblesFetchWithTimeout,
   buildBlueBubblesApiUrl,
   type BlueBubblesAttachment,
   type SsrFPolicy,
@@ -94,6 +94,13 @@ function readMediaFetchErrorCode(error: unknown): MediaFetchErrorCode | undefine
     : undefined;
 }
 
+function isMockedFetch(fetchImpl: typeof fetch | undefined): boolean {
+  if (typeof fetchImpl !== "function") {
+    return false;
+  }
+  return typeof (fetchImpl as typeof fetch & { mock?: unknown }).mock === "object";
+}
+
 export async function downloadBlueBubblesAttachment(
   attachment: BlueBubblesAttachment,
   opts: BlueBubblesAttachmentOpts & { maxBytes?: number } = {},
@@ -122,12 +129,16 @@ export async function downloadBlueBubblesAttachment(
         : trustedHostname && (allowPrivateNetworkConfig !== false || !trustedHostnameIsPrivate)
           ? { allowedHostnames: [trustedHostname] }
           : undefined,
-      fetchImpl: async (input, init) =>
-        await blueBubblesFetchWithTimeout(
-          resolveRequestUrl(input),
-          { ...init, method: init?.method ?? "GET" },
-          opts.timeoutMs,
-        ),
+      fetchImpl: async (input, init) => {
+        const useFetch = init && "dispatcher" in init && !isMockedFetch(globalThis.fetch)
+          ? fetchWithRuntimeDispatcher
+          : globalThis.fetch;
+        return await useFetch(resolveRequestUrl(input), {
+          ...init,
+          method: init?.method ?? "GET",
+          ...(!init?.signal ? { signal: AbortSignal.timeout(opts.timeoutMs ?? 10_000) } : {}),
+        });
+      },
     });
     return {
       buffer: new Uint8Array(fetched.buffer),


### PR DESCRIPTION
## Summary

BlueBubbles attachment downloads fail on Node 24+ because the SSRF guard's pinned-DNS dispatcher is an undici 8.x `Agent`, but Node 24's built-in `globalThis.fetch` uses undici 7.x internally. Passing the 8.x dispatcher causes `"invalid onRequestStart method"` errors.

Routes through `fetchWithRuntimeDispatcher` (bundled undici's own fetch) when a dispatcher is present in `init`, matching the approach used by the Slack extension (#62239).

Supersedes #66103 and #63984.

## Changes

- `extensions/bluebubbles/src/attachments.ts`:
  - Use `fetchWithRuntimeDispatcher` when `init` contains a `dispatcher` (preserves SSRF DNS pinning)
  - Add `isMockedFetch` guard so test-installed `globalThis.fetch` mocks are honoured (parity with Slack)
  - Forward `opts.timeoutMs` (default 10s) via `AbortSignal.timeout` — no timeout regression
  - Remove unused `blueBubblesFetchWithTimeout` import

## Test plan

- [ ] Send an image to a BB-connected agent on Node 24+ — confirm attachment downloads
- [ ] Verify no SSRF guard regressions (DNS pinning preserved)
- [ ] Confirm stalled downloads still timeout after 10s (or configured `timeoutMs`)
- [ ] Verify existing tests pass (isMockedFetch guard preserves mock behaviour)