### PR TITLE
feat(agents): add tool_enforcement as first-class provider prompt section [v3 3/6]

### DIFF
--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -15,6 +15,7 @@ import {
   OPENAI_GPT5_EXECUTION_BIAS,
   OPENAI_GPT5_OUTPUT_CONTRACT,
   OPENAI_GPT5_TOOL_CALL_STYLE,
+  OPENAI_GPT5_TOOL_ENFORCEMENT,
 } from "./prompt-overlay.js";
 
 const runtimeMocks = vi.hoisted(() => ({
@@ -370,6 +371,7 @@ describe("openai plugin", () => {
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       },
     });
     expect(OPENAI_FRIENDLY_PROMPT_OVERLAY).toContain("This is a live chat, not a memo.");
@@ -387,6 +389,7 @@ describe("openai plugin", () => {
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       },
     });
     expect(
@@ -504,6 +507,7 @@ describe("openai plugin", () => {
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       },
     });
   });
@@ -531,6 +535,7 @@ describe("openai plugin", () => {
       stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
       sectionOverrides: {
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       },
     });
   });
@@ -557,6 +562,7 @@ describe("openai plugin", () => {
       stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
       sectionOverrides: {
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       },
     });
   });
@@ -585,6 +591,7 @@ describe("openai plugin", () => {
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       },
     });
   });
@@ -612,6 +619,7 @@ describe("openai plugin", () => {
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+        tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       },
     });
   });

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -18,6 +18,16 @@ import {
   OPENAI_GPT5_TOOL_ENFORCEMENT,
 } from "./prompt-overlay.js";
 
