### PR TITLE
Gateway: add mesh backend auth seam

### DIFF
--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -11,7 +11,10 @@ import { coreGatewayHandlers } from "./server-methods.js";
 
 const RESERVED_ADMIN_PLUGIN_METHOD = "config.plugin.inspect";
 
-function setPluginGatewayMethodScope(method: string, scope: "operator.read" | "operator.write") {
+function setPluginGatewayMethodScope(
+  method: string,
+  scope: "operator.read" | "operator.write" | "operator.mesh",
+) {
   const registry = createEmptyPluginRegistry();
   registry.gatewayMethodScopes = {
     [method]: scope,
@@ -122,6 +125,18 @@ describe("operator scope authorization", () => {
     });
     expect(authorizeOperatorScopesForMethod(method, ["operator.approvals"])).toEqual({
       allowed: true,
+    });
+  });
+
+  it("requires mesh scope for mesh methods", () => {
+    setPluginGatewayMethodScope("mesh.send_task", "operator.mesh");
+
+    expect(authorizeOperatorScopesForMethod("mesh.send_task", ["operator.mesh"])).toEqual({
+      allowed: true,
+    });
+    expect(authorizeOperatorScopesForMethod("mesh.send_task", ["operator.write"])).toEqual({
+      allowed: false,
+      missingScope: "operator.mesh",
     });
   });
 

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -3,6 +3,7 @@ import { resolveReservedGatewayMethodScope } from "../shared/gateway-method-poli
 import {
   ADMIN_SCOPE,
   APPROVALS_SCOPE,
+  MESH_SCOPE,
   PAIRING_SCOPE,
   READ_SCOPE,
   TALK_SECRETS_SCOPE,
@@ -13,6 +14,7 @@ import {
 export {
   ADMIN_SCOPE,
   APPROVALS_SCOPE,
+  MESH_SCOPE,
   PAIRING_SCOPE,
   READ_SCOPE,
   TALK_SECRETS_SCOPE,
@@ -65,6 +67,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "device.token.revoke",
     "node.rename",
   ],
+  [MESH_SCOPE]: [],
   [READ_SCOPE]: [
     "health",
     "doctor.memory.status",

--- a/src/gateway/operator-scopes.ts
+++ b/src/gateway/operator-scopes.ts
@@ -4,6 +4,7 @@ export const WRITE_SCOPE = "operator.write" as const;
 export const APPROVALS_SCOPE = "operator.approvals" as const;
 export const PAIRING_SCOPE = "operator.pairing" as const;
 export const TALK_SECRETS_SCOPE = "operator.talk.secrets" as const;
+export const MESH_SCOPE = "operator.mesh" as const;
 
 export type OperatorScope =
   | typeof ADMIN_SCOPE
@@ -11,4 +12,5 @@ export type OperatorScope =
   | typeof WRITE_SCOPE
   | typeof APPROVALS_SCOPE
   | typeof PAIRING_SCOPE
-  | typeof TALK_SECRETS_SCOPE;
+  | typeof TALK_SECRETS_SCOPE
+  | typeof MESH_SCOPE;

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -18,7 +18,10 @@ type AgentRunSnapshot = {
   status: "ok" | "error" | "timeout";
   startedAt?: number;
   endedAt?: number;
+  summary?: string;
+  outputText?: string;
   error?: string;
+  sessionKey?: string;
   ts: number;
 };
 

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -65,7 +65,10 @@ describe("agent wait dedupe helper", () => {
       status: "ok",
       startedAt: 100,
       endedAt: 200,
+      summary: undefined,
+      outputText: undefined,
       error: undefined,
+      sessionKey: undefined,
     });
     expect(__testing.getWaiterCount(runId)).toBe(0);
   });
@@ -143,7 +146,10 @@ describe("agent wait dedupe helper", () => {
       status: "ok",
       startedAt: 1,
       endedAt: 2,
+      summary: undefined,
+      outputText: undefined,
       error: undefined,
+      sessionKey: undefined,
     });
   });
 
@@ -193,7 +199,10 @@ describe("agent wait dedupe helper", () => {
       status: "ok",
       startedAt: 123,
       endedAt: 456,
+      summary: undefined,
+      outputText: undefined,
       error: undefined,
+      sessionKey: undefined,
     });
   });
 
