### PR TITLE
fix: support explicit active-memory chat types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.
 - fix(device-pairing): validate callerScopes against resolved token scopes on repair [AI]. (#72925) Thanks @pgondhi987.
 - fix(agents): canonicalize provider aliases in byProvider tool policy lookup [AI]. (#72917) Thanks @pgondhi987.
 - fix(security): block npm_execpath injection from workspace .env [AI-assisted]. (#73262) Thanks @pgondhi987.

--- a/extensions/active-memory/config.test.ts
+++ b/extensions/active-memory/config.test.ts
@@ -36,6 +36,20 @@ describe("active-memory manifest config schema", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts explicit in allowedChatTypes", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "active-memory.manifest.allowed-chat-types.explicit",
+      value: {
+        enabled: true,
+        agents: ["main"],
+        allowedChatTypes: ["direct", "explicit"],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it("rejects timeoutMs values above the runtime ceiling", () => {
     const result = validateJsonSchemaValue({
       schema: manifest.configSchema,
@@ -44,6 +58,20 @@ describe("active-memory manifest config schema", () => {
         enabled: true,
         agents: ["main"],
         timeoutMs: 120_001,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects unknown allowedChatTypes values", () => {
+    const result = validateJsonSchemaValue({
+      schema: manifest.configSchema,
+      cacheKey: "active-memory.manifest.allowed-chat-types.invalid",
+      value: {
+        enabled: true,
+        agents: ["main"],
+        allowedChatTypes: ["direct", "portal"],
       },
     });
 

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -548,6 +548,54 @@ describe("active-memory plugin", () => {
     });
   });
 
+  it("runs for explicit sessions when explicit chat types are explicitly allowed", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      allowedChatTypes: ["explicit"],
+    };
+    await plugin.register(api as unknown as OpenClawPluginApi);
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what should i work on next?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:explicit:portal-123",
+        messageProvider: "webchat",
+        channelId: "webchat",
+      },
+    );
+
+    expect(runEmbeddedPiAgent).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      prependContext: expect.stringContaining("<active_memory_plugin>"),
+    });
+  });
+
+  it("keeps explicit session classification when the opaque session id contains chat-type tokens", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      allowedChatTypes: ["explicit"],
+    };
+    await plugin.register(api as unknown as OpenClawPluginApi);
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what should i work on next?", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:explicit:portal-123:group:shadow",
+        messageProvider: "webchat",
+        channelId: "webchat",
+      },
+    );
+
+    expect(runEmbeddedPiAgent).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      prependContext: expect.stringContaining("<active_memory_plugin>"),
+    });
+  });
+
   it("skips group sessions whose conversation id is not in allowedChatIds", async () => {
     api.pluginConfig = {
       agents: ["main"],

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -643,10 +643,7 @@ function normalizePluginConfig(pluginConfig: unknown): ResolvedActiveRecallPlugi
   const allowedChatTypes = Array.isArray(raw.allowedChatTypes)
     ? raw.allowedChatTypes.filter(
         (value): value is ActiveMemoryChatType =>
-          value === "direct" ||
-          value === "group" ||
-          value === "channel" ||
-          value === "explicit",
+          value === "direct" || value === "group" || value === "channel" || value === "explicit",
       )
     : [];
   return {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -68,7 +68,7 @@ type ActiveRecallPluginConfig = {
   model?: string;
   modelFallback?: string;
   modelFallbackPolicy?: "default-remote" | "resolved-only";
-  allowedChatTypes?: Array<"direct" | "group" | "channel">;
+  allowedChatTypes?: Array<"direct" | "group" | "channel" | "explicit">;
   allowedChatIds?: string[];
   deniedChatIds?: string[];
   thinking?: ActiveMemoryThinkingLevel;
@@ -105,7 +105,7 @@ type ResolvedActiveRecallPluginConfig = {
   model?: string;
   modelFallback?: string;
   modelFallbackPolicy: "default-remote" | "resolved-only";
-  allowedChatTypes: Array<"direct" | "group" | "channel">;
+  allowedChatTypes: Array<"direct" | "group" | "channel" | "explicit">;
   allowedChatIds: string[];
   deniedChatIds: string[];
   thinking: ActiveMemoryThinkingLevel;
@@ -176,7 +176,7 @@ type CachedActiveRecallResult = {
   result: ActiveRecallResult;
 };
 
-type ActiveMemoryChatType = "direct" | "group" | "channel";
+type ActiveMemoryChatType = "direct" | "group" | "channel" | "explicit";
 
 type ActiveMemoryToggleStore = {
   sessions?: Record<string, { disabled?: boolean; updatedAt?: number }>;
@@ -643,7 +643,10 @@ function normalizePluginConfig(pluginConfig: unknown): ResolvedActiveRecallPlugi
   const allowedChatTypes = Array.isArray(raw.allowedChatTypes)
     ? raw.allowedChatTypes.filter(
         (value): value is ActiveMemoryChatType =>
-          value === "direct" || value === "group" || value === "channel",
+          value === "direct" ||
+          value === "group" ||
+          value === "channel" ||
+          value === "explicit",
       )
     : [];
   return {
@@ -913,6 +916,9 @@ function resolveChatType(ctx: {
 }): ActiveMemoryChatType | undefined {
   const sessionKey = ctx.sessionKey?.trim().toLowerCase();
   if (sessionKey) {
+    if (sessionKey.startsWith("agent:") && sessionKey.split(":")[2] === "explicit") {
+      return "explicit";
+    }
     if (sessionKey.includes(":group:")) {
       return "group";
     }

--- a/extensions/active-memory/openclaw.plugin.json
+++ b/extensions/active-memory/openclaw.plugin.json
@@ -24,7 +24,7 @@
         "type": "array",
         "items": {
           "type": "string",
-          "enum": ["direct", "group", "channel"]
+          "enum": ["direct", "group", "channel", "explicit"]
         }
       },
       "allowedChatIds": {
@@ -101,7 +101,7 @@
     },
     "allowedChatTypes": {
       "label": "Allowed Chat Types",
-      "help": "Choose which session types may run Active Memory. Defaults to direct-message style sessions only."
+      "help": "Choose which session types may run Active Memory. Defaults to direct-message style sessions only, but explicit portal/webchat sessions can also be enabled."
     },
     "allowedChatIds": {
       "label": "Allowed Chat IDs",


### PR DESCRIPTION
## Summary
- allow `allowedChatTypes` to accept `"explicit"` in the active-memory plugin schema and runtime config normalization
- treat `agent:...:explicit:...` sessions as an explicit chat type during gating
- add regression coverage for schema validation and explicit-session execution

Closes #65775.

## AI Assistance
- AI-assisted: Codex
- Testing: fully tested locally on targeted lanes

<details>
<summary>Before</summary>

```text
$ node --import tsx -e "import fs from 'node:fs'; import { validateJsonSchemaValue } from './src/plugins/schema-validator.js'; const manifest=JSON.parse(fs.readFileSync('./extensions/active-memory/openclaw.plugin.json','utf-8')); const result=validateJsonSchemaValue({schema:manifest.configSchema,cacheKey:'active-memory-before',value:{enabled:true,agents:['main'],allowedChatTypes:['direct','explicit']}}); console.log(JSON.stringify({ok:result.ok, errors:result.errors?.map((e)=>e.message)}, null, 2));"
{
  "ok": false,
  "errors": [
    "must be equal to one of the allowed values (allowed: \"direct\", \"group\", \"channel\")"
  ]
}
```

</details>

<details>
<summary>After</summary>

```text
$ node --import tsx -e "import fs from 'node:fs'; import { validateJsonSchemaValue } from './src/plugins/schema-validator.js'; const manifest=JSON.parse(fs.readFileSync('./extensions/active-memory/openclaw.plugin.json','utf-8')); const result=validateJsonSchemaValue({schema:manifest.configSchema,cacheKey:'active-memory-after',value:{enabled:true,agents:['main'],allowedChatTypes:['direct','explicit']}}); console.log(JSON.stringify({ok:result.ok, errors:result.errors?.map((e)=>e.message)}, null, 2));"
{
  "ok": true
}

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/active-memory/index.test.ts extensions/active-memory/config.test.ts
EXIT:0
```

</details>

## Test plan
- [x] targeted schema validation for `allowedChatTypes: ["direct", "explicit"]`
- [x] targeted active-memory extension tests
