### PR TITLE
fix(config): recover from schema-invalid config via backup rotation ring

### DIFF
--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   maybeRecoverSuspiciousConfigRead,
   maybeRecoverSuspiciousConfigReadSync,
+  maybeRecoverFromSchemaInvalidConfigSync,
   type ObserveRecoveryDeps,
 } from "./io.observe-recovery.js";
 
@@ -156,6 +157,138 @@ describe("config observe recovery", () => {
         .findLast((line) => line.event === "config.observe");
       expect(observe?.backupHash).toBeTypeOf("string");
       expect(observe?.lastKnownGoodIno ?? null).toBeNull();
+    });
+  });
+
+  describe("maybeRecoverFromSchemaInvalidConfigSync", () => {
+    // A validate stub that accepts any object with a `gateway.mode` field.
+    function validateHasGatewayMode(parsed: unknown): boolean {
+      return (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        typeof (parsed as Record<string, unknown>).gateway === "object" &&
+        (parsed as Record<string, unknown>).gateway !== null &&
+        typeof ((parsed as Record<string, { mode?: unknown }>).gateway as { mode?: unknown })
+          .mode === "string"
+      );
+    }
+
+    it("restores the primary .bak when it passes schema validation", async () => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath, warn } = makeDeps(home);
+
+        // Seed a valid backup
+        await seedConfig(`${configPath}.bak`, { gateway: { mode: "local" } });
+
+        // Write a schema-invalid primary config
+        await seedConfig(configPath, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+
+        const result = maybeRecoverFromSchemaInvalidConfigSync({
+          deps,
+          configPath,
+          validate: validateHasGatewayMode,
+        });
+
+        expect(result).toBe(true);
+        // Primary config should now match the backup
+        const restoredRaw = await fsp.readFile(configPath, "utf-8");
+        const restoredParsed = JSON.parse(restoredRaw) as Record<string, unknown>;
+        expect((restoredParsed.gateway as { mode?: string } | undefined)?.mode).toBe("local");
+        // Warning logged
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("schema-invalid"));
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining(".bak"));
+        // Clobbered snapshot archived
+        const dir = path.dirname(configPath);
+        const entries = await fsp.readdir(dir);
+        expect(entries.some((e) => e.includes(".clobbered."))).toBe(true);
+      });
+    });
+
+    it("falls through to .bak.1 when primary .bak is also schema-invalid", async () => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath, warn } = makeDeps(home);
+
+        // Primary .bak is also invalid; .bak.1 is valid
+        await seedConfig(`${configPath}.bak`, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+        await seedConfig(`${configPath}.bak.1`, { gateway: { mode: "local" } });
+        await seedConfig(configPath, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+
+        const result = maybeRecoverFromSchemaInvalidConfigSync({
+          deps,
+          configPath,
+          validate: validateHasGatewayMode,
+        });
+
+        expect(result).toBe(true);
+        const restoredRaw = await fsp.readFile(configPath, "utf-8");
+        const restoredParsed = JSON.parse(restoredRaw) as Record<string, unknown>;
+        expect((restoredParsed.gateway as { mode?: string } | undefined)?.mode).toBe("local");
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining(".bak.1"));
+      });
+    });
+
+    it("returns false when all backups fail schema validation", async () => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath, warn } = makeDeps(home);
+
+        // All backups are also invalid
+        await seedConfig(`${configPath}.bak`, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+        await seedConfig(configPath, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+
+        const result = maybeRecoverFromSchemaInvalidConfigSync({
+          deps,
+          configPath,
+          validate: validateHasGatewayMode,
+        });
+
+        expect(result).toBe(false);
+        // Config should be unchanged
+        const rawAfter = await fsp.readFile(configPath, "utf-8");
+        expect(JSON.parse(rawAfter)).toEqual({
+          env: { shellEnv: { vars: { HOME: "/bad" } } },
+        });
+        expect(warn).not.toHaveBeenCalled();
+      });
+    });
+
+    it("returns false when no backup files exist", async () => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath, warn } = makeDeps(home);
+
+        await seedConfig(configPath, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+
+        const result = maybeRecoverFromSchemaInvalidConfigSync({
+          deps,
+          configPath,
+          validate: validateHasGatewayMode,
+        });
+
+        expect(result).toBe(false);
+        expect(warn).not.toHaveBeenCalled();
+      });
+    });
+
+    it("tolerates a missing primary config file when scanning backups", async () => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath, warn } = makeDeps(home);
+
+        await fsp.mkdir(path.dirname(configPath), { recursive: true });
+        await seedConfig(`${configPath}.bak`, { gateway: { mode: "local" } });
+        // No primary config file
+
+        const result = maybeRecoverFromSchemaInvalidConfigSync({
+          deps,
+          configPath,
+          validate: validateHasGatewayMode,
+        });
+
+        // Backup is valid but copyFile target doesn't exist; copy should still succeed
+        // (or at minimum return false gracefully without throwing)
+        expect(typeof result).toBe("boolean");
+        if (result) {
+          expect(warn).toHaveBeenCalledWith(expect.stringContaining("schema-invalid"));
+        }
+      });
     });
   });
 });

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import JSON5 from "json5";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { IS_WINDOWS } from "./config.backup-rotation.test-helpers.js";
 import {
   maybeRecoverSuspiciousConfigRead,
   maybeRecoverSuspiciousConfigReadSync,
@@ -268,13 +269,13 @@ describe("config observe recovery", () => {
       });
     });
 
