### PR TITLE
fix(memory-core): run Dreaming once per cron schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Cron/scheduler: preserve the active error-backoff floor when maintenance repair recomputes a missing cron next-run, so recurring errored jobs do not resume early after a transient next-run resolution failure. (#66019, #66083, #66113) Thanks @mbelinky.
 - Outbound/delivery-queue: persist the originating outbound `session` context on queued delivery entries and replay it during recovery, so write-ahead-queued sends keep their original outbound media policy context after restart instead of evaluating against a missing session. (#66025) Thanks @eleqtrizit.
 - Auto-reply/queue: split collect-mode followup drains into contiguous groups by per-message authorization context (sender id, owner status, exec/bash-elevated overrides), so queued items from different senders or exec configs no longer execute under the last queued run's owner-only and exec-approval context. (#66024) Thanks @eleqtrizit.
+- Dreaming/memory-core: require a live queued Dreaming cron event before the heartbeat hook runs the sweep, so managed Dreaming no longer replays on later heartbeats after the scheduled run was already consumed. (#66139) Thanks @mbelinky.
 
 ## 2026.4.12
 

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { enqueueSystemEvent, resetSystemEventsForTest } from "openclaw/plugin-sdk/infra-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearInternalHooks,
   createInternalHookEvent,
@@ -20,6 +21,10 @@ import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
 const constants = __testing.constants;
 const { createTempWorkspace } = createMemoryCoreTestHarness();
+
+afterEach(() => {
+  resetSystemEventsForTest();
+});
 
 type CronParam = NonNullable<Parameters<typeof reconcileShortTermDreamingCronJob>[0]["cron"]>;
 type CronJobLike = Awaited<ReturnType<CronParam["list"]>>[number];
@@ -138,7 +143,7 @@ function getBeforeAgentReplyHandler(
   onMock: ReturnType<typeof vi.fn>,
 ): (
   event: { cleanedBody: string },
-  ctx: { trigger?: string; workspaceDir?: string },
+  ctx: { trigger?: string; workspaceDir?: string; sessionKey?: string },
 ) => Promise<unknown> {
   const call = onMock.mock.calls.find(([eventName]) => eventName === "before_agent_reply");
   if (!call) {
@@ -146,7 +151,7 @@ function getBeforeAgentReplyHandler(
   }
   return call[1] as (
     event: { cleanedBody: string },
-    ctx: { trigger?: string; workspaceDir?: string },
+    ctx: { trigger?: string; workspaceDir?: string; sessionKey?: string },
   ) => Promise<unknown>;
 }
 
@@ -1108,6 +1113,130 @@ describe("gateway startup reconciliation", () => {
       expect(harness.listCalls).toBe(2);
     } finally {
       nowSpy.mockRestore();
+      clearInternalHooks();
+    }
+  });
+
+  it("only triggers managed dreaming when the queued cron event is still pending", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      registerHook: (event: string, handler: Parameters<typeof registerInternalHook>[1]) => {
+        registerInternalHook(event, handler);
+      },
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerInternalHook(
+        createInternalHookEvent("gateway", "startup", "gateway:startup", {
+          cfg: api.config,
+          deps: { cron: harness.cron },
+        }),
+      );
+
+      const sessionKey = "agent:main:main";
+      enqueueSystemEvent(constants.DREAMING_SYSTEM_EVENT_TEXT, {
+        sessionKey,
+        contextKey: "cron:memory-dreaming",
+      });
+
+      const beforeAgentReply = getBeforeAgentReplyHandler(onMock);
+      const first = await beforeAgentReply(
+        { cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT },
+        { trigger: "heartbeat", workspaceDir: ".", sessionKey },
+      );
+
+      expect(first).toEqual({
+        handled: true,
+        reason: "memory-core: short-term dreaming disabled",
+      });
+
+      resetSystemEventsForTest();
+
+      const second = await beforeAgentReply(
+        { cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT },
+        { trigger: "heartbeat", workspaceDir: ".", sessionKey },
+      );
+
+      expect(second).toBeUndefined();
+    } finally {
+      clearInternalHooks();
+    }
+  });
+
+  it("resolves queued managed dreaming cron events from the base session for isolated heartbeats", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      registerHook: (event: string, handler: Parameters<typeof registerInternalHook>[1]) => {
+        registerInternalHook(event, handler);
+      },
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerInternalHook(
+        createInternalHookEvent("gateway", "startup", "gateway:startup", {
+          cfg: api.config,
+          deps: { cron: harness.cron },
+        }),
+      );
+
+      enqueueSystemEvent(constants.DREAMING_SYSTEM_EVENT_TEXT, {
+        sessionKey: "agent:main:main",
+        contextKey: "cron:memory-dreaming",
+      });
+
+      const beforeAgentReply = getBeforeAgentReplyHandler(onMock);
+      const result = await beforeAgentReply(
+        { cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT },
+        { trigger: "heartbeat", workspaceDir: ".", sessionKey: "agent:main:main:heartbeat" },
+      );
+
+      expect(result).toEqual({
+        handled: true,
+        reason: "memory-core: short-term dreaming disabled",
+      });
+    } finally {
       clearInternalHooks();
     }
   });

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -1,3 +1,4 @@
+import { peekSystemEventEntries } from "openclaw/plugin-sdk/infra-runtime";
 import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
 import {
   DEFAULT_MEMORY_DREAMING_FREQUENCY as DEFAULT_MEMORY_DREAMING_CRON_EXPR,
@@ -36,6 +37,7 @@ const LEGACY_REM_SLEEP_CRON_NAME = "Memory REM Dreaming";
 const LEGACY_REM_SLEEP_CRON_TAG = "[managed-by=memory-core.dreaming.rem]";
 const LEGACY_REM_SLEEP_EVENT_TEXT = "__openclaw_memory_core_rem_sleep__";
 const RUNTIME_CRON_RECONCILE_INTERVAL_MS = 60_000;
+const HEARTBEAT_ISOLATED_SESSION_SUFFIX = ":heartbeat";
 
 type Logger = Pick<OpenClawPluginApi["logger"], "info" | "warn" | "error">;
 
@@ -342,6 +344,35 @@ function resolveStartupConfigFromEvent(event: unknown, fallback: OpenClawConfig)
     return fallback;
   }
   return startupCfg as OpenClawConfig;
