### PR TITLE
fix(memory): prefer --mask for qmd collection add compatibility

### DIFF
--- a/extensions/memory-core/src/memory/qmd-compat.test.ts
+++ b/extensions/memory-core/src/memory/qmd-compat.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import { resolveQmdCollectionPatternFlags } from "./qmd-compat.js";
 
 describe("resolveQmdCollectionPatternFlags", () => {
-  it("prefers modern --glob by default and falls back to legacy --mask", () => {
-    expect(resolveQmdCollectionPatternFlags(null)).toEqual(["--glob", "--mask"]);
+  it("prefers legacy --mask by default and falls back to --glob", () => {
+    expect(resolveQmdCollectionPatternFlags(null)).toEqual(["--mask", "--glob"]);
+  });
+
+  it("keeps preferring --glob after a glob-capable qmd succeeds", () => {
     expect(resolveQmdCollectionPatternFlags("--glob")).toEqual(["--glob", "--mask"]);
   });
 

--- a/extensions/memory-core/src/memory/qmd-compat.ts
+++ b/extensions/memory-core/src/memory/qmd-compat.ts
@@ -3,5 +3,8 @@ export type QmdCollectionPatternFlag = "--glob" | "--mask";
 export function resolveQmdCollectionPatternFlags(
   preferredFlag: QmdCollectionPatternFlag | null,
 ): QmdCollectionPatternFlag[] {
-  return preferredFlag === "--mask" ? ["--mask", "--glob"] : ["--glob", "--mask"];
+  // QMD 2.1.0 still parses collection-add patterns through the legacy `--mask`
+  // option. Prefer it first until we can prove a given binary actually honors
+  // `--glob` for `qmd collection add`.
+  return preferredFlag === "--glob" ? ["--glob", "--mask"] : ["--mask", "--glob"];
 }

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -954,6 +954,79 @@ describe("QmdMemoryManager", () => {
     expect(logWarnMock).not.toHaveBeenCalledWith(expect.stringContaining("rebinding"));
   });
 
+  it("prefers --mask for fresh-manager default collection adds", async () => {
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# canonical root");
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [],
+        },
+      },
+    } as OpenClawConfig;
+
+    const listedCollections = new Map<
+      string,
+      {
+        path: string;
+        pattern: string;
+      }
+    >();
+    const addFlagCalls: string[] = [];
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify(
+            [...listedCollections.entries()].map(([name, info]) => ({
+              name,
+              path: info.path,
+              mask: info.pattern,
+            })),
+          ),
+        );
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "add") {
+        const child = createMockChild({ autoClose: false });
+        const pathArg = args[2] ?? "";
+        const name = args[args.indexOf("--name") + 1] ?? "";
+        const flag = args.includes("--glob") ? "--glob" : args.includes("--mask") ? "--mask" : "";
+        addFlagCalls.push(flag);
+        const globIdx = args.indexOf("--glob");
+        const maskIdx = args.indexOf("--mask");
+        const pattern =
+          (globIdx !== -1 ? args[globIdx + 1] : maskIdx !== -1 ? args[maskIdx + 1] : "") ?? "";
+        listedCollections.set(name, { path: pathArg, pattern });
+        queueMicrotask(() => child.closeWith(0));
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    await manager.close();
+
+    expect(addFlagCalls).toEqual(["--mask", "--mask"]);
+    expect(listedCollections.get("memory-root-main")).toEqual({
+      path: workspaceDir,
+      pattern: "MEMORY.md",
+    });
+    expect(listedCollections.get("memory-dir-main")).toEqual({
+      path: path.join(workspaceDir, "memory"),
+      pattern: "**/*.md",
+    });
+    expect(logWarnMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("retrying with legacy compatibility flag"),
+    );
+  });
+
   it("warns instead of silently succeeding when add conflict metadata is unavailable", async () => {
     cfg = {
       ...cfg,
@@ -1147,7 +1220,11 @@ describe("QmdMemoryManager", () => {
       return createMockChild();
     });
 
-    const { manager } = await createManager({ mode: "full" });
+    const { manager } = await createManager({ mode: "status" });
+    (
+      manager as unknown as { collectionPatternFlag: "--glob" | "--mask" | null }
+    ).collectionPatternFlag = "--glob";
+    await (manager as unknown as { ensureCollections: () => Promise<void> }).ensureCollections();
     await manager.close();
 
     expect(addFlagCalls).toEqual(["--glob", "--mask", "--mask"]);

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -333,7 +333,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private attemptedNullByteCollectionRepair = false;
   private attemptedDuplicateDocumentRepair = false;
   private readonly sessionWarm = new Set<string>();
-  private collectionPatternFlag: QmdCollectionPatternFlag | null = "--glob";
+  private collectionPatternFlag: QmdCollectionPatternFlag | null = null;
 
   private constructor(params: {
     agentId: string;


### PR DESCRIPTION
# fix(memory): prefer --mask for qmd collection add compatibility (AI assisted)

Codex (on my Mac mini) helped rundown the root cause of this issue, proposed the fix. I verified the fix in OpenClaw and asked Codex to update unittests and provide a PR description. I moved patch over to my dev machine (Windows) where I had the fork of the openclaw repo and created the PR and asked GitHub Copilot (don't remember which model) to take the PR description written by Codex and use it to fill out your PR template.

## Summary

- Problem: QMD-backed memory collection initialization failed on OpenClaw `2026.4.11` with QMD `2.1.0` due to a CLI compatibility mismatch.
- Why it matters: This issue broke semantic memory search functionality on fresh deployments.
- What changed: Updated QMD collection-pattern compatibility ordering to prefer `--mask` over `--glob` and initialized `collectionPatternFlag` to `null`.
- What did NOT change (scope boundary): No changes to auto-creation of `MEMORY.md` or unrelated CLI agent-alias issues.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: QMD CLI `collection add` still honored `--mask` instead of `--glob`, causing incorrect pattern registration.
- Missing detection / guardrail: No prior compatibility check for QMD CLI version.
- Contributing context (if known): OpenClaw initialized `collectionPatternFlag` to `"--glob"` by default.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/memory/qmd-compat.test.ts`
- Scenario the test should lock in: Correct pattern registration for QMD collections.
- Why this is the smallest reliable guardrail: Ensures compatibility with QMD CLI versions.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Correct pattern registration for QMD collections.
- Semantic memory search functionality restored on fresh deployments.

## Diagram (if applicable)

```text
Before:
[user action] -> [QMD collection registration failed] -> [semantic memory search broken]

After:
[user action] -> [QMD collection registration succeeded] -> [semantic memory search functional]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS/Linux
- clawd is a non-admin user running nvm
- Runtime/container: Node.js
- Model/provider: QMD `2.1.0`
- Integration/channel (if any): N/A
- Relevant config (redacted):
  ```bash
  openclaw config set agents.defaults.sandbox.mode off
  openclaw config set agents.defaults.workspace /Users/clawd/workspace
  openclaw config set memory.qmd.command /Users/clawd/.nvm/versions/node/v24.14.1/bin/qmd
  openclaw config set memory.backend qmd
  ```

### Steps

1. Remove existing OpenClaw state.
2. Re-onboard.
3. Configure as shown above.
4. Restart the gateway.
5. Inspect the agent-managed QMD store:
   ```bash
   XDG_CONFIG_HOME=/Users/clawd/.openclaw/agents/main/qmd/xdg-config \
   XDG_CACHE_HOME=/Users/clawd/.openclaw/agents/main/qmd/xdg-cache \
   QMD_CONFIG_DIR=/Users/clawd/.openclaw/agents/main/qmd/xdg-config/qmd \
   /Users/clawd/.nvm/versions/node/v24.14.1/bin/qmd collection list --json
   ```

### Expected

- `memory-root-main` pattern `MEMORY.md`
- `memory-alt-main` pattern `memory.md`
- `memory-dir-main` pattern `**/*.md`

### Actual

- `memory-root-main` pattern `**/*.md`
- `memory-dir-main` pattern `**/*.md`
- `memory-alt-main` missing

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Correct QMD collection registration and semantic memory search functionality.
- Edge cases checked: Compatibility with QMD `2.1.0`.
- What you did **not** verify: N/A

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: N/A
