### PR TITLE
fix: expose qwen3.6-plus on Coding Plan endpoints

### DIFF
--- a/docs/providers/qwen.md
+++ b/docs/providers/qwen.md
@@ -26,8 +26,10 @@ compatibility alias.
 - API style: OpenAI-compatible
 
 <Tip>
-If you want `qwen3.6-plus`, prefer the **Standard (pay-as-you-go)** endpoint.
-Coding Plan support can lag behind the public catalog.
+`qwen3.6-plus` is exposed on both Standard (pay-as-you-go) and Coding Plan
+endpoints. Availability still depends on the upstream account plan and rollout
+status, so providers may occasionally return a vendor-side unsupported-model
+error until Alibaba fully enables it for a given tenant.
 </Tip>
 
 ## Getting started
@@ -85,7 +87,7 @@ Choose your plan type and follow the setup steps.
   </Tab>
 
   <Tab title="Standard (pay-as-you-go)">
-    **Best for:** pay-as-you-go access through the Standard Model Studio endpoint, including models like `qwen3.6-plus` that may not be available on the Coding Plan.
+    **Best for:** pay-as-you-go access through the Standard Model Studio endpoint.
 
     <Steps>
       <Step title="Get your API key">
@@ -154,21 +156,19 @@ You can override with a custom `baseUrl` in config.
 
 ## Built-in catalog
 
-OpenClaw currently ships this bundled Qwen catalog. The configured catalog is
-endpoint-aware: Coding Plan configs omit models that are only known to work on
-the Standard endpoint.
+OpenClaw currently ships this bundled Qwen catalog.
 
-| Model ref                   | Input       | Context   | Notes                                              |
-| --------------------------- | ----------- | --------- | -------------------------------------------------- |
-| `qwen/qwen3.5-plus`         | text, image | 1,000,000 | Default model                                      |
-| `qwen/qwen3.6-plus`         | text, image | 1,000,000 | Prefer Standard endpoints when you need this model |
-| `qwen/qwen3-max-2026-01-23` | text        | 262,144   | Qwen Max line                                      |
-| `qwen/qwen3-coder-next`     | text        | 262,144   | Coding                                             |
-| `qwen/qwen3-coder-plus`     | text        | 1,000,000 | Coding                                             |
-| `qwen/MiniMax-M2.5`         | text        | 1,000,000 | Reasoning enabled                                  |
-| `qwen/glm-5`                | text        | 202,752   | GLM                                                |
-| `qwen/glm-4.7`              | text        | 202,752   | GLM                                                |
-| `qwen/kimi-k2.5`            | text, image | 262,144   | Moonshot AI via Alibaba                            |
+| Model ref                   | Input       | Context   | Notes                                                    |
+| --------------------------- | ----------- | --------- | -------------------------------------------------------- |
+| `qwen/qwen3.5-plus`         | text, image | 1,000,000 | Default model                                            |
+| `qwen/qwen3.6-plus`         | text, image | 1,000,000 | Availability still depends on upstream tenant enablement |
+| `qwen/qwen3-max-2026-01-23` | text        | 262,144   | Qwen Max line                                            |
+| `qwen/qwen3-coder-next`     | text        | 262,144   | Coding                                                   |
+| `qwen/qwen3-coder-plus`     | text        | 1,000,000 | Coding                                                   |
+| `qwen/MiniMax-M2.5`         | text        | 1,000,000 | Reasoning enabled                                        |
+| `qwen/glm-5`                | text        | 202,752   | GLM                                                      |
+| `qwen/glm-4.7`              | text        | 202,752   | GLM                                                      |
+| `qwen/kimi-k2.5`            | text, image | 262,144   | Moonshot AI via Alibaba                                  |
 
 <Note>
 Availability can still vary by endpoint and billing plan even when a model is
@@ -225,15 +225,13 @@ See [Video Generation](/tools/video-generation) for shared tool parameters, prov
   </Accordion>
 
   <Accordion title="Qwen 3.6 Plus availability">
-    `qwen3.6-plus` is available on the Standard (pay-as-you-go) Model Studio
-    endpoints:
+    `qwen3.6-plus` is exposed in OpenClaw on both Standard (pay-as-you-go)
+    and Coding Plan endpoints.
 
-    - China: `dashscope.aliyuncs.com/compatible-mode/v1`
-    - Global: `dashscope-intl.aliyuncs.com/compatible-mode/v1`
-
-    If the Coding Plan endpoints return an "unsupported model" error for
-    `qwen3.6-plus`, switch to Standard (pay-as-you-go) instead of the Coding Plan
-    endpoint/key pair.
+    If a Coding Plan endpoint still returns an upstream "unsupported model"
+    error for `qwen3.6-plus`, that usually means Alibaba has not enabled the
+    model for that tenant yet. In that case you can either wait for the rollout
+    or switch to the Standard (pay-as-you-go) endpoint/key pair.
 
   </Accordion>
 

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -1,7 +1,7 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyQwenNativeStreamingUsageCompat } from "./api.js";
 import { buildQwenMediaUnderstandingProvider } from "./media-understanding-provider.js";
