### PR TITLE
fix(browser): unblock loopback CDP readiness under strict SSRF defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Browser/SSRF: restore hostname navigation under the default browser SSRF policy while keeping explicit strict mode reachable from config, and keep managed loopback CDP `/json/new` fallback requests on the local CDP control policy so browser follow-up fixes stop regressing normal navigation or self-blocking local CDP control. (#66386) Thanks @obviyus.
 - Browser/SSRF: preserve explicit strict browser navigation mode for legacy `browser.ssrfPolicy.allowPrivateNetwork: false` configs by normalizing the legacy alias to the canonical strict marker instead of silently widening those installs to the default non-strict hostname-navigation path.
 - Agents/subagents: emit the subagent registry lazy-runtime stub on the stable dist path that both source and bundled runtime imports resolve, so the follow-up dist fix no longer still fails with `ERR_MODULE_NOT_FOUND` at runtime. (#66420) Thanks @obviyus.
+- Browser: keep loopback CDP readiness checks reachable under strict SSRF defaults so OpenClaw can reconnect to locally started managed Chrome. (#66354) Thanks @hxy91819.
 
 ## 2026.4.14-beta.1
 

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -33,6 +33,20 @@ openclaw browser --browser-profile openclaw open https://example.com
 openclaw browser --browser-profile openclaw snapshot
 ```
 
+## Quick troubleshooting
+
+If `start` fails with `not reachable after start`, troubleshoot CDP readiness first. If `start` and `tabs` succeed but `open` or `navigate` fails, the browser control plane is healthy and the failure is usually navigation SSRF policy.
+
+Minimal sequence:
+
+```bash
+openclaw browser --browser-profile openclaw start
+openclaw browser --browser-profile openclaw tabs
+openclaw browser --browser-profile openclaw open https://example.com
+```
+
+Detailed guidance: [Browser troubleshooting](/tools/browser#cdp-startup-failure-vs-navigation-ssrf-block)
+
 ## Lifecycle
 
 ```bash

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -884,6 +884,63 @@ For Linux-specific issues (especially snap Chromium), see
 For WSL2 Gateway + Windows Chrome split-host setups, see
 [WSL2 + Windows + remote Chrome CDP troubleshooting](/tools/browser-wsl2-windows-remote-cdp-troubleshooting).
 
+### CDP startup failure vs navigation SSRF block
+
+These are different failure classes and they point to different code paths.
+
+- **CDP startup or readiness failure** means OpenClaw cannot confirm that the browser control plane is healthy.
+- **Navigation SSRF block** means the browser control plane is healthy, but a page navigation target is rejected by policy.
+
+Common examples:
+
+- CDP startup or readiness failure:
+  - `Chrome CDP websocket for profile "openclaw" is not reachable after start`
+  - `Remote CDP for profile "<name>" is not reachable at <cdpUrl>`
+- Navigation SSRF block:
+  - `open`, `navigate`, snapshot, or tab-opening flows fail with a browser/network policy error while `start` and `tabs` still work
+
+Use this minimal sequence to separate the two:
+
+```bash
+openclaw browser --browser-profile openclaw start
+openclaw browser --browser-profile openclaw tabs
+openclaw browser --browser-profile openclaw open https://example.com
+```
+
+How to read the results:
+
+- If `start` fails with `not reachable after start`, troubleshoot CDP readiness first.
+- If `start` succeeds but `tabs` fails, the control plane is still unhealthy. Treat this as a CDP reachability problem, not a page-navigation problem.
+- If `start` and `tabs` succeed but `open` or `navigate` fails, the browser control plane is up and the failure is in navigation policy or the target page.
+- If `start`, `tabs`, and `open` all succeed, the basic managed-browser control path is healthy.
+
+Important behavior details:
+
+- Browser config defaults to a fail-closed SSRF policy object even when you do not configure `browser.ssrfPolicy`.
+- For the local loopback `openclaw` managed profile, CDP health checks intentionally skip browser SSRF reachability enforcement for OpenClaw's own local control plane.
+- Navigation protection is separate. A successful `start` or `tabs` result does not mean a later `open` or `navigate` target is allowed.
+
+Security guidance:
+
+- Do **not** relax browser SSRF policy by default.
+- Prefer narrow host exceptions such as `hostnameAllowlist` or `allowedHostnames` over broad private-network access.
+- Use `dangerouslyAllowPrivateNetwork: true` only in intentionally trusted environments where private-network browser access is required and reviewed.
+
+Example: navigation blocked, control plane healthy
+
+- `start` succeeds
+- `tabs` succeeds
+- `open http://internal.example` fails
+
+That usually means browser startup is fine and the navigation target needs policy review.
+
+Example: startup blocked before navigation matters
+
+- `start` fails with `not reachable after start`
+- `tabs` also fails or cannot run
+
+That points to browser launch or CDP reachability, not a page URL allowlist problem.
+
 ## Agent tools + how control works
 
 The agent gets **one tool** for browser automation:

--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -51,6 +51,15 @@ describe("cdp helpers", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("still enforces hostname allowlist for loopback CDP endpoints", async () => {
+    await expect(
+      assertCdpEndpointAllowed("http://127.0.0.1:9222/json/version", {
+        dangerouslyAllowPrivateNetwork: false,
+        hostnameAllowlist: ["*.corp.example"],
+      }),
+    ).rejects.toThrow("browser endpoint blocked by policy");
+  });
+
   it("releases guarded CDP fetches for bodyless requests", async () => {
     const release = vi.fn(async () => {});
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
@@ -92,6 +101,36 @@ describe("cdp helpers", () => {
         url: "http://127.0.0.1:9222/json/version",
         policy: {
           dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["127.0.0.1"],
+        },
+      }),
+    );
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves hostname allowlist while allowing exact loopback CDP fetches", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: {
+        ok: true,
+        status: 200,
+      },
+      release,
+    });
+
+    await expect(
+      fetchOk("http://127.0.0.1:9222/json/version", 250, undefined, {
+        dangerouslyAllowPrivateNetwork: false,
+        hostnameAllowlist: ["*.corp.example"],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://127.0.0.1:9222/json/version",
+        policy: {
+          dangerouslyAllowPrivateNetwork: false,
+          hostnameAllowlist: ["*.corp.example"],
           allowedHostnames: ["127.0.0.1"],
         },
       }),

--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -10,7 +10,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   };
 });
 
