### PR TITLE
fix(qqbot): null guard in parseFaceTags — fixes cron agentTurn crash

### DIFF
--- a/extensions/qqbot/src/gateway.ts
+++ b/extensions/qqbot/src/gateway.ts
@@ -596,7 +596,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
         const voiceText = formatVoiceText(voiceTranscripts);
         const hasAsrReferFallback = voiceTranscriptSources.includes("asr");
 
-        const parsedContent = parseFaceTags(event.content);
+        const parsedContent = parseFaceTags(event.content ?? "");
         const userContent = voiceText
           ? (parsedContent.trim() ? `${parsedContent}\n${voiceText}` : voiceText) + attachmentInfo
           : parsedContent + attachmentInfo;

--- a/extensions/qqbot/src/utils/text-parsing.test.ts
+++ b/extensions/qqbot/src/utils/text-parsing.test.ts
@@ -14,4 +14,23 @@ describe("parseFaceTags", () => {
       bufferFromSpy.mockRestore();
     }
   });
+
+  it("returns empty string when input is undefined (null guard)", () => {
+    // @ts-ignore — intentionally passing undefined at runtime to test boundary
+    expect(parseFaceTags(undefined)).toBe("");
+  });
+
+  it("returns empty string when input is null", () => {
+    // @ts-ignore — intentionally passing null at runtime to test boundary
+    expect(parseFaceTags(null)).toBe("");
+  });
+
+  it("returns empty string when input is empty string", () => {
+    expect(parseFaceTags("")).toBe("");
+  });
+
+  it("still parses normal face tags correctly", () => {
+    const tag = `<faceType=1,faceId="1",ext="${Buffer.from(JSON.stringify({text:"Smile"})).toString("base64")}">`;
+    expect(parseFaceTags(tag)).toBe("[Emoji: Smile]");
+  });
 });

--- a/extensions/qqbot/src/utils/text-parsing.ts
+++ b/extensions/qqbot/src/utils/text-parsing.ts
@@ -7,7 +7,7 @@ const MAX_FACE_EXT_BYTES = 64 * 1024;
 /** Replace QQ face tags with readable text labels. */
 export function parseFaceTags(text: string): string {
   if (!text) {
-    return text;
+    return "";
   }
 
   return text.replace(/<faceType=\d+,faceId="[^"]*",ext="([^"]*)">/g, (_match, ext: string) => {
@@ -28,7 +28,7 @@ export function parseFaceTags(text: string): string {
 /** Remove internal framework markers before sending text outward. */
 export function filterInternalMarkers(text: string): string {
   if (!text) {
-    return text;
+    return "";
   }
 
   let result = text.replace(/\[\[[a-z_]+:\s*[^\]]*\]\]/gi, "");


### PR DESCRIPTION
## Fix: cron agentTurn crash (fixes #66283)

**Root cause confirmed by @johnturek**

Two-line fix:

1. `extensions/qqbot/src/utils/text-parsing.ts` — return "" instead of undefined when input is falsy:
   \`ts
   if (!text) {
     return "";
   }
   \`

2. `extensions/qqbot/src/gateway.ts:599` — null guard on event.content:
   \`ts
   const parsedContent = parseFaceTags(event.content ?? "");
   \`

This prevents userContent from becoming undefined, which was causing userContent.startsWith("/") to throw TypeError in ~6ms on every cron-triggered agentTurn job.

**Testing**: The fix makes both parseFaceTags(undefined) and parseFaceTags("") return "", which is safe for all downstream string operations.

Closes #66283
Fixes #66283
Resolves #66283

cc @johnturek @openclaw/maintainers