### PR TITLE
fix(cli): harden approvals get timeout handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - Outbound/relay-status: suppress internal relay-status placeholder payloads (`No channel reply.`, `Replied in-thread.`, `Replied in #...`, wiki-update status variants ending in `No channel reply.`) before channel delivery so internal housekeeping text does not leak to users.
 - Slack/doctor: add a dedicated doctor-contract sidecar so config warmup paths such as `openclaw cron` no longer fall back to Slack's broader contract surface, which could trigger Slack-related config-read crashes on affected setups. (#63192) Thanks @shhtheonlyperson.
 - Hooks/session-memory: pass the resolved agent workspace into gateway `/new` and `/reset` session-memory hooks so reset snapshots stay scoped to the right agent workspace instead of leaking into the default workspace. (#64735) Thanks @suboss87 and @vincentkoc.
+- CLI/approvals: raise the default `openclaw approvals get` gateway timeout and report config-load timeouts explicitly, so slow hosts stop showing a misleading `Config unavailable.` note when the approvals snapshot succeeds but the follow-up config RPC needs more time. (#66239) Thanks @neeravmakwana.
 
 ## 2026.4.12
 

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -359,11 +359,11 @@ describe("exec approvals CLI", () => {
     expect(runtimeErrors).toHaveLength(0);
   });
 
-  it("reports gateway config timeout explicitly", async () => {
+  it("reports gateway config timeout explicitly and sanitizes the error message", async () => {
     callGatewayFromCli.mockImplementation(
       async (method: string, _opts: unknown, params?: unknown) => {
         if (method === "config.get") {
-          throw new Error("gateway timeout after 10000ms\nRPC config.get");
+          throw new Error("gateway timeout after 10000ms\u001b[2K\u0007\nRPC config.get");
         }
         if (method === "exec.approvals.get") {
           return {

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -141,19 +141,32 @@ describe("exec approvals CLI", () => {
     expect(callGatewayFromCli).toHaveBeenNthCalledWith(
       1,
       "exec.approvals.get",
-      expect.anything(),
+      expect.objectContaining({ timeout: "60000" }),
       {},
     );
-    expect(callGatewayFromCli).toHaveBeenNthCalledWith(2, "config.get", expect.anything(), {});
+    expect(callGatewayFromCli).toHaveBeenNthCalledWith(
+      2,
+      "config.get",
+      expect.objectContaining({ timeout: "60000" }),
+      {},
+    );
     expect(runtimeErrors).toHaveLength(0);
     callGatewayFromCli.mockClear();
 
     await runApprovalsCommand(["approvals", "get", "--node", "macbook"]);
 
-    expect(callGatewayFromCli).toHaveBeenCalledWith("exec.approvals.node.get", expect.anything(), {
-      nodeId: "node-1",
-    });
-    expect(callGatewayFromCli).toHaveBeenCalledWith("config.get", expect.anything(), {});
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "exec.approvals.node.get",
+      expect.objectContaining({ timeout: "60000" }),
+      {
+        nodeId: "node-1",
+      },
+    );
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "config.get",
+      expect.objectContaining({ timeout: "60000" }),
+      {},
+    );
     expect(runtimeErrors).toHaveLength(0);
   });
 
@@ -338,6 +351,38 @@ describe("exec approvals CLI", () => {
       expect.objectContaining({
         effectivePolicy: {
           note: "Config unavailable.",
+          scopes: [],
+        },
+      }),
+      0,
+    );
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("reports gateway config timeout explicitly", async () => {
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "config.get") {
+          throw new Error("gateway timeout after 10000ms\nRPC config.get");
+        }
+        if (method === "exec.approvals.get") {
+          return {
+            path: "/tmp/exec-approvals.json",
+            exists: true,
+            hash: "hash-1",
+            file: { version: 1, agents: {} },
+          };
+        }
+        return { method, params };
+      },
+    );
+
+    await runApprovalsCommand(["approvals", "get", "--gateway", "--timeout", "10000", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: {
+          note: "Config fetch timed out (gateway timeout after 10000ms). Re-run with a higher --timeout to inspect Effective Policy.",
           scopes: [],
         },
       }),

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -359,7 +359,7 @@ describe("exec approvals CLI", () => {
     expect(runtimeErrors).toHaveLength(0);
   });
 
-  it("reports gateway config timeout explicitly and sanitizes the error message", async () => {
+  it("reports gateway config timeout explicitly", async () => {
     callGatewayFromCli.mockImplementation(
       async (method: string, _opts: unknown, params?: unknown) => {
         if (method === "config.get") {
@@ -382,7 +382,7 @@ describe("exec approvals CLI", () => {
     expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
       expect.objectContaining({
         effectivePolicy: {
-          note: "Config fetch timed out (gateway timeout after 10000ms). Re-run with a higher --timeout to inspect Effective Policy.",
+          note: "Config fetch timed out. Re-run with a higher --timeout to inspect Effective Policy.",
           scopes: [],
         },
       }),

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -33,11 +33,17 @@ type ExecApprovalsSnapshot = {
 type ConfigSnapshotLike = {
   config?: OpenClawConfig;
 };
+type ConfigLoadResult = {
+  config: OpenClawConfig | null;
+  errorMessage?: string;
+  timedOut?: boolean;
+};
 type ApprovalsTargetSource = "gateway" | "node" | "local";
 type EffectivePolicyReport = {
   scopes: ExecPolicyScopeSnapshot[];
   note?: string;
 };
+const APPROVALS_GET_DEFAULT_TIMEOUT_MS = 60_000;
 
 type ExecApprovalsCliOpts = NodesRpcOpts & {
   node?: string;
@@ -165,53 +171,66 @@ function formatCliError(err: unknown): string {
 async function loadConfigForApprovalsTarget(params: {
   opts: ExecApprovalsCliOpts;
   source: ApprovalsTargetSource;
-}): Promise<OpenClawConfig | null> {
+}): Promise<ConfigLoadResult> {
   try {
     if (params.source === "local") {
-      return await readBestEffortConfig();
+      return { config: await readBestEffortConfig() };
     }
     const snapshot = (await callGatewayFromCli(
       "config.get",
       params.opts,
       {},
     )) as ConfigSnapshotLike;
-    return snapshot.config && typeof snapshot.config === "object" ? snapshot.config : null;
-  } catch {
-    return null;
+    return {
+      config: snapshot.config && typeof snapshot.config === "object" ? snapshot.config : null,
+    };
+  } catch (err) {
+    const errorMessage = formatCliError(err);
+    return {
+      config: null,
+      errorMessage,
+      timedOut: /^gateway timeout after \d+ms\b/i.test(errorMessage),
+    };
   }
 }
 
 function buildEffectivePolicyReport(params: {
-  cfg: OpenClawConfig | null;
+  configLoad: ConfigLoadResult;
   source: ApprovalsTargetSource;
   approvals: ExecApprovalsFile;
   hostPath: string;
 }): EffectivePolicyReport {
+  const cfg = params.configLoad.config;
+  const timeoutNote = params.configLoad.timedOut
+    ? `Config fetch timed out (${params.configLoad.errorMessage}). Re-run with a higher --timeout to inspect Effective Policy.`
+    : null;
   if (params.source === "node") {
-    if (!params.cfg) {
+    if (!cfg) {
       return {
         scopes: [],
-        note: "Gateway config unavailable. Node output above shows host approvals state only, and final runtime policy still intersects with gateway tools.exec.",
+        note:
+          timeoutNote ??
+          "Gateway config unavailable. Node output above shows host approvals state only, and final runtime policy still intersects with gateway tools.exec.",
       };
     }
     return {
       scopes: collectExecPolicyScopeSnapshots({
-        cfg: params.cfg,
+        cfg,
         approvals: params.approvals,
         hostPath: params.hostPath,
       }),
       note: "Effective exec policy is the node host approvals file intersected with gateway tools.exec policy.",
     };
   }
-  if (!params.cfg) {
+  if (!cfg) {
     return {
       scopes: [],
-      note: "Config unavailable.",
+      note: timeoutNote ?? "Config unavailable.",
     };
   }
   return {
     scopes: collectExecPolicyScopeSnapshots({
-      cfg: params.cfg,
+      cfg,
       approvals: params.approvals,
       hostPath: params.hostPath,
     }),
@@ -473,9 +492,9 @@ export function registerExecApprovalsCli(program: Command) {
     .action(async (opts: ExecApprovalsCliOpts) => {
       try {
         const { snapshot, nodeId, source } = await loadSnapshotTarget(opts);
-        const cfg = await loadConfigForApprovalsTarget({ opts, source });
+        const configLoad = await loadConfigForApprovalsTarget({ opts, source });
         const effectivePolicy = buildEffectivePolicyReport({
-          cfg,
+          configLoad,
           source,
           approvals: snapshot.file,
           hostPath: snapshot.path,
@@ -498,7 +517,7 @@ export function registerExecApprovalsCli(program: Command) {
         defaultRuntime.exit(1);
       }
     });
-  nodesCallOpts(getCmd);
+  nodesCallOpts(getCmd, { timeoutMs: APPROVALS_GET_DEFAULT_TIMEOUT_MS });
 
   const setCmd = approvals
     .command("set")

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -36,8 +36,7 @@ type ConfigSnapshotLike = {
 };
 type ConfigLoadResult = {
   config: OpenClawConfig | null;
-  errorMessage?: string;
-  timedOut?: boolean;
+  timedOut: boolean;
 };
 type ApprovalsTargetSource = "gateway" | "node" | "local";
 type EffectivePolicyReport = {
@@ -177,7 +176,7 @@ async function loadConfigForApprovalsTarget(params: {
 }): Promise<ConfigLoadResult> {
   try {
     if (params.source === "local") {
-      return { config: await readBestEffortConfig() };
+      return { config: await readBestEffortConfig(), timedOut: false };
     }
     const snapshot = (await callGatewayFromCli(
       "config.get",
@@ -186,13 +185,12 @@ async function loadConfigForApprovalsTarget(params: {
     )) as ConfigSnapshotLike;
     return {
       config: snapshot.config && typeof snapshot.config === "object" ? snapshot.config : null,
+      timedOut: false,
     };
   } catch (err) {
-    const errorMessage = formatCliError(err);
     return {
       config: null,
-      errorMessage,
-      timedOut: /^gateway timeout after \d+ms\b/i.test(errorMessage),
+      timedOut: /^gateway timeout after \d+ms\b/i.test(formatCliError(err)),
     };
   }
 }
@@ -205,7 +203,7 @@ function buildEffectivePolicyReport(params: {
 }): EffectivePolicyReport {
   const cfg = params.configLoad.config;
   const timeoutNote = params.configLoad.timedOut
-    ? `Config fetch timed out (${params.configLoad.errorMessage}). Re-run with a higher --timeout to inspect Effective Policy.`
+    ? "Config fetch timed out. Re-run with a higher --timeout to inspect Effective Policy."
     : null;
   if (params.source === "node") {
     if (!cfg) {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -16,6 +16,7 @@ import {
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { defaultRuntime } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { sanitizeForLog } from "../terminal/ansi.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { isRich, theme } from "../terminal/theme.js";
@@ -165,7 +166,9 @@ async function saveSnapshotTargeted(params: {
 
 function formatCliError(err: unknown): string {
   const msg = formatErrorMessage(err);
-  return msg.includes("\n") ? msg.split("\n")[0] : msg;
+  const firstLine = msg.includes("\n") ? msg.split("\n")[0] : msg;
+  const safe = sanitizeForLog(firstLine);
+  return safe.length > 300 ? `${safe.slice(0, 300)}...` : safe;
 }
 
 async function loadConfigForApprovalsTarget(params: {


### PR DESCRIPTION
## Summary

- Problem: `openclaw approvals get --gateway` inherited a 10s CLI timeout and could silently downgrade a `config.get` timeout into `Config unavailable.` even when the approvals snapshot itself succeeded.
- Why it matters: on slower hosts this makes healthy exec approval state look broken or missing to operators.
- What changed: `approvals get` now defaults to a 60s gateway timeout, preserves the approvals snapshot output, and reports config-load timeouts explicitly; the focused CLI regression test and changelog were updated too.
- What did NOT change (scope boundary): this does not change gateway RPC semantics or the underlying approval policy calculation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66234
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `approvals get` used the generic `nodesCallOpts` 10s timeout even though the command does multiple serial RPCs (`exec.approvals.get` or `exec.approvals.node.get`, then `config.get`).
- Missing detection / guardrail: `config.get` failures were collapsed to `null`, so timeouts and genuine config unavailability both rendered the same `Config unavailable.` note.
- Contributing context (if known): the reported slow host completed successfully once the timeout was raised.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/exec-approvals-cli.test.ts`
- Scenario the test should lock in: `approvals get --gateway` uses the longer default timeout, and an explicit `config.get` timeout renders a timeout-specific Effective Policy note instead of a generic unavailability message.
- Why this is the smallest reliable guardrail: the bug lives in CLI option defaults and CLI-side degradation/reporting, so the focused command test covers the exact decision points without requiring a live slow host.
- Existing test that already covers this (if any): the file already covered the generic `config.get`-failure fallback path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw approvals get` now defaults to a 60s gateway timeout instead of inheriting the generic 10s node CLI timeout.
- When the follow-up `config.get` call times out, Effective Policy now reports that timeout explicitly and suggests rerunning with a higher `--timeout`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.0 (Darwin 25.3.0)
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): gateway-mode CLI
- Relevant config (redacted): N/A

### Steps

1. Reproduce the code path for `openclaw approvals get --gateway` on `HEAD`.
2. Run `pnpm test src/cli/exec-approvals-cli.test.ts`.
3. Verify the command now uses the longer default timeout and that an explicit timeout failure renders the timeout-specific note.

### Expected

- Healthy approvals snapshots on slow hosts should no longer misleadingly degrade to `Config unavailable.` under the default command timeout.
- If config loading still times out, the CLI should say that it timed out.

### Actual

- The CLI now keeps the approvals snapshot output, defaults the command to a higher timeout budget, and distinguishes timeouts from genuine config unavailability.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the exact `approvals get` CLI path; ran `pnpm test src/cli/exec-approvals-cli.test.ts`; the scoped commit hook also passed the repo `pnpm check` lane.
- Edge cases checked: explicit `--timeout 10000` still yields a timeout-specific Effective Policy note; non-timeout config failures still preserve the generic unavailability fallback.
- What you did **not** verify: a live reproduction against a remote slow-host gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: operators may wait longer before seeing a timeout if the gateway is genuinely stalled.
  - Mitigation: `--timeout` remains user-configurable, and the degraded note now explains that the failure was a timeout.

## Disclosure

- AI-assisted: Yes
- Testing level: focused local test plus repo hook verification (`pnpm check`)

Made with [Cursor](https://cursor.com)