### PR TITLE
feat(astraflow): add UCloud AstraFlow provider plugin (Global + China)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -261,6 +261,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/arcee/**"
+"extensions: astraflow":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/astraflow/**"
 "extensions: byteplus":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/providers/astraflow.md
+++ b/docs/providers/astraflow.md
@@ -74,6 +74,12 @@ or `ASTRAFLOW_CN_API_KEY` is available to that process (for example, in
 `~/.openclaw/.env` or via `env.shellEnv`).
 </Warning>
 
+<Tip>
+Base URLs can be overridden with `ASTRAFLOW_BASE_URL` (default:
+`https://api-us-ca.umodelverse.ai/v1`) and `ASTRAFLOW_CN_BASE_URL` (default:
+`https://api.modelverse.cn/v1`) for self-hosted or testing deployments.
+</Tip>
+
 ## Built-in catalog
 
 ### Global catalog

--- a/docs/providers/astraflow.md
+++ b/docs/providers/astraflow.md
@@ -1,0 +1,149 @@
+---
+title: "UCloud AstraFlow"
+summary: "UCloud AstraFlow setup (auth + model selection)"
+read_when:
+  - You want to use UCloud AstraFlow with OpenClaw
+  - You need the API key env var or CLI auth choice
+---
+
+# UCloud AstraFlow
+
+[UCloud AstraFlow](https://astraflow.ucloud-global.com) provides 200+ curated models with an OpenAI-compatible API, available in both global and China endpoints.
+
+| Property | Global                                | China                          |
+| -------- | ------------------------------------- | ------------------------------ |
+| Provider | `astraflow`                           | `astraflow-cn`                 |
+| Auth     | `ASTRAFLOW_API_KEY`                   | `ASTRAFLOW_CN_API_KEY`         |
+| API      | OpenAI-compatible                     | OpenAI-compatible              |
+| Base URL | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    - Global: [astraflow.ucloud-global.com](https://astraflow.ucloud-global.com/en-us/modelverse/api-keys)
+    - China: [astraflow.ucloud.cn](https://astraflow.ucloud.cn/modelverse/api-keys)
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    # Global endpoint
+    openclaw onboard --auth-choice astraflow-api-key
+
+    # China endpoint
+    openclaw onboard --auth-choice astraflow-cn-api-key
+    ```
+
+  </Step>
+  <Step title="Verify models are available">
+    ```bash
+    openclaw models list --provider astraflow
+    # or
+    openclaw models list --provider astraflow-cn
+    ```
+  </Step>
+</Steps>
+
+<AccordionGroup>
+  <Accordion title="Non-interactive setup">
+    For scripted or headless installations, pass all flags directly:
+
+    ```bash
+    # Global
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice astraflow-api-key \
+      --astraflow-api-key "$ASTRAFLOW_API_KEY" \
+      --skip-health \
+      --accept-risk
+
+    # China
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice astraflow-cn-api-key \
+      --astraflow-cn-api-key "$ASTRAFLOW_CN_API_KEY" \
+      --skip-health \
+      --accept-risk
+    ```
+
+  </Accordion>
+</AccordionGroup>
+
+<Warning>
+If the Gateway runs as a daemon (launchd/systemd), make sure `ASTRAFLOW_API_KEY`
+or `ASTRAFLOW_CN_API_KEY` is available to that process (for example, in
+`~/.openclaw/.env` or via `env.shellEnv`).
+</Warning>
+
+## Built-in catalog
+
+### Global catalog
+
+| Model ref                       | Name                   | Input       | Context   | Max output |
+| ------------------------------- | ---------------------- | ----------- | --------- | ---------- |
+| `claude-opus-4-6`               | Claude Opus 4.6        | text, image | 1,000,000 | 128,000    |
+| `claude-sonnet-4-6`             | Claude Sonnet 4.6      | text, image | 1,000,000 | 64,000     |
+| `claude-haiku-4-5-20251001`     | Claude Haiku 4.5       | text, image | 200,000   | 64,000     |
+| `gpt-5.4`                       | GPT-5.4                | text, image | 1,050,000 | 128,000    |
+| `gpt-5.4-mini`                  | GPT-5.4 Mini           | text, image | 400,000   | 128,000    |
+| `gpt-5.4-nano`                  | GPT-5.4 Nano           | text        | 400,000   | 128,000    |
+| `gpt-5.3-chat-latest`           | GPT-5.3 Chat           | text, image | 128,000   | 16,384     |
+| `gpt-5.2`                       | GPT-5.2                | text, image | 128,000   | 16,384     |
+| `deepseek-ai/DeepSeek-V3.2`     | DeepSeek V3.2          | text        | 131,072   | 8,192      |
+| `glm-5.1`                       | GLM 5.1                | text        | 202,800   | 131,100    |
+| `glm-5-turbo`                   | GLM 5 Turbo            | text        | 202,800   | 131,100    |
+| `glm-5v-turbo`                  | GLM 5V Turbo           | text, image | 202,800   | 131,100    |
+| `zai-org/glm-5`                 | GLM 5                  | text        | 202,800   | 131,100    |
+| `moonshot/kimi-k2.5`            | Kimi K2.5              | text        | 262,144   | 32,768     |
+| `moonshotai/kimi-k2.5`          | Kimi K2.5 (MoonshotAI) | text        | 262,144   | 32,768     |
+| `qwen3.6-plus`                  | Qwen 3.6 Plus          | text, image | 1,000,000 | 65,536     |
+| `qwen3.5-plus`                  | Qwen 3.5 Plus          | text, image | 1,000,000 | 65,536     |
+| `MiniMax-M2.7`                  | MiniMax M2.7           | text, image | 204,800   | 131,072    |
+| `MiniMax-M2.7-highspeed`        | MiniMax M2.7 Highspeed | text        | 204,800   | 131,072    |
+| `MiniMax-M2.5`                  | MiniMax M2.5           | text        | 204,800   | 131,072    |
+| `MiniMax-M2.5-lightning`        | MiniMax M2.5 HighSpeed | text        | 204,800   | 131,072    |
+| `gemini-3.1-pro-preview`        | Gemini 3.1 Pro         | text, image | 1,048,576 | 65,536     |
+| `gemini-3.1-flash-lite-preview` | Gemini 3.1 Flash Lite  | text, image | 1,048,576 | 65,536     |
+
+### China catalog
+
+The China endpoint excludes Claude, GPT, and Gemini models:
+
+| Model ref                   | Name                   | Input       | Context   | Max output |
+| --------------------------- | ---------------------- | ----------- | --------- | ---------- |
+| `deepseek-ai/DeepSeek-V3.2` | DeepSeek V3.2          | text        | 131,072   | 8,192      |
+| `glm-5.1`                   | GLM 5.1                | text        | 202,800   | 131,100    |
+| `glm-5-turbo`               | GLM 5 Turbo            | text        | 202,800   | 131,100    |
+| `glm-5v-turbo`              | GLM 5V Turbo           | text, image | 202,800   | 131,100    |
+| `zai-org/glm-5`             | GLM 5                  | text        | 202,800   | 131,100    |
+| `moonshot/kimi-k2.5`        | Kimi K2.5              | text        | 262,144   | 32,768     |
+| `moonshotai/kimi-k2.5`      | Kimi K2.5 (MoonshotAI) | text        | 262,144   | 32,768     |
+| `qwen3.6-plus`              | Qwen 3.6 Plus          | text, image | 1,000,000 | 65,536     |
+| `qwen3.5-plus`              | Qwen 3.5 Plus          | text, image | 1,000,000 | 65,536     |
+| `MiniMax-M2.7`              | MiniMax M2.7           | text, image | 204,800   | 131,072    |
+| `MiniMax-M2.7-highspeed`    | MiniMax M2.7 Highspeed | text        | 204,800   | 131,072    |
+| `MiniMax-M2.5`              | MiniMax M2.5           | text        | 204,800   | 131,072    |
+| `MiniMax-M2.5-lightning`    | MiniMax M2.5 HighSpeed | text        | 204,800   | 131,072    |
+
+## Config example
+
+```json5
+{
+  env: { ASTRAFLOW_API_KEY: "sk-..." },
+  agents: {
+    defaults: {
+      model: { primary: "astraflow/claude-sonnet-4-6" },
+    },
+  },
+}
+```
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config reference for agents, models, and providers.
+  </Card>
+</CardGroup>

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -30,6 +30,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Amazon Bedrock](/providers/bedrock)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Arcee AI (Trinity models)](/providers/arcee)
+- [UCloud AstraFlow (Global + China)](/providers/astraflow)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)
 - [Chutes](/providers/chutes)
 - [ComfyUI](/providers/comfy)

--- a/extensions/astraflow/api.ts
+++ b/extensions/astraflow/api.ts
@@ -1,0 +1,14 @@
+export {
+  ASTRAFLOW_BASE_URL,
+  ASTRAFLOW_CN_BASE_URL,
+  ASTRAFLOW_CN_MODEL_CATALOG,
+  ASTRAFLOW_MODEL_CATALOG,
+  buildAstraflowModelDefinition,
+} from "./models.js";
+export { buildAstraflowCnProvider, buildAstraflowProvider } from "./provider-catalog.js";
+export {
+  applyAstraflowCnConfig,
+  applyAstraflowConfig,
+  ASTRAFLOW_CN_DEFAULT_MODEL_REF,
+  ASTRAFLOW_DEFAULT_MODEL_REF,
+} from "./onboard.js";

--- a/extensions/astraflow/index.test.ts
+++ b/extensions/astraflow/index.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
+
+vi.mock("./provider-catalog.js", () => ({
+  buildAstraflowProvider: vi.fn(() => ({
+    baseUrl: "https://api-us-ca.umodelverse.ai/v1",
+    api: "openai-completions",
+    models: [],
+  })),
+  buildAstraflowCnProvider: vi.fn(() => ({
+    baseUrl: "https://api.modelverse.cn/v1",
+    api: "openai-completions",
+    models: [],
+  })),
+}));
+
+vi.mock("./onboard.js", () => ({
+  applyAstraflowConfig: vi.fn((cfg) => cfg),
+  applyAstraflowCnConfig: vi.fn((cfg) => cfg),
+  ASTRAFLOW_DEFAULT_MODEL_REF: "astraflow/claude-sonnet-4-6",
+  ASTRAFLOW_CN_DEFAULT_MODEL_REF: "astraflow-cn/deepseek-ai/DeepSeek-V3.2",
+}));
+
+import plugin from "./index.js";
+
+function registerProviders() {
+  const registerProviderMock = vi.fn();
+
+  plugin.register(
+    createTestPluginApi({
+      id: "astraflow",
+      name: "UCloud AstraFlow",
+      source: "test",
+      config: {},
+      pluginConfig: {},
+      runtime: {} as never,
+      registerProvider: registerProviderMock,
+    }),
+  );
+
+  return registerProviderMock.mock.calls.map((call) => call[0]);
+}
+
+describe("astraflow plugin", () => {
+  it("registers both global and china providers", () => {
+    const providers = registerProviders();
+
+    expect(providers).toHaveLength(2);
+    expect(providers[0].id).toBe("astraflow");
+    expect(providers[0].label).toBe("UCloud AstraFlow");
+    expect(providers[0].envVars).toEqual(["ASTRAFLOW_API_KEY"]);
+    expect(providers[0].auth).toHaveLength(1);
+
+    expect(providers[1].id).toBe("astraflow-cn");
+    expect(providers[1].label).toBe("UCloud AstraFlow (China)");
+    expect(providers[1].envVars).toEqual(["ASTRAFLOW_CN_API_KEY"]);
+    expect(providers[1].auth).toHaveLength(1);
+  });
+
+  it("global provider has correct auth wizard metadata", () => {
+    const providers = registerProviders();
+    const globalAuth = providers[0].auth[0];
+
+    expect(globalAuth.id).toBe("api-key");
+    expect(globalAuth.wizard.choiceId).toBe("astraflow-api-key");
+    expect(globalAuth.wizard.groupId).toBe("astraflow");
+  });
+
+  it("china provider has correct auth wizard metadata", () => {
+    const providers = registerProviders();
+    const cnAuth = providers[1].auth[0];
+
+    expect(cnAuth.id).toBe("api-key");
+    expect(cnAuth.wizard.choiceId).toBe("astraflow-cn-api-key");
+    expect(cnAuth.wizard.groupId).toBe("astraflow");
+  });
+
+  it("global catalog resolves when API key is present", async () => {
+    const providers = registerProviders();
+
+    const result = await providers[0].catalog.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as never);
+
+    expect(result).not.toBeNull();
+    expect(result?.provider?.baseUrl).toBe("https://api-us-ca.umodelverse.ai/v1");
+    expect(result?.provider?.api).toBe("openai-completions");
+  });
+
+  it("china catalog resolves when API key is present", async () => {
+    const providers = registerProviders();
+
+    const result = await providers[1].catalog.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as never);
+
+    expect(result).not.toBeNull();
+    expect(result?.provider?.baseUrl).toBe("https://api.modelverse.cn/v1");
+    expect(result?.provider?.api).toBe("openai-completions");
+  });
+
+  it("catalog returns null when no API key is available", async () => {
+    const providers = registerProviders();
+
+    const result = await providers[0].catalog.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => null,
+    } as never);
+
+    expect(result).toBeNull();
+  });
+});

--- a/extensions/astraflow/index.ts
+++ b/extensions/astraflow/index.ts
@@ -1,0 +1,122 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import {
+  applyAstraflowCnConfig,
+  applyAstraflowConfig,
+  ASTRAFLOW_CN_DEFAULT_MODEL_REF,
+  ASTRAFLOW_DEFAULT_MODEL_REF,
+} from "./onboard.js";
+import { buildAstraflowCnProvider, buildAstraflowProvider } from "./provider-catalog.js";
+
+const GLOBAL_PROVIDER_ID = "astraflow";
+const CN_PROVIDER_ID = "astraflow-cn";
+
+export default definePluginEntry({
+  id: "astraflow",
+  name: "UCloud AstraFlow",
+  description: "Bundled UCloud AstraFlow provider plugin (Global + China)",
+  register(api) {
+    api.registerProvider({
+      id: GLOBAL_PROVIDER_ID,
+      label: "UCloud AstraFlow",
+      docsPath: "/providers/astraflow",
+      envVars: ["ASTRAFLOW_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: GLOBAL_PROVIDER_ID,
+          methodId: "api-key",
+          label: "UCloud AstraFlow API key (Global)",
+          hint: "Global endpoint - api-us-ca.umodelverse.ai",
+          optionKey: "astraflowApiKey",
+          flagName: "--astraflow-api-key",
+          envVar: "ASTRAFLOW_API_KEY",
+          promptMessage:
+            "Enter UCloud AstraFlow API key\nhttps://astraflow.ucloud-global.com/en-us/modelverse/api-keys",
+          defaultModel: ASTRAFLOW_DEFAULT_MODEL_REF,
+          expectedProviders: [GLOBAL_PROVIDER_ID],
+          applyConfig: (cfg) => applyAstraflowConfig(cfg),
+          wizard: {
+            choiceId: "astraflow-api-key",
+            choiceLabel: "UCloud AstraFlow API key (Global)",
+            choiceHint: "Global endpoint - api-us-ca.umodelverse.ai",
+            groupId: "astraflow",
+            groupLabel: "UCloud AstraFlow",
+            groupHint: "200+ curated models, pay-as-you-go",
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(GLOBAL_PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          return {
+            provider: {
+              ...buildAstraflowProvider(),
+              apiKey,
+            },
+          };
+        },
+      },
+      augmentModelCatalog: ({ config }) =>
+        readConfiguredProviderCatalogEntries({
+          config,
+          providerId: GLOBAL_PROVIDER_ID,
+        }),
+    });
+
+    api.registerProvider({
+      id: CN_PROVIDER_ID,
+      label: "UCloud AstraFlow (China)",
+      docsPath: "/providers/astraflow",
+      envVars: ["ASTRAFLOW_CN_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: CN_PROVIDER_ID,
+          methodId: "api-key",
+          label: "UCloud AstraFlow API key (China)",
+          hint: "China endpoint - api.modelverse.cn",
+          optionKey: "astraflowCnApiKey",
+          flagName: "--astraflow-cn-api-key",
+          envVar: "ASTRAFLOW_CN_API_KEY",
+          promptMessage:
+            "Enter UCloud AstraFlow China API key\nhttps://astraflow.ucloud.cn/modelverse/api-keys",
+          defaultModel: ASTRAFLOW_CN_DEFAULT_MODEL_REF,
+          expectedProviders: [CN_PROVIDER_ID],
+          applyConfig: (cfg) => applyAstraflowCnConfig(cfg),
+          wizard: {
+            choiceId: "astraflow-cn-api-key",
+            choiceLabel: "UCloud AstraFlow API key (China)",
+            choiceHint: "China endpoint - api.modelverse.cn",
+            groupId: "astraflow",
+            groupLabel: "UCloud AstraFlow",
+            groupHint: "200+ curated models, pay-as-you-go",
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(CN_PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          return {
+            provider: {
+              ...buildAstraflowCnProvider(),
+              apiKey,
+            },
+          };
+        },
+      },
+      augmentModelCatalog: ({ config }) =>
+        readConfiguredProviderCatalogEntries({
+          config,
+          providerId: CN_PROVIDER_ID,
+        }),
+    });
+  },
+});

--- a/extensions/astraflow/models.ts
+++ b/extensions/astraflow/models.ts
@@ -127,15 +127,6 @@ export const ASTRAFLOW_MODEL_CATALOG: ModelDefinitionConfig[] = [
     maxTokens: 16384,
     cost: GPT_52_COST,
   },
-  {
-    id: "gpt-5.2-chat",
-    name: "GPT-5.2 Chat",
-    reasoning: false,
-    input: ["text", "image"],
-    contextWindow: 128000,
-    maxTokens: 16384,
-    cost: GPT_52_COST,
-  },
   // DeepSeek V3.2
   {
     id: "deepseek-ai/DeepSeek-V3.2",

--- a/extensions/astraflow/models.ts
+++ b/extensions/astraflow/models.ts
@@ -1,0 +1,292 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const ASTRAFLOW_BASE_URL = "https://api-us-ca.umodelverse.ai/v1";
+export const ASTRAFLOW_CN_BASE_URL = "https://api.modelverse.cn/v1";
+
+// Anthropic pricing (per 1M tokens)
+const CLAUDE_OPUS_46_COST = { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 } as const;
+const CLAUDE_SONNET_46_COST = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } as const;
+const CLAUDE_HAIKU_45_COST = { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 } as const;
+
+// OpenAI pricing (per 1M tokens)
+const GPT_54_COST = { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 } as const;
+const GPT_54_MINI_COST = { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 } as const;
+const GPT_54_NANO_COST = { input: 0.2, output: 1.25, cacheRead: 0.02, cacheWrite: 0 } as const;
+const GPT_53_COST = { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 } as const;
+const GPT_52_COST = { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 } as const;
+
+// DeepSeek pricing (per 1M tokens)
+const DEEPSEEK_V32_COST = { input: 0.28, output: 0.42, cacheRead: 0.028, cacheWrite: 0 } as const;
+
+// GLM pricing (per 1M tokens)
+const GLM_51_COST = { input: 1.2, output: 4, cacheRead: 0.24, cacheWrite: 0 } as const;
+const GLM_5_COST = { input: 1, output: 3.2, cacheRead: 0.2, cacheWrite: 0 } as const;
+const GLM_5_TURBO_COST = { input: 1.2, output: 4, cacheRead: 0.24, cacheWrite: 0 } as const;
+
+// MiniMax pricing (per 1M tokens)
+const MINIMAX_M27_COST = { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 } as const;
+const MINIMAX_M27_HS_COST = {
+  input: 0.6,
+  output: 2.4,
+  cacheRead: 0.06,
+  cacheWrite: 0.375,
+} as const;
+const MINIMAX_M25_COST = { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.375 } as const;
+const MINIMAX_M25_LN_COST = {
+  input: 0.6,
+  output: 2.4,
+  cacheRead: 0.03,
+  cacheWrite: 0.375,
+} as const;
+
+// Gemini pricing (per 1M tokens, converted from CNY at ~7.2 CNY/USD)
+const GEMINI_31_PRO_COST = { input: 1.98, output: 11.87, cacheRead: 0.2, cacheWrite: 0 } as const;
+const GEMINI_31_FLASH_LITE_COST = {
+  input: 0.25,
+  output: 1.48,
+  cacheRead: 0.024,
+  cacheWrite: 0.49,
+} as const;
+
+// Zero cost for models without public pricing
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+export const ASTRAFLOW_MODEL_CATALOG: ModelDefinitionConfig[] = [
+  // Claude 4.6
+  {
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4.6",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    cost: CLAUDE_OPUS_46_COST,
+  },
+  {
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1000000,
+    maxTokens: 64000,
+    cost: CLAUDE_SONNET_46_COST,
+  },
+  // Claude Haiku 4.5
+  {
+    id: "claude-haiku-4-5-20251001",
+    name: "Claude Haiku 4.5",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 64000,
+    cost: CLAUDE_HAIKU_45_COST,
+  },
+  // GPT 5.2+
+  {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    cost: GPT_54_COST,
+  },
+  {
+    id: "gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 400000,
+    maxTokens: 128000,
+    cost: GPT_54_MINI_COST,
+  },
+  {
+    id: "gpt-5.4-nano",
+    name: "GPT-5.4 Nano",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 400000,
+    maxTokens: 128000,
+    cost: GPT_54_NANO_COST,
+  },
+  {
+    id: "gpt-5.3-chat-latest",
+    name: "GPT-5.3 Chat",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 128000,
+    maxTokens: 16384,
+    cost: GPT_53_COST,
+  },
+  {
+    id: "gpt-5.2",
+    name: "GPT-5.2",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 128000,
+    maxTokens: 16384,
+    cost: GPT_52_COST,
+  },
+  {
+    id: "gpt-5.2-chat",
+    name: "GPT-5.2 Chat",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 128000,
+    maxTokens: 16384,
+    cost: GPT_52_COST,
+  },
+  // DeepSeek V3.2
+  {
+    id: "deepseek-ai/DeepSeek-V3.2",
+    name: "DeepSeek V3.2",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+    cost: DEEPSEEK_V32_COST,
+  },
+  // GLM-5+
+  {
+    id: "glm-5.1",
+    name: "GLM 5.1",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 202800,
+    maxTokens: 131100,
+    cost: GLM_51_COST,
+  },
+  {
+    id: "glm-5-turbo",
+    name: "GLM 5 Turbo",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 202800,
+    maxTokens: 131100,
+    cost: GLM_5_TURBO_COST,
+  },
+  {
+    id: "glm-5v-turbo",
+    name: "GLM 5V Turbo",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 202800,
+    maxTokens: 131100,
+    cost: GLM_5_TURBO_COST,
+  },
+  {
+    id: "zai-org/glm-5",
+    name: "GLM 5",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 202800,
+    maxTokens: 131100,
+    cost: GLM_5_COST,
+  },
+  // Kimi K2.5+
+  {
+    id: "moonshot/kimi-k2.5",
+    name: "Kimi K2.5",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 262144,
+    maxTokens: 32768,
+    cost: ZERO_COST,
+  },
+  {
+    id: "moonshotai/kimi-k2.5",
+    name: "Kimi K2.5 (MoonshotAI)",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 262144,
+    maxTokens: 32768,
+    cost: ZERO_COST,
+  },
+  // Qwen 3.5+
+  {
+    id: "qwen3.6-plus",
+    name: "Qwen 3.6 Plus",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 1000000,
+    maxTokens: 65536,
+    cost: ZERO_COST,
+  },
+  {
+    id: "qwen3.5-plus",
+    name: "Qwen 3.5 Plus",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 1000000,
+    maxTokens: 65536,
+    cost: ZERO_COST,
+  },
+  // MiniMax M2.5+
+  {
+    id: "MiniMax-M2.7",
+    name: "MiniMax M2.7",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 204800,
+    maxTokens: 131072,
+    cost: MINIMAX_M27_COST,
+  },
+  {
+    id: "MiniMax-M2.7-highspeed",
+    name: "MiniMax M2.7 Highspeed",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 204800,
+    maxTokens: 131072,
+    cost: MINIMAX_M27_HS_COST,
+  },
+  {
+    id: "MiniMax-M2.5",
+    name: "MiniMax M2.5",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 204800,
+    maxTokens: 131072,
+    cost: MINIMAX_M25_COST,
+  },
+  {
+    id: "MiniMax-M2.5-lightning",
+    name: "MiniMax M2.5 HighSpeed",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 204800,
+    maxTokens: 131072,
+    cost: MINIMAX_M25_LN_COST,
+  },
+  // Gemini 3.1+
+  {
+    id: "gemini-3.1-pro-preview",
+    name: "Gemini 3.1 Pro",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    cost: GEMINI_31_PRO_COST,
+  },
+  {
+    id: "gemini-3.1-flash-lite-preview",
+    name: "Gemini 3.1 Flash Lite",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    cost: GEMINI_31_FLASH_LITE_COST,
+  },
+];
+
+// CN catalog: domestic models only (no GPT/Claude/Gemini)
+export const ASTRAFLOW_CN_MODEL_CATALOG: ModelDefinitionConfig[] = ASTRAFLOW_MODEL_CATALOG.filter(
+  (m) => !m.id.startsWith("claude-") && !m.id.startsWith("gpt-") && !m.id.startsWith("gemini-"),
+);
+
+export function buildAstraflowModelDefinition(model: ModelDefinitionConfig): ModelDefinitionConfig {
+  return {
+    ...model,
+    api: "openai-completions",
+  };
+}

--- a/extensions/astraflow/onboard.ts
+++ b/extensions/astraflow/onboard.ts
@@ -1,0 +1,61 @@
+import {
+  applyAgentDefaultModelPrimary,
+  applyProviderConfigWithModelCatalog,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  ASTRAFLOW_BASE_URL,
+  ASTRAFLOW_CN_BASE_URL,
+  ASTRAFLOW_CN_MODEL_CATALOG,
+  ASTRAFLOW_MODEL_CATALOG,
+  buildAstraflowModelDefinition,
+} from "./models.js";
+
+export const ASTRAFLOW_DEFAULT_MODEL_REF = "astraflow/claude-sonnet-4-6";
+export const ASTRAFLOW_CN_DEFAULT_MODEL_REF = "astraflow-cn/deepseek-ai/DeepSeek-V3.2";
+
+export function applyAstraflowProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[ASTRAFLOW_DEFAULT_MODEL_REF] = {
+    ...models[ASTRAFLOW_DEFAULT_MODEL_REF],
+    alias: models[ASTRAFLOW_DEFAULT_MODEL_REF]?.alias ?? "UCloud AstraFlow",
+  };
+
+  return applyProviderConfigWithModelCatalog(cfg, {
+    agentModels: models,
+    providerId: "astraflow",
+    api: "openai-completions",
+    baseUrl: ASTRAFLOW_BASE_URL,
+    catalogModels: ASTRAFLOW_MODEL_CATALOG.map(buildAstraflowModelDefinition),
+  });
+}
+
+export function applyAstraflowConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(
+    applyAstraflowProviderConfig(cfg),
+    ASTRAFLOW_DEFAULT_MODEL_REF,
+  );
+}
+
+export function applyAstraflowCnProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[ASTRAFLOW_CN_DEFAULT_MODEL_REF] = {
+    ...models[ASTRAFLOW_CN_DEFAULT_MODEL_REF],
+    alias: models[ASTRAFLOW_CN_DEFAULT_MODEL_REF]?.alias ?? "UCloud AstraFlow (China)",
+  };
+
+  return applyProviderConfigWithModelCatalog(cfg, {
+    agentModels: models,
+    providerId: "astraflow-cn",
+    api: "openai-completions",
+    baseUrl: ASTRAFLOW_CN_BASE_URL,
+    catalogModels: ASTRAFLOW_CN_MODEL_CATALOG.map(buildAstraflowModelDefinition),
+  });
+}
+
+export function applyAstraflowCnConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(
+    applyAstraflowCnProviderConfig(cfg),
+    ASTRAFLOW_CN_DEFAULT_MODEL_REF,
+  );
+}

--- a/extensions/astraflow/openclaw.plugin.json
+++ b/extensions/astraflow/openclaw.plugin.json
@@ -1,0 +1,51 @@
+{
+  "id": "astraflow",
+  "enabledByDefault": true,
+  "providers": ["astraflow", "astraflow-cn"],
+  "providerAuthEnvVars": {
+    "astraflow": ["ASTRAFLOW_API_KEY"],
+    "astraflow-cn": ["ASTRAFLOW_CN_API_KEY"]
+  },
+  "providerAuthAliases": {
+    "astra-flow": "astraflow",
+    "astra_flow": "astraflow",
+    "modelverse": "astraflow",
+    "astraflow-china": "astraflow-cn",
+    "astraflow_cn": "astraflow-cn"
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "astraflow",
+      "method": "api-key",
+      "choiceId": "astraflow-api-key",
+      "choiceLabel": "UCloud AstraFlow API key (Global)",
+      "choiceHint": "Global endpoint - api-us-ca.umodelverse.ai",
+      "groupId": "astraflow",
+      "groupLabel": "UCloud AstraFlow",
+      "groupHint": "200+ curated models, pay-as-you-go",
+      "optionKey": "astraflowApiKey",
+      "cliFlag": "--astraflow-api-key",
+      "cliOption": "--astraflow-api-key <key>",
+      "cliDescription": "UCloud AstraFlow API key (Global)"
+    },
+    {
+      "provider": "astraflow-cn",
+      "method": "api-key",
+      "choiceId": "astraflow-cn-api-key",
+      "choiceLabel": "UCloud AstraFlow API key (China)",
+      "choiceHint": "China endpoint - api.modelverse.cn",
+      "groupId": "astraflow",
+      "groupLabel": "UCloud AstraFlow",
+      "groupHint": "200+ curated models, pay-as-you-go",
+      "optionKey": "astraflowCnApiKey",
+      "cliFlag": "--astraflow-cn-api-key",
+      "cliOption": "--astraflow-cn-api-key <key>",
+      "cliDescription": "UCloud AstraFlow API key (China)"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/astraflow/package.json
+++ b/extensions/astraflow/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/astraflow-provider",
+  "version": "2026.4.12",
+  "private": true,
+  "description": "OpenClaw UCloud AstraFlow provider plugin (Global + China)",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/astraflow/provider-catalog.ts
+++ b/extensions/astraflow/provider-catalog.ts
@@ -1,0 +1,26 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  ASTRAFLOW_BASE_URL,
+  ASTRAFLOW_CN_BASE_URL,
+  ASTRAFLOW_CN_MODEL_CATALOG,
+  ASTRAFLOW_MODEL_CATALOG,
+  buildAstraflowModelDefinition,
+} from "./models.js";
+
+export function buildAstraflowProvider(): ModelProviderConfig {
+  const baseUrl = process.env.ASTRAFLOW_BASE_URL?.trim() || ASTRAFLOW_BASE_URL;
+  return {
+    baseUrl,
+    api: "openai-completions",
+    models: ASTRAFLOW_MODEL_CATALOG.map(buildAstraflowModelDefinition),
+  };
+}
+
+export function buildAstraflowCnProvider(): ModelProviderConfig {
+  const baseUrl = process.env.ASTRAFLOW_CN_BASE_URL?.trim() || ASTRAFLOW_CN_BASE_URL;
+  return {
+    baseUrl,
+    api: "openai-completions",
+    models: ASTRAFLOW_CN_MODEL_CATALOG.map(buildAstraflowModelDefinition),
+  };
+}

--- a/extensions/astraflow/tsconfig.json
+++ b/extensions/astraflow/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["./*.ts"],
+  "include": ["./*.ts", "./src/**/*.ts"],
   "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**"]
 }

