### PR TITLE
feat(openai): add act-don't-ask and tool retry directives for GPT-5 [v3 2/6]

### DIFF
--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -76,12 +76,12 @@ When a question has an obvious default interpretation, act on it immediately ins
 - "Is port 443 open?" → check THIS machine (don't ask "open where?")
 - "What OS am I running?" → check the live system (don't use cached data)
 - "What time is it?" → run \`date\` (don't guess)
-Only ask for clarification when the ambiguity genuinely changes what tool you would call.
+Only ask for clarification when the ambiguity genuinely changes what tool you would call or when the action is destructive and scope is unclear.
 
 ### Tool Persistence
 If a tool returns empty or partial results, retry with a different query or strategy before giving up.
-Keep calling tools until: (1) the task is complete, AND (2) you have verified the result.
-Do not abandon a viable approach after a single failure — diagnose why it failed and adjust.`;
+Keep calling tools until the task is complete.
+Do not abandon a viable approach after a single failure. Diagnose why it failed and adjust.`;
 
 export const OPENAI_GPT5_TOOL_CALL_STYLE = `## Tool Call Style
 

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -69,7 +69,19 @@ Commentary-only turns are incomplete when tools are available and the next actio
 If the work will take multiple steps, keep calling tools until the task is done or you hit a real blocker. Do not stop after one step to ask permission.
 Do prerequisite lookup or discovery before dependent actions.
 Multi-part requests stay incomplete until every requested item is handled or clearly marked blocked.
-Act first, then verify if needed. Do not pause to summarize or verify before taking the next action.`;
+Act first, then verify if needed. Do not pause to summarize or verify before taking the next action.
+
+### Act, Don't Ask
+When a question has an obvious default interpretation, act on it immediately instead of asking for clarification. Examples:
+- "Is port 443 open?" → check THIS machine (don't ask "open where?")
+- "What OS am I running?" → check the live system (don't use cached data)
+- "What time is it?" → run \`date\` (don't guess)
+Only ask for clarification when the ambiguity genuinely changes what tool you would call.
+
+### Tool Persistence
+If a tool returns empty or partial results, retry with a different query or strategy before giving up.
+Keep calling tools until: (1) the task is complete, AND (2) you have verified the result.
+Do not abandon a viable approach after a single failure — diagnose why it failed and adjust.`;
 
 export const OPENAI_GPT5_TOOL_CALL_STYLE = `## Tool Call Style
 

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -73,15 +73,16 @@ Act first, then verify if needed. Do not pause to summarize or verify before tak
 
 ### Act, Don't Ask
 When a question has an obvious default interpretation, act on it immediately instead of asking for clarification. Examples:
-- "Is port 443 open?" → check THIS machine (don't ask "open where?")
-- "What OS am I running?" → check the live system (don't use cached data)
-- "What time is it?" → run \`date\` (don't guess)
-Only ask for clarification when the ambiguity genuinely changes what tool you would call or when the action is destructive and scope is unclear.
+- 'Is port 443 open?' → check THIS machine (don't ask 'open where?')
+- 'What OS am I running?' → check the live system (don't use user profile)
+- 'What time is it?' → run \`date\` (don't guess)
+Only ask for clarification when the ambiguity genuinely changes what tool you would call.
 
 ### Tool Persistence
-If a tool returns empty or partial results, retry with a different query or strategy before giving up.
-Keep calling tools until the task is complete.
-Do not abandon a viable approach after a single failure. Diagnose why it failed and adjust.`;
+- Use tools whenever they improve correctness, completeness, or grounding.
+- Do not stop early when another tool call would materially improve the result.
+- If a tool returns empty or partial results, retry with a different query or strategy before giving up.
+- Keep calling tools until: (1) the task is complete, AND (2) you have verified the result.`;
 
 export const OPENAI_GPT5_TOOL_CALL_STYLE = `## Tool Call Style
 


### PR DESCRIPTION
## GPT 5.4 Enhancement v3 — PR 2/6
**Tracking: #66345 | Issue: #66347**
**Priority: P0 — HIGH | Gap closure: ~25%**

## Problem

GPT 5.4 on OpenClaw exhibits two failure modes Hermes avoids:

```
  User: "Is port 8080 open?"         Tool returns empty result
           │                                   │
  ┌────────┴─────────┐               ┌────────┴─────────┐
  │                  │               │                  │
  ▼                  ▼               ▼                  ▼
Hermes             OpenClaw        Hermes             OpenClaw
  │                  │               │                  │
  │ "act on obvious  │ "prerequisite │ "retry with      │ (no retry
  │  defaults" +     │  lookup"      │  different       │  guidance)
  │  examples        │ (too vague)   │  strategy"       │
  ▼                  ▼               ▼                  ▼
Runs               Asks user:      Retries with       Reports:
`ss -tlnp |        "Which host     broader query      "No results
 grep 8080`        should I check?"                    found."
✅ ACTS             ❌ STALLS        ✅ PERSISTS         ❌ SURRENDERS
```

## Changes

**`extensions/openai/prompt-overlay.ts`** — Enhanced `OPENAI_GPT5_EXECUTION_BIAS` with two new subsections:

1. **Act, Don't Ask**: Concrete examples showing when to act on obvious defaults vs when to ask
2. **Tool Persistence**: Retry-on-failure directive — diagnose and adjust instead of surrendering

## Defense-in-Depth

```
  ┌──────────────────────────────────────────────┐
  │          Defense-in-Depth Stack               │
  │                                               │
  │  Layer 1: PROMPT (this PR)                    │
  │  ├─ Act-don't-ask → prevents stall           │
  │  ├─ Tool retry → prevents surrender           │
  │  │                                             │
  │  Layer 2: RUNTIME (already exists)             │
  │  ├─ Planning-only detection → catches misses   │
  │  ├─ Ack fast path → "ok do it" acceleration    │
  │  └─ Strict-agentic blocked exit                │
  └──────────────────────────────────────────────┘
```

## Hermes Reference

- `agent/prompt_builder.py:221-229` — `<act_dont_ask>` block
- `agent/prompt_builder.py:199-202` — retry-with-different-strategy directive

## Verification

- "Is port 8080 open?" → runs `ss`/`netstat`, doesn't ask "where?"
- "Find all TODO comments" → if first grep misses, retries with different pattern
- "What packages are outdated?" → runs `npm outdated`, doesn't ask which project