### PR TITLE
fix(qqbot): guard parseFaceTags against undefined event.content

### DIFF
--- a/extensions/qqbot/src/utils/text-parsing.ts
+++ b/extensions/qqbot/src/utils/text-parsing.ts
@@ -5,9 +5,9 @@ import type { RefAttachmentSummary } from "../ref-index-store.js";
 const MAX_FACE_EXT_BYTES = 64 * 1024;
 
 /** Replace QQ face tags with readable text labels. */
-export function parseFaceTags(text: string): string {
+export function parseFaceTags(text: string | undefined): string {
   if (!text) {
-    return text;
+    return text ?? "";
   }
 
   return text.replace(/<faceType=\d+,faceId="[^"]*",ext="([^"]*)">/g, (_match, ext: string) => {


### PR DESCRIPTION
## Bug: cron agentTurn payload crashes with startsWith error

**Issue**: [#66283](https://github.com/openclaw/openclaw/issues/66283)

**Root Cause**: When a cron job with payload.kind=agentTurn fires, the qqbot gateway event handler calls parseFaceTags(event.content) where event.content is undefined. This causes:
1. parseFaceTags(undefined) crashes on .replace() call
2. Later userContent.startsWith("/") crashes on undefined

**Fix**: Accept string | undefined in parseFaceTags, return "" when input is null/undefined. Backwards compatible with existing calls.

**Testing**: pnpm test -- extensions/qqbot/src/utils/text-parsing.test.ts passed

**Files**: extensions/qqbot/src/utils/text-parsing.ts (2 lines)