### PR TITLE
fix(agents): detect billing from FallbackSummaryError structured reasons

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -912,6 +912,65 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("shows billing message when all fallback attempts have reason=billing (cooldown skip path)", async () => {
+    state.runWithModelFallbackMock.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          "All models failed (2): anthropic/claude-opus-4-6: Provider anthropic has billing issue (skipping all models) (billing) | anthropic/claude-sonnet-4-6: Provider anthropic has billing issue (skipping all models) (billing)",
+        ),
+        {
+          name: "FallbackSummaryError",
+          attempts: [
+            {
+              provider: "anthropic",
+              model: "claude-opus-4-6",
+              error: "Provider anthropic has billing issue (skipping all models)",
+              reason: "billing",
+            },
+            {
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+              error: "Provider anthropic has billing issue (skipping all models)",
+              reason: "billing",
+            },
+          ],
+          soonestCooldownExpiry: null,
+        },
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      // BILLING_ERROR_USER_MESSAGE is mocked as "billing" at ln45
+      expect(result.payload.text).toBe("billing");
+    }
+  });
+
   it("surfaces gateway restart text when fallback exhaustion wraps a drain error", async () => {
     const { replyOperation, failMock } = createMockReplyOperation();
     state.runWithModelFallbackMock.mockRejectedValueOnce(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -311,6 +311,20 @@ function isPureTransientRateLimitSummary(err: unknown): boolean {
   );
 }
 
+/**
+ * When all fallback attempts failed due to billing (e.g. auth profile in
+ * billing cooldown), the summary message contains 'has billing issue' which
+ * `isBillingErrorMessage()` does not recognise. Use the structured
+ * `attempt.reason` instead. Note: mirrors `isPureTransientRateLimitSummary`.
+ */
+function isPureBillingSummary(err: unknown): boolean {
+  return (
+    isFallbackSummaryError(err) &&
+    err.attempts.length > 0 &&
+    err.attempts.every((attempt) => attempt.reason === "billing")
+  );
+}
+
 function isToolResultTurnMismatchError(message: string): boolean {
   const lower = normalizeLowercaseStringOrEmpty(message);
   return (
@@ -1320,7 +1334,7 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
       const message = formatErrorMessage(err);
-      const isBilling = isBillingErrorMessage(message);
+      const isBilling = isPureBillingSummary(err) || isBillingErrorMessage(message);
       const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);


### PR DESCRIPTION
## Summary

- Problem: When auth profiles enter billing cooldown, model-fallback skips all candidates with `"Provider X has billing issue (skipping all models)"`. This message does not match any pattern in `isBillingErrorMessage()`, so users see `"Something went wrong while processing your request"` instead of `BILLING_ERROR_USER_MESSAGE`.
- Why it matters: Only the very first billing failure (containing raw `"out of extra usage"`) is detected correctly. Every subsequent attempt, which is the majority of what users see falls through to the generic error path. Especially common with OAuth users who exhaust personal Anthropic "extra usage" quotas.
- What changed: Added `isPureBillingSummary()` in `agent-runner-execution.ts` that checks the structured `attempt.reason === "billing"` on `FallbackSummaryError`, used as a fast-path before `isBillingErrorMessage()` string matching. Added test covering this path.
- What did NOT change (scope boundary):  `isBillingErrorMessage()` patterns in `failover-matches.ts` are untouched. `BILLING_ERROR_USER_MESSAGE` text is unchanged. No changes to model-fallback logic itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66314
- Related #48526, #64224, #64308, #62375, #61608
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `agent-runner-execution.ts` line 1337 classifies billing errors using `isBillingErrorMessage(message)` which string-matches the formatted `FallbackSummaryError` message. When all candidates are skipped due to billing cooldown, the message contains `"has billing issue (skipping all models)"` none of the patterns in `ERROR_PATTERNS.billing` match this string.
- Missing detection / guardrail: The rate-limit path already uses structured `FallbackSummaryError` data via `isPureTransientRateLimitSummary()` (checking `attempt.reason`), but the billing path had no equivalent and relied solely on string matching.
- Contributing context (if known): PR #61608 added `"out of extra usage"` to the billing patterns, fixing detection for the raw Anthropic API error. But the cooldown-generated skip message uses different wording that was never added to the pattern list.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/agent-runner-execution.test.ts`
- Scenario the test should lock in: `FallbackSummaryError` where every `attempt.reason === "billing"` (cooldown skip path) must return `BILLING_ERROR_USER_MESSAGE`, not the generic fallback.
- Why this is the smallest reliable guardrail: Unit test directly verifies the classification logic in the catch block without needing a live provider or gateway.
- Existing test that already covers this (if any): `"does not show a rate-limit countdown for mixed-cause fallback exhaustion"` covers the mixed billing+rate_limit case (which should NOT be classified as pure billing). The new test covers the pure-billing case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

When all model candidates are skipped due to billing cooldown, users now see:

> ⚠️  API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different
   API key.

Instead of:

> ⚠️  Something went wrong while processing your request. Please try again, or use /new to start a fresh session.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[billing cooldown] -> FallbackSummaryError("...has billing issue...")
    -> isBillingErrorMessage() = false
    -> buildExternalRunFailureText()
    -> "Something went wrong"

After:
[billing cooldown] -> FallbackSummaryError(attempts[].reason="billing")
    -> isPureBillingSummary() = true
    -> BILLING_ERROR_USER_MESSAGE
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Debian 12 (Bookworm) — Docker container (ghcr.io/openclaw/openclaw)
- Runtime/container: Docker
- Model/provider: anthropic/claude-opus-4-6, anthropic/claude-sonnet-4-6 (OAuth)
- Integration/channel (if any): Web UI / gateway
- Relevant config (redacted): Single-provider setup with Anthropic OAuth authentication

### Steps

1. Configure OpenClaw with Anthropic provider using OAuth authentication.
2. The personal "extra usage" quota on claude.ai becomes exhausted.
3. A background/scheduled agent task hits the billing error first, putting the auth profile into billing cooldown.
4. User sends a message, all candidates are skipped due to billing cooldown.
5. Observe the user-facing error message.

### Expected

- User sees BILLING_ERROR_USER_MESSAGE on every billing failure, including cooldown skips.

### Actual

- User sees generic "Something went wrong while processing your request" with no billing context.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```
# Cooldown skip path:  isBillingErrorMessage() misses this:
[model-fallback] decision=skip_candidate reason=billing detail=Provider anthropic has billing issue (skipping all models)
Embedded agent failed before reply: All models failed (2): anthropic/claude-opus-4-6: Provider anthropic has billing issue (skipping all models) (billing) | anthropic/claude-sonnet-4-6: Provider anthropic has billing issue (skipping all models) (billing)
```

Test results: 31/31 pass in `agent-runner-execution.test.ts`, 150/150 pass in related billing/error tests.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: New test confirms pure-billing `FallbackSummaryError` returns `BILLING_ERROR_USER_MESSAGE`. Ran full test suites for `agent-runner-execution.test.ts` (31 pass), `pi-embedded-helpers.isbillingerrormessage.test.ts` and `formatassistanterrortext.test.ts` (150 pass).
- Edge cases checked: Mixed-cause summary (billing + rate_limit) is NOT classified as pure billing, existing test `"does not show a rate-limit countdown for mixed-cause fallback exhaustion"` still passes.
- What you did **not** verify: Live end-to-end test with an actual exhausted OAuth account. The fix is a classification-only change with no side effects on the model-fallback or auth-profile logic.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

None
