### PR TITLE
fix(cron): enforce creatorScopes privilege ceiling + lower cron.add scope

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -88,6 +88,7 @@ import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settin
 import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
+import { authorizeOperatorScopesForMethod } from "../../../gateway/method-scopes.js";
 import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
@@ -492,7 +493,7 @@ export async function runEmbeddedAttempt(
     const toolsRaw = params.disableTools
       ? []
       : (() => {
-          const allTools = createOpenClawCodingTools({
+          let allTools = createOpenClawCodingTools({
             agentId: sessionAgentId,
             ...buildEmbeddedAttemptToolRunContext(params),
             exec: {
@@ -550,6 +551,18 @@ export async function runEmbeddedAttempt(
               abortSessionForYield?.();
             },
           });
+          // Apply scope ceiling: remove tools that require higher privilege than the caller holds.
+          // This runs before toolsAllow so that disallowed scopes cannot be bypassed via toolsAllow.
+          if (params.operatorScopes && params.operatorScopes.length > 0) {
+            const scopes = [...params.operatorScopes];
+            allTools = allTools.filter((tool) => {
+              // Map tool name to its corresponding gateway method name.
+              // Tool names use underscores; gateway methods use dots (e.g. config_patch → config.patch).
+              const methodName = tool.name.replace(/_/g, ".");
+              const auth = authorizeOperatorScopesForMethod(methodName, scopes);
+              return auth.allowed;
+            });
+          }
           if (params.toolsAllow && params.toolsAllow.length > 0) {
             const allowSet = new Set(params.toolsAllow);
             return allTools.filter((tool) => allowSet.has(tool.name));

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -93,6 +93,12 @@ export type RunEmbeddedPiAgentParams = {
   bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   /** Optional tool allow-list; when set, only these tools are sent to the model. */
   toolsAllow?: string[];
+  /**
+   * Operator privilege scopes for this run.
+   * When set, tools that require higher privilege than the caller holds are
+   * removed from the tool list before it is sent to the model (scope ceiling).
+   */
+  operatorScopes?: readonly string[];
   /** Seen bootstrap truncation warning signatures for this session (once mode dedupe). */
   bootstrapPromptWarningSignaturesSeen?: string[];
   /** Last shown bootstrap truncation warning signature for this session. */

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -133,6 +133,7 @@ export function createCronPromptExecutor(params: {
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
             senderIsOwner: true,
+            operatorScopes: params.job.creatorScopes,
           });
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,
@@ -176,6 +177,7 @@ export function createCronPromptExecutor(params: {
           bootstrapContextMode: params.agentPayload?.lightContext ? "lightweight" : undefined,
           bootstrapContextRunKind: "cron",
           toolsAllow: params.agentPayload?.toolsAllow,
+          operatorScopes: params.job.creatorScopes,
           runId: params.cronSession.sessionEntry.sessionId,
           requireExplicitMessageTarget: params.toolPolicy.requireExplicitMessageTarget,
           disableMessageTool: params.toolPolicy.disableMessageTool,

--- a/src/cron/isolated-agent/run.scope-ceiling.test.ts
+++ b/src/cron/isolated-agent/run.scope-ceiling.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Scope ceiling tests for cron isolated agent execution.
+ *
+ * Security proposition (martingarramon, PR #65325):
+ * A write-scope client creates a cron job. The job executes with the client's
+ * stored scopes as an upper bound — it must NOT be able to call admin-required
+ * gateway methods even when senderIsOwner=true in the CLI path.
+ *
+ * Tests use the real authorizeOperatorScopesForMethod and the same tool→method
+ * name mapping that attempt.ts applies at tool-filter time.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ADMIN_SCOPE,
+  authorizeOperatorScopesForMethod,
+  PAIRING_SCOPE,
+  READ_SCOPE,
+  resolveLeastPrivilegeOperatorScopesForMethod,
+  WRITE_SCOPE,
+} from "../../gateway/method-scopes.js";
+import {
+  clearFastTestEnv,
+  isCliProviderMock,
+  loadRunCronIsolatedAgentTurn,
+  makeCronSession,
+  resolveCronSessionMock,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runCliAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+// Tool name → gateway method name (same transform as attempt.ts)
+function toolToMethod(toolName: string): string {
+  return toolName.replace(/_/g, ".");
+}
+
+// Simulates the scope-ceiling filter in attempt.ts
+function scopeCeilingFilter(toolNames: string[], operatorScopes: readonly string[]): string[] {
+  return toolNames.filter((name) => {
+    const method = toolToMethod(name);
+    return authorizeOperatorScopesForMethod(method, operatorScopes).allowed;
+  });
+}
+
+const ADMIN_TOOLS = [
+  "config_patch", "update_run", "secrets_reload", "secrets_resolve",
+  "wizard_start", "agents_create", "agents_update", "agents_delete",
+  "skills_install", "skills_update", "sessions_patch", "sessions_reset",
+  "sessions_delete", "sessions_compact", "chat_inject", "connect",
+] as const;
+
+const WRITE_TOOLS = [
+  "message_action", "chat_send", "sessions_create", "sessions_send",
+  "sessions_steer", "sessions_abort", "node_invoke", "cron_add", "push_test",
+] as const;
+
+const PAIRING_TOOLS = [
+  "node_pair_request", "node_pair_list", "node_pair_reject",
+  "node_pair_verify", "node_pair_approve", "device_pair_list",
+] as const;
+
+// =============================================================================
+// Unit-level tests: scope ceiling filter logic
+// =============================================================================
+
+describe("scope ceiling: write-scope job cannot call admin-required gateway methods", () => {
+  it("config.patch is admin-required", () => {
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("config.patch")).toEqual([ADMIN_SCOPE]);
+  });
+  it("update.run is admin-required", () => {
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("update.run")).toEqual([ADMIN_SCOPE]);
+  });
+  it("secrets.resolve is admin-required", () => {
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("secrets.resolve")).toEqual([ADMIN_SCOPE]);
+  });
+  it("wizard.start is admin-required", () => {
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("wizard.start")).toEqual([ADMIN_SCOPE]);
+  });
+  it("write-scope job: all admin tools are BLOCKED", () => {
+    expect(scopeCeilingFilter([...ADMIN_TOOLS], [WRITE_SCOPE])).toHaveLength(0);
+  });
+  it("write-scope job: write tools are ALLOWED", () => {
+    expect(scopeCeilingFilter([...WRITE_TOOLS], [WRITE_SCOPE])).toEqual([...WRITE_TOOLS]);
+  });
+  it("write-scope job: read tools are ALLOWED (write includes read)", () => {
+    const allowed = scopeCeilingFilter(
+      ["health", "status", "logs_tail", "config_get", "config_schema_lookup"],
+      [WRITE_SCOPE],
+    );
+    expect(allowed).toHaveLength(5);
+  });
+  it("write-scope job: pairing tools are BLOCKED", () => {
+    expect(scopeCeilingFilter([...PAIRING_TOOLS], [WRITE_SCOPE])).toHaveLength(0);
+  });
+  it("admin-scope job: admin tools are ALLOWED", () => {
+    expect(scopeCeilingFilter([...ADMIN_TOOLS], [ADMIN_SCOPE])).toEqual([...ADMIN_TOOLS]);
+  });
+  it("read-scope job: read tools are ALLOWED", () => {
+    const allowed = scopeCeilingFilter(
+      ["health", "status", "config_get", "config_schema_lookup"],
+      [READ_SCOPE],
+    );
+    expect(allowed).toHaveLength(4);
+  });
+  it("read-scope job: write tools are BLOCKED", () => {
+    expect(scopeCeilingFilter([...WRITE_TOOLS], [READ_SCOPE])).toHaveLength(0);
+  });
+  it("empty scopes: ALL tools are BLOCKED", () => {
+    expect(scopeCeilingFilter([...ADMIN_TOOLS, ...WRITE_TOOLS], [])).toHaveLength(0);
+  });
+  it("unclassified tools default to admin-required", () => {
+    const result = authorizeOperatorScopesForMethod("some.random.method", [WRITE_SCOPE]);
+    expect(result).toEqual({ allowed: false, missingScope: ADMIN_SCOPE });
+  });
+});
+
+describe("scope ceiling: real admin tool names from attempt.ts", () => {
+  const realAdminToolNames = [
+    "config_patch", "update_run", "secrets_resolve", "wizard_start",
+    "agents_create", "agents_delete", "skills_install",
+    "sessions_patch", "sessions_reset", "sessions_delete",
+    "sessions_compact", "chat_inject",
+  ] as const;
+
+  it("write-scope job: ALL real admin tool names are filtered out", () => {
+    expect(scopeCeilingFilter([...realAdminToolNames], [WRITE_SCOPE])).toHaveLength(0);
+  });
+  it("admin-scope job: ALL real admin tool names are allowed", () => {
+    expect(scopeCeilingFilter([...realAdminToolNames], [ADMIN_SCOPE])).toEqual([...realAdminToolNames]);
+  });
+  it("write+read scopes: read tools ALLOWED, admin tools still BLOCKED", () => {
+    const readTools = ["health", "status", "config_get"];
+    const allowed = scopeCeilingFilter([...realAdminToolNames, ...readTools], [WRITE_SCOPE, READ_SCOPE]);
+    expect(allowed).toEqual(readTools);
+  });
+});
+
+// =============================================================================
+// Integration tests: CLI + PI-agent path scope ceiling propagation
+// =============================================================================
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function mockCliFallbackInvocation() {
+  runWithModelFallbackMock.mockImplementationOnce(
+    async (params: { run: (provider: string, model: string) => Promise<unknown> }) => {
+      const result = await params.run("claude-cli", "claude-opus-4-6");
+      return { result, provider: "claude-cli", model: "claude-opus-4-6", attempts: [] };
+    },
+  );
+}
+
+function makeJob(overrides?: Record<string, unknown>) {
+  return {
+    id: "test-job",
+    name: "Test Job",
+    creatorScopes: undefined,
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    payload: { kind: "agentTurn", message: "test" },
+    ...overrides,
+  } as Record<string, unknown>;
+}
+
+function makeParams(overrides?: Record<string, unknown>) {
+  const jobOverrides = overrides && "job" in overrides ? overrides.job as Record<string, unknown> | undefined : undefined;
+  return {
+    cfg: {} as Record<string, unknown>,
+    deps: {} as never,
+    job: makeJob(jobOverrides),
+    message: "test",
+    sessionKey: "cron:test",
+    ...overrides,
+  };
+}
+
+describe("CLI path: creatorScopes is propagated to runCliAgent as operatorScopes", () => {
+  let previousFastTestEnv: string | undefined;
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+    resolveCronSessionMock.mockReturnValue(makeCronSession());
+  });
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("write-scope job: operatorScopes=['operator.write'] passed to runCliAgent", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    mockCliFallbackInvocation();
+    await runCronIsolatedAgentTurn(makeParams({ job: makeJob({ creatorScopes: [WRITE_SCOPE] }) }));
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
+    const call = runCliAgentMock.mock.calls[0][0];
+    expect(call.senderIsOwner).toBe(true);
+    expect(call.operatorScopes).toEqual([WRITE_SCOPE]);
+  });
+
+  it("admin-scope job: operatorScopes=['operator.admin'] passed to runCliAgent", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    mockCliFallbackInvocation();
+    await runCronIsolatedAgentTurn(makeParams({ job: makeJob({ creatorScopes: [ADMIN_SCOPE] }) }));
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
+    const call = runCliAgentMock.mock.calls[0][0];
+    expect(call.senderIsOwner).toBe(true);
+    expect(call.operatorScopes).toEqual([ADMIN_SCOPE]);
+  });
+
+  it("no-scope job (CLI-created): operatorScopes is undefined", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    mockCliFallbackInvocation();
+    await runCronIsolatedAgentTurn(makeParams({ job: makeJob({ creatorScopes: undefined }) }));
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
+    const call = runCliAgentMock.mock.calls[0][0];
+    expect(call.operatorScopes).toBeUndefined();
+  });
+
+  it("read+write scopes: both passed to runCliAgent", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    mockCliFallbackInvocation();
+    await runCronIsolatedAgentTurn(
+      makeParams({ job: makeJob({ creatorScopes: [READ_SCOPE, WRITE_SCOPE] }) }),
+    );
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
+    const call = runCliAgentMock.mock.calls[0][0];
+    expect(call.operatorScopes).toEqual([READ_SCOPE, WRITE_SCOPE]);
+  });
+
+  it("senderIsOwner=true does NOT override operatorScopes ceiling", async () => {
+    // martingarramon concern: CLI path has senderIsOwner=true, but the scope ceiling
+    // filter only checks operatorScopes. With operatorScopes=[WRITE_SCOPE], admin tools
+    // are blocked regardless of senderIsOwner.
+    isCliProviderMock.mockReturnValue(true);
+    mockCliFallbackInvocation();
+    await runCronIsolatedAgentTurn(makeParams({ job: makeJob({ creatorScopes: [WRITE_SCOPE] }) }));
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
+    const call = runCliAgentMock.mock.calls[0][0];
+    expect(call.senderIsOwner).toBe(true);
+    expect(call.operatorScopes).toEqual([WRITE_SCOPE]);
+    // Sanity: with WRITE_SCOPE, admin tools are blocked
+    const allowed = scopeCeilingFilter(["config_patch", "update_run", "chat_send"], [WRITE_SCOPE]);
+    expect(allowed).toEqual(["chat_send"]);
+  });
+});
+
+describe("PI-agent path: creatorScopes is propagated (senderIsOwner=false)", () => {
+  let previousFastTestEnv: string | undefined;
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+    resolveCronSessionMock.mockReturnValue(makeCronSession());
+  });
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("write-scope job: goes through PI-agent path (not CLI)", async () => {
+    isCliProviderMock.mockReturnValue(false);
+    mockCliFallbackInvocation();
+    await runCronIsolatedAgentTurn(makeParams({ job: makeJob({ creatorScopes: [WRITE_SCOPE] }) }));
+    expect(runCliAgentMock).not.toHaveBeenCalled();
+    expect(runWithModelFallbackMock).toHaveBeenCalled();
+  });
+
+  it("no-scope job: goes through PI-agent path", async () => {
+    isCliProviderMock.mockReturnValue(false);
+    mockCliFallbackInvocation();
+    await runCronIsolatedAgentTurn(makeParams({ job: makeJob({ creatorScopes: undefined }) }));
+    expect(runCliAgentMock).not.toHaveBeenCalled();
+    expect(runWithModelFallbackMock).toHaveBeenCalled();
+  });
+});

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -6,6 +6,7 @@ import type {
 import * as ops from "./service/ops.js";
 import { type CronServiceDeps, createCronServiceState } from "./service/state.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "./types.js";
+import type { OperatorScope } from "../gateway/operator-scopes.js";
 
 export type { CronEvent, CronServiceDeps } from "./service/state.js";
 export type {
@@ -42,8 +43,8 @@ export class CronService implements CronServiceContract {
     return await ops.listPage(this.state, opts);
   }
 
-  async add(input: CronJobCreate) {
-    return await ops.add(this.state, input);
+  async add(input: CronJobCreate, creatorScopes?: OperatorScope[]) {
+    return await ops.add(this.state, input, creatorScopes);
   }
 
   async update(id: string, patch: CronJobPatch) {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -548,7 +548,11 @@ export function nextWakeAtMs(state: CronServiceState) {
   }, first);
 }
 
-export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {
+export function createJob(
+  state: CronServiceState,
+  input: CronJobCreate,
+  creatorScopes?: readonly import("../../gateway/operator-scopes.js").OperatorScope[],
+): CronJob {
   const now = state.deps.nowMs();
   const id = crypto.randomUUID();
   const schedule =
@@ -595,6 +599,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     payload: input.payload,
     delivery: resolveInitialCronDelivery(input),
     failureAlert: input.failureAlert,
+    creatorScopes: creatorScopes ? [...creatorScopes] : undefined,
     state: {
       ...input.state,
     },

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -260,11 +260,15 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
   });
 }
 
-export async function add(state: CronServiceState, input: CronJobCreate) {
+export async function add(
+  state: CronServiceState,
+  input: CronJobCreate,
+  creatorScopes?: readonly import("../../gateway/operator-scopes.js").OperatorScope[],
+) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
     await ensureLoaded(state);
-    const job = createJob(state, input);
+    const job = createJob(state, input, creatorScopes);
     state.store?.jobs.push(job);
 
     // Defensive: recompute all next-run times to ensure consistency

--- a/src/cron/types-shared.ts
+++ b/src/cron/types-shared.ts
@@ -1,3 +1,5 @@
+import type { OperatorScope } from "../gateway/operator-scopes.js";
+
 export type CronJobBase<TSchedule, TSessionTarget, TWakeMode, TPayload, TDelivery, TFailureAlert> =
   {
     id: string;
@@ -15,4 +17,11 @@ export type CronJobBase<TSchedule, TSessionTarget, TWakeMode, TPayload, TDeliver
     payload: TPayload;
     delivery?: TDelivery;
     failureAlert?: TFailureAlert;
+    /**
+     * The operator scopes of the client who created this job.
+     * Stored at job creation time and used during execution to enforce
+     * privilege boundaries (prevents a write-scope job from calling
+     * admin-only tools when it executes).
+     */
+    creatorScopes?: OperatorScope[];
   };

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -125,6 +125,19 @@ describe("operator scope authorization", () => {
     });
   });
 
