### PR TITLE
fix(codex): default provider api to responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
+- OpenAI Codex/config: default `openai-codex` provider entries to the Responses API so Codex sessions stop coming up misconfigured when the API is omitted from provider config. (#64561) Thanks @mraleko and @vincentkoc.
 
 ## 2026.4.14-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
-- OpenAI Codex/config: default `openai-codex` provider entries to the Responses API so Codex sessions stop coming up misconfigured when the API is omitted from provider config. (#64561) Thanks @mraleko and @vincentkoc.
+- OpenAI Codex/config: default `openai-codex` provider entries to the Responses API so Codex sessions stop coming up misconfigured when the API is omitted from provider config. (#66448) Thanks @mraleko.
 
 ## 2026.4.14-beta.1
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the Codex provider path could default an unset OpenAI provider API to the wrong API family.
- Why it matters: Codex requests can silently route through the wrong OpenAI API shape when config leaves the provider API unset.
- What changed: default the Codex provider API to Responses, keep the change scoped to that provider path, and carry the missing changelog entry.
- What did NOT change (scope boundary): no generic OpenAI provider default was changed outside the Codex-specific path.
- Supersedes #64561.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #64561
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Codex provider inherited an outdated default API assumption instead of the current Responses-first path it actually depends on.
- Missing detection / guardrail: there was no focused provider test for the unset-provider-api Codex default path.
- Contributing context (if known): Codex and broader OpenAI provider behaviors have diverged enough that shared defaults are risky.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: extensions/codex/provider.test.ts
- Scenario the test should lock in: an unset provider API for Codex resolves to Responses, not Chat Completions.
- Why this is the smallest reliable guardrail: the behavior is a local provider policy default with no extra runtime dependency.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Codex now defaults to the Responses API path when the provider API is not explicitly configured.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / `pnpm test:serial`
- Model/provider: OpenAI Codex / Responses API
- Integration/channel (if any): Codex provider
- Relevant config (redacted): targeted fixture/test doubles only

### Steps

1. Leave the Codex provider API unset in config or fixture state.
2. Run `pnpm test:serial extensions/codex/provider.test.ts`.
3. Verify the resolved provider API is Responses.

### Expected

- Unset Codex provider API resolves to Responses.

### Actual

- Before the fix, the path could fall back to the wrong API family.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test:serial extensions/codex/provider.test.ts`.
- Edge cases checked: unset provider API on the Codex provider path.
- What you did **not** verify: live Codex traffic outside the targeted provider test.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: narrow fix may miss adjacent provider-specific edge cases not covered by the focused regression.
  - Mitigation: keep the patch scoped and ship targeted regression coverage for the implicated path only.
