### PR TITLE
[codex] fix exec completion system-event history leak

### DIFF
--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import type { TemplateContext } from "../templating.js";
 import { buildInboundUserContextPrefix } from "./inbound-meta.js";
-import { extractInboundSenderLabel, stripInboundMetadata } from "./strip-inbound-meta.js";
+import {
+  extractInboundSenderLabel,
+  stripInboundMetadata,
+  stripLeadingSystemEventPromptPrefix,
+} from "./strip-inbound-meta.js";
 
 const CONV_BLOCK = `Conversation info (untrusted metadata):
 \`\`\`json
@@ -165,6 +169,29 @@ Hello`;
 
 [Thu 2026-03-12 07:00 UTC] what time is it?`;
     expect(stripInboundMetadata(input)).toBe("what time is it?");
+  });
+
+  it("preserves timestamped System lines that are ordinary user content", () => {
+    const input = `System: [Mon 2026-04-13 09:30:01 EDT] this is part of my example
+
+and this second paragraph is still part of the same user message`;
+    expect(stripInboundMetadata(input)).toBe(input);
+  });
+});
+
+describe("stripLeadingSystemEventPromptPrefix", () => {
+  it("strips leading queued system-event blocks before visible user text", () => {
+    const input = `System (untrusted): [Mon 2026-04-13 09:30:01 EDT] Exec completed (abc12345, code 0) :: npm test
+System (untrusted): stdout: all green
+
+Please summarize the result`;
+    expect(stripLeadingSystemEventPromptPrefix(input)).toBe("Please summarize the result");
+  });
+
+  it("does not strip literal System lines when no separator follows the first line", () => {
+    const input = `System: [Mon 2026-04-13 09:30:01 EDT] this is part of my example
+and this second line is still the same message`;
+    expect(stripLeadingSystemEventPromptPrefix(input)).toBe(input);
   });
 });
 

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -16,6 +16,8 @@ import { z } from "zod";
 import { safeParseJsonWithSchema } from "../../utils/zod-parse.js";
 
 const LEADING_TIMESTAMP_PREFIX_RE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] */;
+const LEADING_SYSTEM_EVENT_PREFIX_RE =
+  /^(?:\s*\n)*System(?: \(untrusted\))?: \[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] /;
 
 /**
  * Sentinel strings that identify the start of an injected metadata block.
@@ -60,6 +62,43 @@ function restoreNeutralizedMarkdownFences(value: unknown): unknown {
   return Object.fromEntries(
     Object.entries(value).map(([key, entry]) => [key, restoreNeutralizedMarkdownFences(entry)]),
   );
+}
+
+function isTimestampedSystemEventLine(line: string): boolean {
+  return LEADING_SYSTEM_EVENT_PREFIX_RE.test(line.trim());
+}
+
+function isSystemEventLine(line: string): boolean {
+  return /^System(?: \(untrusted\))?: /.test(line.trim());
+}
+
+function stripLeadingSystemEventPrefix(lines: string[]): string[] {
+  let start = 0;
+  while (start < lines.length && lines[start]?.trim() === "") {
+    start += 1;
+  }
+  if (start >= lines.length || !isTimestampedSystemEventLine(lines[start] ?? "")) {
+    return lines;
+  }
+
+  let end = start;
+  while (end < lines.length && isSystemEventLine(lines[end] ?? "")) {
+    end += 1;
+  }
+
+  let contentStart = end;
+  while (contentStart < lines.length && lines[contentStart]?.trim() === "") {
+    contentStart += 1;
+  }
+
+  // Only strip when the system-event prefix is separated from visible user
+  // content by a blank line (the normal injected prompt shape) or consumes the
+  // whole message.
+  if (contentStart === end && contentStart < lines.length) {
+    return lines;
+  }
+
+  return lines.slice(contentStart);
 }
 
 function parseInboundMetaBlock(lines: string[], sentinel: string): Record<string, unknown> | null {
@@ -204,6 +243,17 @@ export function stripInboundMetadata(text: string): string {
     .replace(/^\n+/, "")
     .replace(/\n+$/, "")
     .replace(LEADING_TIMESTAMP_PREFIX_RE, "");
+}
+
+export function stripLeadingSystemEventPromptPrefix(text: string): string {
+  if (!text || !LEADING_SYSTEM_EVENT_PREFIX_RE.test(text)) {
+    return text;
+  }
+
+  return stripLeadingSystemEventPrefix(text.split("\n"))
+    .join("\n")
+    .replace(/^\n+/, "")
+    .replace(/\n+$/, "");
 }
 
 export function stripLeadingInboundMetadata(text: string): string {

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -90,4 +90,16 @@ describe("stripEnvelopeFromMessage", () => {
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("hello");
   });
+
+  test("strips leading system-event prompt prefixes from user messages", () => {
+    const input = {
+      role: "user",
+      content:
+        "System (untrusted): [Mon 2026-04-13 09:30:01 EDT] Exec completed (abc12345, code 0) :: npm test\n" +
+        "System (untrusted): stdout: all green\n\n" +
+        "What changed?",
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("What changed?");
+  });
 });

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,5 +1,6 @@
 import {
   extractInboundSenderLabel,
+  stripLeadingSystemEventPromptPrefix,
   stripInboundMetadata,
 } from "../auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
@@ -48,7 +49,9 @@ function stripEnvelopeFromContentWithRole(
     if (entry.type !== "text" || typeof entry.text !== "string") {
       return item;
     }
-    const inboundStripped = stripInboundMetadata(entry.text);
+    const inboundStripped = stripUserEnvelope
+      ? stripLeadingSystemEventPromptPrefix(stripInboundMetadata(entry.text))
+      : stripInboundMetadata(entry.text);
     const stripped = stripUserEnvelope
       ? stripMessageIdHints(stripEnvelope(inboundStripped))
       : inboundStripped;
@@ -81,7 +84,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   }
 
   if (typeof entry.content === "string") {
-    const inboundStripped = stripInboundMetadata(entry.content);
+    const inboundStripped = stripUserEnvelope
+      ? stripLeadingSystemEventPromptPrefix(stripInboundMetadata(entry.content))
+      : stripInboundMetadata(entry.content);
     const stripped = stripUserEnvelope
       ? stripMessageIdHints(stripEnvelope(inboundStripped))
       : inboundStripped;
@@ -96,7 +101,9 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (typeof entry.text === "string") {
-    const inboundStripped = stripInboundMetadata(entry.text);
+    const inboundStripped = stripUserEnvelope
+      ? stripLeadingSystemEventPromptPrefix(stripInboundMetadata(entry.text))
+      : stripInboundMetadata(entry.text);
     const stripped = stripUserEnvelope
       ? stripMessageIdHints(stripEnvelope(inboundStripped))
       : inboundStripped;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -9,6 +9,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
+import { stripLeadingSystemEventPromptPrefix } from "../../auto-reply/reply/strip-inbound-meta.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
@@ -138,6 +139,8 @@ export const DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 let chatHistoryPlaceholderEmitCount = 0;
+type SessionAppendMessage = Parameters<SessionManager["appendMessage"]>[0];
+type SessionUserMessage = Extract<SessionAppendMessage, { role: "user" }>;
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
   "main",
   "direct",
@@ -515,14 +518,37 @@ function extractTranscriptUserText(content: unknown): string | undefined {
   return textBlocks.length > 0 ? textBlocks.join("") : undefined;
 }
 
-async function rewriteChatSendUserTurnMediaPaths(params: {
+function hasSessionTranscriptHeader(transcriptPath: string): boolean {
+  try {
+    const fd = fs.openSync(transcriptPath, "r");
+    try {
+      const buffer = Buffer.alloc(512);
+      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+      if (bytesRead <= 0) {
+        return false;
+      }
+      const firstLine = buffer.toString("utf8", 0, bytesRead).split(/\r?\n/u, 1)[0]?.trim();
+      if (!firstLine) {
+        return false;
+      }
+      const parsed = JSON.parse(firstLine) as { type?: unknown };
+      return parsed.type === "session";
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return false;
+  }
+}
+
+export async function rewriteChatSendUserTurnMediaPaths(params: {
   transcriptPath: string;
   sessionKey: string;
   message: string;
   savedImages: SavedMedia[];
 }) {
   const mediaFields = resolveChatSendTranscriptMediaFields(params.savedImages);
-  if (!("MediaPath" in mediaFields)) {
+  if (!hasSessionTranscriptHeader(params.transcriptPath)) {
     return;
   }
   const sessionManager = SessionManager.open(params.transcriptPath);
@@ -531,26 +557,54 @@ async function rewriteChatSendUserTurnMediaPaths(params: {
     if (entry.type !== "message" || entry.message.role !== "user") {
       return false;
     }
-    const existingPaths = Array.isArray((entry.message as { MediaPaths?: unknown }).MediaPaths)
-      ? (entry.message as { MediaPaths?: unknown[] }).MediaPaths
-      : undefined;
-    if (
-      (typeof (entry.message as { MediaPath?: unknown }).MediaPath === "string" &&
-        (entry.message as { MediaPath?: string }).MediaPath) ||
-      (existingPaths && existingPaths.length > 0)
-    ) {
+    const contentText = extractTranscriptUserText((entry.message as { content?: unknown }).content);
+    if (typeof contentText !== "string") {
       return false;
     }
     return (
-      extractTranscriptUserText((entry.message as { content?: unknown }).content) === params.message
+      contentText === params.message ||
+      stripLeadingSystemEventPromptPrefix(contentText) === params.message
     );
   });
   if (!target || target.type !== "message") {
     return;
   }
-  const rewrittenMessage = {
-    ...target.message,
+  const currentMessage = target.message as SessionUserMessage & {
+    MediaPath?: unknown;
+    MediaPaths?: unknown;
+    MediaType?: unknown;
+    MediaTypes?: unknown;
+  };
+  const nextMessage: SessionUserMessage = {
+    ...currentMessage,
+    role: "user",
+    content: params.message,
     ...mediaFields,
+  };
+  const nextMessageWithMedia = nextMessage as SessionUserMessage & {
+    MediaPath?: unknown;
+    MediaPaths?: unknown;
+    MediaType?: unknown;
+    MediaTypes?: unknown;
+  };
+  const currentPaths = Array.isArray(currentMessage.MediaPaths) ? currentMessage.MediaPaths : [];
+  const nextPaths = Array.isArray(nextMessageWithMedia.MediaPaths)
+    ? (nextMessageWithMedia.MediaPaths ?? [])
+    : [];
+  if (
+    currentMessage.content === nextMessage.content &&
+    currentMessage.MediaPath === nextMessageWithMedia.MediaPath &&
+    currentMessage.MediaType === nextMessageWithMedia.MediaType &&
+    JSON.stringify(currentPaths) === JSON.stringify(nextPaths) &&
+    JSON.stringify(Array.isArray(currentMessage.MediaTypes) ? currentMessage.MediaTypes : []) ===
+      JSON.stringify(
+        Array.isArray(nextMessageWithMedia.MediaTypes) ? nextMessageWithMedia.MediaTypes : [],
+      )
+  ) {
+    return;
+  }
+  const rewrittenMessage = {
+    ...nextMessage,
   };
   await rewriteTranscriptEntriesInSessionFile({
     sessionFile: params.transcriptPath,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -3,6 +3,7 @@ import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
@@ -20,6 +21,7 @@ import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   augmentChatHistoryWithCanvasBlocks,
   resolveEffectiveChatHistoryMaxChars,
+  rewriteChatSendUserTurnMediaPaths,
   sanitizeChatHistoryMessages,
   sanitizeChatSendMessageInput,
 } from "./chat.js";
@@ -300,6 +302,77 @@ describe("sanitizeChatHistoryMessages", () => {
         timestamp: 3,
       },
     ]);
+  });
+});
+
+describe("rewriteChatSendUserTurnMediaPaths", () => {
+  it("rewrites polluted user transcript turns back to the raw webchat message", async () => {
+    const dir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-session-header-"));
+    const transcriptPath = path.join(dir, "sess-main.jsonl");
+    await fsPromises.writeFile(
+      transcriptPath,
+      `${JSON.stringify({ type: "session", version: 1, id: "sess-main" })}\n`,
+      "utf-8",
+    );
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({
+      role: "user",
+      content:
+        "System (untrusted): [Mon 2026-04-13 09:30:01 EDT] Exec completed (abc12345, code 0) :: npm test\n\n" +
+        "please summarize",
+      timestamp: 1,
+    });
+    const openSpy = vi
+      .spyOn(SessionManager, "open")
+      .mockReturnValue(sessionManager as unknown as ReturnType<typeof SessionManager.open>);
+    try {
+      await rewriteChatSendUserTurnMediaPaths({
+        transcriptPath,
+        sessionKey: "agent:main:main",
+        message: "please summarize",
+        savedImages: [],
+      });
+
+      const branch = sessionManager.getBranch();
+      const userEntry = branch.findLast(
+        (entry) => entry.type === "message" && entry.message.role === "user",
+      );
+      expect(userEntry?.type).toBe("message");
+      const userContent =
+        userEntry && userEntry.type === "message" && userEntry.message.role === "user"
+          ? userEntry.message.content
+          : undefined;
+      expect(userContent).toBe("please summarize");
+    } finally {
+      openSpy.mockRestore();
+      await fsPromises.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips legacy raw jsonl transcripts that do not have a session header", async () => {
+    const dir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-rewrite-"));
+    const transcriptPath = path.join(dir, "sess-main.jsonl");
+    const original = `${JSON.stringify({
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "main thread context" }],
+        timestamp: 1,
+      },
+    })}\n`;
+    await fsPromises.writeFile(transcriptPath, original, "utf-8");
+
+    try {
+      await rewriteChatSendUserTurnMediaPaths({
+        transcriptPath,
+        sessionKey: "agent:main:main",
+        message: "different message",
+        savedImages: [],
+      });
+
+      await expect(fsPromises.readFile(transcriptPath, "utf-8")).resolves.toBe(original);
+    } finally {
+      await fsPromises.rm(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -75,4 +75,44 @@ describe("SessionHistorySseState", () => {
     expect(snapshot.history.messages[0]?.__openclaw?.seq).toBe(2);
     expect(snapshot.rawTranscriptSeq).toBe(2);
   });
+
+  test("strips leading system-event prompt prefixes from user history snapshots", () => {
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "user",
+          content:
+            "System (untrusted): [Mon 2026-04-13 09:30:01 EDT] Exec completed (abc12345, code 0) :: npm test\n" +
+            "System (untrusted): stdout: all green\n\n" +
+            "Please summarize",
+          __openclaw: { seq: 1 },
+        },
+      ],
+    });
+
+    expect(snapshot.history.messages).toHaveLength(1);
+    expect(snapshot.history.messages[0]?.content).toBe("Please summarize");
+  });
+
+  test("strips leading system-event prompt prefixes from inline SSE updates", () => {
+    const state = SessionHistorySseState.fromRawSnapshot({
+      target: { sessionId: "sess-main" },
+      rawMessages: [],
+    });
+
+    const appended = state.appendInlineMessage({
+      message: {
+        role: "user",
+        content:
+          "System (untrusted): [Mon 2026-04-13 09:30:01 EDT] Exec completed (abc12345, code 0) :: npm test\n" +
+          "System (untrusted): stdout: all green\n\n" +
+          "What changed?",
+      },
+      messageId: "msg-1",
+    });
+
+    expect(appended).not.toBeNull();
+    expect((appended?.message as { content?: string }).content).toBe("What changed?");
+    expect((state.snapshot().messages[0] as { content?: string }).content).toBe("What changed?");
+  });
 });

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -1,3 +1,4 @@
+import { stripEnvelopeFromMessages } from "./chat-sanitize.js";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   sanitizeChatHistoryMessages,
@@ -99,10 +100,11 @@ export function buildSessionHistorySnapshot(params: {
   limit?: number;
   cursor?: string;
 }): SessionHistorySnapshot {
+  const strippedMessages = stripEnvelopeFromMessages(params.rawMessages);
   const history = paginateSessionMessages(
     toSessionHistoryMessages(
       sanitizeChatHistoryMessages(
-        params.rawMessages,
+        strippedMessages,
         params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
       ),
     ),
@@ -178,7 +180,10 @@ export class SessionHistorySseState {
       ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
       seq: this.rawTranscriptSeq,
     });
-    const sanitized = sanitizeChatHistoryMessages([nextMessage], this.maxChars);
+    const sanitized = sanitizeChatHistoryMessages(
+      stripEnvelopeFromMessages([nextMessage]),
+      this.maxChars,
+    );
     if (sanitized.length === 0) {
       return null;
     }

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -77,6 +77,23 @@ describe("extractTextCached", () => {
     expect(extractText(message)).toBeNull();
     expect(extractTextCached(message)).toBeNull();
   });
+
+  it("strips leading system-event prompt prefixes from user text", () => {
+    const message = {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text:
+            "System (untrusted): [Mon 2026-04-13 09:30:01 EDT] Exec completed (abc12345, code 0) :: npm test\n" +
+            "System (untrusted): stdout: all green\n\n" +
+            "Please summarize the result",
+        },
+      ],
+    };
+    expect(extractText(message)).toBe("Please summarize the result");
+    expect(extractTextCached(message)).toBe("Please summarize the result");
+  });
 });
 
 describe("extractThinkingCached", () => {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,4 +1,7 @@
-import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+import {
+  stripInboundMetadata,
+  stripLeadingSystemEventPromptPrefix,
+} from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
 import { extractAssistantVisibleText as extractSharedAssistantVisibleText } from "../../../../src/shared/chat-message-content.js";
 import { stripThinkingTags } from "../format.ts";
@@ -13,7 +16,7 @@ function processMessageText(text: string, role: string): string {
     return stripThinkingTags(text);
   }
   return shouldStripInboundMetadata
-    ? stripInboundMetadata(stripEnvelope(text))
+    ? stripLeadingSystemEventPromptPrefix(stripInboundMetadata(stripEnvelope(text)))
     : stripEnvelope(text);
 }
 

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -33,6 +33,18 @@ describe("message-normalizer", () => {
       });
     });
 
+    it("strips leading system-event prompt prefixes from user content", () => {
+      const result = normalizeMessage({
+        role: "user",
+        content:
+          "System (untrusted): [Mon 2026-04-13 09:30:01 EDT] Exec completed (abc12345, code 0) :: npm test\n" +
+          "System (untrusted): stdout: all green\n\n" +
+          "What changed?",
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: "What changed?" }]);
+    });
+
     it("does not reinterpret directive-like user string content", () => {
       const result = normalizeMessage({
         role: "user",

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -2,7 +2,10 @@
  * Message normalization utilities for chat rendering.
  */
 
-import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
+import {
+  stripInboundMetadata,
+  stripLeadingSystemEventPromptPrefix,
+} from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { extractCanvasShortcodes } from "../../../../src/chat/canvas-render.js";
 import {
   isToolCallContentType,
@@ -379,7 +382,10 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   if (role === "user" || role === "User") {
     content = content.map((item) => {
       if (item.type === "text" && typeof item.text === "string") {
-        return { ...item, text: stripInboundMetadata(item.text) };
+        return {
+          ...item,
+          text: stripLeadingSystemEventPromptPrefix(stripInboundMetadata(item.text)),
+        };
       }
       return item;
     });


### PR DESCRIPTION
## Summary

- Problem: background exec completion events could leak into webchat and session-history user messages as leading `System (untrusted)` text.
- Why it matters: Control UI history could show internal system-event noise as if the user sent it, and modern session transcripts could keep the polluted user turn.
- What changed: added a display-only system-event prefix stripper for user-visible history/render paths, aligned `/sessions/:key/history` snapshot/SSE sanitization with `chat.history`, and rewrote newly written modern session transcripts back to raw user text when this leak occurred.
- What did NOT change (scope boundary): this PR does not change exec/system-event generation, trust semantics, or any third-party integration behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65994
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: queued exec completion system events were reaching user-visible history/render paths as ordinary user text, and the modern webchat transcript path could persist that polluted user turn verbatim.
- Missing detection / guardrail: there was no regression coverage ensuring `chat.history`, `/sessions/:key/history`, and UI render helpers all stripped the same injected system-event prefix shape.
- Contributing context (if known): `stripInboundMetadata` could not safely own this globally because non-display call sites like command detection must preserve literal user text, so the fix needed a display-only seam.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/strip-inbound-meta.test.ts`
  - `src/gateway/chat-sanitize.test.ts`
  - `src/gateway/session-history-state.test.ts`
  - `src/gateway/server-methods/server-methods.test.ts`
  - `ui/src/ui/chat/message-extract.test.ts`
  - `ui/src/ui/chat/message-normalizer.test.ts`
