### PR TITLE
fix(build): correct subagent registry runtime import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Agents/local models: clarify low-context preflight hints for self-hosted models, point config-backed caps at the relevant OpenClaw setting, and stop suggesting larger models when `agents.defaults.contextTokens` is the real limit. (#66236) Thanks @ImLukeF.
 - Browser/SSRF: restore hostname navigation under the default browser SSRF policy while keeping explicit strict mode reachable from config, and keep managed loopback CDP `/json/new` fallback requests on the local CDP control policy so browser follow-up fixes stop regressing normal navigation or self-blocking local CDP control. (#66386) Thanks @obviyus.
 - Browser/SSRF: preserve explicit strict browser navigation mode for legacy `browser.ssrfPolicy.allowPrivateNetwork: false` configs by normalizing the legacy alias to the canonical strict marker instead of silently widening those installs to the default non-strict hostname-navigation path.
+- Agents/subagents: point the built subagent registry lazy-runtime import at the emitted `dist/agents/subagent-registry.runtime.js` stub so the follow-up dist fix no longer still fails with `ERR_MODULE_NOT_FOUND` at runtime. (#66420) Thanks @obviyus.
 
 ## 2026.4.14-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Docs: https://docs.openclaw.ai
 - Agents/local models: clarify low-context preflight hints for self-hosted models, point config-backed caps at the relevant OpenClaw setting, and stop suggesting larger models when `agents.defaults.contextTokens` is the real limit. (#66236) Thanks @ImLukeF.
 - Browser/SSRF: restore hostname navigation under the default browser SSRF policy while keeping explicit strict mode reachable from config, and keep managed loopback CDP `/json/new` fallback requests on the local CDP control policy so browser follow-up fixes stop regressing normal navigation or self-blocking local CDP control. (#66386) Thanks @obviyus.
 - Browser/SSRF: preserve explicit strict browser navigation mode for legacy `browser.ssrfPolicy.allowPrivateNetwork: false` configs by normalizing the legacy alias to the canonical strict marker instead of silently widening those installs to the default non-strict hostname-navigation path.
-- Agents/subagents: point the built subagent registry lazy-runtime import at the emitted `dist/agents/subagent-registry.runtime.js` stub so the follow-up dist fix no longer still fails with `ERR_MODULE_NOT_FOUND` at runtime. (#66420) Thanks @obviyus.
+- Agents/subagents: emit the subagent registry lazy-runtime stub on the stable dist path that both source and bundled runtime imports resolve, so the follow-up dist fix no longer still fails with `ERR_MODULE_NOT_FOUND` at runtime. (#66420) Thanks @obviyus.
 
 ## 2026.4.14-beta.1
 

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -113,7 +113,7 @@ type RuntimePluginsModule = Pick<
   "ensureRuntimePluginsLoaded"
 >;
 
-const SUBAGENT_REGISTRY_RUNTIME_SPEC = ["./subagent-registry.runtime", ".js"] as const;
+const SUBAGENT_REGISTRY_RUNTIME_SPEC = ["./agents/subagent-registry.runtime", ".js"] as const;
 
 let contextEngineInitPromise: Promise<ContextEngineInitModule> | null = null;
 let contextEngineRegistryPromise: Promise<ContextEngineRegistryModule> | null = null;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -113,7 +113,7 @@ type RuntimePluginsModule = Pick<
   "ensureRuntimePluginsLoaded"
 >;
 
-const SUBAGENT_REGISTRY_RUNTIME_SPEC = ["./agents/subagent-registry.runtime", ".js"] as const;
+const SUBAGENT_REGISTRY_RUNTIME_SPEC = ["./subagent-registry.runtime", ".js"] as const;
 
 let contextEngineInitPromise: Promise<ContextEngineInitModule> | null = null;
 let contextEngineRegistryPromise: Promise<ContextEngineRegistryModule> | null = null;

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -69,7 +69,7 @@ describe("tsdown config", () => {
         "agents/auth-profiles.runtime",
         "agents/model-catalog.runtime",
         "agents/models-config.runtime",
-        "agents/subagent-registry.runtime",
+        "subagent-registry.runtime",
         "agents/pi-model-discovery-runtime",
         "index",
         "commands/status.summary.runtime",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -146,7 +146,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
-    "agents/subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
+    "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",


### PR DESCRIPTION
## Summary
- point the subagent registry lazy runtime import at the stable stub that tsdown emits under `dist/agents/`
- fix the `ERR_MODULE_NOT_FOUND` regression where the built root chunk looked for `./subagent-registry.runtime.js`

## Verification
- `pnpm build`
- direct Node import of the built runtime path from the emitted subagent registry chunk

## Notes
- current `main` has unrelated `pnpm tsgo` failures in `extensions/qa-lab/src/scenario-catalog.test.ts`