### PR TITLE
fix(gateway): use provider runtime hooks in startup warmup

### DIFF
--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -74,14 +74,9 @@ async function prewarmConfiguredPrimaryModel(params: {
   const agentDir = resolveOpenClawAgentDir();
   try {
     await ensureOpenClawModelsJson(params.cfg, agentDir);
-    const resolved = resolveModel(provider, model, agentDir, params.cfg, {
-      skipProviderRuntimeHooks: true,
-    });
+    const resolved = resolveModel(provider, model, agentDir, params.cfg);
     if (!resolved.model) {
-      throw new Error(
-        resolved.error ??
-          `Unknown model: ${provider}/${model} (startup warmup only checks static model resolution)`,
-      );
+      throw new Error(resolved.error ?? `Unknown model: ${provider}/${model}`);
     }
   } catch (err) {
     params.log.warn(`startup model warmup failed for ${provider}/${model}: ${String(err)}`);

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -11,7 +11,7 @@ const resolveModelMock = vi.fn<
     agentDir: unknown,
     cfg: unknown,
     options?: unknown,
-  ) => { model: { id: string; provider: string; api: string } }
+  ) => { model?: { id: string; provider: string; api: string }; error?: string }
 >(() => ({
   model: {
     id: "gpt-5.4",
@@ -42,7 +42,10 @@ vi.mock("../agents/pi-embedded-runner/model.js", () => ({
     agentDir: unknown,
     cfg: unknown,
     options?: unknown,
-  ) => resolveModelMock(provider, modelId, agentDir, cfg, options),
+  ) =>
+    options === undefined
+      ? resolveModelMock(provider, modelId, agentDir, cfg)
+      : resolveModelMock(provider, modelId, agentDir, cfg, options),
 }));
 
 vi.mock("../agents/pi-embedded-runner/runtime.js", () => ({
@@ -84,9 +87,52 @@ describe("gateway startup primary model warmup", () => {
     });
 
     expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(cfg, "/tmp/agent");
-    expect(resolveModelMock).toHaveBeenCalledWith("openai-codex", "gpt-5.4", "/tmp/agent", cfg, {
-      skipProviderRuntimeHooks: true,
+    expect(resolveModelMock).toHaveBeenCalledWith("openai-codex", "gpt-5.4", "/tmp/agent", cfg);
+  });
+
+  it("keeps provider-runtime-resolved codex warmup from warning", async () => {
+    resolveModelMock.mockImplementation(
+      (
+        provider: unknown,
+        modelId: unknown,
+        _agentDir: unknown,
+        _cfg: unknown,
+        options?: unknown,
+      ) => {
+        const skipProviderRuntimeHooks =
+          typeof options === "object" && options !== null && "skipProviderRuntimeHooks" in options
+            ? (options as { skipProviderRuntimeHooks?: boolean }).skipProviderRuntimeHooks
+            : undefined;
+        if (provider === "codex" && modelId === "gpt-5.4" && skipProviderRuntimeHooks) {
+          return { error: "Unknown model: codex/gpt-5.4" };
+        }
+        return {
+          model: {
+            id: "gpt-5.4",
+            provider: typeof provider === "string" ? provider : "codex",
+            api: "openai-codex-responses",
+          },
+        };
+      },
+    );
+    const warn = vi.fn();
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "codex/gpt-5.4",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await prewarmConfiguredPrimaryModel({
+      cfg,
+      log: { warn },
     });
+
+    expect(resolveModelMock).toHaveBeenCalledWith("codex", "gpt-5.4", "/tmp/agent", cfg);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("skips warmup when no explicit primary model is configured", async () => {


### PR DESCRIPTION
## Summary

- Problem: gateway startup warmup forced `resolveModel(..., { skipProviderRuntimeHooks: true })`, so provider-owned dynamic models such as `codex/gpt-5.4` were misreported as `Unknown model` during startup.
- Why it matters: the warning suggests the model is unsupported even when the normal runtime path resolves and uses it successfully.
- What changed: startup warmup now uses the normal `resolveModel(...)` path, removes the stale static-only error text, and adds regression coverage for provider-runtime-resolved Codex models.
- What did NOT change (scope boundary): this PR does not claim to fix broader model catalog/listing or harness-activation issues tracked elsewhere.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #64938
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `prewarmConfiguredPrimaryModel()` in `src/gateway/server-startup-post-attach.ts` forced the startup warmup through `resolveModel(..., { skipProviderRuntimeHooks: true })`, which swaps in `STATIC_PROVIDER_RUNTIME_HOOKS` and disables `runProviderDynamicModel`. Provider-owned dynamic models like `codex/*` depend on that hook to resolve.
- Missing detection / guardrail: `src/gateway/server-startup.test.ts` asserted the static-only warmup behavior instead of locking in parity with the normal runtime resolution path.
- Contributing context (if known): the old error text explicitly documented warmup as “static model resolution” only, which baked the degraded behavior into startup diagnostics.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-startup.test.ts`
- Scenario the test should lock in: startup warmup should not warn when a configured primary model is resolved via provider runtime hooks, using `codex/gpt-5.4` as the regression case.
- Why this is the smallest reliable guardrail: the bug is isolated to the startup warmup call-site and can be reproduced by observing whether it passes the skip flag into `resolveModel`.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Gateway startup no longer emits a false `Unknown model: codex/gpt-5.4` warning when the model is provider-runtime-resolved.

## Diagram (if applicable)

```text
Before:
[startup warmup] -> resolveModel(skipProviderRuntimeHooks=true) -> static-only resolution -> false Unknown model warning

After:
[startup warmup] -> resolveModel() -> provider runtime resolution -> no false warning
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm workspace checkout
- Model/provider: `codex/gpt-5.4`
- Integration/channel (if any): Gateway startup warmup
- Relevant config (redacted): `agents.defaults.model.primary = "codex/gpt-5.4"`

### Steps

1. Configure `agents.defaults.model.primary` to `codex/gpt-5.4`.
2. Start the gateway and let startup warmup run.
3. Observe whether startup emits `startup model warmup failed for codex/gpt-5.4: Error: Unknown model: codex/gpt-5.4`.

### Expected

- Startup warmup should resolve the configured primary model the same way the normal runtime path does and should not emit a false `Unknown model` warning for provider-runtime-resolved Codex models.

### Actual

- Before this patch, startup warmup forced static-only resolution and emitted the false warning.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/gateway/server-startup.test.ts`
  - `pnpm test src/gateway/server-startup-post-attach.test.ts`
  - `pnpm test extensions/codex/provider.test.ts -t "resolves arbitrary Codex app-server model ids through the codex provider"`
  - `pnpm build`
- Edge cases checked:
  - explicit `openai-codex/gpt-5.4` warmup still prewarms successfully
  - provider-runtime-resolved `codex/gpt-5.4` no longer warns in the startup unit test path
- What you did **not** verify:
  - live gateway startup logs on a real Codex-configured install in this branch
  - repo-wide `pnpm check` is currently red on unrelated pre-existing `tsgo` failures outside the touched surface

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: startup warmup now allows provider runtime hooks for the configured primary model.
  - Mitigation: the warmup path still uses synchronous `resolveModel()` (not `resolveModelAsync()`), so this change re-enables provider runtime model resolution without introducing `prepareProviderDynamicModel()` async prefetch behavior; regression coverage locks the intended call path.