--- a/extensions/astraflow/tsconfig.json
+++ b/extensions/astraflow/tsconfig.json
@@ -4,5 +4,13 @@
     "rootDir": "."
   },
   "include": ["./*.ts", "./src/**/*.ts"],
-  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**"]
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
 }

--- a/extensions/astraflow/tsconfig.json
+++ b/extensions/astraflow/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts"],
+  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/astraflow:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/bluebubbles:
     devDependencies:
       '@openclaw/plugin-sdk':
@@ -4367,8 +4373,8 @@ packages:
       link-preview-js:
         optional: true
 
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
+  '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    resolution: {commit: 1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, repo: git@github.com:whiskeysockets/libsignal-node.git, type: git}
     version: 2.0.1
 
   abbrev@1.1.1:
@@ -11428,7 +11434,7 @@ snapshots:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      libsignal: '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
       lru-cache: 11.3.3
       music-metadata: 11.12.3
       p-queue: 9.1.2
@@ -11444,7 +11450,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+  '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4373,8 +4373,8 @@ packages:
       link-preview-js:
         optional: true
 
-  '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {commit: 1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, repo: git@github.com:whiskeysockets/libsignal-node.git, type: git}
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
     version: 2.0.1
 
   abbrev@1.1.1:
@@ -11434,7 +11434,7 @@ snapshots:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
       lru-cache: 11.3.3
       music-metadata: 11.12.3
       p-queue: 9.1.2
