### PR TITLE
feat(chunker): add table protection to streaming block chunker

### DIFF
--- a/src/agents/pi-embedded-block-chunker.test.ts
+++ b/src/agents/pi-embedded-block-chunker.test.ts
@@ -160,4 +160,253 @@ describe("EmbeddedBlockChunker", () => {
       expect(chunk).not.toContain("``\n```");
     }
   });
+
+  describe("table protection", () => {
+    it("does not split inside a markdown table with separator row", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 200,
+        breakPreference: "paragraph",
+      });
+
+      const table = [
+        "| Header 1 | Header 2 |",
+        "|----------|----------|",
+        "| Cell 1   | Cell 2   |",
+      ].join("\n");
+      const text = `Intro text.\n\n${table}\n\nAfter table.`;
+
+      chunker.append(text);
+      const chunks = drainChunks(chunker);
+
+      const tableChunk = chunks.find((c) => c.includes("|---"));
+      expect(tableChunk).toBeDefined();
+      expect(tableChunk).toContain("| Header 1");
+      expect(tableChunk).toContain("| Cell 1");
+    });
+
+    it("does not split a partial table without separator row", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 25,
+        breakPreference: "paragraph",
+      });
+
+      const table = ["| a | b |", "| c | d |", "| e | f |"].join("\n");
+
+      chunker.append(table);
+      const chunks = drainChunks(chunker);
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toContain("| a | b |");
+      expect(chunks[0]).toContain("| e | f |");
+    });
+
+    it("breaks at paragraph boundary after a table", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 200,
+        breakPreference: "paragraph",
+      });
+
+      const table = ["| H1 | H2 |", "|----|----|", "| v1 | v2 |"].join("\n");
+      const after = "Summary text after table.";
+      const text = `${table}\n\n${after}`;
+
+      chunker.append(text);
+      const chunks = drainChunks(chunker);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      const first = chunks[0];
+      expect(first).toContain("| H1 |");
+      expect(first).toContain("| v1 |");
+      expect(first).not.toContain("Summary");
+    });
+
+    it("keeps table intact during streaming when buffer ends mid-table", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 40,
+        breakPreference: "paragraph",
+      });
+
+      chunker.append("| Name | Age |\n| Alice | 30 |");
+      const chunks = drainChunks(chunker);
+
+      expect(chunks).toHaveLength(0);
+      expect(chunker.bufferedText).toContain("| Name");
+    });
+
+    it("allows splitting shell pipe commands normally", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 30,
+        breakPreference: "paragraph",
+      });
+
+      const text = [
+        'cat file.txt | grep "error" | sort',
+        'ps aux | grep python | awk "{print $2}"',
+      ].join("\n");
+
+      chunker.append(text);
+      const chunks = drainChunks(chunker);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("force drains a table intact when table fits in maxChars", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 200,
+        breakPreference: "paragraph",
+      });
+
+      const table = ["| A | B |", "|---|---|", "| 1 | 2 |"].join("\n");
+      chunker.append(table);
+      const chunks = drainChunks(chunker, true);
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toContain("| A | B |");
+      expect(chunks[0]).toContain("| 1 | 2 |");
+    });
+
+    it("extends break to table end when maxChars lands inside a table (tail-skip)", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 25,
+        breakPreference: "paragraph",
+      });
+
+      const table = ["| H1 | H2 |", "|----|----|", "| ab | cd |"].join("\n");
+
+      chunker.append(table);
+      const chunks = drainChunks(chunker, true);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      const first = chunks[0];
+      expect(first).toContain("| H1 |");
+      expect(first).toContain("| ab |");
+    });
+
+    it("protects both fence and table in the same buffer", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 120,
+        breakPreference: "paragraph",
+      });
+
+      const fenceBlock = "```js\nconsole.log('hello');\n```";
+      const table = ["| A | B |", "|---|---|", "| 1 | 2 |"].join("\n");
+      const text = `${fenceBlock}\n\n${table}\n\nAfter both.`;
+
+      chunker.append(text);
+      const chunks = drainChunks(chunker);
+
+      const first = chunks[0];
+      expect(first).toContain("console.log");
+      expect(first).toContain("| A | B |");
+      expect(first).toContain("| 1 | 2 |");
+      expect(first).not.toContain("After both");
+    });
+
+    it("hard cuts an oversized table exceeding maxChars * 2", () => {
+      const maxChars = 30;
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars,
+        breakPreference: "paragraph",
+      });
+
+      const rows = Array.from({ length: 20 }, (_, i) => `| row${i} | value${i} |`);
+      const hugeTable = rows.join("\n");
+
+      chunker.append(hugeTable);
+      const chunks = drainChunks(chunker, true);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(maxChars * 3);
+      }
+    });
+
+    it("keeps partial table intact across multiple append calls", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 100,
+        maxChars: 200,
+        breakPreference: "paragraph",
+      });
+
+      chunker.append("| H1 | H2 |\n");
+      chunker.append("|----|----|\n");
+      chunker.append("| v1 | v2 |");
+      const chunks = drainChunks(chunker, true);
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toContain("| H1 | H2 |");
+      expect(chunks[0]).toContain("| v1 | v2 |");
+    });
+
+    it("protects table with sentence break preference", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 60,
+        breakPreference: "sentence",
+      });
+
+      const table = [
+        "| Header 1 | Header 2 |",
+        "|----------|----------|",
+        "| Cell 1   | Cell 2   |",
+      ].join("\n");
+      const text = `Intro.\n\n${table}\n\nDone.`;
+
+      chunker.append(text);
+      const chunks = drainChunks(chunker);
+
+      const tableChunk = chunks.find((c) => c.includes("|---"));
+      expect(tableChunk).toBeDefined();
+      expect(tableChunk).toContain("| Header 1");
+      expect(tableChunk).toContain("| Cell 1");
+    });
+
+    it("does not split table when flushOnParagraph is enabled", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 200,
+        breakPreference: "paragraph",
+        flushOnParagraph: true,
+      });
+
+      const table = ["| A | B |", "|---|---|", "| 1 | 2 |"].join("\n");
+      const text = `Intro.\n\n${table}\n\nAfter.`;
+
+      chunker.append(text);
+      const chunks = drainChunks(chunker);
+
+      const tableChunk = chunks.find((c) => c.includes("|---"));
+      expect(tableChunk).toBeDefined();
+      expect(tableChunk).toContain("| A |");
+      expect(tableChunk).toContain("| 1 |");
+    });
+
+    it("protects table with newline break preference", () => {
+      const chunker = new EmbeddedBlockChunker({
+        minChars: 1,
+        maxChars: 60,
+        breakPreference: "newline",
+      });
+
+      const table = ["| H1 | H2 |", "|----|----|", "| v1 | v2 |"].join("\n");
+      const text = `Before.\n${table}\nAfter.`;
+
+      chunker.append(text);
+      const chunks = drainChunks(chunker, true);
+
+      const tableChunk = chunks.find((c) => c.includes("|----"));
+      expect(tableChunk).toBeDefined();
+      expect(tableChunk).toContain("| H1 |");
+      expect(tableChunk).toContain("| v1 |");
+    });
+  });
 });

