### PR TITLE
feat: surface upstream request ids in diagnostics

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -271,6 +271,35 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("attaches upstream request id to model usage spans", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "model.usage",
+      sessionKey: "agent:main:test:dm:peer",
+      sessionId: "sess-1",
+      channel: "telegram",
+      provider: "openai",
+      model: "gpt-5.4",
+      upstreamRequestId: "req_otel_span_123",
+      usage: {
+        input: 10,
+        output: 5,
+        total: 15,
+      },
+    });
+
+    const call = telemetryState.tracer.startSpan.mock.calls.find(
+      (args) => args[0] === "openclaw.model.usage",
+    );
+    const attrs = (call?.[1] as { attributes?: Record<string, unknown> } | undefined)?.attributes;
+    expect(attrs?.["openclaw.upstream_request_id"]).toBe("req_otel_span_123");
+
+    await service.stop?.(ctx);
+  });
+
   test("appends signal path when endpoint contains non-signal /v1 segment", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createTraceOnlyContext("https://www.comet.com/opik/api/v1/private/otel");

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -431,6 +431,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           "openclaw.tokens.cache_write": usage.cacheWrite ?? 0,
           "openclaw.tokens.total": usage.total ?? 0,
         };
+        if (evt.upstreamRequestId) {
+          spanAttrs["openclaw.upstream_request_id"] = evt.upstreamRequestId;
+        }
 
         const span = spanWithDuration("openclaw.model.usage", spanAttrs, evt.durationMs);
         span.end();

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -336,4 +336,58 @@ describe("anthropic transport stream", () => {
       undefined,
     );
   });
