### PR TITLE
feat(system-prompt): inject sessionKey into Runtime line

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -711,6 +711,7 @@ export async function runEmbeddedAttempt(
         channel: runtimeChannel,
         capabilities: runtimeCapabilities,
         channelActions,
+        sessionKey: params.sessionKey,
       },
     });
     const isDefaultAgent = sessionAgentId === defaultAgentId;

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -33,6 +33,7 @@ export function buildEmbeddedSystemPrompt(params: {
   acpEnabled?: boolean;
   runtimeInfo: {
     agentId?: string;
+    sessionKey?: string;
     host: string;
     os: string;
     arch: string;

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -13,6 +13,7 @@ import {
 
 export type RuntimeInfoInput = {
   agentId?: string;
+  sessionKey?: string;
   host: string;
   os: string;
   arch: string;

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -738,6 +738,42 @@ describe("buildAgentSystemPrompt", () => {
     expect(line).toContain("thinking=low");
   });
 
+  it("includes sessionKey in runtime line when provided", () => {
+    const line = buildRuntimeLine(
+      {
+        agentId: "main",
+        sessionKey: "agent:main:draft:abc123",
+        host: "host",
+        os: "Linux",
+        arch: "x64",
+        node: "v20",
+        model: "anthropic/claude",
+      },
+      "webchat",
+      [],
+    );
+
+    expect(line).toContain("sessionKey=agent:main:draft:abc123");
+    expect(line).toContain("agent=main");
+  });
+
+  it("omits sessionKey from runtime line when not provided", () => {
+    const line = buildRuntimeLine(
+      {
+        agentId: "main",
+        host: "host",
+        os: "Linux",
+        arch: "x64",
+        node: "v20",
+        model: "anthropic/claude",
+      },
+      "webchat",
+      [],
+    );
+
+    expect(line).not.toContain("sessionKey=");
+  });
+
   it("renders extra system prompt exactly once", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -404,6 +404,7 @@ export function buildAgentSystemPrompt(params: {
   acpEnabled?: boolean;
   runtimeInfo?: {
     agentId?: string;
+    sessionKey?: string;
     host?: string;
     os?: string;
     arch?: string;
@@ -929,6 +930,7 @@ export function buildAgentSystemPrompt(params: {
 export function buildRuntimeLine(
   runtimeInfo?: {
     agentId?: string;
+    sessionKey?: string;
     host?: string;
     os?: string;
     arch?: string;
@@ -945,6 +947,7 @@ export function buildRuntimeLine(
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
   return `Runtime: ${[
     runtimeInfo?.agentId ? `agent=${runtimeInfo.agentId}` : "",
+    runtimeInfo?.sessionKey ? `sessionKey=${runtimeInfo.sessionKey}` : "",
     runtimeInfo?.host ? `host=${runtimeInfo.host}` : "",
     runtimeInfo?.repoRoot ? `repo=${runtimeInfo.repoRoot}` : "",
     runtimeInfo?.os


### PR DESCRIPTION
## Summary

Injects \sessionKey\ into the system prompt Runtime line so the agent can identify its own session and accurately retrieve its own conversation history.

Closes #66292

## Problem

\RuntimeInfoInput\ did not include \sessionKey\, so the Runtime line only showed:

\\\
Runtime: agent=main | host=xxx | channel=webchat | ...
\\\

When a user asked the agent to recall prior context, it had no way to identify which session it was in — it would guess (typically defaulting to \main\), which was wrong for named draft sessions like \gent:main:draft:xxx\.

## Solution

Added \sessionKey\ at 3 layers:

1. **\src/agents/system-prompt-params.ts\** — Added \sessionKey?: string\ to \RuntimeInfoInput\
2. **\src/agents/pi-embedded-runner/run/attempt.ts\** — Pass \params.sessionKey\ into the runtime object (the value was already available at the call site)
3. **\src/agents/system-prompt.ts\** — Added \sessionKey\ to \uildRuntimeLine()\ and the \BuildSystemPromptParams\ runtimeInfo type
4. **\src/agents/pi-embedded-runner/system-prompt.ts\** — Added \sessionKey\ to the local runtimeInfo type

Result:
\\\
Runtime: agent=main | sessionKey=agent:main:draft:abc123 | host=xxx | channel=webchat | ...
\\\

The agent can now call \sessions_history(currentSessionKey)\ directly.

## Testing

- Added 2 new test cases in \system-prompt.test.ts\:
  - \sessionKey\ appears in Runtime line when provided
  - \sessionKey\ is omitted when not provided
- All system-prompt tests pass (54 tests)
- Type checker (\	sgo --noEmit\) passes cleanly

## AI Disclosure

- [x] AI-assisted (GitHub Copilot CLI)
- [x] Fully tested — ran \	sgo --noEmit\ and \pnpm test:unit:fast\, all relevant tests pass
- [x] I understand what the code does