### PR TITLE
Control UI: avoid chat flicker on session reload

### DIFF
--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -147,18 +147,60 @@ describe("handleGatewayEvent session.message", () => {
     const host = createHost();
     host.sessionKey = "agent:qa:main";
     host.chatRunId = "run-1";
+    host.chatMessages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 123,
+      },
+    ];
 
     handleGatewayEvent(host, {
       type: "event",
       event: "session.message",
       payload: {
         sessionKey: "agent:qa:main",
-        message: { role: "user", id: "msg-user-1" },
+        message: {
+          role: "user",
+          id: "msg-user-1",
+          content: [{ type: "text", text: "hello" }],
+        },
       },
       seq: 1,
     });
 
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("still reloads history for a different user message during an active run", () => {
+    loadChatHistoryMock.mockReset();
+    const host = createHost();
+    host.sessionKey = "agent:qa:main";
+    host.chatRunId = "run-1";
+    host.chatMessages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 123,
+      },
+    ];
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: "agent:qa:main",
+        message: {
+          role: "user",
+          id: "msg-user-2",
+          content: [{ type: "text", text: "from another client" }],
+        },
+      },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
   });
 
   it("ignores transcript updates for other sessions", () => {

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -160,9 +160,9 @@ describe("handleGatewayEvent session.message", () => {
       event: "session.message",
       payload: {
         sessionKey: "agent:qa:main",
+        messageId: "msg-user-1",
         message: {
           role: "user",
-          id: "msg-user-1",
           content: [{ type: "text", text: "hello" }],
         },
       },
@@ -190,9 +190,9 @@ describe("handleGatewayEvent session.message", () => {
       event: "session.message",
       payload: {
         sessionKey: "agent:qa:main",
+        messageId: "msg-user-2",
         message: {
           role: "user",
-          id: "msg-user-2",
           content: [{ type: "text", text: "from another client" }],
         },
       },

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -142,6 +142,25 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
   });
 
+  it("keeps the optimistic local user message visible while a run is active", () => {
+    loadChatHistoryMock.mockReset();
+    const host = createHost();
+    host.sessionKey = "agent:qa:main";
+    host.chatRunId = "run-1";
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: "agent:qa:main",
+        message: { role: "user", id: "msg-user-1" },
+      },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
   it("ignores transcript updates for other sessions", () => {
     loadChatHistoryMock.mockReset();
     const host = createHost();

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -421,7 +421,7 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
 
 function handleSessionMessageGatewayEvent(
   host: GatewayHost,
-  payload: { sessionKey?: string; message?: unknown } | undefined,
+  payload: { sessionKey?: string; message?: unknown; messageId?: unknown } | undefined,
 ) {
   const sessionKey = payload?.sessionKey?.trim();
   if (!sessionKey || sessionKey !== host.sessionKey) {
@@ -432,11 +432,20 @@ function handleSessionMessageGatewayEvent(
     message && typeof message === "object" && typeof (message as { role?: unknown }).role === "string"
       ? (message as { role: string }).role.trim().toLowerCase()
       : "";
-  const hasStableMessageId =
+  const metaId =
     message &&
     typeof message === "object" &&
-    (typeof (message as { id?: unknown }).id === "string" ||
-      typeof (message as { messageId?: unknown }).messageId === "string");
+    (message as { __openclaw?: { id?: unknown } }).__openclaw &&
+    typeof (message as { __openclaw?: { id?: unknown } }).__openclaw?.id === "string"
+      ? (message as { __openclaw: { id: string } }).__openclaw.id
+      : "";
+  const hasStableMessageId =
+    typeof payload?.messageId === "string" ||
+    Boolean(metaId) ||
+    (message &&
+      typeof message === "object" &&
+      (typeof (message as { id?: unknown }).id === "string" ||
+        typeof (message as { messageId?: unknown }).messageId === "string"));
   const chatMessages = (host as GatewayHostWithChatMessages).chatMessages;
   const lastMessage = Array.isArray(chatMessages) ? chatMessages.at(-1) : undefined;
   const lastRole =
@@ -505,7 +514,7 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
   if (evt.event === "session.message") {
     handleSessionMessageGatewayEvent(
       host,
-      evt.payload as { sessionKey?: string; message?: unknown } | undefined,
+      evt.payload as { sessionKey?: string; message?: unknown; messageId?: unknown } | undefined,
     );
     return;
   }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -416,10 +416,21 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
 
 function handleSessionMessageGatewayEvent(
   host: GatewayHost,
-  payload: { sessionKey?: string } | undefined,
+  payload: { sessionKey?: string; message?: unknown } | undefined,
 ) {
   const sessionKey = payload?.sessionKey?.trim();
   if (!sessionKey || sessionKey !== host.sessionKey) {
+    return;
+  }
+  const message = payload.message;
+  const role =
+    message && typeof message === "object" && typeof (message as { role?: unknown }).role === "string"
+      ? (message as { role: string }).role.trim().toLowerCase()
+      : "";
+  // The active run already rendered this user message optimistically. Reloading
+  // history here can briefly replace it with a stale snapshot before the
+  // persisted transcript catches up, which causes the visible flicker.
+  if (host.chatRunId && role === "user") {
     return;
   }
   void loadChatHistory(host as unknown as ChatState);
@@ -462,7 +473,10 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
   }
 
   if (evt.event === "session.message") {
-    handleSessionMessageGatewayEvent(host, evt.payload as { sessionKey?: string } | undefined);
+    handleSessionMessageGatewayEvent(
+      host,
+      evt.payload as { sessionKey?: string; message?: unknown } | undefined,
+    );
     return;
   }
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -16,6 +16,7 @@ import {
 } from "./app-settings.ts";
 import { handleAgentEvent, resetToolStream, type AgentEventPayload } from "./app-tool-stream.ts";
 import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
+import { extractText } from "./chat/message-extract.ts";
 import { parseChatSideResult, type ChatSideResult } from "./chat/side-result.ts";
 import { formatConnectError } from "./connect-error.ts";
 import { loadAgents, type AgentsState } from "./controllers/agents.ts";
@@ -112,6 +113,10 @@ type GatewayHostWithShutdownMessage = GatewayHost & {
 type GatewayHostWithSideResults = GatewayHost & {
   chatSideResult?: ChatSideResult | null;
   chatSideResultTerminalRuns?: Set<string>;
+};
+
+type GatewayHostWithChatMessages = GatewayHost & {
+  chatMessages?: unknown[];
 };
 
 function isTerminalChatState(
@@ -422,15 +427,40 @@ function handleSessionMessageGatewayEvent(
   if (!sessionKey || sessionKey !== host.sessionKey) {
     return;
   }
-  const message = payload.message;
+  const message = payload?.message;
   const role =
     message && typeof message === "object" && typeof (message as { role?: unknown }).role === "string"
       ? (message as { role: string }).role.trim().toLowerCase()
       : "";
+  const hasStableMessageId =
+    message &&
+    typeof message === "object" &&
+    (typeof (message as { id?: unknown }).id === "string" ||
+      typeof (message as { messageId?: unknown }).messageId === "string");
+  const chatMessages = (host as GatewayHostWithChatMessages).chatMessages;
+  const lastMessage = Array.isArray(chatMessages) ? chatMessages.at(-1) : undefined;
+  const lastRole =
+    lastMessage &&
+    typeof lastMessage === "object" &&
+    typeof (lastMessage as { role?: unknown }).role === "string"
+      ? (lastMessage as { role: string }).role.trim().toLowerCase()
+      : "";
+  const lastHasStableMessageId =
+    lastMessage &&
+    typeof lastMessage === "object" &&
+    (typeof (lastMessage as { id?: unknown }).id === "string" ||
+      typeof (lastMessage as { messageId?: unknown }).messageId === "string");
+  const matchesOptimisticUserEcho =
+    host.chatRunId &&
+    role === "user" &&
+    hasStableMessageId &&
+    lastRole === "user" &&
+    !lastHasStableMessageId &&
+    extractText(lastMessage) === extractText(message);
   // The active run already rendered this user message optimistically. Reloading
   // history here can briefly replace it with a stale snapshot before the
   // persisted transcript catches up, which causes the visible flicker.
-  if (host.chatRunId && role === "user") {
+  if (matchesOptimisticUserEcho) {
     return;
   }
   void loadChatHistory(host as unknown as ChatState);


### PR DESCRIPTION
## Summary

- Problem: Control UI user messages can disappear briefly after send in 2026.4.12.
- Why it matters: the chat transcript visibly flickers on every send, which makes the UI feel unreliable.
- What changed: skip the `session.message`-triggered history reload when it is only echoing the active run's own optimistic user message, and add a regression test.
- What did NOT change (scope boundary): no broader optimistic-message reconciliation or transcript merge behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66207
- Related #66207
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: 2026.4.12 added a Control UI `session.message` handler that unconditionally reloaded `chat.history` for the active session. The chat UI already renders the user's message optimistically, and `loadChatHistory` replaces `chatMessages` wholesale, so an early reload can briefly swap in a stale transcript snapshot before persistence catches up.
- Missing detection / guardrail: there was no regression test covering an active optimistic user message during a `session.message` echo.
- Contributing context (if known): 4.11 did not have this `session.message` reload path in Control UI.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/app-gateway.sessions.node.test.ts`
- Scenario the test should lock in: while `chatRunId` is active, a same-session `session.message` event carrying a user message should not trigger `loadChatHistory`.
- Why this is the smallest reliable guardrail: the regression was introduced in the Control UI gateway event handler, so that seam isolates the behavior directly.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Just-sent user messages remain visible continuously instead of disappearing briefly before transcript persistence catches up.

## Diagram (if applicable)

```text
Before:
[user send] -> [optimistic user message visible] -> [session.message reloads history] -> [stale history replaces optimistic row] -> [later history reload restores message]

After:
[user send] -> [optimistic user message visible] -> [session.message user echo is ignored during active run] -> [message stays visible]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local UI test runner
- Model/provider: N/A
- Integration/channel (if any): Control UI webchat
- Relevant config (redacted): default local dev config

### Steps

1. Start from the Control UI chat send flow with an active `chatRunId`.
2. Receive a `session.message` event for the same session containing a user message echo.
3. Observe whether the handler reloads `chat.history`.

### Expected

- The optimistic local user message remains visible and the handler skips the redundant reload.

### Actual

- The focused regression test now passes and confirms the reload is skipped in that case.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test ui/src/ui/app-gateway.sessions.node.test.ts` and confirmed the new regression test plus existing session-message coverage pass.
- Edge cases checked: same-session events still reload when no active run is present; other-session events remain ignored.
- What you did **not** verify: manual browser reproduction in a running Control UI instance.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a non-local user `session.message` event could be delayed if it arrives while `chatRunId` is active and only exposes `role: user`.
  - Mitigation: the guard is narrowly limited to the active run window and only the user-echo case that is already rendered optimistically; final assistant events and other transcript reload paths still run.