+
+  it("propagates upstream request id from stream response headers", async () => {
+    const streamedEvents = (async function* () {
+      yield {
+        type: "message_start",
+        message: { id: "msg_1", usage: { input_tokens: 4, output_tokens: 0 } },
+      };
+      yield {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { input_tokens: 4, output_tokens: 2 },
+      };
+    })();
+    anthropicMessagesStreamMock.mockReturnValueOnce(
+      Object.assign(streamedEvents, {
+        withResponse: async () => ({
+          data: streamedEvents,
+          response: new Response(null, {
+            headers: {
+              "request-id": "req_header_123",
+            },
+          }),
+          request_id: "req_fallback_abc",
+        }),
+      }),
+    );
+
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        {
+          id: "claude-sonnet-4-6",
+          name: "Claude Sonnet 4.6",
+          api: "anthropic-messages",
+          provider: "anthropic",
+          baseUrl: "https://api.anthropic.com",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } as Model<"anthropic-messages">,
+        {
+          messages: [{ role: "user", content: "hello" }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect((result as { upstreamRequestId?: string }).upstreamRequestId).toBe("req_header_123");
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -25,6 +25,8 @@ import {
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
+  resolveTransportUpstreamRequestId,
+  resolveTransportUpstreamRequestIdFromHeaders,
   sanitizeTransportPayloadText,
 } from "./transport-stream-shared.js";
 
@@ -95,6 +97,7 @@ type MutableAssistantOutput = {
   stopReason: string;
   timestamp: number;
   responseId?: string;
+  upstreamRequestId?: string;
   errorMessage?: string;
 };
 
@@ -626,19 +629,46 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
         if (nextParams !== undefined) {
           params = nextParams as Record<string, unknown>;
         }
-        const anthropicStream = client.messages.stream(
+        const anthropicRequest = client.messages.stream(
           { ...params, stream: true } as never,
           transportOptions.signal ? { signal: transportOptions.signal } : undefined,
-        ) as AsyncIterable<Record<string, unknown>>;
+        ) as AsyncIterable<Record<string, unknown>> & {
+          request_id?: string | null;
+          withResponse?: () => Promise<{
+            data: AsyncIterable<Record<string, unknown>>;
+            response?: Response;
+            request_id?: string | null;
+          }>;
+        };
+        let anthropicStream: AsyncIterable<Record<string, unknown>> = anthropicRequest;
+        if (typeof anthropicRequest.withResponse === "function") {
+          const withResponse = await anthropicRequest.withResponse();
+          anthropicStream = withResponse.data;
+          output.upstreamRequestId = resolveTransportUpstreamRequestId(
+            resolveTransportUpstreamRequestIdFromHeaders(withResponse.response?.headers),
+            withResponse.request_id,
+          );
+        } else {
+          output.upstreamRequestId = resolveTransportUpstreamRequestId(anthropicRequest.request_id);
+        }
         stream.push({ type: "start", partial: output as never });
         const blocks = output.content;
         for await (const event of anthropicStream) {
           if (event.type === "message_start") {
             const message = event.message as
-              | { id?: string; usage?: Record<string, unknown> }
+              | {
+                  id?: string;
+                  usage?: Record<string, unknown>;
+                  _request_id?: string;
+                  request_id?: string;
+                }
               | undefined;
             const usage = message?.usage ?? {};
             output.responseId = typeof message?.id === "string" ? message.id : undefined;
+            output.upstreamRequestId ||= resolveTransportUpstreamRequestId(
+              message?._request_id,
+              message?.request_id,
+            );
             output.usage.input = typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
             output.usage.output = typeof usage.output_tokens === "number" ? usage.output_tokens : 0;
             output.usage.cacheRead =
@@ -846,6 +876,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             calculateCost(model, output.usage);
           }
         }
+        output.upstreamRequestId ||= resolveTransportUpstreamRequestId(anthropicRequest.request_id);
         finalizeTransportStream({ stream, output, signal: transportOptions.signal });
       } catch (error) {
         failTransportStream({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -569,6 +569,34 @@ describe("failover-error", () => {
     expect(err?.model).toBe("claude-opus-4-6");
   });
 
+  it("captures upstream request ids from structured error response headers", () => {
+    const err = coerceToFailoverError(
+      {
+        status: 429,
+        response: {
+          headers: new Headers({
+            "x-request-id": "xreq_429_test",
+          }),
+        },
+      },
+      {
+        provider: "openai",
+        model: "gpt-5.4",
+      },
+    );
+    expect(err?.upstreamRequestId).toBe("xreq_429_test");
+    expect(describeFailoverError(err).upstreamRequestId).toBe("xreq_429_test");
+  });
+
+  it("captures upstream request ids from raw error text", () => {
+    const described = describeFailoverError({
+      status: 429,
+      message:
+        "request failed: RESOURCE_EXHAUSTED (request_id: 20260303141547610b7f574d1b44cb) please retry",
+    });
+    expect(described.upstreamRequestId).toBe("20260303141547610b7f574d1b44cb");
+  });
+
   it("maps overloaded to a 503 fallback status", () => {
     expect(resolveFailoverStatus("overloaded")).toBe(503);
   });

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -5,8 +5,16 @@ import {
   type FailoverClassification,
   type FailoverSignal,
 } from "./pi-embedded-helpers/errors.js";
+import {
+  resolveTransportUpstreamRequestId,
+  resolveTransportUpstreamRequestIdFromHeaders,
+} from "./transport-stream-shared.js";
 
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
+const UPSTREAM_REQUEST_ID_PATTERNS = [
+  /\b(?:x-request-id|request-id|request_id|trace-id|trace_id)\s*[:=]\s*([a-zA-Z0-9._:-]+)/i,
+  /\((?:request_id|trace_id)\s*:\s*([a-zA-Z0-9._:-]+)\)/i,
+] as const;
 
 export class FailoverError extends Error {
   readonly reason: FailoverReason;
@@ -15,6 +23,7 @@ export class FailoverError extends Error {
   readonly profileId?: string;
   readonly status?: number;
   readonly code?: string;
+  readonly upstreamRequestId?: string;
 
   constructor(
     message: string,
@@ -25,6 +34,7 @@ export class FailoverError extends Error {
       profileId?: string;
       status?: number;
       code?: string;
+      upstreamRequestId?: string;
       cause?: unknown;
     },
   ) {
@@ -36,6 +46,7 @@ export class FailoverError extends Error {
     this.profileId = params.profileId;
     this.status = params.status;
     this.code = params.code;
+    this.upstreamRequestId = params.upstreamRequestId;
   }
 }
 
@@ -138,6 +149,60 @@ function readDirectErrorCode(err: unknown): string | undefined {
 
 function getErrorCode(err: unknown): string | undefined {
   return findErrorProperty(err, readDirectErrorCode);
+}
+
+function readDirectUpstreamRequestId(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const candidate = err as {
+    upstreamRequestId?: unknown;
+    request_id?: unknown;
+    requestId?: unknown;
+    _request_id?: unknown;
+    trace_id?: unknown;
+    traceId?: unknown;
+    headers?: Headers | Record<string, unknown>;
+    response?: {
+      headers?: Headers | Record<string, unknown>;
+      request_id?: unknown;
+      requestId?: unknown;
+      _request_id?: unknown;
+      trace_id?: unknown;
+      traceId?: unknown;
+    };
+  };
+  return resolveTransportUpstreamRequestId(
+    candidate.upstreamRequestId,
+    candidate.request_id,
+    candidate.requestId,
+    candidate._request_id,
+    candidate.trace_id,
+    candidate.traceId,
+    resolveTransportUpstreamRequestIdFromHeaders(candidate.headers),
+    resolveTransportUpstreamRequestIdFromHeaders(candidate.response?.headers),
+    candidate.response?.request_id,
+    candidate.response?.requestId,
+    candidate.response?._request_id,
+    candidate.response?.trace_id,
+    candidate.response?.traceId,
+  );
+}
+
+function getUpstreamRequestId(err: unknown): string | undefined {
+  const direct = findErrorProperty(err, readDirectUpstreamRequestId);
+  if (direct) {
+    return direct;
+  }
+  const message = getErrorMessage(err);
+  for (const pattern of UPSTREAM_REQUEST_ID_PATTERNS) {
+    const matched = message.match(pattern);
+    const id = resolveTransportUpstreamRequestId(matched?.[1]);
+    if (id) {
+      return id;
+    }
+  }
+  return undefined;
 }
 
 function readDirectProvider(err: unknown): string | undefined {
@@ -277,6 +342,7 @@ export function describeFailoverError(err: unknown): {
   reason?: FailoverReason;
   status?: number;
   code?: string;
+  upstreamRequestId?: string;
 } {
   if (isFailoverError(err)) {
     return {
@@ -284,6 +350,7 @@ export function describeFailoverError(err: unknown): {
       reason: err.reason,
       status: err.status,
       code: err.code,
+      upstreamRequestId: err.upstreamRequestId,
     };
   }
   const signal = normalizeErrorSignal(err);
@@ -293,6 +360,7 @@ export function describeFailoverError(err: unknown): {
     reason: resolveFailoverReasonFromError(err) ?? undefined,
     status: signal.status,
     code: signal.code,
+    upstreamRequestId: getUpstreamRequestId(err),
   };
 }
 
@@ -302,6 +370,7 @@ export function coerceToFailoverError(
     provider?: string;
     model?: string;
     profileId?: string;
+    upstreamRequestId?: string;
   },
 ): FailoverError | null {
   if (isFailoverError(err)) {
@@ -316,6 +385,7 @@ export function coerceToFailoverError(
   const message = signal.message ?? String(err);
   const status = signal.status ?? resolveFailoverStatus(reason);
   const code = signal.code;
+  const upstreamRequestId = getUpstreamRequestId(err) ?? context?.upstreamRequestId;
 
   return new FailoverError(message, {
     reason,
@@ -324,6 +394,7 @@ export function coerceToFailoverError(
     profileId: context?.profileId,
     status,
     code,
+    upstreamRequestId,
     cause: err instanceof Error ? err : undefined,
   });
 }

--- a/src/agents/openai-transport-stream.request-id.test.ts
+++ b/src/agents/openai-transport-stream.request-id.test.ts
@@ -1,0 +1,189 @@
+import type { Model } from "@mariozechner/pi-ai";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  openAICtorMock,
+  azureOpenAICtorMock,
+  responsesCreateMock,
+  completionsCreateMock,
+  buildGuardedModelFetchMock,
+  guardedFetchMock,
+} = vi.hoisted(() => ({
+  openAICtorMock: vi.fn(),
+  azureOpenAICtorMock: vi.fn(),
+  responsesCreateMock: vi.fn(),
+  completionsCreateMock: vi.fn(),
+  buildGuardedModelFetchMock: vi.fn(),
+  guardedFetchMock: vi.fn(),
+}));
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    responses = { create: responsesCreateMock };
+    chat = { completions: { create: completionsCreateMock } };
+
+    constructor(options?: unknown) {
+      openAICtorMock(options);
+    }
+  },
+  AzureOpenAI: class MockAzureOpenAI {
+    responses = { create: responsesCreateMock };
+    chat = { completions: { create: completionsCreateMock } };
+
+    constructor(options?: unknown) {
+      azureOpenAICtorMock(options);
+    }
+  },
+}));
+
+vi.mock("./provider-transport-fetch.js", () => ({
+  buildGuardedModelFetch: buildGuardedModelFetchMock,
+}));
+
+let createOpenAIResponsesTransportStreamFn: typeof import("./openai-transport-stream.js").createOpenAIResponsesTransportStreamFn;
+let createOpenAICompletionsTransportStreamFn: typeof import("./openai-transport-stream.js").createOpenAICompletionsTransportStreamFn;
+
+describe("openai transport stream upstream request ids", () => {
+  beforeAll(async () => {
+    ({ createOpenAIResponsesTransportStreamFn, createOpenAICompletionsTransportStreamFn } =
+      await import("./openai-transport-stream.js"));
+  });
+
+  beforeEach(() => {
+    openAICtorMock.mockReset();
+    azureOpenAICtorMock.mockReset();
+    responsesCreateMock.mockReset();
+    completionsCreateMock.mockReset();
+    buildGuardedModelFetchMock.mockReset();
+    guardedFetchMock.mockReset();
+    buildGuardedModelFetchMock.mockReturnValue(guardedFetchMock);
+  });
+
+  it("captures response header request ids for responses streams", async () => {
+    const streamedEvents = (async function* () {
+      yield {
+        type: "response.created",
+        response: { id: "resp_1" },
+      };
+      yield {
+        type: "response.output_item.added",
+        item: { type: "message", id: "msg_1" },
+      };
+      yield {
+        type: "response.output_text.delta",
+        delta: "hello",
+      };
+      yield {
+        type: "response.output_item.done",
+        item: {
+          type: "message",
+          id: "msg_1",
+          content: [{ type: "output_text", text: "hello" }],
+        },
+      };
+      yield {
+        type: "response.completed",
+        response: {
+          id: "resp_1",
+          usage: {
+            input_tokens: 4,
+            output_tokens: 2,
+            total_tokens: 6,
+          },
+        },
+      };
+    })();
+    responsesCreateMock.mockReturnValueOnce({
+      withResponse: async () => ({
+        data: streamedEvents,
+        response: new Response(null, {
+          headers: {
+            "x-request-id": "req_header_123",
+          },
+        }),
+        request_id: "req_fallback_456",
+      }),
+    });
+
+    const streamFn = createOpenAIResponsesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          api: "openai-responses",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } as Model<"openai-responses">,
+        {
+          messages: [{ role: "user", content: "hello" }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-openai-api",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect((result as { upstreamRequestId?: string }).upstreamRequestId).toBe("req_header_123");
+    expect(openAICtorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to bare stream metadata when withResponse is unavailable", async () => {
+    const streamedChunks = Object.assign(
+      (async function* () {
+        yield {
+          id: "chatcmpl_1",
+          choices: [
+            {
+              delta: { content: "hello" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: 3,
+            completion_tokens: 1,
+            total_tokens: 4,
+          },
+        };
+      })(),
+      {
+        request_id: "req_stream_789",
+      },
+    );
+    completionsCreateMock.mockReturnValueOnce(streamedChunks);
+
+    const streamFn = createOpenAICompletionsTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          api: "openai-completions",
+          provider: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } as Model<"openai-completions">,
+        {
+          messages: [{ role: "user", content: "hello" }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-openai-api",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect((result as { upstreamRequestId?: string }).upstreamRequestId).toBe("req_stream_789");
+    expect(openAICtorMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -36,7 +36,12 @@ import {
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
 import { stripSystemPromptCacheBoundary } from "./system-prompt-cache-boundary.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
-import { mergeTransportMetadata, sanitizeTransportPayloadText } from "./transport-stream-shared.js";
+import {
+  mergeTransportMetadata,
+  resolveTransportUpstreamRequestId,
+  resolveTransportUpstreamRequestIdFromHeaders,
+  sanitizeTransportPayloadText,
+} from "./transport-stream-shared.js";
 
 const DEFAULT_AZURE_OPENAI_API_VERSION = "2024-12-01-preview";
 
@@ -79,6 +84,14 @@ type OpenAIModeModel = Model<Api> & {
   compat?: Record<string, unknown>;
 };
 
+type OpenAIStreamRequest<T> = (AsyncIterable<T> | PromiseLike<AsyncIterable<T>>) & {
+  withResponse?: () => Promise<{
+    data: AsyncIterable<T>;
+    response?: Response;
+    request_id?: string | null;
+  }>;
+};
+
 type MutableAssistantOutput = {
   role: "assistant";
   content: Array<Record<string, unknown>>;
@@ -96,6 +109,7 @@ type MutableAssistantOutput = {
   stopReason: string;
   timestamp: number;
   responseId?: string;
+  upstreamRequestId?: string;
   errorMessage?: string;
 };
 
@@ -122,6 +136,65 @@ function stringifyJsonLike(value: unknown, fallback = ""): string {
     return String(value);
   }
   return fallback;
+}
+
+function resolveOpenAIUpstreamRequestId(candidate: unknown): string | undefined {
+  if (!candidate || typeof candidate !== "object") {
+    return undefined;
+  }
+  const record = candidate as {
+    upstreamRequestId?: unknown;
+    request_id?: unknown;
+    requestId?: unknown;
+    _request_id?: unknown;
+    trace_id?: unknown;
+    traceId?: unknown;
+    headers?: Headers | Record<string, unknown>;
+    response?: {
+      headers?: Headers | Record<string, unknown>;
+      request_id?: unknown;
+      requestId?: unknown;
+      _request_id?: unknown;
+      trace_id?: unknown;
+      traceId?: unknown;
+    };
+  };
+  return resolveTransportUpstreamRequestId(
+    record.upstreamRequestId,
+    record.request_id,
+    record.requestId,
+    record._request_id,
+    record.trace_id,
+    record.traceId,
+    resolveTransportUpstreamRequestIdFromHeaders(record.headers),
+    resolveTransportUpstreamRequestIdFromHeaders(record.response?.headers),
+    record.response?.request_id,
+    record.response?.requestId,
+    record.response?._request_id,
+    record.response?.trace_id,
+    record.response?.traceId,
+  );
+}
+
+async function resolveOpenAIStreamResponse<T>(
+  request: OpenAIStreamRequest<T>,
+): Promise<{ data: AsyncIterable<T>; upstreamRequestId?: string }> {
+  if (typeof request.withResponse === "function") {
+    const responseWithMeta = await request.withResponse();
+    return {
+      data: responseWithMeta.data,
+      upstreamRequestId: resolveTransportUpstreamRequestId(
+        resolveTransportUpstreamRequestIdFromHeaders(responseWithMeta.response?.headers),
+        responseWithMeta.request_id,
+      ),
+    };
+  }
+  const data = await request;
+  return {
+    data,
+    upstreamRequestId:
+      resolveOpenAIUpstreamRequestId(request) ?? resolveOpenAIUpstreamRequestId(data),
+  };
 }
 
 function getServiceTierCostMultiplier(serviceTier: ResponseCreateParamsStreaming["service_tier"]) {
@@ -381,8 +454,10 @@ async function processResponsesStream(
   for await (const rawEvent of openaiStream) {
     const event = rawEvent as Record<string, unknown>;
     const type = stringifyUnknown(event.type);
+    output.upstreamRequestId ||= resolveOpenAIUpstreamRequestId(event);
     if (type === "response.created") {
       output.responseId = stringifyUnknown((event.response as { id?: string } | undefined)?.id);
+      output.upstreamRequestId ||= resolveOpenAIUpstreamRequestId(event.response);
     } else if (type === "response.output_item.added") {
       const item = event.item as Record<string, unknown>;
       if (item.type === "reasoning") {
@@ -502,6 +577,7 @@ async function processResponsesStream(
       if (typeof response?.id === "string") {
         output.responseId = response.id;
       }
+      output.upstreamRequestId ||= resolveOpenAIUpstreamRequestId(response);
       const usage = response?.usage as
         | {
             input_tokens?: number;
@@ -691,10 +767,13 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           params = nextParams as typeof params;
         }
         params = mergeTransportMetadata(params, turnState?.metadata);
-        const responseStream = (await client.responses.create(
+        const responseRequest = client.responses.create(
           params as never,
           options?.signal ? { signal: options.signal } : undefined,
-        )) as unknown as AsyncIterable<unknown>;
+        ) as OpenAIStreamRequest<unknown>;
+        const responseWithMeta = await resolveOpenAIStreamResponse(responseRequest);
+        output.upstreamRequestId = responseWithMeta.upstreamRequestId;
+        const responseStream = responseWithMeta.data;
         stream.push({ type: "start", partial: output as never });
         await processResponsesStream(responseStream, output, stream, model, {
           serviceTier: (options as OpenAIResponsesOptions | undefined)?.serviceTier,
@@ -852,10 +931,13 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
           params = nextParams as typeof params;
         }
         params = mergeTransportMetadata(params, turnState?.metadata);
-        const responseStream = (await client.responses.create(
+        const responseRequest = client.responses.create(
           params as never,
           options?.signal ? { signal: options.signal } : undefined,
-        )) as unknown as AsyncIterable<unknown>;
+        ) as OpenAIStreamRequest<unknown>;
+        const responseWithMeta = await resolveOpenAIStreamResponse(responseRequest);
+        output.upstreamRequestId = responseWithMeta.upstreamRequestId;
+        const responseStream = responseWithMeta.data;
         stream.push({ type: "start", partial: output as never });
         await processResponsesStream(responseStream, output, stream, model);
         if (options?.signal?.aborted) {
@@ -981,9 +1063,12 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         if (nextParams !== undefined) {
           params = nextParams as typeof params;
         }
-        const responseStream = (await client.chat.completions.create(params as never, {
+        const responseRequest = client.chat.completions.create(params as never, {
           signal: options?.signal,
-        })) as unknown as AsyncIterable<ChatCompletionChunk>;
+        }) as OpenAIStreamRequest<ChatCompletionChunk>;
+        const responseWithMeta = await resolveOpenAIStreamResponse(responseRequest);
+        output.upstreamRequestId = responseWithMeta.upstreamRequestId;
+        const responseStream = responseWithMeta.data;
         stream.push({ type: "start", partial: output as never });
         await processOpenAICompletionsStream(responseStream, output, model, stream);
         if (options?.signal?.aborted) {
@@ -1035,6 +1120,7 @@ async function processOpenAICompletionsStream(
   };
   for await (const chunk of responseStream) {
     output.responseId ||= chunk.id;
+    output.upstreamRequestId ||= resolveOpenAIUpstreamRequestId(chunk);
     if (chunk.usage) {
       output.usage = parseTransportChunkUsage(chunk.usage, model);
     }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1488,10 +1488,14 @@ export async function runEmbeddedPiAgent(
             lastRunPromptUsage,
             lastTurnTotal,
           });
+          const upstreamRequestId = normalizeOptionalString(
+            (sessionLastAssistant as { upstreamRequestId?: unknown } | undefined)?.upstreamRequestId,
+          );
           const agentMeta: EmbeddedPiAgentMeta = {
             sessionId: sessionIdUsed,
             provider: sessionLastAssistant?.provider ?? provider,
             model: sessionLastAssistant?.model ?? model.id,
+            ...(upstreamRequestId ? { upstreamRequestId } : {}),
             usage: usageMeta.usage,
             lastCallUsage: usageMeta.lastCallUsage,
             promptTokens: usageMeta.promptTokens,

--- a/src/agents/pi-embedded-runner/run/helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { resolveFinalAssistantVisibleText } from "./helpers.js";
+import { createUsageAccumulator, mergeUsageIntoAccumulator } from "../usage-accumulator.js";
+import { buildErrorAgentMeta, resolveFinalAssistantVisibleText } from "./helpers.js";
 
 function makeAssistantMessage(
   content: AssistantMessage["content"],
@@ -59,5 +60,36 @@ describe("resolveFinalAssistantVisibleText", () => {
     ]);
 
     expect(resolveFinalAssistantVisibleText(lastAssistant)).toBeUndefined();
+  });
+});
+
+describe("buildErrorAgentMeta", () => {
+  it("preserves upstream request ids in error agent meta", () => {
+    const usageAccumulator = createUsageAccumulator();
+    mergeUsageIntoAccumulator(usageAccumulator, {
+      input: 12,
+      output: 3,
+      total: 15,
+    });
+
+    const meta = buildErrorAgentMeta({
+      sessionId: "session-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      usageAccumulator,
+      lastRunPromptUsage: { input: 12, output: 3, total: 15 },
+      lastAssistant: {
+        usage: {
+          inputTokens: 12,
+          outputTokens: 3,
+          totalTokens: 15,
+        },
+        upstreamRequestId: " req_err_123 ",
+      },
+      lastTurnTotal: 15,
+    });
+
+    expect(meta.upstreamRequestId).toBe("req_err_123");
+    expect(meta.usage).toMatchObject({ total: 15 });
   });
 });

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { generateSecureToken } from "../../../infra/secure-random.js";
 import { extractAssistantVisibleText } from "../../pi-embedded-utils.js";
+import { normalizeOptionalString } from "../../../shared/string-coerce.js";
 import { derivePromptTokens, normalizeUsage } from "../../usage.js";
 import type { EmbeddedPiAgentMeta } from "../types.js";
 import { toLastCallUsage, toNormalizedUsage, type UsageAccumulator } from "../usage-accumulator.js";
@@ -125,7 +126,7 @@ export function buildErrorAgentMeta(params: {
   model: string;
   usageAccumulator: UsageAccumulator;
   lastRunPromptUsage: UsageSnapshot | undefined;
-  lastAssistant?: { usage?: unknown } | null;
+  lastAssistant?: { usage?: unknown; upstreamRequestId?: unknown } | null;
   lastTurnTotal?: number;
 }): EmbeddedPiAgentMeta {
   const usageMeta = buildUsageAgentMetaFields({
@@ -134,10 +135,12 @@ export function buildErrorAgentMeta(params: {
     lastRunPromptUsage: params.lastRunPromptUsage,
     lastTurnTotal: params.lastTurnTotal,
   });
+  const upstreamRequestId = normalizeOptionalString(params.lastAssistant?.upstreamRequestId);
   return {
     sessionId: params.sessionId,
     provider: params.provider,
     model: params.model,
+    ...(upstreamRequestId ? { upstreamRequestId } : {}),
     ...(usageMeta.usage ? { usage: usageMeta.usage } : {}),
     ...(usageMeta.lastCallUsage ? { lastCallUsage: usageMeta.lastCallUsage } : {}),
     ...(usageMeta.promptTokens ? { promptTokens: usageMeta.promptTokens } : {}),

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -5,6 +5,7 @@ export type EmbeddedPiAgentMeta = {
   sessionId: string;
   provider: string;
   model: string;
+  upstreamRequestId?: string;
   cliSessionBinding?: CliSessionBinding;
   compactionCount?: number;
   promptTokens?: number;

--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -3,6 +3,8 @@ import {
   failTransportStream,
   finalizeTransportStream,
   mergeTransportHeaders,
+  resolveTransportUpstreamRequestId,
+  resolveTransportUpstreamRequestIdFromHeaders,
   sanitizeTransportPayloadText,
 } from "./transport-stream-shared.js";
 
@@ -71,5 +73,29 @@ describe("transport stream shared helpers", () => {
       error: output,
     });
     expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the first non-empty normalized upstream id candidate", () => {
+    expect(resolveTransportUpstreamRequestId(undefined, "   ", "req_123", "trace_abc")).toBe(
+      "req_123",
+    );
+  });
+
+  it("extracts request-id style headers from Headers objects", () => {
+    const headers = new Headers({
+      "x-request-id": "xreq_456",
+      "trace-id": "trace_789",
+    });
+    expect(resolveTransportUpstreamRequestIdFromHeaders(headers)).toBe("xreq_456");
+  });
+
+  it("prefers request-id over x-request-id and trace-id in record headers", () => {
+    expect(
+      resolveTransportUpstreamRequestIdFromHeaders({
+        "Trace-Id": "trace_789",
+        "X-Request-Id": "xreq_456",
+        "Request-Id": "req_123",
+      }),
+    ).toBe("req_123");
   });
 });

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -19,6 +19,19 @@ type TransportOutputShape = {
   errorMessage?: string;
 };
 
+const TRANSPORT_UPSTREAM_ID_HEADERS = ["request-id", "x-request-id", "trace-id"] as const;
+
+function normalizeTransportId(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+  return undefined;
+}
+
 export function sanitizeTransportPayloadText(text: string): string {
   return text.replace(
     /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
@@ -42,6 +55,42 @@ export function coerceTransportToolCallArguments(argumentsValue: unknown): Recor
     }
   }
   return {};
+}
+
+export function resolveTransportUpstreamRequestId(...candidates: Array<unknown>): string | undefined {
+  for (const candidate of candidates) {
+    const normalized = normalizeTransportId(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
+export function resolveTransportUpstreamRequestIdFromHeaders(
+  headers: Headers | Record<string, unknown> | undefined,
+): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    for (const headerName of TRANSPORT_UPSTREAM_ID_HEADERS) {
+      const value = resolveTransportUpstreamRequestId(headers.get(headerName));
+      if (value) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+  const entries = Object.entries(headers);
+  for (const headerName of TRANSPORT_UPSTREAM_ID_HEADERS) {
+    const matched = entries.find(([key]) => key.toLowerCase() === headerName);
+    const value = resolveTransportUpstreamRequestId(matched?.[1]);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 export function mergeTransportHeaders(

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -10,6 +10,9 @@ import {
 import * as sessionTypesModule from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
+import { onAgentEvent } from "../../infra/agent-events.js";
+import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../../infra/diagnostic-events.js";
+import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
 import {
   clearMemoryPluginState,
   registerMemoryFlushPlanResolver,
@@ -157,6 +160,8 @@ beforeEach(() => {
   loadCronStoreMock.mockClear();
   // Default: no cron jobs in store.
   loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+  resetDiagnosticEventsForTest();
+  resetSystemEventsForTest();
 
   // Default: no provider switch; execute the chosen provider+model.
   runWithModelFallbackMock.mockImplementation(
@@ -170,6 +175,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  resetDiagnosticEventsForTest();
+  resetSystemEventsForTest();
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
@@ -1452,7 +1459,11 @@ describe("runReplyAgent fallback reasoning tags", () => {
 });
 
 describe("runReplyAgent response usage footer", () => {
-  function createRun(params: { responseUsage: "tokens" | "full"; sessionKey: string }) {
+  function createRun(params: {
+    responseUsage: "tokens" | "full";
+    sessionKey: string;
+    config?: Record<string, unknown>;
+  }) {
     const typing = createMockTypingController();
     const sessionCtx = {
       Provider: "whatsapp",
@@ -1480,7 +1491,7 @@ describe("runReplyAgent response usage footer", () => {
         messageProvider: "whatsapp",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: createCliBackendTestConfig(),
+        config: params.config ?? createCliBackendTestConfig(),
         skillsSnapshot: {},
         provider: "anthropic",
         model: "claude",
@@ -1558,6 +1569,38 @@ describe("runReplyAgent response usage footer", () => {
     const text = payload?.text ?? "";
     expect(text).toContain("Usage:");
     expect(text).not.toContain("· session ");
+  });
+
+  it("emits upstream request ids on model usage diagnostics", async () => {
+    const capturedRequestIds: string[] = [];
+    const stop = onDiagnosticEvent((event) => {
+      if (event.type === "model.usage" && event.upstreamRequestId) {
+        capturedRequestIds.push(event.upstreamRequestId);
+      }
+    });
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          provider: "anthropic",
+          model: "claude",
+          usage: { input: 12, output: 3 },
+          upstreamRequestId: "req_diag_123",
+        },
+      },
+    });
+
+    await createRun({
+      responseUsage: "tokens",
+      sessionKey: "agent:main:whatsapp:dm:+1000",
+      config: {
+        ...createCliBackendTestConfig(),
+        diagnostics: { enabled: true },
+      },
+    });
+    stop();
+
+    expect(capturedRequestIds).toEqual(["req_diag_123"]);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -644,6 +644,9 @@ export async function runReplyAgent(params: {
         config: cfg,
       });
       const costUsd = estimateUsageCost({ usage, cost: costConfig });
+      const upstreamRequestId = normalizeOptionalString(
+        runResult.meta?.agentMeta?.upstreamRequestId,
+      );
       emitDiagnosticEvent({
         type: "model.usage",
         sessionKey,
@@ -651,6 +654,7 @@ export async function runReplyAgent(params: {
         channel: replyToChannel,
         provider: providerUsed,
         model: modelUsed,
+        upstreamRequestId,
         usage: {
           input,
           output,

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -39,6 +39,23 @@ describe("diagnostic-events", () => {
     ]);
   });
 
+  it("keeps optional upstream request ids on model usage events", () => {
+    const captured: Array<{ upstreamRequestId?: string }> = [];
+    onDiagnosticEvent((event) => {
+      if (event.type === "model.usage") {
+        captured.push({ upstreamRequestId: event.upstreamRequestId });
+      }
+    });
+
+    emitDiagnosticEvent({
+      type: "model.usage",
+      upstreamRequestId: "req_otel_123",
+      usage: { total: 1 },
+    });
+
+    expect(captured).toEqual([{ upstreamRequestId: "req_otel_123" }]);
+  });
+
   it("isolates listener failures and logs them", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const seen: string[] = [];

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -14,6 +14,7 @@ export type DiagnosticUsageEvent = DiagnosticBaseEvent & {
   channel?: string;
   provider?: string;
   model?: string;
+  upstreamRequestId?: string;
   usage: {
     input?: number;
     output?: number;


### PR DESCRIPTION
## Summary
- extract upstream request ids from OpenAI and Anthropic transport responses
- thread the id through failover metadata, embedded agent metadata, and `model.usage` diagnostic events
- record `openclaw.upstream_request_id` on diagnostics-otel spans and add regression coverage for transport/error/diagnostic paths

Closes #65787.

## AI Assistance
- AI-assisted: Codex
- Testing: fully tested locally on targeted lanes

<details>
<summary>Before</summary>

```text
$ node --import tsx -e "import { describeFailoverError } from './src/agents/failover-error.js'; const described=describeFailoverError({status:429,message:'request failed: RESOURCE_EXHAUSTED (request_id: 20260303141547610b7f574d1b44cb) please retry'}); console.log(JSON.stringify(described, null, 2));"
{
  "message": "request failed: RESOURCE_EXHAUSTED (request_id: 20260303141547610b7f574d1b44cb) please retry",
  "reason": "rate_limit",
  "status": 429
}
```

</details>

<details>
<summary>After</summary>

```text
$ node --import tsx -e "import { describeFailoverError } from './src/agents/failover-error.js'; const described=describeFailoverError({status:429,message:'request failed: RESOURCE_EXHAUSTED (request_id: 20260303141547610b7f574d1b44cb) please retry'}); console.log(JSON.stringify(described, null, 2));"
{
  "message": "request failed: RESOURCE_EXHAUSTED (request_id: 20260303141547610b7f574d1b44cb) please retry",
  "reason": "rate_limit",
  "status": 429,
  "upstreamRequestId": "20260303141547610b7f574d1b44cb"
}

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/anthropic-transport-stream.test.ts src/agents/openai-transport-stream.test.ts src/agents/openai-transport-stream.request-id.test.ts src/agents/failover-error.test.ts src/agents/transport-stream-shared.test.ts src/agents/pi-embedded-runner/run/helpers.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/infra/diagnostic-events.test.ts
EXIT:0

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/diagnostics-otel/src/service.test.ts
EXIT:0
```

</details>

## Test plan
- [x] targeted transport/failover/diagnostic unit tests
- [x] targeted diagnostics-otel extension tests
