### PR TITLE
fix(tui): reset activity after late terminal events

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -603,6 +603,21 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(setActivityStatus).toHaveBeenCalledWith("error");
   });
 
+  it("resets activity to aborted when a terminal aborted arrives after the active run was already cleared", () => {
+    const { state, setActivityStatus, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null, activityStatus: "streaming" },
+    });
+
+    handleChatEvent({
+      runId: "run-late-aborted",
+      sessionKey: state.currentSessionKey,
+      state: "aborted",
+    });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("aborted");
+  });
+
   it("drops streaming assistant when chat final has no message", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
@@ -681,5 +696,55 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets activity to idle when a BTW run finalizes and activeChatRunId is null", () => {
+    const { state, setActivityStatus, noteLocalBtwRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null, activityStatus: "streaming" },
+    });
+
+    noteLocalBtwRunId("run-btw-final");
+    handleChatEvent({
+      runId: "run-btw-final",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "BTW result" }] },
+    });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+  });
+
+  it("resets activity to error when a BTW run errors and activeChatRunId is null", () => {
+    const { state, setActivityStatus, noteLocalBtwRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null, activityStatus: "streaming" },
+    });
+
+    noteLocalBtwRunId("run-btw-error");
+    handleChatEvent({
+      runId: "run-btw-error",
+      sessionKey: state.currentSessionKey,
+      state: "error",
+      errorMessage: "BTW error",
+    });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+  });
+
+  it("resets activity to aborted when a BTW run aborts and activeChatRunId is null", () => {
+    const { state, setActivityStatus, noteLocalBtwRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null, activityStatus: "streaming" },
+    });
+
+    noteLocalBtwRunId("run-btw-aborted");
+    handleChatEvent({
+      runId: "run-btw-aborted",
+      sessionKey: state.currentSessionKey,
+      state: "aborted",
+    });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("aborted");
   });
 });

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -571,6 +571,38 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.dropAssistant).not.toHaveBeenCalledWith("run-error-envelope");
   });
 
+  it("resets activity to idle when a final arrives after the active run was already cleared", () => {
+    const { state, setActivityStatus, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null, activityStatus: "streaming" },
+    });
+
+    handleChatEvent({
+      runId: "run-late-final",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+  });
+
+  it("resets activity to error when a terminal error arrives after the active run was already cleared", () => {
+    const { state, setActivityStatus, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null, activityStatus: "streaming" },
+    });
+
+    handleChatEvent({
+      runId: "run-late-error",
+      sessionKey: state.currentSessionKey,
+      state: "error",
+      errorMessage: "boom",
+    });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("error");
+  });
+
   it("drops streaming assistant when chat final has no message", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -138,7 +138,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     noteFinalizedRun(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    if (params.wasActiveRun || state.activeChatRunId == null) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
@@ -153,7 +153,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    if (params.wasActiveRun || state.activeChatRunId == null) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();


### PR DESCRIPTION
## Summary
- reset the TUI activity status when a terminal chat event arrives after `activeChatRunId` has already been cleared
- apply the same safeguard to both `finalizeRun` and `terminateRun`
- add regression coverage for late `final` and late `error` terminal events

## Problem
The TUI could stay visually stuck in `streaming` or `running` if a terminal event arrived after the active run had already been cleared. In that case, the existing logic skipped `setActivityStatus(...)` because it only updated status when `wasActiveRun` was true.

## Fix
If the finishing run was the active run, keep the current behavior. Otherwise, also reset the activity status when there is no longer any active run (`state.activeChatRunId == null`). That preserves the concurrent-run guard while avoiding a stale busy indicator when the run has already been cleared.

## Test plan
- `./node_modules/.bin/vitest run src/tui/tui-event-handlers.test.ts`
