### PR TITLE
fix: keep typing alive through long quiet phases

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   makeAttemptResult,
   makeCompactionSuccess,
@@ -122,6 +122,28 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         }),
       }),
     );
+  });
+
+  it("emits compaction lifecycle events during explicit overflow recovery", async () => {
+    const onAgentEvent = vi.fn();
+    mockOverflowRetrySuccess({
+      runEmbeddedAttempt: mockedRunEmbeddedAttempt,
+      compactDirect: mockedCompactDirect,
+    });
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      onAgentEvent,
+    });
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "compaction",
+      data: { phase: "start" },
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "compaction",
+      data: { phase: "end", willRetry: true, completed: true },
+    });
   });
 
   it("threads prompt-cache runtime context into overflow compaction", async () => {

--- a/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeAttemptResult, makeCompactionSuccess } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
@@ -100,6 +100,33 @@ describe("timeout-triggered compaction", () => {
     );
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.meta.error).toBeUndefined();
+  });
+
+  it("emits a terminal compaction event when timeout recovery compaction throws", async () => {
+    const onAgentEvent = vi.fn();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        timedOut: true,
+        lastAssistant: {
+          usage: { input: 150000 },
+        } as never,
+      }),
+    );
+    mockedCompactDirect.mockRejectedValueOnce(new Error("boom"));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      onAgentEvent,
+    });
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "compaction",
+      data: { phase: "start" },
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "compaction",
+      data: { phase: "end", willRetry: false, completed: false },
+    });
   });
 
   it("retries the prompt after successful timeout compaction", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import { resolveContextEngine } from "../../context-engine/registry.js";
-import { emitAgentPlanEvent } from "../../infra/agent-events.js";
+import { emitAgentEvent, emitAgentPlanEvent } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -604,6 +604,57 @@ export async function runEmbeddedPiAgent(
             log.warn(`after_compaction hook failed during ${reason}: ${String(hookErr)}`);
           }
         };
+        const emitExplicitCompactionEvent = async (
+          data:
+            | { phase: "start" }
+            | {
+                phase: "end";
+                willRetry: boolean;
+                completed: boolean;
+              },
+        ) => {
+          emitAgentEvent({
+            runId: params.runId,
+            ...(resolvedSessionKey ? { sessionKey: resolvedSessionKey } : {}),
+            stream: "compaction",
+            data,
+          });
+          params.onAgentEvent?.({
+            stream: "compaction",
+            data,
+          });
+        };
+        const runExplicitCompactionRecovery = async (params: {
+          reason: string;
+          runCompact: () => Promise<Awaited<ReturnType<typeof contextEngine.compact>>>;
+        }) => {
+          await emitExplicitCompactionEvent({ phase: "start" });
+          await runOwnsCompactionBeforeHook(params.reason);
+          try {
+            const compactResult = await params.runCompact();
+            await runOwnsCompactionAfterHook(params.reason, compactResult);
+            const completed = compactResult.ok && compactResult.compacted;
+            await emitExplicitCompactionEvent({
+              phase: "end",
+              willRetry: completed,
+              completed,
+            });
+            return compactResult;
+          } catch (err) {
+            const compactResult = {
+              ok: false as const,
+              compacted: false as const,
+              reason: String(err),
+            };
+            await runOwnsCompactionAfterHook(params.reason, compactResult);
+            await emitExplicitCompactionEvent({
+              phase: "end",
+              willRetry: false,
+              completed: false,
+            });
+            throw err;
+          }
+        };
         let authRetryPending = false;
         let accumulatedReplayState = createEmbeddedRunReplayState();
         // Hoisted so the retry-limit error path can use the most recent API total.
@@ -880,7 +931,6 @@ export async function runEmbeddedPiAgent(
                   `attempting compaction before retry (attempt ${timeoutCompactionAttempts}/${MAX_TIMEOUT_COMPACTION_ATTEMPTS}) diagId=${timeoutDiagId}`,
               );
               let timeoutCompactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
