### PR TITLE
test(voice-call): add replay quality harness baseline

### DIFF
--- a/extensions/voice-call/scripts/replay-regression.test.ts
+++ b/extensions/voice-call/scripts/replay-regression.test.ts
@@ -1,0 +1,106 @@
+import { spawnSync as runChildProcessSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function runNodeScript(scriptPath: string, args: string[]): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+} {
+  const result = runChildProcessSync(process.execPath, [scriptPath, ...args], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function writeRawArtifact(rawDir: string, callId: string, timestamp: number, transcript: unknown[]): string {
+  const filePath = path.join(rawDir, `${callId}-${timestamp}.json`);
+  const payload = {
+    schema: "voice.postsync.raw.v1",
+    createdAt: new Date(timestamp).toISOString(),
+    call: {
+      callId,
+      transcript,
+    },
+  };
+  fs.mkdirSync(rawDir, { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return filePath;
+}
+
+describe("replay-regression script", () => {
+  it("fails with violations and writes latest pointer under voice-quality-harness root", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "replay-regression-test-"));
+    const rawDir = path.join(tmpDir, "raw");
+
+    writeRawArtifact(rawDir, "call-bad", 1_777_000_001_000, [
+      { speaker: "bot", text: "That sounded nowwwww strange." },
+      { speaker: "bot", text: "Sure thing." },
+      { speaker: "bot", text: "sure thing!" },
+    ]);
+
+    const outPath = path.join(
+      tmpDir,
+      "projects/tess-phone-voice-v2/03_logs/voice-quality-harness/replay-regression/runs/run-1.json",
+    );
+
+    const script = path.resolve(process.cwd(), "scripts/replay-regression.ts");
+    const result = runNodeScript(script, [
+      "--call-id",
+      "call-bad",
+      "--raw-dir",
+      rawDir,
+      "--calls-file",
+      path.join(tmpDir, "missing.jsonl"),
+      "--out",
+      outPath,
+      "--json",
+    ]);
+
+    expect(result.status).toBe(1);
+    const json = JSON.parse(result.stdout);
+    expect(json.summary.totalViolations).toBe(2);
+    expect(json.summary.violationsByRule.NO_ELONGATED_TOKEN).toBe(1);
+    expect(json.summary.violationsByRule.NO_CONSECUTIVE_DUPLICATE_BOT_LINE).toBe(1);
+
+    expect(fs.existsSync(outPath)).toBe(true);
+    const latestPath = path.join(
+      tmpDir,
+      "projects/tess-phone-voice-v2/03_logs/voice-quality-harness/replay-regression/latest.json",
+    );
+    expect(fs.existsSync(latestPath)).toBe(true);
+  });
+
+  it("passes clean transcripts and exits 0", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "replay-regression-clean-test-"));
+    const rawDir = path.join(tmpDir, "raw");
+
+    writeRawArtifact(rawDir, "call-good", 1_777_000_002_000, [
+      { speaker: "bot", text: "Hey there, how can I help?" },
+      { speaker: "user", text: "need a summary" },
+      { speaker: "bot", text: "Got it. I can do that after the call." },
+    ]);
+
+    const script = path.resolve(process.cwd(), "scripts/replay-regression.ts");
+    const result = runNodeScript(script, [
+      "--call-id",
+      "call-good",
+      "--raw-dir",
+      rawDir,
+      "--calls-file",
+      path.join(tmpDir, "missing.jsonl"),
+      "--json",
+    ]);
+
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.summary.totalViolations).toBe(0);
+    expect(json.summary.failedCalls).toBe(0);
+  });
+});

