### PR TITLE
Fix ollama memory embedding provider registration

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -6,6 +6,7 @@ import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearMemoryEmbeddingProviders as clearRegistry,
+  getRegisteredMemoryEmbeddingProvider,
   registerMemoryEmbeddingProvider as registerAdapter,
 } from "../../../../src/plugins/memory-embedding-providers.js";
 import "./test-runtime-mocks.js";
@@ -444,6 +445,17 @@ describe("memory index", () => {
     } finally {
       vi.unstubAllEnvs();
     }
+  });
+
+  it("registers builtin ollama memory embedding provider", () => {
+    expect(getRegisteredMemoryEmbeddingProvider("ollama")).toEqual(
+      expect.objectContaining({
+        adapter: expect.objectContaining({
+          id: "ollama",
+          defaultModel: "nomic-embed-text",
+        }),
+      }),
+    );
   });
 
   it("bootstraps an empty index on first search so session transcript hits are available", async () => {

--- a/extensions/memory-core/src/memory/provider-adapters.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_LMSTUDIO_EMBEDDING_MODEL,
   DEFAULT_LOCAL_MODEL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
+  DEFAULT_OLLAMA_EMBEDDING_MODEL,
   DEFAULT_OPENAI_EMBEDDING_MODEL,
   DEFAULT_VOYAGE_EMBEDDING_MODEL,
   OPENAI_BATCH_ENDPOINT,
@@ -12,6 +13,7 @@ import {
   createLmstudioEmbeddingProvider,
   createLocalEmbeddingProvider,
   createMistralEmbeddingProvider,
+  createOllamaEmbeddingProvider,
   createOpenAiEmbeddingProvider,
   createVoyageEmbeddingProvider,
   hasNonTextEmbeddingParts,
@@ -290,6 +292,30 @@ const mistralAdapter: MemoryEmbeddingProviderAdapter = {
   },
 };
 
+const ollamaAdapter: MemoryEmbeddingProviderAdapter = {
+  id: "ollama",
+  defaultModel: DEFAULT_OLLAMA_EMBEDDING_MODEL,
+  transport: "remote",
+  allowExplicitWhenConfiguredAuto: true,
+  create: async (options) => {
+    const { provider, client } = await createOllamaEmbeddingProvider({
+      ...options,
+      provider: "ollama",
+      fallback: "none",
+    });
+    return {
+      provider,
+      runtime: {
+        id: "ollama",
+        cacheKeyData: {
+          provider: "ollama",
+          model: client.model,
+        },
+      },
+    };
+  },
+};
+
 const lmstudioAdapter: MemoryEmbeddingProviderAdapter = {
   id: "lmstudio",
   defaultModel: DEFAULT_LMSTUDIO_EMBEDDING_MODEL,
@@ -347,16 +373,16 @@ export const builtinMemoryEmbeddingProviderAdapters = [
   geminiAdapter,
   voyageAdapter,
   mistralAdapter,
+  ollamaAdapter,
   lmstudioAdapter,
 ] as const;
 
-const builtinMemoryEmbeddingProviderAdapterById = new Map(
-  builtinMemoryEmbeddingProviderAdapters.map((adapter) => [adapter.id, adapter]),
-);
+const builtinMemoryEmbeddingProviderAdapterById: ReadonlyMap<
+  string,
+  (typeof builtinMemoryEmbeddingProviderAdapters)[number]
+> = new Map(builtinMemoryEmbeddingProviderAdapters.map((adapter) => [adapter.id, adapter]));
 
-export function getBuiltinMemoryEmbeddingProviderAdapter(
-  id: string,
-): MemoryEmbeddingProviderAdapter | undefined {
+export function getBuiltinMemoryEmbeddingProviderAdapter(id: string) {
   return builtinMemoryEmbeddingProviderAdapterById.get(id);
 }
 
@@ -409,6 +435,7 @@ export {
   DEFAULT_LMSTUDIO_EMBEDDING_MODEL,
   DEFAULT_LOCAL_MODEL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
+  DEFAULT_OLLAMA_EMBEDDING_MODEL,
   DEFAULT_OPENAI_EMBEDDING_MODEL,
   DEFAULT_VOYAGE_EMBEDDING_MODEL,
   canAutoSelectLocal,


### PR DESCRIPTION
## Summary
- restore builtin `ollama` memory embedding adapter registration in memory-core
- make explicit `memorySearch.provider: ollama` resolve again
- add a regression test covering builtin ollama registration

## Root cause
`extensions/memory-core/src/memory/provider-adapters.ts` no longer registered an `ollama` adapter even though memory embedding defaults and provider selection logic still supported explicit ollama configuration. That caused flows like `openclaw memory status --deep` to fail with `Unknown memory embedding provider: ollama` when `memorySearch.provider` was set to `ollama`.

## Testing
- `pnpm exec vitest run extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/memory/manager.mistral-provider.test.ts src/plugins/contracts/memory-embedding-provider.contract.test.ts`

## Notes
- I also tried the broader repo test/check path after installing dependencies.
- Current `main` appears to have unrelated failing checks outside this patch scope, so I validated with the targeted memory/provider test slice above.