@@ -226,7 +235,10 @@ describe("agent wait dedupe helper", () => {
       status: "error",
       startedAt: 30,
       endedAt: 40,
+      summary: undefined,
+      outputText: undefined,
       error: "chat failed",
+      sessionKey: undefined,
     });
 
     const dedupeReverse = new Map();
@@ -254,7 +266,45 @@ describe("agent wait dedupe helper", () => {
       status: "timeout",
       startedAt: 3,
       endedAt: 4,
+      summary: undefined,
+      outputText: undefined,
       error: "still running",
+      sessionKey: undefined,
+    });
+  });
+
+  it("preserves summary, outputText, and sessionKey from terminal agent entries", () => {
+    const dedupe = new Map();
+    const runId = "run-mesh-details";
+
+    setRunEntry({
+      dedupe,
+      kind: "agent",
+      runId,
+      payload: {
+        runId,
+        status: "ok",
+        startedAt: 10,
+        endedAt: 20,
+        summary: "completed",
+        outputText: "mesh output",
+        sessionKey: "mesh:caller@example.com",
+      },
+    });
+
+    expect(
+      readTerminalSnapshotFromGatewayDedupe({
+        dedupe,
+        runId,
+      }),
+    ).toEqual({
+      status: "ok",
+      startedAt: 10,
+      endedAt: 20,
+      summary: "completed",
+      outputText: "mesh output",
+      error: undefined,
+      sessionKey: "mesh:caller@example.com",
     });
   });
 

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -4,7 +4,10 @@ export type AgentWaitTerminalSnapshot = {
   status: "ok" | "error" | "timeout";
   startedAt?: number;
   endedAt?: number;
+  summary?: string;
+  outputText?: string;
   error?: string;
+  sessionKey?: string;
 };
 
 const AGENT_WAITERS_BY_RUN_ID = new Map<string, Set<() => void>>();
