### PR TITLE
fix(memory): allow capability fallback lookup for missing runtime embedding provider

### DIFF
--- a/src/plugins/memory-embedding-provider-runtime.test.ts
+++ b/src/plugins/memory-embedding-provider-runtime.test.ts
@@ -60,14 +60,14 @@ describe("memory embedding provider runtime resolution", () => {
     expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledTimes(2);
   });
 
-  it("does not consult capability fallback once runtime adapters are registered", () => {
+  it("allows capability fallback for missing providers even if others are registered", () => {
     registerMemoryEmbeddingProvider({
       id: "openai",
       create: async () => ({ provider: null }),
     });
     mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("ollama")]);
 
-    expect(runtimeModule.getMemoryEmbeddingProvider("ollama")).toBeUndefined();
+    expect(runtimeModule.getMemoryEmbeddingProvider("ollama")?.id).toBe("ollama");
     expect(mocks.resolvePluginCapabilityProviders).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/memory-embedding-provider-runtime.test.ts
+++ b/src/plugins/memory-embedding-provider-runtime.test.ts
@@ -68,6 +68,6 @@ describe("memory embedding provider runtime resolution", () => {
     mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("ollama")]);
 
     expect(runtimeModule.getMemoryEmbeddingProvider("ollama")?.id).toBe("ollama");
-    expect(mocks.resolvePluginCapabilityProviders).not.toHaveBeenCalled();
+    expect(mocks.resolvePluginCapabilityProviders).not.toHaveBeenCalled(1);
   });
 });

--- a/src/plugins/memory-embedding-provider-runtime.test.ts
+++ b/src/plugins/memory-embedding-provider-runtime.test.ts
@@ -68,6 +68,6 @@ describe("memory embedding provider runtime resolution", () => {
     mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("ollama")]);
 
     expect(runtimeModule.getMemoryEmbeddingProvider("ollama")?.id).toBe("ollama");
-    expect(mocks.resolvePluginCapabilityProviders).not.toHaveBeenCalled(1);
+    expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/plugins/memory-embedding-provider-runtime.ts
+++ b/src/plugins/memory-embedding-provider-runtime.ts
@@ -32,8 +32,5 @@ export function getMemoryEmbeddingProvider(
   if (registered) {
     return registered.adapter;
   }
-  if (listRegisteredMemoryEmbeddingProviders().length > 0) {
-    return undefined;
-  }
   return listMemoryEmbeddingProviders(cfg).find((adapter) => adapter.id === id);
 }

--- a/src/plugins/memory-embedding-provider-runtime.ts
+++ b/src/plugins/memory-embedding-provider-runtime.ts
@@ -11,6 +11,7 @@ export { listRegisteredMemoryEmbeddingProviders };
 export function listRegisteredMemoryEmbeddingProviderAdapters(): MemoryEmbeddingProviderAdapter[] {
   return listRegisteredMemoryEmbeddingProviders().map((entry) => entry.adapter);
 }
+
 export function listMemoryEmbeddingProviders(
   cfg?: OpenClawConfig,
 ): MemoryEmbeddingProviderAdapter[] {
@@ -32,5 +33,9 @@ export function getMemoryEmbeddingProvider(
   if (registered) {
     return registered.adapter;
   }
-  return listMemoryEmbeddingProviders(cfg).find((adapter) => adapter.id === id);
+
+  return resolvePluginCapabilityProviders({
+    key: "memoryEmbeddingProviders",
+    cfg,
+  }).find((adapter) => adapter.id === id);
 }


### PR DESCRIPTION
Currently, getMemoryEmbeddingProvider() returns undefined if any runtime adapters are registered,
even if the requested provider is not among them.

This prevents capability-based providers (e.g. ollama) from being resolved when other providers
(e.g. openai) are already registered.

This patch removes the early return and allows fallback lookup for the requested provider.

Tested with Ollama embeddings:
- provider correctly resolves
- embeddings initialize successfully
- memory system works as expected

This fixes a real-world issue where ollama cannot be used alongside other providers.