### PR TITLE
feat(memory-wiki): add ctx-aware templating for vault.path

### DIFF
--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -317,6 +317,14 @@ Put config under `plugins.entries.memory-wiki.config`:
 Key toggles:
 
 - `vaultMode`: `isolated`, `bridge`, `unsafe-local`
+- `vault.path`: supports `~` home expansion and the template tokens
+  `{workspaceDir}`, `{agentDir}`, `{agentId}`, `{sessionKey}`. Templates are
+  expanded against the tool invocation context on each wiki tool call, so
+  agents in different workspaces can share the plugin instance while writing
+  to their own vaults. Example: `{workspaceDir}/wiki`. Templates are only
+  expanded for the tool surfaces (`wiki_status`, `wiki_lint`, `wiki_apply`,
+  `wiki_search`, `wiki_get`); the `openclaw wiki` CLI and non-agent gateway
+  methods use the literal configured path.
 - `vault.renderMode`: `native` or `obsidian`
 - `bridge.readMemoryArtifacts`: import active memory plugin public artifacts
 - `bridge.followMemoryEvents`: include event logs in bridge mode

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -25,9 +25,9 @@ export default definePluginEntry({
       createWikiCorpusSupplement({ config, appConfig: api.config }),
     );
     registerMemoryWikiGatewayMethods({ api, config, appConfig: api.config });
-    api.registerTool(createWikiStatusTool(config, api.config), { name: "wiki_status" });
-    api.registerTool(createWikiLintTool(config, api.config), { name: "wiki_lint" });
-    api.registerTool(createWikiApplyTool(config, api.config), { name: "wiki_apply" });
+    api.registerTool(() => createWikiStatusTool(config, api.config), { name: "wiki_status" });
+    api.registerTool(() => createWikiLintTool(config, api.config), { name: "wiki_lint" });
+    api.registerTool(() => createWikiApplyTool(config, api.config), { name: "wiki_apply" });
     api.registerTool(
       (ctx) =>
         createWikiSearchTool(config, api.config, {

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -1,6 +1,10 @@
 import { definePluginEntry } from "./api.js";
 import { registerWikiCli } from "./src/cli.js";
-import { memoryWikiConfigSchema, resolveMemoryWikiConfig } from "./src/config.js";
+import {
+  memoryWikiConfigSchema,
+  resolveMemoryWikiConfig,
+  resolveMemoryWikiConfigForCtx,
+} from "./src/config.js";
 import { createWikiCorpusSupplement } from "./src/corpus-supplement.js";
 import { registerMemoryWikiGatewayMethods } from "./src/gateway.js";
 import { createWikiPromptSectionBuilder } from "./src/prompt-section.js";
@@ -25,12 +29,21 @@ export default definePluginEntry({
       createWikiCorpusSupplement({ config, appConfig: api.config }),
     );
     registerMemoryWikiGatewayMethods({ api, config, appConfig: api.config });
-    api.registerTool(() => createWikiStatusTool(config, api.config), { name: "wiki_status" });
-    api.registerTool(() => createWikiLintTool(config, api.config), { name: "wiki_lint" });
-    api.registerTool(() => createWikiApplyTool(config, api.config), { name: "wiki_apply" });
+    api.registerTool(
+      (ctx) => createWikiStatusTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      { name: "wiki_status" },
+    );
+    api.registerTool(
+      (ctx) => createWikiLintTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      { name: "wiki_lint" },
+    );
+    api.registerTool(
+      (ctx) => createWikiApplyTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      { name: "wiki_apply" },
+    );
     api.registerTool(
       (ctx) =>
-        createWikiSearchTool(config, api.config, {
+        createWikiSearchTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config, {
           agentId: ctx.agentId,
           agentSessionKey: ctx.sessionKey,
         }),
@@ -38,7 +51,7 @@ export default definePluginEntry({
     );
     api.registerTool(
       (ctx) =>
-        createWikiGetTool(config, api.config, {
+        createWikiGetTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config, {
           agentId: ctx.agentId,
           agentSessionKey: ctx.sessionKey,
         }),

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -2,12 +2,15 @@ import fs from "node:fs";
 import AjvPkg from "ajv";
 import { describe, expect, it } from "vitest";
 import {
+  containsVaultPathTemplate,
   DEFAULT_WIKI_RENDER_MODE,
   DEFAULT_WIKI_SEARCH_BACKEND,
   DEFAULT_WIKI_SEARCH_CORPUS,
   DEFAULT_WIKI_VAULT_MODE,
+  expandVaultPathTemplate,
   resolveDefaultMemoryWikiVaultPath,
   resolveMemoryWikiConfig,
+  resolveMemoryWikiConfigForCtx,
 } from "./config.js";
 
 function compileManifestConfigSchema() {
@@ -56,6 +59,66 @@ describe("resolveMemoryWikiConfig", () => {
     });
 
     expect(canonical.bridge.readMemoryArtifacts).toBe(false);
+  });
+});
+
+describe("vault path templating", () => {
+  it("detects template tokens", () => {
+    expect(containsVaultPathTemplate("/Users/a/wiki")).toBe(false);
+    expect(containsVaultPathTemplate("/tmp/{workspaceDir}/wiki")).toBe(true);
+    expect(containsVaultPathTemplate("{agentId}")).toBe(true);
+    expect(containsVaultPathTemplate("{unknownToken}")).toBe(false);
+  });
+
+  it("expands known tokens and normalizes the result", () => {
+    expect(
+      expandVaultPathTemplate("{workspaceDir}/wiki", {
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toBe("/tmp/workspace/wiki");
+
+    // `..` traversal is applied only after expansion, not to the template.
+    expect(
+      expandVaultPathTemplate("{workspaceDir}/../shared-wiki", {
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toBe("/tmp/shared-wiki");
+  });
+
+  it("leaves literal paths untouched (identity fast path)", () => {
+    const base = resolveMemoryWikiConfig(
+      { vault: { path: "/literal/wiki" } },
+      { homedir: "/Users/tester" },
+    );
+    const resolved = resolveMemoryWikiConfigForCtx(base, { workspaceDir: "/tmp/w" });
+    expect(resolved).toBe(base);
+  });
+
+  it("returns a new config with expanded vault.path when templates are present", () => {
+    const base = resolveMemoryWikiConfig(
+      { vault: { path: "{workspaceDir}/wiki" } },
+      { homedir: "/Users/tester" },
+    );
+    expect(base.vault.path).toBe("{workspaceDir}/wiki");
+
+    const resolved = resolveMemoryWikiConfigForCtx(base, {
+      workspaceDir: "/tmp/workspace",
+      agentId: "agent-a",
+    });
+    expect(resolved).not.toBe(base);
+    expect(resolved.vault.path).toBe("/tmp/workspace/wiki");
+    // Unrelated fields pass through unchanged.
+    expect(resolved.vaultMode).toBe(base.vaultMode);
+    expect(resolved.vault.renderMode).toBe(base.vault.renderMode);
+  });
+
+  it("supports agentId templating and leaves unresolved tokens as empty strings", () => {
+    const base = resolveMemoryWikiConfig(
+      { vault: { path: "/tmp/{agentId}/{sessionKey}/wiki" } },
+      { homedir: "/Users/tester" },
+    );
+    const resolved = resolveMemoryWikiConfigForCtx(base, { agentId: "abc" });
+    expect(resolved.vault.path).toBe("/tmp/abc/wiki");
   });
 });
 

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -202,6 +202,72 @@ export function resolveDefaultMemoryWikiVaultPath(homedir = os.homedir()): strin
   return path.join(homedir, ".openclaw", "wiki", "main");
 }
 
+/**
+ * Context fields available for `vault.path` template expansion. All fields are
+ * optional; missing values expand to an empty string so callers can detect
+ * unresolved templates via {@link containsVaultPathTemplate}.
+ */
+export type VaultPathTemplateContext = {
+  workspaceDir?: string;
+  agentDir?: string;
+  agentId?: string;
+  sessionKey?: string;
+};
+
+const VAULT_PATH_TEMPLATE_TOKENS = ["workspaceDir", "agentDir", "agentId", "sessionKey"] as const;
+
+const VAULT_PATH_TEMPLATE_PATTERN = new RegExp(
+  `\\{(${VAULT_PATH_TEMPLATE_TOKENS.join("|")})\\}`,
+  "g",
+);
+
+export function containsVaultPathTemplate(candidatePath: string): boolean {
+  VAULT_PATH_TEMPLATE_PATTERN.lastIndex = 0;
+  return VAULT_PATH_TEMPLATE_PATTERN.test(candidatePath);
+}
+
+/**
+ * Expand `{workspaceDir}`, `{agentDir}`, `{agentId}`, `{sessionKey}` placeholders
+ * in a vault path using the supplied tool invocation context. Missing values
+ * expand to an empty string; the result is normalized so path-traversal
+ * segments (e.g. `..`) collapse only after expansion.
+ */
+export function expandVaultPathTemplate(
+  templatePath: string,
+  ctx: VaultPathTemplateContext,
+): string {
+  if (!containsVaultPathTemplate(templatePath)) {
+    return templatePath;
+  }
+  const expanded = templatePath.replace(
+    VAULT_PATH_TEMPLATE_PATTERN,
+    (_match, token: (typeof VAULT_PATH_TEMPLATE_TOKENS)[number]) => ctx[token] ?? "",
+  );
+  return path.normalize(expanded);
+}
+
+/**
+ * Return a {@link ResolvedMemoryWikiConfig} with `vault.path` expanded against
+ * the supplied invocation context. If the path has no template tokens the
+ * input config is returned unchanged (identity) so the fast path allocates
+ * nothing.
+ */
+export function resolveMemoryWikiConfigForCtx(
+  base: ResolvedMemoryWikiConfig,
+  ctx: VaultPathTemplateContext,
+): ResolvedMemoryWikiConfig {
+  if (!containsVaultPathTemplate(base.vault.path)) {
+    return base;
+  }
+  return {
+    ...base,
+    vault: {
+      ...base.vault,
+      path: expandVaultPathTemplate(base.vault.path, ctx),
+    },
+  };
+}
+
 export function resolveMemoryWikiConfig(
   config: MemoryWikiPluginConfig | undefined,
   options?: { homedir?: string },


### PR DESCRIPTION
## Summary

- **Problem:** `vault.path` is resolved once at `register(api)` time, so a single plugin instance cannot serve agents living in different workspaces — they all share one vault. There is no way to derive the vault location from the per-invocation tool context (`workspaceDir`, `agentId`, etc.) that the tool factories already receive.
- **Why it matters:** Setups where one OpenClaw instance runs multiple agent workspaces (shared hosts, containerized deployments, multi-profile setups) currently require either forking the plugin or running one OpenClaw process per agent. Both are heavy for a config-shaped problem.
- **What changed:** `vault.path` now supports the template tokens `{workspaceDir}`, `{agentDir}`, `{agentId}`, `{sessionKey}`. Templates are expanded against the tool invocation context on each wiki tool call, using the factory registration landed in the prior commit. A new public helper `resolveMemoryWikiConfigForCtx(base, ctx)` handles the expansion and returns `base` by identity when no tokens are present.
- **What did NOT change (scope boundary):** No change to default config values, resolved config shape, or any existing API. Non-templated paths hit an identity fast path (zero allocations). The `openclaw wiki` CLI and non-agent gateway methods intentionally continue to use the literal configured path — they have no invocation context to expand against, and silently pretending otherwise would be worse than the documented limitation.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Memory / storage
- [x] Skills / tool execution

## Linked Issue/PR

- **Depends on #66134** (factory registration for `wiki_apply`/`status`/`lint` — this PR is stacked on that branch and includes its commit). Please review/merge #66134 first; once it lands I'll rebase this on `main` and the diff will shrink to this feature commit only.
- Related #66003

## Root Cause (if applicable)

N/A — additive feature.

## Regression Test Plan (if applicable)

N/A — new feature. Added 5 unit tests in `extensions/memory-wiki/src/config.test.ts` covering:
- template token detection (including unknown tokens not triggering expansion)
- expansion order vs `path.normalize` (traversal segments collapse only after expansion)
- identity fast path for non-templated configs
- full config expansion with `{workspaceDir}`
- partial expansion when some ctx fields are absent

## User-visible / Behavior Changes

- New: `vault.path` accepts `{workspaceDir}`, `{agentDir}`, `{agentId}`, `{sessionKey}` placeholders.
- Unchanged: existing literal and `~`-prefixed paths continue to work identically.
- Documented in `docs/plugins/memory-wiki.md` under "Key toggles".

## Diagram (if applicable)

```text
Before (shared vault):
  agent-a ──┐
  agent-b ──┼──> single resolved vault.path ──> /Users/me/.openclaw/wiki/main
  agent-c ──┘

After (templated vault, same plugin instance):
  agent-a (workspaceDir=/ws/a) ──> {workspaceDir}/wiki ──> /ws/a/wiki
  agent-b (workspaceDir=/ws/b) ──> {workspaceDir}/wiki ──> /ws/b/wiki
  agent-c (workspaceDir=/ws/c) ──> {workspaceDir}/wiki ──> /ws/c/wiki
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (tool contracts unchanged)
- Data access scope changed? **Yes** — if the user opts in to templating, wiki writes now land in ctx-derived paths instead of a single shared path.
- **Risk + mitigation:** A malicious or mis-configured ctx could in principle coerce a vault into an unexpected location. Mitigations: (1) templates are opt-in — the default remains `~/.openclaw/wiki/main`; (2) the `fsPolicy` check inside `applyMemoryWikiMutation` still applies; (3) only four specific tokens are substituted (no arbitrary string interpolation); (4) expansion happens via `path.normalize` which cannot escape by itself — the caller has to explicitly use `..` segments. This is analogous to how `~` already allows user-scoped paths.

## Repro + Verification

### Environment

- OS: macOS 15.3
- Runtime: Node 20, pnpm 10.32.1
- Model/provider: N/A

### Steps

1. `pnpm install`
2. `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts extensions/memory-wiki/`

### Expected

All memory-wiki tests pass, including the 5 new vault-path-templating tests.

### Actual

```
 Test Files  22 passed (22)
      Tests  86 passed (86)
```

## Evidence

- [x] Passing test output (above)

## Human Verification (required)

- **Verified scenarios:** Unit tests cover the identity fast path, the expansion path, traversal-after-expansion, and missing-ctx-field fallback. Manually walked through `index.ts` to confirm all five tool factories now route through `resolveMemoryWikiConfigForCtx`.
- **Edge cases checked:**
  - `{unknownToken}` is left literal (does not match the pattern) — this means typos surface as "directory not found" rather than silently falling back, which is better UX.
  - `{workspaceDir}/../shared-wiki` → resolves `..` only after expansion, so the result is the expected sibling directory and not the collapsed-template mistake of just `shared-wiki`.
  - `ctx.workspaceDir === undefined` → expands to an empty string, producing a relative-ish path. Documented; users opting in are expected to guarantee the fields they template against are populated.
- **What I did not verify:** End-to-end run of `wiki_apply` through a live agent session with a templated `vault.path`. The unit tests exercise the config resolution but not the full `applyMemoryWikiMutation` pipeline against a real FS. Maintainers may want to spot-check this.

## Compatibility / Migration

- Backward compatible? `Yes` — existing configs take the identity fast path.
- Config/env changes? `No` (schema unchanged — `vault.path` is still a string).
- Migration needed? `No`.

## Risks and Mitigations

- **Risk:** Someone templates `vault.path` and later runs `openclaw wiki doctor` (or other CLI surfaces) which don't have ctx to expand against — the literal path contains `{...}` and throws a cryptic error.
  - **Mitigation:** Documented in `docs/plugins/memory-wiki.md`. Happy to add a runtime check + friendly error to the CLI surfaces in a follow-up if preferred.
- **Risk:** Expansion is silent when a ctx field is unset, substituting empty string — could surprise users.
  - **Mitigation:** Tested; considered throwing instead but felt defensive coding against runtime-internal invariants was un-idiomatic. Open to flipping this to a warn-log or throw if maintainers prefer.