-              await runOwnsCompactionBeforeHook("timeout recovery");
               try {
                 const timeoutCompactionRuntimeContext = {
                   ...buildEmbeddedCompactionRuntimeContext({
@@ -913,14 +963,18 @@ export async function runEmbeddedPiAgent(
                   attempt: timeoutCompactionAttempts,
                   maxAttempts: MAX_TIMEOUT_COMPACTION_ATTEMPTS,
                 };
-                timeoutCompactResult = await contextEngine.compact({
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                  sessionFile: params.sessionFile,
-                  tokenBudget: ctxInfo.tokens,
-                  force: true,
-                  compactionTarget: "budget",
-                  runtimeContext: timeoutCompactionRuntimeContext,
+                timeoutCompactResult = await runExplicitCompactionRecovery({
+                  reason: "timeout recovery",
+                  runCompact: async () =>
+                    await contextEngine.compact({
+                      sessionId: params.sessionId,
+                      sessionKey: params.sessionKey,
+                      sessionFile: params.sessionFile,
+                      tokenBudget: ctxInfo.tokens,
+                      force: true,
+                      compactionTarget: "budget",
+                      runtimeContext: timeoutCompactionRuntimeContext,
+                    }),
                 });
               } catch (compactErr) {
                 log.warn(
@@ -932,7 +986,6 @@ export async function runEmbeddedPiAgent(
                   reason: String(compactErr),
                 };
               }
-              await runOwnsCompactionAfterHook("timeout recovery", timeoutCompactResult);
               if (timeoutCompactResult.compacted) {
                 autoCompactionCount += 1;
                 if (contextEngine.info.ownsCompaction === true) {
@@ -1022,7 +1075,6 @@ export async function runEmbeddedPiAgent(
                 `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
               );
               let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
-              await runOwnsCompactionBeforeHook("overflow recovery");
               try {
                 const overflowCompactionRuntimeContext = {
                   ...buildEmbeddedCompactionRuntimeContext({
@@ -1058,17 +1110,21 @@ export async function runEmbeddedPiAgent(
                   attempt: overflowCompactionAttempts,
                   maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
                 };
-                compactResult = await contextEngine.compact({
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                  sessionFile: params.sessionFile,
-                  tokenBudget: ctxInfo.tokens,
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
-                    : {}),
-                  force: true,
-                  compactionTarget: "budget",
-                  runtimeContext: overflowCompactionRuntimeContext,
+                compactResult = await runExplicitCompactionRecovery({
+                  reason: "overflow recovery",
+                  runCompact: async () =>
+                    await contextEngine.compact({
+                      sessionId: params.sessionId,
+                      sessionKey: params.sessionKey,
+                      sessionFile: params.sessionFile,
+                      tokenBudget: ctxInfo.tokens,
+                      ...(observedOverflowTokens !== undefined
+                        ? { currentTokenCount: observedOverflowTokens }
+                        : {}),
+                      force: true,
+                      compactionTarget: "budget",
+                      runtimeContext: overflowCompactionRuntimeContext,
+                    }),
                 });
                 if (compactResult.ok && compactResult.compacted) {
                   await runContextEngineMaintenance({
@@ -1090,7 +1146,6 @@ export async function runEmbeddedPiAgent(
                   reason: String(compactErr),
                 };
               }
-              await runOwnsCompactionAfterHook("overflow recovery", compactResult);
               if (compactResult.compacted) {
                 if (preflightRecovery?.route === "compact_then_truncate") {
                   const truncResult = await truncateOversizedToolResultsInSession({

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -165,6 +165,9 @@ function createMockTypingSignaler(): TypingSignaler {
     signalTextDelta: vi.fn(async () => {}),
     signalReasoningDelta: vi.fn(async () => {}),
     signalToolStart: vi.fn(async () => {}),
+    signalProgress: vi.fn(() => {}),
+    enterLongQuietPhase: vi.fn(() => {}),
+    exitLongQuietPhase: vi.fn(() => {}),
   };
 }
 
@@ -764,6 +767,7 @@ describe("runAgentTurnWithFallback", () => {
     const onBlockReply = vi.fn();
     const onCompactionStart = vi.fn();
     const onCompactionEnd = vi.fn();
+    const typingSignals = createMockTypingSignaler();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
       await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
       await params.onAgentEvent?.({
@@ -786,7 +790,7 @@ describe("runAgentTurnWithFallback", () => {
         onCompactionStart,
         onCompactionEnd,
       },
-      typingSignals: createMockTypingSignaler(),
+      typingSignals,
       blockReplyPipeline: null,
       blockStreamingEnabled: false,
       resolvedBlockStreamingBreak: "message_end",
@@ -805,7 +809,185 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("success");
     expect(onCompactionStart).toHaveBeenCalledTimes(1);
     expect(onCompactionEnd).toHaveBeenCalledTimes(1);
+    expect(typingSignals.enterLongQuietPhase).toHaveBeenCalledTimes(1);
+    expect(typingSignals.exitLongQuietPhase).toHaveBeenCalledTimes(1);
     expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("leases typing through tool execution and releases it on tool result", async () => {
+    const typingSignals = createMockTypingSignaler();
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "start", name: "read" },
+      });
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "result", name: "read", isError: false },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals,
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    expect(typingSignals.enterLongQuietPhase).toHaveBeenCalledTimes(1);
+    expect(typingSignals.signalToolStart).toHaveBeenCalledTimes(1);
+    expect(typingSignals.exitLongQuietPhase).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the compaction lease on compaction error", async () => {
+    const typingSignals = createMockTypingSignaler();
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "error" } });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals,
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    expect(typingSignals.enterLongQuietPhase).toHaveBeenCalledTimes(1);
+    expect(typingSignals.exitLongQuietPhase).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the tool lease on a tool result error", async () => {
+    const typingSignals = createMockTypingSignaler();
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "start", name: "read" },
+      });
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "result", name: "read", isError: true },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals,
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    expect(typingSignals.enterLongQuietPhase).toHaveBeenCalledTimes(1);
+    expect(typingSignals.exitLongQuietPhase).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps overlapping tool and compaction leases until both phases end", async () => {
+    const typingSignals = createMockTypingSignaler();
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "start", name: "read" },
+      });
+      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "result", name: "read", isError: false },
+      });
+      await params.onAgentEvent?.({
+        stream: "compaction",
+        data: { phase: "end", completed: true },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals,
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    expect(typingSignals.enterLongQuietPhase).toHaveBeenCalledTimes(2);
+    expect(typingSignals.exitLongQuietPhase).toHaveBeenCalledTimes(2);
   });
 
   it("emits a compaction start notice when notifyUser is enabled", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1024,15 +1024,24 @@ export async function runAgentTurnWithFallback(params: {
                     evt.stream === "lifecycle" && typeof evt.data.phase === "string";
                   if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
                     notifyAgentRunStart();
+                    params.typingSignals.signalProgress();
                   }
                   // Trigger typing when tools start executing.
                   // Must await to ensure typing indicator starts before tool summaries are emitted.
                   if (evt.stream === "tool") {
                     const phase = readStringValue(evt.data.phase) ?? "";
                     const name = readStringValue(evt.data.name);
+                    const toolPhaseEnded =
+                      phase === "result" || phase === "end" || phase === "error";
+                    if (phase === "start") {
+                      params.typingSignals.enterLongQuietPhase();
+                    }
                     if (phase === "start" || phase === "update") {
                       await params.typingSignals.signalToolStart();
                       await params.opts?.onToolStart?.({ name, phase });
+                    }
+                    if (toolPhaseEnded) {
+                      params.typingSignals.exitLongQuietPhase();
                     }
                   }
                   if (evt.stream === "item") {
@@ -1123,6 +1132,7 @@ export async function runAgentTurnWithFallback(params: {
                   if (evt.stream === "compaction") {
                     const phase = readStringValue(evt.data.phase) ?? "";
                     if (phase === "start") {
+                      params.typingSignals.enterLongQuietPhase();
                       // Keep custom compaction callbacks active, but gate the
                       // fallback user-facing notice behind explicit opt-in.
                       const notifyUser =
@@ -1151,6 +1161,9 @@ export async function runAgentTurnWithFallback(params: {
                           );
                         }
                       }
+                    }
+                    if (phase === "end" || phase === "error") {
+                      params.typingSignals.exitLongQuietPhase();
                     }
                     const completed = evt.data?.completed === true;
                     if (phase === "end" && completed) {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -10,6 +10,7 @@ import {
 import type { TemplateContext } from "../templating.js";
 import { runMemoryFlushIfNeeded, setAgentRunnerMemoryTestDeps } from "./agent-runner-memory.js";
 import type { FollowupRun } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
 
 const runWithModelFallbackMock = vi.fn();
 const runEmbeddedPiAgentMock = vi.fn();
@@ -286,5 +287,33 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.silentExpected).toBe(true);
     expect(flushCall.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
     expect(flushCall.bootstrapPromptWarningSignature).toBe("sig-b");
+  });
+
+  it("leases typing around the silent memory flush run", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+    };
+    const typing = createMockTypingController();
+
+    await runMemoryFlushIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createFollowupRun(),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+      typing,
+    });
+
+    expect(typing.enterLongQuietPhase).toHaveBeenCalledTimes(1);
+    expect(typing.exitLongQuietPhase).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -43,6 +43,7 @@ import { readPostCompactionContext } from "./post-compaction-context.js";
 import { refreshQueuedFollowupSession, type FollowupRun } from "./queue.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import { incrementCompactionCount } from "./session-updates.js";
+import type { TypingController } from "./typing.js";
 
 async function compactEmbeddedPiSessionDefault(
   ...args: Parameters<typeof import("../../agents/pi-embedded.js").compactEmbeddedPiSession>
@@ -355,6 +356,7 @@ export async function runPreflightCompactionIfNeeded(params: {
   storePath?: string;
   isHeartbeat: boolean;
   replyOperation: ReplyOperation;
+  typing?: TypingController;
 }): Promise<SessionEntry | undefined> {
   if (!params.sessionKey) {
     return params.sessionEntry;
@@ -445,61 +447,66 @@ export async function runPreflightCompactionIfNeeded(params: {
   );
 
   params.replyOperation.setPhase("preflight_compacting");
-  const sessionFile = resolveSessionLogPath(
-    entry.sessionId,
-    entry.sessionFile ? entry : { ...entry, sessionFile: params.followupRun.run.sessionFile },
-    params.sessionKey ?? params.followupRun.run.sessionKey,
-    { storePath: params.storePath },
-  );
-  const result = await memoryDeps.compactEmbeddedPiSession({
-    sessionId: entry.sessionId,
-    sessionKey: params.sessionKey,
-    allowGatewaySubagentBinding: true,
-    messageChannel: params.followupRun.run.messageProvider,
-    groupId: entry.groupId ?? params.followupRun.run.groupId,
-    groupChannel: entry.groupChannel ?? params.followupRun.run.groupChannel,
-    groupSpace: entry.space ?? params.followupRun.run.groupSpace,
-    senderId: params.followupRun.run.senderId,
-    senderName: params.followupRun.run.senderName,
-    senderUsername: params.followupRun.run.senderUsername,
-    senderE164: params.followupRun.run.senderE164,
-    sessionFile: sessionFile ?? params.followupRun.run.sessionFile,
-    workspaceDir: params.followupRun.run.workspaceDir,
-    agentDir: params.followupRun.run.agentDir,
-    config: params.cfg,
-    skillsSnapshot: entry.skillsSnapshot ?? params.followupRun.run.skillsSnapshot,
-    provider: params.followupRun.run.provider,
-    model: params.followupRun.run.model,
-    thinkLevel: params.followupRun.run.thinkLevel,
-    bashElevated: params.followupRun.run.bashElevated,
-    trigger: "budget",
-    currentTokenCount: tokenCountForCompaction,
-    senderIsOwner: params.followupRun.run.senderIsOwner,
-    ownerNumbers: params.followupRun.run.ownerNumbers,
-    abortSignal: params.replyOperation.abortSignal,
-  });
-
-  if (!result?.ok || !result.compacted) {
-    logVerbose(
-      `preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${result?.reason ?? "not_compacted"}`,
+  params.typing?.enterLongQuietPhase?.();
+  try {
+    const sessionFile = resolveSessionLogPath(
+      entry.sessionId,
+      entry.sessionFile ? entry : { ...entry, sessionFile: params.followupRun.run.sessionFile },
+      params.sessionKey ?? params.followupRun.run.sessionKey,
+      { storePath: params.storePath },
     );
-    return entry ?? params.sessionEntry;
-  }
+    const result = await memoryDeps.compactEmbeddedPiSession({
+      sessionId: entry.sessionId,
+      sessionKey: params.sessionKey,
+      allowGatewaySubagentBinding: true,
+      messageChannel: params.followupRun.run.messageProvider,
+      groupId: entry.groupId ?? params.followupRun.run.groupId,
+      groupChannel: entry.groupChannel ?? params.followupRun.run.groupChannel,
+      groupSpace: entry.space ?? params.followupRun.run.groupSpace,
+      senderId: params.followupRun.run.senderId,
+      senderName: params.followupRun.run.senderName,
+      senderUsername: params.followupRun.run.senderUsername,
+      senderE164: params.followupRun.run.senderE164,
+      sessionFile: sessionFile ?? params.followupRun.run.sessionFile,
+      workspaceDir: params.followupRun.run.workspaceDir,
+      agentDir: params.followupRun.run.agentDir,
+      config: params.cfg,
+      skillsSnapshot: entry.skillsSnapshot ?? params.followupRun.run.skillsSnapshot,
+      provider: params.followupRun.run.provider,
+      model: params.followupRun.run.model,
+      thinkLevel: params.followupRun.run.thinkLevel,
+      bashElevated: params.followupRun.run.bashElevated,
+      trigger: "budget",
+      currentTokenCount: tokenCountForCompaction,
+      senderIsOwner: params.followupRun.run.senderIsOwner,
+      ownerNumbers: params.followupRun.run.ownerNumbers,
+      abortSignal: params.replyOperation.abortSignal,
+    });
 
-  await incrementCompactionCount({
-    cfg: params.cfg,
-    sessionEntry: entry,
-    sessionStore: params.sessionStore,
-    sessionKey: params.sessionKey,
-    storePath: params.storePath,
-    tokensAfter: result.result?.tokensAfter,
-  });
-  await appendPostCompactionRefreshPrompt({
-    cfg: params.cfg,
-    followupRun: params.followupRun,
-  });
-  entry = params.sessionStore?.[params.sessionKey] ?? entry;
-  return entry ?? params.sessionEntry;
+    if (!result?.ok || !result.compacted) {
+      logVerbose(
+        `preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${result?.reason ?? "not_compacted"}`,
+      );
+      return entry ?? params.sessionEntry;
+    }
+
+    await incrementCompactionCount({
+      cfg: params.cfg,
+      sessionEntry: entry,
+      sessionStore: params.sessionStore,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      tokensAfter: result.result?.tokensAfter,
+    });
+    await appendPostCompactionRefreshPrompt({
+      cfg: params.cfg,
+      followupRun: params.followupRun,
+    });
+    entry = params.sessionStore?.[params.sessionKey] ?? entry;
+    return entry ?? params.sessionEntry;
+  } finally {
+    params.typing?.exitLongQuietPhase?.();
+  }
 }
 
 export async function runMemoryFlushIfNeeded(params: {
@@ -517,6 +524,7 @@ export async function runMemoryFlushIfNeeded(params: {
   storePath?: string;
   isHeartbeat: boolean;
   replyOperation: ReplyOperation;
+  typing?: TypingController;
 }): Promise<SessionEntry | undefined> {
   const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
   if (!memoryFlushPlan) {
@@ -707,6 +715,7 @@ export async function runMemoryFlushIfNeeded(params: {
   );
 
   params.replyOperation.setPhase("memory_flushing");
+  params.typing?.enterLongQuietPhase?.();
   let activeSessionEntry = entry ?? params.sessionEntry;
   const activeSessionStore = params.sessionStore;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
@@ -842,6 +851,8 @@ export async function runMemoryFlushIfNeeded(params: {
     }
   } catch (err) {
     logVerbose(`memory flush run failed: ${String(err)}`);
+  } finally {
+    params.typing?.exitLongQuietPhase?.();
   }
 
   return activeSessionEntry;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1090,6 +1090,7 @@ export async function runReplyAgent(params: {
       storePath,
       isHeartbeat,
       replyOperation,
+      typing,
     });
     preflightCompactionApplied =
       (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
@@ -1109,6 +1110,7 @@ export async function runReplyAgent(params: {
       storePath,
       isHeartbeat,
       replyOperation,
+      typing,
     });
 
     runFollowupTurn = createFollowupRunner({

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -513,6 +513,27 @@ describe("createFollowupRunner runtime config", () => {
       | undefined;
     expect(call?.config).toBe(runtimeConfig);
   });
+
+  it("forwards typing into preflight compaction so silent compaction can lease typing", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+    const typing = createMockTypingController();
+    const runner = createFollowupRunner({
+      typing,
+      typingMode: "instant",
+      defaultModel: "openai/gpt-5.4",
+    });
+
+    await runner(createQueuedRun());
+
+    expect(runPreflightCompactionIfNeededMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typing,
+      }),
+    );
+  });
 });
 
 describe("createFollowupRunner compaction", () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -182,6 +182,7 @@ export function createFollowupRunner(params: {
         storePath,
         isHeartbeat: opts?.isHeartbeat === true,
         replyOperation,
+        typing,
       });
       let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
         activeSessionEntry?.systemPromptReport,

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -679,6 +679,22 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
+
+  it("refreshes ttl on progress only when typing is already active", () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "message",
+      isHeartbeat: false,
+    });
+
+    signaler.signalProgress();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
+
+    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    signaler.signalProgress();
+    expect(typing.refreshTypingTtl).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("block reply coalescer", () => {

--- a/src/auto-reply/reply/reply.test-helpers.ts
+++ b/src/auto-reply/reply/reply.test-helpers.ts
@@ -4,6 +4,8 @@ export function createMockTypingController() {
     startTypingLoop: async () => undefined,
     startTypingOnText: async () => undefined,
     refreshTypingTtl: () => undefined,
+    enterLongQuietPhase: () => undefined,
+    exitLongQuietPhase: () => undefined,
     isActive: () => false,
     markRunComplete: () => undefined,
     markDispatchIdle: () => undefined,

--- a/src/auto-reply/reply/test-helpers.ts
+++ b/src/auto-reply/reply/test-helpers.ts
@@ -10,6 +10,8 @@ export function createMockTypingController(
     startTypingLoop: vi.fn(async () => {}),
     startTypingOnText: vi.fn(async () => {}),
     refreshTypingTtl: vi.fn(),
+    enterLongQuietPhase: vi.fn(),
+    exitLongQuietPhase: vi.fn(),
     isActive: vi.fn(() => false),
     markRunComplete: vi.fn(),
     markDispatchIdle: vi.fn(),

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -52,6 +52,9 @@ export type TypingSignaler = {
   signalTextDelta: (text?: string) => Promise<void>;
   signalReasoningDelta: () => Promise<void>;
   signalToolStart: () => Promise<void>;
+  signalProgress: () => void;
+  enterLongQuietPhase: () => void;
+  exitLongQuietPhase: () => void;
 };
 
 export function createTypingSignaler(params: {
@@ -141,6 +144,24 @@ export function createTypingSignaler(params: {
     typing.refreshTypingTtl();
   };
 
+  const signalProgress = () => {
+    if (disabled || !typing.isActive()) {
+      return;
+    }
+    typing.refreshTypingTtl();
+  };
+
+  const enterLongQuietPhase = () => {
+    if (disabled) {
+      return;
+    }
+    typing.enterLongQuietPhase?.();
+  };
+
+  const exitLongQuietPhase = () => {
+    typing.exitLongQuietPhase?.();
+  };
+
   return {
     mode,
     shouldStartImmediately,
@@ -152,5 +173,8 @@ export function createTypingSignaler(params: {
     signalTextDelta,
     signalReasoningDelta,
     signalToolStart,
+    signalProgress,
+    enterLongQuietPhase,
+    exitLongQuietPhase,
   };
 }

--- a/src/auto-reply/reply/typing-persistence.test.ts
+++ b/src/auto-reply/reply/typing-persistence.test.ts
@@ -40,6 +40,116 @@ describe("typing persistence bug fix", () => {
     expect(onReplyStartSpy).not.toHaveBeenCalledTimes(2);
   });
 
+  it("stops a generic active run when the typing TTL expires without a quiet-phase lease", async () => {
+    controller = createTypingController({
+      onReplyStart: onReplyStartSpy,
+      onCleanup: onCleanupSpy,
+      typingIntervalSeconds: 6,
+      typingTtlMs: 10_000,
+      log: vi.fn(),
+    });
+
+    await controller.startTypingLoop();
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(2);
+    expect(onCleanupSpy).not.toHaveBeenCalled();
+
+    // Past the 10s TTL, a generic active run should self-clean.
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(2);
+    expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps typing alive past the run TTL during an explicit long quiet phase", async () => {
+    controller = createTypingController({
+      onReplyStart: onReplyStartSpy,
+      onCleanup: onCleanupSpy,
+      typingIntervalSeconds: 6,
+      typingTtlMs: 10_000,
+      log: vi.fn(),
+    });
+
+    await controller.startTypingLoop();
+    controller.enterLongQuietPhase?.();
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(2);
+    expect(onCleanupSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(3);
+    expect(onCleanupSpy).not.toHaveBeenCalled();
+
+    controller.exitLongQuietPhase?.();
+
+    controller.markRunComplete();
+    expect(onCleanupSpy).not.toHaveBeenCalled();
+
+    controller.markDispatchIdle();
+    expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns to normal TTL cleanup after a long quiet phase ends", async () => {
+    controller = createTypingController({
+      onReplyStart: onReplyStartSpy,
+      onCleanup: onCleanupSpy,
+      typingIntervalSeconds: 6,
+      typingTtlMs: 10_000,
+      log: vi.fn(),
+    });
+
+    await controller.startTypingLoop();
+    controller.enterLongQuietPhase?.();
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    // While the quiet phase is active, the old 10s TTL should not stop typing.
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(3);
+    expect(onCleanupSpy).not.toHaveBeenCalled();
+
+    controller.exitLongQuietPhase?.();
+
+    // The loop can still tick once more, but without the lease the watchdog
+    // should eventually self-clean if no new lifecycle signal arrives.
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(4);
+    expect(onCleanupSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the quiet-phase lease active until the final nested phase exits", async () => {
+    controller = createTypingController({
+      onReplyStart: onReplyStartSpy,
+      onCleanup: onCleanupSpy,
+      typingIntervalSeconds: 6,
+      typingTtlMs: 10_000,
+      log: vi.fn(),
+    });
+
+    await controller.startTypingLoop();
+    controller.enterLongQuietPhase?.();
+    controller.enterLongQuietPhase?.();
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(3);
+    expect(onCleanupSpy).not.toHaveBeenCalled();
+
+    controller.exitLongQuietPhase?.();
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(onReplyStartSpy).toHaveBeenCalledTimes(5);
+    expect(onCleanupSpy).not.toHaveBeenCalled();
+
+    controller.exitLongQuietPhase?.();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("should stop typing when both runComplete and dispatchIdle are true", async () => {
     // Start typing
     await controller.startTypingLoop();

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -8,6 +8,8 @@ export type TypingController = {
   startTypingLoop: () => Promise<void>;
   startTypingOnText: (text?: string) => Promise<void>;
   refreshTypingTtl: () => void;
+  enterLongQuietPhase?: () => void;
+  exitLongQuietPhase?: () => void;
   isActive: () => boolean;
   markRunComplete: () => void;
   markDispatchIdle: () => void;
@@ -36,6 +38,8 @@ export function createTypingController(params: {
       startTypingLoop: async () => {},
       startTypingOnText: async () => {},
       refreshTypingTtl: () => {},
+      enterLongQuietPhase: () => {},
+      exitLongQuietPhase: () => {},
       isActive: () => false,
       markRunComplete: () => {},
       markDispatchIdle: () => {},
@@ -46,6 +50,7 @@ export function createTypingController(params: {
   let active = false;
   let runComplete = false;
   let dispatchIdle = false;
+  let longQuietPhaseDepth = 0;
   // Important: callbacks (tool/block streaming) can fire late (after the run completed),
   // especially when upstream event emitters don't await async listeners.
   // Once we stop typing, we "seal" the controller so late events can't restart typing forever.
@@ -102,6 +107,8 @@ export function createTypingController(params: {
     if (typingTtlTimer) {
       clearTimeout(typingTtlTimer);
     }
+    // Safety watchdog: stop typing when no lifecycle signal refreshes typing
+    // within the configured budget.
     typingTtlTimer = setTimeout(() => {
       if (!typingLoop.isRunning()) {
         return;
@@ -112,6 +119,18 @@ export function createTypingController(params: {
   };
 
   const isActive = () => active && !sealed;
+
+  const enterLongQuietPhase = () => {
+    if (sealed) {
+      return;
+    }
+    longQuietPhaseDepth += 1;
+    refreshTypingTtl();
+  };
+
+  const exitLongQuietPhase = () => {
+    longQuietPhaseDepth = Math.max(0, longQuietPhaseDepth - 1);
+  };
 
   const startGuard = createTypingStartGuard({
     isSealed: () => sealed,
@@ -127,7 +146,17 @@ export function createTypingController(params: {
 
   const typingLoop = createTypingKeepaliveLoop({
     intervalMs: typingIntervalMs,
-    onTick: triggerTyping,
+    onTick: async () => {
+      if (sealed || runComplete) {
+        return;
+      }
+      // Extend the watchdog only during known long-quiet phases such as
+      // compaction and memory flush. Generic stale runs should still self-clean.
+      if (longQuietPhaseDepth > 0) {
+        refreshTypingTtl();
+      }
+      await triggerTyping();
+    },
   });
 
   const ensureStart = async () => {
@@ -226,6 +255,8 @@ export function createTypingController(params: {
     startTypingLoop,
     startTypingOnText,
     refreshTypingTtl,
+    enterLongQuietPhase,
+    exitLongQuietPhase,
     isActive,
     markRunComplete,
     markDispatchIdle,


### PR DESCRIPTION
## Summary

Fixes long quiet turns losing configured typing before the run actually finishes.

This keeps typing alive through known long-quiet phases instead of letting the run-side typing TTL expire while the run is still healthy.

Fixes #65919.

## What changed

- add an internal long-quiet typing lease in `src/auto-reply/reply/typing.ts`
- refresh the typing watchdog on real progress while typing is already active in `src/auto-reply/reply/typing-mode.ts`
- lease typing through:
  - preflight compaction and memory flush
  - in-run compaction
  - long tool execution
- emit compaction lifecycle events for explicit overflow/timeout recovery compaction in `src/agents/pi-embedded-runner/run.ts` so those recovery paths also hold the lease
- add regression coverage for generic TTL cleanup, leased quiet phases, nested quiet phases, tool/compaction error release, and explicit recovery compaction lifecycle events

## Why

Before this change, typing lifetime was governed by local TTLs. That meant a healthy run could still lose typing during silent but expected phases like compaction, memory flush, or long tool execution.

This PR keeps the stale watchdog behavior for generic suspicious silence, but treats known long-quiet phases as explicit leased phases so typing stays alive until the run actually reaches its normal completion path.

## Non-goals

- no default change to compaction disclosure
- no new progress/status message surface
- no public SDK change
- no Telegram-only special case

## Validation

Ran:

- `pnpm test src/auto-reply/reply/typing-persistence.test.ts src/auto-reply/reply/reply-utils.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/followup-runner.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts`
- `pnpm check`

Manual validation:

- Telegram auto-compaction kept `typing…` visible throughout an almost 10 minute silent compaction run.

AI-assisted with Codex. Tested locally and manually validated for the main Telegram compaction repro.