--- a/extensions/voice-call/scripts/replay-regression.ts
+++ b/extensions/voice-call/scripts/replay-regression.ts
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  evaluateReplayQuality,
+  type ReplayRule,
+  type ReplayTurn,
+  type ReplayViolation,
+} from "../src/response-quality.ts";
+
+type Args = {
+  callIds: string[];
+  rawDir: string;
+  callsFile: string;
+  outPath: string;
+  latestPath: string;
+  json: boolean;
+  help: boolean;
+};
+
+type ViolationRecord = ReplayViolation & {
+  callId: string;
+};
+
+type CallReport = {
+  callId: string;
+  source: string;
+  turnsAnalyzed: number;
+  passed: boolean;
+  violations: ViolationRecord[];
+};
+
+type ReplayReport = {
+  generatedAt: string;
+  rules: ReplayRule[];
+  inputs: {
+    rawDir: string;
+    callsFile: string;
+    callIds: string[];
+  };
+  calls: CallReport[];
+  summary: {
+    totalCalls: number;
+    failedCalls: number;
+    totalViolations: number;
+    violationsByRule: Record<ReplayRule, number>;
+  };
+};
+
+const DEFAULT_RAW_DIR = path.join(os.homedir(), ".openclaw", "voice-calls", "postsync", "raw");
+const DEFAULT_CALLS_FILE = path.join(os.homedir(), ".openclaw", "voice-calls", "calls.jsonl");
+
+function usage(): void {
+  console.log(
+    `Usage: node scripts/replay-regression.ts --call-id <id> [--call-id <id> ...] [--raw-dir <path>] [--calls-file <path>] [--out <path>] [--latest <path>] [--json]\n\n` +
+      `Replay bot transcript turns and fail on response-quality regressions.\n` +
+      `Exit codes: 0=pass, 1=violations found, 2=invalid input or artifact load failure.`,
+  );
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    callIds: [],
+    rawDir: DEFAULT_RAW_DIR,
+    callsFile: DEFAULT_CALLS_FILE,
+    outPath: "",
+    latestPath: "",
+    json: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--call-id") {
+      const next = String(argv[i + 1] ?? "").trim();
+      if (next) {
+        args.callIds.push(next);
+      }
+      i += 1;
+      continue;
+    }
+    if (token === "--raw-dir") {
+      const next = String(argv[i + 1] ?? "").trim();
+      if (next) {
+        args.rawDir = next;
+      }
+      i += 1;
+      continue;
+    }
+    if (token === "--calls-file") {
+      const next = String(argv[i + 1] ?? "").trim();
+      if (next) {
+        args.callsFile = next;
+      }
+      i += 1;
+      continue;
+    }
+    if (token === "--out") {
+      args.outPath = String(argv[i + 1] ?? "").trim();
+      i += 1;
+      continue;
+    }
+    if (token === "--latest") {
+      args.latestPath = String(argv[i + 1] ?? "").trim();
+      i += 1;
+      continue;
+    }
+    if (token === "--json") {
+      args.json = true;
+      continue;
+    }
+    if (token === "--help" || token === "-h") {
+      args.help = true;
+      continue;
+    }
+  }
+
+  args.callIds = Array.from(new Set(args.callIds));
+  return args;
+}
+
+function getRecordTimeMs(record: Record<string, unknown>): number {
+  const candidates = [record.endedAt, record.answeredAt, record.startedAt];
+  for (const value of candidates) {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  }
+  return 0;
+}
+
+function parseTranscriptLike(value: unknown): ReplayTurn[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const turns: ReplayTurn[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const speaker = (item as { speaker?: unknown }).speaker;
+    const text = (item as { text?: unknown }).text;
+    if ((speaker === "user" || speaker === "bot") && typeof text === "string") {
+      turns.push({ speaker, text });
+    }
+  }
+  return turns;
+}
+
+function resolveLatestRawFile(rawDir: string, callId: string): string | null {
+  if (!fs.existsSync(rawDir)) {
+    return null;
+  }
+  const entries = fs
+    .readdirSync(rawDir)
+    .filter((name) => name.startsWith(`${callId}-`) && name.endsWith(".json"));
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const ranked = entries
+    .map((name) => {
+      const match = name.match(/-(\d+)\.json$/);
+      const ts = match ? Number(match[1]) : 0;
+      return { name, ts };
+    })
+    .sort((a, b) => b.ts - a.ts || b.name.localeCompare(a.name));
+
+  return path.join(rawDir, ranked[0].name);
+}
+
+function loadTranscriptFromRaw(rawDir: string, callId: string): { turns: ReplayTurn[]; source: string } | null {
+  const filePath = resolveLatestRawFile(rawDir, callId);
+  if (!filePath) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    const turns = parseTranscriptLike(parsed?.call?.transcript);
+    if (turns.length === 0) {
+      return null;
+    }
+    return { turns, source: filePath };
+  } catch {
+    return null;
+  }
+}
+
+function loadTranscriptFromCallsJsonl(callsFile: string, callId: string): { turns: ReplayTurn[]; source: string } | null {
+  if (!fs.existsSync(callsFile)) {
+    return null;
+  }
+
+  const lines = fs
+    .readFileSync(callsFile, "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  let bestMatch: { turns: ReplayTurn[]; timeMs: number } | null = null;
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      if (parsed.callId !== callId) {
+        continue;
+      }
+      const turns = parseTranscriptLike(parsed.transcript);
+      if (turns.length === 0) {
+        continue;
+      }
+      const timeMs = getRecordTimeMs(parsed);
+      if (!bestMatch || timeMs >= bestMatch.timeMs) {
+        bestMatch = { turns, timeMs };
+      }
+    } catch {
+      // ignore malformed lines
+    }
+  }
+
+  if (!bestMatch) {
+    return null;
+  }
+
+  return { turns: bestMatch.turns, source: callsFile };
+}
+
+function loadTranscript(args: Args, callId: string): { turns: ReplayTurn[]; source: string } | null {
+  return loadTranscriptFromRaw(args.rawDir, callId) ?? loadTranscriptFromCallsJsonl(args.callsFile, callId);
+}
+
+function writeJsonFile(targetPath: string, value: unknown): void {
+  const resolved = path.resolve(targetPath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function inferLatestPath(outPath: string): string | null {
+  const normalized = path.resolve(outPath);
+  const marker = `${path.sep}runs${path.sep}`;
+  const idx = normalized.lastIndexOf(marker);
+  if (idx === -1) {
+    return null;
+  }
+  const root = normalized.slice(0, idx);
+  return path.join(root, "latest.json");
+}
+
+function buildReport(args: Args): { report: ReplayReport; missingCallIds: string[] } {
+  const calls: CallReport[] = [];
+  const missingCallIds: string[] = [];
+
+  for (const callId of args.callIds) {
+    const loaded = loadTranscript(args, callId);
+    if (!loaded) {
+      missingCallIds.push(callId);
+      continue;
+    }
+
+    const { turns, source } = loaded;
+    const { violations } = evaluateReplayQuality(turns);
+    const records: ViolationRecord[] = violations.map((violation) => ({ ...violation, callId }));
+
+    calls.push({
+      callId,
+      source,
+      turnsAnalyzed: turns.filter((turn) => turn.speaker === "bot").length,
+      passed: records.length === 0,
+      violations: records,
+    });
+  }
+
+  const violationsByRule: Record<ReplayRule, number> = {
+    NO_ELONGATED_TOKEN: 0,
+    NO_CONSECUTIVE_DUPLICATE_BOT_LINE: 0,
+  };
+
+  let totalViolations = 0;
+  let failedCalls = 0;
+  for (const call of calls) {
+    if (!call.passed) {
+      failedCalls += 1;
+    }
+    for (const violation of call.violations) {
+      violationsByRule[violation.rule] += 1;
+      totalViolations += 1;
+    }
+  }
+
+  const report: ReplayReport = {
+    generatedAt: new Date().toISOString(),
+    rules: ["NO_ELONGATED_TOKEN", "NO_CONSECUTIVE_DUPLICATE_BOT_LINE"],
+    inputs: {
+      rawDir: path.resolve(args.rawDir),
+      callsFile: path.resolve(args.callsFile),
+      callIds: [...args.callIds],
+    },
+    calls,
+    summary: {
+      totalCalls: calls.length,
+      failedCalls,
+      totalViolations,
+      violationsByRule,
+    },
+  };
+
+  return { report, missingCallIds };
+}
+
+function run(): number {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    usage();
+    return 0;
+  }
+
+  if (args.callIds.length === 0) {
+    console.error("replay-regression: at least one --call-id is required");
+    return 2;
+  }
+
+  const { report, missingCallIds } = buildReport(args);
+  if (missingCallIds.length > 0) {
+    console.error(`replay-regression: could not load artifacts for callId(s): ${missingCallIds.join(", ")}`);
+    return 2;
+  }
+
+  if (args.outPath) {
+    writeJsonFile(args.outPath, report);
+
+    const latestPath = args.latestPath || inferLatestPath(args.outPath);
+    if (latestPath) {
+      writeJsonFile(latestPath, report);
+    }
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log("Replay regression report");
+    console.log(`calls: ${report.summary.totalCalls}`);
+    console.log(`failed: ${report.summary.failedCalls}`);
+    console.log(`violations: ${report.summary.totalViolations}`);
+    console.log(`rules: ${report.rules.join(", ")}`);
+    if (args.outPath) {
+      console.log(`output: ${path.resolve(args.outPath)}`);
+      const latestPath = args.latestPath || inferLatestPath(args.outPath);
+      if (latestPath) {
+        console.log(`latest: ${path.resolve(latestPath)}`);
+      }
+    }
+  }
+
+  return report.summary.totalViolations > 0 ? 1 : 0;
+}
+
+const code = run();
+process.exit(code);

--- a/extensions/voice-call/src/response-quality.test.ts
+++ b/extensions/voice-call/src/response-quality.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  containsElongatedToken,
+  evaluateReplayQuality,
+  isConsecutiveDuplicateBotLine,
+  normalizeBotLineForDedupe,
+  sanitizeVoiceResponse,
+} from "./response-quality.js";
+
+describe("response-quality", () => {
+  it("sanitizes reply tags and tool blobs out of spoken responses", () => {
+    const raw = '[[reply_to_current]] Here\n```json\n{"tool":"x"}\n```';
+    expect(sanitizeVoiceResponse(raw)).toBe("Here");
+  });
+
+  it("detects elongated tokens", () => {
+    expect(containsElongatedToken('that sounded nowwwww weird')).toBe(true);
+    expect(containsElongatedToken("that sounds fine now")).toBe(false);
+  });
+
+  it("normalizes bot lines for duplicate checks", () => {
+    expect(normalizeBotLineForDedupe("  Sounds good!  ")).toBe("sounds good");
+    expect(isConsecutiveDuplicateBotLine("Sounds good!", "sounds good")).toBe(true);
+    expect(isConsecutiveDuplicateBotLine("Sounds good", "Sounds better")).toBe(false);
+  });
+
+  it("evaluates replay quality against elongated + duplicate rules", () => {
+    const result = evaluateReplayQuality([
+      { speaker: "bot", text: "Hey there." },
+      { speaker: "bot", text: "That was nowwwww weird." },
+      { speaker: "user", text: "ok" },
+      { speaker: "bot", text: "Sounds good." },
+      { speaker: "bot", text: "sounds good!" },
+    ]);
+
+    expect(result.violations.map((v) => v.rule)).toEqual([
+      "NO_ELONGATED_TOKEN",
+      "NO_CONSECUTIVE_DUPLICATE_BOT_LINE",
+    ]);
+    expect(result.violations[0]?.turnIndex).toBe(1);
+    expect(result.violations[1]?.turnIndex).toBe(4);
+  });
+});