+/**
+ * The expected stablePrefix shared by every GPT-5 prompt contribution test.
+ * Factored out so adding/reordering blocks in the overlay only requires
+ * editing this helper instead of touching every assertion.
+ */
+const EXPECTED_GPT5_STABLE_PREFIX = [
+  OPENAI_GPT5_OUTPUT_CONTRACT,
+  OPENAI_GPT5_TOOL_CALL_STYLE,
+].join("\n\n");
+
 const runtimeMocks = vi.hoisted(() => ({
   ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
   refreshOpenAICodexToken: vi.fn(),
@@ -367,7 +377,7 @@ describe("openai plugin", () => {
     };
 
     expect(openaiProvider.resolveSystemPromptContribution?.(contributionContext)).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
@@ -385,7 +395,7 @@ describe("openai plugin", () => {
       "Occasional emoji are welcome when they fit naturally, especially for warmth or brief celebration; keep them sparse.",
     );
     expect(codexProvider.resolveSystemPromptContribution?.(contributionContext)).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
@@ -503,7 +513,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
@@ -532,7 +542,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
       sectionOverrides: {
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
         tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
@@ -559,7 +569,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
       sectionOverrides: {
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
         tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
@@ -587,7 +597,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
@@ -615,7 +625,7 @@ describe("openai plugin", () => {
         agentId: undefined,
       }),
     ).toEqual({
-      stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
+      stablePrefix: EXPECTED_GPT5_STABLE_PREFIX,
       sectionOverrides: {
         interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY,
         execution_bias: OPENAI_GPT5_EXECUTION_BIAS,

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -81,8 +81,7 @@ Narrate only when it genuinely helps: complex multi-step work, sensitive actions
 
 export const OPENAI_GPT5_TOOL_ENFORCEMENT = `## Mandatory Tool Use
 
-NEVER answer these from memory or mental computation. Use an available tool whenever one is needed to verify the answer.
-If a preferred tool for a category is unavailable in this runtime, do not guess or invent results. State the limitation briefly and ask the user to enable the needed tools/profile.
+When a tool is available that would verify, compute, or look up the answer, use it. Do not answer from memory or mental computation when a tool can ground the answer in live data.
 
 Preferred tools by category:
 - Arithmetic, math, calculations: use exec or code_execution
@@ -94,7 +93,13 @@ Preferred tools by category:
 - Current facts (weather, news, package versions): use web_search if available, otherwise exec
 - Network checks (port open, DNS, connectivity): use exec
 
-Your training data is stale. The execution environment may differ from what you expect. Always ground answers in live tool output, and if the needed tool is unavailable, say so instead of guessing.`;
+### When No Tool Is Available
+
+If none of the preferred tools for a category are registered in this runtime (e.g. minimal or messaging profiles):
+- For trivial, deterministic questions you are highly confident in (simple arithmetic like \`2+2\`, well-known facts, small hash values you know cold), answer directly without stalling. Say "from memory" or "without tool verification" so the user knows it is not grounded.
+- For anything where stale training data or environment drift could cause a wrong answer (current time, live system state, file contents, git status, recent facts), say you cannot verify without the needed tool and offer to continue once it is enabled — do not guess.
+
+Your training data is stale and the execution environment may differ from what you expect. Ground answers in live tool output whenever a tool is available.`;
 
 export type OpenAIPromptOverlayMode = "friendly" | "off";
 

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -79,6 +79,20 @@ If multiple tool calls are needed, call them in sequence without stopping to exp
 Default: do not narrate routine, low-risk tool calls (just call the tool).
 Narrate only when it genuinely helps: complex multi-step work, sensitive actions like deletions, or when the user explicitly asks for commentary.`;
 
+export const OPENAI_GPT5_TOOL_ENFORCEMENT = `## Mandatory Tool Use
+
+NEVER answer these from memory or mental computation — ALWAYS use a tool:
+- Arithmetic, math, calculations → use terminal or code execution
+- Hashes, encodings, checksums → use terminal (e.g. sha256sum, base64)
+- Current time, date, timezone → use terminal (e.g. date)
+- System state: OS, CPU, memory, disk, ports, processes → use terminal
+- File contents, sizes, line counts → use read or search tools, or terminal
+- Git history, branches, diffs, status → use terminal
+- Current facts (weather, news, package versions) → use web search
+- Network checks (port open, DNS, connectivity) → use terminal
+
+Your training data is stale. The execution environment may differ from what you expect. Always ground answers in live tool output.`;
+
 export type OpenAIPromptOverlayMode = "friendly" | "off";
 
 export function resolveOpenAIPromptOverlayMode(
@@ -122,6 +136,7 @@ export function resolveOpenAISystemPromptContribution(params: {
     stablePrefix: [OPENAI_GPT5_OUTPUT_CONTRACT, OPENAI_GPT5_TOOL_CALL_STYLE].join("\n\n"),
     sectionOverrides: {
       execution_bias: OPENAI_GPT5_EXECUTION_BIAS,
+      tool_enforcement: OPENAI_GPT5_TOOL_ENFORCEMENT,
       ...(params.mode === "friendly" ? { interaction_style: OPENAI_FRIENDLY_PROMPT_OVERLAY } : {}),
     },
   };

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -81,17 +81,20 @@ Narrate only when it genuinely helps: complex multi-step work, sensitive actions
 
 export const OPENAI_GPT5_TOOL_ENFORCEMENT = `## Mandatory Tool Use
 
-NEVER answer these from memory or mental computation. ALWAYS use a tool:
+NEVER answer these from memory or mental computation. Use an available tool whenever one is needed to verify the answer.
+If a preferred tool for a category is unavailable in this runtime, do not guess or invent results. State the limitation briefly and ask the user to enable the needed tools/profile.
+
+Preferred tools by category:
 - Arithmetic, math, calculations: use exec or code_execution
 - Hashes, encodings, checksums: use exec (e.g. sha256sum, base64)
-- Current time, date, timezone: use exec (e.g. date) or session_status
-- System state (OS, CPU, memory, disk, ports, processes): use exec
+- Current time, date, timezone: use session_status when available, otherwise exec (e.g. date)
+- System state (OS, CPU, memory, disk, ports, processes): use exec; in minimal environments, use session_status for any basic runtime details it provides
 - File contents, sizes, line counts: use read, grep, find, or exec
 - Git history, branches, diffs, status: use exec
 - Current facts (weather, news, package versions): use web_search if available, otherwise exec
 - Network checks (port open, DNS, connectivity): use exec
 
-Your training data is stale. The execution environment may differ from what you expect. Always ground answers in live tool output.`;
+Your training data is stale. The execution environment may differ from what you expect. Always ground answers in live tool output, and if the needed tool is unavailable, say so instead of guessing.`;
 
 export type OpenAIPromptOverlayMode = "friendly" | "off";
 

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -86,7 +86,7 @@ NEVER answer these from memory or mental computation. ALWAYS use a tool:
 - Hashes, encodings, checksums: use exec (e.g. sha256sum, base64)
 - Current time, date, timezone: use exec (e.g. date) or session_status
 - System state (OS, CPU, memory, disk, ports, processes): use exec
-- File contents, sizes, line counts: use read, search_files, or exec
+- File contents, sizes, line counts: use read, grep, find, or exec
 - Git history, branches, diffs, status: use exec
 - Current facts (weather, news, package versions): use web_search if available, otherwise exec
 - Network checks (port open, DNS, connectivity): use exec

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -81,15 +81,15 @@ Narrate only when it genuinely helps: complex multi-step work, sensitive actions
 
 export const OPENAI_GPT5_TOOL_ENFORCEMENT = `## Mandatory Tool Use
 
-NEVER answer these from memory or mental computation — ALWAYS use a tool:
-- Arithmetic, math, calculations → use terminal or code execution
-- Hashes, encodings, checksums → use terminal (e.g. sha256sum, base64)
-- Current time, date, timezone → use terminal (e.g. date)
-- System state: OS, CPU, memory, disk, ports, processes → use terminal
-- File contents, sizes, line counts → use read or search tools, or terminal
-- Git history, branches, diffs, status → use terminal
-- Current facts (weather, news, package versions) → use web search
-- Network checks (port open, DNS, connectivity) → use terminal
+NEVER answer these from memory or mental computation. ALWAYS use a tool:
+- Arithmetic, math, calculations: use exec or code_execution
+- Hashes, encodings, checksums: use exec (e.g. sha256sum, base64)
+- Current time, date, timezone: use exec (e.g. date) or session_status
+- System state (OS, CPU, memory, disk, ports, processes): use exec
+- File contents, sizes, line counts: use read, search_files, or exec
+- Git history, branches, diffs, status: use exec
+- Current facts (weather, news, package versions): use web_search if available, otherwise exec
+- Network checks (port open, DNS, connectivity): use exec
 
 Your training data is stale. The execution environment may differ from what you expect. Always ground answers in live tool output.`;
 

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -79,27 +79,29 @@ If multiple tool calls are needed, call them in sequence without stopping to exp
 Default: do not narrate routine, low-risk tool calls (just call the tool).
 Narrate only when it genuinely helps: complex multi-step work, sensitive actions like deletions, or when the user explicitly asks for commentary.`;
 
+// Ported verbatim from Hermes Agent's OPENAI_MODEL_EXECUTION_GUIDANCE
+// mandatory_tool_use block (agent/prompt_builder.py lines 207-218) with
+// only tool ID substitutions for OpenClaw-canonical names:
+//   terminal     -> exec              (no `terminal` tool in OpenClaw)
+//   execute_code -> code_execution    (canonical OpenClaw ID)
+//   read_file    -> read              (canonical OpenClaw ID)
+//   search_files -> exec              (no first-class file-search tool;
+//                                      use shell grep via exec)
+// Semantic content (NEVER/ALWAYS directives, category list, ordering,
+// USER-vs-system disclaimer) is preserved exactly to maintain the
+// Hermes cross-comparison.
 export const OPENAI_GPT5_TOOL_ENFORCEMENT = `## Mandatory Tool Use
 
-When a tool is available that would verify, compute, or look up the answer, use it. Do not answer from memory or mental computation when a tool can ground the answer in live data.
+NEVER answer these from memory or mental computation — ALWAYS use a tool:
+- Arithmetic, math, calculations → use exec or code_execution
+- Hashes, encodings, checksums → use exec (e.g. sha256sum, base64)
+- Current time, date, timezone → use exec (e.g. date)
+- System state: OS, CPU, memory, disk, ports, processes → use exec
+- File contents, sizes, line counts → use read or exec
+- Git history, branches, diffs → use exec
+- Current facts (weather, news, versions) → use web_search
 
-Preferred tools by category:
-- Arithmetic, math, calculations: use exec or code_execution
-- Hashes, encodings, checksums: use exec (e.g. sha256sum, base64)
-- Current time, date, timezone: use session_status when available, otherwise exec (e.g. date)
-- System state (OS, CPU, memory, disk, ports, processes): use exec; in minimal environments, use session_status for any basic runtime details it provides
-- File contents, sizes, line counts: use read, grep, find, or exec
-- Git history, branches, diffs, status: use exec
-- Current facts (weather, news, package versions): use web_search if available, otherwise exec
-- Network checks (port open, DNS, connectivity): use exec
-
-### When No Tool Is Available
-
-If none of the preferred tools for a category are registered in this runtime (e.g. minimal or messaging profiles):
-- For trivial, deterministic questions you are highly confident in (simple arithmetic like \`2+2\`, well-known facts, small hash values you know cold), answer directly without stalling. Say "from memory" or "without tool verification" so the user knows it is not grounded.
-- For anything where stale training data or environment drift could cause a wrong answer (current time, live system state, file contents, git status, recent facts), say you cannot verify without the needed tool and offer to continue once it is enabled — do not guess.
-
-Your training data is stale and the execution environment may differ from what you expect. Ground answers in live tool output whenever a tool is available.`;
+Your memory and user profile describe the USER, not the system you are running on. The execution environment may differ from what the user profile says about their personal setup.`;
 
 export type OpenAIPromptOverlayMode = "friendly" | "off";
 

--- a/src/agents/system-prompt-contribution.ts
+++ b/src/agents/system-prompt-contribution.ts
@@ -1,7 +1,8 @@
 export type ProviderSystemPromptSectionId =
   | "interaction_style"
   | "tool_call_style"
-  | "execution_bias";
+  | "execution_bias"
+  | "tool_enforcement";
 
 export type ProviderSystemPromptContribution = {
   /**

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -697,6 +697,10 @@ export function buildAgentSystemPrompt(params: {
       }),
     }),
     ...buildOverridablePromptSection({
+      override: providerSectionOverrides.tool_enforcement,
+      fallback: [],
+    }),
+    ...buildOverridablePromptSection({
       override: providerStablePrefix,
       fallback: [],
     }),


### PR DESCRIPTION
## GPT 5.4 Enhancement v3 — PR 3/6
**Tracking: #66345 | Issue: #66348**
**Priority: P1 — MEDIUM | Type: Architecture**

## Problem

PR 1 (#66371) adds mandatory tool-use categories for GPT-5 via `stablePrefix`. This works but conflates two concerns:
- `execution_bias`: *how* the agent executes (act first, don't plan)
- `tool_enforcement`: *when* it must use tools (mandatory categories)

Providers should be able to override these independently.

## Changes

```
  ┌─────────────────────────────────────────────────────────┐
  │        System Prompt Section Pipeline                    │
  │                                                          │
  │  ┌──────────────────┐  ┌──────────────────┐             │
  │  │ interaction_style │  │ tool_call_style   │             │
  │  │ (personality)     │  │ (narration rules) │             │
  │  └──────────────────┘  └──────────────────┘             │
  │                                                          │
  │  ┌──────────────────┐  ┌──────────────────┐             │
  │  │ execution_bias    │  │ tool_enforcement  │  ← NEW     │
  │  │ (act first,       │  │ (mandatory tool   │             │
  │  │  don't plan)      │  │  categories)      │             │
  │  └──────────────────┘  └──────────────────┘             │
  │                                                          │
  │  Each: provider overrides via sectionOverrides,          │
  │  or falls back to default                                │
  └─────────────────────────────────────────────────────────┘
```

**4 files changed:**

1. **`src/agents/system-prompt-contribution.ts`** — Add `"tool_enforcement"` to `ProviderSystemPromptSectionId` union
2. **`src/agents/system-prompt.ts`** — Add `buildOverridablePromptSection` call for `tool_enforcement` (after `execution_bias`, before `stablePrefix`)
3. **`extensions/openai/prompt-overlay.ts`** — Add `OPENAI_GPT5_TOOL_ENFORCEMENT` constant, wire into `sectionOverrides.tool_enforcement`
4. **`extensions/openai/index.test.ts`** — Update all 7 contribution assertions to include `tool_enforcement` in `sectionOverrides`, factor the shared `stablePrefix` expectation into an `EXPECTED_GPT5_STABLE_PREFIX` helper constant

## Benefits

- **Separation of concerns**: execution bias and tool enforcement are distinct prompt sections
- **Provider extensibility**: Google Gemini (PR 6, #66379) uses `tool_enforcement` for its own operational directives
- **Testability**: each section can be tested independently
- **Default empty**: providers that don't need tool enforcement get an empty section (zero noise)