### PR TITLE
docs: clarify mobile pairing routing and approval flow

### DIFF
--- a/docs/cli/qr.md
+++ b/docs/cli/qr.md
@@ -50,3 +50,4 @@ openclaw qr --url wss://gateway.example/ws
 - After scanning, approve device pairing with:
   - `openclaw devices list`
   - `openclaw devices approve <requestId>`
+- During onboarding, a valid gateway route can still surface `pairing required` until you approve the pending request. If you see repeated fresh requests, that is client retry churn, not a routing failure. Approve the newest pending request and prefer the latest Android build with the pairing retry fix.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2859,8 +2859,11 @@ Related: [/concepts/oauth](/concepts/oauth) (OAuth flows, token storage, multi-a
     Quick fixes:
 
     1. Use the WS URL: `ws://<host>:18789` (or `wss://...` if HTTPS).
-    2. Don't open the WS port in a normal browser tab.
-    3. If auth is on, include the token/password in the `connect` frame.
+    2. For Tailscale/public mobile pairing, do not use raw `ws://` tailnet/public URLs. Use Tailscale Serve/Funnel or another `wss://` route.
+    3. Don't open the WS port in a normal browser tab.
+    4. If auth is on, include the token/password in the `connect` frame.
+
+    If mobile onboarding reaches `pairing required`, the route is usually working and the next step is approving the pending device request. Repeatedly rotating pending requests points to client retry churn rather than a transport failure.
 
     If you're using the CLI or TUI, the URL should look like:
 


### PR DESCRIPTION
## Summary
- clarify that Tailscale/public mobile pairing must use `wss://` or Tailscale Serve/Funnel
- document that `pairing required` means transport is working and approval is the next step
- note that repeated fresh pending requests indicate client retry churn, not necessarily a broken route

## Why
While validating Android mobile pairing over Tailscale Serve, it was easy to misread the transition from transport errors to `pairing required` as another routing failure.

In practice:
- `Expected HTTP 101 response but was '200 OK'` pointed to the wrong transport URL or wrong service behind the route
- `pairing required` meant the device was finally reaching the real gateway
- repeated pending requests were a separate client UX issue

These docs updates make that progression clearer for the next person debugging the same flow.
