### PR TITLE
fix(memory): use native parser for openai embeddings proxy

### DIFF
--- a/src/memory-host-sdk/host/embeddings-openai.test.ts
+++ b/src/memory-host-sdk/host/embeddings-openai.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { normalizeOpenAiModel, DEFAULT_OPENAI_EMBEDDING_MODEL } from "./embeddings-openai.js";
+
+describe("normalizeOpenAiModel", () => {
+  it("returns default model when input is blank", () => {
+    expect(normalizeOpenAiModel("   ")).toBe(DEFAULT_OPENAI_EMBEDDING_MODEL);
+    expect(normalizeOpenAiModel("")).toBe(DEFAULT_OPENAI_EMBEDDING_MODEL);
+  });
+
+  it("strips the openai/ prefix correctly", () => {
+    expect(normalizeOpenAiModel("openai/text-embedding-3-small")).toBe("text-embedding-3-small");
+    expect(normalizeOpenAiModel("openai/text-embedding-ada-002")).toBe("text-embedding-ada-002");
+  });
+
+  it("preserves explicit third-party model providers like spark/", () => {
+    // This previously triggered the 'Invalid model name' bug before the provider guard was added
+    expect(normalizeOpenAiModel("spark/text-embedding-3-small")).toBe(
+      "spark/text-embedding-3-small",
+    );
+    expect(normalizeOpenAiModel("litellm/azure/ada-002")).toBe("litellm/azure/ada-002");
+  });
+
+  it("handles models without explicit prefixes appropriately", () => {
+    expect(normalizeOpenAiModel("text-embedding-3-large")).toBe("text-embedding-3-large");
+  });
+});

--- a/src/memory-host-sdk/host/embeddings-openai.ts
+++ b/src/memory-host-sdk/host/embeddings-openai.ts
@@ -1,6 +1,6 @@
+import { parseStaticModelRef } from "../../agents/model-ref-shared.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { OPENAI_DEFAULT_EMBEDDING_MODEL } from "../../plugins/provider-model-defaults.js";
-import { normalizeEmbeddingModelWithPrefixes } from "./embeddings-model-normalize.js";
 import {
   createRemoteEmbeddingProvider,
   resolveRemoteEmbeddingClient,
@@ -24,11 +24,12 @@ const OPENAI_MAX_INPUT_TOKENS: Record<string, number> = {
 };
 
 export function normalizeOpenAiModel(model: string): string {
-  return normalizeEmbeddingModelWithPrefixes({
-    model,
-    defaultModel: DEFAULT_OPENAI_EMBEDDING_MODEL,
-    prefixes: ["openai/"],
-  });
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return DEFAULT_OPENAI_EMBEDDING_MODEL;
+  }
+  const parsed = parseStaticModelRef(trimmed, "openai");
+  return parsed && parsed.provider === "openai" ? parsed.model : trimmed;
 }
 
 export async function createOpenAiEmbeddingProvider(


### PR DESCRIPTION
## Description

Currently,  sends config strings directly to the  adapter without utilizing OpenClaw's native Model Parser (`parseStaticModelRef`). As a result, the `openai` proxy adapter defaults to a regex that only matches `openai/`, failing when users configure memory embedding models using fully qualified IDs or alternative custom provider proxies (e.g. `spark/embedding`).

This PR updates `embeddings-openai.ts` to use `parseStaticModelRef` instead of brittle manual-regex prefix stripping. This aligns memory search routing with how OpenClaw system models inherently process and decode `{provider}/{model}` identities, natively supporting arbitrary fallback providers safely.

## Motivation & Context
- Without this, memorySearch forces hardcoded config typings or upstream 400 Bad Request gateway crashes.
- Enhances interoperability for self-hosted instances utilizing generic openai-compatible wrappers like LiteLLM/VLLM.
