### PR TITLE
fix(agents): honor embedded ollama timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Ollama: forward the configured embedded-run timeout into the global undici stream timeout tuning so slow local Ollama runs no longer inherit the default stream cutoff instead of the operator-set run timeout. (#63175) Thanks @mindcraftreader and @vincentkoc.
 - Models/Codex: include `apiKey` in the codex provider catalog output so the Pi ModelRegistry validator no longer rejects the entry and silently drops all custom models from every provider in `models.json`. (#66180) Thanks @hoyyeva.
 - Slack/interactions: apply the configured global `allowFrom` owner allowlist to channel block-action and modal interactive events, require an expected sender id for cross-verification, and reject ambiguous channel types so interactive triggers can no longer bypass the documented allowlist intent in channels without a `users` list. Open-by-default behavior is preserved when no allowlists are configured. (#66028) Thanks @eleqtrizit.
 - Media-understanding/attachments: fail closed when a local attachment path cannot be canonically resolved via `realpath`, so a `realpath` error can no longer downgrade the canonical-roots allowlist check to a non-canonical comparison; attachments that also have a URL still fall back to the network fetch path. (#66022) Thanks @eleqtrizit.

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -47,6 +47,8 @@ type AttemptSpawnWorkspaceHoisted = {
   createAgentSessionMock: UnknownMock;
   sessionManagerOpenMock: UnknownMock;
   resolveSandboxContextMock: UnknownMock;
+  ensureGlobalUndiciEnvProxyDispatcherMock: UnknownMock;
+  ensureGlobalUndiciStreamTimeoutsMock: UnknownMock;
   buildEmbeddedMessageActionDiscoveryInputMock: UnknownMock;
   subscribeEmbeddedPiSessionMock: Mock<SubscribeEmbeddedPiSessionFn>;
   acquireSessionWriteLockMock: Mock<AcquireSessionWriteLockFn>;
@@ -71,6 +73,8 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const createAgentSessionMock = vi.fn();
   const sessionManagerOpenMock = vi.fn();
   const resolveSandboxContextMock = vi.fn();
+  const ensureGlobalUndiciEnvProxyDispatcherMock = vi.fn();
+  const ensureGlobalUndiciStreamTimeoutsMock = vi.fn();
   const buildEmbeddedMessageActionDiscoveryInputMock = vi.fn((params: unknown) => params);
   const installToolResultContextGuardMock = vi.fn(() => () => {});
   const flushPendingToolResultsAfterIdleMock = vi.fn(async () => {});
@@ -135,6 +139,8 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     createAgentSessionMock,
     sessionManagerOpenMock,
     resolveSandboxContextMock,
+    ensureGlobalUndiciEnvProxyDispatcherMock,
+    ensureGlobalUndiciStreamTimeoutsMock,
     buildEmbeddedMessageActionDiscoveryInputMock,
     subscribeEmbeddedPiSessionMock,
     acquireSessionWriteLockMock,
@@ -209,8 +215,10 @@ vi.mock("../../../infra/machine-name.js", () => ({
 }));
 
 vi.mock("../../../infra/net/undici-global-dispatcher.js", () => ({
-  ensureGlobalUndiciEnvProxyDispatcher: () => {},
-  ensureGlobalUndiciStreamTimeouts: () => {},
+  ensureGlobalUndiciEnvProxyDispatcher: (...args: unknown[]) =>
+    hoisted.ensureGlobalUndiciEnvProxyDispatcherMock(...args),
+  ensureGlobalUndiciStreamTimeouts: (...args: unknown[]) =>
+    hoisted.ensureGlobalUndiciStreamTimeoutsMock(...args),
 }));
 
 vi.mock("../../bootstrap-files.js", async () => {
@@ -683,6 +691,8 @@ export function resetEmbeddedAttemptHarness(
   hoisted.createAgentSessionMock.mockReset();
   hoisted.sessionManagerOpenMock.mockReset().mockReturnValue(hoisted.sessionManager);
   hoisted.resolveSandboxContextMock.mockReset();
+  hoisted.ensureGlobalUndiciEnvProxyDispatcherMock.mockReset();
+  hoisted.ensureGlobalUndiciStreamTimeoutsMock.mockReset();
   hoisted.buildEmbeddedMessageActionDiscoveryInputMock
     .mockReset()
     .mockImplementation((params) => params);

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.timeout.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  getHoisted,
+  resetEmbeddedAttemptHarness,
+} from "./attempt.spawn-workspace.test-support.js";
+
+const hoisted = getHoisted();
+
+describe("runEmbeddedAttempt undici timeout wiring", () => {
+  const tempPaths: string[] = [];
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness();
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+  });
+
+  it("forwards the configured run timeout into global undici stream tuning", async () => {
+    await createContextEngineAttemptRunner({
+      sessionKey: "agent:main:ollama-timeout-test",
+      tempPaths,
+      contextEngine: {
+        assemble: async ({ messages }) => ({
+          messages,
+          estimatedTokens: 1,
+        }),
+      },
+      attemptOverrides: {
+        timeoutMs: 123_456,
+      },
+    });
+
+    expect(hoisted.ensureGlobalUndiciEnvProxyDispatcherMock).toHaveBeenCalledOnce();
+    expect(hoisted.ensureGlobalUndiciStreamTimeoutsMock).toHaveBeenCalledWith({
+      timeoutMs: 123_456,
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -361,7 +361,7 @@ export async function runEmbeddedAttempt(
   // Proxy bootstrap must happen before timeout tuning so the timeouts wrap the
   // active EnvHttpProxyAgent instead of being replaced by a bare proxy dispatcher.
   ensureGlobalUndiciEnvProxyDispatcher();
-  ensureGlobalUndiciStreamTimeouts();
+  ensureGlobalUndiciStreamTimeouts({ timeoutMs: params.timeoutMs });
 
   log.debug(
     `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,


### PR DESCRIPTION
## Summary

- Problem: embedded Pi runs still initialized global undici stream timeouts with the default 30-minute value instead of the configured run timeout.
- Why it matters: slow local Ollama requests could still hit the wrong lower-level stream behavior even when operators set a larger `agents.defaults.timeoutSeconds`.
- What changed: `runEmbeddedAttempt()` now forwards `params.timeoutMs` into `ensureGlobalUndiciStreamTimeouts()`, and a focused harness test locks that wiring in.
- What did NOT change (scope boundary): this does not broaden into unrelated Ollama timeout behavior outside the embedded runner path, so #66237 stays separate for now.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63175
- Related #66237
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/agents/pi-embedded-runner/run/attempt.ts` called `ensureGlobalUndiciStreamTimeouts()` without `params.timeoutMs`, so the dispatcher stayed on `DEFAULT_UNDICI_STREAM_TIMEOUT_MS` instead of the operator-configured run timeout.
- Missing detection / guardrail: there was no regression test covering timeout propagation from `runEmbeddedAttempt()` into the undici global dispatcher seam.
- Contributing context (if known): the dispatcher helper already supported a caller-supplied timeout; only the embedded runner call site dropped it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.timeout.test.ts`
- Scenario the test should lock in: an embedded run with a non-default timeout forwards that timeout into `ensureGlobalUndiciStreamTimeouts({ timeoutMs })`.
- Why this is the smallest reliable guardrail: it exercises the implicated `runEmbeddedAttempt()` call site directly without dragging real model/network behavior into the test.
- Existing test that already covers this (if any): `src/infra/net/undici-global-dispatcher.test.ts` covers dispatcher behavior once a timeout reaches the helper.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Slow local Ollama runs now honor the configured embedded-run timeout when OpenClaw tunes the global undici stream timeout layer.

## Diagram (if applicable)

```text
Before:
[embedded run timeout config] -> runEmbeddedAttempt -> ensureGlobalUndiciStreamTimeouts() -> default 30m dispatcher timeout

After:
[embedded run timeout config] -> runEmbeddedAttempt -> ensureGlobalUndiciStreamTimeouts({ timeoutMs }) -> configured dispatcher timeout
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.4 local maintainer worktree
- Runtime/container: Node 22+, pnpm
- Model/provider: local Ollama path via embedded runner timeout wiring
- Integration/channel (if any): N/A
- Relevant config (redacted): embedded run `timeoutMs` override in harness

### Steps

1. Run an embedded attempt with a non-default `timeoutMs`.
2. Observe the undici global dispatcher helper call.
3. Verify the helper receives the same `timeoutMs` value.

### Expected

- The dispatcher tuning uses the configured run timeout.

### Actual

- Before this change, the helper was called with no argument and silently fell back to the default timeout.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test:serial src/agents/pi-embedded-runner/run/attempt.spawn-workspace.timeout.test.ts`; `pnpm test:serial src/infra/net/undici-global-dispatcher.test.ts`; `pnpm build`
- Edge cases checked: existing dispatcher helper behavior for default, proxy, idempotence, and WSL2 auto-family handling stayed green.
- What you did **not** verify: I did not run a live slow Ollama model end-to-end in Docker for this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: this touches the global dispatcher tuning path used by embedded runs.
  - Mitigation: the code only starts forwarding the timeout value the helper already supports, and existing helper unit coverage stays green.