+}
+
+function resolveDreamingTriggerSessionKeys(sessionKey?: string): string[] {
+  const normalized = normalizeTrimmedString(sessionKey);
+  if (!normalized) {
+    return [];
+  }
+
+  const keys = [normalized];
+  // Isolated heartbeat runs execute in a sibling `:heartbeat` session while cron
+  // system events stay queued on the base main session.
+  if (normalized.endsWith(HEARTBEAT_ISOLATED_SESSION_SUFFIX)) {
+    const baseSessionKey = normalized.slice(0, -HEARTBEAT_ISOLATED_SESSION_SUFFIX.length).trim();
+    if (baseSessionKey) {
+      keys.push(baseSessionKey);
+    }
+  }
+
+  return Array.from(new Set(keys));
+}
+
+function hasPendingManagedDreamingCronEvent(sessionKey?: string): boolean {
+  return resolveDreamingTriggerSessionKeys(sessionKey).some((candidateSessionKey) =>
+    peekSystemEventEntries(candidateSessionKey).some(
+      (event) =>
+        event.contextKey?.startsWith("cron:") === true &&
+        normalizeTrimmedString(event.text) === DREAMING_SYSTEM_EVENT_TEXT,
+    ),
+  );
 }
 
 export function resolveShortTermPromotionDreamingConfig(params: {
@@ -716,6 +747,12 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
       const config = await reconcileManagedDreamingCron({
         reason: "runtime",
       });
+      if (
+        !hasPendingManagedDreamingCronEvent(ctx.sessionKey) ||
+        !includesSystemEventToken(event.cleanedBody, DREAMING_SYSTEM_EVENT_TEXT)
+      ) {
+        return undefined;
+      }
       return await runShortTermDreamingPromotionIfTriggered({
         cleanedBody: event.cleanedBody,
         trigger: ctx.trigger,


### PR DESCRIPTION
## Summary

- Problem: managed Dreaming could re-trigger on later heartbeat turns even after the cron event had already been consumed.
- Why it matters: this creates repeated empty Dreaming-related sessions and extra sweep churn instead of running once per schedule.
- What changed: gate the Dreaming heartbeat trigger on a real pending queued `cron:*` Dreaming system event, with isolated-heartbeat fallback to the base session queue.
- What did NOT change (scope boundary): this does not broaden into the separate cron-service-unavailable reconciliation issue.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65705
- Related #65652
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the `before_agent_reply` Dreaming hook treated the rendered heartbeat prompt text as the trigger source, so the same Dreaming token could be re-detected on later heartbeats even after the original cron event had already been handled.
- Missing detection / guardrail: the trigger path did not verify that a live queued Dreaming `cron:*` system event still existed for the session being processed.
- Contributing context (if known): isolated heartbeat runs use a sibling `:heartbeat` session while cron events stay queued on the base session.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming.test.ts`
- Scenario the test should lock in: stale Dreaming token text without a pending cron event must not retrigger; isolated heartbeat sessions must still honor the base-session queued cron event.
- Why this is the smallest reliable guardrail: the bug lives at the plugin hook plus session-queue seam, not in the cron expression math itself.
- Existing test that already covers this (if any): `src/infra/heartbeat-runner.ghost-reminder.test.ts` already covers the core queue-drain contract for cron-tagged system events.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Dreaming now runs once per cron schedule instead of replaying on subsequent ordinary heartbeats after the scheduled event has already been consumed.

## Diagram (if applicable)

```text
Before:
[cron fires] -> [heartbeat prompt includes Dreaming token] -> [Dreaming runs]
[next heartbeat still contains replayed token text] -> [Dreaming runs again]

After:
[cron fires] -> [queued Dreaming cron event exists] -> [Dreaming runs once]
[next heartbeat without queued cron event] -> [no Dreaming replay]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo worktree
- Model/provider: N/A
- Integration/channel (if any): heartbeat / cron / memory-core Dreaming
- Relevant config (redacted): memory-core Dreaming enabled with managed cron schedule; isolated heartbeat path also exercised

### Steps

1. Queue a managed Dreaming cron system event for the main session.
2. Run a heartbeat that contains the Dreaming token and let the Dreaming hook handle it.
3. Run a later heartbeat with the same token text but without a pending queued cron event.

### Expected

- Dreaming runs only for the heartbeat backed by the queued cron event.
- Later heartbeats do not retrigger unless a new cron event is actually pending.

### Actual

- Before the fix, later heartbeats could retrigger Dreaming from stale/replayed token text alone.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Dreaming regression tests, isolated-heartbeat queue behavior, and core cron-event drain behavior.
- Edge cases checked: base-session queued cron events for isolated `:heartbeat` runs; replay-shaped stale prompt text without a pending event.
- What you did **not** verify: a full live gateway reproduce-before / verify-after run on this machine.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a future synthetic `before_agent_reply` caller that omits `sessionKey` would suppress Dreaming instead of triggering it.
  - Mitigation: current production wiring passes `sessionKey`, and suppression is safer than replay.