-    it("tolerates a missing primary config file when scanning backups", async () => {
+    it("creates the primary config file when it was missing and a valid backup exists", async () => {
       await withSuiteHome(async (home) => {
         const { deps, configPath, warn } = makeDeps(home);
 
         await fsp.mkdir(path.dirname(configPath), { recursive: true });
         await seedConfig(`${configPath}.bak`, { gateway: { mode: "local" } });
-        // No primary config file
+        // No primary config file — copyFile to a new path should succeed
 
         const result = maybeRecoverFromSchemaInvalidConfigSync({
           deps,
@@ -282,12 +283,119 @@ describe("config observe recovery", () => {
           validate: validateHasGatewayMode,
         });
 
-        // Backup is valid but copyFile target doesn't exist; copy should still succeed
-        // (or at minimum return false gracefully without throwing)
-        expect(typeof result).toBe("boolean");
-        if (result) {
-          expect(warn).toHaveBeenCalledWith(expect.stringContaining("schema-invalid"));
-        }
+        expect(result).toBe(true);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("schema-invalid"));
+        const restoredRaw = await fsp.readFile(configPath, "utf-8");
+        const restoredParsed = JSON.parse(restoredRaw) as Record<string, unknown>;
+        expect((restoredParsed.gateway as { mode?: string } | undefined)?.mode).toBe("local");
+      });
+    });
+
+    it.skipIf(IS_WINDOWS)(
+      "skips a backup candidate that is a symlink (CWE-59 / TOCTOU guard)",
+      async () => {
+        await withSuiteHome(async (home) => {
+          const { deps, configPath, warn } = makeDeps(home);
+
+          await fsp.mkdir(path.dirname(configPath), { recursive: true });
+
+          // Plant a symlink at .bak pointing to an unrelated file
+          const innocentTarget = path.join(path.dirname(configPath), "innocent.txt");
+          await fsp.writeFile(innocentTarget, "should not be read", "utf-8");
+          await fsp.symlink(innocentTarget, `${configPath}.bak`);
+
+          // .bak.1 is a real valid backup
+          await seedConfig(`${configPath}.bak.1`, { gateway: { mode: "local" } });
+          await seedConfig(configPath, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+
+          const result = maybeRecoverFromSchemaInvalidConfigSync({
+            deps,
+            configPath,
+            validate: validateHasGatewayMode,
+          });
+
+          // Should have fallen through to .bak.1, skipping the symlink at .bak
+          expect(result).toBe(true);
+          expect(warn).toHaveBeenCalledWith(expect.stringContaining(".bak.1"));
+          // The symlink target must not have been overwritten
+          await expect(fsp.readFile(innocentTarget, "utf-8")).resolves.toBe("should not be read");
+        });
+      },
+    );
+
+    it.skipIf(IS_WINDOWS)(
+      "aborts recovery when the primary config path is a symlink (CWE-59 / TOCTOU guard)",
+      async () => {
+        await withSuiteHome(async (home) => {
+          const { deps, configPath, warn } = makeDeps(home);
+
+          await fsp.mkdir(path.dirname(configPath), { recursive: true });
+
+          // configPath is a symlink to an unrelated file
+          const sensitiveTarget = path.join(path.dirname(configPath), "sensitive.txt");
+          await fsp.writeFile(sensitiveTarget, "do not overwrite", "utf-8");
+          await fsp.symlink(sensitiveTarget, configPath);
+
+          await seedConfig(`${configPath}.bak`, { gateway: { mode: "local" } });
+
+          const result = maybeRecoverFromSchemaInvalidConfigSync({
+            deps,
+            configPath,
+            validate: validateHasGatewayMode,
+          });
+
+          expect(result).toBe(false);
+          expect(warn).not.toHaveBeenCalled();
+          // The symlink target must be intact
+          await expect(fsp.readFile(sensitiveTarget, "utf-8")).resolves.toBe("do not overwrite");
+        });
+      },
+    );
+
+    it("skips backup candidates that exceed the size limit (CWE-400 guard)", async () => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath, warn } = makeDeps(home);
+
+        // Oversize .bak (exceeds RECOVERY_MAX_BYTES = 10 MB)
+        const oversizeContent = `{"x":"${"a".repeat(11 * 1024 * 1024)}"}`;
+        await fsp.mkdir(path.dirname(configPath), { recursive: true });
+        await fsp.writeFile(`${configPath}.bak`, oversizeContent, "utf-8");
+
+        // .bak.1 is normal and valid
+        await seedConfig(`${configPath}.bak.1`, { gateway: { mode: "local" } });
+        await seedConfig(configPath, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+
+        const result = maybeRecoverFromSchemaInvalidConfigSync({
+          deps,
+          configPath,
+          validate: validateHasGatewayMode,
+        });
+
+        expect(result).toBe(true);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining(".bak.1"));
+      });
+    });
+
+    it("archives the corrupted config exactly once across multiple candidate attempts", async () => {
+      await withSuiteHome(async (home) => {
+        const { deps, configPath } = makeDeps(home);
+
+        // .bak invalid, .bak.1 valid — two loop iterations before success
+        await seedConfig(`${configPath}.bak`, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+        await seedConfig(`${configPath}.bak.1`, { gateway: { mode: "local" } });
+        await seedConfig(configPath, { env: { shellEnv: { vars: { HOME: "/bad" } } } });
+
+        const result = maybeRecoverFromSchemaInvalidConfigSync({
+          deps,
+          configPath,
+          validate: validateHasGatewayMode,
+        });
+
+        expect(result).toBe(true);
+        const dir = path.dirname(configPath);
+        const entries = await fsp.readdir(dir);
+        const clobbered = entries.filter((e) => e.includes(".clobbered."));
+        expect(clobbered).toHaveLength(1);
       });
     });
   });

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import { isRecord } from "../utils.js";
+import { CONFIG_BACKUP_COUNT } from "./backup-rotation.js";
 import {
   appendConfigAuditRecord,
   appendConfigAuditRecordSync,
@@ -681,6 +682,97 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
   });
   writeConfigHealthStateSync(params.deps, healthState);
   return { raw: backupRaw, parsed: backupParsed };
