### PR TITLE
fix(whatsapp): bypass legacy send dep for media sends

### DIFF
--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -54,6 +54,45 @@ describe("createWhatsAppOutboundBase", () => {
     expect(result).toMatchObject({ channel: "whatsapp", messageId: "msg-1" });
   });
 
+  it("bypasses legacy outbound deps for media sends", async () => {
+    const sendMessageWhatsApp = vi.fn(async () => ({
+      messageId: "msg-runtime",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const legacySendWhatsApp = vi.fn(async () => ({
+      messageId: "msg-legacy",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const outbound = createWhatsAppOutboundBase({
+      chunker: (text) => [text],
+      sendMessageWhatsApp,
+      sendPollWhatsApp: vi.fn(),
+      shouldLogVerbose: () => false,
+      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+    });
+
+    const result = await outbound.sendMedia!({
+      cfg: {} as never,
+      to: "whatsapp:+15551234567",
+      text: "photo",
+      mediaUrl: "/tmp/workspace/photo.png",
+      accountId: "default",
+      deps: { sendWhatsApp: legacySendWhatsApp },
+      gifPlayback: false,
+    });
+
+    expect(legacySendWhatsApp).not.toHaveBeenCalled();
+    expect(sendMessageWhatsApp).toHaveBeenCalledWith(
+      "whatsapp:+15551234567",
+      "photo",
+      expect.objectContaining({
+        mediaUrl: "/tmp/workspace/photo.png",
+        accountId: "default",
+      }),
+    );
+    expect(result).toMatchObject({ channel: "whatsapp", messageId: "msg-runtime" });
+  });
+
   it("threads cfg into sendPollWhatsApp call", async () => {
     const sendPollWhatsApp = vi.fn(async () => ({
       messageId: "wa-poll-1",

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -18,7 +18,7 @@ describe("createWhatsAppOutboundBase", () => {
   it("forwards mediaLocalRoots to sendMessageWhatsApp", async () => {
     const sendMessageWhatsApp = vi.fn(async () => ({
       messageId: "msg-1",
-      toJid: "15551234567@s.whatsapp.net",
+      toJid: "test-user@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
       chunker: (text) => [text],
@@ -31,7 +31,7 @@ describe("createWhatsAppOutboundBase", () => {
 
     const result = await outbound.sendMedia!({
       cfg: {} as never,
-      to: "whatsapp:+15551234567",
+      to: "whatsapp:test-user",
       text: "photo",
       mediaUrl: "/tmp/workspace/photo.png",
       mediaLocalRoots,
@@ -41,7 +41,7 @@ describe("createWhatsAppOutboundBase", () => {
     });
 
     expect(sendMessageWhatsApp).toHaveBeenCalledWith(
-      "whatsapp:+15551234567",
+      "whatsapp:test-user",
       "photo",
       expect.objectContaining({
         verbose: false,
@@ -57,11 +57,11 @@ describe("createWhatsAppOutboundBase", () => {
   it("bypasses legacy outbound deps for media sends", async () => {
     const sendMessageWhatsApp = vi.fn(async () => ({
       messageId: "msg-runtime",
-      toJid: "15551234567@s.whatsapp.net",
+      toJid: "test-user@s.whatsapp.net",
     }));
     const legacySendWhatsApp = vi.fn(async () => ({
       messageId: "msg-legacy",
-      toJid: "15551234567@s.whatsapp.net",
+      toJid: "test-user@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
       chunker: (text) => [text],
@@ -73,7 +73,7 @@ describe("createWhatsAppOutboundBase", () => {
 
     const result = await outbound.sendMedia!({
       cfg: {} as never,
-      to: "whatsapp:+15551234567",
+      to: "whatsapp:test-user",
       text: "photo",
       mediaUrl: "/tmp/workspace/photo.png",
       accountId: "default",
@@ -83,7 +83,7 @@ describe("createWhatsAppOutboundBase", () => {
 
     expect(legacySendWhatsApp).not.toHaveBeenCalled();
     expect(sendMessageWhatsApp).toHaveBeenCalledWith(
-      "whatsapp:+15551234567",
+      "whatsapp:test-user",
       "photo",
       expect.objectContaining({
         mediaUrl: "/tmp/workspace/photo.png",
@@ -96,7 +96,7 @@ describe("createWhatsAppOutboundBase", () => {
   it("threads cfg into sendPollWhatsApp call", async () => {
     const sendPollWhatsApp = vi.fn(async () => ({
       messageId: "wa-poll-1",
-      toJid: "1555@s.whatsapp.net",
+      toJid: "test-poll@s.whatsapp.net",
     }));
     const outbound = createWhatsAppOutboundBase({
       chunker: (text) => [text],
@@ -122,7 +122,7 @@ describe("createWhatsAppOutboundBase", () => {
     expect(result).toEqual({
       channel: "whatsapp",
       messageId: "wa-poll-1",
-      toJid: "1555@s.whatsapp.net",
+      toJid: "test-poll@s.whatsapp.net",
     });
   });
 });

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -97,14 +97,10 @@ export function createWhatsAppOutboundBase({
         mediaLocalRoots,
         mediaReadFile,
         accountId,
-        deps,
+        deps: _deps,
         gifPlayback,
       }) => {
-        const send =
-          resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
-            legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
-          }) ?? sendMessageWhatsApp;
-        return await send(to, normalizeText(text), {
+        return await sendMessageWhatsApp(to, normalizeText(text), {
           verbose: false,
           cfg,
           mediaUrl,


### PR DESCRIPTION
## Summary
- bypass the legacy outbound send dep path for WhatsApp media sends
- keep text sends on the existing dep resolution path
- add a regression test proving media sends ignore the legacy dep and use the runtime sender

## Why
WhatsApp media sends can regress when they route through the legacy outbound dep shim instead of the runtime media-capable sender. This patch keeps media delivery on the direct runtime path while preserving the current text-send behavior.

## Testing
- corepack pnpm test -- --run extensions/whatsapp/src/outbound-base.test.ts