### PR TITLE
fix(matrix): fix E2EE SSSS bootstrap for passwordless token-auth bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Docs: https://docs.openclaw.ai
 - Media/store: honor configured agent media limits when saving generated media and persisting outbound reply media, so the store no longer hard-stops those flows at 5 MB before the configured limit applies. (#66229) Thanks @neeravmakwana and @vincentkoc.
 - Plugins/setup-entry: preserve separate setup-entry secrets exports when loading bundled setup-runtime channels, so setup-mode flows keep the channel secret contract for split plugin + secrets entrypoints. (#66261) Thanks @hxy91819.
 - CLI/update: prune stale packaged `dist` chunks after npm upgrades, verify installed package inventory, and keep downgrade/update verification working across older releases. (#66959) Thanks @obviyus.
+- Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 
 ## 2026.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
+- Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 
 ## 2026.4.15-beta.1
 
@@ -146,7 +147,6 @@ Docs: https://docs.openclaw.ai
 - Media/store: honor configured agent media limits when saving generated media and persisting outbound reply media, so the store no longer hard-stops those flows at 5 MB before the configured limit applies. (#66229) Thanks @neeravmakwana and @vincentkoc.
 - Plugins/setup-entry: preserve separate setup-entry secrets exports when loading bundled setup-runtime channels, so setup-mode flows keep the channel secret contract for split plugin + secrets entrypoints. (#66261) Thanks @hxy91819.
 - CLI/update: prune stale packaged `dist` chunks after npm upgrades, verify installed package inventory, and keep downgrade/update verification working across older releases. (#66959) Thanks @obviyus.
-- Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 
 ## 2026.4.12
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -613,7 +613,8 @@ if you want a shorter or longer retry window.
 Startup also performs a conservative crypto bootstrap pass automatically.
 That pass tries to reuse the current secret storage and cross-signing identity first, and avoids resetting cross-signing unless you run an explicit bootstrap repair flow.
 
-If startup finds broken bootstrap state and `channels.matrix.password` is configured, OpenClaw can attempt a stricter repair path.
+If startup still finds broken bootstrap state, OpenClaw can attempt a guarded repair path even when `channels.matrix.password` is not configured.
+If the homeserver requires password-based UIA for that repair, OpenClaw logs a warning and keeps startup non-fatal instead of aborting the bot.
 If the current device is already owner-signed, OpenClaw preserves that identity instead of resetting it automatically.
 
 See [Matrix migration](/install/migrating-matrix) for the full upgrade flow, limits, recovery commands, and common migration messages.

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1280,7 +1280,6 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(bootstrapSpy).toHaveBeenCalledTimes(1);
     expect((bootstrapSpy.mock.calls as unknown[][])[0]?.[1] ?? {}).toEqual({
       allowAutomaticCrossSigningReset: false,
-      allowSecretStorageRecreateWithoutRecoveryKey: true,
     });
   });
 

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1284,16 +1284,24 @@ describe("MatrixClient crypto bootstrapping", () => {
     });
   });
 
-  it("does not force-reset bootstrap when password is unavailable", async () => {
+  it("attempts repair bootstrap even when no password is configured", async () => {
     matrixJsClient.getCrypto = vi.fn(() => ({ on: vi.fn() }));
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
+      // no password — passwordless token-auth bot
     });
-    const bootstrapSpy = vi.fn().mockResolvedValue({
-      crossSigningReady: false,
-      crossSigningPublished: false,
-      ownDeviceVerified: false,
-    });
+    const bootstrapSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        crossSigningReady: false,
+        crossSigningPublished: false,
+        ownDeviceVerified: false,
+      })
+      .mockResolvedValueOnce({
+        crossSigningReady: true,
+        crossSigningPublished: true,
+        ownDeviceVerified: true,
+      });
     await (
       client as unknown as {
         ensureCryptoSupportInitialized: () => Promise<void>;
@@ -1307,7 +1315,12 @@ describe("MatrixClient crypto bootstrapping", () => {
 
     await client.start();
 
-    expect(bootstrapSpy).toHaveBeenCalledTimes(1);
+    expect(bootstrapSpy).toHaveBeenCalledTimes(2);
+    expect((bootstrapSpy.mock.calls as unknown[][])[1]?.[1] ?? {}).toEqual({
+      forceResetCrossSigning: true,
+      allowSecretStorageRecreateWithoutRecoveryKey: true,
+      strict: true,
+    });
   });
 
   it("provides secret storage callbacks and resolves stored recovery key", async () => {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1323,6 +1323,39 @@ describe("MatrixClient crypto bootstrapping", () => {
     });
   });
 
+  it("catches and logs repair bootstrap failure when UIA is unavailable without password", async () => {
+    matrixJsClient.getCrypto = vi.fn(() => ({ on: vi.fn() }));
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      encryption: true,
+      // no password
+    });
+    const uiaError = new Error("Interactive auth required");
+    const bootstrapSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        crossSigningReady: false,
+        crossSigningPublished: false,
+        ownDeviceVerified: false,
+      })
+      .mockRejectedValueOnce(uiaError);
+    await (
+      client as unknown as {
+        ensureCryptoSupportInitialized: () => Promise<void>;
+      }
+    ).ensureCryptoSupportInitialized();
+    (
+      client as unknown as {
+        cryptoBootstrapper: { bootstrap: typeof bootstrapSpy };
+      }
+    ).cryptoBootstrapper.bootstrap = bootstrapSpy;
+
+    // start() must NOT throw even when the repair bootstrap fails
+    await expect(client.start()).resolves.not.toThrow();
+
+    // repair was attempted
+    expect(bootstrapSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("provides secret storage callbacks and resolves stored recovery key", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-test-"));
     const recoveryKeyPath = path.join(tmpDir, "recovery-key.json");

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1280,6 +1280,7 @@ describe("MatrixClient crypto bootstrapping", () => {
     expect(bootstrapSpy).toHaveBeenCalledTimes(1);
     expect((bootstrapSpy.mock.calls as unknown[][])[0]?.[1] ?? {}).toEqual({
       allowAutomaticCrossSigningReset: false,
+      allowSecretStorageRecreateWithoutRecoveryKey: true,
     });
   });
 

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -607,7 +607,7 @@ export class MatrixClient {
           "MatrixClientLite",
           "Cross-signing/bootstrap is incomplete for an already owner-signed device; skipping automatic reset and preserving the current identity. Restore the recovery key or run an explicit verification bootstrap if repair is needed.",
         );
-      } else if (this.password?.trim()) {
+      } else {
         try {
           // The repair path already force-resets cross-signing; allow secret storage
           // recreation so the new keys can be persisted. Without this, a device that
@@ -631,11 +631,6 @@ export class MatrixClient {
             err,
           );
         }
-      } else {
-        LogService.warn(
-          "MatrixClientLite",
-          "Cross-signing/bootstrap incomplete and no password is configured for UIA fallback",
-        );
       }
     }
     this.cryptoBootstrapped = true;

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -139,6 +139,7 @@ export type MatrixVerificationBootstrapResult = {
 
 const MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS = {
   allowAutomaticCrossSigningReset: false,
+  allowSecretStorageRecreateWithoutRecoveryKey: true,
 } satisfies MatrixCryptoBootstrapOptions;
 
 const MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS = {

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -608,6 +608,8 @@ export class MatrixClient {
           "Cross-signing/bootstrap is incomplete for an already owner-signed device; skipping automatic reset and preserving the current identity. Restore the recovery key or run an explicit verification bootstrap if repair is needed.",
         );
       } else {
+        // No password guard: passwordless token-auth bots should still attempt repair.
+        // UIA failures inside bootstrap() are caught below and logged as warnings.
         try {
           // The repair path already force-resets cross-signing; allow secret storage
           // recreation so the new keys can be persisted. Without this, a device that

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -139,7 +139,6 @@ export type MatrixVerificationBootstrapResult = {
 
 const MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS = {
   allowAutomaticCrossSigningReset: false,
-  allowSecretStorageRecreateWithoutRecoveryKey: true,
 } satisfies MatrixCryptoBootstrapOptions;
 
 const MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS = {

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -277,6 +277,49 @@ describe("MatrixCryptoBootstrapper", () => {
     expectSecretStorageRepairRetry(deps, crypto, bootstrapCrossSigning);
   });
 
+  it("does not mutate secret storage before forced repair fails on password UIA without a password", async () => {
+    const deps = createBootstrapperDeps();
+    deps.getPassword = vi.fn(() => undefined);
+    const bootstrapCrossSigning = vi.fn<
+      ({
+        authUploadDeviceSigningKeys,
+      }: {
+        authUploadDeviceSigningKeys?: <T>(
+          makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
+        ) => Promise<T>;
+      }) => Promise<void>
+    >(async ({ authUploadDeviceSigningKeys }) => {
+      await authUploadDeviceSigningKeys?.(async (authData) => {
+        if (authData === null) {
+          throw new Error("need auth");
+        }
+        if (authData.type === "m.login.dummy") {
+          throw new Error("dummy rejected");
+        }
+        return undefined;
+      });
+    });
+    const crypto = createCryptoApi({
+      bootstrapCrossSigning,
+      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
+    });
+    const bootstrapper = new MatrixCryptoBootstrapper(
+      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
+    );
+
+    await expect(
+      bootstrapper.bootstrap(crypto, {
+        strict: true,
+        forceResetCrossSigning: true,
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
+      }),
+    ).rejects.toThrow(
+      "Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback",
+    );
+
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+  });
+
   it("fails in strict mode when cross-signing keys are still unpublished", async () => {
     const deps = createBootstrapperDeps();
     const crypto = createCryptoApi({

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -47,14 +47,18 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     options: MatrixCryptoBootstrapOptions = {},
   ): Promise<MatrixCryptoBootstrapResult> {
     const strict = options.strict === true;
+    const deferSecretStorageBootstrapUntilAfterCrossSigning =
+      options.forceResetCrossSigning === true;
     // Register verification listeners before expensive bootstrap work so incoming requests
     // are not missed during startup.
     this.registerVerificationRequestHandler(crypto);
-    await this.bootstrapSecretStorage(crypto, {
-      strict,
-      allowSecretStorageRecreateWithoutRecoveryKey:
-        options.allowSecretStorageRecreateWithoutRecoveryKey === true,
-    });
+    if (!deferSecretStorageBootstrapUntilAfterCrossSigning) {
+      await this.bootstrapSecretStorage(crypto, {
+        strict,
+        allowSecretStorageRecreateWithoutRecoveryKey:
+          options.allowSecretStorageRecreateWithoutRecoveryKey === true,
+      });
+    }
     const crossSigning = await this.bootstrapCrossSigning(crypto, {
       forceResetCrossSigning: options.forceResetCrossSigning === true,
       allowAutomaticCrossSigningReset: options.allowAutomaticCrossSigningReset !== false,
@@ -62,6 +66,9 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
         options.allowSecretStorageRecreateWithoutRecoveryKey === true,
       strict,
     });
+    // Forced repair may need password UIA to upload new cross-signing keys. Delay any
+    // secret-storage repair/recreation until after that step succeeds so passwordless bots do
+    // not partially mutate SSSS on homeservers that require password-based UIA.
     await this.bootstrapSecretStorage(crypto, {
       strict,
       allowSecretStorageRecreateWithoutRecoveryKey:


### PR DESCRIPTION
## Summary

Fixes #66171

Passwordless token-auth Matrix bots fail to complete E2EE bootstrap when the homeserver has existing SSSS data but the bot has no local recovery key.

## Problem Statement

Two independent bugs in `extensions/matrix/src/matrix/sdk.ts` combine to permanently block E2EE bootstrap for passwordless token-auth bots connecting to a homeserver with existing (but inaccessible) SSSS:

**Bug 1:** `MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS` (line 140) is missing `allowSecretStorageRecreateWithoutRecoveryKey: true`. Without this flag, when `bootstrapCrossSigning` encounters a null `getSecretStorageKey` response (because the bot has no local recovery key), `shouldRepairSecretStorage` evaluates to `false && true = false`, so SSSS is never recreated. The explicit bootstrap path (`bootstrapOwnDeviceVerification`) already sets this flag correctly — the initial auto-startup path does not.

**Bug 2:** `bootstrapCryptoIfNeeded` repair path (line ~609) is gated behind `this.password?.trim()`. Passwordless token-auth bots have no password, so even if Bug 1 were fixed, the repair bootstrap would never run. The intent of the gate was to ensure a UIA credential was available — but UIA failures are already caught and logged gracefully in the existing try/catch, so the gate is overly conservative.

## Solution Approach Applied

Two minimal edits to `extensions/matrix/src/matrix/sdk.ts`:

**Edit 1 — Add flag to initial bootstrap options (~line 140):**
```typescript
const MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS = {
  allowAutomaticCrossSigningReset: false,
  allowSecretStorageRecreateWithoutRecoveryKey: true,  // added
} satisfies MatrixCryptoBootstrapOptions;
```

**Edit 2 — Remove password gate in repair path (~line 609):**
Replace `else if (this.password?.trim()) { ... } else { LogService.warn(...) }` with a plain `else { ... }` — the try/catch body stays identical, only the gate is removed. Added comment explaining passwordless repair intent to prevent regression.

**Test updates in `extensions/matrix/src/matrix/sdk.test.ts`:**
- Line 1283: Update initial bootstrap options assertion to include new flag
- Lines 1287-1324: Update test to assert repair runs without password (was asserting repair does NOT run)
- Lines 1326-1358: New regression test verifying repair catches UIA failure without throwing

## Bottleneck Solved

**Before:** Fresh bot / bot with wiped data directory connecting to homeserver that has existing SSSS → `getSecretStorageKey` returns null → error silently swallowed → no repair attempted → bot stays unverified forever.

**After:** Same scenario → `getSecretStorageKey` returns null → repair bootstrap runs → SSSS recreated with new keys → bot becomes verified.

## Expected Outcomes

- Passwordless token-auth bots can complete E2EE bootstrap on first connection to homeserver with existing SSSS
- Bots with wiped data directories can recover by recreating SSSS
- UIA failures (when homeserver requires password but bot has none) are caught and logged as warnings, not fatal errors
- No behavior change for bots with passwords or explicit bootstrap flows

## Current Flow

1. Bot connects to homeserver with encryption enabled
2. Initial bootstrap runs with `MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS` (now includes `allowSecretStorageRecreateWithoutRecoveryKey: true`)
3. If `getSecretStorageKey` returns null, `bootstrapCrossSigning` recreates SSSS
4. If initial bootstrap incomplete and device not owner-signed, repair bootstrap runs (no password gate)
5. Repair bootstrap attempts SSSS recreation with `MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS`
6. UIA failures caught and logged, bot continues operating

## Verification

`pnpm build` passes (TypeScript compilation confirms types are correct).

Full test suite not run in this PR (monorepo tests take 10+ min). CI will verify.