### PR TITLE
fix(billing): recognize billing cooldown skip messages as billing errors

### DIFF
--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -135,6 +135,9 @@ const ERROR_PATTERNS = {
     /extra usage is required(?: for long context requests)?/i,
     // Z.ai: error 1311 = model not included in current subscription plan (#48988)
     ZAI_BILLING_CODE_1311_RE,
+    // Billing cooldown skip path messages (#66314)
+    /has billing issue/i,
+    /skipping all models/i,
   ],
   authPermanent: HIGH_CONFIDENCE_AUTH_PERMANENT_PATTERNS,
   auth: [


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Billing cooldown skip messages (e.g., "Provider X has billing issue") were not recognized by `isBillingErrorMessage()`, causing the system to display a generic error instead of the specific billing error message.
- Why it matters: Users see "Something went wrong" instead of actionable billing instructions ("API provider returned a billing error..."), leading to poor user experience and confusion.
- What changed: Added regex patterns `/has billing issue/i` and `/skipping all models/i` to `ERROR_PATTERNS.billing` in `src/agents/pi-embedded-helpers/failover-matches.ts`.
- What did NOT change (scope boundary): No changes to the billing cooldown logic itself, error generation, or other error classification patterns.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66314

## User-visible / Behavior Changes

Users encountering a billing cooldown (where all models are skipped) will now see the specific `BILLING_ERROR_USER_MESSAGE` ("API provider returned a billing error — your API key has run out of credits or has an insufficient balance...") instead of the generic "Something went wrong" message.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: N/A (AI-generated)
- Runtime/container: N/A
- Model/provider: Anthropic (OAuth)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Configure OpenClaw with an Anthropic provider using OAuth authentication.
2. Exhaust the personal "extra usage" quota to trigger a billing error.
3. Allow a background or scheduled agent task to hit the billing error first, putting the auth profile into billing cooldown.
4. Send a user message that attempts to use the provider.
5. Observe the error message displayed to the user.

### Expected

User sees: "⚠️ API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key."

### Actual

Before fix: User sees "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session."
After fix: User sees the expected billing message.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: local scoped validation and targeted checks for the changed area passed
- Edge cases checked: relevant changed-path scenarios covered by selected validation
- What you did **not** verify: full repository integration coverage beyond the selected validation scope

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the two new regex lines (`/has billing issue/i`, `/skipping all models/i`) from `ERROR_PATTERNS.billing` in `src/agents/pi-embedded-helpers/failover-matches.ts`.
- Files/config to restore: `src/agents/pi-embedded-helpers/failover-matches.ts`
- Known bad symptoms reviewers should watch for: Users reverting to seeing generic "Something went wrong" errors during billing cooldown scenarios.

## Risks and Mitigations

Risk: The new regex patterns could theoretically match non-billing error strings containing "has billing issue" or "skipping all models".
Mitigation: The patterns are derived from specific internal log messages generated by the billing cooldown logic ("Provider X has billing issue (skipping all models)"), making false positives unlikely.