-import { fetchJson, fetchOk } from "./cdp.helpers.js";
+import { assertCdpEndpointAllowed, fetchJson, fetchOk } from "./cdp.helpers.js";
 
 describe("cdp helpers", () => {
   afterEach(() => {
@@ -43,6 +43,14 @@ describe("cdp helpers", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("allows loopback CDP endpoints in strict SSRF mode", async () => {
+    await expect(
+      assertCdpEndpointAllowed("http://127.0.0.1:9222/json/version", {
+        dangerouslyAllowPrivateNetwork: false,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("releases guarded CDP fetches for bodyless requests", async () => {
     const release = vi.fn(async () => {});
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
@@ -60,6 +68,34 @@ describe("cdp helpers", () => {
       }),
     ).resolves.toBeUndefined();
 
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses an exact loopback allowlist for guarded loopback CDP fetches", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: {
+        ok: true,
+        status: 200,
+      },
+      release,
+    });
+
+    await expect(
+      fetchOk("http://127.0.0.1:9222/json/version", 250, undefined, {
+        dangerouslyAllowPrivateNetwork: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://127.0.0.1:9222/json/version",
+        policy: {
+          dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["127.0.0.1"],
+        },
+      }),
+    );
     expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -68,6 +68,11 @@ export async function assertCdpEndpointAllowed(
   if (!["http:", "https:", "ws:", "wss:"].includes(parsed.protocol)) {
     throw new Error(`Invalid CDP URL protocol: ${parsed.protocol.replace(":", "")}`);
   }
+  // Loopback CDP endpoints are internal browser-control hops, not
+  // agent-controlled navigation targets.
+  if (isLoopbackHost(parsed.hostname)) {
+    return;
+  }
   try {
     await resolvePinnedHostnameWithPolicy(parsed.hostname, {
       policy: ssrfPolicy,
@@ -263,11 +268,20 @@ export async function fetchCdpChecked(
   try {
     const headers = getHeadersWithAuth(url, (init?.headers as Record<string, string>) || {});
     const res = await withNoProxyForCdpUrl(url, async () => {
+      const parsedUrl = new URL(url);
+      const policy = isLoopbackHost(parsedUrl.hostname)
+        ? {
+            ...ssrfPolicy,
+            allowedHostnames: Array.from(
+              new Set([...(ssrfPolicy?.allowedHostnames ?? []), parsedUrl.hostname]),
+            ),
+          }
+        : (ssrfPolicy ?? { allowPrivateNetwork: true });
       const guarded = await fetchWithSsrFGuard({
         url,
         init: { ...init, headers },
         signal: ctrl.signal,
-        policy: ssrfPolicy ?? { allowPrivateNetwork: true },
+        policy,
         auditContext: "browser-cdp",
       });
       guardedRelease = guarded.release;

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -68,14 +68,17 @@ export async function assertCdpEndpointAllowed(
   if (!["http:", "https:", "ws:", "wss:"].includes(parsed.protocol)) {
     throw new Error(`Invalid CDP URL protocol: ${parsed.protocol.replace(":", "")}`);
   }
-  // Loopback CDP endpoints are internal browser-control hops, not
-  // agent-controlled navigation targets.
-  if (isLoopbackHost(parsed.hostname)) {
-    return;
-  }
   try {
+    const policy = isLoopbackHost(parsed.hostname)
+      ? {
+          ...ssrfPolicy,
+          allowedHostnames: Array.from(
+            new Set([...(ssrfPolicy?.allowedHostnames ?? []), parsed.hostname]),
+          ),
+        }
+      : ssrfPolicy;
     await resolvePinnedHostnameWithPolicy(parsed.hostname, {
-      policy: ssrfPolicy,
+      policy,
     });
   } catch (error) {
     throw new BrowserCdpEndpointBlockedError({ cause: error });

--- a/extensions/browser/src/browser/chrome.loopback-ssrf.integration.test.ts
+++ b/extensions/browser/src/browser/chrome.loopback-ssrf.integration.test.ts
@@ -1,0 +1,70 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { getChromeWebSocketUrl, isChromeReachable } from "./chrome.js";
+
+type RunningServer = {
+  server: Server;
+  baseUrl: string;
+};
+
+const runningServers: Server[] = [];
+
+async function startLoopbackCdpServer(): Promise<RunningServer> {
+  const server = createServer((req, res) => {
+    if (req.url !== "/json/version") {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    const address = server.address() as AddressInfo;
+    res.setHeader("content-type", "application/json");
+    res.end(
+      JSON.stringify({
+        Browser: "Chrome/999.0.0.0",
+        webSocketDebuggerUrl: `ws://127.0.0.1:${address.port}/devtools/browser/TEST`,
+      }),
+    );
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  runningServers.push(server);
+  const address = server.address() as AddressInfo;
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    runningServers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve, reject) =>
+            server.close((err) => (err ? reject(err) : resolve())),
+          ),
+      ),
+  );
+});
+
+describe("chrome loopback SSRF integration", () => {
+  it("keeps loopback CDP HTTP reachability working under strict default SSRF policy", async () => {
+    const { baseUrl } = await startLoopbackCdpServer();
+
+    await expect(isChromeReachable(baseUrl, 500, {})).resolves.toBe(true);
+  });
+
+  it("returns the loopback websocket URL under strict default SSRF policy", async () => {
+    const { baseUrl } = await startLoopbackCdpServer();
+
+    await expect(getChromeWebSocketUrl(baseUrl, 500, {})).resolves.toMatch(
+      /\/devtools\/browser\/TEST$/,
+    );
+  });
+});

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -312,22 +312,28 @@ describe("browser chrome helpers", () => {
     await expect(isChromeReachable("http://127.0.0.1:12345", 50)).resolves.toBe(false);
   });
 
-  it("blocks private CDP probes when strict SSRF policy is enabled", async () => {
-    const fetchSpy = vi.fn().mockRejectedValue(new Error("should not be called"));
+  it("allows loopback CDP probes while still blocking non-loopback private targets in strict SSRF mode", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" }),
+      } as unknown as Response)
+      .mockRejectedValue(new Error("should not be called"));
     vi.stubGlobal("fetch", fetchSpy);
 
     await expect(
       isChromeReachable("http://127.0.0.1:12345", 50, {
         dangerouslyAllowPrivateNetwork: false,
       }),
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
     await expect(
-      isChromeReachable("ws://127.0.0.1:19999", 50, {
+      isChromeReachable("http://169.254.169.254:12345", 50, {
         dangerouslyAllowPrivateNetwork: false,
       }),
     ).resolves.toBe(false);
 
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("blocks cross-host websocket pivots returned by /json/version in strict SSRF mode", async () => {

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -71,7 +71,6 @@ export function createProfileAvailability({
 
   const getCdpReachabilityPolicy = () =>
     resolveCdpReachabilityPolicy(profile, state().resolved.ssrfPolicy);
-
   const isReachable = async (timeoutMs?: number) => {
     if (capabilities.usesChromeMcp) {
       // listChromeMcpTabs creates the session if needed — no separate ensureChromeMcpAvailable call required

--- a/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -76,17 +76,13 @@ describe("browser server-context ensureBrowserAvailable", () => {
       1,
       "http://127.0.0.1:18800",
       PROFILE_HTTP_REACHABILITY_TIMEOUT_MS,
-      {
-        allowPrivateNetwork: true,
-      },
+      undefined,
     );
     expect(isChromeReachable).toHaveBeenNthCalledWith(
       2,
       "http://127.0.0.1:18800",
       PROFILE_ATTACH_RETRY_TIMEOUT_MS,
-      {
-        allowPrivateNetwork: true,
-      },
+      undefined,
     );
     expect(launchOpenClawChrome).not.toHaveBeenCalled();
     expect(stopOpenClawChrome).not.toHaveBeenCalled();

--- a/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -76,13 +76,17 @@ describe("browser server-context ensureBrowserAvailable", () => {
       1,
       "http://127.0.0.1:18800",
       PROFILE_HTTP_REACHABILITY_TIMEOUT_MS,
-      undefined,
+      {
+        allowPrivateNetwork: true,
+      },
     );
     expect(isChromeReachable).toHaveBeenNthCalledWith(
       2,
       "http://127.0.0.1:18800",
       PROFILE_ATTACH_RETRY_TIMEOUT_MS,
-      undefined,
+      {
+        allowPrivateNetwork: true,
+      },
     );
     expect(launchOpenClawChrome).not.toHaveBeenCalled();
     expect(stopOpenClawChrome).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Problem: managed loopback Chrome can come up healthy on 127.0.0.1, but OpenClaw still reports `Chrome CDP websocket for profile "openclaw" is not reachable after start` under strict default SSRF policy.
- Why it matters: the browser child process is healthy, but OpenClaw self-blocks its own CDP readiness/status probes and tears the browser down as unavailable.
- What changed: move the fix to the shared CDP helper layer so loopback CDP endpoint validation and guarded fetches remain reachable without weakening the global browser SSRF default.
- What did NOT change (scope boundary): browser navigation SSRF enforcement and non-loopback/private remote CDP enforcement remain in place.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65695
- Related #64978
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveBrowserSsrFPolicy()` now defaults to `{}`, which is correct for fail-closed browser navigation, but the same policy also flowed into local CDP helper paths. In `cdp.helpers.ts`, loopback CDP endpoint validation and guarded `/json/version` fetches treated the managed loopback control plane like an untrusted private-network target and blocked OpenClaw from probing the browser it had just launched.
- Missing detection / guardrail: no regression test locked the invariant that strict SSRF defaults must not block OpenClaw's own loopback CDP control plane.
- Contributing context (if known): proxy-related localhost probing can be a separate failure mode, but this PR addresses the policy-driven false negative in the shared helper layer.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/browser/src/browser/cdp.helpers.test.ts`, `extensions/browser/src/browser/chrome.test.ts`, `extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts`, `extensions/browser/src/browser/cdp.test.ts`, `extensions/browser/src/browser/chrome.loopback-ssrf.integration.test.ts`
- Scenario the test should lock in: strict/default SSRF policy must still allow managed loopback CDP readiness/status probes, while non-loopback private targets remain blocked.
- Why this is the smallest reliable guardrail: the regression came from shared CDP helper behavior, so the new seam test uses a real loopback HTTP `/json/version` server and the real `isChromeReachable()` / `getChromeWebSocketUrl()` path without paying the cost of a full browser launch.
- Existing test that already covers this (if any): `extensions/browser/src/browser/server-context.loopback-direct-ws.test.ts` covers the direct-loopback readiness path, but before this PR the repo did not have a real loopback CDP regression test that exercised the shared Chrome helper path end-to-end enough to catch this failure.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Managed local browser profiles no longer get misclassified as dead when Chrome is already serving loopback CDP under strict/default SSRF configuration.

## Diagram (if applicable)

```text
Before:
[OpenClaw launches Chrome] -> [/json/version on 127.0.0.1 works] -> [CDP helper applies strict SSRF policy to loopback] -> [readiness false negative] -> [browser killed]

After:
[OpenClaw launches Chrome] -> [loopback CDP helper allows exact local control endpoint] -> [readiness succeeds] -> [browser stays running]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo worktree
- Model/provider: N/A
- Integration/channel (if any): browser / managed Chrome
- Relevant config (redacted): browser profile using loopback CDP (`http://127.0.0.1:<port>`)

### Steps

1. Configure a managed local browser profile with loopback CDP.
2. Start the profile under strict/default SSRF settings.
3. Observe readiness/status probes and loopback `/json/version` handling.

### Expected

- Managed loopback browser stays reachable.
- Non-loopback/private remote CDP targets still honor SSRF enforcement.

### Actual

- Before this fix, loopback CDP was treated as blocked/unreachable and the browser was torn down.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: helper-layer loopback endpoint allow, guarded loopback fetch allowlist, loopback readiness/status path, the new real loopback seam regression on latest `upstream/main` (red before fix, green with this branch), and a real Chrome launch regression run via the local maintainer script for the full CLI/browser-start path.
- Edge cases checked: non-loopback private target remains blocked in strict mode; attach-only loopback profile expectations remain aligned with current reachability-policy semantics; loopback hostname allowlist enforcement remains in place.
- What you did **not** verify: a persistent CI-owned full Chrome launch suite in-repo. Real browser launch regression evidence for this PR comes from local/manual verification, including the browser CDP loopback regression script run on macOS, rather than from a shipped automated e2e lane.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: loopback bypass accidentally broadens beyond the exact managed control endpoint.
  - Mitigation: the helper path only early-exits on loopback hostname validation and the guarded fetch path narrows to an exact loopback hostname allowlist; remote/private non-loopback targets still use normal SSRF enforcement.


