### PR TITLE
fix(dreaming): default storage.mode to "separate" so phase blocks stop polluting daily memory files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Docs: https://docs.openclaw.ai
 - Agents/context + Memory: trim default startup/skills prompt budgets, cap `memory_get` excerpts by default with explicit continuation metadata, and keep QMD reads aligned with the same bounded excerpt contract so long sessions pull less context by default without losing deterministic follow-up reads.
 - Matrix/commands: skip DM pairing-store reads on room traffic now that room control-command authorization ignores pairing-store entries, keeping the room path narrower without changing room auth behavior. (#67325) Thanks @gumadeiras.
 - Memory-core/dreaming: skip dreaming narrative transcripts from session-store metadata before bootstrap records land so dream diary prompt/prose lines do not pollute session ingestion. (#67315) thanks @jalehman.
+- Agents/local models: clarify low-context preflight hints for self-hosted models, point config-backed caps at the relevant OpenClaw setting, and stop suggesting larger models when `agents.defaults.contextTokens` is the real limit. (#66236) Thanks @ImLukeF.
+- Dreaming/memory-core: change the default `dreaming.storage.mode` from `inline` to `separate` so Dreaming phase blocks (`## Light Sleep`, `## REM Sleep`) land in `memory/dreaming/{phase}/YYYY-MM-DD.md` instead of being injected into `memory/YYYY-MM-DD.md`. Daily memory files no longer get dominated by structured candidate output, and the daily-ingestion scanner that already strips dream marker blocks no longer has to compete with hundreds of phase-block lines on every run. Operators who want the previous behavior can opt in by setting `plugins.entries.memory-core.config.dreaming.storage.mode: "inline"`. (#66412) Thanks @mjamiv.
 
 ## 2026.4.15-beta.1
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -27,6 +27,11 @@ const LIGHT_DREAMING_TEST_CONFIG: OpenClawConfig = {
           dreaming: {
             enabled: true,
             timezone: "UTC",
+            // The existing tests in this file were written when "inline" was the
+            // default storage mode and assert against `memory/<day>.md` directly.
+            // Pin the storage mode explicitly so they keep covering inline mode
+            // after the default flipped to "separate" in #66328.
+            storage: { mode: "inline", separateReports: false },
             phases: {
               light: {
                 enabled: true,
@@ -305,6 +310,10 @@ describe("memory-core dreaming phases", () => {
               config: {
                 dreaming: {
                   enabled: true,
+                  // This test asserts inline-mode side effects on the daily
+                  // file; pin storage explicitly after the default flipped to
+                  // "separate" in #66328.
+                  storage: { mode: "inline", separateReports: false },
                   phases: {
                     light: {
                       enabled: true,

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -184,7 +184,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 30,
       verboseLogging: false,
       storage: {
-        mode: "inline",
+        mode: "separate",
         separateReports: false,
       },
     });
@@ -223,7 +223,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 30,
       verboseLogging: true,
       storage: {
-        mode: "inline",
+        mode: "separate",
         separateReports: false,
       },
     });
@@ -259,7 +259,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 45,
       verboseLogging: false,
       storage: {
-        mode: "inline",
+        mode: "separate",
         separateReports: false,
       },
     });
@@ -294,7 +294,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 30,
       verboseLogging: false,
       storage: {
-        mode: "inline",
+        mode: "separate",
         separateReports: false,
       },
     });

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -615,7 +615,7 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
         bodyLines: reportLines,
         nowMs: sweepNowMs,
         timezone: params.config.timezone,
-        storage: params.config.storage ?? { mode: "inline", separateReports: false },
+        storage: params.config.storage ?? { mode: "separate", separateReports: false },
       });
       // Generate dream diary narrative from promoted memories.
       if (params.subagent && (candidates.length > 0 || applied.applied > 0)) {

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -90,6 +90,31 @@ describe("memory dreaming host helpers", () => {
     });
   });
 
+  it("defaults storage mode to separate so phase blocks do not pollute daily memory files", () => {
+    const resolved = resolveMemoryDreamingConfig({
+      pluginConfig: {},
+    });
+
+    expect(resolved.storage).toEqual({
+      mode: "separate",
+      separateReports: false,
+    });
+  });
+
+  it("preserves explicit inline storage mode for callers that opt in", () => {
+    const resolved = resolveMemoryDreamingConfig({
+      pluginConfig: {
+        dreaming: {
+          storage: {
+            mode: "inline",
+          },
+        },
+      },
+    });
+
+    expect(resolved.storage.mode).toBe("inline");
+  });
+
   it("applies top-level dreaming frequency across all phases", () => {
     const resolved = resolveMemoryDreamingConfig({
       pluginConfig: {

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -12,7 +12,7 @@ import {
 export const DEFAULT_MEMORY_DREAMING_ENABLED = false;
 export const DEFAULT_MEMORY_DREAMING_TIMEZONE = undefined;
 export const DEFAULT_MEMORY_DREAMING_VERBOSE_LOGGING = false;
-export const DEFAULT_MEMORY_DREAMING_STORAGE_MODE = "inline";
+export const DEFAULT_MEMORY_DREAMING_STORAGE_MODE = "separate";
 export const DEFAULT_MEMORY_DREAMING_SEPARATE_REPORTS = false;
 export const DEFAULT_MEMORY_DREAMING_FREQUENCY = "0 3 * * *";
 export const DEFAULT_MEMORY_DREAMING_PLUGIN_ID = "memory-core";


### PR DESCRIPTION
## Summary

Closes #66328.

The dreaming pipeline writes Light Sleep and REM Sleep phase blocks to the location selected by `dreaming.storage.mode`. The mode was already wired up to support `"inline" | "separate" | "both"` in `writeDailyDreamingPhaseBlock`, but the unset-default fallback in `src/memory-host-sdk/dreaming.ts` was hardcoded to `"inline"`. As a result, every installation that didn't explicitly set `plugins.entries.memory-core.config.dreaming.storage.mode` silently got dream phase blocks injected straight into `memory/YYYY-MM-DD.md`.

This PR flips the unset-default to `"separate"`. Phase blocks now land in `memory/dreaming/{phase}/YYYY-MM-DD.md` by default, leaving the daily memory file alone.

## Why this matters (#66328)

The reporter measured 340 lines of Light Sleep narrative being injected into a single daily file. A second host on a v2026.4.12 install observed 475 inline lines from the Light phase plus 14 from REM in a single sweep, leaving the daily file unusable as a "what happened today" record - the same dreaming output that gets dumped into `DREAMS.md` (working correctly) was also being dumped inline.

The reporter also surfaced the symptom side: when an agent reads `memory/YYYY-MM-DD.md` to answer "what did I do yesterday?" it ends up reading hundreds of lines of dreaming narrative instead of actual event records.

`stripManagedDailyDreamingLines` already protects the daily-ingestion scanner from re-ingesting dream marker blocks as recall candidates, so the recall side is unaffected by either mode. Flipping the default just stops the daily file from being written to in the first place.

## Backward compatibility

Operators who actually want inline behavior can opt in explicitly:

```jsonc
"plugins": {
  "entries": {
    "memory-core": {
      "config": {
        "dreaming": {
          "storage": { "mode": "inline" }
        }
      }
    }
  }
}
```

`normalizeStorageMode` continues to accept all three documented modes (`inline | separate | both`); only the unset-default fallback changes. The `MemoryDreamingStorageMode` type is unchanged.

## Test changes

- **`src/memory-host-sdk/dreaming.test.ts`** adds two new assertions: one pinning the new default shape, and one confirming explicit `"inline"` still round-trips for opt-in callers.
- **`extensions/memory-core/src/dreaming.test.ts`** updates four default-output assertions in `resolveShortTermPromotionDreamingConfig` from `mode: "inline"` to `mode: "separate"`.
- **`extensions/memory-core/src/dreaming-phases.test.ts`** pins `LIGHT_DREAMING_TEST_CONFIG` and the inline-mode harness in *checkpoints daily ingestion and skips unchanged daily files* to `storage.mode: "inline"` with an inline comment, since those tests rely on inline-mode side effects on `memory/<day>.md` and now need to opt in explicitly. The substantive coverage they provide is unchanged.

The schema accept-test in `extensions/memory-core/src/config.test.ts` and the inline-mode write-path tests in `extensions/memory-core/src/dreaming-markdown.test.ts` intentionally keep asserting `mode: "inline"` because they cover input handling and the inline write path itself, both of which still need to work.

## Validation

- Targeted suite (the 9 test files touching this code): 125/125 pass
  - `pnpm vitest run extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/dreaming-markdown.test.ts extensions/memory-core/src/dreaming-narrative.test.ts extensions/memory-core/src/dreaming-command.test.ts extensions/memory-core/src/dreaming-repair.test.ts extensions/memory-core/src/memory-events.test.ts extensions/memory-core/src/config.test.ts src/memory-host-sdk/dreaming.test.ts`
- Pre-commit checks (`pnpm check`): madge import cycles, tsgo, oxlint, host-env-policy:swift, webhook auth body order, pairing-store-group, pairing-account-scope - all clean.