### PR TITLE
[codex] Telegram: let immediate queue modes bypass busy topic lanes

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -1,7 +1,9 @@
 import {
   isNativeCommandsExplicitlyDisabled,
+  loadSessionStore,
   resolveNativeCommandsEnabled,
   resolveNativeSkillsEnabled,
+  resolveStorePath,
 } from "openclaw/plugin-sdk/config-runtime";
 import {
   resolveChannelGroupPolicy,
@@ -15,6 +17,7 @@ import {
 import { formatErrorMessage, formatUncaughtError } from "openclaw/plugin-sdk/error-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
+import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -43,6 +46,7 @@ import { tagTelegramNetworkError } from "./network-errors.js";
 import { resolveTelegramRequestTimeoutMs } from "./request-timeouts.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
+import { createTelegramSequentialKey } from "./sequential-key.runtime.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
 
 export type { TelegramBotOptions } from "./bot.types.js";
@@ -383,8 +387,6 @@ export function createTelegramBotCore(
     }
   });
 
-  bot.use(botRuntime.sequentialize(getTelegramSequentialKey));
-
   const rawUpdateLogger = createSubsystemLogger("gateway/channels/telegram/raw-update");
   const MAX_RAW_UPDATE_CHARS = 8000;
   const MAX_RAW_UPDATE_STRING = 500;
@@ -541,6 +543,18 @@ export function createTelegramBotCore(
       messageThreadId != null ? groupConfig?.topics?.[String(messageThreadId)] : undefined;
     return { groupConfig, topicConfig };
   };
+
+  bot.use(
+    botRuntime.sequentialize(
+      createTelegramSequentialKey({
+        accountId: account.accountId,
+        loadRuntimeConfig: () => getRuntimeConfigSnapshot() ?? telegramDeps.loadConfig(),
+        loadSessionStore: telegramDeps.loadSessionStore ?? loadSessionStore,
+        resolveTelegramGroupConfig,
+        resolveStorePath: telegramDeps.resolveStorePath ?? resolveStorePath,
+      }),
+    ),
+  );
 
   // Global sendChatAction handler with 401 backoff / circuit breaker (issue #27092).
   // Created BEFORE the message processor so it can be injected into every message context.

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -247,10 +247,19 @@ const sentMessageCacheHoisted = vi.hoisted(() => ({
 }));
 export const wasSentByBot = sentMessageCacheHoisted.wasSentByBot;
 
+const replyRunHoisted = vi.hoisted(() => ({
+  isReplyRunActiveForSessionKey: vi.fn(() => false),
+}));
+export const isReplyRunActiveForSessionKeySpy = replyRunHoisted.isReplyRunActiveForSessionKey;
+
 vi.doMock("./sent-message-cache.js", () => ({
   wasSentByBot: sentMessageCacheHoisted.wasSentByBot,
   recordSentMessage: vi.fn(),
   clearSentMessageCache: vi.fn(),
+}));
+
+vi.doMock("./reply-run-runtime.js", () => ({
+  isReplyRunActiveForSessionKey: replyRunHoisted.isReplyRunActiveForSessionKey,
 }));
 
 // All spy variables used inside vi.mock("grammy", ...) must be created via
