### PR TITLE
Systemd: keep managed env in drop-in so upgrades preserve user directives

### DIFF
--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { buildSystemdUnit } from "./systemd-unit.js";
+import {
+  buildSystemdManagedDropIn,
+  buildSystemdUnit,
+  OPENCLAW_MANAGED_DROPIN_FILENAME,
+  OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR,
+  splitSystemdManagedEnvironment,
+  stripManagedEnvFromSystemdUnit,
+  updateExecStartInSystemdUnit,
+} from "./systemd-unit.js";
 
 describe("buildSystemdUnit", () => {
   it("quotes arguments with whitespace", () => {
@@ -37,5 +45,219 @@ describe("buildSystemdUnit", () => {
         },
       }),
     ).toThrow(/CR or LF/);
+  });
+
+  it("excludes managed env from the main unit when the sentinel is present", () => {
+    const unit = buildSystemdUnit({
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "managed-token",
+        OPENCLAW_SERVICE_VERSION: "2026.4.12",
+        [OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR]:
+          "OPENCLAW_GATEWAY_TOKEN,OPENCLAW_SERVICE_VERSION",
+        USER_ADDED_KEY: "keep-me",
+      },
+    });
+    expect(unit).not.toContain("OPENCLAW_GATEWAY_TOKEN=");
+    expect(unit).not.toContain("OPENCLAW_SERVICE_VERSION=");
+    expect(unit).not.toContain(OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR);
+    expect(unit).toContain("Environment=USER_ADDED_KEY=keep-me");
+  });
+
+  it("keeps all env inline when no sentinel is present", () => {
+    const unit = buildSystemdUnit({
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+      environment: { FOO: "bar", BAZ: "qux" },
+    });
+    expect(unit).toContain("Environment=FOO=bar");
+    expect(unit).toContain("Environment=BAZ=qux");
+  });
+});
+
+describe("splitSystemdManagedEnvironment", () => {
+  it("partitions managed vs user by the sentinel list", () => {
+    const { managed, user } = splitSystemdManagedEnvironment({
+      OPENCLAW_GATEWAY_TOKEN: "token",
+      OPENCLAW_SERVICE_VERSION: "v",
+      [OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR]:
+        "OPENCLAW_GATEWAY_TOKEN,OPENCLAW_SERVICE_VERSION",
+      HOME: "/home/test",
+      USER_ADDED: "x",
+    });
+    expect(managed).toEqual({
+      OPENCLAW_GATEWAY_TOKEN: "token",
+      OPENCLAW_SERVICE_VERSION: "v",
+      [OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR]:
+        "OPENCLAW_GATEWAY_TOKEN,OPENCLAW_SERVICE_VERSION",
+    });
+    expect(user).toEqual({ HOME: "/home/test", USER_ADDED: "x" });
+  });
+
+  it("treats all env as user when no sentinel is present", () => {
+    const { managed, user } = splitSystemdManagedEnvironment({ FOO: "bar" });
+    expect(managed).toEqual({});
+    expect(user).toEqual({ FOO: "bar" });
+  });
+
+  it("handles undefined and empty input", () => {
+    expect(splitSystemdManagedEnvironment(undefined)).toEqual({ managed: {}, user: {} });
+    expect(splitSystemdManagedEnvironment({})).toEqual({ managed: {}, user: {} });
+  });
+
+  it("matches managed keys case-insensitively against the sentinel", () => {
+    const { managed, user } = splitSystemdManagedEnvironment({
+      openclaw_gateway_token: "lower",
+      OPENCLAW_GATEWAY_TOKEN: "upper",
+      [OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR]: "OPENCLAW_GATEWAY_TOKEN",
+    });
+    expect(managed.OPENCLAW_GATEWAY_TOKEN).toBe("upper");
+    expect(managed.openclaw_gateway_token).toBe("lower");
+    expect(user).toEqual({});
+  });
+});
+
+describe("buildSystemdManagedDropIn", () => {
+  it("emits a [Service] block with only managed env", () => {
+    const text = buildSystemdManagedDropIn({
+      OPENCLAW_GATEWAY_TOKEN: "token",
+      OPENCLAW_SERVICE_VERSION: "2026.4.12",
+      [OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR]:
+        "OPENCLAW_GATEWAY_TOKEN,OPENCLAW_SERVICE_VERSION",
+      HOME: "/home/test",
+    });
+    expect(text).toContain("# Auto-managed by openclaw.");
+    expect(text).toContain("[Service]");
+    expect(text).toContain("Environment=OPENCLAW_GATEWAY_TOKEN=token");
+    expect(text).toContain("Environment=OPENCLAW_SERVICE_VERSION=2026.4.12");
+    expect(text).toContain(
+      `Environment=${OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR}=OPENCLAW_GATEWAY_TOKEN,OPENCLAW_SERVICE_VERSION`,
+    );
+    // Non-managed entries stay out.
+    expect(text).not.toContain("Environment=HOME=");
+  });
+
+  it("returns an empty string when there is nothing to manage", () => {
+    expect(buildSystemdManagedDropIn(undefined)).toBe("");
+    expect(buildSystemdManagedDropIn({})).toBe("");
+    expect(buildSystemdManagedDropIn({ FOO: "bar" })).toBe("");
+  });
+
+  it("uses the stable drop-in filename in documentation-relevant constants", () => {
+    expect(OPENCLAW_MANAGED_DROPIN_FILENAME).toBe("openclaw-managed.conf");
+  });
+});
+
+describe("stripManagedEnvFromSystemdUnit", () => {
+  const UNIT_WITH_INLINE_MANAGED = [
+    "[Unit]",
+    "Description=OpenClaw Gateway (v2026.4.11)",
+    "",
+    "[Service]",
+    "ExecStart=/usr/bin/node /home/user/openclaw/dist/entry.js gateway --port 18789",
+    "Restart=always",
+    "Environment=OPENCLAW_GATEWAY_TOKEN=managed-token",
+    "Environment=TELEGRAM_BOT_TOKEN=managed-tg",
+    "EnvironmentFile=/home/user/.openclaw/workspace/.env",
+    "Environment=HOME=/home/user",
+    "Environment=PATH=/usr/bin:/bin",
+    "Environment=OPENCLAW_SERVICE_VERSION=2026.4.11",
+    "Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS=OPENCLAW_GATEWAY_TOKEN,TELEGRAM_BOT_TOKEN,OPENCLAW_SERVICE_VERSION",
+    "",
+    "[Install]",
+    "WantedBy=default.target",
+    "",
+  ].join("\n");
+
+  it("removes managed Environment= lines and the sentinel itself", () => {
+    const stripped = stripManagedEnvFromSystemdUnit(UNIT_WITH_INLINE_MANAGED);
+    expect(stripped).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=");
+    expect(stripped).not.toContain("Environment=TELEGRAM_BOT_TOKEN=");
+    expect(stripped).not.toContain("Environment=OPENCLAW_SERVICE_VERSION=");
+    expect(stripped).not.toContain("OPENCLAW_SERVICE_MANAGED_ENV_KEYS=");
+  });
+
+  it("preserves user-added EnvironmentFile= and unmanaged Environment= lines", () => {
+    const stripped = stripManagedEnvFromSystemdUnit(UNIT_WITH_INLINE_MANAGED);
+    expect(stripped).toContain("EnvironmentFile=/home/user/.openclaw/workspace/.env");
+    expect(stripped).toContain("Environment=HOME=/home/user");
+    expect(stripped).toContain("Environment=PATH=/usr/bin:/bin");
+  });
+
+  it("preserves ExecStart, [Unit], [Install], and blank lines", () => {
+    const stripped = stripManagedEnvFromSystemdUnit(UNIT_WITH_INLINE_MANAGED);
+    expect(stripped).toContain(
+      "ExecStart=/usr/bin/node /home/user/openclaw/dist/entry.js gateway --port 18789",
+    );
+    expect(stripped).toContain("[Unit]");
+    expect(stripped).toContain("[Install]");
+    expect(stripped).toContain("WantedBy=default.target");
+    expect(stripped).toContain("Restart=always");
+  });
+
+  it("returns the input unchanged when there is no sentinel", () => {
+    const text = "[Service]\nExecStart=/bin/true\nEnvironment=FOO=bar\n";
+    expect(stripManagedEnvFromSystemdUnit(text)).toBe(text);
+  });
+
+  it("leaves unmanaged Environment= lines that happen to share a prefix with managed keys", () => {
+    const text = [
+      "[Service]",
+      "ExecStart=/bin/true",
+      "Environment=OPENCLAW_GATEWAY_TOKEN=managed",
+      "Environment=OPENCLAW_GATEWAY_TOKEN_BACKUP=user-copy",
+      "Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS=OPENCLAW_GATEWAY_TOKEN",
+      "",
+    ].join("\n");
+    const stripped = stripManagedEnvFromSystemdUnit(text);
+    expect(stripped).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=managed");
+    expect(stripped).toContain("Environment=OPENCLAW_GATEWAY_TOKEN_BACKUP=user-copy");
+  });
+});
+
+describe("updateExecStartInSystemdUnit", () => {
+  const BASE_UNIT = [
+    "[Unit]",
+    "Description=OpenClaw Gateway",
+    "",
+    "[Service]",
+    "ExecStart=/usr/bin/node /home/user/openclaw/dist/entry.js gateway --port 18789",
+    "Restart=always",
+    "Environment=HOME=/home/user",
+    "",
+    "[Install]",
+    "WantedBy=default.target",
+    "",
+  ].join("\n");
+
+  it("updates only the ExecStart line when the entry path has drifted", () => {
+    const { text, updated } = updateExecStartInSystemdUnit(BASE_UNIT, [
+      "/usr/bin/node",
+      "/home/user/openclaw/dist/index.js",
+      "gateway",
+      "--port",
+      "18789",
+    ]);
+    expect(updated).toBe(true);
+    expect(text).toContain(
+      "ExecStart=/usr/bin/node /home/user/openclaw/dist/index.js gateway --port 18789",
+    );
+    expect(text).not.toContain("dist/entry.js");
+    expect(text).toContain("Environment=HOME=/home/user");
+    expect(text).toContain("Description=OpenClaw Gateway");
+    expect(text).toContain("[Install]");
+  });
+
+  it("returns updated=false when the ExecStart already matches", () => {
+    const { text, updated } = updateExecStartInSystemdUnit(BASE_UNIT, [
+      "/usr/bin/node",
+      "/home/user/openclaw/dist/entry.js",
+      "gateway",
+      "--port",
+      "18789",
+    ]);
+    expect(updated).toBe(false);
+    expect(text).toBe(BASE_UNIT);
   });
 });

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -3,6 +3,23 @@ import type { GatewayServiceRenderArgs } from "./service-types.js";
 
 const SYSTEMD_LINE_BREAKS = /[\r\n]/;
 
