### PR TITLE
fix(exec-approvals): honor OPENCLAW_STATE_DIR for default host paths

### DIFF
--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -169,7 +169,7 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
   if (cfg.approvals?.exec?.enabled === false) {
     warnings.push(
       "- Note: approvals.exec.enabled=false disables approval forwarding only.",
-      "  Host exec gating still comes from ~/.openclaw/exec-approvals.json.",
+      "  Host exec gating still comes from exec-approvals.json in the active OPENCLAW_STATE_DIR.",
       `  Check local policy with: ${formatCliCommand("openclaw approvals get --gateway")}`,
     );
   }

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -28,6 +28,7 @@ let resolveExecApprovalsSocketPath: ExecApprovalsModule["resolveExecApprovalsSoc
 
 const tempDirs: string[] = [];
 const originalOpenClawHome = process.env.OPENCLAW_HOME;
+const originalOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
 
 beforeAll(async () => {
   ({
@@ -57,6 +58,11 @@ afterEach(() => {
   } else {
     process.env.OPENCLAW_HOME = originalOpenClawHome;
   }
+  if (originalOpenClawStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = originalOpenClawStateDir;
+  }
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -73,6 +79,13 @@ function approvalsFilePath(homeDir: string): string {
   return path.join(homeDir, ".openclaw", "exec-approvals.json");
 }
 
+function createStateDir(): string {
+  const dir = makeTempDir();
+  tempDirs.push(dir);
+  process.env.OPENCLAW_STATE_DIR = dir;
+  return dir;
+}
+
 function readApprovalsFile(homeDir: string): ExecApprovalsFile {
   return JSON.parse(fs.readFileSync(approvalsFilePath(homeDir), "utf8")) as ExecApprovalsFile;
 }
@@ -86,6 +99,17 @@ describe("exec approvals store helpers", () => {
     );
     expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
       path.normalize(path.join(dir, ".openclaw", "exec-approvals.sock")),
+    );
+  });
+
+  it("prefers OPENCLAW_STATE_DIR for file and socket paths", () => {
+    const dir = createStateDir();
+
+    expect(path.normalize(resolveExecApprovalsPath())).toBe(
+      path.normalize(path.join(dir, "exec-approvals.json")),
+    );
+    expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
+      path.normalize(path.join(dir, "exec-approvals.sock")),
     );
   });
 

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -170,8 +171,8 @@ const DEFAULT_SECURITY: ExecSecurity = "full";
 const DEFAULT_ASK: ExecAsk = "off";
 export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+const EXEC_APPROVALS_SOCKET_BASENAME = "exec-approvals.sock";
+const EXEC_APPROVALS_FILE_BASENAME = "exec-approvals.json";
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -181,11 +182,11 @@ function hashExecApprovalsRaw(raw: string | null): string {
 }
 
 export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+  return path.join(resolveStateDir(), EXEC_APPROVALS_FILE_BASENAME);
 }
 
 export function resolveExecApprovalsSocketPath(): string {
-  return expandHomePrefix(DEFAULT_SOCKET);
+  return path.join(resolveStateDir(), EXEC_APPROVALS_SOCKET_BASENAME);
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {


### PR DESCRIPTION
  ## Summary

  `exec-approvals` still resolved its default file and socket paths from `~/.openclaw`, even when
  runtime state was redirected via `OPENCLAW_STATE_DIR`.

  This caused exec approval state to drift from the rest of the state-dir-based runtime layout.
  This PR switches the default exec-approvals paths to the shared state-dir resolver and updates
  related coverage and messaging.

  ## Changes

  - resolve default exec-approvals file/socket paths from `resolveStateDir()`
  - add test coverage for `OPENCLAW_STATE_DIR` path resolution
  - update `doctor-security` wording to match the actual host-path behavior

  ## Why

  OpenClaw already has a shared state-dir abstraction. Keeping `exec-approvals` on a hardcoded
  `~/.openclaw` path makes redirected state layouts incomplete and inconsistent with the rest of
  the runtime.

  ## Validation

  - `pnpm vitest src/infra/exec-approvals-store.test.ts src/commands/doctor-security.test.ts`