### PR TITLE
fix(google): strip thinkingBudget=0 for gemini-2.5-pro thinking-required model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Doctor/systemd: keep `openclaw doctor --repair` and service reinstall from re-embedding dotenv-backed secrets in user systemd units, while preserving newer inline overrides over stale state-dir `.env` values. (#66249) Thanks @tmimmanuel.
 - Doctor/plugins: cache external `preferOver` catalog lookups within each plugin auto-enable pass so large `agents.list` configs no longer peg CPU and repeatedly reread plugin catalogs during doctor/plugins resolution. (#66246) Thanks @yfge.
 - Agents/local models: clarify low-context preflight hints for self-hosted models, point config-backed caps at the relevant OpenClaw setting, and stop suggesting larger models when `agents.defaults.contextTokens` is the real limit. (#66236) Thanks @ImLukeF.
+- Agents/Google: strip `thinkingBudget=0` for the thinking-required `gemini-2.5-pro` model in the embedded runner Google sanitizer, so requests no longer fail with "Budget 0 is invalid. This model only works in thinking mode." and the API uses its default thinking behavior instead. Thanks @josmithiii.
 
 ## 2026.4.14-beta.1
 

--- a/src/agents/pi-embedded-runner/google-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/google-stream-wrappers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeGoogleThinkingPayload } from "./google-stream-wrappers.js";
+
+describe("sanitizeGoogleThinkingPayload — gemini-2.5-pro zero budget", () => {
+  it("removes thinkingBudget=0 for gemini-2.5-pro", () => {
+    const payload = {
+      config: {
+        thinkingConfig: { thinkingBudget: 0 },
+      },
+    };
+    sanitizeGoogleThinkingPayload({ payload, modelId: "gemini-2.5-pro" });
+    expect(payload.config.thinkingConfig).not.toHaveProperty("thinkingBudget");
+  });
+
+  it("removes thinkingBudget=0 for gemini-2.5-pro with provider prefix", () => {
+    const payload = {
+      config: {
+        thinkingConfig: { thinkingBudget: 0 },
+      },
+    };
+    sanitizeGoogleThinkingPayload({ payload, modelId: "google/gemini-2.5-pro-preview" });
+    expect(payload.config.thinkingConfig).not.toHaveProperty("thinkingBudget");
+  });
+
+  it("keeps thinkingBudget=0 for gemini-2.5-flash (not thinking-required)", () => {
+    const payload = {
+      config: {
+        thinkingConfig: { thinkingBudget: 0 },
+      },
+    };
+    sanitizeGoogleThinkingPayload({ payload, modelId: "gemini-2.5-flash" });
+    expect(payload.config.thinkingConfig).toHaveProperty("thinkingBudget", 0);
+  });
+
+  it("keeps positive thinkingBudget for gemini-2.5-pro", () => {
+    const payload = {
+      config: {
+        thinkingConfig: { thinkingBudget: 1000 },
+      },
+    };
+    sanitizeGoogleThinkingPayload({ payload, modelId: "gemini-2.5-pro" });
+    expect(payload.config.thinkingConfig).toHaveProperty("thinkingBudget", 1000);
+  });
+});

--- a/src/agents/pi-embedded-runner/google-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/google-stream-wrappers.ts
@@ -13,6 +13,12 @@ function isGemma4Model(modelId: string): boolean {
   return normalizeLowercaseStringOrEmpty(modelId).startsWith("gemma-4");
 }
 
+// Gemini 2.5 Pro only works in thinking mode and rejects thinkingBudget=0 with
+// "Budget 0 is invalid. This model only works in thinking mode."
+function isThinkingRequiredModel(modelId: string): boolean {
+  return normalizeLowercaseStringOrEmpty(modelId).includes("gemini-2.5-pro");
+}
+
 function mapThinkLevelToGoogleThinkingLevel(
   thinkingLevel: ThinkLevel,
 ): "MINIMAL" | "LOW" | "MEDIUM" | "HIGH" | undefined {
@@ -116,6 +122,17 @@ export function sanitizeGoogleThinkingPayload(params: {
   }
 
   const thinkingBudget = thinkingConfigObj.thinkingBudget;
+
+  // Gemini 2.5 Pro rejects thinkingBudget=0; remove it so the API uses its default.
+  if (
+    thinkingBudget === 0 &&
+    typeof params.modelId === "string" &&
+    isThinkingRequiredModel(params.modelId)
+  ) {
+    delete thinkingConfigObj.thinkingBudget;
+    return;
+  }
+
   if (typeof thinkingBudget !== "number" || thinkingBudget >= 0) {
     return;
   }


### PR DESCRIPTION
## Summary

- **Problem:** Embedded-runner Google requests for `gemini-2.5-pro` with `thinkingBudget=0` fail with `Budget 0 is invalid. This model only works in thinking mode.`
- **Why it matters:** Gemini 2.5 Pro is unusable through the embedded runner whenever an upstream caller (or pi-ai) sets a zero budget — the entire turn errors out.
- **What changed:** `sanitizeGoogleThinkingPayload` now also strips `thinkingBudget=0` when the model id matches the thinking-required `gemini-2.5-pro` family, so the API uses its default thinking behavior.
- **What did NOT change:** Gemma 4 handling, Gemini 3.1 negative-budget handling, non-thinking-required models (e.g. `gemini-2.5-flash`) where `thinkingBudget=0` is still preserved.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: The sanitizer only deleted `thinkingBudget` when the value was negative. `gemini-2.5-pro` is thinking-required and rejects `thinkingBudget=0` outright, so a zero value passed through unmodified and the request was rejected by the Google API.
- Missing detection / guardrail: No unit coverage for the model-specific zero-budget case in `google-stream-wrappers.ts`.
- Contributing context: Some upstream callers normalize "no thinking" to `thinkingBudget=0` regardless of model; that is fine for `gemini-2.5-flash` but not for `gemini-2.5-pro`.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/pi-embedded-runner/google-stream-wrappers.test.ts` (new)
- Scenario the test should lock in: thinkingBudget=0 is removed for gemini-2.5-pro (and provider-prefixed variants), preserved for gemini-2.5-flash, and positive budgets for gemini-2.5-pro are left alone.
- Why this is the smallest reliable guardrail: The sanitizer is a pure function over a payload object; a unit test exercises the exact branch that was missing without needing the streaming runner.
- Existing test that already covers this: None.