### PR TITLE
fix(build): ship subagent-registry runtime sidecar

### DIFF
--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -46,6 +46,7 @@ const requiredPathGroups = [
   "dist/build-info.json",
   "dist/channel-catalog.json",
   "dist/control-ui/index.html",
+  "dist/subagent-registry.runtime.js",
 ];
 const forbiddenPrefixes = [
   "dist-runtime/",

--- a/test/helpers/bundled-runtime-sidecars.ts
+++ b/test/helpers/bundled-runtime-sidecars.ts
@@ -1,4 +1,5 @@
 export const TEST_BUNDLED_RUNTIME_SIDECAR_PATHS = [
+  "dist/subagent-registry.runtime.js",
   "dist/extensions/discord/runtime-api.js",
   "dist/extensions/slack/helper-api.js",
   "dist/extensions/telegram/thread-bindings-runtime.js",

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -302,6 +302,7 @@ describe("collectMissingPackPaths", () => {
         bundledDistPluginFile("matrix", "thread-bindings-runtime.js"),
         bundledDistPluginFile("matrix", "openclaw.plugin.json"),
         bundledDistPluginFile("matrix", "package.json"),
+        "dist/subagent-registry.runtime.js",
         bundledDistPluginFile("whatsapp", "light-runtime-api.js"),
         bundledDistPluginFile("whatsapp", "runtime-api.js"),
         bundledDistPluginFile("whatsapp", "openclaw.plugin.json"),
@@ -329,6 +330,7 @@ describe("collectMissingPackPaths", () => {
         "dist/plugin-sdk/root-alias.cjs",
         "dist/build-info.json",
         "dist/channel-catalog.json",
+        "dist/subagent-registry.runtime.js",
       ]),
     ).toEqual([]);
   });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -146,6 +146,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
+    "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",


### PR DESCRIPTION
## Summary

- Problem: npm/global builds ship chunks that import `dist/subagent-registry.runtime.js`, but that runtime sidecar is not emitted into `dist`.
- Why it matters: subagent cleanup/session resume fails after successful subagent runs with `ERR_MODULE_NOT_FOUND`.
- What changed: added the missing tsdown entry and taught the release/update pack checks to require the sidecar.
- What did NOT change (scope boundary): no runtime behavior, subagent registry semantics, or loader logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #66151
- Related #66096
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/agents/subagent-registry.runtime.ts` was imported by emitted chunks, but `tsdown.config.ts` did not emit a root `dist/subagent-registry.runtime.js` sidecar for packaged installs.
- Missing detection / guardrail: release-pack validation did not require that runtime sidecar, so the missing artifact shipped.
- Contributing context (if known): the regression only surfaced on packaged installs where the chunk import could not fall back to source files.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/release-check.test.ts`
- Scenario the test should lock in: pack validation fails when `dist/subagent-registry.runtime.js` is missing and passes once it is present.
- Why this is the smallest reliable guardrail: the shipped artifact list is what regressed; asserting the release-check inputs keeps the fix pinned without needing a full packaged install smoke test.
- Existing test that already covers this (if any): `src/cli/update-cli.test.ts` already verifies bundled runtime sidecar presence during package install verification.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Packaged installs now include the `subagent-registry.runtime.js` sidecar required for subagent cleanup/session resume.

## Diagram (if applicable)

```text
Before:
packaged install -> chunk imports subagent-registry.runtime.js -> file missing -> cleanup/session resume warns + fails

After:
packaged install -> chunk imports subagent-registry.runtime.js -> file exists -> cleanup/session resume completes
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: Node 22 / pnpm workspace checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build/package a checkout that emits chunks importing `subagent-registry.runtime.js`.
2. Inspect the shipped root `dist/` artifacts.
3. Run the release-pack checks and the targeted update-cli verification.

### Expected

- `dist/subagent-registry.runtime.js` is shipped and release/update verification passes.

### Actual

- Before this fix, the runtime sidecar was missing from packaged installs and subagent cleanup could hit `ERR_MODULE_NOT_FOUND`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: confirmed `dist/subagent-registry.runtime.js` is emitted by the build; ran `npx --yes pnpm exec tsdown --config-loader unrun --logLevel info`; ran `npx --yes pnpm exec vitest run test/release-check.test.ts -t "collectMissingPackPaths"`; ran `npx --yes pnpm exec vitest run src/cli/update-cli.test.ts -t "installed correction version does not match the requested target"`.
- Edge cases checked: ensured both release-pack validation and package-install verification now treat the sidecar as required.
- What you did **not** verify: full npm publish/install smoke test outside the workspace.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: release validation could drift from the actual shipped runtime sidecars again if new root runtime files are added without updating the pack checks.
  - Mitigation: this PR wires the sidecar into both the build entry list and the release/update verification tests.
