### PR TITLE
fix(daemon): avoid inline dotenv secrets in systemd unit during service repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Media-understanding/attachments: fail closed when a local attachment path cannot be canonically resolved via `realpath`, so a `realpath` error can no longer downgrade the canonical-roots allowlist check to a non-canonical comparison; attachments that also have a URL still fall back to the network fetch path. (#66022) Thanks @eleqtrizit.
 - Agents/gateway-tool: reject `config.patch` and `config.apply` calls from the model-facing gateway tool when they would newly enable any flag enumerated by `openclaw security audit` (for example `dangerouslyDisableDeviceAuth`, `allowInsecureAuth`, `dangerouslyAllowHostHeaderOriginFallback`, `hooks.gmail.allowUnsafeExternalContent`, `tools.exec.applyPatch.workspaceOnly: false`); already-enabled flags pass through unchanged so non-dangerous edits in the same patch still apply, and direct authenticated operator RPC behavior is unchanged. (#62006) Thanks @eleqtrizit.
 - Telegram/forum topics: persist learned topic names to the Telegram session sidecar store so agent context can keep using human topic names after a restart instead of relearning from future service metadata. (#66107) Thanks @obviyus.
+- Doctor/systemd: keep `openclaw doctor --repair` and service reinstall from re-embedding dotenv-backed secrets in user systemd units, while preserving newer inline overrides over stale state-dir `.env` values. (#66249) Thanks @tmimmanuel.
 
 ## 2026.4.14-beta.1
 

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -14,24 +14,7 @@ function isBlockedServiceEnvVar(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
 }
 
-/**
- * Read and parse `~/.openclaw/.env` (or `$OPENCLAW_STATE_DIR/.env`), returning
- * a filtered record of key-value pairs suitable for embedding in a service
- * environment (LaunchAgent plist, systemd unit, Scheduled Task).
- */
-export function readStateDirDotEnvVars(
-  env: Record<string, string | undefined>,
-): Record<string, string> {
-  const stateDir = resolveStateDir(env as NodeJS.ProcessEnv);
-  const dotEnvPath = path.join(stateDir, ".env");
-
-  let content: string;
-  try {
-    content = fs.readFileSync(dotEnvPath, "utf8");
-  } catch {
-    return {};
-  }
-
+function parseStateDirDotEnvContent(content: string): Record<string, string> {
   const parsed = dotenv.parse(content);
   const entries: Record<string, string> = {};
   for (const [rawKey, value] of Object.entries(parsed)) {
@@ -48,6 +31,27 @@ export function readStateDirDotEnvVars(
     entries[key] = value;
   }
   return entries;
+}
+
+export function readStateDirDotEnvVarsFromStateDir(stateDir: string): Record<string, string> {
+  const dotEnvPath = path.join(stateDir, ".env");
+  try {
+    return parseStateDirDotEnvContent(fs.readFileSync(dotEnvPath, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Read and parse `~/.openclaw/.env` (or `$OPENCLAW_STATE_DIR/.env`), returning
+ * a filtered record of key-value pairs suitable for embedding in a service
+ * environment (LaunchAgent plist, systemd unit, Scheduled Task).
+ */
+export function readStateDirDotEnvVars(
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  const stateDir = resolveStateDir(env as NodeJS.ProcessEnv);
+  return readStateDirDotEnvVarsFromStateDir(stateDir);
 }
 
 /**

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -56,4 +56,5 @@ export type GatewayServiceRenderArgs = {
   programArguments: string[];
   workingDirectory?: string;
   environment?: GatewayServiceEnv;
+  environmentFiles?: string[];
 };

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -38,4 +38,20 @@ describe("buildSystemdUnit", () => {
       }),
     ).toThrow(/CR or LF/);
   });
+
+  it("renders EnvironmentFile entries before inline Environment values", () => {
+    const unit = buildSystemdUnit({
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+      environmentFiles: ["/home/test/.openclaw/.env"],
+      environment: {
+        OPENCLAW_GATEWAY_PORT: "18789",
+      },
+    });
+    expect(unit).toContain("EnvironmentFile=/home/test/.openclaw/.env");
+    expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
+    expect(unit.indexOf("EnvironmentFile=/home/test/.openclaw/.env")).toBeLessThan(
+      unit.indexOf("Environment=OPENCLAW_GATEWAY_PORT=18789"),
+    );
+  });
 });

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -48,9 +48,9 @@ describe("buildSystemdUnit", () => {
         OPENCLAW_GATEWAY_PORT: "18789",
       },
     });
-    expect(unit).toContain("EnvironmentFile=/home/test/.openclaw/.env");
+    expect(unit).toContain("EnvironmentFile=-/home/test/.openclaw/.env");
     expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
-    expect(unit.indexOf("EnvironmentFile=/home/test/.openclaw/.env")).toBeLessThan(
+    expect(unit.indexOf("EnvironmentFile=-/home/test/.openclaw/.env")).toBeLessThan(
       unit.indexOf("Environment=OPENCLAW_GATEWAY_PORT=18789"),
     );
   });

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -44,7 +44,7 @@ function renderEnvironmentFileLines(environmentFiles: string[] | undefined): str
     .filter(Boolean)
     .map((entry) => {
       assertNoSystemdLineBreaks(entry, "Systemd EnvironmentFile values");
-      return `EnvironmentFile=${systemdEscapeArg(entry)}`;
+      return `EnvironmentFile=-${systemdEscapeArg(entry)}`;
     });
 }
 

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -35,11 +35,25 @@ function renderEnvLines(env: Record<string, string | undefined> | undefined): st
   });
 }
 
+function renderEnvironmentFileLines(environmentFiles: string[] | undefined): string[] {
+  if (!environmentFiles) {
+    return [];
+  }
+  return environmentFiles
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      assertNoSystemdLineBreaks(entry, "Systemd EnvironmentFile values");
+      return `EnvironmentFile=${systemdEscapeArg(entry)}`;
+    });
+}
+
 export function buildSystemdUnit({
   description,
   programArguments,
   workingDirectory,
   environment,
+  environmentFiles,
 }: GatewayServiceRenderArgs): string {
   const execStart = programArguments.map(systemdEscapeArg).join(" ");
   const descriptionValue = description?.trim() || "OpenClaw Gateway";
@@ -49,6 +63,7 @@ export function buildSystemdUnit({
     ? `WorkingDirectory=${systemdEscapeArg(workingDirectory)}`
     : null;
   const envLines = renderEnvLines(environment);
+  const environmentFileLines = renderEnvironmentFileLines(environmentFiles);
   return [
     "[Unit]",
     descriptionLine,
@@ -69,6 +84,7 @@ export function buildSystemdUnit({
     // orphan ACP/runtime workers behind.
     "KillMode=control-group",
     workingDirLine,
+    ...environmentFileLines,
     ...envLines,
     "",
     "[Install]",

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -701,6 +701,55 @@ describe("stageSystemdService", () => {
       await fs.rm(tempHomeRoot, { recursive: true, force: true });
     }
   });
+
+  it("keeps inline overrides out of the generated env file", async () => {
+    const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-stage-"));
+    const home = path.join(tempHomeRoot, "home");
+    const stateDir = path.join(home, ".openclaw");
+    const env = {
+      HOME: home,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-stage-test",
+    };
+    const unitPath = resolveSystemdUserUnitPath(env);
+    const envFilePath = path.join(stateDir, "gateway.systemd.env");
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      path.join(stateDir, ".env"),
+      ["OPENCLAW_GATEWAY_TOKEN=stale-token", "LLM_API_KEY=dotenv-key"].join("\n"),
+      "utf8",
+    );
+
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      assertUserSystemctlArgs(args, "status");
+      cb(null, "", "");
+    });
+
+    try {
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/tmp",
+        environment: {
+          OPENCLAW_GATEWAY_TOKEN: "fresh-token",
+          LLM_API_KEY: "dotenv-key",
+        },
+      });
+
+      const [unit, envFile] = await Promise.all([
+        fs.readFile(unitPath, "utf8"),
+        fs.readFile(envFilePath, "utf8"),
+      ]);
+
+      expect(unit).toContain(`EnvironmentFile=-${envFilePath}`);
+      expect(unit).toContain("Environment=OPENCLAW_GATEWAY_TOKEN=fresh-token");
+      expect(envFile).toBe("LLM_API_KEY=dotenv-key\n");
+    } finally {
+      await fs.rm(tempHomeRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("systemd service control", () => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
@@ -26,6 +27,7 @@ import {
   readSystemdServiceExecStart,
   restartSystemdService,
   resolveSystemdUserUnitPath,
+  stageSystemdService,
   stopSystemdService,
 } from "./systemd.js";
 
@@ -637,6 +639,67 @@ describe("readSystemdServiceExecStart", () => {
       OPENCLAW_GATEWAY_TOKEN: "file",
       OPENCLAW_GATEWAY_PASSWORD: "file", // pragma: allowlist secret
     });
+  });
+});
+
+describe("stageSystemdService", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    execFileMock.mockReset();
+  });
+
+  it("writes dotenv-backed values to a separate env file and keeps inline env minimal", async () => {
+    const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-stage-"));
+    const home = path.join(tempHomeRoot, "home");
+    const stateDir = path.join(home, ".openclaw");
+    const env = {
+      HOME: home,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-stage-test",
+    };
+    const unitPath = resolveSystemdUserUnitPath(env);
+    const envFilePath = path.join(stateDir, "gateway.systemd.env");
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      path.join(stateDir, ".env"),
+      ["OPENCLAW_GATEWAY_TOKEN=dotenv-token", "LLM_API_KEY=dotenv-key"].join("\n"),
+      "utf8",
+    );
+
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      assertUserSystemctlArgs(args, "status");
+      cb(null, "", "");
+    });
+
+    try {
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/tmp",
+        environment: {
+          OPENCLAW_GATEWAY_TOKEN: "dotenv-token",
+          LLM_API_KEY: "dotenv-key",
+          OPENCLAW_GATEWAY_PORT: "18789",
+        },
+      });
+
+      const [unit, envFile, envFileStat] = await Promise.all([
+        fs.readFile(unitPath, "utf8"),
+        fs.readFile(envFilePath, "utf8"),
+        fs.stat(envFilePath),
+      ]);
+
+      expect(unit).toContain(`EnvironmentFile=-${envFilePath}`);
+      expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
+      expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=dotenv-token");
+      expect(unit).not.toContain("Environment=LLM_API_KEY=dotenv-key");
+      expect(envFile).toBe("OPENCLAW_GATEWAY_TOKEN=dotenv-token\nLLM_API_KEY=dotenv-key\n");
+      expect(envFileStat.mode & 0o777).toBe(0o600);
+    } finally {
+      await fs.rm(tempHomeRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
@@ -26,6 +27,7 @@ import {
   readSystemdServiceExecStart,
   restartSystemdService,
   resolveSystemdUserUnitPath,
+  stageSystemdService,
   stopSystemdService,
 } from "./systemd.js";
 
@@ -637,6 +639,62 @@ describe("readSystemdServiceExecStart", () => {
       OPENCLAW_GATEWAY_TOKEN: "file",
       OPENCLAW_GATEWAY_PASSWORD: "file", // pragma: allowlist secret
     });
+  });
+});
+
+describe("stageSystemdService", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    execFileMock.mockReset();
+  });
+
+  it("renders state-dir dotenv values via EnvironmentFile instead of inline Environment entries", async () => {
+    const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-stage-"));
+    const home = path.join(tempHomeRoot, "home");
+    const stateDir = path.join(home, ".openclaw");
+    const env = {
+      HOME: home,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-stage-test",
+    };
+    const unitPath = resolveSystemdUserUnitPath(env);
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      path.join(stateDir, ".env"),
+      [
+        "OPENCLAW_GATEWAY_TOKEN=dotenv-token", // pragma: allowlist secret
+        "LLM_API_KEY=dotenv-key", // pragma: allowlist secret
+      ].join("\n"),
+      "utf8",
+    );
+
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      assertUserSystemctlArgs(args, "status");
+      cb(null, "", "");
+    });
+
+    try {
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/tmp",
+        environment: {
+          OPENCLAW_GATEWAY_TOKEN: "dotenv-token", // pragma: allowlist secret
+          LLM_API_KEY: "dotenv-key", // pragma: allowlist secret
+          OPENCLAW_GATEWAY_PORT: "18789",
+        },
+      });
+
+      const unit = await fs.readFile(unitPath, "utf8");
+      expect(unit).toContain(`EnvironmentFile=${path.join(stateDir, ".env")}`);
+      expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
+      expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=dotenv-token");
+      expect(unit).not.toContain("Environment=LLM_API_KEY=dotenv-key");
+    } finally {
+      await fs.rm(tempHomeRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import os from "node:os";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
@@ -27,7 +26,6 @@ import {
   readSystemdServiceExecStart,
   restartSystemdService,
   resolveSystemdUserUnitPath,
-  stageSystemdService,
   stopSystemdService,
 } from "./systemd.js";
 
@@ -639,62 +637,6 @@ describe("readSystemdServiceExecStart", () => {
       OPENCLAW_GATEWAY_TOKEN: "file",
       OPENCLAW_GATEWAY_PASSWORD: "file", // pragma: allowlist secret
     });
-  });
-});
-
-describe("stageSystemdService", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    execFileMock.mockReset();
-  });
-
-  it("renders state-dir dotenv values via EnvironmentFile instead of inline Environment entries", async () => {
-    const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-stage-"));
-    const home = path.join(tempHomeRoot, "home");
-    const stateDir = path.join(home, ".openclaw");
-    const env = {
-      HOME: home,
-      OPENCLAW_STATE_DIR: stateDir,
-      OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-stage-test",
-    };
-    const unitPath = resolveSystemdUserUnitPath(env);
-
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      path.join(stateDir, ".env"),
-      [
-        "OPENCLAW_GATEWAY_TOKEN=dotenv-token", // pragma: allowlist secret
-        "LLM_API_KEY=dotenv-key", // pragma: allowlist secret
-      ].join("\n"),
-      "utf8",
-    );
-
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      assertUserSystemctlArgs(args, "status");
-      cb(null, "", "");
-    });
-
-    try {
-      await stageSystemdService({
-        env,
-        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          OPENCLAW_GATEWAY_TOKEN: "dotenv-token", // pragma: allowlist secret
-          LLM_API_KEY: "dotenv-key", // pragma: allowlist secret
-          OPENCLAW_GATEWAY_PORT: "18789",
-        },
-      });
-
-      const unit = await fs.readFile(unitPath, "utf8");
-      expect(unit).toContain(`EnvironmentFile=${path.join(stateDir, ".env")}`);
-      expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
-      expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=dotenv-token");
-      expect(unit).not.toContain("Environment=LLM_API_KEY=dotenv-key");
-    } finally {
-      await fs.rm(tempHomeRoot, { recursive: true, force: true });
-    }
   });
 });
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { readStateDirDotEnvVars } from "../config/state-dir-dotenv.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -449,11 +451,27 @@ async function writeSystemdUnit({
   }
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
+  const stateDirDotEnvVars = readStateDirDotEnvVars(env as NodeJS.ProcessEnv);
+  const stateDirDotEnvPath = path.join(resolveStateDir(env as NodeJS.ProcessEnv), ".env");
+  const environmentFiles = Object.keys(stateDirDotEnvVars).length > 0 ? [stateDirDotEnvPath] : [];
+  const environmentSansDotEnvEntries = Object.fromEntries(
+    Object.entries(environment ?? {}).filter(([key, value]) => {
+      if (typeof value !== "string") {
+        return false;
+      }
+      const stateDirValue = stateDirDotEnvVars[key];
+      if (typeof stateDirValue !== "string") {
+        return true;
+      }
+      return value.trim() !== stateDirValue.trim();
+    }),
+  );
   const unit = buildSystemdUnit({
     description: serviceDescription,
     programArguments,
     workingDirectory,
-    environment,
+    environment: environmentSansDotEnvEntries,
+    environmentFiles,
   });
   await fs.writeFile(unitPath, unit, "utf8");
   return { unitPath, backedUp };

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
-import { readStateDirDotEnvVars } from "../config/state-dir-dotenv.js";
+import { readStateDirDotEnvVarsFromStateDir } from "../config/state-dir-dotenv.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -41,6 +41,8 @@ import {
   parseSystemdEnvAssignment,
   parseSystemdExecStart,
 } from "./systemd-unit.js";
+
+const SYSTEMD_GATEWAY_DOTENV_FILENAME = "gateway.systemd.env";
 
 function resolveSystemdUnitPathForName(env: GatewayServiceEnv, name: string): string {
   const home = toPosixPath(resolveHomeDir(env));
@@ -451,9 +453,12 @@ async function writeSystemdUnit({
   }
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
-  const stateDirDotEnvVars = readStateDirDotEnvVars(env as NodeJS.ProcessEnv);
-  const stateDirDotEnvPath = path.join(resolveStateDir(env as NodeJS.ProcessEnv), ".env");
-  const environmentFiles = Object.keys(stateDirDotEnvVars).length > 0 ? [stateDirDotEnvPath] : [];
+  const stateDir = resolveStateDir(env as NodeJS.ProcessEnv);
+  const stateDirDotEnvVars = readStateDirDotEnvVarsFromStateDir(stateDir);
+  const environmentFiles = await writeSystemdGatewayEnvironmentFile({
+    stateDir,
+    dotenvVars: stateDirDotEnvVars,
+  });
   const environmentSansDotEnvEntries = Object.fromEntries(
     Object.entries(environment ?? {}).filter(([key, value]) => {
       if (typeof value !== "string") {
@@ -475,6 +480,21 @@ async function writeSystemdUnit({
   });
   await fs.writeFile(unitPath, unit, "utf8");
   return { unitPath, backedUp };
+}
+
+async function writeSystemdGatewayEnvironmentFile(params: {
+  stateDir: string;
+  dotenvVars: Record<string, string>;
+}): Promise<string[]> {
+  const entries = Object.entries(params.dotenvVars).filter(([, value]) => !/[\r\n]/.test(value));
+  if (entries.length === 0) {
+    return [];
+  }
+  const envFilePath = path.join(params.stateDir, SYSTEMD_GATEWAY_DOTENV_FILENAME);
+  const content = entries.map(([key, value]) => `${key}=${value}`).join("\n");
+  await fs.writeFile(envFilePath, `${content}\n`, { encoding: "utf8", mode: 0o600 });
+  await fs.chmod(envFilePath, 0o600);
+  return [envFilePath];
 }
 
 export async function stageSystemdService({

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -486,9 +486,16 @@ async function writeSystemdGatewayEnvironmentFile(params: {
   stateDir: string;
   dotenvVars: Record<string, string>;
 }): Promise<string[]> {
-  const entries = Object.entries(params.dotenvVars).filter(([, value]) => !/[\r\n]/.test(value));
+  const entries = Object.entries(params.dotenvVars);
   if (entries.length === 0) {
     return [];
+  }
+  for (const [key, value] of entries) {
+    if (/[\r\n]/.test(value)) {
+      throw new Error(
+        `state-dir .env contains a multiline value for ${key}; systemd EnvironmentFile values must be single-line`,
+      );
+    }
   }
   const envFilePath = path.join(params.stateDir, SYSTEMD_GATEWAY_DOTENV_FILENAME);
   const content = entries.map(([key, value]) => `${key}=${value}`).join("\n");

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -454,7 +454,15 @@ async function writeSystemdUnit({
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
   const stateDir = resolveStateDir(env as NodeJS.ProcessEnv);
-  const stateDirDotEnvVars = readStateDirDotEnvVarsFromStateDir(stateDir);
+  const stateDirDotEnvVars = Object.fromEntries(
+    Object.entries(readStateDirDotEnvVarsFromStateDir(stateDir)).filter(([key, value]) => {
+      const inlineValue = environment?.[key];
+      if (typeof inlineValue !== "string") {
+        return true;
+      }
+      return inlineValue.trim() === value.trim();
+    }),
+  );
   const environmentFiles = await writeSystemdGatewayEnvironmentFile({
     stateDir,
     dotenvVars: stateDirDotEnvVars,


### PR DESCRIPTION
## Summary

Fixes #66219.

`openclaw doctor --repair` / gateway service rewrites could keep reintroducing inline `Environment=...` secret values (for example `OPENCLAW_GATEWAY_TOKEN`) when those values came from state-dir `.env`. This caused recurring embedded-token findings and a repair loop.

This PR changes Linux systemd unit rendering to:

- add `EnvironmentFile=<state-dir>/.env` when state-dir dotenv values exist
- remove matching dotenv-backed key/value pairs from inline `Environment=` lines
- keep non-dotenv service env (for example `OPENCLAW_GATEWAY_PORT`) inline

## Why

The service audit treats inline `OPENCLAW_GATEWAY_TOKEN` as embedded and recommends reinstall. If reinstall writes the same token inline again, the warning never clears.

Using `EnvironmentFile` for dotenv-sourced secrets keeps runtime behavior while avoiding plaintext secret embedding in the unit file.

## Changes

- `src/daemon/systemd.ts`
  - detect state-dir dotenv vars
  - pass `environmentFiles` to unit renderer
  - filter dotenv-sourced entries from inline environment map
- `src/daemon/systemd-unit.ts`
  - support rendering `EnvironmentFile=` lines
- `src/daemon/service-types.ts`
  - extend `GatewayServiceRenderArgs` with `environmentFiles?: string[]`
- tests:
  - `src/daemon/systemd.test.ts` (new regression for `stageSystemdService`)
  - `src/daemon/systemd-unit.test.ts` (new rendering coverage)

## Validation

Ran:
- `PATH=$HOME/.nvm/versions/node/v22.14.0/bin:$PATH pnpm test src/daemon/systemd-unit.test.ts src/daemon/systemd.test.ts`

Result:
- unit-fast project: pass
- daemon project: pass (`46` tests)