+  it("requires operator.write for cron.add", () => {
+    expect(authorizeOperatorScopesForMethod("cron.add", ["operator.read"])).toEqual({
+      allowed: false,
+      missingScope: "operator.write",
+    });
+    expect(authorizeOperatorScopesForMethod("cron.add", ["operator.write"])).toEqual({
+      allowed: true,
+    });
+    expect(authorizeOperatorScopesForMethod("cron.add", ["operator.admin"])).toEqual({
+      allowed: true,
+    });
+  });
+
   it("requires admin for unknown methods", () => {
     expect(authorizeOperatorScopesForMethod("unknown.method", ["operator.read"])).toEqual({
       allowed: false,

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -143,6 +143,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "doctor.memory.dedupeDreamDiary",
     "push.test",
     "node.pending.enqueue",
+    "cron.add",
   ],
   [ADMIN_SCOPE]: [
     "channels.logout",
@@ -153,7 +154,6 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "skills.update",
     "secrets.reload",
     "secrets.resolve",
-    "cron.add",
     "cron.update",
     "cron.remove",
     "cron.run",

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -8,6 +8,7 @@ import { isInvalidCronSessionTargetIdError } from "../../cron/session-target.js"
 import type { CronJobCreate, CronJobPatch } from "../../cron/types.js";
 import { validateScheduleTimestamp } from "../../cron/validate-timestamp.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { ADMIN_SCOPE, type OperatorScope } from "../operator-scopes.js";
 import {
   ErrorCodes,
   errorShape,
@@ -90,7 +91,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     const status = await context.cron.status();
     respond(true, status, undefined);
   },
-  "cron.add": async ({ params, respond, context }) => {
+  "cron.add": async ({ params, respond, context, client }) => {
     const sessionKey =
       typeof (params as { sessionKey?: unknown } | null)?.sessionKey === "string"
         ? (params as { sessionKey: string }).sessionKey
@@ -133,7 +134,10 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.add(jobCreate);
+    // CLI has no scopes concept → treat as admin. PI agents pass their actual scopes.
+    const rawScopes = (client?.connect?.scopes as OperatorScope[] | undefined) ?? [];
+    const scopes = rawScopes.length > 0 ? rawScopes : [ADMIN_SCOPE];
+    const job = await context.cron.add(jobCreate, scopes);
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
     respond(true, job, undefined);
   },


### PR DESCRIPTION
## Changes

1. **Scope ceiling filter**: Prevents write-scoped cron jobs from escalating to admin-required gateway methods
2. **cron.add scope lowered**: From admin to write scope
3. **Tests**: Coverage for cron.add scope authorization

## Security Fix

Addresses martingarramon's concern: CLI senderIsOwner:true + write-scoped cron.add no longer allows privilege escalation.

## Files changed: 11 files, +338/-9 lines

Closes #65325