### PR TITLE
fix(reply): classify billing cooldown summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/webhook: harden the webhook transport and card-action replay guards to fail closed on missing `encryptKey` and blank callback tokens — refuse to start the webhook transport without an `encryptKey`, reject unsigned requests when no key is present instead of accepting them, and drop blank card-action tokens before the dedupe claim and dispatcher. Defense-in-depth over the already-closed monitor-account layer. (#66707) Thanks @eleqtrizit.
 - Agents/workspace files: route `agents.files.get`, `agents.files.set`, and workspace listing through the shared `fs-safe` helpers (`openFileWithinRoot`/`readFileWithinRoot`/`writeFileWithinRoot`), reject symlink aliases for allowlisted agent files, and have `fs-safe` resolve opened-file real paths from the file descriptor before falling back to path-based `realpath` so a symlink swap between `open` and `realpath` can no longer redirect the validated path off the intended inode. (#66636) Thanks @eleqtrizit.
 - Gateway/MCP loopback: switch the `/mcp` bearer comparison from plain `!==` to constant-time `safeEqualSecret` (matching the convention every other auth surface in the codebase uses), and reject non-loopback browser-origin requests via `checkBrowserOrigin` before the auth gate runs. Loopback origins (`127.0.0.1:*`, `localhost:*`, same-origin) still go through, including the `localhost`↔`127.0.0.1` host mismatch that browsers flag as `Sec-Fetch-Site: cross-site`. (#66665) Thanks @eleqtrizit.
+- Auto-reply/billing: classify pure billing cooldown fallback summaries from structured fallback reasons so users see billing guidance instead of the generic failure reply. (#66363) Thanks @Rohan5commit.
 
 ## 2026.4.14
 
@@ -106,7 +107,6 @@ Docs: https://docs.openclaw.ai
 - CLI/approvals: raise the default `openclaw approvals get` gateway timeout and report config-load timeouts explicitly, so slow hosts stop showing a misleading `Config unavailable.` note when the approvals snapshot succeeds but the follow-up config RPC needs more time. (#66239) Thanks @neeravmakwana.
 - Media/store: honor configured agent media limits when saving generated media and persisting outbound reply media, so the store no longer hard-stops those flows at 5 MB before the configured limit applies. (#66229) Thanks @neeravmakwana and @vincentkoc.
 - Plugins/setup-entry: preserve separate setup-entry secrets exports when loading bundled setup-runtime channels, so setup-mode flows keep the channel secret contract for split plugin + secrets entrypoints. (#66261) Thanks @hxy91819.
-- Auto-reply/billing: classify pure billing cooldown fallback summaries from structured fallback reasons so users see billing guidance instead of the generic failure reply. (#66363) Thanks @Rohan5commit.
 
 ## 2026.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Docs: https://docs.openclaw.ai
 - CLI/approvals: raise the default `openclaw approvals get` gateway timeout and report config-load timeouts explicitly, so slow hosts stop showing a misleading `Config unavailable.` note when the approvals snapshot succeeds but the follow-up config RPC needs more time. (#66239) Thanks @neeravmakwana.
 - Media/store: honor configured agent media limits when saving generated media and persisting outbound reply media, so the store no longer hard-stops those flows at 5 MB before the configured limit applies. (#66229) Thanks @neeravmakwana and @vincentkoc.
 - Plugins/setup-entry: preserve separate setup-entry secrets exports when loading bundled setup-runtime channels, so setup-mode flows keep the channel secret contract for split plugin + secrets entrypoints. (#66261) Thanks @hxy91819.
+- Auto-reply/billing: classify pure billing cooldown fallback summaries from structured fallback reasons so users see billing guidance instead of the generic failure reply. (#66363) Thanks @Rohan5commit.
 
 ## 2026.4.12
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -912,6 +912,64 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("surfaces billing guidance for pure billing cooldown fallback exhaustion", async () => {
+    state.runWithModelFallbackMock.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          "All models failed (2): anthropic/claude-opus-4-6: Provider anthropic has billing issue (skipping all models) (billing) | anthropic/claude-sonnet-4-6: Provider anthropic has billing issue (skipping all models) (billing)",
+        ),
+        {
+          name: "FallbackSummaryError",
+          attempts: [
+            {
+              provider: "anthropic",
+              model: "claude-opus-4-6",
+              error: "Provider anthropic has billing issue (skipping all models)",
+              reason: "billing",
+            },
+            {
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+              error: "Provider anthropic has billing issue (skipping all models)",
+              reason: "billing",
+            },
+          ],
+          soonestCooldownExpiry: Date.now() + 60_000,
+        },
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe("billing");
+    }
+  });
+
   it("surfaces gateway restart text when fallback exhaustion wraps a drain error", async () => {
     const { replyOperation, failMock } = createMockReplyOperation();
     state.runWithModelFallbackMock.mockRejectedValueOnce(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -311,6 +311,14 @@ function isPureTransientRateLimitSummary(err: unknown): boolean {
   );
 }
 
+function isPureBillingSummary(err: unknown): boolean {
+  return (
+    isFallbackSummaryError(err) &&
+    err.attempts.length > 0 &&
+    err.attempts.every((attempt) => attempt.reason === "billing")
+  );
+}
+
 function isToolResultTurnMismatchError(message: string): boolean {
   const lower = normalizeLowercaseStringOrEmpty(message);
   return (
@@ -1320,7 +1328,9 @@ export async function runAgentTurnWithFallback(params: {
         continue;
       }
       const message = formatErrorMessage(err);
-      const isBilling = isBillingErrorMessage(message);
+      const isBilling = isFallbackSummaryError(err)
+        ? isPureBillingSummary(err)
+        : isBillingErrorMessage(message);
       const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);


### PR DESCRIPTION
## Summary

- Problem: pure billing-cooldown fallback summaries are classified from message text only, so users get the generic failure text instead of billing guidance.
- Why it matters: exhausted Anthropic OAuth/API-key users keep retrying without actionable billing guidance even though every fallback attempt is already tagged `reason="billing"`.
- What changed: billing classification now uses `FallbackSummaryError.attempts[*].reason` for pure billing summaries and adds a regression test for the cooldown summary path.
- What did NOT change (scope boundary): no provider matching patterns, rate-limit handling, or fallback selection behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66314
- Related #61608
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `runAgentTurnWithFallback` only called `isBillingErrorMessage(message)`, but billing cooldown summaries use generic text like `Provider anthropic has billing issue (skipping all models)` while still carrying structured `attempt.reason === "billing"` metadata.
- Missing detection / guardrail: there was a structured helper for pure transient rate-limit summaries, but no equivalent structured billing summary classification.
- Contributing context (if known): this is especially visible on Anthropic OAuth accounts where personal extra-usage caps are hit and the cooldown summary repeats for hours.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/agent-runner-execution.test.ts`
- Scenario the test should lock in: a pure billing `FallbackSummaryError` with cooldown summary text still returns `BILLING_ERROR_USER_MESSAGE`.
- Why this is the smallest reliable guardrail: the bug lives in the final user-facing classification branch, so the smallest reliable test is a runner-level summary error unit test.
- Existing test that already covers this (if any): the existing mixed-cause fallback exhaustion test already guards against false rate-limit messaging for summary errors.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Users hitting pure billing cooldown summaries now see the billing guidance text instead of the generic "Something went wrong" message.

## Diagram (if applicable)

```text
Before:
billing cooldown summary -> string matcher misses it -> generic failure text

After:
billing cooldown summary -> all attempts tagged billing -> billing guidance text
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: Node 22 / pnpm workspace checkout
- Model/provider: reproduced via unit test using Anthropic billing-cooldown summary payload
- Integration/channel (if any): WhatsApp test fixture
- Relevant config (redacted): N/A

### Steps

1. Throw a `FallbackSummaryError` whose attempts are all tagged `reason: "billing"` and whose message uses the cooldown summary wording.
2. Run `runAgentTurnWithFallback`.
3. Inspect the final user-facing reply text.

### Expected

- The runner returns `BILLING_ERROR_USER_MESSAGE`.

### Actual

- Before this fix, the runner returned the generic failure text because the billing check only string-matched the summary message.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `npx --yes pnpm exec vitest run src/auto-reply/reply/agent-runner-execution.test.ts -t "billing cooldown fallback exhaustion"`.
- Edge cases checked: kept mixed-cause fallback summaries on the generic path; only all-billing summaries take the billing guidance branch.
- What you did **not** verify: live provider cooldown behavior outside the unit test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: mixed-cause fallback summaries could be over-classified as billing.
  - Mitigation: the new helper only returns billing when every summary attempt is tagged `billing`.
