### PR TITLE
fix(browser): close SSRF browser follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Doctor/systemd: keep `openclaw doctor --repair` and service reinstall from re-embedding dotenv-backed secrets in user systemd units, while preserving newer inline overrides over stale state-dir `.env` values. (#66249) Thanks @tmimmanuel.
 - Doctor/plugins: cache external `preferOver` catalog lookups within each plugin auto-enable pass so large `agents.list` configs no longer peg CPU and repeatedly reread plugin catalogs during doctor/plugins resolution. (#66246) Thanks @yfge.
 - Agents/local models: clarify low-context preflight hints for self-hosted models, point config-backed caps at the relevant OpenClaw setting, and stop suggesting larger models when `agents.defaults.contextTokens` is the real limit. (#66236) Thanks @ImLukeF.
+- Browser/SSRF: restore hostname navigation under the default browser SSRF policy while keeping explicit strict mode reachable from config, and keep managed loopback CDP `/json/new` fallback requests on the local CDP control policy so browser follow-up fixes stop regressing normal navigation or self-blocking local CDP control. (#66386) Thanks @obviyus.
 
 ## 2026.4.14-beta.1
 

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -318,7 +318,7 @@ describe("browser config", () => {
         dangerouslyAllowPrivateNetwork: false,
       },
     });
-    expect(resolved.ssrfPolicy).toEqual({});
+    expect(resolved.ssrfPolicy).toEqual({ dangerouslyAllowPrivateNetwork: false });
   });
 
   it("keeps allowlist-only browser SSRF policy strict by default", () => {

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -149,7 +149,9 @@ function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | 
   }
 
   return {
-    ...(resolvedAllowPrivateNetwork ? { dangerouslyAllowPrivateNetwork: true } : {}),
+    ...(resolvedAllowPrivateNetwork || dangerouslyAllowPrivateNetwork === false
+      ? { dangerouslyAllowPrivateNetwork: resolvedAllowPrivateNetwork }
+      : {}),
     ...(allowedHostnames ? { allowedHostnames } : {}),
     ...(hostnameAllowlist ? { hostnameAllowlist } : {}),
   };

--- a/extensions/browser/src/browser/navigation-guard.test.ts
+++ b/extensions/browser/src/browser/navigation-guard.test.ts
@@ -128,6 +128,18 @@ describe("browser navigation guard", () => {
     expect(lookupFn).not.toHaveBeenCalled();
   });
 
+  it("allows hostname navigation when the default strict policy object is present", async () => {
+    const lookupFn = createLookupFn("93.184.216.34");
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "https://example.com",
+        lookupFn,
+        ssrfPolicy: {},
+      }),
+    ).resolves.toBeUndefined();
+    expect(lookupFn).toHaveBeenCalledWith("example.com", { all: true });
+  });
+
   it("allows explicitly allowed hostnames in strict mode", async () => {
     const lookupFn = createLookupFn("93.184.216.34");
     await expect(
@@ -300,8 +312,11 @@ describe("browser navigation guard", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("treats default browser SSRF mode as requiring redirect-hop inspection", () => {
-    expect(requiresInspectableBrowserNavigationRedirects()).toBe(true);
+  it("requires redirect-hop inspection only in explicit strict mode", () => {
+    expect(requiresInspectableBrowserNavigationRedirects()).toBe(false);
+    expect(
+      requiresInspectableBrowserNavigationRedirects({ dangerouslyAllowPrivateNetwork: false }),
+    ).toBe(true);
     expect(requiresInspectableBrowserNavigationRedirects({ allowPrivateNetwork: true })).toBe(
       false,
     );

--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -43,7 +43,7 @@ export function withBrowserNavigationPolicy(
 }
 
 export function requiresInspectableBrowserNavigationRedirects(ssrfPolicy?: SsrFPolicy): boolean {
-  return !isPrivateNetworkAllowedByPolicy(ssrfPolicy);
+  return ssrfPolicy?.dangerouslyAllowPrivateNetwork === false;
 }
 
 export function requiresInspectableBrowserNavigationRedirectsForUrl(
@@ -122,6 +122,7 @@ export async function assertBrowserNavigationAllowed(
   // the same address that passed policy checks.
   if (
     opts.ssrfPolicy &&
+    opts.ssrfPolicy.dangerouslyAllowPrivateNetwork === false &&
     !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy) &&
     !isIpLiteralHostname(parsed.hostname) &&
     !isExplicitlyAllowedBrowserHostname(parsed.hostname, opts.ssrfPolicy)

--- a/extensions/browser/src/browser/routes/tabs.attach-only.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.attach-only.test.ts
@@ -42,7 +42,7 @@ describe("browser tab routes attachOnly loopback profiles", () => {
           {
             id: "PAGE-1",
             title: "WordPress",
-            url: "https://example.test/wp-login.php",
+            url: "https://example.com/wp-login.php",
             webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/PAGE-1",
             type: "page",
           },
@@ -73,7 +73,7 @@ describe("browser tab routes attachOnly loopback profiles", () => {
         {
           targetId: "PAGE-1",
           title: "WordPress",
-          url: "",
+          url: "https://example.com/wp-login.php",
           wsUrl: "ws://127.0.0.1:9222/devtools/page/PAGE-1",
           type: "page",
         },

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts
@@ -80,7 +80,7 @@ describe("browser remote profile fallback and attachOnly behavior", () => {
   it("fails closed for remote tab opens in strict mode without Playwright", async () => {
     vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue(null);
     const { state, remote, fetchMock } = deps.createRemoteRouteHarness();
-    state.resolved.ssrfPolicy = {};
+    state.resolved.ssrfPolicy = { dangerouslyAllowPrivateNetwork: false };
 
     await expect(remote.openTab("https://example.com")).rejects.toBeInstanceOf(
       deps.InvalidBrowserNavigationUrlError,

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -230,14 +230,14 @@ export function createProfileTabOps({
       {
         method: "PUT",
       },
-      ssrfPolicyOpts.ssrfPolicy,
+      getCdpControlPolicy(),
     ).catch(async (err) => {
       if (String(err).includes("HTTP 405")) {
         return await fetchJson<CdpTarget>(
           endpoint,
           CDP_JSON_NEW_TIMEOUT_MS,
           undefined,
-          ssrfPolicyOpts.ssrfPolicy,
+          getCdpControlPolicy(),
         );
       }
       throw err;

--- a/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
+++ b/extensions/browser/src/browser/server-context.tab-selection-state.test.ts
@@ -6,6 +6,7 @@ vi.hoisted(() => {
 });
 
 import "./server-context.chrome-test-harness.js";
+import * as cdpHelpersModule from "./cdp.helpers.js";
 import * as cdpModule from "./cdp.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import { createBrowserRouteContext } from "./server-context.js";
@@ -295,5 +296,39 @@ describe("browser server-context tab selection state", () => {
       InvalidBrowserNavigationUrlError,
     );
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the loopback CDP control policy for /json/new fallback requests", async () => {
+    vi.spyOn(cdpModule, "createTargetViaCdp").mockRejectedValue(new Error("cdp unavailable"));
+    const fetchJson = vi.spyOn(cdpHelpersModule, "fetchJson");
+    fetchJson.mockRejectedValueOnce(new Error("HTTP 405")).mockResolvedValueOnce({
+      id: "NEW",
+      title: "New Tab",
+      url: "https://example.com",
+      webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/NEW",
+      type: "page",
+    });
+
+    const state = makeState("openclaw");
+    state.resolved.ssrfPolicy = {};
+    const ctx = createBrowserRouteContext({ getState: () => state });
+    const openclaw = ctx.forProfile("openclaw");
+
+    const opened = await openclaw.openTab("https://example.com");
+    expect(opened.targetId).toBe("NEW");
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/json/new"),
+      expect.any(Number),
+      { method: "PUT" },
+      undefined,
+    );
+    expect(fetchJson).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/json/new"),
+      expect.any(Number),
+      undefined,
+      undefined,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- allow hostname navigation under the default browser SSRF policy object
- keep strict hostname blocking and redirect-hop inspection for explicit strict mode only
- use the loopback CDP control policy for the `/json/new` fallback path

Fixes #66074
Fixes #66170
Fixes #66065

## Testing
- `pnpm test extensions/browser/src/browser/config.test.ts extensions/browser/src/browser/navigation-guard.test.ts extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts extensions/browser/src/browser/routes/tabs.attach-only.test.ts extensions/browser/src/browser/server-context.tab-selection-state.test.ts extensions/browser/src/browser/server-context.remote-profile-tab-ops.fallback.test.ts`