### PR TITLE
fix(telegram): restore proxy media downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Browser: keep loopback CDP readiness checks reachable under strict SSRF defaults so OpenClaw can reconnect to locally started managed Chrome. (#66354) Thanks @hxy91819.
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
+- Telegram/media: stop trusted explicit-proxy downloads from forcing a local target DNS pin before the request reaches the configured proxy, so Telegram media fetches work again in proxy-only environments. (#66245) Thanks @dawei41468 and @vincentkoc.
 
 ## 2026.4.14-beta.1
 

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -286,4 +286,47 @@ describe("fetchRemoteMedia", () => {
 
     await expectBoundedErrorBodyCase(testCase.fetchImpl);
   });
+
+  it("skips local DNS pinning for trusted explicit proxy dispatcher attempts", async () => {
+    const dispatcherPolicy = {
+      mode: "explicit-proxy" as const,
+      proxyUrl: "http://127.0.0.1:7890",
+      allowPrivateProxy: true,
+    };
+
+    await fetchRemoteMedia(
+      createFetchRemoteMediaParams({
+        url: "https://api.telegram.org/file/bot123/photos/1.jpg",
+        fetchImpl: async () => new Response("ok", { status: 200 }),
+        dispatcherAttempts: [{ dispatcherPolicy }],
+      }),
+    );
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatcherPolicy,
+        pinDns: false,
+      }),
+    );
+  });
+
+  it("keeps local DNS pinning for untrusted explicit proxy dispatcher attempts", async () => {
+    const dispatcherPolicy = {
+      mode: "explicit-proxy" as const,
+      proxyUrl: "http://127.0.0.1:7890",
+    };
+
+    await fetchRemoteMedia(
+      createFetchRemoteMediaParams({
+        url: "https://api.telegram.org/file/bot123/photos/1.jpg",
+        fetchImpl: async () => new Response("ok", { status: 200 }),
+        dispatcherAttempts: [{ dispatcherPolicy }],
+      }),
+    );
+
+    const guardedCall = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as
+      | { pinDns?: boolean }
+      | undefined;
+    expect(guardedCall?.pinDns).toBeUndefined();
+  });
 });

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -93,6 +93,13 @@ function redactMediaUrl(url: string): string {
   return redactSensitiveText(url);
 }
 
+function shouldSkipPinnedDnsForMediaAttempt(attempt: FetchDispatcherAttempt): boolean {
+  return (
+    attempt.dispatcherPolicy?.mode === "explicit-proxy" &&
+    attempt.dispatcherPolicy.allowPrivateProxy === true
+  );
+}
+
 export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<FetchMediaResult> {
   const {
     url,
@@ -126,6 +133,11 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
         policy: ssrfPolicy,
         lookupFn: attempt.lookupFn ?? lookupFn,
         dispatcherPolicy: attempt.dispatcherPolicy,
+        // Operator-configured explicit proxies resolve the target hostname on
+        // the proxy hop. For those trusted routes, forcing a local pinned DNS
+        // lookup breaks media downloads in proxy-only environments without
+        // strengthening the real SSRF boundary.
+        ...(shouldSkipPinnedDnsForMediaAttempt(attempt) ? { pinDns: false } : {}),
       }),
     );
   try {


### PR DESCRIPTION
## Summary

- stop trusted explicit-proxy media downloads from forcing a local target DNS pin before the request reaches the configured proxy
- cover the trusted vs untrusted explicit-proxy behavior in `src/media/fetch.test.ts`
- add the user-facing changelog entry for the Telegram proxy media regression

## Why

Telegram media downloads flow through `src/media/fetch.ts`, which was always wrapping dispatcher attempts in strict guarded-fetch mode. For operator-configured explicit proxies that means we still tried to resolve and pin the target hostname locally before the request ever reached the proxy, which breaks proxy-only environments and defeats the point of the configured proxy hop.

This keeps the change narrow: only trusted explicit-proxy attempts (`allowPrivateProxy: true`) skip the local target DNS pin. Untrusted/direct attempts stay on the old strict path.

Fixes #66245

## Testing

- `OPENCLAW_LOCAL_CHECK=0 pnpm test:serial src/media/fetch.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm test:serial extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm test:serial extensions/telegram/src/fetch.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm build`

## Notes

- AI-assisted: yes
- `#66191` looks separate; it is an outbound group-media/send surface, not this inbound proxy-download path.