+/**
+ * Filename for the OpenClaw-owned drop-in that carries managed environment
+ * variables. The drop-in is written into `<unit>.d/` next to the main unit so
+ * systemd composes it automatically at load time. Keeping managed env out of
+ * the main unit lets user-added `EnvironmentFile=`/`Environment=` directives
+ * survive upgrades that regenerate the managed state.
+ */
+export const OPENCLAW_MANAGED_DROPIN_FILENAME = "openclaw-managed.conf";
+
+/**
+ * Env var that tracks which keys in the managed drop-in (or, for legacy units,
+ * inline in the main unit) are OpenClaw-owned. Mirrors the constant in
+ * `src/commands/daemon-install-helpers.ts`; duplicated here to keep
+ * `systemd-unit.ts` free of cross-module imports.
+ */
+export const OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR = "OPENCLAW_SERVICE_MANAGED_ENV_KEYS";
+
 function assertNoSystemdLineBreaks(value: string, label: string): void {
   if (SYSTEMD_LINE_BREAKS.test(value)) {
     throw new Error(`${label} cannot contain CR or LF characters.`);
@@ -35,12 +52,65 @@ function renderEnvLines(env: Record<string, string | undefined> | undefined): st
   });
 }
 
+function parseManagedKeyList(raw: string | undefined): Set<string> {
+  if (!raw) {
+    return new Set();
+  }
+  const keys = new Set<string>();
+  for (const entry of raw.split(",")) {
+    const normalized = entry.trim().toUpperCase();
+    if (normalized) {
+      keys.add(normalized);
+    }
+  }
+  return keys;
+}
+
+/**
+ * Split an environment dict into managed and user partitions based on the
+ * `OPENCLAW_SERVICE_MANAGED_ENV_KEYS` sentinel. Managed keys (plus the sentinel
+ * itself) belong in the drop-in; everything else belongs in the main unit so
+ * user-added entries survive regeneration.
+ *
+ * If the sentinel is absent, all env is treated as user-owned — the caller
+ * gets back `{ managed: {}, user: environment }` and no drop-in gets written.
+ */
+export function splitSystemdManagedEnvironment(
+  environment: Record<string, string | undefined> | undefined,
+): {
+  managed: Record<string, string | undefined>;
+  user: Record<string, string | undefined>;
+} {
+  if (!environment) {
+    return { managed: {}, user: {} };
+  }
+  const sentinelValue = environment[OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR];
+  const managedKeys = parseManagedKeyList(sentinelValue ?? undefined);
+  if (managedKeys.size === 0) {
+    return { managed: {}, user: { ...environment } };
+  }
+  const managed: Record<string, string | undefined> = {};
+  const user: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(environment)) {
+    const upper = key.toUpperCase();
+    if (upper === OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR || managedKeys.has(upper)) {
+      managed[key] = value;
+      continue;
+    }
+    user[key] = value;
+  }
+  return { managed, user };
+}
+
 export function buildSystemdUnit({
   description,
   programArguments,
   workingDirectory,
   environment,
 }: GatewayServiceRenderArgs): string {
+  // Main-unit rendering excludes managed env — the managed drop-in carries it
+  // now so user customizations in the main unit survive openclaw update.
+  const { user } = splitSystemdManagedEnvironment(environment);
   const execStart = programArguments.map(systemdEscapeArg).join(" ");
   const descriptionValue = description?.trim() || "OpenClaw Gateway";
   assertNoSystemdLineBreaks(descriptionValue, "Systemd Description");
@@ -48,7 +118,7 @@ export function buildSystemdUnit({
   const workingDirLine = workingDirectory
     ? `WorkingDirectory=${systemdEscapeArg(workingDirectory)}`
     : null;
-  const envLines = renderEnvLines(environment);
+  const envLines = renderEnvLines(user);
   return [
     "[Unit]",
     descriptionLine,
@@ -77,6 +147,119 @@ export function buildSystemdUnit({
   ]
     .filter((line) => line !== null)
     .join("\n");
+}
+
+/**
+ * Render the OpenClaw-managed drop-in text. Contains only the `[Service]`
+ * section with `Environment=` lines for managed keys, plus a header comment
+ * flagging the file as auto-managed so users know not to hand-edit it.
+ *
+ * Returns an empty string when there is nothing to manage, so callers can skip
+ * writing the drop-in entirely in that case.
+ */
+export function buildSystemdManagedDropIn(
+  environment: Record<string, string | undefined> | undefined,
+): string {
+  const { managed } = splitSystemdManagedEnvironment(environment);
+  const envLines = renderEnvLines(managed);
+  if (envLines.length === 0) {
+    return "";
+  }
+  return [
+    "# Auto-managed by openclaw. Do not edit — customizations belong in the main unit.",
+    "# See https://github.com/openclaw/openclaw/issues/66248 for background.",
+    "",
+    "[Service]",
+    ...envLines,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Strip inline managed env from existing main-unit text while preserving
+ * everything else (comments, blank lines, user `Environment=`, `EnvironmentFile=`,
+ * and non-`[Service]` sections). Used by `openclaw update` to migrate legacy
+ * units that have managed env inline into the new drop-in layout without
+ * touching user customizations in the same file.
+ *
+ * Lines removed:
+ *   - `Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS=...` (the sentinel)
+ *   - `Environment=<KEY>=...` for every KEY listed in the sentinel's value
+ *
+ * Lines kept untouched:
+ *   - `EnvironmentFile=...`
+ *   - `Environment=` lines for keys not in the sentinel
+ *   - `[Unit]`, `[Service]`, `[Install]` headers
+ *   - Blank lines and comments
+ *   - Any other directive
+ */
+export function stripManagedEnvFromSystemdUnit(text: string): string {
+  const lines = text.split("\n");
+  let managedKeys: Set<string> | null = null;
+
+  // First pass: locate the sentinel line to discover what's managed.
+  for (const rawLine of lines) {
+    const parsed = parseEnvironmentDirective(rawLine);
+    if (!parsed) {
+      continue;
+    }
+    if (parsed.key.toUpperCase() === OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR) {
+      managedKeys = parseManagedKeyList(parsed.value);
+      break;
+    }
+  }
+
+  if (!managedKeys || managedKeys.size === 0) {
+    // Nothing to strip — no sentinel means no inline managed state.
+    return text;
+  }
+
+  const filtered: string[] = [];
+  for (const rawLine of lines) {
+    const parsed = parseEnvironmentDirective(rawLine);
+    if (parsed) {
+      const upper = parsed.key.toUpperCase();
+      if (upper === OPENCLAW_MANAGED_SERVICE_ENV_KEYS_VAR || managedKeys.has(upper)) {
+        continue;
+      }
+    }
+    filtered.push(rawLine);
+  }
+  return filtered.join("\n");
+}
+
+/**
+ * Replace the `ExecStart=` line in an existing unit, preserving all other
+ * content. Returns the original text unchanged if no `ExecStart=` line is
+ * found (caller should treat that as a corrupt unit and rewrite from scratch).
+ *
+ * Used by `openclaw update` to propagate entry-filename bumps across versions
+ * without wiping user customizations elsewhere in the main unit.
+ */
+export function updateExecStartInSystemdUnit(
+  text: string,
+  programArguments: readonly string[],
+): { text: string; updated: boolean } {
+  const newExecStart = `ExecStart=${programArguments.map(systemdEscapeArg).join(" ")}`;
+  const lines = text.split("\n");
+  let updated = false;
+  const next = lines.map((line) => {
+    if (line.startsWith("ExecStart=") && line !== newExecStart) {
+      updated = true;
+      return newExecStart;
+    }
+    return line;
+  });
+  return { text: next.join("\n"), updated };
+}
+
+function parseEnvironmentDirective(rawLine: string): { key: string; value: string } | null {
+  const trimmed = rawLine.trim();
+  if (!trimmed.startsWith("Environment=")) {
+    return null;
+  }
+  const raw = trimmed.slice("Environment=".length).trim();
+  return parseSystemdEnvAssignment(raw);
 }
 
 export function parseSystemdExecStart(value: string): string[] {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -16,6 +16,7 @@ vi.mock("node:child_process", async () => {
   );
 });
 
+import path from "node:path";
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import { parseSystemdExecStart } from "./systemd-unit.js";
 import {
@@ -25,7 +26,9 @@ import {
   parseSystemdShow,
   readSystemdServiceExecStart,
   restartSystemdService,
+  resolveSystemdUserManagedDropInPath,
   resolveSystemdUserUnitPath,
+  stageSystemdService,
   stopSystemdService,
 } from "./systemd.js";
 
@@ -785,5 +788,181 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     await assertRestartSuccess({ USER: "debian" });
+  });
+});
+
+describe("stageSystemdService drop-in migration", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    // Every writeSystemdUnit path asserts systemd is available before touching
+    // disk. Return success for any systemctl call so the integration can focus
+    // on file-write behavior.
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(null, "", "");
+    });
+  });
+
+  async function makeTempHome(): Promise<string> {
+    const tmpRoot = os.tmpdir();
+    const tmpHome = await fs.mkdtemp(path.join(tmpRoot, "openclaw-systemd-test-"));
+    return tmpHome;
+  }
+
+  it("writes main unit + managed drop-in on a fresh install", async () => {
+    const tmpHome = await makeTempHome();
+    const env = { HOME: tmpHome };
+    const { stdout } = createWritableStreamMock();
+
+    await stageSystemdService({
+      env,
+      stdout,
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/node", "/opt/openclaw/dist/index.js", "gateway", "--port", "18789"],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "fresh-token",
+        OPENCLAW_SERVICE_VERSION: "2026.4.12",
+        OPENCLAW_SERVICE_MANAGED_ENV_KEYS: "OPENCLAW_GATEWAY_TOKEN,OPENCLAW_SERVICE_VERSION",
+        HOME: tmpHome,
+        PATH: "/usr/bin",
+      },
+    });
+
+    const unitPath = resolveSystemdUserUnitPath(env);
+    const dropInPath = resolveSystemdUserManagedDropInPath(env);
+    const unitText = await fs.readFile(unitPath, "utf8");
+    const dropInText = await fs.readFile(dropInPath, "utf8");
+
+    // Main unit has non-managed env inline but no managed keys or sentinel.
+    expect(unitText).toContain("ExecStart=/usr/bin/node /opt/openclaw/dist/index.js gateway --port 18789");
+    expect(unitText).toContain(`Environment=HOME=${tmpHome}`);
+    expect(unitText).toContain("Environment=PATH=/usr/bin");
+    expect(unitText).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+    expect(unitText).not.toContain("OPENCLAW_SERVICE_MANAGED_ENV_KEYS");
+
+    // Drop-in carries the managed keys + sentinel.
+    expect(dropInText).toContain("Environment=OPENCLAW_GATEWAY_TOKEN=fresh-token");
+    expect(dropInText).toContain("Environment=OPENCLAW_SERVICE_VERSION=2026.4.12");
+    expect(dropInText).toContain(
+      "Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS=OPENCLAW_GATEWAY_TOKEN,OPENCLAW_SERVICE_VERSION",
+    );
+    expect(dropInText).toContain("Auto-managed by openclaw");
+  });
+
+  it("migrates inline managed env out of a legacy unit while preserving user EnvironmentFile= and Environment=", async () => {
+    const tmpHome = await makeTempHome();
+    const env = { HOME: tmpHome };
+    const { stdout } = createWritableStreamMock();
+
+    // Seed a legacy-style unit with inline managed env + user customizations.
+    const unitPath = resolveSystemdUserUnitPath(env);
+    await fs.mkdir(path.dirname(unitPath), { recursive: true });
+    const legacyUnit = [
+      "[Unit]",
+      "Description=OpenClaw Gateway (v2026.4.11)",
+      "",
+      "[Service]",
+      "ExecStart=/usr/bin/node /opt/openclaw/dist/entry.js gateway --port 18789",
+      "Restart=always",
+      "Environment=OPENCLAW_GATEWAY_TOKEN=legacy-token",
+      "Environment=OPENCLAW_SERVICE_VERSION=2026.4.11",
+      `EnvironmentFile=${tmpHome}/.openclaw/workspace/.env`,
+      `Environment=HOME=${tmpHome}`,
+      "Environment=USER_ADDED_VAR=keep-this",
+      "Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS=OPENCLAW_GATEWAY_TOKEN,OPENCLAW_SERVICE_VERSION",
+      "",
+      "[Install]",
+      "WantedBy=default.target",
+      "",
+    ].join("\n");
+    await fs.writeFile(unitPath, legacyUnit, "utf8");
+
+    await stageSystemdService({
+      env,
+      stdout,
+      description: "OpenClaw Gateway",
+      // Entry filename intentionally bumped entry.js -> index.js to verify
+      // the targeted ExecStart update hits only that line.
+      programArguments: ["/usr/bin/node", "/opt/openclaw/dist/index.js", "gateway", "--port", "18789"],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "rotated-token",
+        OPENCLAW_SERVICE_VERSION: "2026.4.12",
+        OPENCLAW_SERVICE_MANAGED_ENV_KEYS: "OPENCLAW_GATEWAY_TOKEN,OPENCLAW_SERVICE_VERSION",
+        HOME: tmpHome,
+      },
+    });
+
+    const dropInPath = resolveSystemdUserManagedDropInPath(env);
+    const unitText = await fs.readFile(unitPath, "utf8");
+    const dropInText = await fs.readFile(dropInPath, "utf8");
+
+    // Managed env is gone from the main unit.
+    expect(unitText).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+    expect(unitText).not.toContain("OPENCLAW_SERVICE_VERSION=");
+    expect(unitText).not.toContain("OPENCLAW_SERVICE_MANAGED_ENV_KEYS");
+
+    // User customizations survived migration byte-for-byte.
+    expect(unitText).toContain(`EnvironmentFile=${tmpHome}/.openclaw/workspace/.env`);
+    expect(unitText).toContain("Environment=USER_ADDED_VAR=keep-this");
+    expect(unitText).toContain(`Environment=HOME=${tmpHome}`);
+    expect(unitText).toContain("[Install]");
+    expect(unitText).toContain("WantedBy=default.target");
+
+    // ExecStart was updated (entry.js -> index.js) without touching anything
+    // else on that line or adjacent lines.
+    expect(unitText).toContain("ExecStart=/usr/bin/node /opt/openclaw/dist/index.js gateway --port 18789");
+    expect(unitText).not.toContain("dist/entry.js");
+
+    // Drop-in holds the rotated managed values; old values are not sticky.
+    expect(dropInText).toContain("Environment=OPENCLAW_GATEWAY_TOKEN=rotated-token");
+    expect(dropInText).toContain("Environment=OPENCLAW_SERVICE_VERSION=2026.4.12");
+    expect(dropInText).not.toContain("legacy-token");
+    expect(dropInText).not.toContain("2026.4.11");
+
+    // Backup of the pre-migration unit is captured alongside.
+    await expect(fs.access(`${unitPath}.bak`)).resolves.toBeUndefined();
+  });
+
+  it("leaves main unit byte-identical when nothing drifted between upgrades", async () => {
+    const tmpHome = await makeTempHome();
+    const env = { HOME: tmpHome };
+    const { stdout } = createWritableStreamMock();
+
+    // First install — writes the initial main unit + drop-in.
+    const programArguments = [
+      "/usr/bin/node",
+      "/opt/openclaw/dist/index.js",
+      "gateway",
+      "--port",
+      "18789",
+    ];
+    const baseEnv = {
+      OPENCLAW_GATEWAY_TOKEN: "token",
+      OPENCLAW_SERVICE_MANAGED_ENV_KEYS: "OPENCLAW_GATEWAY_TOKEN",
+      HOME: tmpHome,
+    };
+    await stageSystemdService({
+      env,
+      stdout,
+      description: "OpenClaw Gateway",
+      programArguments,
+      environment: baseEnv,
+    });
+
+    const unitPath = resolveSystemdUserUnitPath(env);
+    const firstUnit = await fs.readFile(unitPath, "utf8");
+
+    // Second install with the same ExecStart and same user env — main unit
+    // should be untouched (not even a .bak should appear).
+    await stageSystemdService({
+      env,
+      stdout,
+      description: "OpenClaw Gateway",
+      programArguments,
+      environment: { ...baseEnv, OPENCLAW_GATEWAY_TOKEN: "rotated-token" },
+    });
+
+    const secondUnit = await fs.readFile(unitPath, "utf8");
+    expect(secondUnit).toBe(firstUnit);
+    await expect(fs.access(`${unitPath}.bak`)).rejects.toThrow();
   });
 });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -793,6 +793,10 @@ describe("systemd service control", () => {
 
 describe("stageSystemdService drop-in migration", () => {
   beforeEach(() => {
+    // Clear fs.readFile spies from earlier describe blocks so this one runs
+    // against real fs. We want real file-write behavior here — only the
+    // systemctl probe should be mocked.
+    vi.restoreAllMocks();
     execFileMock.mockReset();
     // Every writeSystemdUnit path asserts systemd is available before touching
     // disk. Return success for any systemctl call so the integration can focus

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -525,7 +525,8 @@ describe("readSystemdServiceExecStart", () => {
 
     const command = await readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME });
     expect(command?.environment?.OPENCLAW_GATEWAY_TOKEN).toBe("env-file-token");
-    expect(readFileSpy).toHaveBeenCalledTimes(2);
+    // Main unit + managed drop-in probe (absent here) + resolved env file.
+    expect(readFileSpy).toHaveBeenCalledTimes(3);
   });
 
   it("lets EnvironmentFile override inline Environment values", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -35,9 +35,14 @@ import {
   isSystemdUserBusUnavailableDetail,
 } from "./systemd-unavailable.js";
 import {
+  buildSystemdManagedDropIn,
   buildSystemdUnit,
+  OPENCLAW_MANAGED_DROPIN_FILENAME,
   parseSystemdEnvAssignment,
   parseSystemdExecStart,
+  splitSystemdManagedEnvironment,
+  stripManagedEnvFromSystemdUnit,
+  updateExecStartInSystemdUnit,
 } from "./systemd-unit.js";
 
 function resolveSystemdUnitPathForName(env: GatewayServiceEnv, name: string): string {
@@ -57,8 +62,19 @@ function resolveSystemdUnitPath(env: GatewayServiceEnv): string {
   return resolveSystemdUnitPathForName(env, resolveSystemdServiceName(env));
 }
 
+function resolveSystemdManagedDropInPath(env: GatewayServiceEnv): string {
+  const unitPath = resolveSystemdUnitPath(env);
+  const unitDir = path.posix.dirname(unitPath);
+  const unitFile = path.posix.basename(unitPath);
+  return path.posix.join(unitDir, `${unitFile}.d`, OPENCLAW_MANAGED_DROPIN_FILENAME);
+}
+
 export function resolveSystemdUserUnitPath(env: GatewayServiceEnv): string {
   return resolveSystemdUnitPath(env);
+}
+
+export function resolveSystemdUserManagedDropInPath(env: GatewayServiceEnv): string {
+  return resolveSystemdManagedDropInPath(env);
 }
 
 export { enableSystemdUserLinger, readSystemdUserLingerStatus };
@@ -66,58 +82,87 @@ export type { SystemdUserLingerStatus };
 
 // Unit file parsing/rendering: see systemd-unit.ts
 
+function parseSystemdUnitText(text: string): {
+  execStart: string;
+  workingDirectory: string;
+  inlineEnvironment: Record<string, string>;
+  environmentFileSpecs: string[];
+} {
+  let execStart = "";
+  let workingDirectory = "";
+  const inlineEnvironment: Record<string, string> = {};
+  const environmentFileSpecs: string[] = [];
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    if (line.startsWith("ExecStart=")) {
+      execStart = line.slice("ExecStart=".length).trim();
+    } else if (line.startsWith("WorkingDirectory=")) {
+      workingDirectory = line.slice("WorkingDirectory=".length).trim();
+    } else if (line.startsWith("Environment=")) {
+      const raw = line.slice("Environment=".length).trim();
+      const parsed = parseSystemdEnvAssignment(raw);
+      if (parsed) {
+        inlineEnvironment[parsed.key] = parsed.value;
+      }
+    } else if (line.startsWith("EnvironmentFile=")) {
+      const raw = line.slice("EnvironmentFile=".length).trim();
+      if (raw) {
+        environmentFileSpecs.push(raw);
+      }
+    }
+  }
+  return { execStart, workingDirectory, inlineEnvironment, environmentFileSpecs };
+}
+
 export async function readSystemdServiceExecStart(
   env: GatewayServiceEnv,
 ): Promise<GatewayServiceCommandConfig | null> {
   const unitPath = resolveSystemdUnitPath(env);
+  const dropInPath = resolveSystemdManagedDropInPath(env);
   try {
-    const content = await fs.readFile(unitPath, "utf8");
-    let execStart = "";
-    let workingDirectory = "";
-    const inlineEnvironment: Record<string, string> = {};
-    const environmentFileSpecs: string[] = [];
-    for (const rawLine of content.split("\n")) {
-      const line = rawLine.trim();
-      if (!line || line.startsWith("#")) {
-        continue;
-      }
-      if (line.startsWith("ExecStart=")) {
-        execStart = line.slice("ExecStart=".length).trim();
-      } else if (line.startsWith("WorkingDirectory=")) {
-        workingDirectory = line.slice("WorkingDirectory=".length).trim();
-      } else if (line.startsWith("Environment=")) {
-        const raw = line.slice("Environment=".length).trim();
-        const parsed = parseSystemdEnvAssignment(raw);
-        if (parsed) {
-          inlineEnvironment[parsed.key] = parsed.value;
-        }
-      } else if (line.startsWith("EnvironmentFile=")) {
-        const raw = line.slice("EnvironmentFile=".length).trim();
-        if (raw) {
-          environmentFileSpecs.push(raw);
-        }
-      }
-    }
-    if (!execStart) {
+    const mainContent = await fs.readFile(unitPath, "utf8");
+    const main = parseSystemdUnitText(mainContent);
+    if (!main.execStart) {
       return null;
     }
+
+    // Merge drop-in env as a separate inline source so the install-time
+    // preservation pipeline sees every key the running service actually has.
+    // Drop-in values override main-unit inline values by design: operators
+    // depend on the managed drop-in to carry the canonical token/version
+    // state across upgrades.
+    const dropInContent = await readOptionalFile(dropInPath);
+    const dropInParsed = dropInContent ? parseSystemdUnitText(dropInContent) : null;
+
+    const combinedInlineEnvironment: Record<string, string> = {
+      ...main.inlineEnvironment,
+      ...(dropInParsed?.inlineEnvironment ?? {}),
+    };
+    const combinedEnvironmentFileSpecs: string[] = [
+      ...main.environmentFileSpecs,
+      ...(dropInParsed?.environmentFileSpecs ?? []),
+    ];
+
     const environmentFromFiles = await resolveSystemdEnvironmentFiles({
-      environmentFileSpecs,
+      environmentFileSpecs: combinedEnvironmentFileSpecs,
       env,
       unitPath,
     });
     const mergedEnvironment = {
-      ...inlineEnvironment,
+      ...combinedInlineEnvironment,
       ...environmentFromFiles.environment,
     };
     const mergedEnvironmentSources = {
-      ...buildEnvironmentValueSources(inlineEnvironment, "inline"),
+      ...buildEnvironmentValueSources(combinedInlineEnvironment, "inline"),
       ...buildEnvironmentValueSources(environmentFromFiles.environment, "file"),
     };
-    const programArguments = parseSystemdExecStart(execStart);
+    const programArguments = parseSystemdExecStart(main.execStart);
     return {
       programArguments,
-      ...(workingDirectory ? { workingDirectory } : {}),
+      ...(main.workingDirectory ? { workingDirectory: main.workingDirectory } : {}),
       ...(Object.keys(mergedEnvironment).length > 0 ? { environment: mergedEnvironment } : {}),
       ...(Object.keys(mergedEnvironmentSources).length > 0
         ? { environmentValueSources: mergedEnvironmentSources }
@@ -425,45 +470,126 @@ async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as Ga
   throw new Error(`systemctl --user unavailable: ${detail || "unknown error"}`.trim());
 }
 
+async function readOptionalFile(pathname: string): Promise<string | null> {
+  try {
+    return await fs.readFile(pathname, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
 async function writeSystemdUnit({
   env,
   programArguments,
   workingDirectory,
   environment,
   description,
-}: Omit<GatewayServiceInstallArgs, "stdout">): Promise<{ unitPath: string; backedUp: boolean }> {
+}: Omit<GatewayServiceInstallArgs, "stdout">): Promise<{
+  unitPath: string;
+  dropInPath: string;
+  backedUp: boolean;
+  mainUnitWritten: boolean;
+  dropInWritten: boolean;
+  migratedInlineManagedEnv: boolean;
+}> {
   await assertSystemdAvailable(env);
 
   const unitPath = resolveSystemdUnitPath(env);
+  const dropInPath = resolveSystemdManagedDropInPath(env);
   await fs.mkdir(path.dirname(unitPath), { recursive: true });
-
-  // Preserve user customizations: back up existing unit file before overwriting.
-  let backedUp = false;
-  try {
-    await fs.access(unitPath);
-    const backupPath = `${unitPath}.bak`;
-    await fs.copyFile(unitPath, backupPath);
-    backedUp = true;
-  } catch {
-    // File does not exist yet — nothing to back up.
-  }
+  await fs.mkdir(path.dirname(dropInPath), { recursive: true });
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
-  const unit = buildSystemdUnit({
-    description: serviceDescription,
-    programArguments,
-    workingDirectory,
-    environment,
-  });
-  await fs.writeFile(unitPath, unit, "utf8");
-  return { unitPath, backedUp };
+  const { managed } = splitSystemdManagedEnvironment(environment);
+  const dropInText = buildSystemdManagedDropIn(environment);
+
+  const existingUnit = await readOptionalFile(unitPath);
+  let backedUp = false;
+  let mainUnitWritten = false;
+  let migratedInlineManagedEnv = false;
+
+  if (existingUnit === null) {
+    // Fresh install — write a clean main unit with only user-preserved env.
+    // Managed keys go into the drop-in exclusively so future upgrades can
+    // rewrite the drop-in freely without touching the main unit.
+    const freshUnit = buildSystemdUnit({
+      description: serviceDescription,
+      programArguments,
+      workingDirectory,
+      environment,
+    });
+    await fs.writeFile(unitPath, freshUnit, "utf8");
+    mainUnitWritten = true;
+  } else {
+    // Existing unit — migrate inline managed env out if present, update
+    // ExecStart when the entry path has drifted between versions, and keep
+    // everything else (user EnvironmentFile=, user Environment=, comments,
+    // custom [Service] directives) verbatim.
+    const strippedText = stripManagedEnvFromSystemdUnit(existingUnit);
+    migratedInlineManagedEnv = strippedText !== existingUnit;
+    const { text: execStartUpdated, updated: execStartChanged } = updateExecStartInSystemdUnit(
+      strippedText,
+      programArguments,
+    );
+
+    if (execStartUpdated !== existingUnit) {
+      // Back up before rewriting so operators can diff if the migration or
+      // ExecStart update removes something unexpected.
+      const backupPath = `${unitPath}.bak`;
+      await fs.copyFile(unitPath, backupPath);
+      backedUp = true;
+      await fs.writeFile(unitPath, execStartUpdated, "utf8");
+      mainUnitWritten = true;
+    }
+
+    // Touching only the drop-in on pure-env changes keeps the main unit
+    // byte-identical across upgrades when nothing else drifted. execStartChanged
+    // is captured separately so callers/log surfaces can reason about why the
+    // main unit changed when it did.
+    void execStartChanged;
+  }
+
+  let dropInWritten = false;
+  if (dropInText) {
+    await fs.writeFile(dropInPath, dropInText, "utf8");
+    dropInWritten = true;
+  } else {
+    // No managed env this round — remove a stale drop-in so we never leave
+    // orphan managed state on disk after a reconfiguration shrinks the
+    // managed set to zero.
+    try {
+      await fs.unlink(dropInPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  // Silence unused-variable lint when `managed` is empty but we still want the
+  // split result available for future introspection hooks without exporting
+  // another readCommand seam.
+  void managed;
+
+  return {
+    unitPath,
+    dropInPath,
+    backedUp,
+    mainUnitWritten,
+    dropInWritten,
+    migratedInlineManagedEnv,
+  };
 }
 
 export async function stageSystemdService({
   stdout,
   ...args
-}: GatewayServiceInstallArgs): Promise<{ unitPath: string }> {
-  const { unitPath, backedUp } = await writeSystemdUnit(args);
+}: GatewayServiceInstallArgs): Promise<{ unitPath: string; dropInPath: string }> {
+  const { unitPath, dropInPath, backedUp, dropInWritten, migratedInlineManagedEnv } =
+    await writeSystemdUnit(args);
   writeFormattedLines(
     stdout,
     [
@@ -471,6 +597,22 @@ export async function stageSystemdService({
         label: "Staged systemd service",
         value: unitPath,
       },
+      ...(dropInWritten
+        ? [
+            {
+              label: "Managed env drop-in",
+              value: dropInPath,
+            },
+          ]
+        : []),
+      ...(migratedInlineManagedEnv
+        ? [
+            {
+              label: "Migrated inline managed env to drop-in",
+              value: dropInPath,
+            },
+          ]
+        : []),
       ...(backedUp
         ? [
             {
@@ -482,7 +624,7 @@ export async function stageSystemdService({
     ],
     { leadingBlankLine: true },
   );
-  return { unitPath };
+  return { unitPath, dropInPath };
 }
 
 async function activateSystemdService(params: { env: GatewayServiceEnv }) {
@@ -506,8 +648,9 @@ async function activateSystemdService(params: { env: GatewayServiceEnv }) {
 
 export async function installSystemdService(
   args: GatewayServiceInstallArgs,
-): Promise<{ unitPath: string }> {
-  const { unitPath, backedUp } = await writeSystemdUnit(args);
+): Promise<{ unitPath: string; dropInPath: string }> {
+  const { unitPath, dropInPath, backedUp, dropInWritten, migratedInlineManagedEnv } =
+    await writeSystemdUnit(args);
   await activateSystemdService({ env: args.env });
   writeFormattedLines(
     args.stdout,
@@ -516,6 +659,22 @@ export async function installSystemdService(
         label: "Installed systemd service",
         value: unitPath,
       },
+      ...(dropInWritten
+        ? [
+            {
+              label: "Managed env drop-in",
+              value: dropInPath,
+            },
+          ]
+        : []),
+      ...(migratedInlineManagedEnv
+        ? [
+            {
+              label: "Migrated inline managed env to drop-in",
+              value: dropInPath,
+            },
+          ]
+        : []),
       ...(backedUp
         ? [
             {
@@ -527,7 +686,7 @@ export async function installSystemdService(
     ],
     { leadingBlankLine: true },
   );
-  return { unitPath };
+  return { unitPath, dropInPath };
 }
 
 export async function uninstallSystemdService({
@@ -545,6 +704,24 @@ export async function uninstallSystemdService({
     stdout.write(`${formatLine("Removed systemd service", unitPath)}\n`);
   } catch {
     stdout.write(`Systemd service not found at ${unitPath}\n`);
+  }
+
+  // Also remove the managed drop-in (if any) and its parent `.d/` directory
+  // when it becomes empty. Leaves untouched any user drop-ins the operator
+  // added alongside the managed one.
+  const dropInPath = resolveSystemdManagedDropInPath(env);
+  try {
+    await fs.unlink(dropInPath);
+    stdout.write(`${formatLine("Removed managed env drop-in", dropInPath)}\n`);
+  } catch {
+    // Missing drop-in is the common case for pre-drop-in installs or fresh
+    // unit configurations; do not surface that as an error.
+  }
+  try {
+    const dropInDir = path.posix.dirname(dropInPath);
+    await fs.rmdir(dropInDir);
+  } catch {
+    // Directory is either missing or still holds user drop-ins — leave it alone.
   }
 }
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -134,7 +134,7 @@ export async function readSystemdServiceExecStart(
     // Drop-in values override main-unit inline values by design: operators
     // depend on the managed drop-in to carry the canonical token/version
     // state across upgrades.
-    const dropInContent = await readOptionalFile(dropInPath);
+    const dropInContent = await readManagedDropInForMerge(dropInPath);
     const dropInParsed = dropInContent ? parseSystemdUnitText(dropInContent) : null;
 
     const combinedInlineEnvironment: Record<string, string> = {
@@ -470,7 +470,7 @@ async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as Ga
   throw new Error(`systemctl --user unavailable: ${detail || "unknown error"}`.trim());
 }
 
-async function readOptionalFile(pathname: string): Promise<string | null> {
+async function readUnitFileIfPresent(pathname: string): Promise<string | null> {
   try {
     return await fs.readFile(pathname, "utf8");
   } catch (error) {
@@ -478,6 +478,19 @@ async function readOptionalFile(pathname: string): Promise<string | null> {
       return null;
     }
     throw error;
+  }
+}
+
+async function readManagedDropInForMerge(pathname: string): Promise<string | null> {
+  try {
+    return await fs.readFile(pathname, "utf8");
+  } catch {
+    // Drop-in is strictly additive context for the merge view — an
+    // unreadable drop-in must not fail the whole read, whether the cause is
+    // ENOENT, a permission issue, or a stale mount. Mirrors
+    // `resolveSystemdEnvironmentFiles`'s policy for missing EnvironmentFile=
+    // entries.
+    return null;
   }
 }
 
@@ -506,7 +519,7 @@ async function writeSystemdUnit({
   const { managed } = splitSystemdManagedEnvironment(environment);
   const dropInText = buildSystemdManagedDropIn(environment);
 
-  const existingUnit = await readOptionalFile(unitPath);
+  const existingUnit = await readUnitFileIfPresent(unitPath);
   let backedUp = false;
   let mainUnitWritten = false;
   let migratedInlineManagedEnv = false;

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -139,7 +139,7 @@ export async function readSystemdServiceExecStart(
 
     const combinedInlineEnvironment: Record<string, string> = {
       ...main.inlineEnvironment,
-      ...(dropInParsed?.inlineEnvironment ?? {}),
+      ...dropInParsed?.inlineEnvironment,
     };
     const combinedEnvironmentFileSpecs: string[] = [
       ...main.environmentFileSpecs,


### PR DESCRIPTION
## Summary

- **Problem:** Every `openclaw update` regenerates `~/.config/systemd/user/openclaw-gateway.service` and silently drops user-added `EnvironmentFile=` or extra `Environment=` directives. The next gateway start then crash-loops on `SecretRefResolutionError: Environment variable "KIMI_API_KEY" is missing or empty` (or whichever secret the lost env file was carrying).
- **Why it matters:** Every minor upgrade re-bites the same users, the failure mode is misleading (`SecretRefResolutionError` looks like fresh secrets misconfiguration, not "your unit was rewritten 2 minutes ago"), and the existing preservation pipeline can't reliably recover inline env when the read path encounters permission or timing issues.
- **What changed:** Managed env (the `OPENCLAW_SERVICE_MANAGED_ENV_KEYS` set) now lives in its own OpenClaw-owned drop-in at `<unit>.d/openclaw-managed.conf`. The main unit is written once on fresh install and from then on is user-owned; upgrades only touch `ExecStart=` if the entry path drifted (targeted single-line edit) and leave everything else byte-identical. Legacy units with inline managed env get migrated into the new layout on the first install/update under the new code, with a `.bak` captured so operators can diff.
- **What did NOT change (scope boundary):** macOS launchd, Windows Scheduled Task, and the CLI entry points. This PR is systemd-only. Issue #45163 is the launchd analog and needs a different mechanism (launchd has no drop-in equivalent); Windows has a similar shape. Both are out of scope here. The managed-env tracking mechanism (`OPENCLAW_SERVICE_MANAGED_ENV_KEYS` in `src/commands/daemon-install-helpers.ts`) is reused as-is — this PR only changes **where** that set is written.

Fixes #66248.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #66248
- Related #41914 (update removes unit entirely — different symptom, related lifecycle bug)
- Related #66219 (doctor --repair re-embeds sensitive tokens — same root cause: regeneration loses user state)
- Related #54521, #57104 (inlining `.env` secrets / stale tokens in unit — relieved by moving managed keys to a drop-in that owners know not to hand-edit)
- Related #53926 (install-time EnvironmentFile path mismatch)
- Related #45163 (same pattern on macOS LaunchAgent — NOT addressed here, needs its own fix)
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `writeSystemdUnit()` (`src/daemon/systemd.ts`) rewrites the entire unit file on every install/update. Managed env is written as inline `Environment=` lines alongside user-added directives, so any regeneration that misses a user's `EnvironmentFile=` (for permissions, timing, or path-resolution reasons at read time) silently strips it. The `collectPreservedExistingServiceEnvVars()` helper in `daemon-install-helpers.ts` is meant to preserve inline user env, but (a) it depends on `readSystemdServiceExecStart()` successfully reading the previous unit and resolving every referenced `EnvironmentFile=`, and (b) even when it works, it loses the `EnvironmentFile=` **directive itself** — only the resolved key/value pairs are fed forward, inline-ified, and often stripped again next round.
- **Missing detection / guardrail:** No test or CI gate asserted that user-added directives in the main unit survive an install → install round-trip. The unit generator didn't distinguish OpenClaw-owned content from user-owned content even though the `OPENCLAW_SERVICE_MANAGED_ENV_KEYS` sentinel already tracks exactly that distinction.
- **Contributing context (if known):** The pattern has bitten users across multiple minor upgrades (documented locally as far back as 2026.4.2, reproduced again on 2026.4.12). The `gateway install --force` and `openclaw doctor --fix` paths flow through the same writer, so the same behavior shows up as several different-looking issues (#41914, #66219, #54521, #57104).

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/daemon/systemd-unit.test.ts` (pure-function coverage for strip/split/drop-in/ExecStart helpers) + `src/daemon/systemd.test.ts` (integration against real tempdir for `stageSystemdService` fresh/migrate/no-op paths).
- Scenario the test should lock in: user-added `EnvironmentFile=` and `Environment=USER_ADDED_VAR=...` in the main unit survive a legacy-to-new-layout install; ExecStart drift is updated with a single-line edit; repeat installs with identical inputs leave the main unit byte-identical (no `.bak` appears).
- Why this is the smallest reliable guardrail: the pure-function tests pin the transform invariants (strip preserves everything outside the managed set, ExecStart update touches only that one line, drop-in output is deterministic). The integration tests pin the file-system wiring. Together they cover the load-bearing behavior without standing up systemctl.
- Existing test that already covers this (if any): none — `systemd-unit.test.ts` and `systemd.test.ts` previously had no coverage for the regen/preservation contract.

## User-visible / Behavior Changes

- A new drop-in file appears at `~/.config/systemd/user/openclaw-gateway.service.d/openclaw-managed.conf` after the next install/update. It carries `OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_SERVICE_VERSION`, `TELEGRAM_BOT_TOKEN`, and any other keys listed in `OPENCLAW_SERVICE_MANAGED_ENV_KEYS`.
- The main unit no longer contains those keys after the migration runs. `.bak` of the pre-migration unit is written alongside it.
- `openclaw gateway uninstall` now removes the drop-in and its `<unit>.d/` directory (when empty).
- `readSystemdServiceExecStart` (used by `gateway status --deep` and `doctor`) now merges drop-in values into its audit view so reporting stays consistent with what systemd actually loads.
- No config or env changes required from users.

## Diagram

```text
Before:
openclaw update
  -> writeSystemdUnit(env) rewrites ENTIRE main unit
  -> user EnvironmentFile= / Environment= lost
  -> gateway restart -> SecretRefResolutionError

After:
First install:
  -> main unit written once with only user/unmanaged env inline
  -> drop-in written at <unit>.d/openclaw-managed.conf with managed env + sentinel

Subsequent update:
  -> main unit read
  -> inline managed env (if legacy) stripped into drop-in (one-time migration, .bak taken)
  -> ExecStart updated ONLY if the entry path drifted (single-line edit)
  -> everything else in main unit byte-identical
  -> drop-in rewritten freely with latest managed values
```

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes` (managed secrets move from main unit to a managed drop-in; both live under the same user-owned `~/.config/systemd/user/` tree with identical `0644` permissions, so the trust boundary and storage location are effectively unchanged)
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: The drop-in file has the same owner and permissions as the main unit. Splitting managed state into its own file actually **reduces** the blast radius of accidental hand-edits or regen bugs: users who edit the main unit no longer risk clobbering OpenClaw-managed tokens, and regen bugs in the managed writer no longer risk clobbering user directives. The drop-in header explicitly flags the file as auto-managed.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (kernel 6.17), and reproducible in the repo's `openclaw-prbuild` LXC (unprivileged)
- Runtime/container: systemd user service, Node 22 + pnpm 10.32.1
- Model/provider: N/A (install/update path, no model involvement)
- Integration/channel (if any): N/A
- Relevant config (redacted): `~/.openclaw/workspace/.env` with `KIMI_API_KEY`, `OPENCLAW_GATEWAY_TOKEN`, etc.; user-added `EnvironmentFile=/home/<user>/.openclaw/workspace/.env` in the main unit after a prior install.

### Steps

1. Install OpenClaw 2026.4.11 or earlier, let `gateway install` write the systemd unit.
2. Add `EnvironmentFile=/home/<user>/.openclaw/workspace/.env` to the unit (needed because the shipped unit inlines tokens but does not pull supplementary secrets from the `.env` the rest of OpenClaw writes to).
3. Run `openclaw update --yes`.
4. Gateway restart attempt runs; service fails.

### Expected

- Gateway starts cleanly after the update, loading `KIMI_API_KEY` (or whichever secret the user-added `EnvironmentFile=` was carrying).
- Main unit's user-added directives stay in place.

### Actual (before this PR)

- Main unit regenerated wholesale without the `EnvironmentFile=` directive.
- Gateway crash-loops: `[secrets] [SECRETS_RELOADER_DEGRADED] SecretRefResolutionError: Environment variable "KIMI_API_KEY" is missing or empty. Gateway failed to start: Error: Startup failed: required secrets are unavailable.`

## Evidence

- [x] Failing test/log before + passing after

**Before** — actual crash log captured on a real host that ran `openclaw update` from 2026.4.11 → 2026.4.12:

```
Apr 13 19:49:53 rocinante node[2776813]: [secrets] [SECRETS_RELOADER_DEGRADED] SecretRefResolutionError: Environment variable "KIMI_API_KEY" is missing or empty.
Apr 13 19:49:53 rocinante node[2776813]: Gateway failed to start: Error: Startup failed: required secrets are unavailable.
Apr 13 19:49:53 rocinante systemd[3958]: openclaw-gateway.service: Main process exited, code=exited, status=1/FAILURE
Apr 13 19:49:53 rocinante systemd[3958]: openclaw-gateway.service: Failed with result 'exit-code'.
Apr 13 19:49:59 rocinante systemd[3958]: openclaw-gateway.service: Scheduled restart job, restart counter is at 1.
```

The pre-upgrade unit had `EnvironmentFile=/home/<user>/.openclaw/workspace/.env` between `Environment=GEMINI_API_KEY=…` and `Environment=HOME=…`. The post-upgrade unit was missing that line entirely, causing the restart loop.

**After** — test suite in CT 112:

```
RUN v4.1.4 /home/solomon/openclaw-fork
✓ daemon src/daemon/systemd.test.ts (48 tests) 21ms
✓ unit-fast src/daemon/systemd-unit.test.ts (19 tests) 7ms

Test Files  2 passed (2)
     Tests  67 passed (67)
```

Key integration test names (see `src/daemon/systemd.test.ts`):

- `stageSystemdService drop-in migration > writes main unit + managed drop-in on a fresh install`
- `stageSystemdService drop-in migration > migrates inline managed env out of a legacy unit while preserving user EnvironmentFile= and Environment=`
- `stageSystemdService drop-in migration > leaves main unit byte-identical when nothing drifted between upgrades`

## Human Verification (required)

- Verified scenarios:
  - Full test suite for `src/daemon/` (67 tests) passes clean in the repo's `openclaw-prbuild` LXC (Ubuntu + systemd, pnpm 10.32.1, Node 22).
  - `pnpm tsgo` clean.
  - Repro reproduced on a live production gateway on 2026.4.11 → 2026.4.12 (see Evidence); same host then upgraded by hand, `EnvironmentFile=` restored manually, confirmed gateway comes up clean with the restored directive.
- Edge cases checked:
  - Unit with no sentinel (`OPENCLAW_SERVICE_MANAGED_ENV_KEYS`) present — `stripManagedEnvFromSystemdUnit` is a no-op, nothing gets rewritten (covered in `systemd-unit.test.ts`).
  - `Environment=OPENCLAW_GATEWAY_TOKEN_BACKUP=…` (user-added entry that shares a prefix with a managed key) is NOT stripped (covered in `systemd-unit.test.ts`).
  - ExecStart matches current args → no write, no `.bak` (covered in `systemd.test.ts`).
  - Drop-in absent/unreadable during `readSystemdServiceExecStart` merge → audit view gracefully falls back to main-unit-only view (covered by an existing `systemd.test.ts` test whose call-count assertion I updated for the additional probe).
- What I did **not** verify:
  - Windows Scheduled Task path and macOS LaunchAgent (intentionally out of scope — see #45163 for the launchd analog).
  - Interaction with operator-installed third-party drop-ins in the same `<unit>.d/` directory beyond the `openclaw-managed.conf` we write (systemd's composition rules should handle this, but I haven't stress-tested with deliberately conflicting operator drop-ins).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` (automatic one-time migration on first install/update under the new code; older OpenClaw versions reading a unit written by this code still see the ExecStart, and the drop-in is plain systemd — no OpenClaw-specific parsing required)
- Config/env changes? `No`
- Migration needed? `Yes` (automatic, no user action required)
- If yes, exact upgrade steps:
  - Install the new OpenClaw version as usual (`openclaw update --yes` or `openclaw gateway install --force`).
  - On the first run, `writeSystemdUnit` notices the sentinel inline in the main unit, moves those lines into `<unit>.d/openclaw-managed.conf`, and writes a `.bak` of the pre-migration main unit.
  - Subsequent installs/updates leave the main unit byte-identical unless ExecStart has drifted.

## Risks and Mitigations

- **Risk:** The targeted `ExecStart=` rewrite could miss an edge-case formatting that `parseSystemdExecStart` handles but the line-level matcher doesn't.
  - **Mitigation:** `updateExecStartInSystemdUnit` uses `startsWith("ExecStart=")` and reconstructs the line through the same `systemdEscapeArg` path the fresh-install writer uses, so the output format stays consistent. Covered by a test asserting other lines (including Environment=, EnvironmentFile=, [Install]) are untouched when only ExecStart needs updating.
- **Risk:** If an operator has manually populated `<unit>.d/openclaw-managed.conf` before upgrade (unlikely — the filename is OpenClaw-specific), the drop-in writer would overwrite it.
  - **Mitigation:** Drop-in header explicitly labels the file as auto-managed and links to this issue. Operator drop-ins should use a different filename — systemd composes all `*.conf` files alphabetically from `<unit>.d/`, so coexistence is trivial.
- **Risk:** On the first upgrade under this PR, users will see a new `.bak` file appear and the main unit shrink. If they diff without context, it can look alarming.
  - **Mitigation:** The install-complete output now includes a `Migrated inline managed env to drop-in` line pointing at the drop-in path, plus the existing `Previous unit backed up to` line.