@@ -497,6 +506,8 @@ beforeEach(() => {
   sendMessageSpy.mockResolvedValue({ message_id: 77 });
   getFileSpy.mockReset();
   getFileSpy.mockResolvedValue({ file_path: "media/file.jpg" });
+  isReplyRunActiveForSessionKeySpy.mockReset();
+  isReplyRunActiveForSessionKeySpy.mockReturnValue(false);
 
   setMessageReactionSpy.mockReset();
   setMessageReactionSpy.mockResolvedValue(undefined);

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -302,6 +302,38 @@ describe("createTelegramBot", () => {
     expect(harness.sequentializeKey?.(ctx)).toBe(getTelegramSequentialKey(ctx));
   });
 
+  it.each(["coalesce", "followups", "follow-ups"] as const)(
+    "keeps busy Telegram messages on the ordinary topic lane when %s overrides a lower-precedence immediate mode",
+    (mode) => {
+      loadConfig.mockReturnValue({
+        messages: {
+          queue: {
+            mode: "interrupt",
+            byChannel: {
+              telegram: mode,
+            },
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      });
+
+      createTelegramBot({ token: "tok" });
+      const ctx = makeForumGroupMessageCtx({
+        threadId: 99,
+        text: "follow up please",
+      }) as unknown as TelegramSequentialKeyContext;
+      isReplyRunActiveForSessionKeySpy.mockReturnValue(true);
+
+      expect(harness.sequentializeKey?.(ctx)).toBe(getTelegramSequentialKey(ctx));
+    },
+  );
+
   it("does not reroute whole-message control commands through the busy session lane", () => {
     loadConfig.mockReturnValue({
       messages: {

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -243,7 +243,7 @@ describe("createTelegramBot", () => {
     expect(harness.sequentializeKey?.(ctx)).toBe(getTelegramSequentialKey(ctx));
   });
 
-  it.each(["steer", "steer-backlog", "interrupt"] as const)(
+  it.each(["steer", "queued", "steer-backlog", "interrupt"] as const)(
     "routes busy %s-mode Telegram messages onto a session control lane",
     (mode) => {
       loadConfig.mockReturnValue({

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -276,6 +276,44 @@ describe("createTelegramBot", () => {
     },
   );
 
+  it("routes busy media-only Telegram messages onto a session control lane", () => {
+    loadConfig.mockReturnValue({
+      messages: {
+        queue: {
+          mode: "interrupt",
+        },
+      },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const baseCtx = makeForumGroupMessageCtx({
+      threadId: 99,
+      text: "",
+    }) as unknown as TelegramSequentialKeyContext;
+    const ctx = {
+      ...baseCtx,
+      message: {
+        ...baseCtx.message,
+        text: undefined,
+        voice: { file_id: "voice-1" },
+      },
+    } as unknown as TelegramSequentialKeyContext;
+    isReplyRunActiveForSessionKeySpy.mockReturnValue(true);
+
+    const key = harness.sequentializeKey?.(ctx);
+
+    expect(key).toMatch(/^telegram:session-control:/);
+    expect(key).not.toBe(getTelegramSequentialKey(ctx));
+    expect(isReplyRunActiveForSessionKeySpy).toHaveBeenCalledOnce();
+  });
+
   it("keeps busy collect-mode Telegram messages on the ordinary topic lane", () => {
     loadConfig.mockReturnValue({
       messages: {

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -2,6 +2,7 @@ import type { GetReplyOptions, MsgContext } from "openclaw/plugin-sdk/reply-runt
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../../test/helpers/envelope-timestamp.js";
 import type { TelegramBotOptions } from "./bot.types.js";
+import type { TelegramSequentialKeyContext } from "./sequential-key.js";
 const harness = await import("./bot.create-telegram-bot.test-harness.js");
 const conversationRuntime = await import("openclaw/plugin-sdk/conversation-runtime");
 const configRuntime = await import("openclaw/plugin-sdk/config-runtime");
@@ -21,6 +22,7 @@ const {
   getOnHandler,
   getReadChannelAllowFromStoreMock,
   getUpsertChannelPairingRequestMock,
+  isReplyRunActiveForSessionKeySpy,
   listSkillCommandsForAgents,
   makeForumGroupMessageCtx,
   middlewareUseSpy,
@@ -234,7 +236,96 @@ describe("createTelegramBot", () => {
     createTelegramBot({ token: "tok" });
     expect(sequentializeSpy).toHaveBeenCalledTimes(1);
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
-    expect(harness.sequentializeKey).toBe(getTelegramSequentialKey);
+    const ctx = makeForumGroupMessageCtx({
+      threadId: 9,
+      text: "hello",
+    }) as unknown as TelegramSequentialKeyContext;
+    expect(harness.sequentializeKey?.(ctx)).toBe(getTelegramSequentialKey(ctx));
+  });
+
+  it.each(["steer", "steer-backlog", "interrupt"] as const)(
+    "routes busy %s-mode Telegram messages onto a session control lane",
+    (mode) => {
+      loadConfig.mockReturnValue({
+        messages: {
+          queue: {
+            mode,
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      });
+
+      createTelegramBot({ token: "tok" });
+      const ctx = makeForumGroupMessageCtx({
+        threadId: 99,
+        text: "follow up please",
+      }) as unknown as TelegramSequentialKeyContext;
+      isReplyRunActiveForSessionKeySpy.mockReturnValue(true);
+
+      const key = harness.sequentializeKey?.(ctx);
+
+      expect(key).toMatch(/^telegram:session-control:/);
+      expect(key).not.toBe(getTelegramSequentialKey(ctx));
+      expect(isReplyRunActiveForSessionKeySpy).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps busy collect-mode Telegram messages on the ordinary topic lane", () => {
+    loadConfig.mockReturnValue({
+      messages: {
+        queue: {
+          mode: "collect",
+        },
+      },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const ctx = makeForumGroupMessageCtx({
+      threadId: 99,
+      text: "follow up please",
+    }) as unknown as TelegramSequentialKeyContext;
+    isReplyRunActiveForSessionKeySpy.mockReturnValue(true);
+
+    expect(harness.sequentializeKey?.(ctx)).toBe(getTelegramSequentialKey(ctx));
+  });
+
+  it("does not reroute whole-message control commands through the busy session lane", () => {
+    loadConfig.mockReturnValue({
+      messages: {
+        queue: {
+          mode: "interrupt",
+        },
+      },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const ctx = makeForumGroupMessageCtx({
+      threadId: 99,
+      text: "/queue interrupt",
+    }) as unknown as TelegramSequentialKeyContext;
+    isReplyRunActiveForSessionKeySpy.mockReturnValue(true);
+
+    expect(harness.sequentializeKey?.(ctx)).toBe(getTelegramSequentialKey(ctx));
   });
 
   it("lets /status bypass a busy Telegram topic lane", async () => {

--- a/extensions/telegram/src/reply-run-runtime.ts
+++ b/extensions/telegram/src/reply-run-runtime.ts
@@ -1,0 +1,1 @@
+export { isReplyRunActiveForSessionKey } from "openclaw/plugin-sdk/reply-runtime";

--- a/extensions/telegram/src/sequential-key.runtime.ts
+++ b/extensions/telegram/src/sequential-key.runtime.ts
@@ -39,11 +39,20 @@ function normalizeQueueMode(value: unknown): QueueMode | undefined {
   if (!normalized) {
     return undefined;
   }
-  if (normalized === "queue" || normalized === "queued" || normalized === "steering") {
+  if (normalized === "queue" || normalized === "queued") {
     return "steer";
   }
-  if (normalized === "interrupts" || normalized === "abort") {
+  if (normalized === "interrupt" || normalized === "interrupts" || normalized === "abort") {
     return "interrupt";
+  }
+  if (normalized === "steer" || normalized === "steering") {
+    return "steer";
+  }
+  if (normalized === "followup" || normalized === "followups" || normalized === "follow-ups") {
+    return "followup";
+  }
+  if (normalized === "collect" || normalized === "coalesce") {
+    return "collect";
   }
   if (
     normalized === "steer+backlog" ||
@@ -51,14 +60,6 @@ function normalizeQueueMode(value: unknown): QueueMode | undefined {
     normalized === "steer_backlog"
   ) {
     return "steer-backlog";
-  }
-  if (
-    normalized === "collect" ||
-    normalized === "followup" ||
-    normalized === "interrupt" ||
-    normalized === "steer"
-  ) {
-    return normalized;
   }
   return undefined;
 }

--- a/extensions/telegram/src/sequential-key.runtime.ts
+++ b/extensions/telegram/src/sequential-key.runtime.ts
@@ -9,6 +9,11 @@ import type { loadSessionStore as loadSessionStoreRuntime } from "openclaw/plugi
 import type { resolveStorePath as resolveStorePathRuntime } from "openclaw/plugin-sdk/config-runtime";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
+import {
+  extractTelegramLocation,
+  getTelegramTextParts,
+  resolveTelegramPrimaryMedia,
+} from "./bot/body-helpers.js";
 import { resolveTelegramForumThreadId } from "./bot/helpers.js";
 import {
   resolveTelegramConversationBaseSessionKey,
@@ -117,12 +122,17 @@ function resolveBusySessionControlLane(
   if (msg.chat?.type === "channel") {
     return undefined;
   }
-  const rawText = msg.text ?? msg.caption;
-  if (!rawText?.trim()) {
+  const rawText = getTelegramTextParts(msg).text.trim();
+  const hasTurnContent =
+    Boolean(rawText) ||
+    Boolean(extractTelegramLocation(msg)) ||
+    Boolean(resolveTelegramPrimaryMedia(msg));
+  if (!hasTurnContent) {
     return undefined;
   }
   const cfg = params.loadRuntimeConfig();
   if (
+    rawText &&
     hasControlCommand(rawText, cfg, ctx.me?.username ? { botUsername: ctx.me.username } : undefined)
   ) {
     return undefined;

--- a/extensions/telegram/src/sequential-key.runtime.ts
+++ b/extensions/telegram/src/sequential-key.runtime.ts
@@ -1,0 +1,191 @@
+import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
+import {
+  resolveSessionStoreEntry,
+  type OpenClawConfig,
+  type TelegramGroupConfig,
+  type TelegramTopicConfig,
+} from "openclaw/plugin-sdk/config-runtime";
+import type { loadSessionStore as loadSessionStoreRuntime } from "openclaw/plugin-sdk/config-runtime";
+import type { resolveStorePath as resolveStorePathRuntime } from "openclaw/plugin-sdk/config-runtime";
+import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
+import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
+import { resolveTelegramForumThreadId } from "./bot/helpers.js";
+import {
+  resolveTelegramConversationBaseSessionKey,
+  resolveTelegramConversationRoute,
+} from "./conversation-route.js";
+import { isReplyRunActiveForSessionKey } from "./reply-run-runtime.js";
+import { getTelegramSequentialKey, type TelegramSequentialKeyContext } from "./sequential-key.js";
+
+type ResolveTelegramGroupConfig = (
+  chatId: string | number,
+  messageThreadId?: number,
+) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
+
+type CreateTelegramSequentialKeyParams = {
+  accountId: string;
+  loadRuntimeConfig: () => OpenClawConfig;
+  loadSessionStore: typeof loadSessionStoreRuntime;
+  resolveTelegramGroupConfig: ResolveTelegramGroupConfig;
+  resolveStorePath: typeof resolveStorePathRuntime;
+};
+
+type QueueMode = "collect" | "followup" | "interrupt" | "steer" | "steer-backlog";
+
+function normalizeQueueMode(value: unknown): QueueMode | undefined {
+  const normalized = normalizeOptionalLowercaseString(
+    typeof value === "string" ? value : undefined,
+  );
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "queue" || normalized === "steering") {
+    return "steer";
+  }
+  if (normalized === "interrupts" || normalized === "abort") {
+    return "interrupt";
+  }
+  if (
+    normalized === "steer+backlog" ||
+    normalized === "steer-backlog" ||
+    normalized === "steer_backlog"
+  ) {
+    return "steer-backlog";
+  }
+  if (
+    normalized === "collect" ||
+    normalized === "followup" ||
+    normalized === "interrupt" ||
+    normalized === "steer"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function resolveQueueModeForSession(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  loadSessionStore: typeof loadSessionStoreRuntime;
+  resolveStorePath: typeof resolveStorePathRuntime;
+  sessionKey: string;
+}): QueueMode {
+  const storePath = params.resolveStorePath(params.cfg.session?.store, {
+    agentId: params.agentId,
+  });
+  const store = params.loadSessionStore(storePath);
+  const sessionEntry = resolveSessionStoreEntry({
+    store,
+    sessionKey: params.sessionKey,
+  }).existing;
+  const providerModeRaw =
+    params.cfg.messages?.queue?.byChannel && typeof params.cfg.messages.queue.byChannel === "object"
+      ? params.cfg.messages.queue.byChannel.telegram
+      : undefined;
+  return (
+    normalizeQueueMode(sessionEntry?.queueMode) ??
+    normalizeQueueMode(providerModeRaw) ??
+    normalizeQueueMode(params.cfg.messages?.queue?.mode) ??
+    "collect"
+  );
+}
+
+function resolvesImmediateQueueMode(mode: QueueMode): boolean {
+  return mode === "interrupt" || mode === "steer" || mode === "steer-backlog";
+}
+
+function resolveBusySessionControlLane(
+  ctx: TelegramSequentialKeyContext,
+  params: CreateTelegramSequentialKeyParams,
+): string | undefined {
+  const msg =
+    ctx.message ??
+    ctx.channelPost ??
+    ctx.editedChannelPost ??
+    ctx.update?.message ??
+    ctx.update?.edited_message ??
+    ctx.update?.channel_post ??
+    ctx.update?.edited_channel_post;
+  if (!msg) {
+    return undefined;
+  }
+  const chatId = msg.chat?.id ?? ctx.chat?.id;
+  if (typeof chatId !== "number") {
+    return undefined;
+  }
+  if (msg.chat?.type === "channel") {
+    return undefined;
+  }
+  const rawText = msg.text ?? msg.caption;
+  if (!rawText?.trim()) {
+    return undefined;
+  }
+  const cfg = params.loadRuntimeConfig();
+  if (
+    hasControlCommand(rawText, cfg, ctx.me?.username ? { botUsername: ctx.me.username } : undefined)
+  ) {
+    return undefined;
+  }
+  const isGroup = msg.chat?.type === "group" || msg.chat?.type === "supergroup";
+  const resolvedThreadId = isGroup
+    ? resolveTelegramForumThreadId({
+        isForum: msg.chat?.is_forum,
+        messageThreadId: msg.message_thread_id,
+      })
+    : undefined;
+  const dmThreadId = !isGroup ? msg.message_thread_id : undefined;
+  const topicThreadId = resolvedThreadId ?? dmThreadId;
+  const { topicConfig } = params.resolveTelegramGroupConfig(chatId, topicThreadId);
+  const senderId = msg.from?.id;
+  const { route } = resolveTelegramConversationRoute({
+    cfg,
+    accountId: params.accountId,
+    chatId,
+    isGroup,
+    resolvedThreadId,
+    replyThreadId: topicThreadId,
+    senderId,
+    topicAgentId: topicConfig?.agentId,
+  });
+  const baseSessionKey = resolveTelegramConversationBaseSessionKey({
+    cfg,
+    route,
+    chatId,
+    isGroup,
+    senderId,
+  });
+  const threadKeys =
+    dmThreadId != null
+      ? resolveThreadSessionKeys({ baseSessionKey, threadId: `${chatId}:${dmThreadId}` })
+      : null;
+  const sessionKey = threadKeys?.sessionKey ?? baseSessionKey;
+  if (!isReplyRunActiveForSessionKey(sessionKey)) {
+    return undefined;
+  }
+  const queueMode = resolveQueueModeForSession({
+    cfg,
+    agentId: route.agentId,
+    loadSessionStore: params.loadSessionStore,
+    resolveStorePath: params.resolveStorePath,
+    sessionKey,
+  });
+  if (!resolvesImmediateQueueMode(queueMode)) {
+    return undefined;
+  }
+  // Preserve ordinary per-topic sequencing unless a session is already busy
+  // and the queue policy expects a prompt control-style handoff.
+  return `telegram:session-control:${sessionKey}`;
+}
+
+export function createTelegramSequentialKey(params: CreateTelegramSequentialKeyParams) {
+  return (ctx: TelegramSequentialKeyContext): string => {
+    const baseKey = getTelegramSequentialKey(ctx);
+    if (baseKey.endsWith(":control") || baseKey.includes(":btw:") || baseKey.endsWith(":btw")) {
+      return baseKey;
+    }
+    if (baseKey.endsWith(":approval")) {
+      return baseKey;
+    }
+    return resolveBusySessionControlLane(ctx, params) ?? baseKey;
+  };
+}

--- a/extensions/telegram/src/sequential-key.runtime.ts
+++ b/extensions/telegram/src/sequential-key.runtime.ts
@@ -39,7 +39,7 @@ function normalizeQueueMode(value: unknown): QueueMode | undefined {
   if (!normalized) {
     return undefined;
   }
-  if (normalized === "queue" || normalized === "steering") {
+  if (normalized === "queue" || normalized === "queued" || normalized === "steering") {
     return "steer";
   }
   if (normalized === "interrupts" || normalized === "abort") {

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -3,6 +3,7 @@ import {
   __testing,
   abortActiveReplyRuns,
   createReplyOperation,
+  isReplyRunActiveForSessionKey,
   isReplyRunActiveForSessionId,
   queueReplyRunMessage,
   replyRunRegistry,
@@ -63,6 +64,20 @@ describe("reply run registry", () => {
 
     expect(operation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
     expect(replyRunRegistry.isActive("agent:main:main")).toBe(false);
+  });
+
+  it("exposes active state lookups by session key", () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:main",
+      sessionId: "session-active",
+      resetTriggered: false,
+    });
+
+    expect(isReplyRunActiveForSessionKey("agent:main:main")).toBe(true);
+
+    operation.complete();
+
+    expect(isReplyRunActiveForSessionKey("agent:main:main")).toBe(false);
   });
 
   it("queues messages only through the active running backend", async () => {

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -441,6 +441,10 @@ export const replyRunRegistry: ReplyRunRegistry = {
   },
 };
 
+export function isReplyRunActiveForSessionKey(sessionKey: string): boolean {
+  return replyRunRegistry.isActive(sessionKey);
+}
+
 export function resolveActiveReplyRunSessionId(sessionKey: string): string | undefined {
   return replyRunRegistry.resolveSessionId(sessionKey);
 }

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -30,6 +30,7 @@ export { getReplyFromConfig } from "../auto-reply/reply/get-reply.js";
 export { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 export { isAbortRequestText } from "../auto-reply/reply/abort.js";
 export { isBtwRequestText } from "../auto-reply/reply/btw-command.js";
+export { isReplyRunActiveForSessionKey } from "../auto-reply/reply/reply-run-registry.js";
 export { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
 export { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 export {


### PR DESCRIPTION
## Summary
This fixes a Telegram-specific queueing bug where immediate queue modes could not take effect while a topic already had an in-flight turn.

## Root Cause
Telegram sequentializes inbound updates per chat/topic before they reach core queue policy. That means a second message in the same busy topic could sit behind the adapter lane and never reach core steering/interrupt handling promptly.

## Design
- Keep ordinary Telegram per-chat/per-topic sequencing unchanged by default.
- Add a Telegram-only sequential-key wrapper that checks whether the current session already has an active reply run.
- When the session is busy and the effective queue mode is `steer`, `steer-backlog`, or `interrupt`, route that inbound message onto a session-scoped control lane instead of the normal topic lane.
- Preserve the existing lanes for `/stop`, approval callbacks, `/btw`, and whole-message control commands.

## Before / After
Before: a follow-up Telegram message in a busy topic could not steer or interrupt promptly because it was blocked at the adapter sequencer.
After: immediate queue modes can reach core queue handling promptly in busy Telegram sessions, while normal collect/followup behavior remains serialized.

## Risks
The main risk is limited extra concurrency for busy Telegram sessions when an immediate queue mode is explicitly configured. The bypass is narrow: it only applies when the session is already busy and the effective queue policy expects prompt handoff behavior.

## Validation
- `pnpm test extensions/telegram/src/bot.create-telegram-bot.test.ts src/auto-reply/reply/reply-run-registry.test.ts`
- `pnpm tsgo`
- `pnpm build`
- `pnpm plugin-sdk:api:check`