### PR TITLE
Gateway: retry Windows loopback CLI WS handshakes (#50380 #52424)

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { GATEWAY_HANDSHAKE_CLOSE_GRACE_MS } from "./handshake-timeouts.js";
 import {
   loadConfigMock as loadConfig,
   pickPrimaryLanIPv4Mock as pickPrimaryLanIPv4,
@@ -20,6 +21,19 @@ const deviceIdentityState = vi.hoisted(() => ({
     privateKeyPem: "test-private-key",
   } satisfies DeviceIdentity,
   throwOnLoad: false,
+}));
+
+const gatewayHandshakeRetryTestState = vi.hoisted(() => ({
+  startCount: 0,
+  /** When > 0, the first N `start()` calls emit a gateway handshake-timeout close. */
+  failHandshakeTimeoutFirstStarts: 0,
+  handshakeTimeoutCloseDelayMs: 0,
+  /** When > 0, `request()` resolves after this delay (fake-timer ms). */
+  requestResolveDelayMs: 0,
+  /** With requestResolveDelayMs: fire onClose at this offset while the request is in flight. */
+  closeDuringRequestAtMs: undefined as number | undefined,
+  closeDuringRequestCode: 1008,
+  closeDuringRequestReason: "policy",
 }));
 
 let lastClientOptions: {
@@ -38,6 +52,7 @@ let lastRequestOptions: {
   params?: unknown;
   opts?: { expectFinal?: boolean; timeoutMs?: number | null };
 } | null = null;
+let requestErrorMessage: string | null = null;
 type StartMode = "hello" | "close" | "silent";
 let startMode: StartMode = "hello";
 let closeCode = 1006;
@@ -71,10 +86,42 @@ vi.mock("./client.js", () => ({
       params: unknown,
       opts?: { expectFinal?: boolean; timeoutMs?: number | null },
     ) {
+      const delayMs = gatewayHandshakeRetryTestState.requestResolveDelayMs;
+      const closeDuringAt = gatewayHandshakeRetryTestState.closeDuringRequestAtMs;
+      if (delayMs > 0 && closeDuringAt !== undefined) {
+        setTimeout(() => {
+          lastClientOptions?.onClose?.(
+            gatewayHandshakeRetryTestState.closeDuringRequestCode,
+            gatewayHandshakeRetryTestState.closeDuringRequestReason,
+          );
+        }, closeDuringAt);
+      }
+      if (delayMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+      }
+      if (requestErrorMessage) {
+        throw new Error(requestErrorMessage);
+      }
       lastRequestOptions = { method, params, opts };
       return { ok: true };
     }
     start() {
+      gatewayHandshakeRetryTestState.startCount += 1;
+      const failUntil = gatewayHandshakeRetryTestState.failHandshakeTimeoutFirstStarts;
+      if (
+        failUntil > 0 &&
+        gatewayHandshakeRetryTestState.startCount <= failUntil
+      ) {
+        const closeDelayMs = gatewayHandshakeRetryTestState.handshakeTimeoutCloseDelayMs;
+        if (closeDelayMs > 0) {
+          setTimeout(() => {
+            lastClientOptions?.onClose?.(1000, "openclaw:handshake-timeout");
+          }, closeDelayMs);
+        } else {
+          lastClientOptions?.onClose?.(1000, "openclaw:handshake-timeout");
+        }
+        return;
+      }
       if (startMode === "hello") {
         void lastClientOptions?.onHelloOk?.({
           features: {
@@ -109,10 +156,39 @@ class StubGatewayClient {
     params: unknown,
     opts?: { expectFinal?: boolean; timeoutMs?: number | null },
   ) {
+    const delayMs = gatewayHandshakeRetryTestState.requestResolveDelayMs;
+    const closeDuringAt = gatewayHandshakeRetryTestState.closeDuringRequestAtMs;
+    if (delayMs > 0 && closeDuringAt !== undefined) {
+      setTimeout(() => {
+        lastClientOptions?.onClose?.(
+          gatewayHandshakeRetryTestState.closeDuringRequestCode,
+          gatewayHandshakeRetryTestState.closeDuringRequestReason,
+        );
+      }, closeDuringAt);
+    }
+    if (delayMs > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    }
+    if (requestErrorMessage) {
+      throw new Error(requestErrorMessage);
+    }
     lastRequestOptions = { method, params, opts };
     return { ok: true };
   }
   start() {
+    gatewayHandshakeRetryTestState.startCount += 1;
+    const failUntil = gatewayHandshakeRetryTestState.failHandshakeTimeoutFirstStarts;
+    if (failUntil > 0 && gatewayHandshakeRetryTestState.startCount <= failUntil) {
+      const closeDelayMs = gatewayHandshakeRetryTestState.handshakeTimeoutCloseDelayMs;
+      if (closeDelayMs > 0) {
+        setTimeout(() => {
+          lastClientOptions?.onClose?.(1000, "openclaw:handshake-timeout");
+        }, closeDelayMs);
+      } else {
+        lastClientOptions?.onClose?.(1000, "openclaw:handshake-timeout");
+      }
+      return;
+    }
     if (startMode === "hello") {
       void lastClientOptions?.onHelloOk?.({
         features: {
@@ -134,10 +210,18 @@ function resetGatewayCallMocks() {
   pickPrimaryLanIPv4.mockClear();
   lastClientOptions = null;
   lastRequestOptions = null;
+  requestErrorMessage = null;
   startMode = "hello";
   closeCode = 1006;
   closeReason = "";
   helloMethods = ["health", "secrets.resolve"];
+  gatewayHandshakeRetryTestState.startCount = 0;
+  gatewayHandshakeRetryTestState.failHandshakeTimeoutFirstStarts = 0;
+  gatewayHandshakeRetryTestState.handshakeTimeoutCloseDelayMs = 0;
+  gatewayHandshakeRetryTestState.requestResolveDelayMs = 0;
+  gatewayHandshakeRetryTestState.closeDuringRequestAtMs = undefined;
+  gatewayHandshakeRetryTestState.closeDuringRequestCode = 1008;
+  gatewayHandshakeRetryTestState.closeDuringRequestReason = "policy";
   const loadConfigForTests = loadConfig as unknown as () => OpenClawConfig;
   const resolveGatewayPortForTests = resolveGatewayPort as unknown as (
     cfg?: OpenClawConfig,
@@ -185,6 +269,7 @@ describe("callGateway url resolution", () => {
     "OPENCLAW_GATEWAY_PORT",
     "OPENCLAW_GATEWAY_URL",
     "OPENCLAW_GATEWAY_TOKEN",
+    "OPENCLAW_GATEWAY_CONNECT_ATTEMPTS",
     "OPENCLAW_STATE_DIR",
   ]);
 
@@ -195,6 +280,7 @@ describe("callGateway url resolution", () => {
     delete process.env.OPENCLAW_GATEWAY_PORT;
     delete process.env.OPENCLAW_GATEWAY_URL;
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS;
     delete process.env.OPENCLAW_STATE_DIR;
     resetGatewayCallMocks();
   });
@@ -301,6 +387,204 @@ describe("callGateway url resolution", () => {
     expect(loadConfig).not.toHaveBeenCalled();
     expect(lastClientOptions?.url).toBe("ws://127.0.0.1:18800");
     expect(lastClientOptions?.token).toBe("test-token");
+  });
+
+  it("retries CLI gateway connect when the server closes with openclaw handshake-timeout", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS = "3";
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token";
+    gatewayHandshakeRetryTestState.failHandshakeTimeoutFirstStarts = 2;
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    try {
+      await callGatewayCli({ method: "health" });
+
+      expect(gatewayHandshakeRetryTestState.startCount).toBe(3);
+      expect(lastRequestOptions?.method).toBe("health");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("does not retry CLI gateway connect on non-handshake-timeout closes", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS = "3";
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token";
+    startMode = "close";
+    closeCode = 1008;
+    closeReason = "policy";
+
+    await expect(callGatewayCli({ method: "health" })).rejects.toThrow(/gateway closed/);
+    expect(gatewayHandshakeRetryTestState.startCount).toBe(1);
+  });
+
+  it("does not retry handshake-timeout closes for non-loopback gateway urls", async () => {
+    process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS = "3";
+    gatewayHandshakeRetryTestState.failHandshakeTimeoutFirstStarts = 2;
+
+    await expect(
+      callGatewayCli({
+        method: "health",
+        url: "wss://remote.example/ws",
+        token: "remote-token",
+      }),
+    ).rejects.toThrow(/handshake-timeout/);
+    expect(gatewayHandshakeRetryTestState.startCount).toBe(1);
+  });
+
+  it("does not retry handshake-timeout closes for scoped non-CLI gateway calls", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS = "3";
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token";
+    gatewayHandshakeRetryTestState.failHandshakeTimeoutFirstStarts = 2;
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    try {
+      await expect(
+        callGateway({
+          method: "health",
+          scopes: ["operator.read"],
+        }),
+      ).rejects.toThrow(/handshake-timeout/);
+      expect(gatewayHandshakeRetryTestState.startCount).toBe(1);
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("does not retry request errors that only mention openclaw handshake-timeout", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS = "3";
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token";
+    requestErrorMessage = "server mutation failed: openclaw:handshake-timeout";
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    try {
+      await expect(callGatewayCli({ method: "sessions.delete" })).rejects.toThrow(
+        /server mutation failed/,
+      );
+      expect(gatewayHandshakeRetryTestState.startCount).toBe(1);
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("keeps retry budget after a near-timeout handshake close", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS = "2";
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token";
+    gatewayHandshakeRetryTestState.failHandshakeTimeoutFirstStarts = 1;
+    gatewayHandshakeRetryTestState.handshakeTimeoutCloseDelayMs = 9;
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    vi.useFakeTimers();
+    try {
+      const promise = callGatewayCli({ method: "health", timeoutMs: 10 });
+      await vi.advanceTimersByTimeAsync(9);
+      await vi.advanceTimersByTimeAsync(250);
+      await promise;
+
+      expect(gatewayHandshakeRetryTestState.startCount).toBe(2);
+      expect(lastRequestOptions?.method).toBe("health");
+    } finally {
+      platformSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries when the explicit handshake close lands just after the caller timeout", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS = "2";
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token";
+    gatewayHandshakeRetryTestState.failHandshakeTimeoutFirstStarts = 1;
+    gatewayHandshakeRetryTestState.handshakeTimeoutCloseDelayMs = 11;
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    vi.useFakeTimers();
+    try {
+      const promise = callGatewayCli({ method: "health", timeoutMs: 10 });
+      await vi.advanceTimersByTimeAsync(11);
+      await vi.advanceTimersByTimeAsync(250);
+      await promise;
+
+      expect(gatewayHandshakeRetryTestState.startCount).toBe(2);
+      expect(lastRequestOptions?.method).toBe("health");
+    } finally {
+      platformSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps each retry-attempt watchdog bounded to the original timeout", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS = "3";
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token";
+    startMode = "silent";
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    vi.useFakeTimers();
+    try {
+      let caught: unknown;
+      const promise = callGatewayCli({ method: "health", timeoutMs: 10 }).catch((err) => {
+        caught = err;
+      });
+      await vi.advanceTimersByTimeAsync(10 + GATEWAY_HANDSHAKE_CLOSE_GRACE_MS);
+      await promise;
+
+      expect(String(caught)).toContain("gateway timeout after 10ms");
+      expect(gatewayHandshakeRetryTestState.startCount).toBe(1);
+    } finally {
+      platformSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not return success when the caller deadline elapses while the RPC is in flight", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token";
+    gatewayHandshakeRetryTestState.requestResolveDelayMs = 50;
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    vi.useFakeTimers();
+    try {
+      let caught: unknown;
+      const promise = callGatewayCli({ method: "health", timeoutMs: 10 }).catch((err) => {
+        caught = err;
+      });
+      await vi.advanceTimersByTimeAsync(50);
+      await promise;
+      expect(String(caught)).toContain("gateway timeout after 10ms");
+      expect(lastRequestOptions?.method).toBe("health");
+    } finally {
+      platformSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("during handshake-close grace, a non-handshake-timeout close surfaces caller timeout (not gateway closed)", async () => {
+    setLocalLoopbackGatewayConfig();
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token";
+    gatewayHandshakeRetryTestState.requestResolveDelayMs = 50;
+    gatewayHandshakeRetryTestState.closeDuringRequestAtMs = 15;
+    gatewayHandshakeRetryTestState.closeDuringRequestCode = 1008;
+    gatewayHandshakeRetryTestState.closeDuringRequestReason = "policy";
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    vi.useFakeTimers();
+    try {
+      let caught: unknown;
+      const promise = callGatewayCli({ method: "health", timeoutMs: 10 }).catch((err) => {
+        caught = err;
+      });
+      await vi.advanceTimersByTimeAsync(15);
+      await promise;
+
+      expect(String(caught)).toContain("gateway timeout after 10ms");
+      expect(String(caught)).not.toMatch(/gateway closed/);
+    } finally {
+      platformSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("keeps device identity enabled for local loopback shared-token auth", async () => {
@@ -1460,5 +1744,16 @@ describe("callGateway password resolution", () => {
     });
 
     expect(lastClientOptions?.[testCase.authKey]).toBe(testCase.explicitValue);
+  });
+});
+
+describe("gateway connect retry budget", () => {
+  it("caps inter-attempt wait to remaining deadline (unit)", () => {
+    expect(__testing.gatewayConnectRetryDelayMs(1)).toBe(250);
+    expect(__testing.gatewayConnectRetryDelayMs(2)).toBe(500);
+    expect(__testing.capGatewayConnectRetryWaitMs(1, 10_000)).toBe(250);
+    expect(__testing.capGatewayConnectRetryWaitMs(1, 7)).toBe(7);
+    expect(__testing.capGatewayConnectRetryWaitMs(2, 200)).toBe(200);
+    expect(__testing.capGatewayConnectRetryWaitMs(1, 0)).toBe(0);
   });
 });

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -36,6 +36,13 @@ import {
   resolveLeastPrivilegeOperatorScopesForMethod,
   type OperatorScope,
 } from "./method-scopes.js";
+import {
+  DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS,
+  GATEWAY_HANDSHAKE_CLOSE_GRACE_MS,
+  GATEWAY_HANDSHAKE_TIMEOUT_CLOSE_REASON,
+  getPreauthHandshakeTimeoutMsFromEnv,
+} from "./handshake-timeouts.js";
+import { isLoopbackHost } from "./net.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
 export type { GatewayConnectionDetails };
 
@@ -163,6 +170,11 @@ export function buildGatewayConnectionDetails(
 }
 
 export const __testing = {
+  /** Nominal delay between handshake-timeout retries (capped by remaining deadline at runtime). */
+  gatewayConnectRetryDelayMs,
+  capGatewayConnectRetryWaitMs(attempt: number, remainingMs: number): number {
+    return Math.min(gatewayConnectRetryDelayMs(attempt), Math.max(0, remainingMs));
+  },
   setDepsForTests(deps: Partial<typeof defaultGatewayCallDeps> | undefined): void {
     gatewayCallDeps.createGatewayClient =
       deps?.createGatewayClient ?? defaultGatewayCallDeps.createGatewayClient;
@@ -434,6 +446,106 @@ function formatGatewayTimeoutError(
   return `gateway timeout after ${timeoutMs}ms\n${connectionDetails.message}`;
 }
 
+class GatewayCloseTransportError extends Error {
+  readonly closeCode: number;
+  readonly closeReason: string;
+
+  constructor(params: {
+    code: number;
+    reason: string;
+    connectionDetails: GatewayConnectionDetails;
+  }) {
+    super(formatGatewayCloseError(params.code, params.reason, params.connectionDetails));
+    this.name = "GatewayCloseTransportError";
+    this.closeCode = params.code;
+    this.closeReason = normalizeOptionalString(params.reason) || "no close reason";
+  }
+}
+
+function canRetryGatewayHandshakeClose(params: {
+  allowHandshakeCloseRetry: boolean;
+  url: string;
+}): boolean {
+  if (!params.allowHandshakeCloseRetry) {
+    return false;
+  }
+  if (process.platform !== "win32") {
+    return false;
+  }
+  try {
+    const parsed = new URL(params.url);
+    return isLoopbackHost(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function shouldRetryGatewayHandshakeClose(params: {
+  allowHandshakeCloseRetry: boolean;
+  url: string;
+  err: unknown;
+}): boolean {
+  if (!(params.err instanceof GatewayCloseTransportError)) {
+    return false;
+  }
+  if (!canRetryGatewayHandshakeClose(params)) {
+    return false;
+  }
+  if (params.err.closeCode !== 1000) {
+    return false;
+  }
+  if (params.err.closeReason !== GATEWAY_HANDSHAKE_TIMEOUT_CLOSE_REASON) {
+    return false;
+  }
+  return true;
+}
+
+function resolveGatewayConnectAttempts(params: {
+  shouldRetryHandshakeClose: boolean;
+}): number {
+  if (!params.shouldRetryHandshakeClose) {
+    return 1;
+  }
+  const raw = process.env.OPENCLAW_GATEWAY_CONNECT_ATTEMPTS?.trim();
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) {
+      const n = Math.floor(parsed);
+      if (n >= 1 && n <= 10) {
+        return n;
+      }
+    }
+  }
+  return 3;
+}
+
+function gatewayConnectRetryDelayMs(attempt: number): number {
+  return Math.min(750, 250 * attempt);
+}
+
+function resolveGatewayConnectRetryBudgetMs(params: {
+  shouldRetryHandshakeClose: boolean;
+  connectAttempts: number;
+}): number {
+  if (!params.shouldRetryHandshakeClose || params.connectAttempts <= 1) {
+    return 0;
+  }
+  const handshakeTimeoutMs =
+    getPreauthHandshakeTimeoutMsFromEnv() || DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
+  let budgetMs = 0;
+  for (let attempt = 1; attempt < params.connectAttempts; attempt += 1) {
+    budgetMs += handshakeTimeoutMs;
+    budgetMs += gatewayConnectRetryDelayMs(attempt);
+  }
+  return budgetMs;
+}
+
+function resolveGatewayHandshakeCloseGraceMs(params: {
+  shouldRetryHandshakeClose: boolean;
+}): number {
+  return params.shouldRetryHandshakeClose ? GATEWAY_HANDSHAKE_CLOSE_GRACE_MS : 0;
+}
+
 function ensureGatewaySupportsRequiredMethods(params: {
   requiredMethods: string[] | undefined;
   methods: string[] | undefined;
@@ -463,7 +575,7 @@ function ensureGatewaySupportsRequiredMethods(params: {
   }
 }
 
-async function executeGatewayRequestWithScopes<T>(params: {
+async function runSingleGatewayConnectAttempt<T>(params: {
   opts: CallGatewayBaseOptions;
   scopes: OperatorScope[];
   url: string;
@@ -472,24 +584,30 @@ async function executeGatewayRequestWithScopes<T>(params: {
   tlsFingerprint?: string;
   timeoutMs: number;
   safeTimerTimeoutMs: number;
+  handshakeCloseGraceMs: number;
   connectionDetails: GatewayConnectionDetails;
 }): Promise<T> {
   const { opts, scopes, url, token, password, tlsFingerprint, timeoutMs, safeTimerTimeoutMs } =
     params;
-  // Yield to the event loop before starting the WebSocket connection.
-  // On Windows with large dist bundles, heavy synchronous module loading
-  // can starve the event loop, preventing timely processing of the
-  // connect.challenge frame and causing handshake timeouts (#48736).
-  await new Promise<void>((r) => setImmediate(r));
   return await new Promise<T>((resolve, reject) => {
     let settled = false;
     let ignoreClose = false;
+    let timeoutExpired = false;
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
+    const stopWithTimeoutError = () => {
+      ignoreClose = true;
+      client.stop();
+      stop(new Error(formatGatewayTimeoutError(timeoutMs, params.connectionDetails)));
+    };
     const stop = (err?: Error, value?: T) => {
       if (settled) {
         return;
       }
       settled = true;
       clearTimeout(timer);
+      if (graceTimer) {
+        clearTimeout(graceTimer);
+      }
       void stopGatewayClient(client).finally(() => {
         if (err) {
           reject(err);
@@ -519,6 +637,10 @@ async function executeGatewayRequestWithScopes<T>(params: {
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
       onHelloOk: async (hello) => {
+        if (timeoutExpired) {
+          stopWithTimeoutError();
+          return;
+        }
         try {
           ensureGatewaySupportsRequiredMethods({
             requiredMethods: opts.requiredMethods,
@@ -529,10 +651,20 @@ async function executeGatewayRequestWithScopes<T>(params: {
             expectFinal: opts.expectFinal,
             timeoutMs: opts.timeoutMs,
           });
+          // The caller watchdog can fire while `request` is in flight; during handshake-close
+          // grace we must not return success after the configured deadline has elapsed.
+          if (timeoutExpired) {
+            stopWithTimeoutError();
+            return;
+          }
           ignoreClose = true;
           stop(undefined, result);
         } catch (err) {
           ignoreClose = true;
+          if (timeoutExpired && params.handshakeCloseGraceMs > 0) {
+            stopWithTimeoutError();
+            return;
+          }
           stop(err as Error);
         }
       },
@@ -540,23 +672,136 @@ async function executeGatewayRequestWithScopes<T>(params: {
         if (settled || ignoreClose) {
           return;
         }
+        const normalizedReason = normalizeOptionalString(reason) ?? "";
+        const isHandshakeTimeoutClose =
+          code === 1000 && normalizedReason === GATEWAY_HANDSHAKE_TIMEOUT_CLOSE_REASON;
+
+        // After the watchdog fires we enter a short grace window for the explicit
+        // handshake-timeout close (retry path). Any other close during grace must not
+        // override the caller timeout — surface timeout instead (Codex #66297).
+        if (
+          timeoutExpired &&
+          params.handshakeCloseGraceMs > 0 &&
+          !isHandshakeTimeoutClose
+        ) {
+          ignoreClose = true;
+          client.stop();
+          stopWithTimeoutError();
+          return;
+        }
+
         ignoreClose = true;
-        stop(new Error(formatGatewayCloseError(code, reason, params.connectionDetails)));
+        stop(
+          new GatewayCloseTransportError({
+            code,
+            reason,
+            connectionDetails: params.connectionDetails,
+          }),
+        );
       },
     });
 
     const timer = setTimeout(() => {
-      ignoreClose = true;
-      stop(new Error(formatGatewayTimeoutError(timeoutMs, params.connectionDetails)));
+      if (params.handshakeCloseGraceMs <= 0) {
+        stopWithTimeoutError();
+        return;
+      }
+      timeoutExpired = true;
+      graceTimer = setTimeout(() => {
+        stopWithTimeoutError();
+      }, params.handshakeCloseGraceMs);
     }, safeTimerTimeoutMs);
 
     client.start();
   });
 }
 
+async function executeGatewayRequestWithScopes<T>(params: {
+  opts: CallGatewayBaseOptions;
+  allowHandshakeCloseRetry: boolean;
+  scopes: OperatorScope[];
+  url: string;
+  token?: string;
+  password?: string;
+  tlsFingerprint?: string;
+  timeoutMs: number;
+  safeTimerTimeoutMs: number;
+  connectionDetails: GatewayConnectionDetails;
+}): Promise<T> {
+  // Yield to the event loop before starting the WebSocket connection.
+  // On Windows with large dist bundles, heavy synchronous module loading
+  // can starve the event loop, preventing timely processing of the
+  // connect.challenge frame and causing handshake timeouts (#48736).
+  await new Promise<void>((r) => setImmediate(r));
+
+  const shouldRetryHandshakeClose = canRetryGatewayHandshakeClose({
+    allowHandshakeCloseRetry: params.allowHandshakeCloseRetry,
+    url: params.url,
+  });
+  const connectAttempts = resolveGatewayConnectAttempts({ shouldRetryHandshakeClose });
+  const retryBudgetMs = resolveGatewayConnectRetryBudgetMs({
+    shouldRetryHandshakeClose,
+    connectAttempts,
+  });
+  const handshakeCloseGraceMs = resolveGatewayHandshakeCloseGraceMs({
+    shouldRetryHandshakeClose,
+  });
+  const deadline =
+    Date.now() +
+    params.safeTimerTimeoutMs +
+    retryBudgetMs +
+    handshakeCloseGraceMs * connectAttempts;
+
+  let lastError: Error | undefined;
+  for (let attempt = 1; attempt <= connectAttempts; attempt++) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw (
+        lastError ??
+        new Error(formatGatewayTimeoutError(params.timeoutMs, params.connectionDetails))
+      );
+    }
+    const cappedTimeoutMs = Math.min(params.timeoutMs, remainingMs);
+    const cappedSafeTimerMs = Math.max(1, Math.min(params.safeTimerTimeoutMs, remainingMs));
+    const cappedHandshakeCloseGraceMs = Math.max(
+      0,
+      Math.min(handshakeCloseGraceMs, remainingMs - cappedSafeTimerMs),
+    );
+    try {
+      return await runSingleGatewayConnectAttempt<T>({
+        ...params,
+        timeoutMs: cappedTimeoutMs,
+        safeTimerTimeoutMs: cappedSafeTimerMs,
+        handshakeCloseGraceMs: cappedHandshakeCloseGraceMs,
+      });
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (
+        attempt >= connectAttempts ||
+        !shouldRetryGatewayHandshakeClose({
+          allowHandshakeCloseRetry: params.allowHandshakeCloseRetry,
+          url: params.url,
+          err: lastError,
+        })
+      ) {
+        throw lastError;
+      }
+      const waitMs = Math.min(
+        gatewayConnectRetryDelayMs(attempt),
+        Math.max(0, deadline - Date.now()),
+      );
+      if (waitMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, waitMs));
+      }
+    }
+  }
+  throw lastError ?? new Error("gateway connect failed");
+}
+
 async function callGatewayWithScopes<T = Record<string, unknown>>(
   opts: CallGatewayBaseOptions,
   scopes: OperatorScope[],
+  runtime: { allowHandshakeCloseRetry: boolean } = { allowHandshakeCloseRetry: false },
 ): Promise<T> {
   const { timeoutMs, safeTimerTimeoutMs } = resolveGatewayCallTimeout(opts.timeoutMs);
   const context = resolveGatewayCallContext(opts);
@@ -581,6 +826,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   const { token, password } = resolvedCredentials;
   return await executeGatewayRequestWithScopes<T>({
     opts,
+    allowHandshakeCloseRetry: runtime.allowHandshakeCloseRetry,
     scopes,
     url,
     token,
@@ -602,7 +848,7 @@ export async function callGatewayCli<T = Record<string, unknown>>(
   opts: CallGatewayCliOptions,
 ): Promise<T> {
   const scopes = Array.isArray(opts.scopes) ? opts.scopes : CLI_DEFAULT_OPERATOR_SCOPES;
-  return await callGatewayWithScopes(opts, scopes);
+  return await callGatewayWithScopes(opts, scopes, { allowHandshakeCloseRetry: true });
 }
 
 export async function callGatewayLeastPrivilege<T = Record<string, unknown>>(

--- a/src/gateway/handshake-timeouts.ts
+++ b/src/gateway/handshake-timeouts.ts
@@ -1,4 +1,13 @@
 export const DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 10_000;
+/**
+ * Give the explicit handshake-timeout close frame a brief chance to arrive
+ * after the caller watchdog fires so Windows loopback CLI retries can key off
+ * the close reason instead of a generic timeout.
+ */
+export const GATEWAY_HANDSHAKE_CLOSE_GRACE_MS = 100;
+
+/** WebSocket close reason when the gateway drops an idle pre-auth socket (CLI may retry; #50380 / #52424). */
+export const GATEWAY_HANDSHAKE_TIMEOUT_CLOSE_REASON = "openclaw:handshake-timeout";
 export const MIN_CONNECT_CHALLENGE_TIMEOUT_MS = 250;
 export const MAX_CONNECT_CHALLENGE_TIMEOUT_MS = DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1190,6 +1190,7 @@ export function attachGatewayUpgradeHandler(opts: {
   preauthConnectionBudget: PreauthConnectionBudget;
   resolvedAuth: ResolvedGatewayAuth;
   getResolvedAuth?: () => ResolvedGatewayAuth;
+  getClientIpConfig?: () => HookClientIpConfig;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
   /** Optional logger for error diagnostics. */
@@ -1202,15 +1203,16 @@ export function attachGatewayUpgradeHandler(opts: {
     clients,
     preauthConnectionBudget,
     resolvedAuth,
+    getClientIpConfig,
     rateLimiter,
     log,
   } = opts;
   const getResolvedAuth = opts.getResolvedAuth ?? (() => resolvedAuth);
   httpServer.on("upgrade", (req, socket, head) => {
     void (async () => {
-      const configSnapshot = loadConfig();
-      const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
-      const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
+      const clientIpConfig = getClientIpConfig?.();
+      const trustedProxies = clientIpConfig?.trustedProxies ?? [];
+      const allowRealIpFallback = clientIpConfig?.allowRealIpFallback === true;
       const scopedCanvas = normalizeCanvasScopedUrl(req.url ?? "/");
       if (scopedCanvas.malformedScopedPath) {
         writeUpgradeAuthFailure(socket, { ok: false, reason: "unauthorized" });

--- a/src/gateway/server-live-state.ts
+++ b/src/gateway/server-live-state.ts
@@ -1,4 +1,5 @@
 import type { PluginServicesHandle } from "../plugins/services.js";
+import type { GatewayControlUiConfig } from "../config/types.gateway.js";
 import type { HooksConfigResolved } from "./hooks.js";
 import type { GatewayCronState } from "./server-cron.js";
 import type { HookClientIpConfig } from "./server-http.js";
@@ -10,6 +11,7 @@ import {
 export type GatewayServerLiveState = GatewayServerMutableState & {
   hooksConfig: HooksConfigResolved | null;
   hookClientIpConfig: HookClientIpConfig;
+  controlUiConfig: GatewayControlUiConfig | undefined;
   cronState: GatewayCronState;
   pluginServices: PluginServicesHandle | null;
   gatewayMethods: string[];
@@ -18,6 +20,7 @@ export type GatewayServerLiveState = GatewayServerMutableState & {
 export function createGatewayServerLiveState(params: {
   hooksConfig: HooksConfigResolved | null;
   hookClientIpConfig: HookClientIpConfig;
+  controlUiConfig: GatewayControlUiConfig | undefined;
   cronState: GatewayCronState;
   gatewayMethods: string[];
 }): GatewayServerLiveState {
@@ -25,6 +28,7 @@ export function createGatewayServerLiveState(params: {
     ...createGatewayServerMutableState(),
     hooksConfig: params.hooksConfig,
     hookClientIpConfig: params.hookClientIpConfig,
+    controlUiConfig: params.controlUiConfig,
     cronState: params.cronState,
     pluginServices: null,
     gatewayMethods: params.gatewayMethods,

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -30,6 +30,7 @@ import { startGatewayConfigReloader, type GatewayReloadPlan } from "./config-rel
 import { resolveHooksConfig } from "./hooks.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
 import type { HookClientIpConfig } from "./server-http.js";
+import type { GatewayControlUiConfig } from "../config/types.gateway.js";
 import {
   type GatewayChannelManager,
   startGatewayChannelHealthMonitor,
@@ -47,6 +48,7 @@ import { resolveHookClientIpConfig } from "./server/hooks.js";
 type GatewayHotReloadState = {
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
   hookClientIpConfig: HookClientIpConfig;
+  controlUiConfig: GatewayControlUiConfig | undefined;
   heartbeatRunner: HeartbeatRunner;
   cronState: GatewayCronState;
   channelHealthMonitor: ChannelHealthMonitor | null;
@@ -126,6 +128,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       }
     }
     nextState.hookClientIpConfig = resolveHookClientIpConfig(nextConfig);
+    nextState.controlUiConfig = nextConfig.gateway?.controlUi;
 
     if (plan.restartHeartbeat) {
       nextState.heartbeatRunner.updateConfig(nextConfig);

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -210,6 +210,7 @@ export async function createGatewayRuntimeState(params: {
         preauthConnectionBudget,
         resolvedAuth: params.resolvedAuth,
         getResolvedAuth: params.getResolvedAuth,
+        getClientIpConfig: params.getHookClientIpConfig,
         rateLimiter: params.rateLimiter,
         log: params.log,
       });

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -35,6 +35,8 @@ export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
     getRequiredSharedGatewaySessionGeneration: params.getRequiredSharedGatewaySessionGeneration,
     rateLimiter: params.rateLimiter,
     browserRateLimiter: params.browserRateLimiter,
+    getClientIpConfig: params.getClientIpConfig,
+    getControlUiConfig: params.getControlUiConfig,
     gatewayMethods: params.gatewayMethods,
     events: params.events,
     logGateway: params.logGateway,

--- a/src/gateway/server.canvas-auth.test.ts
+++ b/src/gateway/server.canvas-auth.test.ts
@@ -203,6 +203,7 @@ async function withCanvasGatewayHarness(params: {
   getResolvedAuth?: () => ResolvedGatewayAuth;
   listenHost?: string;
   rateLimiter?: ReturnType<typeof createAuthRateLimiter>;
+  getClientIpConfig?: () => { trustedProxies?: string[]; allowRealIpFallback?: boolean };
   handleHttpRequest: CanvasHostHandler["handleHttpRequest"];
   run: (ctx: {
     listener: Awaited<ReturnType<typeof listen>>;
@@ -251,6 +252,7 @@ async function withCanvasGatewayHarness(params: {
     preauthConnectionBudget: createPreauthConnectionBudget(8),
     resolvedAuth: params.resolvedAuth,
     getResolvedAuth: params.getResolvedAuth,
+    getClientIpConfig: params.getClientIpConfig,
     rateLimiter: params.rateLimiter,
   });
 
@@ -295,6 +297,10 @@ describe("gateway canvas host auth", () => {
     await withLoopbackTrustedProxy(async () => {
       await withCanvasGatewayHarness({
         resolvedAuth: tokenResolvedAuth,
+        getClientIpConfig: () => ({
+          trustedProxies: ["127.0.0.1"],
+          allowRealIpFallback: false,
+        }),
         handleHttpRequest: allowCanvasHostHttp,
         run: async ({ listener, clients }) => {
           const host = "127.0.0.1";
@@ -385,6 +391,10 @@ describe("gateway canvas host auth", () => {
     await withLoopbackTrustedProxy(async () => {
       await withCanvasGatewayHarness({
         resolvedAuth: tokenResolvedAuth,
+        getClientIpConfig: () => ({
+          trustedProxies: ["127.0.0.1"],
+          allowRealIpFallback: false,
+        }),
         handleHttpRequest: allowCanvasHostHttp,
         run: async ({ listener, clients }) => {
           clients.add(
@@ -508,6 +518,10 @@ describe("gateway canvas host auth", () => {
       await withCanvasGatewayHarness({
         resolvedAuth: tokenResolvedAuth,
         rateLimiter,
+        getClientIpConfig: () => ({
+          trustedProxies: ["127.0.0.1"],
+          allowRealIpFallback: false,
+        }),
         handleHttpRequest: async () => false,
         run: async ({ listener }) => {
           const headers = {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -435,6 +435,7 @@ export async function startGatewayServer(
   };
   const initialHooksConfig = runtimeConfig.hooksConfig;
   const initialHookClientIpConfig = resolveHookClientIpConfig(cfgAtStart);
+  const initialControlUiConfig = cfgAtStart.gateway?.controlUi;
   const canvasHostEnabled = runtimeConfig.canvasHostEnabled;
 
   // Create auth rate limiters used by connect/auth flows.
@@ -553,6 +554,7 @@ export async function startGatewayServer(
   runtimeState = createGatewayServerLiveState({
     hooksConfig: initialHooksConfig,
     hookClientIpConfig: initialHookClientIpConfig,
+    controlUiConfig: initialControlUiConfig,
     cronState: buildGatewayCronService({
       cfg: cfgAtStart,
       deps,
@@ -800,6 +802,8 @@ export async function startGatewayServer(
         getRequiredSharedGatewaySessionGeneration(sharedGatewaySessionGenerationState),
       rateLimiter: authRateLimiter,
       browserRateLimiter: browserAuthRateLimiter,
+      getClientIpConfig: () => runtimeState?.hookClientIpConfig ?? initialHookClientIpConfig,
+      getControlUiConfig: () => (runtimeState ? runtimeState.controlUiConfig : initialControlUiConfig),
       gatewayMethods: runtimeState.gatewayMethods,
       events: GATEWAY_EVENTS,
       logGateway: log,
@@ -876,6 +880,7 @@ export async function startGatewayServer(
       getState: () => ({
         hooksConfig: runtimeState.hooksConfig,
         hookClientIpConfig: runtimeState.hookClientIpConfig,
+        controlUiConfig: runtimeState.controlUiConfig,
         heartbeatRunner: runtimeState.heartbeatRunner,
         cronState: runtimeState.cronState,
         channelHealthMonitor: runtimeState.channelHealthMonitor,
@@ -883,6 +888,7 @@ export async function startGatewayServer(
       setState: (nextState) => {
         runtimeState.hooksConfig = nextState.hooksConfig;
         runtimeState.hookClientIpConfig = nextState.hookClientIpConfig;
+        runtimeState.controlUiConfig = nextState.controlUiConfig;
         runtimeState.heartbeatRunner = nextState.heartbeatRunner;
         runtimeState.cronState = nextState.cronState;
         deps.cron = runtimeState.cronState.cron;

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
+import * as configModule from "../config/config.js";
 import {
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -84,6 +85,61 @@ async function requestUpgradeRejection(port: number): Promise<{ status: number; 
 }
 
 describe("gateway pre-auth hardening", () => {
+  it("uses runtime client-ip config for upgrades without reloading config from disk", async () => {
+    const loadConfigSpy = vi.spyOn(configModule, "loadConfig").mockImplementation(() => {
+      throw new Error("upgrade path should not reload config");
+    });
+    const clients = new Set<GatewayWsClient>();
+    const resolvedAuth: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
+    const httpServer = createGatewayHttpServer({
+      canvasHost: null,
+      clients,
+      controlUiEnabled: false,
+      controlUiBasePath: "/__control__",
+      openAiChatCompletionsEnabled: false,
+      openResponsesEnabled: false,
+      handleHooksRequest: async () => false,
+      resolvedAuth,
+    });
+    const wss = new WebSocketServer({ noServer: true });
+    attachGatewayUpgradeHandler({
+      httpServer,
+      wss,
+      canvasHost: null,
+      clients,
+      preauthConnectionBudget: createPreauthConnectionBudget(1),
+      resolvedAuth,
+      getClientIpConfig: () => ({
+        trustedProxies: ["127.0.0.1"],
+        allowRealIpFallback: false,
+      }),
+    });
+
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+    const address = httpServer.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+
+    try {
+      await expect(requestUpgradeRejection(port)).resolves.toEqual({
+        status: 503,
+        body: "Gateway websocket handlers unavailable",
+      });
+      expect(loadConfigSpy).not.toHaveBeenCalled();
+    } finally {
+      loadConfigSpy.mockRestore();
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve();
+        });
+      });
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+    }
+  });
+
   it("rejects upgrades before websocket handlers attach (pre-auth budget enforced, then released)", async () => {
     const clients = new Set<GatewayWsClient>();
     const resolvedAuth: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
@@ -137,13 +193,16 @@ describe("gateway pre-auth hardening", () => {
     try {
       const ws = await harness.openWs();
       await readConnectChallengeNonce(ws);
-      const close = await new Promise<{ code: number; elapsedMs: number }>((resolve) => {
-        const startedAt = Date.now();
-        ws.once("close", (code) => {
-          resolve({ code, elapsedMs: Date.now() - startedAt });
-        });
-      });
+      const close = await new Promise<{ code: number; elapsedMs: number; reason: string }>(
+        (resolve) => {
+          const startedAt = Date.now();
+          ws.once("close", (code, reason) => {
+            resolve({ code, elapsedMs: Date.now() - startedAt, reason: reason.toString() });
+          });
+        },
+      );
       expect(close.code).toBe(1000);
+      expect(close.reason).toContain("openclaw:handshake-timeout");
       expect(close.elapsedMs).toBeGreaterThan(0);
       expect(close.elapsedMs).toBeLessThan(PREAUTH_HANDSHAKE_TEST_CLOSE_LIMIT_MS);
     } finally {

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -59,6 +59,17 @@ describe("attachGatewayWsConnectionHandler", () => {
     };
     const initialAuth = createResolvedAuth("token-before");
     let currentAuth = initialAuth;
+    let currentClientIpConfig = { trustedProxies: ["127.0.0.1"], allowRealIpFallback: false };
+    const initialControlUiConfig = {
+      allowedOrigins: ["https://control-before.example"],
+      dangerouslyAllowHostHeaderOriginFallback: false,
+    };
+    let currentControlUiConfig:
+      | {
+          allowedOrigins?: string[];
+          dangerouslyAllowHostHeaderOriginFallback?: boolean;
+        }
+      | undefined = initialControlUiConfig;
 
     attachGatewayWsConnectionHandler({
       wss,
@@ -68,6 +79,8 @@ describe("attachGatewayWsConnectionHandler", () => {
       canvasHostEnabled: false,
       resolvedAuth: initialAuth,
       getResolvedAuth: () => currentAuth,
+      getClientIpConfig: () => currentClientIpConfig,
+      getControlUiConfig: () => currentControlUiConfig,
       gatewayMethods: [],
       events: [],
       logGateway: createLogger() as never,
@@ -90,12 +103,24 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(attachGatewayWsMessageHandlerMock).toHaveBeenCalledTimes(1);
     const passed = attachGatewayWsMessageHandlerMock.mock.calls[0]?.[0] as {
       getResolvedAuth: () => ResolvedGatewayAuth;
+      getClientIpConfig?: () => {
+        trustedProxies?: string[];
+        allowRealIpFallback?: boolean;
+      };
+      getControlUiConfig?: () => {
+        allowedOrigins?: string[];
+        dangerouslyAllowHostHeaderOriginFallback?: boolean;
+      };
       getRequiredSharedGatewaySessionGeneration?: () => string | undefined;
     };
 
     currentAuth = createResolvedAuth("token-after");
+    currentClientIpConfig = { trustedProxies: ["10.0.0.1"], allowRealIpFallback: true };
+    currentControlUiConfig = undefined;
 
     expect(passed.getResolvedAuth()).toMatchObject({ token: "token-after" });
+    expect(passed.getClientIpConfig?.()).toEqual(currentClientIpConfig);
+    expect(passed.getControlUiConfig?.()).toBeUndefined();
     expect(passed.getRequiredSharedGatewaySessionGeneration?.()).toBe(
       resolveSharedGatewaySessionGeneration(currentAuth),
     );

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -9,15 +9,21 @@ import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { isWebchatClient } from "../../utils/message-channel.js";
+import type { GatewayControlUiConfig } from "../../config/types.gateway.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
-import { getPreauthHandshakeTimeoutMsFromEnv } from "../handshake-timeouts.js";
+import {
+  GATEWAY_HANDSHAKE_TIMEOUT_CLOSE_REASON,
+  getPreauthHandshakeTimeoutMsFromEnv,
+} from "../handshake-timeouts.js";
 import { isLoopbackAddress } from "../net.js";
 import { MAX_PAYLOAD_BYTES, MAX_PREAUTH_PAYLOAD_BYTES } from "../server-constants.js";
+import type { HookClientIpConfig } from "../server-http.js";
 import { clearNodeWakeState } from "../server-methods/nodes.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
 import { logWs } from "../ws-log.js";
+import { truncateCloseReason } from "./close-reason.js";
 import { getHealthVersion, incrementPresenceVersion } from "./health-state.js";
 import type { PreauthConnectionBudget } from "./preauth-connection-budget.js";
 import { broadcastPresenceSnapshot } from "./presence-events.js";
@@ -131,6 +137,8 @@ export type GatewayWsSharedHandlerParams = {
   rateLimiter?: AuthRateLimiter;
   /** Browser-origin fallback limiter (loopback is never exempt). */
   browserRateLimiter?: AuthRateLimiter;
+  getClientIpConfig?: () => HookClientIpConfig;
+  getControlUiConfig?: () => GatewayControlUiConfig | undefined;
   gatewayMethods: string[];
   events: string[];
 };
@@ -166,6 +174,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       resolveSharedGatewaySessionGeneration(getResolvedAuth()),
     rateLimiter,
     browserRateLimiter,
+    getClientIpConfig,
+    getControlUiConfig,
     gatewayMethods,
     events,
     logGateway,
@@ -374,7 +384,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         logWsControl.warn(
           `handshake timeout conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"}`,
         );
-        close();
+        close(1000, truncateCloseReason(GATEWAY_HANDSHAKE_TIMEOUT_CLOSE_REASON));
       }
     }, handshakeTimeoutMs);
 
@@ -394,6 +404,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       requestUserAgent,
       canvasHostUrl,
       connectNonce,
+      getClientIpConfig,
+      getControlUiConfig,
       getResolvedAuth,
       getRequiredSharedGatewaySessionGeneration,
       rateLimiter,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage } from "node:http";
 import os from "node:os";
 import type { WebSocket } from "ws";
 import { loadConfig } from "../../../config/config.js";
+import type { GatewayControlUiConfig } from "../../../config/types.gateway.js";
 import {
   getBoundDeviceBootstrapProfile,
   getDeviceBootstrapTokenProfile,
@@ -126,6 +127,7 @@ import {
   shouldSkipLocalBackendSelfPairing,
 } from "./handshake-auth-helpers.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
+import type { HookClientIpConfig } from "../../server-http.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -178,6 +180,8 @@ export function attachGatewayWsMessageHandler(params: {
   requestUserAgent?: string;
   canvasHostUrl?: string;
   connectNonce: string;
+  getClientIpConfig?: () => HookClientIpConfig;
+  getControlUiConfig?: () => GatewayControlUiConfig | undefined;
   getResolvedAuth: () => ResolvedGatewayAuth;
   getRequiredSharedGatewaySessionGeneration?: () => string | undefined;
   /** Optional rate limiter for auth brute-force protection. */
@@ -218,6 +222,8 @@ export function attachGatewayWsMessageHandler(params: {
     requestUserAgent,
     canvasHostUrl,
     connectNonce,
+    getClientIpConfig,
+    getControlUiConfig,
     getResolvedAuth,
     getRequiredSharedGatewaySessionGeneration,
     rateLimiter,
@@ -252,9 +258,10 @@ export function attachGatewayWsMessageHandler(params: {
       });
     });
 
-  const configSnapshot = loadConfig();
-  const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
-  const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
+  const clientIpConfig = getClientIpConfig?.();
+  const controlUiConfig = getControlUiConfig?.();
+  const trustedProxies = clientIpConfig?.trustedProxies ?? [];
+  const allowRealIpFallback = clientIpConfig?.allowRealIpFallback === true;
   const clientIp = resolveClientIp({
     remoteAddr,
     forwardedFor,
@@ -472,11 +479,11 @@ export function attachGatewayWsMessageHandler(params: {
         const isWebchat = isWebchatConnect(connectParams);
         if (enforceOriginCheckForAnyClient || isBrowserOperatorUi || isWebchat) {
           const hostHeaderOriginFallbackEnabled =
-            configSnapshot.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true;
+            controlUiConfig?.dangerouslyAllowHostHeaderOriginFallback === true;
           const originCheck = checkBrowserOrigin({
             requestHost,
             origin: requestOrigin,
-            allowedOrigins: configSnapshot.gateway?.controlUi?.allowedOrigins,
+            allowedOrigins: controlUiConfig?.allowedOrigins,
             allowHostHeaderOriginFallback: hostHeaderOriginFallbackEnabled,
             isLocalClient,
           });
@@ -518,7 +525,7 @@ export function attachGatewayWsMessageHandler(params: {
         const hasSharedAuth = hasTokenAuth || hasPasswordAuth;
         const controlUiAuthPolicy = resolveControlUiAuthPolicy({
           isControlUi,
-          controlUiConfig: configSnapshot.gateway?.controlUi,
+          controlUiConfig,
           deviceRaw,
         });
         const device = controlUiAuthPolicy.device;


### PR DESCRIPTION
## Summary

- Problem: On Windows, CLI calls to a local loopback gateway can hit a startup/pre-auth WebSocket race where the gateway closes the socket during the connect handshake with no actionable close reason, surfacing as `gateway closed (1000)` / handshake timeout (#50380, #52424).
- Why it matters: `openclaw cron list/create` and other CLI-to-gateway operations fail even though the gateway port is open and the process is otherwise healthy.
- What changed: the gateway now closes pre-auth handshake timeouts with a stable close reason (`openclaw:handshake-timeout`), and the CLI gateway caller retries only that exact failure mode when running on Windows against a loopback gateway URL.
- What did NOT change (scope boundary): no general retry layer for remote gateways, non-CLI callers, or unrelated close codes; no auth model or protocol shape changes.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #50380
- Closes #52424
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: Windows local gateway startup could accept the WebSocket connection but miss the pre-auth connect window, leading the server to close the socket before `connect` completed; the client only saw `gateway closed (1000)` and treated it as a terminal failure.
- Missing detection / guardrail: the close path did not expose a machine-detectable reason for handshake timeout, and the CLI caller did not distinguish this transient startup race from non-retriable close paths.
- Contributing context (if known): the failure reproduces most often on Windows scheduled-task / local service startup where port-open and handshake-ready can briefly diverge.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/call.test.ts`, `src/gateway/server.preauth-hardening.test.ts`
- Scenario the test should lock in: Windows CLI loopback calls retry `openclaw:handshake-timeout` closes and still fail fast for non-handshake or non-loopback closes.
- Why this is the smallest reliable guardrail: the bug is in the gateway close reason + caller retry decision, which is fully exercised at the call-layer seam without requiring a full Windows scheduled-task harness.
- Existing test that already covers this (if any): `src/gateway/handshake-timeouts.test.ts` already covers timeout configuration defaults; this PR adds the missing behavior checks.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Windows CLI commands talking to a local loopback gateway now automatically retry transient pre-auth handshake timeouts instead of failing immediately with `gateway closed (1000)`.

## Diagram

```text
Before:
[CLI -> local gateway WS connect] -> [gateway pre-auth timeout] -> [close 1000 no actionable reason] -> [CLI fails]

After:
[CLI -> local gateway WS connect] -> [gateway pre-auth timeout + close reason] -> [Windows loopback CLI retry] -> [request succeeds or exhausts retries]
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows repro path; verified logic with targeted Vitest coverage locally
- Runtime/container: Node / local gateway call path
- Model/provider: N/A
- Integration/channel (if any): local gateway CLI / cron path
- Relevant config (redacted): loopback gateway URL (`ws://127.0.0.1:18789`)

### Steps

1. Start a local Windows gateway that briefly times out its pre-auth handshake during startup.
2. Run a CLI gateway command such as `openclaw cron list`.
3. Observe that the first `openclaw:handshake-timeout` close is retried automatically for loopback CLI calls.

### Expected

- Transient local Windows handshake timeout closes should be retried automatically.
- Non-loopback or non-handshake closes should remain non-retriable.

### Actual

- Verified by targeted tests covering retry, non-retry, timeout formatting, and server close-reason behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm exec vitest run src/gateway/call.test.ts -t "retries CLI gateway connect" --config test/vitest/vitest.gateway.config.ts`
  - `pnpm exec vitest run src/gateway/call.test.ts -t "does not retry handshake-timeout closes for non-loopback gateway urls" --config test/vitest/vitest.gateway.config.ts`
  - `pnpm exec vitest run src/gateway/call.test.ts -t "includes connection details on timeout" --config test/vitest/vitest.gateway.config.ts`
  - `pnpm exec vitest run src/gateway/handshake-timeouts.test.ts --config test/vitest/vitest.gateway.config.ts`
- Edge cases checked:
  - non-handshake close code does not retry
  - non-loopback URL does not retry
  - overall timeout formatting behavior still preserved
- What you did **not** verify:
  - full Windows scheduled-task end-to-end repro in this environment

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: retrying too broadly could mask unrelated close failures.
  - Mitigation: retry is limited to Windows + CLI + loopback URLs + explicit `openclaw:handshake-timeout` close reason.
