### PR TITLE
fix(bluebubbles): accept updated-message events carrying attachments

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -248,11 +248,21 @@ export async function handleBlueBubblesWebhookRequest(
         return true;
       }
       const reaction = normalizeWebhookReaction(payload);
+      // Allow updated-message events through when they carry attachments.
+      // BB fires new-message (text only), then updated-message ~2-3s later once
+      // attachment data is ready. Without this, inbound images/PDFs/files are
+      // silently dropped. Only check data.attachments (normalizeWebhookMessage
+      // requires a message container in payload.data, so root-only attachment
+      // payloads would pass the filter but fail normalization).
+      const dataAttachments = asRecord(payload.data)?.attachments;
+      const isAttachmentUpdate =
+        eventType === "updated-message" && Array.isArray(dataAttachments) && dataAttachments.length > 0;
       if (
         (eventType === "updated-message" ||
           eventType === "message-reaction" ||
           eventType === "reaction") &&
-        !reaction
+        !reaction &&
+        !isAttachmentUpdate
       ) {
         res.statusCode = 200;
         res.end("ok");


### PR DESCRIPTION
## Summary

BlueBubbles fires `new-message` first (text only), then `updated-message` ~2-3s later once attachment data is ready. The webhook filter unconditionally discards `updated-message` events that are not reactions, silently dropping all inbound images, PDFs, and files.

Lets `updated-message` events through when `data.attachments` is non-empty. Text is preserved (not stripped) so that mention gating in group chats works correctly.

Supersedes #66105 and #63983.

## Changes

- `extensions/bluebubbles/src/monitor.ts`:
  - Detect attachment-bearing `updated-message` via `asRecord(payload.data)?.attachments`
  - Pass these events through the event type filter alongside reactions

## Known limitation

For text+attachment sends, the text body is delivered twice — once from `new-message` and once from the `updated-message` that carries the attachment. The 500ms debounce window is shorter than the ~2-3s BB delay, so they aren't coalesced. A `messageId`-based seen-set in the debouncer would close this gap but is left as a follow-up to keep this fix minimal. Dropping attachments (the current behavior) is a worse outcome than a duplicate text line.

## Test plan

- [ ] Send an image via iMessage to a BB-connected agent — confirm the image is received
- [ ] Send text + image — confirm both arrive (text may appear twice)
- [ ] Verify `updated-message` events without attachments are still filtered out
- [ ] Verify mention gating works in group chats with attachments
- [ ] Verify reactions still work normally