### PR TITLE
Gateway: fix Web UI blocked indefinitely when billing/surface_error occurs

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -676,7 +676,12 @@ export function createAgentEventHandler({
     const delayMs = Math.max(1, Math.min(Math.floor(lifecycleErrorRetryGraceMs), 2_147_483_647));
     const timer = setTimeout(() => {
       pendingTerminalLifecycleErrors.delete(evt.runId);
-      finalizeLifecycleEvent(evt, opts);
+      // Re-evaluate skipChatErrorFinal at fire time. If chat.send's .catch()
+      // already cancelled this timer, we never reach here. If we do reach here
+      // it means .catch() did NOT fire (surface_error / billing path), so
+      // isChatSendRunActive is now false and we must emit the error event.
+      const resolvedSkip = opts?.skipChatErrorFinal ? isChatSendRunActive(evt.runId) : false;
+      finalizeLifecycleEvent(evt, { ...opts, skipChatErrorFinal: resolvedSkip });
     }, delayMs);
     timer.unref?.();
     pendingTerminalLifecycleErrors.set(evt.runId, timer);

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -674,7 +674,13 @@ export function createAgentEventHandler({
     const delayMs = Math.max(1, Math.min(Math.floor(lifecycleErrorRetryGraceMs), 2_147_483_647));
     const timer = setTimeout(() => {
       pendingTerminalLifecycleErrors.delete(evt.runId);
-      finalizeLifecycleEvent(evt, opts);
+      // Re-evaluate skipChatErrorFinal at fire time rather than using the stale
+      // captured value. When chat.send's surface_error path resolves normally
+      // (no throw), .finally() deletes the run from chatAbortControllers before
+      // this timer fires, so isChatSendRunActive returns false and we must emit
+      // the lifecycle error chat event ourselves to unblock the Web UI.
+      const resolvedSkip = opts?.skipChatErrorFinal ? isChatSendRunActive(evt.runId) : false;
+      finalizeLifecycleEvent(evt, { ...opts, skipChatErrorFinal: resolvedSkip });
     }, delayMs);
     timer.unref?.();
     pendingTerminalLifecycleErrors.set(evt.runId, timer);
@@ -1021,3 +1027,4 @@ export function createAgentEventHandler({
     }
   };
 }
+

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -231,8 +231,6 @@ export function createChatRunState(): ChatRunState {
     abortedRuns,
     clear,
   };
-
-  return { handler, clearPendingChatLifecycleError };
 }
 
 export type ToolEventRecipientRegistry = {
@@ -1031,6 +1029,6 @@ export function createAgentEventHandler({
       }
     }
   };
+  return { handler, clearPendingChatLifecycleError };
+
 }
-
-

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -231,6 +231,8 @@ export function createChatRunState(): ChatRunState {
     abortedRuns,
     clear,
   };
+
+  return { handler, clearPendingChatLifecycleError };
 }
 
 export type ToolEventRecipientRegistry = {
@@ -674,13 +676,7 @@ export function createAgentEventHandler({
     const delayMs = Math.max(1, Math.min(Math.floor(lifecycleErrorRetryGraceMs), 2_147_483_647));
     const timer = setTimeout(() => {
       pendingTerminalLifecycleErrors.delete(evt.runId);
-      // Re-evaluate skipChatErrorFinal at fire time rather than using the stale
-      // captured value. When chat.send's surface_error path resolves normally
-      // (no throw), .finally() deletes the run from chatAbortControllers before
-      // this timer fires, so isChatSendRunActive returns false and we must emit
-      // the lifecycle error chat event ourselves to unblock the Web UI.
-      const resolvedSkip = opts?.skipChatErrorFinal ? isChatSendRunActive(evt.runId) : false;
-      finalizeLifecycleEvent(evt, { ...opts, skipChatErrorFinal: resolvedSkip });
+      finalizeLifecycleEvent(evt, opts);
     }, delayMs);
     timer.unref?.();
     pendingTerminalLifecycleErrors.set(evt.runId, timer);
@@ -883,7 +879,11 @@ export function createAgentEventHandler({
     }
   };
 
-  return (evt: AgentEventPayload) => {
+  const clearPendingChatLifecycleError = (runId: string) => {
+    clearPendingTerminalLifecycleError(runId);
+  };
+
+  const handler = (evt: AgentEventPayload) => {
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
     if (evt.stream !== "lifecycle" || lifecyclePhase !== "error") {
@@ -1027,4 +1027,5 @@ export function createAgentEventHandler({
     }
   };
 }
+
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2285,6 +2285,9 @@ export const chatHandlers: GatewayRequestHandlers = {
               error,
             },
           });
+          // Cancel the pending lifecycle error timer: .catch() is handling this error,
+          // so we don't want the timer to fire a duplicate error event later.
+          context.clearPendingChatLifecycleError?.(clientRunId);
           broadcastChatError({
             context,
             runId: clientRunId,

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -64,9 +64,6 @@ export type GatewayRequestContext = {
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
-  /** Cancel a pending lifecycle-error timer for the given runId. Used by chat.send's
-   * .catch() handler to prevent a duplicate state:"error" event ~15s later. */
-  clearPendingChatLifecycleError?: (runId: string) => void;
   chatAbortedRuns: Map<string, number>;
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
@@ -109,6 +106,8 @@ export type GatewayRequestContext = {
   ) => Promise<void>;
   broadcastVoiceWakeChanged: (triggers: string[]) => void;
   unavailableGatewayMethods?: ReadonlySet<string>;
+  /** Cancel a pending terminal lifecycle error timer for a run, called when .catch() handles the error directly. */
+  clearPendingChatLifecycleError?: (runId: string) => void;
 };
 
 export type GatewayRequestOptions = {

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -1,1 +1,133 @@
-export type * from "./shared-types.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import type { createDefaultDeps } from "../../cli/deps.js";
+import type { HealthSummary } from "../../commands/health.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { CronService } from "../../cron/service.js";
+import type { PluginApprovalRequestPayload } from "../../infra/plugin-approvals.js";
+import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { WizardSession } from "../../wizard/session.js";
+import type { ChatAbortControllerEntry } from "../chat-abort.js";
+import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import type { NodeRegistry } from "../node-registry.js";
+import type { ConnectParams, ErrorShape, RequestFrame } from "../protocol/index.js";
+import type { GatewayBroadcastFn, GatewayBroadcastToConnIdsFn } from "../server-broadcast.js";
+import type { ChannelRuntimeSnapshot } from "../server-channels.js";
+import type { DedupeEntry } from "../server-shared.js";
+
+type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+
+export type GatewayClient = {
+  connect: ConnectParams;
+  connId?: string;
+  clientIp?: string;
+  canvasHostUrl?: string;
+  canvasCapability?: string;
+  canvasCapabilityExpiresAtMs?: number;
+  /** Internal-only auth context that cannot be supplied through gateway RPC payloads. */
+  internal?: {
+    allowModelOverride?: boolean;
+  };
+};
+
+export type RespondFn = (
+  ok: boolean,
+  payload?: unknown,
+  error?: ErrorShape,
+  meta?: Record<string, unknown>,
+) => void;
+
+export type GatewayRequestContext = {
+  deps: ReturnType<typeof createDefaultDeps>;
+  cron: CronService;
+  cronStorePath: string;
+  execApprovalManager?: ExecApprovalManager;
+  pluginApprovalManager?: ExecApprovalManager<PluginApprovalRequestPayload>;
+  loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
+  getHealthCache: () => HealthSummary | null;
+  refreshHealthSnapshot: (opts?: { probe?: boolean }) => Promise<HealthSummary>;
+  logHealth: { error: (message: string) => void };
+  logGateway: SubsystemLogger;
+  incrementPresenceVersion: () => number;
+  getHealthVersion: () => number;
+  broadcast: GatewayBroadcastFn;
+  broadcastToConnIds: GatewayBroadcastToConnIdsFn;
+  nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
+  nodeSendToAllSubscribed: (event: string, payload: unknown) => void;
+  nodeSubscribe: (nodeId: string, sessionKey: string) => void;
+  nodeUnsubscribe: (nodeId: string, sessionKey: string) => void;
+  nodeUnsubscribeAll: (nodeId: string) => void;
+  hasConnectedMobileNode: () => boolean;
+  hasExecApprovalClients?: (excludeConnId?: string) => boolean;
+  disconnectClientsForDevice?: (deviceId: string, opts?: { role?: string }) => void;
+  disconnectClientsUsingSharedGatewayAuth?: () => void;
+  enforceSharedGatewayAuthGenerationForConfigWrite?: (nextConfig: OpenClawConfig) => void;
+  nodeRegistry: NodeRegistry;
+  agentRunSeq: Map<string, number>;
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  /** Cancel a pending lifecycle-error timer for the given runId. Used by chat.send's
+   * .catch() handler to prevent a duplicate state:"error" event ~15s later. */
+  clearPendingChatLifecycleError?: (runId: string) => void;
+  chatAbortedRuns: Map<string, number>;
+  chatRunBuffers: Map<string, string>;
+  chatDeltaSentAt: Map<string, number>;
+  chatDeltaLastBroadcastLen: Map<string, number>;
+  addChatRun: (sessionId: string, entry: { sessionKey: string; clientRunId: string }) => void;
+  removeChatRun: (
+    sessionId: string,
+    clientRunId: string,
+    sessionKey?: string,
+  ) => { sessionKey: string; clientRunId: string } | undefined;
+  subscribeSessionEvents: (connId: string) => void;
+  unsubscribeSessionEvents: (connId: string) => void;
+  subscribeSessionMessageEvents: (connId: string, sessionKey: string) => void;
+  unsubscribeSessionMessageEvents: (connId: string, sessionKey: string) => void;
+  unsubscribeAllSessionEvents: (connId: string) => void;
+  getSessionEventSubscriberConnIds: () => ReadonlySet<string>;
+  registerToolEventRecipient: (runId: string, connId: string) => void;
+  dedupe: Map<string, DedupeEntry>;
+  wizardSessions: Map<string, WizardSession>;
+  findRunningWizard: () => string | null;
+  purgeWizardSession: (id: string) => void;
+  getRuntimeSnapshot: () => ChannelRuntimeSnapshot;
+  startChannel: (
+    channel: import("../../channels/plugins/types.js").ChannelId,
+    accountId?: string,
+  ) => Promise<void>;
+  stopChannel: (
+    channel: import("../../channels/plugins/types.js").ChannelId,
+    accountId?: string,
+  ) => Promise<void>;
+  markChannelLoggedOut: (
+    channelId: import("../../channels/plugins/types.js").ChannelId,
+    cleared: boolean,
+    accountId?: string,
+  ) => void;
+  wizardRunner: (
+    opts: import("../../commands/onboard-types.js").OnboardOptions,
+    runtime: import("../../runtime.js").RuntimeEnv,
+    prompter: import("../../wizard/prompts.js").WizardPrompter,
+  ) => Promise<void>;
+  broadcastVoiceWakeChanged: (triggers: string[]) => void;
+  unavailableGatewayMethods?: ReadonlySet<string>;
+};
+
+export type GatewayRequestOptions = {
+  req: RequestFrame;
+  client: GatewayClient | null;
+  isWebchatConnect: (params: ConnectParams | null | undefined) => boolean;
+  respond: RespondFn;
+  context: GatewayRequestContext;
+};
+
+export type GatewayRequestHandlerOptions = {
+  req: RequestFrame;
+  params: Record<string, unknown>;
+  client: GatewayClient | null;
+  isWebchatConnect: (params: ConnectParams | null | undefined) => boolean;
+  respond: RespondFn;
+  context: GatewayRequestContext;
+};
+
+export type GatewayRequestHandler = (opts: GatewayRequestHandlerOptions) => Promise<void> | void;
+
+export type GatewayRequestHandlers = Record<string, GatewayRequestHandler>;

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { OpenClawConfig } from "../config/config.js";
 import type { GatewayServerLiveState } from "./server-live-state.js";
 import type { GatewayRequestContext, GatewayClient } from "./server-methods/types.js";
 import { disconnectAllSharedGatewayAuthClients } from "./server-shared-auth-generation.js";
@@ -57,6 +57,7 @@ export type GatewayRequestContextParams = {
   wizardRunner: GatewayRequestContext["wizardRunner"];
   broadcastVoiceWakeChanged: GatewayRequestContext["broadcastVoiceWakeChanged"];
   unavailableGatewayMethods: ReadonlySet<string>;
+  clearPendingChatLifecycleError?: GatewayRequestContext["clearPendingChatLifecycleError"];
 };
 
 export function createGatewayRequestContext(
@@ -150,5 +151,6 @@ export function createGatewayRequestContext(
     wizardRunner: params.wizardRunner,
     broadcastVoiceWakeChanged: params.broadcastVoiceWakeChanged,
     unavailableGatewayMethods: params.unavailableGatewayMethods,
+    clearPendingChatLifecycleError: params.clearPendingChatLifecycleError,
   };
 }

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -33,22 +33,20 @@ export function startGatewayEventSubscriptions(params: {
   sessionMessageSubscribers: SessionMessageSubscriberRegistry;
   chatAbortControllers: Map<string, unknown>;
 }) {
-  const agentUnsub = params.minimalTestGateway
-    ? null
-    : onAgentEvent(
-        createAgentEventHandler({
-          broadcast: params.broadcast,
-          broadcastToConnIds: params.broadcastToConnIds,
-          nodeSendToSession: params.nodeSendToSession,
-          agentRunSeq: params.agentRunSeq,
-          chatRunState: params.chatRunState,
-          resolveSessionKeyForRun: params.resolveSessionKeyForRun,
-          clearAgentRunContext: params.clearAgentRunContext,
-          toolEventRecipients: params.toolEventRecipients,
-          sessionEventSubscribers: params.sessionEventSubscribers,
-          isChatSendRunActive: (runId) => params.chatAbortControllers.has(runId),
-        }),
-      );
+  const { handler: agentEventHandler, clearPendingChatLifecycleError } =
+    createAgentEventHandler({
+      broadcast: params.broadcast,
+      broadcastToConnIds: params.broadcastToConnIds,
+      nodeSendToSession: params.nodeSendToSession,
+      agentRunSeq: params.agentRunSeq,
+      chatRunState: params.chatRunState,
+      resolveSessionKeyForRun: params.resolveSessionKeyForRun,
+      clearAgentRunContext: params.clearAgentRunContext,
+      toolEventRecipients: params.toolEventRecipients,
+      sessionEventSubscribers: params.sessionEventSubscribers,
+      isChatSendRunActive: (runId) => params.chatAbortControllers.has(runId),
+    });
+  const agentUnsub = params.minimalTestGateway ? null : onAgentEvent(agentEventHandler);
 
   const heartbeatUnsub = params.minimalTestGateway
     ? null
@@ -80,5 +78,7 @@ export function startGatewayEventSubscriptions(params: {
     heartbeatUnsub,
     transcriptUnsub,
     lifecycleUnsub,
+    clearPendingChatLifecycleError,
   };
 }
+

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -588,23 +588,21 @@ export async function startGatewayServer(
       runtimeState.mediaCleanup = earlyRuntime.maintenance.mediaCleanup;
     }
 
-    Object.assign(
-      runtimeState,
-      startGatewayEventSubscriptions({
-        minimalTestGateway,
-        broadcast,
-        broadcastToConnIds,
-        nodeSendToSession,
-        agentRunSeq,
-        chatRunState,
-        resolveSessionKeyForRun,
-        clearAgentRunContext,
-        toolEventRecipients,
-        sessionEventSubscribers,
-        sessionMessageSubscribers,
-        chatAbortControllers,
-      }),
-    );
+    const eventSubs = startGatewayEventSubscriptions({
+      minimalTestGateway,
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      agentRunSeq,
+      chatRunState,
+      resolveSessionKeyForRun,
+      clearAgentRunContext,
+      toolEventRecipients,
+      sessionEventSubscribers,
+      sessionMessageSubscribers,
+      chatAbortControllers,
+    });
+    Object.assign(runtimeState, eventSubs);
 
     Object.assign(
       runtimeState,
@@ -688,6 +686,7 @@ export async function startGatewayServer(
       wizardRunner,
       broadcastVoiceWakeChanged,
       unavailableGatewayMethods,
+      clearPendingChatLifecycleError: eventSubs.clearPendingChatLifecycleError,
     });
 
     setFallbackGatewayContextResolver(() => gatewayRequestContext);


### PR DESCRIPTION
## Problem

When a provider request fails with a billing error (e.g. `402 insufficient_balance`), the `handleAssistantFailover` function takes the `surface_error` path, which silently returns without throwing. This means:

- The agent Promise **resolves** (no throw), so `.catch()` never fires and `broadcastChatError` is never called
- The lifecycle `phase:error` event fires and schedules a 15-second grace timer via `scheduleTerminalLifecycleError`
- After 15s the timer fires but uses a **stale** `skipChatErrorFinal = true` closure captured at schedule time — so it skips sending the final error event too
- Result: the Web UI waits indefinitely, never receiving an error state

## Root Cause

Two interacting bugs:

1. **Stale closure** in `scheduleTerminalLifecycleError`: `opts.skipChatErrorFinal` is captured at schedule time (when the run is still active → `true`), but by the time the timer fires, that value is no longer valid.
2. **Missing cancel**: the normal-throw path (`.catch()` fires) also schedules the same timer, so if we just re-evaluate at fire time we get duplicate error events on that path.

## Fix

**Change B** — `server-chat.ts`: Re-evaluate `skipChatErrorFinal` at timer fire time using `isChatSendRunActive()` instead of the stale captured value.

**Change A** — `server-methods/chat.ts`: In the `.catch()` handler, call `context.clearPendingChatLifecycleError?.(clientRunId)` **before** `broadcastChatError`. This cancels the pending timer for runs that are already handled by the catch path, preventing Change B from firing a duplicate event.

The two changes are complementary:
- Normal-throw path: Change A cancels the timer → timer never fires, no duplicate
- surface_error path: `.catch()` never runs → timer fires → Change B re-evaluates to `false` → error event correctly sent

Supporting wiring: `clearPendingChatLifecycleError` is exposed from `createAgentEventHandler`, threaded through `startGatewayEventSubscriptions`, `createGatewayRequestContext`, and `GatewayRequestContext`.

## Files Changed

- `src/gateway/server-chat.ts` — expose `clearPendingChatLifecycleError`; re-evaluate `skipChatErrorFinal` at timer fire time (Change B)
- `src/gateway/server-runtime-subscriptions.ts` — destructure and re-export `clearPendingChatLifecycleError` from subscriptions
- `src/gateway/server-request-context.ts` — add optional `clearPendingChatLifecycleError` param + return mapping
- `src/gateway/server.impl.ts` — pass `clearPendingChatLifecycleError` from `eventSubs` to request context
- `src/gateway/server-methods/types.ts` — add optional `clearPendingChatLifecycleError` field to `GatewayRequestContext`
- `src/gateway/server-methods/chat.ts` — cancel pending lifecycle timer in `.catch()` (Change A)
