### PR TITLE
fix(gateway): await client cleanup to prevent CLI exit hang

### DIFF
--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -506,11 +506,18 @@ async function executeGatewayRequestWithScopes<T>(params: {
             timeoutMs: opts.timeoutMs,
           });
           ignoreClose = true;
+          // Wait for client cleanup to complete before resolving, to prevent
+          // CLI exit hang (#66227). Use a short timeout so we don't block forever.
+          // Use .catch(() => undefined) so timeout errors don't turn a success into a failure.
+          // Clear the outer timeout timer to avoid a race where the timer fires
+          // during stopAndWait and overrides a valid result with a timeout error.
+          clearTimeout(timer);
+          await client.stopAndWait({ timeoutMs: 500 }).catch(() => undefined);
           stop(undefined, result);
-          client.stop();
         } catch (err) {
           ignoreClose = true;
-          client.stop();
+          clearTimeout(timer);
+          await client.stopAndWait({ timeoutMs: 500 }).catch(() => undefined);
           stop(err as Error);
         }
       },


### PR DESCRIPTION
## Fix: CLI exit hang after cron list / agents list / status (#66227)

**Problem**

CLI commands (`openclaw cron list`, `openclaw agents list`, `openclaw status`) hang indefinitely after outputting data. The process does not exit.

**Root Cause**

In `executeGatewayRequestWithScopes` (`src/gateway/call.ts`), after a gateway request completes:

1. `client.stop()` was called to initiate WebSocket cleanup
2. The Promise resolved immediately without waiting for cleanup to finish
3. If the CLI exited before the async cleanup completed, the process would hang on `futex_wait`

**Solution**

Use `stopAndWait({ timeoutMs: 500 })` instead of `stop()` in the `onHelloOk` callback. This ensures:
- The gateway client's WebSocket connection is properly closed (or times out after 500ms)
- Cleanup completes before the Promise resolves
- The CLI can exit cleanly after the command finishes

```typescript
// Before
stop(undefined, result);
client.stop();  // Fire-and-forget, doesn't wait

// After
await client.stopAndWait({ timeoutMs: 500 });  // Wait for cleanup
stop(undefined, result);
```

**Testing**

- All existing unit tests pass
- Verified that the change doesn't break gateway request/response flow
- The 500ms timeout ensures cleanup doesn't block forever in case of issues

cc @windy1lee @openclaw/maintainers