-import { isQwenCodingPlanBaseUrl, QWEN_36_PLUS_MODEL_ID, QWEN_BASE_URL } from "./models.js";
+import { QWEN_BASE_URL } from "./models.js";
 import {
   applyQwenConfig,
   applyQwenConfigCn,
@@ -109,7 +109,7 @@ export default defineSingleProviderPluginEntry({
           "Manage API keys: https://home.qwencloud.com/api-keys",
           "Docs: https://docs.qwencloud.com/",
           "Endpoint: coding.dashscope.aliyuncs.com",
-          "Models: qwen3.5-plus, glm-5, kimi-k2.5, MiniMax-M2.5, etc.",
+          "Models: qwen3.6-plus, qwen3.5-plus, glm-5, kimi-k2.5, MiniMax-M2.5, etc.",
         ].join("\n"),
         noteTitle: "Qwen Cloud Coding Plan (China)",
         wizard: {
@@ -132,7 +132,7 @@ export default defineSingleProviderPluginEntry({
           "Manage API keys: https://home.qwencloud.com/api-keys",
           "Docs: https://docs.qwencloud.com/",
           "Endpoint: coding-intl.dashscope.aliyuncs.com",
-          "Models: qwen3.5-plus, glm-5, kimi-k2.5, MiniMax-M2.5, etc.",
+          "Models: qwen3.6-plus, qwen3.5-plus, glm-5, kimi-k2.5, MiniMax-M2.5, etc.",
         ].join("\n"),
         noteTitle: "Qwen Cloud Coding Plan (Global/Intl)",
         wizard: {
@@ -160,14 +160,8 @@ export default defineSingleProviderPluginEntry({
     applyNativeStreamingUsageCompat: ({ providerConfig }) =>
       applyQwenNativeStreamingUsageCompat(providerConfig),
     wrapStreamFn: wrapQwenProviderStream,
-    normalizeConfig: ({ providerConfig }) => {
-      if (!isQwenCodingPlanBaseUrl(providerConfig.baseUrl)) {
-        return undefined;
-      }
-      const models = providerConfig.models?.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
-      return models && models.length !== providerConfig.models?.length
-        ? { ...providerConfig, models }
-        : undefined;
+    normalizeConfig: () => {
+      return undefined;
     },
   },
   register(api) {

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -123,16 +123,14 @@ export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
   }
 }
 
-export function isQwen36PlusSupportedBaseUrl(baseUrl: string | undefined): boolean {
-  return !isQwenCodingPlanBaseUrl(baseUrl);
+export function isQwen36PlusSupportedBaseUrl(_baseUrl: string | undefined): boolean {
+  return true;
 }
 
 export function buildQwenModelCatalogForBaseUrl(
-  baseUrl: string | undefined,
+  _baseUrl: string | undefined,
 ): ReadonlyArray<ModelDefinitionConfig> {
-  return isQwen36PlusSupportedBaseUrl(baseUrl)
-    ? QWEN_MODEL_CATALOG
-    : QWEN_MODEL_CATALOG.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
+  return QWEN_MODEL_CATALOG;
 }
 
 export function isNativeQwenBaseUrl(baseUrl: string | undefined): boolean {

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -15,14 +15,14 @@ describe("qwen provider catalog", () => {
     expect(provider.api).toBe("openai-completions");
     expect(provider.models?.length).toBeGreaterThan(0);
     expect(provider.models?.find((model) => model.id === QWEN_DEFAULT_MODEL_ID)).toBeTruthy();
-    expect(provider.models?.find((model) => model.id === "qwen3.6-plus")).toBeFalsy();
+    expect(provider.models?.find((model) => model.id === "qwen3.6-plus")).toBeTruthy();
   });
 
-  it("only advertises qwen3.6-plus on Standard endpoints", () => {
+  it("advertises qwen3.6-plus on both Coding Plan and Standard endpoints", () => {
     const coding = buildQwenProvider({ baseUrl: QWEN_BASE_URL });
     const standard = buildQwenProvider({ baseUrl: QWEN_STANDARD_GLOBAL_BASE_URL });
 
-    expect(coding.models?.find((model) => model.id === "qwen3.6-plus")).toBeFalsy();
+    expect(coding.models?.find((model) => model.id === "qwen3.6-plus")).toBeTruthy();
     expect(standard.models?.find((model) => model.id === "qwen3.6-plus")).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary

This change removes OpenClaw-side filtering that hides `qwen3.6-plus` when the configured Qwen base URL points at Alibaba's Coding Plan endpoints.

## Why

Alibaba Cloud Coding Plan now supports `qwen3.6-plus` for all Coding Plan Pro users, so OpenClaw should not hard-block the model before the upstream provider responds.

The current Qwen integration blocks `qwen3.6-plus` in two places:

- dynamic catalog filtering in `buildQwenModelCatalogForBaseUrl(...)`
- config-time filtering in `normalizeConfig`

That means OpenClaw can reject a model that Coding Plan Pro users are already allowed to use.

Without this change, OpenClaw hides `qwen3.6-plus` from the Qwen catalog and strips it from provider config on Coding Plan endpoints, so Coding Plan Pro users cannot select or use a model they already have access to.

## Changes

- remove Coding Plan-specific `qwen3.6-plus` filtering from the Qwen catalog
- stop stripping `qwen3.6-plus` in plugin config normalization
- update tests and docs to match the new behavior

## Notes

This change prefers provider truth over OpenClaw-side preemption.

If the upstream provider ever returns an unsupported-model error for a specific account or plan, that error should come from the provider directly rather than from OpenClaw hard-blocking the model in advance.