### PR TITLE
fix(gateway): include configured custom provider models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI: recover embedded GPT-style runs when reasoning-only or empty turns need bounded continuation, with replay-safe retry gating and incomplete-turn fallback when no visible answer arrives. (#66167) thanks @jalehman
 - Outbound/relay-status: suppress internal relay-status placeholder payloads (`No channel reply.`, `Replied in-thread.`, `Replied in #...`, wiki-update status variants ending in `No channel reply.`) before channel delivery so internal housekeeping text does not leak to users.
 - Slack/doctor: add a dedicated doctor-contract sidecar so config warmup paths such as `openclaw cron` no longer fall back to Slack's broader contract surface, which could trigger Slack-related config-read crashes on affected setups. (#63192) Thanks @shhtheonlyperson.
+- Gateway/models: include configured custom-provider models in the runtime catalog so multimodal OpenAI-compatible custom models no longer drop image attachments during gateway capability checks. (#66253)
 
 ## 2026.4.12
 

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -311,6 +311,44 @@ describe("loadModelCatalog", () => {
     );
   });
 
+  it("includes configured custom provider models even when Pi discovery omits them", async () => {
+    mockSingleOpenAiCatalogModel();
+
+    const result = await loadModelCatalog({
+      config: {
+        models: {
+          providers: {
+            bigmodel: {
+              api: "openai-completions",
+              baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+              models: [
+                {
+                  id: "glm-5v-turbo",
+                  name: "GLM-5V Turbo",
+                  api: "openai-completions",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 202752,
+                  maxTokens: 131072,
+                },
+              ],
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "bigmodel",
+        id: "glm-5v-turbo",
+        name: "GLM-5V Turbo",
+        input: ["text", "image"],
+      }),
+    );
+  });
+
   it("dedupes supplemental models against registry entries", async () => {
     mockSingleOpenAiCatalogModel();
     augmentCatalogMock.mockResolvedValueOnce([

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -349,6 +349,52 @@ describe("loadModelCatalog", () => {
     );
   });
 
+  it("dedupes configured models against discovered provider aliases", async () => {
+    mockPiDiscoveryModels([
+      {
+        id: "glm-5v-turbo",
+        provider: "z.ai",
+        name: "GLM-5V Turbo",
+        input: ["text", "image"],
+      },
+    ]);
+
+    const result = await loadModelCatalog({
+      config: {
+        models: {
+          providers: {
+            "z-ai": {
+              api: "openai-completions",
+              baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+              models: [
+                {
+                  id: "glm-5v-turbo",
+                  name: "Configured GLM-5V Turbo",
+                  api: "openai-completions",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 202752,
+                  maxTokens: 131072,
+                },
+              ],
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const matches = result.filter(
+      (entry) => findModelInCatalog([entry], "z-ai", "glm-5v-turbo") !== undefined,
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      provider: "z.ai",
+      id: "glm-5v-turbo",
+      name: "GLM-5V Turbo",
+    });
+  });
+
   it("dedupes supplemental models against registry entries", async () => {
     mockSingleOpenAiCatalogModel();
     augmentCatalogMock.mockResolvedValueOnce([

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -74,7 +74,7 @@ function instantiatePiModelRegistry(
 }
 
 function getCatalogEntryKey(provider: string, id: string): string {
-  return `${normalizeLowercaseStringOrEmpty(provider)}::${normalizeLowercaseStringOrEmpty(id)}`;
+  return `${normalizeProviderId(provider)}::${normalizeLowercaseStringOrEmpty(id)}`;
 }
 
 function appendCatalogEntryIfAbsent(

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -73,6 +73,53 @@ function instantiatePiModelRegistry(
   return new Registry(authStorage, modelsFile);
 }
 
+function getCatalogEntryKey(provider: string, id: string): string {
+  return `${normalizeLowercaseStringOrEmpty(provider)}::${normalizeLowercaseStringOrEmpty(id)}`;
+}
+
+function appendCatalogEntryIfAbsent(
+  entries: ModelCatalogEntry[],
+  seen: Set<string>,
+  entry: ModelCatalogEntry,
+): void {
+  const key = getCatalogEntryKey(entry.provider, entry.id);
+  if (seen.has(key)) {
+    return;
+  }
+  entries.push(entry);
+  seen.add(key);
+}
+
+function resolveConfiguredCatalogEntries(config?: OpenClawConfig): ModelCatalogEntry[] {
+  const entries: ModelCatalogEntry[] = [];
+  for (const [providerKey, provider] of Object.entries(config?.models?.providers ?? {})) {
+    const normalizedProvider = normalizeProviderId(providerKey);
+    if (!normalizedProvider) {
+      continue;
+    }
+    for (const model of provider?.models ?? []) {
+      const id = normalizeOptionalString(model?.id) ?? "";
+      if (!id) {
+        continue;
+      }
+      const name = normalizeOptionalString(model?.name ?? id) || id;
+      const contextWindow =
+        typeof model?.contextWindow === "number" && model.contextWindow > 0
+          ? model.contextWindow
+          : undefined;
+      entries.push({
+        id,
+        name,
+        provider: normalizedProvider,
+        contextWindow,
+        reasoning: typeof model?.reasoning === "boolean" ? model.reasoning : undefined,
+        input: Array.isArray(model?.input) ? (model.input as ModelInputType[]) : undefined,
+      });
+    }
+  }
+  return entries;
+}
+
 export async function loadModelCatalog(params?: {
   config?: OpenClawConfig;
   useCache?: boolean;
@@ -86,6 +133,7 @@ export async function loadModelCatalog(params?: {
 
   modelCatalogPromise = (async () => {
     const models: ModelCatalogEntry[] = [];
+    const seenModelKeys = new Set<string>();
     const timingEnabled = shouldLogModelCatalogTiming();
     const startMs = timingEnabled ? Date.now() : 0;
     const logStage = (stage: string, extra?: string) => {
@@ -146,7 +194,19 @@ export async function loadModelCatalog(params?: {
             : undefined;
         const reasoning = typeof entry?.reasoning === "boolean" ? entry.reasoning : undefined;
         const input = Array.isArray(entry?.input) ? entry.input : undefined;
-        models.push({ id, name, provider, contextWindow, reasoning, input });
+        appendCatalogEntryIfAbsent(models, seenModelKeys, {
+          id,
+          name,
+          provider,
+          contextWindow,
+          reasoning,
+          input,
+        });
+      }
+      for (const entry of resolveConfiguredCatalogEntries(cfg)) {
+        // Gateway capability checks must see explicitly configured provider models
+        // even when Pi discovery omits them from the runtime registry.
+        appendCatalogEntryIfAbsent(models, seenModelKeys, entry);
       }
       const supplemental = await augmentModelCatalogWithProviderPlugins({
         config: cfg,
@@ -159,19 +219,8 @@ export async function loadModelCatalog(params?: {
         },
       });
       if (supplemental.length > 0) {
-        const seen = new Set(
-          models.map(
-            (entry) =>
-              `${normalizeLowercaseStringOrEmpty(entry.provider)}::${normalizeLowercaseStringOrEmpty(entry.id)}`,
-          ),
-        );
         for (const entry of supplemental) {
-          const key = `${normalizeLowercaseStringOrEmpty(entry.provider)}::${normalizeLowercaseStringOrEmpty(entry.id)}`;
-          if (seen.has(key)) {
-            continue;
-          }
-          models.push(entry);
-          seen.add(key);
+          appendCatalogEntryIfAbsent(models, seenModelKeys, entry);
         }
       }
       logStage("plugin-models-merged", `entries=${models.length}`);


### PR DESCRIPTION
## Summary

- Problem: gateway attachment capability checks only consulted the runtime model catalog, and that catalog could omit config-defined custom provider models even when `models.json` preserved them.
- Why it matters: multimodal OpenAI-compatible custom models like `bigmodel/glm-5v-turbo` were treated as text-only, so image attachments were dropped before the model ever saw them.
- What changed: `loadModelCatalog()` now merges configured provider models into the runtime catalog before gateway capability checks consume it, and a regression test locks in the custom-provider omission case.
- What did NOT change (scope boundary): this does not change attachment parsing semantics, provider auth flows, or Pi discovery behavior outside catalog assembly.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66253
- Related #65211
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveGatewayModelSupportsImages()` fails closed when the selected provider/model pair is missing from `loadGatewayModelCatalog()`, and config-defined custom provider models were not being merged into that catalog.
- Missing detection / guardrail: there was no catalog-level regression test covering a custom provider model that exists in config but is omitted by Pi discovery.
- Contributing context (if known): Pi discovery can omit custom provider models, while `ensureOpenClawModelsJson()` still writes them into `models.json`, so the gateway catalog and the actual configured runtime diverged.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/model-catalog.test.ts`
- Scenario the test should lock in: a configured custom provider model with `input: ["text", "image"]` is present in the runtime catalog even when Pi discovery omits it.
- Why this is the smallest reliable guardrail: the regression happens at catalog assembly time, before attachment parsing or gateway RPC handling.
- Existing test that already covers this (if any): `src/gateway/session-utils.test.ts` already covers the image-capability helper once a matching catalog row exists.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Custom OpenAI-compatible provider models configured with image input now stay image-capable during gateway attachment checks, so image attachments are no longer dropped just because the runtime catalog omitted that provider/model row.

## Diagram (if applicable)

```text
Before:
[configured custom vision model] -> [missing from runtime catalog] -> [supportsImages=false] -> [gateway drops image attachments]

After:
[configured custom vision model] -> [merged into runtime catalog] -> [supportsImages=true] -> [gateway keeps image attachments]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 25.3.0 (arm64)
- Runtime/container: local dev checkout
- Model/provider: `bigmodel/glm-5v-turbo`
- Integration/channel (if any): gateway / Control UI-style attachment path
- Relevant config (redacted): custom `models.providers.bigmodel` with `api: "openai-completions"`, `baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4"`, and model `input: ["text", "image"]`

### Steps

1. Configure a custom provider model such as `bigmodel/glm-5v-turbo` with `input: ["text", "image"]`.
2. Send an image through a gateway path that calls `resolveGatewayModelSupportsImages()` before `parseMessageWithAttachments()`.
3. Observe whether the selected model exists in the gateway runtime catalog.

### Expected

- The configured model appears in the runtime catalog.
- `supportsImages` resolves to `true`.
- The gateway keeps the image attachment.

### Actual

- Before this change, the configured model could be absent from the runtime catalog even though `models.json` contained it.
- The gateway then resolved `supportsImages` to `false` and dropped the image attachment.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Ran `pnpm test src/agents/model-catalog.test.ts -t "includes configured custom provider models even when Pi discovery omits them"`.
  - Ran `pnpm test src/gateway/session-utils.test.ts -t "resolveGatewayModelSupportsImages"`.
  - Ran `pnpm check`.
  - Reproduced the exact catalog lookup path locally with a temporary `bigmodel/glm-5v-turbo` config and auth profile; before the fix the catalog probe returned `found: false`, and after the fix it returned `found: true` with `supportsImages: true`.
- Edge cases checked:
  - Existing registry and provider-plugin dedupe still go through the same normalized provider/id key path.
- What you did **not** verify:
  - I did not run a full end-to-end webchat/manual UI attachment flow in this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a config-defined provider model could collide with an already discovered provider/id pair.
  - Mitigation: catalog assembly now uses the same normalized provider/id dedupe key across discovered, configured, and supplemental entries, preserving existing discovered rows as authoritative when they already exist.

AI assistance: used for implementation and drafting, with local verification by targeted tests plus a direct runtime repro.

Made with [Cursor](https://cursor.com)