- Scenario the test should lock in: when a user turn begins with injected `System (untrusted)` exec completion lines followed by visible user text, history/rendered text should show only the visible user text; modern session transcripts should be rewritten back to the raw user message; legacy raw JSONL transcripts should be left untouched.
- Why this is the smallest reliable guardrail: the bug crosses a shared helper, gateway history, session-history SSE/snapshot, transcript rewrite, and UI leaf renderers, so the regression needs coverage at those seams rather than only a single browser path.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Webchat and session-history surfaces no longer display queued exec completion events as leading `System (untrusted)` user text.
- Newly written modern session transcripts are cleaned back to the raw user message text when this leak path is hit.

## Diagram (if applicable)

```text
Before:
[user message + queued exec completion event] -> [transcript/history stores prefixed user turn] -> [chat history renders leaked System text]

After:
[user message + queued exec completion event] -> [display/history sanitizers strip prefix] -> [modern transcript rewrite restores raw user turn] -> [history renders only user-authored text]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout, Node `v25.8.1`
- Model/provider: N/A
- Integration/channel (if any): webchat / Control UI, gateway session-history HTTP/SSE
- Relevant config (redacted): default gateway history settings

### Steps

1. Send a webchat user message in a session where an exec completion event is queued into the conversation.
2. Reload `chat.history` or `/sessions/:key/history`, or render the turn in the Control UI.
3. Inspect the visible user turn and the stored modern session transcript entry.

### Expected

- Only the user-authored message text is visible, and modern session transcripts keep the raw user message text.

### Actual

- Before this fix, the user turn could begin with `System (untrusted): [..] Exec completed ...` lines.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted tests for helper stripping, gateway history sanitization, session-history snapshot/SSE sanitization, transcript rewrite, and UI extraction/normalization; `pnpm build` locally on the rebased branch.
- Edge cases checked: literal user-authored timestamped `System:` lines are preserved; display-only stripping does not affect command detection paths; legacy raw JSONL transcripts are not rewritten.
- What you did **not** verify: manual browser clickthrough on the rebased branch; `pnpm tsgo` is currently red on latest `upstream/main` from unrelated pre-existing failures outside this diff.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: system-event stripping matches the current injected prefix shape, so a future prompt-shape change could reintroduce visible leakage.
  - Mitigation: direct regression tests cover the helper, gateway history, session-history snapshot/SSE, transcript rewrite, and UI render helpers.
- Risk: transcript rewrite touches stored history for modern session-manager transcripts.
  - Mitigation: the rewrite is gated to session-header transcripts only, is a no-op when content/media already match, and explicitly skips legacy raw JSONL transcripts.