--- a/extensions/voice-call/src/response-quality.ts
+++ b/extensions/voice-call/src/response-quality.ts
@@ -1,0 +1,162 @@
+export type ReplayRule = "NO_ELONGATED_TOKEN" | "NO_CONSECUTIVE_DUPLICATE_BOT_LINE";
+
+export type ReplayTurn = {
+  speaker: "user" | "bot";
+  text: string;
+};
+
+export type ReplayViolation = {
+  rule: ReplayRule;
+  turnIndex: number;
+  rawText: string;
+  normalizedText: string;
+};
+
+const REPLY_TAG_PATTERN = /\[\[\s*reply_to(?:_current|\s*:[^\]]+)\s*\]\]/gi;
+const CODE_FENCE_PATTERN = /```[\s\S]*?```/g;
+const TOOL_JSON_BLOB_PATTERN = /\{[^{}]{0,900}"tool"\s*:\s*"[^\"]+"[^{}]*\}/gi;
+const TOOL_USE_BLOB_PATTERN =
+  /\{[^{}]{0,900}"recipient_name"\s*:\s*"functions\.[^\"]+"[^{}]*\}/gi;
+
+function hasToolLikePayload(text: string): boolean {
+  return (
+    /\{[^{}]{0,900}"tool"\s*:\s*"[^\"]+"[^{}]*\}/i.test(text) ||
+    /\{[^{}]{0,900}"recipient_name"\s*:\s*"functions\.[^\"]+"[^{}]*\}/i.test(text)
+  );
+}
+
+function looksLikeInternalArtifact(text: string): boolean {
+  const lowered = text.toLowerCase();
+  const signals = [
+    "toolcall",
+    "toolresult",
+    "thinkingsignature",
+    "runid",
+    "sessionid",
+    '"tool":',
+    '"recipient_name":',
+    '"tool_uses":',
+    "/opt/homebrew",
+    "~/.openclaw",
+    "openclaw/docs",
+    "need maybe use",
+    "functions.",
+  ];
+  return signals.some((signal) => lowered.includes(signal));
+}
+
+export function sanitizeVoiceResponse(raw: string): string | null {
+  const text = raw
+    .replace(REPLY_TAG_PATTERN, " ")
+    .replace(CODE_FENCE_PATTERN, " ")
+    .replace(TOOL_JSON_BLOB_PATTERN, " ")
+    .replace(TOOL_USE_BLOB_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!text) {
+    return null;
+  }
+
+  // Guard against leaking internal planning/tool chatter into spoken output.
+  if (looksLikeInternalArtifact(text)) {
+    return null;
+  }
+
+  // Extra guardrail: if text still looks like raw JSON/object payload, do not speak it.
+  if (/^\s*[\[{].+[\]}]\s*$/s.test(text)) {
+    return null;
+  }
+
+  // Defensive fallback when sanitizer strips tool/code wrappers but JSON-like payload remains.
+  if (hasToolLikePayload(text)) {
+    return null;
+  }
+
+  const maxChars = 320;
+  if (text.length <= maxChars) {
+    return text;
+  }
+
+  const truncated = text.slice(0, maxChars);
+  const cutAt = Math.max(
+    truncated.lastIndexOf("."),
+    truncated.lastIndexOf("!"),
+    truncated.lastIndexOf("?"),
+  );
+  if (cutAt >= 80) {
+    return truncated.slice(0, cutAt + 1).trim();
+  }
+
+  const wordCut = truncated.lastIndexOf(" ");
+  if (wordCut >= 80) {
+    return `${truncated.slice(0, wordCut).trim()}...`;
+  }
+
+  return `${truncated.trim()}...`;
+}
+
+export function normalizeBotLineForDedupe(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, " ")
+    .replace(/[.!?]+$/g, "");
+}
+
+export function isConsecutiveDuplicateBotLine(previous: string | null, current: string): boolean {
+  if (!previous) {
+    return false;
+  }
+  const prevNorm = normalizeBotLineForDedupe(previous);
+  const curNorm = normalizeBotLineForDedupe(current);
+  return prevNorm.length > 0 && prevNorm === curNorm;
+}
+
+export function containsElongatedToken(text: string, repeatThreshold = 2): boolean {
+  if (repeatThreshold < 1) {
+    return false;
+  }
+  const repeats = repeatThreshold + 1;
+  const pattern = new RegExp(`([A-Za-z])\\1{${repeats - 1},}`);
+  return pattern.test(text);
+}
+
+export function evaluateReplayQuality(turns: ReplayTurn[]): { violations: ReplayViolation[] } {
+  const violations: ReplayViolation[] = [];
+  let previousBotLine: string | null = null;
+
+  turns.forEach((turn, turnIndex) => {
+    if (turn.speaker !== "bot") {
+      return;
+    }
+
+    const rawText = String(turn.text ?? "");
+    const sanitized = sanitizeVoiceResponse(rawText);
+    if (!sanitized) {
+      return;
+    }
+
+    if (containsElongatedToken(sanitized)) {
+      violations.push({
+        rule: "NO_ELONGATED_TOKEN",
+        turnIndex,
+        rawText,
+        normalizedText: sanitized,
+      });
+    }
+
+    if (isConsecutiveDuplicateBotLine(previousBotLine, sanitized)) {
+      violations.push({
+        rule: "NO_CONSECUTIVE_DUPLICATE_BOT_LINE",
+        turnIndex,
+        rawText,
+        normalizedText: normalizeBotLineForDedupe(sanitized),
+      });
+    }
+
+    previousBotLine = sanitized;
+  });
+
+  return { violations };
+}


### PR DESCRIPTION
Ports replay quality harness baseline from voice-call-custom into extensions/voice-call.\n\nIncludes:\n- scripts/replay-regression.ts\n- scripts/replay-regression.test.ts\n- src/response-quality.ts\n- src/response-quality.test.ts\n\nSource commit: b7f4390592962d2cc504fb793865dfc70dc584de (voice-call-custom)