### PR TITLE
fix: include apiKey in codex provider catalog to unblock models.json loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/Codex: include `apiKey` in the codex provider catalog output so the Pi ModelRegistry validator no longer rejects the entry and silently drops all custom models from every provider in `models.json`. (#66180) Thanks @hoyyeva.
+
 ## 2026.4.14-beta.1
 
 ### Changes

--- a/extensions/codex/provider.ts
+++ b/extensions/codex/provider.ts
@@ -114,6 +114,7 @@ export async function buildCodexProviderCatalog(
   return {
     provider: {
       baseUrl: CODEX_BASE_URL,
+      apiKey: "codex-app-server",
       auth: "token",
       api: "openai-codex-responses",
       models,


### PR DESCRIPTION
 ## Summary

  - Problem: The codex extension's buildCodexProviderCatalog() writes a provider entry to models.json with auth: "token" but no apiKey. The Pi
  ModelRegistry.validateConfig() requires apiKey when a provider defines custom models — when it encounters the codex provider without one, it throws, and the
   catch block silently drops ALL custom models from ALL providers in models.json.
  - Why it matters: Users who configure multiple Ollama models via ollama launch openclaw only see a single fallback model in /models, the TUI picker, and
  Telegram. Any provider with custom models in models.json (not just Ollama) is affected.
  - What changed: Added apiKey: "codex-app-server" to the codex provider catalog output, matching the value already returned by the plugin's
  resolveSyntheticAuth hook.
  - What did NOT change (scope boundary): The codex provider's runtime auth flow (auth: "token" / OAuth) is unchanged. The apiKey only satisfies the Pi
  registry's validation requirement during models.json loading.

  ## Linked Issue/PR

  - Related #64298
  - [x]This PR fixes a regression

  ## Root Cause (if applicable)

  - Root cause: extensions/codex/provider.ts buildCodexProviderCatalog() returns { baseUrl, auth: "token", api, models } without apiKey. The Pi
  ModelRegistry.validateConfig() iterates all providers in models.json in a single try/catch — when validation throws on the codex provider (line 321:
  "apiKey" is required when defining custom models), loadCustomModels() catches the error and returns emptyCustomModelsResult(), dropping custom models from
  every provider including Ollama.
  - Missing detection / guardrail: No test validates that the codex catalog output passes Pi ModelRegistry.validateConfig(). The Pi registry's all-or-nothing
  error handling means one invalid provider silently poisons all others.
  - Contributing context: The codex provider correctly implements resolveSyntheticAuth returning apiKey: "codex-app-server" for runtime auth, but the catalog
  output (which feeds models.json) was missing the same value. Regression introduced in dd26e8c44d (PR #64298).

  ## User-visible / Behavior Changes

  - /models in TUI, Telegram, and other channels now correctly lists all configured Ollama models (and any other custom-provider models) instead of showing
  only the single default fallback model.

  ## Diagram (if applicable)
```
  Before:
  models.json load -> validateConfig() hits codex (no apiKey) -> throws
    -> loadCustomModels() catch -> emptyCustomModelsResult()
    -> 0 custom models (ollama, codex, all dropped)
    -> /models shows 1 fallback model

  After:
  models.json load -> validateConfig() passes all providers -> parseModels()
    -> all custom models loaded (ollama: 9, codex: 4, etc.)
    -> /models shows all configured models
  
  ```

  ## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  ## Repro + Verification

  ### Environment

  - OS: macOS Darwin 25.3.0
  - Runtime/container: Node.js 25.6.1, pnpm
  - Model/provider: Ollama (local), Codex
  - Integration/channel: TUI, Telegram
  - Relevant config: ~/.openclaw/openclaw.json with models.providers.ollama.models containing 9 models

  ### Steps

  1. Configure multiple Ollama models via ollama launch openclaw (select 2+ models)
  2. Start the gateway: openclaw gateway run
  3. Run /models in TUI or Telegram

  Expected

  - All selected Ollama models appear in the model list

  ### Actual

  - Only 1 model shown (the default from agents.defaults.model.primary)

  ## Human Verification (required)

  - Verified scenarios: Ran diagnostic script before/after fix confirming Ollama models appear in catalog; verified models.json codex provider now passes Pi
  registry validation
  - Edge cases checked: Confirmed the apiKey value matches resolveSyntheticAuth return; confirmed codex runtime auth (auth: "token") is unaffected
  - What you did NOT verify: Full end-to-end ollama launch openclaw flow with gateway restart; codex app-server model discovery with live Codex backend