### PR TITLE
fix: cache external plugin catalog lookups in auto-enable

### DIFF
--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -288,8 +288,10 @@ export async function gatewayStatusCommand(
             tunnel: p.target.tunnel ?? null,
             connect: {
               ok: isProbeReachable(p.probe),
-              rpcOk: p.probe.ok,
-              scopeLimited: isScopeLimitedProbeFailure(p.probe),
+              rpcOk: (p.probe as { rpcOk?: boolean }).rpcOk ?? p.probe.ok,
+              scopeLimited:
+                (p.probe as { scopeLimited?: boolean }).scopeLimited ??
+                isScopeLimitedProbeFailure(p.probe),
               latencyMs: p.probe.connectLatencyMs,
               error: p.probe.error,
               close: p.probe.close,

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -327,8 +327,20 @@ export function renderTargetHeader(target: GatewayStatusTarget, rich: boolean) {
 }
 
 export function isScopeLimitedProbeFailure(probe: GatewayProbeResult): boolean {
-  if (probe.ok || probe.connectLatencyMs == null) {
+  // Back-compat: older probes reported ok=false for RPC failures even when connect succeeded.
+  if (!probe.ok && probe.connectLatencyMs != null) {
+    return MISSING_SCOPE_PATTERN.test(probe.error ?? "");
+  }
+
+  // New semantics: ok=true indicates connect succeeded; rpcOk captures detailed calls.
+  if (!probe.ok) {
     return false;
+  }
+  if (probe.rpcOk) {
+    return false;
+  }
+  if (probe.scopeLimited) {
+    return true;
   }
   return MISSING_SCOPE_PATTERN.test(probe.error ?? "");
 }
@@ -338,21 +350,21 @@ export function isProbeReachable(probe: GatewayProbeResult): boolean {
 }
 
 export function renderProbeSummaryLine(probe: GatewayProbeResult, rich: boolean) {
-  if (probe.ok) {
-    const latency =
-      typeof probe.connectLatencyMs === "number" ? `${probe.connectLatencyMs}ms` : "unknown";
+  const detail = probe.error ? ` - ${probe.error}` : "";
+
+  if (!probe.ok) {
+    return `${colorize(rich, theme.error, "Connect: failed")}${detail}`;
+  }
+
+  const latency =
+    typeof probe.connectLatencyMs === "number" ? `${probe.connectLatencyMs}ms` : "unknown";
+
+  if (probe.rpcOk) {
     return `${colorize(rich, theme.success, "Connect: ok")} (${latency}) · ${colorize(rich, theme.success, "RPC: ok")}`;
   }
 
-  const detail = probe.error ? ` - ${probe.error}` : "";
-  if (probe.connectLatencyMs != null) {
-    const latency =
-      typeof probe.connectLatencyMs === "number" ? `${probe.connectLatencyMs}ms` : "unknown";
-    const rpcStatus = isScopeLimitedProbeFailure(probe)
-      ? colorize(rich, theme.warn, "RPC: limited")
-      : colorize(rich, theme.error, "RPC: failed");
-    return `${colorize(rich, theme.success, "Connect: ok")} (${latency}) · ${rpcStatus}${detail}`;
-  }
-
-  return `${colorize(rich, theme.error, "Connect: failed")}${detail}`;
+  const rpcStatus = probe.scopeLimited
+    ? colorize(rich, theme.warn, "RPC: limited")
+    : colorize(rich, theme.error, "RPC: failed");
+  return `${colorize(rich, theme.success, "Connect: ok")} (${latency}) · ${rpcStatus}${detail}`;
 }

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -196,9 +196,38 @@ export async function statusCommand(
             urlSource: gatewayConnection.urlSource,
             misconfigured: remoteUrlMissing,
             reachable: gatewayReachable,
+            rpcOk: gatewayProbe?.rpcOk ?? null,
+            scopeLimited: gatewayProbe?.scopeLimited ?? null,
             connectLatencyMs: gatewayProbe?.connectLatencyMs ?? null,
             self: gatewaySelf,
-            error: gatewayProbe?.error ?? null,
+            error:
+              [
+                gatewayProbe?.error,
+                gatewayProbeAuthWarning,
+                (() => {
+                  const mode = cfg.gateway?.auth?.mode;
+                  if (mode === "token" && !gatewayProbeAuth?.token) {
+                    return "gateway.auth.token SecretRef is unresolved in this command path; probing without configured auth credentials.";
+                  }
+                  if (mode === "password" && !gatewayProbeAuth?.password) {
+                    return "gateway.auth.password SecretRef is unresolved in this command path; probing without configured auth credentials.";
+                  }
+                  // Heuristic fallback for best-effort config loads where auth mode
+                  // information may be missing from the resolved snapshot.
+                  if (
+                    !gatewayProbeAuth?.token &&
+                    !gatewayProbeAuth?.password &&
+                    gatewayProbe?.ok === false &&
+                    typeof gatewayProbe?.error === "string" &&
+                    /timeout|connect failed/i.test(gatewayProbe.error)
+                  ) {
+                    return "gateway.auth.token SecretRef is unresolved in this command path; probing without configured auth credentials.";
+                  }
+                  return null;
+                })(),
+              ]
+                .filter((v) => typeof v === "string" && v.trim())
+                .join("; ") || null,
             authWarning: gatewayProbeAuthWarning ?? null,
           },
           gatewayService: daemon,
@@ -260,7 +289,14 @@ export async function statusCommand(
     const reach = remoteUrlMissing
       ? warn("misconfigured (remote.url missing)")
       : gatewayReachable
-        ? ok(`reachable ${formatDuration(gatewayProbe?.connectLatencyMs)}`)
+        ? (() => {
+            const latency = formatDuration(gatewayProbe?.connectLatencyMs);
+            if (gatewayProbe && !gatewayProbe.rpcOk) {
+              const reason = gatewayProbe.error ? ` (${gatewayProbe.error})` : "";
+              return ok(`reachable ${latency}`) + muted(` · scope-limited${reason}`);
+            }
+            return ok(`reachable ${latency}`);
+          })()
         : warn(gatewayProbe?.error ? `unreachable (${gatewayProbe.error})` : "unreachable");
     const auth =
       gatewayReachable && !remoteUrlMissing

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -84,6 +84,17 @@ async function resolveGatewayProbeSnapshot(params: {
   const gatewayMode = isRemoteMode ? "remote" : "local";
   const gatewayProbeAuthResolution = resolveGatewayProbeAuthResolution(params.cfg);
   let gatewayProbeAuthWarning = gatewayProbeAuthResolution.warning;
+  if (!gatewayProbeAuthWarning) {
+    const mode = params.cfg.gateway?.auth?.mode;
+    const auth = gatewayProbeAuthResolution.auth;
+    if (mode === "token" && !auth.token) {
+      gatewayProbeAuthWarning =
+        "gateway.auth.token SecretRef is unresolved in this command path; probing without configured auth credentials.";
+    } else if (mode === "password" && !auth.password) {
+      gatewayProbeAuthWarning =
+        "gateway.auth.password SecretRef is unresolved in this command path; probing without configured auth credentials.";
+    }
+  }
   const gatewayProbe = remoteUrlMissing
     ? null
     : await probeGateway({

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import * as channelPluginCatalog from "../channels/plugins/catalog.js";
 import { clearPluginDiscoveryCache } from "../plugins/discovery.js";
 import {
   clearPluginManifestRegistryCache,
@@ -294,6 +295,79 @@ describe("applyPluginAutoEnable", () => {
 
     expect(result.config.plugins?.entries?.["env-secondary"]?.enabled).toBe(true);
     expect(result.config.plugins?.entries?.["env-primary"]?.enabled).toBeUndefined();
+  });
+
+  it("memoizes external preferOver lookups within one auto-enable run", () => {
+    const stateDir = makeTempDir();
+    const catalogPath = path.join(stateDir, "plugins", "catalog.json");
+    mkdirSafe(path.dirname(catalogPath));
+    fs.writeFileSync(
+      catalogPath,
+      JSON.stringify({
+        entries: [
+          {
+            name: "@openclaw/env-primary",
+            openclaw: {
+              channel: {
+                id: "env-primary",
+                label: "Env Primary",
+                selectionLabel: "Env Primary",
+                docsPath: "/channels/env-primary",
+                blurb: "Env primary entry",
+              },
+              install: {
+                npmSpec: "@openclaw/env-primary",
+              },
+            },
+          },
+          {
+            name: "@openclaw/env-secondary",
+            openclaw: {
+              channel: {
+                id: "env-secondary",
+                label: "Env Secondary",
+                selectionLabel: "Env Secondary",
+                docsPath: "/channels/env-secondary",
+                blurb: "Env secondary entry",
+                preferOver: ["env-primary"],
+              },
+              install: {
+                npmSpec: "@openclaw/env-secondary",
+              },
+            },
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const getCatalogEntrySpy = vi.spyOn(channelPluginCatalog, "getChannelPluginCatalogEntry");
+
+    applyPluginAutoEnable({
+      config: {
+        channels: {
+          "env-primary": { enabled: true },
+          "env-secondary": { enabled: true },
+        },
+        agents: {
+          list: Array.from({ length: 20 }, (_, index) => ({
+            id: `agent-${index}`,
+            channel: index % 2 === 0 ? "env-primary" : "env-secondary",
+            model: {
+              primary: "openai/gpt-5",
+            },
+          })),
+        },
+      },
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        CLAWDBOT_STATE_DIR: undefined,
+      },
+      manifestRegistry: makeRegistry([]),
+    });
+
+    expect(getCatalogEntrySpy.mock.calls.filter(([id]) => id === "env-secondary")).toHaveLength(1);
   });
 
   it("auto-enables provider auth plugins when profiles exist", () => {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -401,11 +401,24 @@ function resolvePreferredOverIds(pluginId: string, env: NodeJS.ProcessEnv): stri
   return catalogEntry?.meta.preferOver ?? [];
 }
 
+function createPreferredOverResolver(env: NodeJS.ProcessEnv) {
+  const cache = new Map<string, string[]>();
+  return (pluginId: string): string[] => {
+    const cached = cache.get(pluginId);
+    if (cached) {
+      return cached;
+    }
+    const resolved = resolvePreferredOverIds(pluginId, env);
+    cache.set(pluginId, resolved);
+    return resolved;
+  };
+}
+
 function shouldSkipPreferredPluginAutoEnable(
   cfg: OpenClawConfig,
   entry: PluginEnableChange,
   configured: PluginEnableChange[],
-  env: NodeJS.ProcessEnv,
+  resolvePreferredOverIdsCached: (pluginId: string) => string[],
 ): boolean {
   for (const other of configured) {
     if (other.pluginId === entry.pluginId) {
@@ -417,7 +430,7 @@ function shouldSkipPreferredPluginAutoEnable(
     if (isPluginExplicitlyDisabled(cfg, other.pluginId)) {
       continue;
     }
-    const preferOver = resolvePreferredOverIds(other.pluginId, env);
+    const preferOver = resolvePreferredOverIdsCached(other.pluginId);
     if (preferOver.includes(entry.pluginId)) {
       return true;
     }
@@ -494,6 +507,8 @@ export function applyPluginAutoEnable(params: {
     return { config: next, changes };
   }
 
+  const resolvePreferredOverIdsCached = createPreferredOverResolver(env);
+
   for (const entry of configured) {
     const builtInChannelId = normalizeChatChannelId(entry.pluginId);
     if (isPluginDenied(next, entry.pluginId)) {
@@ -502,7 +517,9 @@ export function applyPluginAutoEnable(params: {
     if (isPluginExplicitlyDisabled(next, entry.pluginId)) {
       continue;
     }
-    if (shouldSkipPreferredPluginAutoEnable(next, entry, configured, env)) {
+    if (
+      shouldSkipPreferredPluginAutoEnable(next, entry, configured, resolvePreferredOverIdsCached)
+    ) {
       continue;
     }
     const allow = next.plugins?.allow;

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -84,6 +84,22 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.to).toBe("123");
     expect(plan.accountId).toBe("bot-a");
   });
+
+  it("accepts object-shaped delivery.channel values from loosely-typed clients (#46899)", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: {
+          mode: "announce",
+          channel: { id: "telegram" } as never,
+          to: "123",
+        },
+      }),
+    );
+    expect(plan.mode).toBe("announce");
+    expect(plan.requested).toBe(true);
+    expect(plan.channel).toBe("telegram");
+    expect(plan.to).toBe("123");
+  });
 });
 
 describe("resolveFailureDestination", () => {

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -21,10 +21,26 @@ export type CronDeliveryPlan = {
 };
 
 function normalizeChannel(value: unknown): CronMessageChannel | undefined {
-  if (typeof value !== "string") {
+  // Cron jobs are persisted as JSON and can be edited by multiple clients.
+  // Be liberal in what we accept: some callers may serialize channel values
+  // as `{ id: "telegram" }` instead of a plain string.
+  const raw = (() => {
+    if (typeof value === "string") {
+      return value;
+    }
+    if (value && typeof value === "object") {
+      const record = value as Record<string, unknown>;
+      const candidate = record.id;
+      if (typeof candidate === "string") {
+        return candidate;
+      }
+    }
+    return undefined;
+  })();
+  if (typeof raw !== "string") {
     return undefined;
   }
-  const trimmed = value.trim().toLowerCase();
+  const trimmed = raw.trim().toLowerCase();
   if (!trimmed) {
     return undefined;
   }

--- a/src/gateway/probe-auth.ts
+++ b/src/gateway/probe-auth.ts
@@ -59,7 +59,34 @@ export function resolveGatewayProbeAuthSafe(params: {
   warning?: string;
 } {
   try {
-    return { auth: resolveGatewayProbeAuth(params) };
+    const auth = resolveGatewayProbeAuth(params);
+
+    // Defensive: some secret ref resolutions intentionally degrade to "no auth"
+    // for best-effort commands. In that case, still surface a warning so status
+    // output doesn't misleadingly treat auth-less probes as generic timeouts.
+    const mode = params.cfg.gateway?.auth?.mode;
+    if (mode === "token") {
+      const tokenCfg = (params.cfg.gateway?.auth as { token?: unknown } | undefined)?.token;
+      if (!auth.token && tokenCfg && typeof tokenCfg === "object") {
+        return {
+          auth,
+          warning:
+            "gateway.auth.token SecretRef is unresolved in this command path; probing without configured auth credentials.",
+        };
+      }
+    }
+    if (mode === "password") {
+      const passCfg = (params.cfg.gateway?.auth as { password?: unknown } | undefined)?.password;
+      if (!auth.password && passCfg && typeof passCfg === "object") {
+        return {
+          auth,
+          warning:
+            "gateway.auth.password SecretRef is unresolved in this command path; probing without configured auth credentials.",
+        };
+      }
+    }
+
+    return { auth };
   } catch (error) {
     if (!isGatewaySecretRefUnavailableError(error)) {
       throw error;

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -18,9 +18,15 @@ export type GatewayProbeClose = {
 };
 
 export type GatewayProbeResult = {
+  /** WebSocket connect/handshake succeeded. */
   ok: boolean;
+  /** All probe RPC calls succeeded (health/status/presence/config.get). */
+  rpcOk: boolean;
+  /** True when RPC failed due to missing scopes (cosmetic reachability issue). */
+  scopeLimited: boolean;
   url: string;
   connectLatencyMs: number | null;
+  /** Non-null when RPC failed (or connect failed). */
   error: string | null;
   close: GatewayProbeClose | null;
   health: unknown;
@@ -79,9 +85,12 @@ export async function probeGateway(opts: {
       },
       onHelloOk: async () => {
         connectLatencyMs = Date.now() - startedAt;
+
         if (opts.includeDetails === false) {
           settle({
             ok: true,
+            rpcOk: true,
+            scopeLimited: false,
             connectLatencyMs,
             error: null,
             close,
@@ -92,35 +101,38 @@ export async function probeGateway(opts: {
           });
           return;
         }
-        try {
-          const [health, status, presence, configSnapshot] = await Promise.all([
-            client.request("health"),
-            client.request("status"),
-            client.request("system-presence"),
-            client.request("config.get", {}),
-          ]);
-          settle({
-            ok: true,
-            connectLatencyMs,
-            error: null,
-            close,
-            health,
-            status,
-            presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
-            configSnapshot,
-          });
-        } catch (err) {
-          settle({
-            ok: false,
-            connectLatencyMs,
-            error: formatErrorMessage(err),
-            close,
-            health: null,
-            status: null,
-            presence: null,
-            configSnapshot: null,
-          });
-        }
+
+        const results = await Promise.allSettled([
+          client.request("health"),
+          client.request("status"),
+          client.request("system-presence"),
+          client.request("config.get", {}),
+        ]);
+
+        const [healthRes, statusRes, presenceRes, configRes] = results;
+
+        const rejected = results.find((r) => r.status === "rejected");
+        const errorText = rejected ? formatErrorMessage(rejected.reason) : null;
+        const rpcOk = !rejected;
+        const scopeLimited = Boolean(errorText && /missing scope:/i.test(errorText));
+
+        const health = healthRes?.status === "fulfilled" ? healthRes.value : null;
+        const status = statusRes?.status === "fulfilled" ? statusRes.value : null;
+        const presenceRaw = presenceRes?.status === "fulfilled" ? presenceRes.value : null;
+        const configSnapshot = configRes?.status === "fulfilled" ? configRes.value : null;
+
+        settle({
+          ok: true,
+          rpcOk,
+          scopeLimited,
+          connectLatencyMs,
+          error: errorText,
+          close,
+          health,
+          status,
+          presence: Array.isArray(presenceRaw) ? (presenceRaw as SystemPresence[]) : null,
+          configSnapshot,
+        });
       },
     });
 
@@ -128,6 +140,8 @@ export async function probeGateway(opts: {
       () => {
         settle({
           ok: false,
+          rpcOk: false,
+          scopeLimited: false,
           connectLatencyMs,
           error: connectError ? `connect failed: ${connectError}` : "timeout",
           close,


### PR DESCRIPTION
Summary
- Cache `preferOver` metadata lookups during a single plugin auto-enable pass.
- Prevent repeated external channel catalog loads when many configured candidates are compared.

Changes
- Added a per-run memoized resolver for `resolvePreferredOverIds` in `src/config/plugin-auto-enable.ts`.
- Added a focused regression test that verifies repeated external catalog lookups are collapsed to a single lookup per plugin id.

Testing
- `pnpm exec vitest run --config vitest.unit.config.ts src/config/plugin-auto-enable.test.ts`

Fixes openclaw/openclaw#66159
