### PR TITLE
refactor(memory-wiki): use factory registration for wiki_apply/status/lint

### DIFF
--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -25,9 +25,9 @@ export default definePluginEntry({
       createWikiCorpusSupplement({ config, appConfig: api.config }),
     );
     registerMemoryWikiGatewayMethods({ api, config, appConfig: api.config });
-    api.registerTool(createWikiStatusTool(config, api.config), { name: "wiki_status" });
-    api.registerTool(createWikiLintTool(config, api.config), { name: "wiki_lint" });
-    api.registerTool(createWikiApplyTool(config, api.config), { name: "wiki_apply" });
+    api.registerTool(() => createWikiStatusTool(config, api.config), { name: "wiki_status" });
+    api.registerTool(() => createWikiLintTool(config, api.config), { name: "wiki_lint" });
+    api.registerTool(() => createWikiApplyTool(config, api.config), { name: "wiki_apply" });
     api.registerTool(
       (ctx) =>
         createWikiSearchTool(config, api.config, {


### PR DESCRIPTION
## Summary

- **Problem:** `wiki_apply`, `wiki_status`, and `wiki_lint` are registered with the static `api.registerTool(createX(config, api.config))` form, while their read-side siblings `wiki_search` and `wiki_get` use the factory form `api.registerTool((ctx) => ...)`. The write-side tools close over a single `config` object resolved at `register(api)` call time and never see the per-invocation `OpenClawPluginToolContext`.
- **Why it matters:** The inconsistency means downstream plugins and advanced configurations can hook into wiki reads via ctx but have no equivalent seam for writes without forking. It also makes the plugin harder to reason about — two registration shapes for five tools in the same file.
- **What changed:** Switched `wiki_status`, `wiki_lint`, and `wiki_apply` to factory registration: `api.registerTool(() => createX(config, api.config), { name: ... })`.
- **What did NOT change (scope boundary):** No changes to tool internals, config schema, resolved config values, or any public API surface. Factories currently ignore `ctx` (matching today's write-side behavior) — this PR is purely about registration shape.

## Change Type (select all)

- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Memory / storage
- [x] Skills / tool execution

## Linked Issue/PR

- Related #66003

## Root Cause (if applicable)

N/A — refactor, not a bug fix.

## Regression Test Plan (if applicable)

N/A — existing `extensions/memory-wiki/index.test.ts` asserts all five tool registrations by name and continues to pass unchanged.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
  api.registerTool(createWikiStatusTool(config, api.config), { name: "wiki_status" })  // static
  api.registerTool((ctx) => createWikiSearchTool(config, api.config, {...}), ...)      // factory

After:
  api.registerTool(() => createWikiStatusTool(config, api.config), { name: "wiki_status" })  // factory
  api.registerTool((ctx) => createWikiSearchTool(config, api.config, {...}), ...)            // factory
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (tool behavior identical; only registration shape changes)
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.3
- Runtime/container: Node 20, pnpm 10.32.1
- Model/provider: N/A

### Steps

1. `pnpm install`
2. `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-wiki/`

### Expected

All memory-wiki tests pass (including `index.test.ts` which asserts the five tool registrations).

### Actual

```
 Test Files  22 passed (22)
      Tests  81 passed (81)
```

## Evidence

- [x] Passing test output (above)

## Human Verification (required)

- **Verified scenarios:** Ran the full memory-wiki test suite locally (22 files, 81 tests, all passing). Confirmed `extensions/memory-wiki/index.test.ts` still passes — it asserts registration order and names, which are unchanged.
- **Edge cases checked:** Confirmed `OpenClawPluginApi.registerTool` already accepts `AnyAgentTool | OpenClawPluginToolFactory` (`src/plugins/types.ts:1887`), so no API-level changes are needed.
- **What I did not verify:** End-to-end runtime behavior inside a real OpenClaw agent session. The factories are called once per registration in the existing tool-lookup path, so behavior should be identical, but I have not exercised a live wiki_apply/status/lint call through an agent after the refactor.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Factory is invoked per tool resolution rather than once at `register(api)` time, so any consumer relying on identity of the returned tool object across calls would see a new object each time.
  - **Mitigation:** The read-side tools (`wiki_search`, `wiki_get`) have used this pattern since they were introduced, and no known consumer depends on tool identity. The plugin loader treats registered tools as descriptors, not singletons.