### PR TITLE
Agents: add per-agent TTS and STT overrides

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1619,8 +1619,7 @@ describe("active-memory plugin", () => {
         messages: [
           {
             role: "user",
-            content:
-              "Active Memory: I really do want you to remember that I prefer aisle seats.",
+            content: "Active Memory: I really do want you to remember that I prefer aisle seats.",
           },
           {
             role: "user",

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1527,7 +1527,9 @@ function extractRecentTurns(messages: unknown[]): ActiveRecallRecentTurn[] {
     }
     const rawText = extractTextContent(typed.content);
     const text =
-      role === "assistant" ? stripRecalledContextNoise(rawText) : stripInjectedActiveMemoryPrefixOnly(rawText);
+      role === "assistant"
+        ? stripRecalledContextNoise(rawText)
+        : stripInjectedActiveMemoryPrefixOnly(rawText);
     if (!text) {
       continue;
     }

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -7,6 +7,7 @@ import { ChannelType, type Client, ReadyListener } from "@buape/carbon";
 import type { VoicePlugin } from "@buape/carbon/voice";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { agentCommandFromIngress } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentSpeechConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveTtsConfig, type ResolvedTtsConfig } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig, TtsConfig } from "openclaw/plugin-sdk/config-runtime";
@@ -122,18 +123,23 @@ function mergeTtsConfig(base: TtsConfig, override?: TtsConfig): TtsConfig {
   };
 }
 
-function resolveVoiceTtsConfig(params: { cfg: OpenClawConfig; override?: TtsConfig }): {
+function resolveVoiceTtsConfig(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  override?: TtsConfig;
+}): {
   cfg: OpenClawConfig;
   resolved: ResolvedTtsConfig;
 } {
+  const agentCfg = resolveAgentSpeechConfig(params.cfg, params.agentId);
   if (!params.override) {
-    return { cfg: params.cfg, resolved: resolveTtsConfig(params.cfg) };
+    return { cfg: agentCfg, resolved: resolveTtsConfig(agentCfg) };
   }
-  const base = params.cfg.messages?.tts ?? {};
+  const base = agentCfg.messages?.tts ?? {};
   const merged = mergeTtsConfig(base, params.override);
-  const messages = params.cfg.messages ?? {};
+  const messages = agentCfg.messages ?? {};
   const cfg = {
-    ...params.cfg,
+    ...agentCfg,
     messages: {
       ...messages,
       tts: merged,
@@ -298,6 +304,7 @@ async function transcribeAudio(params: {
   const result = await getDiscordRuntime().mediaUnderstanding.transcribeAudioFile({
     filePath: params.filePath,
     cfg: params.cfg,
+    agentId: params.agentId,
     agentDir: resolveAgentDir(params.cfg, params.agentId),
     mime: "audio/wav",
   });
@@ -804,6 +811,7 @@ export class DiscordVoiceManager {
 
     const { cfg: ttsCfg, resolved: ttsConfig } = resolveVoiceTtsConfig({
       cfg: this.params.cfg,
+      agentId: entry.route.agentId,
       override: this.params.discordConfig.voice?.tts,
     });
     const directive = parseTtsDirectives(replyText, ttsConfig.modelOverrides, {

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -28,6 +28,8 @@ export type ResolvedAgentConfig = {
   groupChat?: AgentEntry["groupChat"];
   subagents?: AgentEntry["subagents"];
   embeddedPi?: AgentEntry["embeddedPi"];
+  tts?: AgentEntry["tts"];
+  stt?: AgentEntry["stt"];
   sandbox?: AgentEntry["sandbox"];
   tools?: AgentEntry["tools"];
 };
@@ -123,6 +125,8 @@ export function resolveAgentConfig(
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,
     embeddedPi:
       typeof entry.embeddedPi === "object" && entry.embeddedPi ? entry.embeddedPi : undefined,
+    tts: entry.tts,
+    stt: entry.stt,
     sandbox: entry.sandbox,
     tools: entry.tools,
   };

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -64,6 +64,8 @@ describe("resolveAgentConfig", () => {
       identity: undefined,
       groupChat: undefined,
       subagents: undefined,
+      tts: undefined,
+      stt: undefined,
       sandbox: undefined,
       tools: undefined,
     });

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -467,7 +467,10 @@ export async function executePreparedCliRun(
           ...parsed,
           rawText,
           finalPromptText: prompt,
-          text: applyPluginTextReplacements(rawText, context.backendResolved.textTransforms?.output),
+          text: applyPluginTextReplacements(
+            rawText,
+            context.backendResolved.textTransforms?.output,
+          ),
         };
       } finally {
         restoreSkillEnv?.();

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -23,6 +23,7 @@ import type { EmbeddedContextFile } from "../pi-embedded-helpers.js";
 import { detectImageReferences, loadImageFromRef } from "../pi-embedded-runner/run/images.js";
 import type { SandboxFsBridge } from "../sandbox/fs-bridge.js";
 import { detectRuntimeShell } from "../shell-utils.js";
+import { resolveAgentSpeechConfig } from "../speech-config.js";
 import { stripSystemPromptCacheBoundary } from "../system-prompt-cache-boundary.js";
 import { buildSystemPromptParams } from "../system-prompt-params.js";
 import { buildAgentSystemPrompt } from "../system-prompt.js";
@@ -97,7 +98,9 @@ export function buildSystemPrompt(params: {
       shell: detectRuntimeShell(),
     },
   });
-  const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+  const ttsHint = params.config
+    ? buildTtsSystemPromptHint(resolveAgentSpeechConfig(params.config, params.agentId))
+    : undefined;
   const ownerDisplay = resolveOwnerDisplaySetting(params.config);
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -89,6 +89,7 @@ import {
   applySkillEnvOverridesFromSnapshot,
   resolveSkillsPromptForRun,
 } from "../skills.js";
+import { resolveAgentSpeechConfig } from "../speech-config.js";
 import { resolveSystemPromptOverride } from "../system-prompt-override.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { classifyCompactionReason, resolveCompactionFailureReason } from "./compact-reasons.js";
@@ -671,7 +672,9 @@ export async function compactEmbeddedPiSessionDirect(
       cwd: effectiveWorkspace,
       moduleUrl: import.meta.url,
     });
-    const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const ttsHint = params.config
+      ? buildTtsSystemPromptHint(resolveAgentSpeechConfig(params.config, sessionAgentId))
+      : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
     const promptContribution = resolveProviderSystemPromptContribution({
       provider,

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
@@ -171,14 +171,16 @@ describe("buildContextEngineMaintenanceRuntimeContext", () => {
       });
       await Promise.resolve();
 
-      rewriteTranscriptEntriesInSessionFileMock.mockImplementationOnce(async (_params?: unknown) => {
-        events.push("rewrite");
-        return {
-          changed: true,
-          bytesFreed: 123,
-          rewrittenEntries: 2,
-        };
-      });
+      rewriteTranscriptEntriesInSessionFileMock.mockImplementationOnce(
+        async (_params?: unknown) => {
+          events.push("rewrite");
+          return {
+            changed: true,
+            bytesFreed: 123,
+            rewrittenEntries: 2,
+          };
+        },
+      );
 
       const runtimeContext = buildContextEngineMaintenanceRuntimeContext({
         sessionId: "session-rewrite-handoff",
@@ -836,19 +838,20 @@ describe("runContextEngineMaintenance", () => {
             allowRewrite = resolve;
           });
           events.push("maintenance-before-rewrite");
-          await (params as { runtimeContext?: ContextEngineRuntimeContext }).runtimeContext
-            ?.rewriteTranscriptEntries?.({
-              replacements: [
-                {
-                  entryId: "entry-1",
-                  message: castAgentMessage({
-                    role: "assistant",
-                    content: [{ type: "text", text: "done" }],
-                    timestamp: 2,
-                  }),
-                },
-              ],
-            });
+          await (
+            params as { runtimeContext?: ContextEngineRuntimeContext }
+          ).runtimeContext?.rewriteTranscriptEntries?.({
+            replacements: [
+              {
+                entryId: "entry-1",
+                message: castAgentMessage({
+                  role: "assistant",
+                  content: [{ type: "text", text: "done" }],
+                  timestamp: 2,
+                }),
+              },
+            ],
+          });
           events.push("maintenance-after-rewrite");
           return {
             changed: false,
@@ -857,14 +860,16 @@ describe("runContextEngineMaintenance", () => {
           };
         });
 
-        rewriteTranscriptEntriesInSessionFileMock.mockImplementationOnce(async (_params?: unknown) => {
-          events.push("rewrite");
-          return {
-            changed: true,
-            bytesFreed: 123,
-            rewrittenEntries: 2,
-          };
-        });
+        rewriteTranscriptEntriesInSessionFileMock.mockImplementationOnce(
+          async (_params?: unknown) => {
+            events.push("rewrite");
+            return {
+              changed: true,
+              bytesFreed: 123,
+              rewrittenEntries: 2,
+            };
+          },
+        );
 
         const backgroundEngine = {
           info: {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1725,9 +1725,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     );
 
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]));
-    const stream = wrapped({ api: "google-gemini" } as never, { messages } as never, {} as never) as
-      | FakeWrappedStream
-      | Promise<FakeWrappedStream>;
+    const stream = wrapped(
+      { api: "google-gemini" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
     await Promise.resolve(stream);
 
     expect(baseFn).toHaveBeenCalledTimes(1);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -106,6 +106,7 @@ import {
   applySkillEnvOverridesFromSnapshot,
   resolveSkillsPromptForRun,
 } from "../../skills.js";
+import { resolveAgentSpeechConfig } from "../../speech-config.js";
 import { resolveSystemPromptOverride } from "../../system-prompt-override.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
@@ -725,7 +726,9 @@ export async function runEmbeddedAttempt(
       cwd: effectiveWorkspace,
       moduleUrl: import.meta.url,
     });
-    const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const ttsHint = params.config
+      ? buildTtsSystemPromptHint(resolveAgentSpeechConfig(params.config, params.agentId))
+      : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
     const heartbeatPrompt = shouldInjectHeartbeatPrompt({
       config: params.config,

--- a/src/agents/speech-config.test.ts
+++ b/src/agents/speech-config.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { resolveAgentSpeechConfig, resolveSessionSpeechConfig } from "./speech-config.js";
+
+describe("resolveAgentSpeechConfig", () => {
+  it("returns the original config when the agent has no speech overrides", () => {
+    const cfg: OpenClawConfig = {
+      messages: {
+        tts: {
+          provider: "openai",
+        },
+      },
+      agents: {
+        list: [{ id: "main" }],
+      },
+    };
+
+    expect(resolveAgentSpeechConfig(cfg, "main")).toBe(cfg);
+  });
+
+  it("merges per-agent tts overrides onto messages.tts", () => {
+    const cfg: OpenClawConfig = {
+      messages: {
+        tts: {
+          provider: "openai",
+          auto: "always",
+          providers: {
+            openai: {
+              voice: "alloy",
+              model: "gpt-4o-mini-tts",
+            },
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "spanish",
+            tts: {
+              auto: "inbound",
+              providers: {
+                openai: {
+                  voice: "coral",
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const resolved = resolveAgentSpeechConfig(cfg, "spanish");
+
+    expect(resolved.messages?.tts).toEqual({
+      provider: "openai",
+      auto: "inbound",
+      providers: {
+        openai: {
+          voice: "coral",
+          model: "gpt-4o-mini-tts",
+        },
+      },
+    });
+  });
+
+  it("merges per-agent stt overrides onto tools.media.audio", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            language: "en",
+            prompt: "Default prompt",
+            models: [
+              {
+                provider: "openai",
+                model: "gpt-4o-transcribe",
+              },
+            ],
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "spanish",
+            stt: {
+              language: "es",
+              models: [
+                {
+                  provider: "deepgram",
+                  model: "nova-3",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const resolved = resolveAgentSpeechConfig(cfg, "spanish");
+
+    expect(resolved.tools?.media?.audio).toEqual({
+      language: "es",
+      prompt: "Default prompt",
+      models: [
+        {
+          provider: "deepgram",
+          model: "nova-3",
+        },
+      ],
+    });
+  });
+});
+
+describe("resolveSessionSpeechConfig", () => {
+  it("resolves the agent from the session key before merging speech config", () => {
+    const cfg: OpenClawConfig = {
+      messages: {
+        tts: {
+          auto: "always",
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "voice",
+            tts: {
+              auto: "tagged",
+            },
+          },
+        ],
+      },
+    };
+
+    const resolved = resolveSessionSpeechConfig({
+      cfg,
+      sessionKey: "agent:voice:main",
+    });
+
+    expect(resolved.messages?.tts?.auto).toBe("tagged");
+  });
+});

--- a/src/agents/speech-config.ts
+++ b/src/agents/speech-config.ts
@@ -1,0 +1,93 @@
+import type { OpenClawConfig } from "../config/types.js";
+import type { MediaUnderstandingConfig } from "../config/types.tools.js";
+import type { TtsConfig } from "../config/types.tts.js";
+import { resolveAgentConfig, resolveSessionAgentId } from "./agent-scope.js";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepMergeDefined<T>(base: T | undefined, override: T | undefined): T | undefined {
+  if (override === undefined) {
+    return base;
+  }
+  if (base === undefined) {
+    return override;
+  }
+  if (Array.isArray(base) || Array.isArray(override)) {
+    return override;
+  }
+  if (!isPlainObject(base) || !isPlainObject(override)) {
+    return override;
+  }
+
+  const merged: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    if (value === undefined) {
+      continue;
+    }
+    merged[key] = key in merged ? deepMergeDefined(merged[key], value) : value;
+  }
+  return merged as T;
+}
+
+function mergeAgentTtsConfig(
+  cfg: OpenClawConfig,
+  override?: TtsConfig,
+): OpenClawConfig["messages"] | undefined {
+  const mergedTts = deepMergeDefined(cfg.messages?.tts, override);
+  if (!mergedTts) {
+    return cfg.messages;
+  }
+  return {
+    ...cfg.messages,
+    tts: mergedTts,
+  };
+}
+
+function mergeAgentSttConfig(
+  cfg: OpenClawConfig,
+  override?: MediaUnderstandingConfig,
+): OpenClawConfig["tools"] | undefined {
+  const mergedAudio = deepMergeDefined(cfg.tools?.media?.audio, override);
+  if (!mergedAudio) {
+    return cfg.tools;
+  }
+  return {
+    ...cfg.tools,
+    media: {
+      ...cfg.tools?.media,
+      audio: mergedAudio,
+    },
+  };
+}
+
+export function resolveAgentSpeechConfig(
+  cfg: OpenClawConfig,
+  agentId?: string | null,
+): OpenClawConfig {
+  if (!agentId) {
+    return cfg;
+  }
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  if (!agentConfig?.tts && !agentConfig?.stt) {
+    return cfg;
+  }
+
+  return {
+    ...cfg,
+    messages: mergeAgentTtsConfig(cfg, agentConfig.tts),
+    tools: mergeAgentSttConfig(cfg, agentConfig.stt),
+  };
+}
+
+export function resolveSessionSpeechConfig(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string | null;
+}): OpenClawConfig {
+  const agentId = resolveSessionAgentId({
+    sessionKey: params.sessionKey ?? undefined,
+    config: params.cfg,
+  });
+  return resolveAgentSpeechConfig(params.cfg, agentId);
+}

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -9,6 +9,7 @@ import { createOpenClawCodingTools } from "../../agents/pi-tools.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
+import { resolveAgentSpeechConfig } from "../../agents/speech-config.js";
 import { buildSystemPromptParams } from "../../agents/system-prompt-params.js";
 import { buildAgentSystemPrompt } from "../../agents/system-prompt.js";
 import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
@@ -134,7 +135,8 @@ export async function resolveCommandsSystemPromptBundle(
         },
       }
     : { enabled: false };
-  const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg) : undefined;
+  const speechCfg = resolveAgentSpeechConfig(params.cfg, sessionAgentId);
+  const ttsHint = buildTtsSystemPromptHint(speechCfg);
 
   const systemPrompt = buildAgentSystemPrompt({
     workspaceDir,

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -491,6 +491,80 @@ describe("tryDispatchAcpReply", () => {
     expect(mediaUnderstandingMocks.applyMediaUnderstanding).not.toHaveBeenCalled();
   });
 
+  it("resolves ACP speech config from the resolved ACP agent instead of the raw session key", async () => {
+    managerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: "main",
+      meta: createAcpSessionMeta({
+        agent: "voice",
+      }),
+    });
+    mockVisibleTextTurn("hola");
+
+    await runDispatch({
+      bodyForAgent: "speak",
+      cfg: createAcpTestConfig({
+        messages: {
+          tts: {
+            auto: "always",
+            mode: "all",
+            provider: "openai",
+            providers: {
+              openai: {
+                voice: "alloy",
+              },
+            },
+          },
+        },
+        tools: {
+          media: {
+            audio: {
+              language: "en",
+            },
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "voice",
+              tts: {
+                providers: {
+                  openai: {
+                    voice: "coral",
+                  },
+                },
+              },
+              stt: {
+                language: "es",
+              },
+            },
+          ],
+        },
+      }),
+      ctxOverrides: {
+        MediaPath: "/tmp/inbound.wav",
+        MediaType: "audio/wav",
+      },
+      sessionKeyOverride: "main",
+    });
+
+    const [mediaParams] = mediaUnderstandingMocks.applyMediaUnderstanding.mock.calls[0] as [
+      { cfg: OpenClawConfig },
+    ];
+    expect(mediaParams.cfg.tools?.media?.audio).toEqual(
+      expect.objectContaining({
+        language: "es",
+      }),
+    );
+
+    const [ttsParams] = ttsMocks.maybeApplyTtsToPayload.mock.calls[0] as [{ cfg: OpenClawConfig }];
+    expect(ttsParams.cfg.messages?.tts?.providers?.openai).toEqual(
+      expect.objectContaining({
+        voice: "coral",
+      }),
+    );
+  });
+
   it("forwards normalized image attachments into ACP turns", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dispatch-acp-"));
     const imagePath = path.join(tempDir, "inbound.png");

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -491,12 +491,12 @@ describe("tryDispatchAcpReply", () => {
     expect(mediaUnderstandingMocks.applyMediaUnderstanding).not.toHaveBeenCalled();
   });
 
-  it("resolves ACP speech config from the resolved ACP agent instead of the raw session key", async () => {
+  it("resolves ACP speech config from the session agent instead of ACP harness ids", async () => {
     managerMocks.resolveSession.mockReturnValue({
       kind: "ready",
-      sessionKey: "main",
+      sessionKey: "agent:voice:session-1",
       meta: createAcpSessionMeta({
-        agent: "voice",
+        agent: "codex",
       }),
     });
     mockVisibleTextTurn("hola");
@@ -504,6 +504,14 @@ describe("tryDispatchAcpReply", () => {
     await runDispatch({
       bodyForAgent: "speak",
       cfg: createAcpTestConfig({
+        acp: {
+          enabled: true,
+          defaultAgent: "claude",
+          stream: {
+            coalesceIdleMs: 0,
+            maxChunkChars: 64,
+          },
+        },
         messages: {
           tts: {
             auto: "always",
@@ -545,7 +553,7 @@ describe("tryDispatchAcpReply", () => {
         MediaPath: "/tmp/inbound.wav",
         MediaType: "audio/wav",
       },
-      sessionKeyOverride: "main",
+      sessionKeyOverride: "agent:voice:session-1",
     });
 
     const [mediaParams] = mediaUnderstandingMocks.applyMediaUnderstanding.mock.calls[0] as [

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -6,6 +6,7 @@ import {
   isSessionIdentityPending,
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
+import { resolveAgentSpeechConfig } from "../../agents/speech-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -194,11 +195,15 @@ async function finalizeAcpTurnOutput(params: {
   await params.delivery.settleVisibleText();
   let queuedFinal =
     params.delivery.hasDeliveredVisibleText() && !params.delivery.hasFailedVisibleTextDelivery();
-  const ttsMode = resolveConfiguredTtsMode(params.cfg);
+  const speechCfg = resolveAgentSpeechConfig(
+    params.cfg,
+    resolveAgentIdFromSessionKey(params.sessionKey),
+  );
+  const ttsMode = resolveConfiguredTtsMode(speechCfg);
   const accumulatedBlockText = params.delivery.getAccumulatedBlockText();
   const hasAccumulatedBlockText = accumulatedBlockText.trim().length > 0;
   const ttsStatus = resolveStatusTtsSnapshot({
-    cfg: params.cfg,
+    cfg: speechCfg,
     sessionAuto: params.sessionTtsAuto,
   });
   const canAttemptFinalTts =
@@ -210,7 +215,7 @@ async function finalizeAcpTurnOutput(params: {
       const { maybeApplyTtsToPayload } = await loadDispatchAcpTtsRuntime();
       const ttsSyntheticReply = await maybeApplyTtsToPayload({
         payload: { text: accumulatedBlockText },
-        cfg: params.cfg,
+        cfg: speechCfg,
         channel: params.ttsChannel,
         kind: "final",
         inboundAudio: params.inboundAudio,
@@ -305,10 +310,14 @@ export async function tryDispatchAcpReply(params: {
     return null;
   }
   const canonicalSessionKey = acpResolution.sessionKey;
+  const speechCfg = resolveAgentSpeechConfig(
+    params.cfg,
+    resolveAgentIdFromSessionKey(canonicalSessionKey),
+  );
 
   let queuedFinal = false;
   const delivery = createAcpDispatchDeliveryCoordinator({
-    cfg: params.cfg,
+    cfg: speechCfg,
     ctx: params.ctx,
     dispatcher: params.dispatcher,
     inboundAudio: params.inboundAudio,

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -276,7 +276,11 @@ async function finalizeAcpTurnOutput(params: {
   return queuedFinal;
 }
 
-function resolveAcpSpeechAgentId(params: {
+function resolveAcpSpeechAgentId(params: { sessionKey: string }): string | undefined {
+  return normalizeOptionalString(resolveAgentIdFromSessionKey(params.sessionKey));
+}
+
+function resolveAcpRuntimeAgentId(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   acpMetaAgent?: string | null;
@@ -325,16 +329,19 @@ export async function tryDispatchAcpReply(params: {
   const canonicalSessionKey = acpResolution.sessionKey;
   const resolvedAcpAgent =
     acpResolution.kind === "ready"
-      ? resolveAcpSpeechAgentId({
+      ? resolveAcpRuntimeAgentId({
           cfg: params.cfg,
           sessionKey: canonicalSessionKey,
           acpMetaAgent: acpResolution.meta.agent,
         })
-      : resolveAcpSpeechAgentId({
+      : resolveAcpRuntimeAgentId({
           cfg: params.cfg,
           sessionKey: canonicalSessionKey,
         });
-  const speechCfg = resolveAgentSpeechConfig(params.cfg, resolvedAcpAgent);
+  const speechAgentId = resolveAcpSpeechAgentId({
+    sessionKey: canonicalSessionKey,
+  });
+  const speechCfg = resolveAgentSpeechConfig(params.cfg, speechAgentId);
 
   let queuedFinal = false;
   const delivery = createAcpDispatchDeliveryCoordinator({
@@ -468,7 +475,7 @@ export async function tryDispatchAcpReply(params: {
       (await finalizeAcpTurnOutput({
         cfg: params.cfg,
         sessionKey: canonicalSessionKey,
-        agentId: resolvedAcpAgent,
+        agentId: speechAgentId,
         delivery,
         inboundAudio: params.inboundAudio,
         sessionTtsAuto: params.sessionTtsAuto,

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -186,6 +186,7 @@ async function maybeUnbindStaleBoundConversations(params: {
 async function finalizeAcpTurnOutput(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
+  agentId?: string | null;
   delivery: AcpDispatchDeliveryCoordinator;
   inboundAudio: boolean;
   sessionTtsAuto?: TtsAutoMode;
@@ -197,7 +198,7 @@ async function finalizeAcpTurnOutput(params: {
     params.delivery.hasDeliveredVisibleText() && !params.delivery.hasFailedVisibleTextDelivery();
   const speechCfg = resolveAgentSpeechConfig(
     params.cfg,
-    resolveAgentIdFromSessionKey(params.sessionKey),
+    params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
   );
   const ttsMode = resolveConfiguredTtsMode(speechCfg);
   const accumulatedBlockText = params.delivery.getAccumulatedBlockText();
@@ -275,6 +276,18 @@ async function finalizeAcpTurnOutput(params: {
   return queuedFinal;
 }
 
+function resolveAcpSpeechAgentId(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  acpMetaAgent?: string | null;
+}): string {
+  return (
+    normalizeOptionalString(params.acpMetaAgent) ??
+    normalizeOptionalString(params.cfg.acp?.defaultAgent) ??
+    resolveAgentIdFromSessionKey(params.sessionKey)
+  );
+}
+
 export async function tryDispatchAcpReply(params: {
   ctx: FinalizedMsgContext;
   cfg: OpenClawConfig;
@@ -310,10 +323,18 @@ export async function tryDispatchAcpReply(params: {
     return null;
   }
   const canonicalSessionKey = acpResolution.sessionKey;
-  const speechCfg = resolveAgentSpeechConfig(
-    params.cfg,
-    resolveAgentIdFromSessionKey(canonicalSessionKey),
-  );
+  const resolvedAcpAgent =
+    acpResolution.kind === "ready"
+      ? resolveAcpSpeechAgentId({
+          cfg: params.cfg,
+          sessionKey: canonicalSessionKey,
+          acpMetaAgent: acpResolution.meta.agent,
+        })
+      : resolveAcpSpeechAgentId({
+          cfg: params.cfg,
+          sessionKey: canonicalSessionKey,
+        });
+  const speechCfg = resolveAgentSpeechConfig(params.cfg, resolvedAcpAgent);
 
   let queuedFinal = false;
   const delivery = createAcpDispatchDeliveryCoordinator({
@@ -347,12 +368,6 @@ export async function tryDispatchAcpReply(params: {
         accountIdRaw: params.ctx.AccountId,
       })));
 
-  const resolvedAcpAgent =
-    acpResolution.kind === "ready"
-      ? (normalizeOptionalString(acpResolution.meta.agent) ??
-        normalizeOptionalString(params.cfg.acp?.defaultAgent) ??
-        resolveAgentIdFromSessionKey(canonicalSessionKey))
-      : resolveAgentIdFromSessionKey(canonicalSessionKey);
   const normalizedDispatchChannel = normalizeOptionalLowercaseString(
     params.ctx.OriginatingChannel ?? params.ctx.Surface ?? params.ctx.Provider,
   );
@@ -410,7 +425,7 @@ export async function tryDispatchAcpReply(params: {
         const { applyMediaUnderstanding } = await loadDispatchAcpMediaRuntime();
         await applyMediaUnderstanding({
           ctx: params.ctx,
-          cfg: params.cfg,
+          cfg: speechCfg,
         });
       } catch (err) {
         logVerbose(
@@ -453,6 +468,7 @@ export async function tryDispatchAcpReply(params: {
       (await finalizeAcpTurnOutput({
         cfg: params.cfg,
         sessionKey: canonicalSessionKey,
+        agentId: resolvedAcpAgent,
         delivery,
         inboundAudio: params.inboundAudio,
         sessionTtsAuto: params.sessionTtsAuto,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,6 +1,7 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { isParentOwnedBackgroundAcpSession } from "../../acp/session-interaction-mode.js";
 import { resolveAgentConfig, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentSpeechConfig } from "../../agents/speech-config.js";
 import {
   resolveConversationBindingRecord,
   touchConversationBindingRecord,
@@ -265,6 +266,7 @@ export async function dispatchReplyFromConfig(
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
   const sessionAgentId = resolveSessionAgentId({ sessionKey: acpDispatchSessionKey, config: cfg });
   const sessionAgentCfg = resolveAgentConfig(cfg, sessionAgentId);
+  const sessionSpeechCfg = resolveAgentSpeechConfig(cfg, sessionAgentId);
   const shouldEmitVerboseProgress = createShouldEmitVerboseProgress({
     sessionKey: acpDispatchSessionKey,
     storePath: sessionStoreEntry.storePath,
@@ -604,7 +606,7 @@ export async function dispatchReplyFromConfig(
     ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
       const ttsPayload = await maybeApplyTtsToReplyPayload({
         payload,
-        cfg,
+        cfg: sessionSpeechCfg,
         channel: ttsChannel,
         kind: "final",
         inboundAudio,
@@ -682,7 +684,7 @@ export async function dispatchReplyFromConfig(
           sendPolicy,
         },
         {
-          cfg,
+          cfg: sessionSpeechCfg,
           dispatcher,
           abortSignal: params.replyOptions?.abortSignal,
           onReplyStart: params.replyOptions?.onReplyStart,
@@ -862,7 +864,7 @@ export async function dispatchReplyFromConfig(
             }
             const ttsPayload = await maybeApplyTtsToReplyPayload({
               payload,
-              cfg,
+              cfg: sessionSpeechCfg,
               channel: ttsChannel,
               kind: "tool",
               inboundAudio,
@@ -941,7 +943,7 @@ export async function dispatchReplyFromConfig(
             await params.replyOptions?.onBlockReplyQueued?.(payload, queuedContext);
             const ttsPayload = await maybeApplyTtsToReplyPayload({
               payload,
-              cfg,
+              cfg: sessionSpeechCfg,
               channel: ttsChannel,
               kind: "block",
               inboundAudio,
@@ -981,7 +983,7 @@ export async function dispatchReplyFromConfig(
             isTailDispatch: true,
           },
           {
-            cfg,
+            cfg: sessionSpeechCfg,
             dispatcher,
             abortSignal: params.replyOptions?.abortSignal,
             onReplyStart: params.replyOptions?.onReplyStart,
@@ -1014,7 +1016,7 @@ export async function dispatchReplyFromConfig(
         routedFinalCount += finalReply.routedFinalCount;
       }
 
-      const ttsMode = resolveConfiguredTtsMode(cfg);
+      const ttsMode = resolveConfiguredTtsMode(sessionSpeechCfg);
       // Generate TTS-only reply after block streaming completes (when there's no final reply).
       // This handles the case where block streaming succeeds and drops final payloads,
       // but we still want TTS audio to be generated from the accumulated block content.
@@ -1027,7 +1029,7 @@ export async function dispatchReplyFromConfig(
         try {
           const ttsSyntheticReply = await maybeApplyTtsToReplyPayload({
             payload: { text: accumulatedBlockText },
-            cfg,
+            cfg: sessionSpeechCfg,
             channel: ttsChannel,
             kind: "final",
             inboundAudio,

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -121,7 +121,9 @@ This is plain user text`;
 
   it("strips an active-memory prompt prefix block even when earlier text precedes it", () => {
     const input = `Queued earlier user turn\n\n${ACTIVE_MEMORY_PREFIX_BLOCK}\n\nWhat should I grab on the way?`;
-    expect(stripInboundMetadata(input)).toBe("Queued earlier user turn\n\nWhat should I grab on the way?");
+    expect(stripInboundMetadata(input)).toBe(
+      "Queued earlier user turn\n\nWhat should I grab on the way?",
+    );
   });
 
   it("does not strip active-memory lookalike user text without exact tag lines", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -682,9 +682,9 @@ export function buildStatusMessage(args: StatusArgs): string {
   const queueDetails = formatQueueDetails(args.queue);
   const verboseLabel =
     verboseLevel === "full" ? "verbose:full" : verboseLevel === "on" ? "verbose" : null;
-  const traceLevel = entry?.traceLevel === "raw" ? "raw" : entry?.traceLevel === "on" ? "on" : "off";
-  const traceLabel =
-    traceLevel === "raw" ? "trace:raw" : traceLevel === "on" ? "trace" : null;
+  const traceLevel =
+    entry?.traceLevel === "raw" ? "raw" : entry?.traceLevel === "on" ? "on" : "off";
+  const traceLabel = traceLevel === "raw" ? "trace:raw" : traceLevel === "on" ? "trace" : null;
   const pluginStatusLines = verboseLevel !== "off" ? resolveSessionPluginStatusLines(entry) : [];
   const pluginTraceLines =
     traceLevel === "on" || traceLevel === "raw" ? resolveSessionPluginTraceLines(entry) : [];

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -6245,6 +6245,2741 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   description:
                     "Optional per-agent embedded Pi overrides. Use this to opt specific agents into stricter GPT-5 execution behavior without changing the global default.",
                 },
+                tts: {
+                  type: "object",
+                  properties: {
+                    auto: {
+                      type: "string",
+                      enum: ["off", "always", "inbound", "tagged"],
+                    },
+                    enabled: {
+                      type: "boolean",
+                    },
+                    mode: {
+                      type: "string",
+                      enum: ["final", "all"],
+                    },
+                    provider: {
+                      type: "string",
+                      minLength: 1,
+                    },
+                    summaryModel: {
+                      type: "string",
+                    },
+                    modelOverrides: {
+                      type: "object",
+                      properties: {
+                        enabled: {
+                          type: "boolean",
+                        },
+                        allowText: {
+                          type: "boolean",
+                        },
+                        allowProvider: {
+                          type: "boolean",
+                        },
+                        allowVoice: {
+                          type: "boolean",
+                        },
+                        allowModelId: {
+                          type: "boolean",
+                        },
+                        allowVoiceSettings: {
+                          type: "boolean",
+                        },
+                        allowNormalization: {
+                          type: "boolean",
+                        },
+                        allowSeed: {
+                          type: "boolean",
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    providers: {
+                      type: "object",
+                      propertyNames: {
+                        type: "string",
+                      },
+                      additionalProperties: {
+                        type: "object",
+                        properties: {
+                          apiKey: {
+                            anyOf: [
+                              {
+                                type: "string",
+                              },
+                              {
+                                oneOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      source: {
+                                        type: "string",
+                                        const: "env",
+                                      },
+                                      provider: {
+                                        type: "string",
+                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                      },
+                                      id: {
+                                        type: "string",
+                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                      },
+                                    },
+                                    required: ["source", "provider", "id"],
+                                    additionalProperties: false,
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      source: {
+                                        type: "string",
+                                        const: "file",
+                                      },
+                                      provider: {
+                                        type: "string",
+                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                      },
+                                      id: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["source", "provider", "id"],
+                                    additionalProperties: false,
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      source: {
+                                        type: "string",
+                                        const: "exec",
+                                      },
+                                      provider: {
+                                        type: "string",
+                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                      },
+                                      id: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["source", "provider", "id"],
+                                    additionalProperties: false,
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        additionalProperties: {
+                          anyOf: [
+                            {
+                              type: "string",
+                            },
+                            {
+                              type: "number",
+                            },
+                            {
+                              type: "boolean",
+                            },
+                            {
+                              type: "null",
+                            },
+                            {
+                              type: "array",
+                              items: {},
+                            },
+                            {
+                              type: "object",
+                              propertyNames: {
+                                type: "string",
+                              },
+                              additionalProperties: {},
+                            },
+                          ],
+                        },
+                      },
+                    },
+                    prefsPath: {
+                      type: "string",
+                    },
+                    maxTextLength: {
+                      type: "integer",
+                      minimum: 1,
+                      maximum: 9007199254740991,
+                    },
+                    timeoutMs: {
+                      type: "integer",
+                      minimum: 1000,
+                      maximum: 120000,
+                    },
+                  },
+                  additionalProperties: false,
+                },
+                stt: {
+                  type: "object",
+                  properties: {
+                    enabled: {
+                      type: "boolean",
+                    },
+                    scope: {
+                      type: "object",
+                      properties: {
+                        default: {
+                          anyOf: [
+                            {
+                              type: "string",
+                              const: "allow",
+                            },
+                            {
+                              type: "string",
+                              const: "deny",
+                            },
+                          ],
+                        },
+                        rules: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              action: {
+                                anyOf: [
+                                  {
+                                    type: "string",
+                                    const: "allow",
+                                  },
+                                  {
+                                    type: "string",
+                                    const: "deny",
+                                  },
+                                ],
+                              },
+                              match: {
+                                type: "object",
+                                properties: {
+                                  channel: {
+                                    type: "string",
+                                  },
+                                  chatType: {
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                        const: "direct",
+                                      },
+                                      {
+                                        type: "string",
+                                        const: "group",
+                                      },
+                                      {
+                                        type: "string",
+                                        const: "channel",
+                                      },
+                                      {
+                                        type: "string",
+                                        const: "dm",
+                                      },
+                                    ],
+                                  },
+                                  keyPrefix: {
+                                    type: "string",
+                                  },
+                                  rawKeyPrefix: {
+                                    type: "string",
+                                  },
+                                },
+                                additionalProperties: false,
+                              },
+                            },
+                            required: ["action"],
+                            additionalProperties: false,
+                          },
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    maxBytes: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    maxChars: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    prompt: {
+                      type: "string",
+                    },
+                    timeoutSeconds: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    language: {
+                      type: "string",
+                    },
+                    providerOptions: {
+                      type: "object",
+                      propertyNames: {
+                        type: "string",
+                      },
+                      additionalProperties: {
+                        type: "object",
+                        propertyNames: {
+                          type: "string",
+                        },
+                        additionalProperties: {
+                          anyOf: [
+                            {
+                              type: "string",
+                            },
+                            {
+                              type: "number",
+                            },
+                            {
+                              type: "boolean",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                    deepgram: {
+                      type: "object",
+                      properties: {
+                        detectLanguage: {
+                          type: "boolean",
+                        },
+                        punctuate: {
+                          type: "boolean",
+                        },
+                        smartFormat: {
+                          type: "boolean",
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    baseUrl: {
+                      type: "string",
+                    },
+                    headers: {
+                      type: "object",
+                      propertyNames: {
+                        type: "string",
+                      },
+                      additionalProperties: {
+                        type: "string",
+                      },
+                    },
+                    request: {
+                      type: "object",
+                      properties: {
+                        headers: {
+                          type: "object",
+                          propertyNames: {
+                            type: "string",
+                          },
+                          additionalProperties: {
+                            anyOf: [
+                              {
+                                type: "string",
+                              },
+                              {
+                                oneOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      source: {
+                                        type: "string",
+                                        const: "env",
+                                      },
+                                      provider: {
+                                        type: "string",
+                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                      },
+                                      id: {
+                                        type: "string",
+                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                      },
+                                    },
+                                    required: ["source", "provider", "id"],
+                                    additionalProperties: false,
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      source: {
+                                        type: "string",
+                                        const: "file",
+                                      },
+                                      provider: {
+                                        type: "string",
+                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                      },
+                                      id: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["source", "provider", "id"],
+                                    additionalProperties: false,
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      source: {
+                                        type: "string",
+                                        const: "exec",
+                                      },
+                                      provider: {
+                                        type: "string",
+                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                      },
+                                      id: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["source", "provider", "id"],
+                                    additionalProperties: false,
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        },
+                        auth: {
+                          anyOf: [
+                            {
+                              type: "object",
+                              properties: {
+                                mode: {
+                                  type: "string",
+                                  const: "provider-default",
+                                },
+                              },
+                              required: ["mode"],
+                              additionalProperties: false,
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                mode: {
+                                  type: "string",
+                                  const: "authorization-bearer",
+                                },
+                                token: {
+                                  anyOf: [
+                                    {
+                                      type: "string",
+                                    },
+                                    {
+                                      oneOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            source: {
+                                              type: "string",
+                                              const: "env",
+                                            },
+                                            provider: {
+                                              type: "string",
+                                              pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                            },
+                                            id: {
+                                              type: "string",
+                                              pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                            },
+                                          },
+                                          required: ["source", "provider", "id"],
+                                          additionalProperties: false,
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            source: {
+                                              type: "string",
+                                              const: "file",
+                                            },
+                                            provider: {
+                                              type: "string",
+                                              pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                            },
+                                            id: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["source", "provider", "id"],
+                                          additionalProperties: false,
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            source: {
+                                              type: "string",
+                                              const: "exec",
+                                            },
+                                            provider: {
+                                              type: "string",
+                                              pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                            },
+                                            id: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["source", "provider", "id"],
+                                          additionalProperties: false,
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              },
+                              required: ["mode", "token"],
+                              additionalProperties: false,
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                mode: {
+                                  type: "string",
+                                  const: "header",
+                                },
+                                headerName: {
+                                  type: "string",
+                                  minLength: 1,
+                                },
+                                value: {
+                                  anyOf: [
+                                    {
+                                      type: "string",
+                                    },
+                                    {
+                                      oneOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            source: {
+                                              type: "string",
+                                              const: "env",
+                                            },
+                                            provider: {
+                                              type: "string",
+                                              pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                            },
+                                            id: {
+                                              type: "string",
+                                              pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                            },
+                                          },
+                                          required: ["source", "provider", "id"],
+                                          additionalProperties: false,
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            source: {
+                                              type: "string",
+                                              const: "file",
+                                            },
+                                            provider: {
+                                              type: "string",
+                                              pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                            },
+                                            id: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["source", "provider", "id"],
+                                          additionalProperties: false,
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            source: {
+                                              type: "string",
+                                              const: "exec",
+                                            },
+                                            provider: {
+                                              type: "string",
+                                              pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                            },
+                                            id: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["source", "provider", "id"],
+                                          additionalProperties: false,
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                prefix: {
+                                  type: "string",
+                                },
+                              },
+                              required: ["mode", "headerName", "value"],
+                              additionalProperties: false,
+                            },
+                          ],
+                        },
+                        proxy: {
+                          anyOf: [
+                            {
+                              type: "object",
+                              properties: {
+                                mode: {
+                                  type: "string",
+                                  const: "env-proxy",
+                                },
+                                tls: {
+                                  type: "object",
+                                  properties: {
+                                    ca: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                        },
+                                        {
+                                          oneOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "env",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                  pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "file",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "exec",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                    cert: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                        },
+                                        {
+                                          oneOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "env",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                  pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "file",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "exec",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                    key: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                        },
+                                        {
+                                          oneOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "env",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                  pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "file",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "exec",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                    passphrase: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                        },
+                                        {
+                                          oneOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "env",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                  pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "file",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "exec",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                    serverName: {
+                                      type: "string",
+                                    },
+                                    insecureSkipVerify: {
+                                      type: "boolean",
+                                    },
+                                  },
+                                  additionalProperties: false,
+                                },
+                              },
+                              required: ["mode"],
+                              additionalProperties: false,
+                            },
+                            {
+                              type: "object",
+                              properties: {
+                                mode: {
+                                  type: "string",
+                                  const: "explicit-proxy",
+                                },
+                                url: {
+                                  type: "string",
+                                  minLength: 1,
+                                },
+                                tls: {
+                                  type: "object",
+                                  properties: {
+                                    ca: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                        },
+                                        {
+                                          oneOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "env",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                  pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "file",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "exec",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                    cert: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                        },
+                                        {
+                                          oneOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "env",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                  pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "file",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "exec",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                    key: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                        },
+                                        {
+                                          oneOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "env",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                  pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "file",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "exec",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                    passphrase: {
+                                      anyOf: [
+                                        {
+                                          type: "string",
+                                        },
+                                        {
+                                          oneOf: [
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "env",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                  pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "file",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                            {
+                                              type: "object",
+                                              properties: {
+                                                source: {
+                                                  type: "string",
+                                                  const: "exec",
+                                                },
+                                                provider: {
+                                                  type: "string",
+                                                  pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                },
+                                                id: {
+                                                  type: "string",
+                                                },
+                                              },
+                                              required: ["source", "provider", "id"],
+                                              additionalProperties: false,
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                    serverName: {
+                                      type: "string",
+                                    },
+                                    insecureSkipVerify: {
+                                      type: "boolean",
+                                    },
+                                  },
+                                  additionalProperties: false,
+                                },
+                              },
+                              required: ["mode", "url"],
+                              additionalProperties: false,
+                            },
+                          ],
+                        },
+                        tls: {
+                          type: "object",
+                          properties: {
+                            ca: {
+                              anyOf: [
+                                {
+                                  type: "string",
+                                },
+                                {
+                                  oneOf: [
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "env",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                          pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "file",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "exec",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                            cert: {
+                              anyOf: [
+                                {
+                                  type: "string",
+                                },
+                                {
+                                  oneOf: [
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "env",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                          pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "file",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "exec",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                            key: {
+                              anyOf: [
+                                {
+                                  type: "string",
+                                },
+                                {
+                                  oneOf: [
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "env",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                          pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "file",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "exec",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                            passphrase: {
+                              anyOf: [
+                                {
+                                  type: "string",
+                                },
+                                {
+                                  oneOf: [
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "env",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                          pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "file",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                    {
+                                      type: "object",
+                                      properties: {
+                                        source: {
+                                          type: "string",
+                                          const: "exec",
+                                        },
+                                        provider: {
+                                          type: "string",
+                                          pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                        },
+                                        id: {
+                                          type: "string",
+                                        },
+                                      },
+                                      required: ["source", "provider", "id"],
+                                      additionalProperties: false,
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                            serverName: {
+                              type: "string",
+                            },
+                            insecureSkipVerify: {
+                              type: "boolean",
+                            },
+                          },
+                          additionalProperties: false,
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    attachments: {
+                      type: "object",
+                      properties: {
+                        mode: {
+                          anyOf: [
+                            {
+                              type: "string",
+                              const: "first",
+                            },
+                            {
+                              type: "string",
+                              const: "all",
+                            },
+                          ],
+                        },
+                        maxAttachments: {
+                          type: "integer",
+                          exclusiveMinimum: 0,
+                          maximum: 9007199254740991,
+                        },
+                        prefer: {
+                          anyOf: [
+                            {
+                              type: "string",
+                              const: "first",
+                            },
+                            {
+                              type: "string",
+                              const: "last",
+                            },
+                            {
+                              type: "string",
+                              const: "path",
+                            },
+                            {
+                              type: "string",
+                              const: "url",
+                            },
+                          ],
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    models: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          provider: {
+                            type: "string",
+                          },
+                          model: {
+                            type: "string",
+                          },
+                          capabilities: {
+                            type: "array",
+                            items: {
+                              anyOf: [
+                                {
+                                  type: "string",
+                                  const: "image",
+                                },
+                                {
+                                  type: "string",
+                                  const: "audio",
+                                },
+                                {
+                                  type: "string",
+                                  const: "video",
+                                },
+                              ],
+                            },
+                          },
+                          type: {
+                            anyOf: [
+                              {
+                                type: "string",
+                                const: "provider",
+                              },
+                              {
+                                type: "string",
+                                const: "cli",
+                              },
+                            ],
+                          },
+                          command: {
+                            type: "string",
+                          },
+                          args: {
+                            type: "array",
+                            items: {
+                              type: "string",
+                            },
+                          },
+                          maxChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxBytes: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          prompt: {
+                            type: "string",
+                          },
+                          timeoutSeconds: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          language: {
+                            type: "string",
+                          },
+                          providerOptions: {
+                            type: "object",
+                            propertyNames: {
+                              type: "string",
+                            },
+                            additionalProperties: {
+                              type: "object",
+                              propertyNames: {
+                                type: "string",
+                              },
+                              additionalProperties: {
+                                anyOf: [
+                                  {
+                                    type: "string",
+                                  },
+                                  {
+                                    type: "number",
+                                  },
+                                  {
+                                    type: "boolean",
+                                  },
+                                ],
+                              },
+                            },
+                          },
+                          deepgram: {
+                            type: "object",
+                            properties: {
+                              detectLanguage: {
+                                type: "boolean",
+                              },
+                              punctuate: {
+                                type: "boolean",
+                              },
+                              smartFormat: {
+                                type: "boolean",
+                              },
+                            },
+                            additionalProperties: false,
+                          },
+                          baseUrl: {
+                            type: "string",
+                          },
+                          headers: {
+                            type: "object",
+                            propertyNames: {
+                              type: "string",
+                            },
+                            additionalProperties: {
+                              type: "string",
+                            },
+                          },
+                          request: {
+                            type: "object",
+                            properties: {
+                              headers: {
+                                type: "object",
+                                propertyNames: {
+                                  type: "string",
+                                },
+                                additionalProperties: {
+                                  anyOf: [
+                                    {
+                                      type: "string",
+                                    },
+                                    {
+                                      oneOf: [
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            source: {
+                                              type: "string",
+                                              const: "env",
+                                            },
+                                            provider: {
+                                              type: "string",
+                                              pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                            },
+                                            id: {
+                                              type: "string",
+                                              pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                            },
+                                          },
+                                          required: ["source", "provider", "id"],
+                                          additionalProperties: false,
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            source: {
+                                              type: "string",
+                                              const: "file",
+                                            },
+                                            provider: {
+                                              type: "string",
+                                              pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                            },
+                                            id: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["source", "provider", "id"],
+                                          additionalProperties: false,
+                                        },
+                                        {
+                                          type: "object",
+                                          properties: {
+                                            source: {
+                                              type: "string",
+                                              const: "exec",
+                                            },
+                                            provider: {
+                                              type: "string",
+                                              pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                            },
+                                            id: {
+                                              type: "string",
+                                            },
+                                          },
+                                          required: ["source", "provider", "id"],
+                                          additionalProperties: false,
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              },
+                              auth: {
+                                anyOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      mode: {
+                                        type: "string",
+                                        const: "provider-default",
+                                      },
+                                    },
+                                    required: ["mode"],
+                                    additionalProperties: false,
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      mode: {
+                                        type: "string",
+                                        const: "authorization-bearer",
+                                      },
+                                      token: {
+                                        anyOf: [
+                                          {
+                                            type: "string",
+                                          },
+                                          {
+                                            oneOf: [
+                                              {
+                                                type: "object",
+                                                properties: {
+                                                  source: {
+                                                    type: "string",
+                                                    const: "env",
+                                                  },
+                                                  provider: {
+                                                    type: "string",
+                                                    pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                  },
+                                                  id: {
+                                                    type: "string",
+                                                    pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                  },
+                                                },
+                                                required: ["source", "provider", "id"],
+                                                additionalProperties: false,
+                                              },
+                                              {
+                                                type: "object",
+                                                properties: {
+                                                  source: {
+                                                    type: "string",
+                                                    const: "file",
+                                                  },
+                                                  provider: {
+                                                    type: "string",
+                                                    pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                  },
+                                                  id: {
+                                                    type: "string",
+                                                  },
+                                                },
+                                                required: ["source", "provider", "id"],
+                                                additionalProperties: false,
+                                              },
+                                              {
+                                                type: "object",
+                                                properties: {
+                                                  source: {
+                                                    type: "string",
+                                                    const: "exec",
+                                                  },
+                                                  provider: {
+                                                    type: "string",
+                                                    pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                  },
+                                                  id: {
+                                                    type: "string",
+                                                  },
+                                                },
+                                                required: ["source", "provider", "id"],
+                                                additionalProperties: false,
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                    },
+                                    required: ["mode", "token"],
+                                    additionalProperties: false,
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      mode: {
+                                        type: "string",
+                                        const: "header",
+                                      },
+                                      headerName: {
+                                        type: "string",
+                                        minLength: 1,
+                                      },
+                                      value: {
+                                        anyOf: [
+                                          {
+                                            type: "string",
+                                          },
+                                          {
+                                            oneOf: [
+                                              {
+                                                type: "object",
+                                                properties: {
+                                                  source: {
+                                                    type: "string",
+                                                    const: "env",
+                                                  },
+                                                  provider: {
+                                                    type: "string",
+                                                    pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                  },
+                                                  id: {
+                                                    type: "string",
+                                                    pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                  },
+                                                },
+                                                required: ["source", "provider", "id"],
+                                                additionalProperties: false,
+                                              },
+                                              {
+                                                type: "object",
+                                                properties: {
+                                                  source: {
+                                                    type: "string",
+                                                    const: "file",
+                                                  },
+                                                  provider: {
+                                                    type: "string",
+                                                    pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                  },
+                                                  id: {
+                                                    type: "string",
+                                                  },
+                                                },
+                                                required: ["source", "provider", "id"],
+                                                additionalProperties: false,
+                                              },
+                                              {
+                                                type: "object",
+                                                properties: {
+                                                  source: {
+                                                    type: "string",
+                                                    const: "exec",
+                                                  },
+                                                  provider: {
+                                                    type: "string",
+                                                    pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                  },
+                                                  id: {
+                                                    type: "string",
+                                                  },
+                                                },
+                                                required: ["source", "provider", "id"],
+                                                additionalProperties: false,
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                      prefix: {
+                                        type: "string",
+                                      },
+                                    },
+                                    required: ["mode", "headerName", "value"],
+                                    additionalProperties: false,
+                                  },
+                                ],
+                              },
+                              proxy: {
+                                anyOf: [
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      mode: {
+                                        type: "string",
+                                        const: "env-proxy",
+                                      },
+                                      tls: {
+                                        type: "object",
+                                        properties: {
+                                          ca: {
+                                            anyOf: [
+                                              {
+                                                type: "string",
+                                              },
+                                              {
+                                                oneOf: [
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "env",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "file",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "exec",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                          cert: {
+                                            anyOf: [
+                                              {
+                                                type: "string",
+                                              },
+                                              {
+                                                oneOf: [
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "env",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "file",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "exec",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                          key: {
+                                            anyOf: [
+                                              {
+                                                type: "string",
+                                              },
+                                              {
+                                                oneOf: [
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "env",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "file",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "exec",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                          passphrase: {
+                                            anyOf: [
+                                              {
+                                                type: "string",
+                                              },
+                                              {
+                                                oneOf: [
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "env",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "file",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "exec",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                          serverName: {
+                                            type: "string",
+                                          },
+                                          insecureSkipVerify: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        additionalProperties: false,
+                                      },
+                                    },
+                                    required: ["mode"],
+                                    additionalProperties: false,
+                                  },
+                                  {
+                                    type: "object",
+                                    properties: {
+                                      mode: {
+                                        type: "string",
+                                        const: "explicit-proxy",
+                                      },
+                                      url: {
+                                        type: "string",
+                                        minLength: 1,
+                                      },
+                                      tls: {
+                                        type: "object",
+                                        properties: {
+                                          ca: {
+                                            anyOf: [
+                                              {
+                                                type: "string",
+                                              },
+                                              {
+                                                oneOf: [
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "env",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "file",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "exec",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                          cert: {
+                                            anyOf: [
+                                              {
+                                                type: "string",
+                                              },
+                                              {
+                                                oneOf: [
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "env",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "file",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "exec",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                          key: {
+                                            anyOf: [
+                                              {
+                                                type: "string",
+                                              },
+                                              {
+                                                oneOf: [
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "env",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "file",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "exec",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                          passphrase: {
+                                            anyOf: [
+                                              {
+                                                type: "string",
+                                              },
+                                              {
+                                                oneOf: [
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "env",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                        pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "file",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                  {
+                                                    type: "object",
+                                                    properties: {
+                                                      source: {
+                                                        type: "string",
+                                                        const: "exec",
+                                                      },
+                                                      provider: {
+                                                        type: "string",
+                                                        pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                                      },
+                                                      id: {
+                                                        type: "string",
+                                                      },
+                                                    },
+                                                    required: ["source", "provider", "id"],
+                                                    additionalProperties: false,
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          },
+                                          serverName: {
+                                            type: "string",
+                                          },
+                                          insecureSkipVerify: {
+                                            type: "boolean",
+                                          },
+                                        },
+                                        additionalProperties: false,
+                                      },
+                                    },
+                                    required: ["mode", "url"],
+                                    additionalProperties: false,
+                                  },
+                                ],
+                              },
+                              tls: {
+                                type: "object",
+                                properties: {
+                                  ca: {
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        oneOf: [
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "env",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                                pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "file",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "exec",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                  cert: {
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        oneOf: [
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "env",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                                pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "file",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "exec",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                  key: {
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        oneOf: [
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "env",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                                pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "file",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "exec",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                  passphrase: {
+                                    anyOf: [
+                                      {
+                                        type: "string",
+                                      },
+                                      {
+                                        oneOf: [
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "env",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                                pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "file",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                          {
+                                            type: "object",
+                                            properties: {
+                                              source: {
+                                                type: "string",
+                                                const: "exec",
+                                              },
+                                              provider: {
+                                                type: "string",
+                                                pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                                              },
+                                              id: {
+                                                type: "string",
+                                              },
+                                            },
+                                            required: ["source", "provider", "id"],
+                                            additionalProperties: false,
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                  serverName: {
+                                    type: "string",
+                                  },
+                                  insecureSkipVerify: {
+                                    type: "boolean",
+                                  },
+                                },
+                                additionalProperties: false,
+                              },
+                            },
+                            additionalProperties: false,
+                          },
+                          profile: {
+                            type: "string",
+                          },
+                          preferredProfile: {
+                            type: "string",
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                    },
+                    echoTranscript: {
+                      type: "boolean",
+                    },
+                    echoFormat: {
+                      type: "string",
+                    },
+                  },
+                  additionalProperties: false,
+                },
                 sandbox: {
                   type: "object",
                   properties: {
@@ -26900,6 +29635,98 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       sensitive: true,
       tags: ["security", "auth"],
     },
+    "agents.list[].tts.providers.*.apiKey": {
+      sensitive: true,
+      tags: ["security", "auth", "media"],
+    },
+    "agents.list[].stt.request.headers.*": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.request.auth.token": {
+      sensitive: true,
+      tags: ["security", "auth", "media"],
+    },
+    "agents.list[].stt.request.auth.value": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.request.proxy.tls.ca": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.request.proxy.tls.cert": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.request.proxy.tls.key": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.request.proxy.tls.passphrase": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.request.tls.ca": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.request.tls.cert": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.request.tls.key": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.request.tls.passphrase": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.headers.*": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.auth.token": {
+      sensitive: true,
+      tags: ["security", "auth", "media"],
+    },
+    "agents.list[].stt.models[].request.auth.value": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.proxy.tls.ca": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.proxy.tls.cert": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.proxy.tls.key": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.proxy.tls.passphrase": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.tls.ca": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.tls.cert": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.tls.key": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
+    "agents.list[].stt.models[].request.tls.passphrase": {
+      sensitive: true,
+      tags: ["security", "media"],
+    },
     "agents.list[].sandbox.ssh.identityData": {
       sensitive: true,
       tags: ["security", "storage"],
@@ -27230,6 +30057,18 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     },
     "agents.list[].memorySearch.remote.baseUrl": {
       tags: ["advanced", "url-secret"],
+    },
+    "agents.list[].stt.baseUrl": {
+      tags: ["media", "url-secret"],
+    },
+    "agents.list[].stt.request.proxy.url": {
+      tags: ["media", "url-secret"],
+    },
+    "agents.list[].stt.models[].baseUrl": {
+      tags: ["media", "url-secret"],
+    },
+    "agents.list[].stt.models[].request.proxy.url": {
+      tags: ["media", "url-secret"],
     },
     "tools.web.fetch.firecrawl.baseUrl": {
       tags: ["tools", "url-secret"],

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -8,6 +8,8 @@ import type {
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
+import type { MediaUnderstandingConfig } from "./types.tools.js";
+import type { TtsConfig } from "./types.tts.js";
 
 export type AgentRuntimeAcpConfig = {
   /** ACP harness adapter id (for example codex, claude). */
@@ -103,6 +105,10 @@ export type AgentConfig = {
     /** Optional per-agent execution contract override. */
     executionContract?: EmbeddedPiExecutionContract;
   };
+  /** Optional per-agent TTS overrides merged onto messages.tts. */
+  tts?: TtsConfig;
+  /** Optional per-agent STT overrides merged onto tools.media.audio. */
+  stt?: MediaUnderstandingConfig;
   /** Optional per-agent sandbox overrides. */
   sandbox?: AgentSandboxConfig;
   /** Optional per-agent stream params (e.g. cacheRetention, temperature). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -11,8 +11,10 @@ import {
   HumanDelaySchema,
   IdentitySchema,
   SecretInputSchema,
+  ToolsMediaUnderstandingSchema,
   ToolsLinksSchema,
   ToolsMediaSchema,
+  TtsConfigSchema,
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
@@ -837,6 +839,8 @@ export const AgentEntrySchema = z
       })
       .strict()
       .optional(),
+    tts: TtsConfigSchema,
+    stt: ToolsMediaUnderstandingSchema,
     sandbox: AgentSandboxSchema,
     params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,

--- a/src/media-understanding/audio-transcription-runner.ts
+++ b/src/media-understanding/audio-transcription-runner.ts
@@ -1,3 +1,4 @@
+import { resolveSessionSpeechConfig } from "../agents/speech-config.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { ActiveMediaModel } from "./active-model.types.js";
@@ -22,8 +23,12 @@ export async function runAudioTranscription(params: {
   if (attachments.length === 0) {
     return { transcript: undefined, attachments };
   }
+  const effectiveCfg = resolveSessionSpeechConfig({
+    cfg: params.cfg,
+    sessionKey: params.ctx.SessionKey,
+  });
 
-  const providerRegistry = buildProviderRegistry(params.providers, params.cfg);
+  const providerRegistry = buildProviderRegistry(params.providers, effectiveCfg);
   const cache = createMediaAttachmentCache(
     attachments,
     params.localPathRoots ? { localPathRoots: params.localPathRoots } : undefined,
@@ -32,13 +37,13 @@ export async function runAudioTranscription(params: {
   try {
     const result = await runCapability({
       capability: "audio",
-      cfg: params.cfg,
+      cfg: effectiveCfg,
       ctx: params.ctx,
       attachments: cache,
       media: attachments,
       agentDir: params.agentDir,
       providerRegistry,
-      config: params.cfg.tools?.media?.audio,
+      config: effectiveCfg.tools?.media?.audio,
       activeModel: params.activeModel,
     });
     const output = result.outputs.find((entry) => entry.kind === "audio.transcription");

--- a/src/media-understanding/runtime-types.ts
+++ b/src/media-understanding/runtime-types.ts
@@ -53,6 +53,7 @@ export type DescribeVideoFileParams = {
 export type TranscribeAudioFileParams = {
   filePath: string;
   cfg: OpenClawConfig;
+  agentId?: string;
   agentDir?: string;
   mime?: string;
   activeModel?: ActiveMediaModel;

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveAgentSpeechConfig } from "../agents/speech-config.js";
 import { normalizeMediaProviderId } from "./provider-registry.js";
 import { findDecisionReason, normalizeDecisionReason } from "./runner.entries.js";
 import {
@@ -140,16 +141,17 @@ export async function describeVideoFile(
 export async function transcribeAudioFile(
   params: TranscribeAudioFileParams,
 ): Promise<{ text: string | undefined }> {
+  const effectiveCfg = resolveAgentSpeechConfig(params.cfg, params.agentId);
   const cfg =
     params.language || params.prompt
       ? {
-          ...params.cfg,
+          ...effectiveCfg,
           tools: {
-            ...params.cfg.tools,
+            ...effectiveCfg.tools,
             media: {
-              ...params.cfg.tools?.media,
+              ...effectiveCfg.tools?.media,
               audio: {
-                ...params.cfg.tools?.media?.audio,
+                ...effectiveCfg.tools?.media?.audio,
                 ...(params.language ? { _requestLanguageOverride: params.language } : {}),
                 ...(params.prompt ? { _requestPromptOverride: params.prompt } : {}),
                 ...(params.language ? { language: params.language } : {}),
@@ -158,7 +160,7 @@ export async function transcribeAudioFile(
             },
           },
         }
-      : params.cfg;
+      : effectiveCfg;
   const result = await runMediaUnderstandingFile({ ...params, cfg, capability: "audio" });
   return { text: result.text };
 }

--- a/src/media-understanding/transcribe-audio.test.ts
+++ b/src/media-understanding/transcribe-audio.test.ts
@@ -56,4 +56,20 @@ describe("transcribeAudioFile", () => {
       }),
     ).rejects.toThrow("boom");
   });
+
+  it("forwards agentId when present", async () => {
+    transcribeAudioFileFromRuntime.mockResolvedValue({ text: "hola" });
+
+    await transcribeAudioFile({
+      filePath: "/tmp/note.wav",
+      cfg: {} as OpenClawConfig,
+      agentId: "spanish",
+    });
+
+    expect(transcribeAudioFileFromRuntime).toHaveBeenCalledWith({
+      filePath: "/tmp/note.wav",
+      cfg: {} as OpenClawConfig,
+      agentId: "spanish",
+    });
+  });
 });

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -1,6 +1,7 @@
 // Public agent/model/runtime helpers for plugins that integrate with core agent flows.
 
 export * from "../agents/agent-scope.js";
+export * from "../agents/speech-config.js";
 export * from "../agents/current-time.js";
 export * from "../agents/date-time.js";
 export * from "../agents/defaults.js";

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -274,7 +274,6 @@ md.linkify.add("www", {
       break;
     }
     return len;
-
   },
   normalize(match) {
     match.url = "http://" + match.url;


### PR DESCRIPTION
## Summary

- Problem: OpenClaw only supported global speech config, so all agents in one instance shared the same TTS voice/provider behavior and the same STT audio defaults.
- Why it matters: multi-agent setups need different speech settings per agent for language, voice, and provider selection without forcing separate deployments.
- What changed: added optional `agents.list[].tts` and `agents.list[].stt` config, merged those overrides onto `messages.tts` and `tools.media.audio` at agent-aware runtime boundaries, and updated agent-aware TTS/STT callsites plus schema/tests.
- What did NOT change (scope boundary): no provider-specific speech API contracts were changed, no new global speech config surface was introduced, and no migration was required for existing configs.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66252
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): OpenClaw already supported per-agent model/runtime/identity overrides, but speech config still resolved only from global surfaces.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/speech-config.test.ts`
  - `src/agents/agent-scope.test.ts`
  - `src/media-understanding/transcribe-audio.test.ts`
- Scenario the test should lock in: agent-level speech overrides merge correctly and agent-aware transcription requests carry the right config context.
- Why this is the smallest reliable guardrail: the behavior is implemented as config overlay plus runtime forwarding, so focused merge/forwarding tests cover the new contract without needing full end-to-end voice infrastructure.
- Existing test that already covers this (if any): existing TTS/media tests cover the downstream runtime behavior once the effective config is resolved.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Users can now set `agents.list[].tts` to override global TTS behavior per agent.
- Users can now set `agents.list[].stt` to override `tools.media.audio` defaults per agent.
- Existing configs remain valid; agents without speech overrides continue using global config.

## Diagram (if applicable)

```text
Before:
[session routed to agent] -> [global messages.tts / tools.media.audio only] -> [shared speech behavior]

After:
[session routed to agent] -> [resolve global config + agent speech overrides] -> [agent-specific TTS/STT behavior]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo runtime
- Model/provider: N/A for merge-path verification
- Integration/channel (if any): generic agent dispatch, ACP dispatch, Discord voice transcription path
- Relevant config (redacted): agent-level `tts` and `stt` entries over global speech config

### Steps

1. Configure global `messages.tts` and `tools.media.audio`.
2. Add per-agent `tts` and `stt` overrides under `agents.list[]`.
3. Route a session or transcription request through that agent.

### Expected

- The agent uses merged speech config, preferring agent overrides over global defaults.

### Actual

- Matches expected after this PR.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - per-agent TTS config merges onto global `messages.tts`
  - per-agent STT config merges onto global `tools.media.audio`
  - agent-aware TTS callsites use merged config in normal reply and ACP flows
  - agent-aware audio transcription forwards the right config context
- Edge cases checked:
  - no speech override returns the original config unchanged
  - nested provider config merges without discarding untouched global keys
  - session-key-based agent resolution applies speech overrides where no explicit agent id is passed
- What you did **not** verify:
  - full live multi-language end-to-end voice conversations against external providers

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - Optional new config only: add `agents.list[].tts` and/or `agents.list[].stt` where needed.

## Risks and Mitigations

- Risk: some agent-aware callsites might still use the unmerged base config.
  - Mitigation: added a shared `resolveAgentSpeechConfig` helper and routed the main agent-aware TTS/STT entrypoints through it.
- Risk: schema drift between Zod and generated config metadata.
  - Mitigation: regenerated `src/config/schema.base.generated.ts` as part of the change.