### PR TITLE
test(cron): fix #66019 maintenance regression coverage

### DIFF
--- a/src/cron/service.issue-66019-unresolved-next-run.test.ts
+++ b/src/cron/service.issue-66019-unresolved-next-run.test.ts
@@ -136,7 +136,7 @@ describe("#66019 unresolved next-run repro", () => {
     const nextRunSpy = vi
       .spyOn(schedule, "computeNextRunAtMs")
       .mockReturnValueOnce(undefined)
-      .mockReturnValueOnce(naturalNext)
+      .mockReturnValueOnce(undefined)
       .mockReturnValue(naturalNext);
     const state = createCronServiceState({
       cronEnabled: true,


### PR DESCRIPTION
## Summary
- make the #66019 regression test force maintenance to repair `nextRunAtMs`
- keep the PR scoped to the existing test only

## Why
The previous mock sequence let `applyJobResult` consume the second `computeNextRunAtMs` result during the built-in next-second retry, so the new maintenance path was not actually what made the test pass.

## Testing
- `pnpm test -- src/cron/service.issue-66019-unresolved-next-run.test.ts`