@@ -11450,7 +11450,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@whiskeysockets/libsignal-node@git+https://git@github.com:whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8


### PR DESCRIPTION
## Summary

- Problem: UCloud AstraFlow is a multi-model aggregation platform offering 200+ curated models via an OpenAI-compatible API, but there is no bundled provider plugin for it yet.
- Why it matters: Adding first-class support lets users in both global and China regions access AstraFlow's curated catalog (Claude, GPT, DeepSeek, GLM, Kimi, Qwen, MiniMax, Gemini) without manual custom-provider configuration.
- What changed: Added a new bundled provider plugin `astraflow` with two providers (`astraflow` for global, `astraflow-cn` for China). Each has its own API key, base URL, and model catalog. 
- What did NOT change (scope boundary): No core code changes. All provider logic is self-contained in `extensions/astraflow/`. Existing providers are untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/astraflow/index.test.ts`
- Scenario the test should lock in: Both providers register correctly with proper auth wizard metadata, catalog resolves with API key, returns null without key.
- Why this is the smallest reliable guardrail: Plugin registration + catalog resolution covers the critical path.

## User-visible / Behavior Changes

- New providers `astraflow` and `astraflow-cn` available in `openclaw onboard` and `openclaw models list`.
- New auth choices: `astraflow-api-key` (Global) and `astraflow-cn-api-key` (China).
- New env vars: `ASTRAFLOW_API_KEY`, `ASTRAFLOW_CN_API_KEY`, `ASTRAFLOW_BASE_URL`, `ASTRAFLOW_CN_BASE_URL`.
- Default model for global: `astraflow/claude-sonnet-4-6`; for China: `astraflow-cn/deepseek-ai/DeepSeek-V3.2`.
- Provider aliases: `astra-flow`, `astra_flow`, `modelverse` → `astraflow`; `astraflow-china`, `astraflow_cn` → `astraflow-cn`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No (standard API key auth via existing `createProviderApiKeyAuthMethod`)
- New/changed network calls? Yes — new provider endpoints
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: Network calls go to UCloud AstraFlow endpoints (`api-us-ca.umodelverse.ai`, `api.modelverse.cn`) using standard OpenAI-compatible API. No new attack surface beyond what existing providers already have.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: astraflow / astraflow-cn

### Steps

1. `pnpm install && pnpm build`
2. `node openclaw.mjs onboard --auth-choice astraflow-api-key`
3. `node openclaw.mjs models list --provider astraflow`

### Expected

- Provider registers successfully, models list shows curated catalog.

### Actual

- Works as expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

6 tests pass in `extensions/astraflow/index.test.ts`. `pnpm check` passes (0 type errors, 0 lint warnings, 0 import cycles).

## Human Verification (required)

- Verified scenarios: Plugin registration, auth wizard metadata, catalog resolution with/without API key, CN catalog excludes Claude/GPT/Gemini models.
- Edge cases checked: Missing API key returns null catalog, provider aliases resolve correctly.
- What you did **not** verify: Live API calls to AstraFlow endpoints (requires real API key).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional env vars (`ASTRAFLOW_API_KEY`, `ASTRAFLOW_CN_API_KEY`)
- Migration needed? No
- If yes, exact upgrade steps: N/A