--- a/src/agents/pi-embedded-block-chunker.ts
+++ b/src/agents/pi-embedded-block-chunker.ts
@@ -1,5 +1,9 @@
 import type { FenceSpan } from "../markdown/fences.js";
-import { findFenceSpanAt, isSafeFenceBreak, parseFenceSpans } from "../markdown/fences.js";
+import { findFenceSpanAt, parseFenceSpans } from "../markdown/fences.js";
+import { parseTableSpans } from "../markdown/table-spans.js";
+import type { TableSpan } from "../markdown/table-spans.js";
+
+type ProtectedSpan = { start: number; end: number };
 
 export type BlockReplyChunking = {
   minChars: number;
@@ -25,9 +29,33 @@ type ParagraphBreak = {
   length: number;
 };
 
+function isInsideAnySpan(spans: ProtectedSpan[], index: number): boolean {
+  let low = 0;
+  let high = spans.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const span = spans[mid];
+    if (!span) {
+      break;
+    }
+    if (index <= span.start) {
+      high = mid - 1;
+    } else if (index >= span.end) {
+      low = mid + 1;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isSafeBreak(spans: ProtectedSpan[], index: number): boolean {
+  return !isInsideAnySpan(spans, index);
+}
+
 function findSafeSentenceBreakIndex(
   text: string,
-  fenceSpans: FenceSpan[],
+  protectedSpans: ProtectedSpan[],
   minChars: number,
   offset = 0,
 ): number {
@@ -39,7 +67,7 @@ function findSafeSentenceBreakIndex(
       continue;
     }
     const candidate = at + 1;
-    if (isSafeFenceBreak(fenceSpans, offset + candidate)) {
+    if (isSafeBreak(protectedSpans, offset + candidate)) {
       sentenceIdx = candidate;
     }
   }
@@ -48,12 +76,12 @@ function findSafeSentenceBreakIndex(
 
 function findSafeParagraphBreakIndex(params: {
   text: string;
-  fenceSpans: FenceSpan[];
+  protectedSpans: ProtectedSpan[];
   minChars: number;
   reverse: boolean;
   offset?: number;
 }): number {
-  const { text, fenceSpans, minChars, reverse, offset = 0 } = params;
+  const { text, protectedSpans, minChars, reverse, offset = 0 } = params;
   let paragraphIdx = reverse ? text.lastIndexOf("\n\n") : text.indexOf("\n\n");
   while (reverse ? paragraphIdx >= minChars : paragraphIdx !== -1) {
     const candidates = [paragraphIdx, paragraphIdx + 1];
@@ -64,7 +92,7 @@ function findSafeParagraphBreakIndex(params: {
       if (candidate < 0 || candidate >= text.length) {
         continue;
       }
-      if (isSafeFenceBreak(fenceSpans, offset + candidate)) {
+      if (isSafeBreak(protectedSpans, offset + candidate)) {
         return candidate;
       }
     }
@@ -77,15 +105,15 @@ function findSafeParagraphBreakIndex(params: {
 
 function findSafeNewlineBreakIndex(params: {
   text: string;
-  fenceSpans: FenceSpan[];
+  protectedSpans: ProtectedSpan[];
   minChars: number;
   reverse: boolean;
   offset?: number;
 }): number {
-  const { text, fenceSpans, minChars, reverse, offset = 0 } = params;
+  const { text, protectedSpans, minChars, reverse, offset = 0 } = params;
   let newlineIdx = reverse ? text.lastIndexOf("\n") : text.indexOf("\n");
   while (reverse ? newlineIdx >= minChars : newlineIdx !== -1) {
-    if (newlineIdx >= minChars && isSafeFenceBreak(fenceSpans, offset + newlineIdx)) {
+    if (newlineIdx >= minChars && isSafeBreak(protectedSpans, offset + newlineIdx)) {
       return newlineIdx;
     }
     newlineIdx = reverse
@@ -102,6 +130,26 @@ function findFenceCloseLineStart(buffer: string, fence: FenceSpan, offset = 0): 
   }
   const lastNewline = buffer.lastIndexOf("\n", relativeFenceEnd - 1);
   return lastNewline >= 0 ? lastNewline + 1 : -1;
+}
+
+function findSpanAt(spans: ProtectedSpan[], index: number): ProtectedSpan | undefined {
+  let low = 0;
+  let high = spans.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const span = spans[mid];
+    if (!span) {
+      break;
+    }
+    if (index <= span.start) {
+      high = mid - 1;
+    } else if (index >= span.end) {
+      low = mid + 1;
+    } else {
+      return span;
+    }
+  }
+  return undefined;
 }
 
 export class EmbeddedBlockChunker {
@@ -132,8 +180,6 @@ export class EmbeddedBlockChunker {
   }
 
   drain(params: { force: boolean; emit: (chunk: string) => void }) {
-    // KNOWN: We cannot split inside fenced code blocks (Markdown breaks + UI glitches).
-    // When forced (maxChars), we close + reopen the fence to keep Markdown valid.
     const { force, emit } = params;
     const minChars = Math.max(1, Math.floor(this.#chunking.minChars));
     const maxChars = Math.max(minChars, Math.floor(this.#chunking.maxChars));
@@ -152,6 +198,10 @@ export class EmbeddedBlockChunker {
 
     const source = this.#buffer;
     const fenceSpans = parseFenceSpans(source);
+    const tableSpans = parseTableSpans(source, fenceSpans);
+    const protectedSpans: ProtectedSpan[] = [...fenceSpans, ...tableSpans].toSorted(
+      (a, b) => a.start - b.start,
+    );
     let start = 0;
     let reopenFence: FenceSpan | undefined;
 
@@ -164,7 +214,7 @@ export class EmbeddedBlockChunker {
       }
 
       if (this.#chunking.flushOnParagraph && !force) {
-        const paragraphBreak = findNextParagraphBreak(source, fenceSpans, start, minChars);
+        const paragraphBreak = findNextParagraphBreak(source, protectedSpans, start, minChars);
         const paragraphLimit = Math.max(1, maxChars - reopenPrefix.length);
         if (paragraphBreak && paragraphBreak.index - start <= paragraphLimit) {
           const chunk = `${reopenPrefix}${source.slice(start, paragraphBreak.index)}`;
@@ -183,8 +233,15 @@ export class EmbeddedBlockChunker {
       const view = source.slice(start);
       const breakResult =
         force && remainingLength <= maxChars
-          ? this.#pickSoftBreakIndex(view, fenceSpans, 1, start)
-          : this.#pickBreakIndex(view, fenceSpans, force ? 1 : undefined, start);
+          ? this.#pickSoftBreakIndex(view, protectedSpans, 1, start)
+          : this.#pickBreakIndex(
+              view,
+              protectedSpans,
+              fenceSpans,
+              tableSpans,
+              force ? 1 : undefined,
+              start,
+            );
       if (breakResult.index <= 0) {
         if (force) {
           emit(`${reopenPrefix}${source.slice(start)}`);
@@ -194,13 +251,7 @@ export class EmbeddedBlockChunker {
         break;
       }
 
-      const consumed = this.#emitBreakResult({
-        breakResult,
-        emit,
-        reopenPrefix,
-        source,
-        start,
-      });
+      const consumed = this.#emitBreakResult({ breakResult, emit, reopenPrefix, source, start });
       if (consumed === null) {
         continue;
       }
@@ -263,7 +314,7 @@ export class EmbeddedBlockChunker {
 
   #pickSoftBreakIndex(
     buffer: string,
-    fenceSpans: FenceSpan[],
+    protectedSpans: ProtectedSpan[],
     minCharsOverride?: number,
     offset = 0,
   ): BreakResult {
@@ -276,7 +327,7 @@ export class EmbeddedBlockChunker {
     if (preference === "paragraph") {
       const paragraphIdx = findSafeParagraphBreakIndex({
         text: buffer,
-        fenceSpans,
+        protectedSpans,
         minChars,
         reverse: false,
         offset,
@@ -289,7 +340,7 @@ export class EmbeddedBlockChunker {
     if (preference === "paragraph" || preference === "newline") {
       const newlineIdx = findSafeNewlineBreakIndex({
         text: buffer,
-        fenceSpans,
+        protectedSpans,
         minChars,
         reverse: false,
         offset,
@@ -300,7 +351,7 @@ export class EmbeddedBlockChunker {
     }
 
     if (preference !== "newline") {
-      const sentenceIdx = findSafeSentenceBreakIndex(buffer, fenceSpans, minChars, offset);
+      const sentenceIdx = findSafeSentenceBreakIndex(buffer, protectedSpans, minChars, offset);
       if (sentenceIdx !== -1) {
         return { index: sentenceIdx };
       }
@@ -311,7 +362,9 @@ export class EmbeddedBlockChunker {
 
   #pickBreakIndex(
     buffer: string,
+    protectedSpans: ProtectedSpan[],
     fenceSpans: FenceSpan[],
+    tableSpans: TableSpan[],
     minCharsOverride?: number,
     offset = 0,
   ): BreakResult {
@@ -323,10 +376,11 @@ export class EmbeddedBlockChunker {
     const window = buffer.slice(0, Math.min(maxChars, buffer.length));
 
     const preference = this.#chunking.breakPreference ?? "paragraph";
+
     if (preference === "paragraph") {
       const paragraphIdx = findSafeParagraphBreakIndex({
         text: window,
-        fenceSpans,
+        protectedSpans,
         minChars,
         reverse: true,
         offset,
@@ -339,7 +393,7 @@ export class EmbeddedBlockChunker {
     if (preference === "paragraph" || preference === "newline") {
       const newlineIdx = findSafeNewlineBreakIndex({
         text: window,
-        fenceSpans,
+        protectedSpans,
         minChars,
         reverse: true,
         offset,
@@ -350,7 +404,7 @@ export class EmbeddedBlockChunker {
     }
 
     if (preference !== "newline") {
-      const sentenceIdx = findSafeSentenceBreakIndex(window, fenceSpans, minChars, offset);
+      const sentenceIdx = findSafeSentenceBreakIndex(window, protectedSpans, minChars, offset);
       if (sentenceIdx !== -1) {
         return { index: sentenceIdx };
       }
@@ -361,15 +415,16 @@ export class EmbeddedBlockChunker {
     }
 
     for (let i = window.length - 1; i >= minChars; i--) {
-      if (/\s/.test(window[i]) && isSafeFenceBreak(fenceSpans, offset + i)) {
+      if (/\s/.test(window[i]) && isSafeBreak(protectedSpans, offset + i)) {
         return { index: i };
       }
     }
 
     if (buffer.length >= maxChars) {
-      if (isSafeFenceBreak(fenceSpans, offset + maxChars)) {
+      if (isSafeBreak(protectedSpans, offset + maxChars)) {
         return { index: maxChars };
       }
+
       const fence = findFenceSpanAt(fenceSpans, offset + maxChars);
       if (fence) {
         const closeFenceStart = findFenceCloseLineStart(buffer, fence, offset);
@@ -392,6 +447,15 @@ export class EmbeddedBlockChunker {
           },
         };
       }
+
+      const table = findSpanAt(tableSpans, offset + maxChars);
+      if (table) {
+        const relativeTableEnd = table.end - offset;
+        if (relativeTableEnd <= buffer.length && relativeTableEnd < maxChars * 2) {
+          return { index: Math.min(relativeTableEnd, buffer.length) };
+        }
+      }
+
       return { index: maxChars };
     }
 
@@ -414,7 +478,7 @@ function stripLeadingNewlines(value: string): string {
 
 function findNextParagraphBreak(
   buffer: string,
-  fenceSpans: FenceSpan[],
+  protectedSpans: ProtectedSpan[],
   startIndex = 0,
   minCharsFromStart = 1,
 ): ParagraphBreak | null {
@@ -432,7 +496,7 @@ function findNextParagraphBreak(
     if (index - startIndex < minCharsFromStart) {
       continue;
     }
-    if (!isSafeFenceBreak(fenceSpans, index)) {
+    if (!isSafeBreak(protectedSpans, index)) {
       continue;
     }
     return { index, length: match[0].length };

--- a/src/markdown/table-spans.test.ts
+++ b/src/markdown/table-spans.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { parseTableSpans } from "./table-spans.js";
+
+function spansOf(text: string, fences: { start: number; end: number }[] = []) {
+  return parseTableSpans(text, fences);
+}
+
+describe("parseTableSpans", () => {
+  describe("first level: complete tables with separator row", () => {
+    it("detects a simple markdown table", () => {
+      const text = [
+        "| Header 1 | Header 2 |",
+        "|----------|----------|",
+        "| Cell 1   | Cell 2   |",
+      ].join("\n");
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toEqual({ start: 0, end: text.length });
+    });
+
+    it("detects a table surrounded by text", () => {
+      const before = "Some intro text.\n\n";
+      const table = ["| A | B |", "|---|---|", "| 1 | 2 |"].join("\n");
+      const after = "\n\nAfter table.";
+      const text = before + table + after;
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(1);
+      expect(spans[0]?.start).toBe(before.length);
+      expect(spans[0]?.end).toBe(before.length + table.length);
+    });
+
+    it("detects multiple tables", () => {
+      const table1 = ["| A | B |", "|---|---|", "| 1 | 2 |"].join("\n");
+      const gap = "\n\nText between.\n\n";
+      const table2 = ["| X | Y |", "|---|---|", "| 3 | 4 |"].join("\n");
+      const text = table1 + gap + table2;
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(2);
+      expect(spans[0]?.start).toBe(0);
+      expect(spans[0]?.end).toBe(table1.length);
+      expect(spans[1]?.start).toBe(table1.length + gap.length);
+    });
+
+    it("detects table without leading pipe in header", () => {
+      const text = ["Header 1 | Header 2", "-------- | --------", "Cell 1   | Cell 2"].join("\n");
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(1);
+    });
+  });
+
+  describe("second level: suspected tables without separator row", () => {
+    it("detects consecutive pipe-delimited lines starting with |", () => {
+      const text = ["| a | b |", "| c | d |"].join("\n");
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toEqual({ start: 0, end: text.length });
+    });
+
+    it("ignores a single line with pipes", () => {
+      const text = "| a | b |";
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(0);
+    });
+
+    it("ignores shell pipe commands that do not start with |", () => {
+      const text = [
+        'cat file.txt | grep "error" | sort',
+        'ps aux | grep python | awk "{print $2}"',
+      ].join("\n");
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(0);
+    });
+
+    it("ignores lines with only one pipe", () => {
+      const text = ["| single column", "| another row"].join("\n");
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(0);
+    });
+
+    it("detects partial table at end of buffer during streaming", () => {
+      const text = ["| Name | Age |", "| Alice | 30 |"].join("\n");
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toEqual({ start: 0, end: text.length });
+    });
+  });
+
+  describe("fence span exclusion", () => {
+    it("does not detect pipe lines inside code fences", () => {
+      const text = ["```", "| a | b |", "|---|---|", "| 1 | 2 |", "```"].join("\n");
+      const fenceSpans = [{ start: 0, end: text.length }];
+
+      const spans = spansOf(text, fenceSpans);
+      expect(spans).toHaveLength(0);
+    });
+
+    it("detects tables outside fences but not inside", () => {
+      const table = ["| A | B |", "|---|---|", "| 1 | 2 |"].join("\n");
+      const codeBlock = `\n\`\`\`\n| x | y |\n|---|---|\n\`\`\`\n`;
+      const text = table + codeBlock;
+      const fenceSpans = [{ start: table.length + 1, end: text.length - 1 }];
+
+      const spans = spansOf(text, fenceSpans);
+      expect(spans).toHaveLength(1);
+      expect(spans[0]?.start).toBe(0);
+      expect(spans[0]?.end).toBe(table.length);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty for plain text without tables", () => {
+      const text = "Hello world.\nNo tables here.\nJust plain text.";
+
+      expect(spansOf(text)).toHaveLength(0);
+    });
+
+    it("returns empty for empty buffer", () => {
+      expect(spansOf("")).toHaveLength(0);
+    });
+
+    it("merges overlapping table spans", () => {
+      const lines = ["| a | b |", "|---|---|", "| 1 | 2 |", "| 3 | 4 |"];
+      const text = lines.join("\n");
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(1);
+    });
+
+    it("handles table at very end without trailing newline", () => {
+      const before = "Some text.\n\n";
+      const table = "| H1 | H2 |\n|----|----|\n| v1 | v2 |";
+      const text = before + table;
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(1);
+      expect(spans[0]?.end).toBe(text.length);
+    });
+
+    it("detects tables with alignment colons", () => {
+      const text = [
+        "| Left | Center | Right |",
+        "|:-----|:------:|------:|",
+        "| a    | b      | c     |",
+      ].join("\n");
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toEqual({ start: 0, end: text.length });
+    });
+
+    it("does not merge tables separated by a blank line", () => {
+      const table1 = ["| A | B |", "|---|---|", "| 1 | 2 |"].join("\n");
+      const gap = "\n\nSome text.\n\n";
+      const table2 = ["| X | Y |", "|---|---|", "| 3 | 4 |"].join("\n");
+      const text = table1 + gap + table2;
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(2);
+    });
+
+    it("handles rows with differing column counts", () => {
+      const text = ["| A | B | C |", "|---|---|---|", "| 1 | 2 |", "| 4 | 5 | 6 | 7 |"].join("\n");
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(1);
+      expect(spans[0]).toEqual({ start: 0, end: text.length });
+    });
+  });
+});

--- a/src/markdown/table-spans.test.ts
+++ b/src/markdown/table-spans.test.ts
@@ -174,5 +174,18 @@ describe("parseTableSpans", () => {
       expect(spans).toHaveLength(1);
       expect(spans[0]).toEqual({ start: 0, end: text.length });
     });
+
+    it("detects level-2 table before level-1 table (addSpan ordering bug)", () => {
+      const level2 = ["| a | b |", "| c | d |"].join("\n");
+      const gap = "\n\nSome text.\n\n";
+      const level1 = ["| H1 | H2 |", "|----|----|", "| v1 | v2 |"].join("\n");
+      const text = level2 + gap + level1;
+
+      const spans = spansOf(text);
+      expect(spans).toHaveLength(2);
+      expect(spans[0]?.start).toBe(0);
+      expect(spans[0]?.end).toBe(level2.length);
+      expect(spans[1]?.start).toBe(level2.length + gap.length);
+    });
   });
 });

--- a/src/markdown/table-spans.ts
+++ b/src/markdown/table-spans.ts
@@ -34,22 +34,29 @@ function isInsideFence(offset: number, fenceSpans: { start: number; end: number 
   return false;
 }
 
-function addSpan(spans: TableSpan[], start: number, end: number) {
-  if (spans.length > 0) {
-    const last = spans[spans.length - 1];
-    if (last && start <= last.end) {
-      last.end = Math.max(last.end, end);
-      return;
+function mergeSpans(candidates: TableSpan[]): TableSpan[] {
+  if (candidates.length === 0) {
+    return [];
+  }
+  const sorted = candidates.toSorted((a, b) => a.start - b.start);
+  const merged: TableSpan[] = [{ start: sorted[0].start, end: sorted[0].end }];
+  for (let i = 1; i < sorted.length; i++) {
+    const last = merged[merged.length - 1];
+    const cur = sorted[i];
+    if (cur.start <= last.end) {
+      last.end = Math.max(last.end, cur.end);
+    } else {
+      merged.push({ start: cur.start, end: cur.end });
     }
   }
-  spans.push({ start, end });
+  return merged;
 }
 
 export function parseTableSpans(
   buffer: string,
   fenceSpans: { start: number; end: number }[] = [],
 ): TableSpan[] {
-  const spans: TableSpan[] = [];
+  const candidates: TableSpan[] = [];
   const lines = buildLineIndex(buffer);
 
   const firstLevelUsed = new Set<number>();
@@ -87,7 +94,7 @@ export function parseTableSpans(
       firstLevelUsed.add(k);
     }
 
-    addSpan(spans, lines[headerStart].start, lines[bodyEnd].end);
+    candidates.push({ start: lines[headerStart].start, end: lines[bodyEnd].end });
     i = bodyEnd;
   }
 
@@ -122,12 +129,12 @@ export function parseTableSpans(
       for (let k = i; k <= groupEnd; k++) {
         firstLevelUsed.add(k);
       }
-      addSpan(spans, lines[i].start, lines[groupEnd].end);
+      candidates.push({ start: lines[i].start, end: lines[groupEnd].end });
       i = groupEnd;
     }
   }
 
-  return spans;
+  return mergeSpans(candidates);
 }
 
 function buildLineIndex(buffer: string): Array<{ start: number; end: number; text: string }> {

--- a/src/markdown/table-spans.ts
+++ b/src/markdown/table-spans.ts
@@ -1,0 +1,146 @@
+export type TableSpan = { start: number; end: number };
+
+const SEPARATOR_RE = /^\s*\|?[\s:-]+\|/;
+
+function isSeparatorLine(line: string): boolean {
+  if (!SEPARATOR_RE.test(line)) {
+    return false;
+  }
+  const stripped = line.replace(/[|\s:-]/g, "");
+  return stripped.length === 0 && line.includes("-");
+}
+
+function isTableRow(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.length > 0 && trimmed.startsWith("|") && countPipes(trimmed) >= 2;
+}
+
+function countPipes(line: string): number {
+  let count = 0;
+  for (const ch of line) {
+    if (ch === "|") {
+      count++;
+    }
+  }
+  return count;
+}
+
+function isInsideFence(offset: number, fenceSpans: { start: number; end: number }[]): boolean {
+  for (const span of fenceSpans) {
+    if (offset > span.start && offset < span.end) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function addSpan(spans: TableSpan[], start: number, end: number) {
+  if (spans.length > 0) {
+    const last = spans[spans.length - 1];
+    if (last && start <= last.end) {
+      last.end = Math.max(last.end, end);
+      return;
+    }
+  }
+  spans.push({ start, end });
+}
+
+export function parseTableSpans(
+  buffer: string,
+  fenceSpans: { start: number; end: number }[] = [],
+): TableSpan[] {
+  const spans: TableSpan[] = [];
+  const lines = buildLineIndex(buffer);
+
+  const firstLevelUsed = new Set<number>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const { start: lineStart, text } = lines[i];
+    if (isInsideFence(lineStart, fenceSpans)) {
+      continue;
+    }
+    if (!isSeparatorLine(text)) {
+      continue;
+    }
+
+    let headerStart = i;
+    while (headerStart > 0) {
+      const prev = lines[headerStart - 1];
+      if (prev && countPipes(prev.text) >= 2 && !isInsideFence(prev.start, fenceSpans)) {
+        headerStart--;
+      } else {
+        break;
+      }
+    }
+
+    let bodyEnd = i;
+    while (bodyEnd + 1 < lines.length) {
+      const next = lines[bodyEnd + 1];
+      if (next && countPipes(next.text) >= 2 && !isInsideFence(next.start, fenceSpans)) {
+        bodyEnd++;
+      } else {
+        break;
+      }
+    }
+
+    for (let k = headerStart; k <= bodyEnd; k++) {
+      firstLevelUsed.add(k);
+    }
+
+    addSpan(spans, lines[headerStart].start, lines[bodyEnd].end);
+    i = bodyEnd;
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    if (firstLevelUsed.has(i)) {
+      continue;
+    }
+    const { start: lineStart, text } = lines[i];
+    if (isInsideFence(lineStart, fenceSpans)) {
+      continue;
+    }
+    if (!isTableRow(text)) {
+      continue;
+    }
+
+    let groupEnd = i;
+    while (groupEnd + 1 < lines.length) {
+      const next = lines[groupEnd + 1];
+      if (
+        !firstLevelUsed.has(groupEnd + 1) &&
+        next &&
+        isTableRow(next.text) &&
+        !isInsideFence(next.start, fenceSpans)
+      ) {
+        groupEnd++;
+      } else {
+        break;
+      }
+    }
+
+    if (groupEnd > i) {
+      for (let k = i; k <= groupEnd; k++) {
+        firstLevelUsed.add(k);
+      }
+      addSpan(spans, lines[i].start, lines[groupEnd].end);
+      i = groupEnd;
+    }
+  }
+
+  return spans;
+}
+
+function buildLineIndex(buffer: string): Array<{ start: number; end: number; text: string }> {
+  const lines: Array<{ start: number; end: number; text: string }> = [];
+  let offset = 0;
+  while (offset <= buffer.length) {
+    const nextNewline = buffer.indexOf("\n", offset);
+    const lineEnd = nextNewline === -1 ? buffer.length : nextNewline;
+    lines.push({ start: offset, end: lineEnd, text: buffer.slice(offset, lineEnd) });
+    if (nextNewline === -1) {
+      break;
+    }
+    offset = nextNewline + 1;
+  }
+  return lines;
+}


### PR DESCRIPTION
## Summary

- **Problem**: When AI streams a reply containing a Markdown table, the `EmbeddedBlockChunker` may split the message in the middle of a table, producing broken/fragmented table rendering across chat messages.
- **Why it matters**: Tables are a common structure in AI responses (comparisons, data summaries, parameter docs). Broken tables degrade readability on Discord, Telegram, Slack, and other channels.
- **What changed**: Add `parseTableSpans` for Markdown table detection (with/without separator row). Extend `EmbeddedBlockChunker` to protect tables alongside code fences using a unified `protectedSpans` mechanism. Add tail-skip logic when `maxChars` lands inside a table.
- **What did NOT change**: Public API (`EmbeddedBlockChunker` constructor, `append`, `drain`, `reset`, `bufferedText`, `hasBuffered`, `BlockReplyChunking` type) is unchanged. Code fence protection behavior is unchanged. `src/auto-reply/chunk.ts` and its `isSafeFenceBreak` usage are untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66614
- Closes #66605
- Related #47454
- Related #17679
- Related #8537
- Related #66568

## Root Cause

N/A — This is a new feature, not a bug fix.

## User-visible / Behavior Changes

- Markdown tables in AI streaming replies are now kept intact across chunks instead of being split mid-table.
- Chunks containing tables may be slightly larger than before (up to `maxChars * 2` in rare cases where the table extends past `maxChars`).

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- All new tests pass:
  - `src/markdown/table-spans.test.ts` — 18 tests
  - `src/agents/pi-embedded-block-chunker.test.ts` — 21 tests (13 new table protection tests)
- No regression on existing tests:
  - `src/auto-reply/chunk.test.ts` — 56 tests passed

## Human Verification

- Verified scenarios: Table protection with separator rows, partial tables without separator, mixed fence+table buffers, streaming across multiple `append` calls, oversized table hard-cut, all three `breakPreference` modes, `flushOnParagraph` mode.
- Edge cases checked: Shell pipe commands are NOT falsely detected as tables (second-level scan requires `|` prefix).
- What I did **not** verify: Live streaming through a real messaging channel (unit test coverage only).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: First-level table scan uses `countPipes >= 2` without requiring `|` prefix, which could absorb adjacent non-table lines with 2+ pipe characters (e.g., shell commands) into the table span.
  - Mitigation: In AI output, non-table lines adjacent to a separator row (`|---|---|`) without a blank line between them is extremely rare. Shell commands are typically inside code blocks or separated by blank lines. This can be tightened in a follow-up if needed.
- Risk: Tail-skip can produce chunks up to `maxChars * 2` in size.
  - Mitigation: This is consistent with the existing fence close/reopen mechanism which can also exceed `maxChars`. The `maxChars * 2` hard cap prevents unbounded growth.