@@ -21,6 +24,39 @@ function parseRunIdFromDedupeKey(key: string): string | null {
 
 function asFiniteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function extractPayloadText(payloads: unknown): string | undefined {
+  if (!Array.isArray(payloads)) {
+    return undefined;
+  }
+  for (let index = payloads.length - 1; index >= 0; index -= 1) {
+    const payload = payloads[index];
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      continue;
+    }
+    const text = asNonEmptyString((payload as Record<string, unknown>).text);
+    if (text) {
+      return text;
+    }
+  }
+  return undefined;
+}
+
+function extractResultOutputText(result: unknown): string | undefined {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return undefined;
+  }
+  const record = result as Record<string, unknown>;
+  const meta =
+    record.meta && typeof record.meta === "object" && !Array.isArray(record.meta)
+      ? (record.meta as Record<string, unknown>)
+      : undefined;
+  return asNonEmptyString(meta?.finalAssistantVisibleText) ?? extractPayloadText(record.payloads);
 }
 
 function removeWaiter(runId: string, waiter: () => void): void {
@@ -70,8 +106,11 @@ export function readTerminalSnapshotFromDedupeEntry(
         status?: unknown;
         startedAt?: unknown;
         endedAt?: unknown;
+        outputText?: unknown;
+        sessionKey?: unknown;
         error?: unknown;
         summary?: unknown;
+        result?: unknown;
       }
     | undefined;
   const status = typeof payload?.status === "string" ? payload.status : undefined;
@@ -81,6 +120,10 @@ export function readTerminalSnapshotFromDedupeEntry(
 
   const startedAt = asFiniteNumber(payload?.startedAt);
   const endedAt = asFiniteNumber(payload?.endedAt) ?? entry.ts;
+  const summary = asNonEmptyString(payload?.summary);
+  const outputText =
+    asNonEmptyString(payload?.outputText) ?? extractResultOutputText(payload?.result);
+  const sessionKey = asNonEmptyString(payload?.sessionKey);
   const errorMessage =
     typeof payload?.error === "string"
       ? payload.error
@@ -93,7 +136,10 @@ export function readTerminalSnapshotFromDedupeEntry(
       status,
       startedAt,
       endedAt,
+      summary,
+      outputText,
       error: status === "timeout" ? errorMessage : undefined,
+      sessionKey,
     };
   }
   if (status === "error" || !entry.ok) {
@@ -101,7 +147,10 @@ export function readTerminalSnapshotFromDedupeEntry(
       status: "error",
       startedAt,
       endedAt,
+      summary,
+      outputText,
       error: errorMessage,
+      sessionKey,
     };
   }
   return null;

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -21,7 +21,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { registerAgentRunContext } from "../../infra/agent-events.js";
+import { getAgentRunContext, registerAgentRunContext } from "../../infra/agent-events.js";
 import {
   resolveAgentDeliveryPlan,
   resolveAgentOutboundTarget,
@@ -205,6 +205,56 @@ function dispatchAgentRunFromGateway(params: {
   respond: GatewayRequestHandlerOptions["respond"];
   context: GatewayRequestHandlerOptions["context"];
 }) {
+  const setRunDedupeEntry = (entry: {
+    ok: boolean;
+    payload: Record<string, unknown>;
+    error?: ReturnType<typeof errorShape>;
+  }) => {
+    const sharedEntry = {
+      ts: Date.now(),
+      ok: entry.ok,
+      payload: entry.payload,
+      ...(entry.error ? { error: entry.error } : {}),
+    };
+    setGatewayDedupeEntry({
+      dedupe: params.context.dedupe,
+      key: `agent:${params.idempotencyKey}`,
+      entry: sharedEntry,
+    });
+    setGatewayDedupeEntry({
+      dedupe: params.context.dedupe,
+      key: `agent:${params.runId}`,
+      entry: sharedEntry,
+    });
+  };
+  const extractOutputText = (result: unknown): string | undefined => {
+    if (!result || typeof result !== "object" || Array.isArray(result)) {
+      return undefined;
+    }
+    const record = result as Record<string, unknown>;
+    const meta =
+      record.meta && typeof record.meta === "object" && !Array.isArray(record.meta)
+        ? (record.meta as Record<string, unknown>)
+        : undefined;
+    const finalAssistantVisibleText = meta?.finalAssistantVisibleText;
+    if (typeof finalAssistantVisibleText === "string" && finalAssistantVisibleText.trim()) {
+      return finalAssistantVisibleText.trim();
+    }
+    if (!Array.isArray(record.payloads)) {
+      return undefined;
+    }
+    for (let index = record.payloads.length - 1; index >= 0; index -= 1) {
+      const payload = record.payloads[index];
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        continue;
+      }
+      const text = (payload as Record<string, unknown>).text;
+      if (typeof text === "string" && text.trim()) {
+        return text.trim();
+      }
+    }
+    return undefined;
+  };
   const inputProvenance = normalizeInputProvenance(params.ingressOpts.inputProvenance);
   const shouldTrackTask =
     params.ingressOpts.sessionKey?.trim() && inputProvenance?.kind !== "inter_session";
@@ -237,16 +287,13 @@ function dispatchAgentRunFromGateway(params: {
         runId: params.runId,
         status: "ok" as const,
         summary: "completed",
+        outputText: extractOutputText(result),
+        sessionKey: params.ingressOpts.sessionKey,
         result,
       };
-      setGatewayDedupeEntry({
-        dedupe: params.context.dedupe,
-        key: `agent:${params.idempotencyKey}`,
-        entry: {
-          ts: Date.now(),
-          ok: true,
-          payload,
-        },
+      setRunDedupeEntry({
+        ok: true,
+        payload,
       });
       // Send a second res frame (same id) so TS clients with expectFinal can wait.
       // Swift clients will typically treat the first res as the result and ignore this.
@@ -258,16 +305,12 @@ function dispatchAgentRunFromGateway(params: {
         runId: params.runId,
         status: "error" as const,
         summary: String(err),
+        sessionKey: params.ingressOpts.sessionKey,
       };
-      setGatewayDedupeEntry({
-        dedupe: params.context.dedupe,
-        key: `agent:${params.idempotencyKey}`,
-        entry: {
-          ts: Date.now(),
-          ok: false,
-          payload,
-          error,
-        },
+      setRunDedupeEntry({
+        ok: false,
+        payload,
+        error,
       });
       params.respond(false, payload, error, {
         runId: params.runId,
@@ -792,16 +835,23 @@ export const agentHandlers: GatewayRequestHandlers = {
       runId,
       status: "accepted" as const,
       acceptedAt: Date.now(),
+      sessionKey: resolvedSessionKey,
     };
     // Store an in-flight ack so retries do not spawn a second run.
+    const acceptedEntry = {
+      ts: Date.now(),
+      ok: true,
+      payload: accepted,
+    };
     setGatewayDedupeEntry({
       dedupe: context.dedupe,
       key: `agent:${idem}`,
-      entry: {
-        ts: Date.now(),
-        ok: true,
-        payload: accepted,
-      },
+      entry: acceptedEntry,
+    });
+    setGatewayDedupeEntry({
+      dedupe: context.dedupe,
+      key: `agent:${runId}`,
+      entry: acceptedEntry,
     });
     respond(true, accepted, undefined, { runId });
 
@@ -980,7 +1030,10 @@ export const agentHandlers: GatewayRequestHandlers = {
         status: cachedGatewaySnapshot.status,
         startedAt: cachedGatewaySnapshot.startedAt,
         endedAt: cachedGatewaySnapshot.endedAt,
+        summary: cachedGatewaySnapshot.summary,
+        outputText: cachedGatewaySnapshot.outputText,
         error: cachedGatewaySnapshot.error,
+        sessionKey: cachedGatewaySnapshot.sessionKey ?? getAgentRunContext(runId)?.sessionKey,
       });
       return;
     }
@@ -1034,7 +1087,10 @@ export const agentHandlers: GatewayRequestHandlers = {
       status: snapshot.status,
       startedAt: snapshot.startedAt,
       endedAt: snapshot.endedAt,
+      summary: snapshot.summary,
+      outputText: snapshot.outputText,
       error: snapshot.error,
+      sessionKey: snapshot.sessionKey ?? getAgentRunContext(runId)?.sessionKey,
     });
   },
 };

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -20,6 +20,8 @@ export type GatewayClient = {
   connect: ConnectParams;
   connId?: string;
   clientIp?: string;
+  authUser?: string;
+  authMethod?: string;
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -596,6 +596,31 @@ describe("loadGatewayPlugins", () => {
     expect((generated as string).length).toBeGreaterThan(0);
   });
 
+  test("passes terminal wait metadata through the subagent runtime", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      opts.respond(true, {
+        status: "ok",
+        summary: "completed",
+        outputText: "mesh result",
+        sessionKey: "mesh:caller@example.com",
+      });
+    });
+
+    await expect(
+      runtime.waitForRun({
+        runId: "run-mesh",
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({
+      status: "ok",
+      summary: "completed",
+      outputText: "mesh result",
+      sessionKey: "mesh:caller@example.com",
+    });
+  });
+
   test("rejects provider/model overrides for fallback runs without explicit authorization", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -355,20 +355,29 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       return { runId };
     },
     async waitForRun(params) {
-      const payload = await dispatchGatewayMethod<{ status?: string; error?: string }>(
-        "agent.wait",
-        {
-          runId: params.runId,
-          ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
-        },
-      );
+      const payload = await dispatchGatewayMethod<{
+        status?: string;
+        summary?: string;
+        outputText?: string;
+        error?: string;
+        sessionKey?: string;
+      }>("agent.wait", {
+        runId: params.runId,
+        ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
+      });
       const status = payload?.status;
       if (status !== "ok" && status !== "error" && status !== "timeout") {
         throw new Error(`Gateway agent.wait returned unexpected status: ${status}`);
       }
       return {
         status,
+        ...(typeof payload?.summary === "string" &&
+          payload.summary && { summary: payload.summary }),
+        ...(typeof payload?.outputText === "string" &&
+          payload.outputText && { outputText: payload.outputText }),
         ...(typeof payload?.error === "string" && payload.error && { error: payload.error }),
+        ...(typeof payload?.sessionKey === "string" &&
+          payload.sessionKey && { sessionKey: payload.sessionKey }),
       };
     },
     getSessionMessages,

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 import {
+  BACKEND_GATEWAY_CLIENT,
   connectReq,
   CONTROL_UI_CLIENT,
   ConnectErrorDetailCodes,
@@ -170,6 +171,18 @@ export function registerAuthModesSuite(): void {
       const res = await connectReq(ws, { skipDefaultAuth: true, device: null });
       expect(res.ok).toBe(false);
       expect(res.error?.message ?? "").toContain("device identity required");
+      ws.close();
+    });
+
+    test("allows mesh-only backend clients without device identity when tailscale auth is available", async () => {
+      const ws = await openTailscaleWs(port);
+      const res = await connectReq(ws, {
+        skipDefaultAuth: true,
+        device: null,
+        scopes: ["operator.mesh"],
+        client: { ...BACKEND_GATEWAY_CLIENT },
+      });
+      expect(res.ok).toBe(true);
       ws.close();
     });
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -57,7 +57,7 @@ import {
   mintCanvasCapabilityToken,
 } from "../../canvas-capability.js";
 import { normalizeDeviceMetadataForAuth } from "../../device-auth.js";
-import { ADMIN_SCOPE } from "../../method-scopes.js";
+import { ADMIN_SCOPE, MESH_SCOPE } from "../../method-scopes.js";
 import {
   isLocalishHost,
   isLoopbackAddress,
@@ -66,6 +66,7 @@ import {
 } from "../../net.js";
 import { reconcileNodePairingOnConnect } from "../../node-connect-reconcile.js";
 import { checkBrowserOrigin } from "../../origin-check.js";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import {
   ConnectErrorDetailCodes,
   resolveDeviceAuthConnectErrorDetailCode,
@@ -529,6 +530,20 @@ export function attachGatewayWsMessageHandler(params: {
           rateLimiter: authRateLimiter,
           clientIp: browserRateLimitClientIp,
         });
+        const isMeshBackendClient =
+          connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+          connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND;
+        const requestedMeshOnly = scopes.every((scope) => scope === MESH_SCOPE);
+        const canSkipDeviceViaTailscaleMesh =
+          authOk &&
+          authMethod === "tailscale" &&
+          isMeshBackendClient &&
+          requestedMeshOnly &&
+          role === "operator";
+        if (canSkipDeviceViaTailscaleMesh && scopes.length === 0) {
+          scopes = [MESH_SCOPE];
+          connectParams.scopes = scopes;
+        }
         const rejectUnauthorized = (failedAuth: GatewayAuthResult) => {
           const { authProvided, canRetryWithDeviceToken, recommendedNextStep } =
             resolveUnauthorizedHandshakeContext({
@@ -576,6 +591,9 @@ export function attachGatewayWsMessageHandler(params: {
           }
         };
         const handleMissingDeviceIdentity = (): boolean => {
+          if (!device && canSkipDeviceViaTailscaleMesh) {
+            return true;
+          }
           const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({
             isControlUi,
             role,
@@ -1254,6 +1272,8 @@ export function attachGatewayWsMessageHandler(params: {
           sharedGatewaySessionGeneration,
           presenceKey,
           clientIp: reportedClientIp,
+          authUser: authResult.user,
+          authMethod,
           canvasHostUrl,
           canvasCapability,
           canvasCapabilityExpiresAtMs,

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -9,6 +9,8 @@ export type GatewayWsClient = {
   sharedGatewaySessionGeneration?: string;
   presenceKey?: string;
   clientIp?: string;
+  authUser?: string;
+  authMethod?: string;
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -27,7 +27,10 @@ export type SubagentWaitParams = {
 
 export type SubagentWaitResult = {
   status: "ok" | "error" | "timeout";
+  summary?: string;
+  outputText?: string;
   error?: string;
+  sessionKey?: string;
 };
 
 export type SubagentGetSessionMessagesParams = {


### PR DESCRIPTION
## Summary
- add first-class `operator.mesh` scope support for gateway methods and plugin-registered mesh RPCs
- allow Tailscale-authenticated backend `gateway-client` operator sessions that request only mesh scope to connect without device identity
- expose trusted `client.authUser` and `client.authMethod` to gateway/plugin handlers
- thread terminal subagent metadata (`summary`, `outputText`, `sessionKey`) through `agent.wait` and plugin runtime `waitForRun`

## Validation
- `corepack pnpm exec vitest --run src/gateway/method-scopes.test.ts src/gateway/server-methods/agent-wait-dedupe.test.ts src/gateway/server-plugins.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.auth.modes.test.ts`

## Notes
- this intentionally excludes CW plugin logic, `/fresh` session reset work, and unrelated local/runtime changes
- live tokenless mesh smoke from the CW overlay flow is what motivated this seam: the patched host accepts the backend Tailscale mesh path, while stock `openclaw@2026.4.10` still rejects it with `device identity required`
- repo-wide `pnpm check` is currently blocked by unrelated pre-existing `tsgo` failures outside this diff, so validation here is focused on the touched gateway/runtime suites
