### PR TITLE
feat(openai): add verification checklist to GPT-5 execution bias [v3 5/6]

### DIFF
--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -72,12 +72,11 @@ Multi-part requests stay incomplete until every requested item is handled or cle
 Act first, then verify if needed. Do not pause to summarize or verify before taking the next action.
 
 ### Verification
-Before finalizing your response, check:
+Before finalizing your response:
 - Correctness: does the output satisfy every stated requirement?
-- Grounding: are factual claims backed by tool outputs, not training data?
-- Coverage: did you address every part of the request?
+- Grounding: are factual claims backed by tool outputs or provided context?
 - Formatting: does the output match the requested format or schema?
-- Safety: for destructive operations (deletions, overwrites, production deploys), confirm scope. Routine reads and writes do not need confirmation.`;
+- Safety: if the next step has side effects (file writes, commands, API calls), confirm scope before executing.`;
 
 export const OPENAI_GPT5_TOOL_CALL_STYLE = `## Tool Call Style
 

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -69,7 +69,15 @@ Commentary-only turns are incomplete when tools are available and the next actio
 If the work will take multiple steps, keep calling tools until the task is done or you hit a real blocker. Do not stop after one step to ask permission.
 Do prerequisite lookup or discovery before dependent actions.
 Multi-part requests stay incomplete until every requested item is handled or clearly marked blocked.
-Act first, then verify if needed. Do not pause to summarize or verify before taking the next action.`;
+Act first, then verify if needed. Do not pause to summarize or verify before taking the next action.
+
+### Verification
+Before finalizing your response, check:
+- Correctness: does the output satisfy every stated requirement?
+- Grounding: are factual claims backed by tool outputs, not training data?
+- Coverage: did you address every part of the request?
+- Formatting: does the output match the requested format or schema?
+- Safety: if the next step has side effects (file writes, commands, API calls), confirm scope before executing.`;
 
 export const OPENAI_GPT5_TOOL_CALL_STYLE = `## Tool Call Style
 

--- a/extensions/openai/prompt-overlay.ts
+++ b/extensions/openai/prompt-overlay.ts
@@ -77,7 +77,7 @@ Before finalizing your response, check:
 - Grounding: are factual claims backed by tool outputs, not training data?
 - Coverage: did you address every part of the request?
 - Formatting: does the output match the requested format or schema?
-- Safety: if the next step has side effects (file writes, commands, API calls), confirm scope before executing.`;
+- Safety: for destructive operations (deletions, overwrites, production deploys), confirm scope. Routine reads and writes do not need confirmation.`;
 
 export const OPENAI_GPT5_TOOL_CALL_STYLE = `## Tool Call Style
 


### PR DESCRIPTION
## GPT 5.4 Enhancement v3 — PR 5/6
**Tracking: #66345 | Issue: #66351**
**Priority: P2 — LOW | Type: Quality Polish**

## Problem

OpenClaw's GPT-5 execution bias says "Act first, then verify if needed" but doesn't specify *what* to verify. Hermes provides a structured checklist. The critical missing dimension is **grounding** — checking that claims are backed by tool output, not training data.

## Changes

**`extensions/openai/prompt-overlay.ts`** — Append verification subsection to `OPENAI_GPT5_EXECUTION_BIAS`:

```
### Verification
Before finalizing your response, check:
- Correctness: does the output satisfy every stated requirement?
- Grounding: are factual claims backed by tool outputs, not training data?
- Coverage: did you address every part of the request?
- Formatting: does the output match the requested format or schema?
- Safety: if the next step has side effects, confirm scope before executing.
```

## Verification Flow

```
  GPT-5 finishes tool calls
           │
           ▼
  ┌─────────────────────┐
  │ Verification Pass    │
  │                      │
  │ ✓ Correctness        │ ← Does output match requirements?
  │ ✓ Grounding          │ ← Claims backed by tool output? (KEY)
  │ ✓ Coverage           │ ← All parts addressed?
  │ ✓ Formatting         │ ← Right format/schema?
  │ ✓ Safety             │ ← Side effects scoped?
  └──────────┬───────────┘
             │
             ▼
  Finalize response
```

## Hermes Reference

`agent/prompt_builder.py` lines 238-245 — `<verification>` block.

## Impact

Modest quality improvement on multi-step tasks. The **Grounding** check specifically reinforces mandatory tool use (PR 1) — even if GPT-5 skips a tool call, the verification step prompts it to notice the gap.