+}
+
+/**
+ * Callback type for schema validation used by the schema-invalid recovery path.
+ * Receives the parsed (but not yet validated) config object and returns true
+ * if it passes schema validation.
+ */
+export type SchemaValidateFn = (parsed: unknown) => boolean;
+
+/**
+ * Attempts to recover from a schema-invalid config file by scanning the backup
+ * rotation ring for the most-recent schema-valid snapshot and restoring it.
+ *
+ * This is the recovery path for the direct-write attack vector: an agent with
+ * `tools.exec` capability can write an invalid config directly to the config
+ * file path, bypassing all validated write paths. The existing
+ * `maybeRecoverSuspiciousConfigReadSync` only handles the `update-channel-only-root`
+ * heuristic and does not detect schema violations; `loadConfig` would then
+ * hard-fail with INVALID_CONFIG and leave OpenClaw permanently bricked.
+ *
+ * Returns `true` if a valid backup was found and restored; `false` otherwise.
+ * The corrupted config file is archived as a `.clobbered.*` snapshot before
+ * being overwritten, so it is available for forensic analysis.
+ */
+export function maybeRecoverFromSchemaInvalidConfigSync(params: {
+  deps: ObserveRecoveryDeps;
+  configPath: string;
+  validate: SchemaValidateFn;
+}): boolean {
+  const { deps, configPath, validate } = params;
+
+  // Archive the corrupted file for forensics before overwriting it.
+  let invalidRaw: string | null = null;
+  try {
+    invalidRaw = deps.fs.readFileSync(configPath, "utf-8");
+  } catch {
+    // If we can't read the invalid file that's fine — proceed to backup scan.
+  }
+
+  // Scan the backup rotation ring: .bak, .bak.1, .bak.2, …, .bak.{N-1}
+  const backupBase = `${configPath}.bak`;
+  const candidatePaths: string[] = [backupBase];
+  for (let i = 1; i < CONFIG_BACKUP_COUNT; i++) {
+    candidatePaths.push(`${backupBase}.${i}`);
+  }
+
+  for (const candidatePath of candidatePaths) {
+    let raw: string;
+    try {
+      raw = deps.fs.readFileSync(candidatePath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = deps.json5.parse(raw);
+    } catch {
+      continue;
+    }
+
+    if (!validate(parsed)) {
+      continue;
+    }
+
+    // Found a schema-valid backup. Archive the corrupted config before restoring.
+    if (invalidRaw !== null) {
+      persistClobberedConfigSnapshotSync({
+        deps,
+        configPath,
+        raw: invalidRaw,
+        observedAt: new Date().toISOString(),
+      });
+    }
+
+    let restored = false;
+    try {
+      deps.fs.copyFileSync(candidatePath, configPath);
+      restored = true;
+    } catch {
+      // Copy failed — we cannot restore, skip to next candidate.
+      continue;
+    }
+
+    deps.logger.warn(
+      `Config schema-invalid; auto-restored from backup: ${configPath} <- ${candidatePath}`,
+    );
+    return restored;
+  }
+
+  return false;
 }
 
 export async function observeConfigSnapshot(

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -54,7 +54,8 @@ export type ObserveRecoveryDeps = {
       options?: { throwIfNoEntry?: boolean },
     ): {
       mode?: number;
-    } | null;
+      size?: number;
+    } | null | undefined;
     readFileSync(path: string, encoding: BufferEncoding): string;
     writeFileSync(
       path: string,
@@ -709,9 +710,15 @@ const RECOVERY_MAX_BYTES = 10 * 1024 * 1024;
 const S_IFMT = 0o170000;
 /** File-type value for a symbolic link. */
 const S_IFLNK = 0o120000;
+/** File-type value for a regular file. */
+const S_IFREG = 0o100000;
 
 function isSymlink(mode: number | undefined): boolean {
   return mode !== undefined && (mode & S_IFMT) === S_IFLNK;
+}
+
+function isRegularFile(mode: number | undefined): boolean {
+  return mode !== undefined && (mode & S_IFMT) === S_IFREG;
 }
 
 /**
@@ -745,8 +752,10 @@ export function maybeRecoverFromSchemaInvalidConfigSync(params: {
   // Safety: refuse to overwrite through a symlink at the primary config path.
   // If configPath is a symlink, copyFileSync would follow it and write to an
   // attacker-controlled target (CWE-59 / TOCTOU). Abort recovery entirely.
+  // Note: lstatSync returns undefined (not null) for missing paths when
+  // throwIfNoEntry is false — normalise with ?? null so the check is reliable.
   try {
-    const configLstat = deps.fs.lstatSync(configPath, { throwIfNoEntry: false });
+    const configLstat = deps.fs.lstatSync(configPath, { throwIfNoEntry: false }) ?? null;
     if (configLstat !== null && isSymlink(configLstat.mode)) {
       return false;
     }
@@ -777,18 +786,29 @@ export function maybeRecoverFromSchemaInvalidConfigSync(params: {
   let invalidArchived = false;
 
   for (const candidatePath of candidatePaths) {
-    // Safety: refuse to read through a symlink in the backup ring.
-    // An attacker could plant a symlink at a .bak path to exfiltrate or poison
-    // data from elsewhere on the filesystem (CWE-59).
+    // Safety: only accept regular files in the backup ring.
+    // Symlinks are a TOCTOU risk (CWE-59); FIFOs/devices can block readFileSync
+    // indefinitely during startup (CWE-400 hang). Normalise with ?? null so that
+    // a missing file (lstat returns undefined) is handled without a TypeError.
+    let candidateSize: number | undefined;
     try {
-      const candidateLstat = deps.fs.lstatSync(candidatePath, { throwIfNoEntry: false });
+      const candidateLstat = deps.fs.lstatSync(candidatePath, { throwIfNoEntry: false }) ?? null;
       if (candidateLstat === null) {
         continue; // file does not exist — try next slot
       }
-      if (isSymlink(candidateLstat.mode)) {
-        continue; // symlink — skip this slot
+      if (!isRegularFile(candidateLstat.mode)) {
+        continue; // symlink, FIFO, device, socket, etc. — skip this slot
       }
+      candidateSize = candidateLstat.size;
     } catch {
+      continue;
+    }
+
+    // Guard against attacker-inflated backup files: check the stat-reported size
+    // before reading so we never load an oversized file into memory (CWE-400).
+    // Fall back to a post-read byte check in case size is not available on the
+    // current platform.
+    if (candidateSize !== undefined && candidateSize > RECOVERY_MAX_BYTES) {
       continue;
     }
 
@@ -799,8 +819,7 @@ export function maybeRecoverFromSchemaInvalidConfigSync(params: {
       continue;
     }
 
-    // Guard against attacker-inflated backup files causing memory/CPU exhaustion
-    // during JSON5 parsing (CWE-400).
+    // Post-read size guard (fallback for platforms where stat size is unavailable).
     if (Buffer.byteLength(raw, "utf-8") > RECOVERY_MAX_BYTES) {
       continue;
     }

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -49,6 +49,12 @@ export type ObserveRecoveryDeps = {
       uid?: number;
       gid?: number;
     } | null;
+    lstatSync(
+      path: string,
+      options?: { throwIfNoEntry?: boolean },
+    ): {
+      mode?: number;
+    } | null;
     readFileSync(path: string, encoding: BufferEncoding): string;
     writeFileSync(
       path: string,
@@ -692,6 +698,23 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
 export type SchemaValidateFn = (parsed: unknown) => boolean;
 
 /**
+ * Maximum byte length accepted when reading a backup candidate during schema
+ * recovery. Files larger than this are skipped rather than parsed. 10 MB is
+ * well above any realistic OpenClaw config file and caps memory/CPU exposure
+ * from attacker-controlled file content (CWE-400).
+ */
+const RECOVERY_MAX_BYTES = 10 * 1024 * 1024;
+
+/** Bitmask for the file-type portion of a POSIX mode word. */
+const S_IFMT = 0o170000;
+/** File-type value for a symbolic link. */
+const S_IFLNK = 0o120000;
+
+function isSymlink(mode: number | undefined): boolean {
+  return mode !== undefined && (mode & S_IFMT) === S_IFLNK;
+}
+
+/**
  * Attempts to recover from a schema-invalid config file by scanning the backup
  * rotation ring for the most-recent schema-valid snapshot and restoring it.
  *
@@ -705,6 +728,12 @@ export type SchemaValidateFn = (parsed: unknown) => boolean;
  * Returns `true` if a valid backup was found and restored; `false` otherwise.
  * The corrupted config file is archived as a `.clobbered.*` snapshot before
  * being overwritten, so it is available for forensic analysis.
+ *
+ * Validation note: backups are validated with `validateConfigObjectRawWithPlugins`
+ * (raw, without applying defaults or include-expansion). This is intentional:
+ * all backups are produced by `writeConfigFile` which already expands includes
+ * before writing, so persisted backups never contain raw `$include` directives.
+ * Using the raw validator avoids re-running include I/O during recovery.
  */
 export function maybeRecoverFromSchemaInvalidConfigSync(params: {
   deps: ObserveRecoveryDeps;
@@ -713,12 +742,27 @@ export function maybeRecoverFromSchemaInvalidConfigSync(params: {
 }): boolean {
   const { deps, configPath, validate } = params;
 
-  // Archive the corrupted file for forensics before overwriting it.
+  // Safety: refuse to overwrite through a symlink at the primary config path.
+  // If configPath is a symlink, copyFileSync would follow it and write to an
+  // attacker-controlled target (CWE-59 / TOCTOU). Abort recovery entirely.
+  try {
+    const configLstat = deps.fs.lstatSync(configPath, { throwIfNoEntry: false });
+    if (configLstat !== null && isSymlink(configLstat.mode)) {
+      return false;
+    }
+  } catch {
+    // lstat unavailable or unexpected error — abort recovery to stay safe.
+    return false;
+  }
+
+  // Read the corrupted file once for the forensic archive. We do this before
+  // the candidate loop so we only archive it once regardless of how many
+  // candidates we try (CWE-400 / duplicate archive fix).
   let invalidRaw: string | null = null;
   try {
     invalidRaw = deps.fs.readFileSync(configPath, "utf-8");
   } catch {
-    // If we can't read the invalid file that's fine — proceed to backup scan.
+    // Primary file unreadable — proceed to backup scan without archiving.
   }
 
   // Scan the backup rotation ring: .bak, .bak.1, .bak.2, …, .bak.{N-1}
@@ -728,11 +772,36 @@ export function maybeRecoverFromSchemaInvalidConfigSync(params: {
     candidatePaths.push(`${backupBase}.${i}`);
   }
 
+  // Track whether the corrupted file has already been archived so we write the
+  // .clobbered snapshot exactly once even if we loop through multiple candidates.
+  let invalidArchived = false;
+
   for (const candidatePath of candidatePaths) {
+    // Safety: refuse to read through a symlink in the backup ring.
+    // An attacker could plant a symlink at a .bak path to exfiltrate or poison
+    // data from elsewhere on the filesystem (CWE-59).
+    try {
+      const candidateLstat = deps.fs.lstatSync(candidatePath, { throwIfNoEntry: false });
+      if (candidateLstat === null) {
+        continue; // file does not exist — try next slot
+      }
+      if (isSymlink(candidateLstat.mode)) {
+        continue; // symlink — skip this slot
+      }
+    } catch {
+      continue;
+    }
+
     let raw: string;
     try {
       raw = deps.fs.readFileSync(candidatePath, "utf-8");
     } catch {
+      continue;
+    }
+
+    // Guard against attacker-inflated backup files causing memory/CPU exhaustion
+    // during JSON5 parsing (CWE-400).
+    if (Buffer.byteLength(raw, "utf-8") > RECOVERY_MAX_BYTES) {
       continue;
     }
 
@@ -747,8 +816,10 @@ export function maybeRecoverFromSchemaInvalidConfigSync(params: {
       continue;
     }
 
-    // Found a schema-valid backup. Archive the corrupted config before restoring.
-    if (invalidRaw !== null) {
+    // Found a schema-valid backup. Archive the corrupted config exactly once
+    // before the first restore attempt.
+    if (invalidRaw !== null && !invalidArchived) {
+      invalidArchived = true;
       persistClobberedConfigSnapshotSync({
         deps,
         configPath,
@@ -757,19 +828,17 @@ export function maybeRecoverFromSchemaInvalidConfigSync(params: {
       });
     }
 
-    let restored = false;
     try {
       deps.fs.copyFileSync(candidatePath, configPath);
-      restored = true;
     } catch {
-      // Copy failed — we cannot restore, skip to next candidate.
+      // Copy failed — skip to next candidate without marking as restored.
       continue;
     }
 
     deps.logger.warn(
       `Config schema-invalid; auto-restored from backup: ${configPath} <- ${candidatePath}`,
     );
-    return restored;
+    return true;
   }
 
   return false;

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1220,7 +1220,19 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           const recovered = maybeRecoverFromSchemaInvalidConfigSync({
             deps,
             configPath,
-            validate: (parsed) => validateConfigObjectRawWithPlugins(parsed, { env: deps.env }).ok,
+            // Mirror loadConfig's pre-validation pipeline: apply runtime legacy
+            // migrations before schema validation so backups containing legacy
+            // alias keys are not falsely rejected during recovery.
+            // Include resolution ($include directives) is intentionally skipped:
+            // writeConfigFile expands includes before persisting, so backups
+            // written through normal paths never contain raw $include refs.
+            validate: (parsed) => {
+              const effective =
+                parsed !== null && typeof parsed === "object"
+                  ? (applyRuntimeLegacyConfigMigrations(parsed).next ?? parsed)
+                  : parsed;
+              return validateConfigObjectRawWithPlugins(effective, { env: deps.env }).ok;
+            },
           });
           if (recovered) {
             return loadConfig(true);

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -48,6 +48,7 @@ import { throwInvalidConfig } from "./io.invalid-config.js";
 import {
   maybeRecoverSuspiciousConfigRead,
   maybeRecoverSuspiciousConfigReadSync,
+  maybeRecoverFromSchemaInvalidConfigSync,
 } from "./io.observe-recovery.js";
 import { persistGeneratedOwnerDisplaySecret } from "./io.owner-display-secret.js";
 import {
@@ -1084,7 +1085,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     return applyConfigOverrides(cfgWithOwnerDisplaySecret);
   }
 
-  function loadConfig(): OpenClawConfig {
+  function loadConfig(isSchemaRecoveryAttempt = false): OpenClawConfig {
     try {
       maybeLoadDotEnvForConfig(deps.env);
       if (!deps.fs.existsSync(configPath)) {
@@ -1206,6 +1207,25 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       const error = err as { code?: string };
       if (error?.code === "INVALID_CONFIG") {
+        // Before failing closed, attempt a one-shot recovery from the backup
+        // rotation ring. This handles the direct-write attack vector where an
+        // agent with `tools.exec` capability writes a schema-invalid config
+        // directly to the config file path, bypassing all validated write
+        // paths. Without this recovery the process would be permanently bricked.
+        //
+        // The guard on isSchemaRecoveryAttempt prevents infinite recursion: if
+        // the restored backup itself fails schema validation we stop immediately
+        // and fail closed as before.
+        if (!isSchemaRecoveryAttempt) {
+          const recovered = maybeRecoverFromSchemaInvalidConfigSync({
+            deps,
+            configPath,
+            validate: (parsed) => validateConfigObjectRawWithPlugins(parsed, { env: deps.env }).ok,
+          });
+          if (recovered) {
+            return loadConfig(true);
+          }
+        }
         // Fail closed so invalid configs cannot silently fall back to permissive defaults.
         throw err;
       }


### PR DESCRIPTION
### Summary

- **Problem**: An agent with `tools.exec` capability can run arbitrary shell or Python commands that write directly to `~/.openclaw/openclaw.json`, bypassing every validated write path (`writeConfigFile`, `config.patch`, `config.apply`, CLI `config set`). Writing a Zod-rejected field such as `env.shellEnv.vars` into the file goes undetected at write time. On the next startup, the inner `loadConfig` in `src/config/io.ts` (line ~1151) calls `validateConfigObjectWithPlugins`, which fails; `throwInvalidConfig` is called at line ~1168 and throws with `code === "INVALID_CONFIG"`; the catch block at line ~1208 detects that code and immediately re-throws with no recovery attempt. The process is permanently unable to start.

- **Root Cause**: Two independent gaps combine to produce the vulnerability:
  1. **Write bypass via `tools.exec`**: Agent exec commands reach the filesystem directly. The Zod front-gate in `writeConfigFile` — where `shellEnv.strict()` correctly rejects `vars` as an unrecognized key — is never invoked for exec-driven writes.
  2. **No backup recovery in the `INVALID_CONFIG` catch branch of `loadConfig`**: `maybeRecoverSuspiciousConfigReadSync` in `src/config/io.observe-recovery.ts` (called before validation) only handles the `update-channel-only-root` heuristic pattern. `resolveConfigObserveSuspiciousReasons` returns an empty slice when no `lastKnownGood` baseline exists (first startup after corruption), so the heuristic never fires for schema violations. The catch block comment reads "Fail closed so invalid configs cannot silently fall back to permissive defaults" — correct as a policy — but there is no one-shot recovery attempt from the existing backup ring before the error is re-thrown.

- **Fix**: Add `maybeRecoverFromSchemaInvalidConfigSync` to `src/config/io.observe-recovery.ts`. In `src/config/io.ts`, call it from the `INVALID_CONFIG` catch branch as a single recovery attempt; on success, retry `loadConfig` with `isSchemaRecoveryAttempt = true` to prevent infinite recursion. This approach was chosen because:
  - It aligns exactly with the existing backup rotation scheme (`backup-rotation.ts`, `.bak` through `.bak.4`) — no new state storage is needed.
  - The validation function is passed in as a `SchemaValidateFn` callback, keeping `io.observe-recovery.ts` free of a reverse dependency on `validation.ts` and avoiding an import cycle.
  - If every backup also fails schema validation, the original `INVALID_CONFIG` error is re-thrown unchanged, preserving fail-closed behavior completely.
  - The corrupted file is archived as `.clobbered.<timestamp>` before being overwritten, maintaining full forensic capability.

- **What changed**:
  - `src/config/io.observe-recovery.ts`: added exported type `SchemaValidateFn`; added exported function `maybeRecoverFromSchemaInvalidConfigSync`; added `CONFIG_BACKUP_COUNT` import from `./backup-rotation.js`
  - `src/config/io.ts`: added `maybeRecoverFromSchemaInvalidConfigSync` to the `./io.observe-recovery.js` import; added optional `isSchemaRecoveryAttempt = false` parameter to the inner `loadConfig` closure; added one-shot backup-recovery block inside the `INVALID_CONFIG` catch branch
  - `src/config/io.observe-recovery.test.ts`: added import for `maybeRecoverFromSchemaInvalidConfigSync`; added `describe("maybeRecoverFromSchemaInvalidConfigSync")` block with 5 test cases

- **What did NOT change (scope boundary)**:
  - `maybeRecoverSuspiciousConfigReadSync` and its `update-channel-only-root` logic are untouched
  - All validated write paths (`writeConfigFile`, `config.patch`, `config.apply`, CLI `config set`) are untouched
  - `tools.exec` capability is not restricted — that requires a separate capability-gate change
  - Zod schema in `src/config/zod-schema.ts` is untouched; `shellEnv.strict()` behavior is unchanged
  - The fail-closed guarantee for `INVALID_CONFIG` when no valid backup exists is fully preserved — no silent fallback to permissive defaults is introduced under any code path

### Reproduction

```bash
# 1. Start OpenClaw with a valid config (gateway.mode=local configured)

# 2. Inside an agent session with tools.exec enabled, corrupt the config:
python3 -c "
import json, os
path = os.path.expanduser('~/.openclaw/openclaw.json')
cfg = json.load(open(path))
cfg['env'] = {'shellEnv': {'vars': {'HOME': '/tmp'}}}
json.dump(cfg, open(path, 'w'), indent=2)
"

# 3. Restart OpenClaw

# Before fix: INVALID_CONFIG thrown on startup — OpenClaw permanently bricked
# After fix:  warn logged, backup auto-restored, startup succeeds
```

### Risk / Mitigation

- **Risk**: The new code path executes only after `loadConfig` has already detected a schema violation — the config is already broken before the new code runs. It cannot be triggered on a healthy config. The `isSchemaRecoveryAttempt` guard ensures at most one recovery attempt per startup, ruling out retry loops or race conditions.

- **Mitigation**: If all five backups also fail schema validation, `maybeRecoverFromSchemaInvalidConfigSync` returns `false` and the original `INVALID_CONFIG` error is re-thrown as-is — fail-closed behavior is identical to the pre-fix state. Five test cases cover: primary `.bak` restored, fallthrough to `.bak.1` when `.bak` is also invalid, all backups invalid (returns false, config unchanged), no backup files present, and missing primary config file at recovery time.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Config load / startup
- [x] Config backup & recovery
- [x] Agent exec attack surface (detection only, no capability change)
- [x] Config observe audit