### PR TITLE
fix(onboard): cap compat probe max_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
-- Onboarding/custom providers: use `max_tokens=16` for OpenAI-compatible verification probes so stricter custom endpoints stop rejecting onboarding checks that only need a tiny completion. (#65738) Thanks @WuKongAI-CMU and @vincentkoc.
+- Onboarding/custom providers: use `max_tokens=16` for OpenAI-compatible verification probes so stricter custom endpoints stop rejecting onboarding checks that only need a tiny completion. (#66450) Thanks @WuKongAI-CMU.
 
 ## 2026.4.14-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
+- Onboarding/custom providers: use `max_tokens=16` for OpenAI-compatible verification probes so stricter custom endpoints stop rejecting onboarding checks that only need a tiny completion. (#65738) Thanks @WuKongAI-CMU and @vincentkoc.
 
 ## 2026.4.14-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,13 @@ Docs: https://docs.openclaw.ai
 - Browser/SSRF: restore hostname navigation under the default browser SSRF policy while keeping explicit strict mode reachable from config, and keep managed loopback CDP `/json/new` fallback requests on the local CDP control policy so browser follow-up fixes stop regressing normal navigation or self-blocking local CDP control. (#66386) Thanks @obviyus.
 - Models/Codex: canonicalize the legacy `openai-codex/gpt-5.4-codex` runtime alias to `openai-codex/gpt-5.4` while still honoring alias-specific and canonical per-model overrides. (#43060) Thanks @Sapientropic and @vincentkoc.
 - Browser/SSRF: preserve explicit strict browser navigation mode for legacy `browser.ssrfPolicy.allowPrivateNetwork: false` configs by normalizing the legacy alias to the canonical strict marker instead of silently widening those installs to the default non-strict hostname-navigation path.
+- Onboarding/custom providers: use `max_tokens=16` for OpenAI-compatible verification probes so stricter custom endpoints stop rejecting onboarding checks that only need a tiny completion. (#66450) Thanks @WuKongAI-CMU.
 - Agents/subagents: emit the subagent registry lazy-runtime stub on the stable dist path that both source and bundled runtime imports resolve, so the follow-up dist fix no longer still fails with `ERR_MODULE_NOT_FOUND` at runtime. (#66420) Thanks @obviyus.
 - Media-understanding/proxy env: auto-upgrade provider HTTP helper requests to trusted env-proxy mode only when `HTTP_PROXY`/`HTTPS_PROXY` is active and the target is not bypassed by `NO_PROXY`, so remote media-understanding and transcription requests stop failing local DNS pre-resolution in proxy-only environments without widening SSRF bypasses. (#52162) Thanks @mjamiv and @vincentkoc.
 - Browser: keep loopback CDP readiness checks reachable under strict SSRF defaults so OpenClaw can reconnect to locally started managed Chrome. (#66354) Thanks @hxy91819.
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
-- Onboarding/custom providers: use `max_tokens=16` for OpenAI-compatible verification probes so stricter custom endpoints stop rejecting onboarding checks that only need a tiny completion. (#66450) Thanks @WuKongAI-CMU.
 
 ## 2026.4.14-beta.1
 

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -202,7 +202,7 @@ describe("promptCustomApiConfig", () => {
 
     const firstCall = fetchMock.mock.calls[0]?.[1] as { body?: string } | undefined;
     expect(firstCall?.body).toBeDefined();
-    expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
+    expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 16 });
   });
 
   it("uses azure responses-specific headers and body for openai verification probes", async () => {
@@ -259,7 +259,7 @@ describe("promptCustomApiConfig", () => {
     expect(body).toEqual({
       model: "deepseek-v3-0324",
       messages: [{ role: "user", content: "Hi" }],
-      max_tokens: 1,
+      max_tokens: 16,
       stream: false,
     });
   });

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -400,7 +400,8 @@ async function requestOpenAiVerification(params: {
       body: {
         model: params.modelId,
         messages: [{ role: "user", content: "Hi" }],
-        max_tokens: 1,
+        // Recent OpenAI-family endpoints reject probes below 16 tokens.
+        max_tokens: 16,
         stream: false,
       },
     });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the custom-provider onboarding compatibility probe used `max_tokens=1`, which some OpenAI-compatible backends reject as invalid or too low.
- Why it matters: onboarding can falsely mark valid OpenAI-compatible providers as broken.
- What changed: raise the probe to a safer low value (`max_tokens=16`), update the focused onboarding test, and carry the missing changelog entry.
- What did NOT change (scope boundary): no broader onboarding probe payload or provider verification flow changed.
- Supersedes #65738.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #65738
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the onboarding probe assumed every compatible backend accepts a 1-token cap, which is not true for several OpenAI-compatible implementations.
- Missing detection / guardrail: there was no regression coverage pinning the minimum-safe `max_tokens` used by onboarding.
- Contributing context (if known): local/self-hosted OpenAI-compatible providers often validate minimum token settings more strictly than OpenAI itself.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: src/commands/onboard-custom.test.ts
- Scenario the test should lock in: the custom onboarding compat probe uses `max_tokens=16` instead of `1`.
- Why this is the smallest reliable guardrail: the failure is in the probe payload assembly, so unit coverage is enough.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Custom-provider onboarding stops rejecting otherwise valid OpenAI-compatible backends just because they dislike a 1-token probe.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / `pnpm test:serial`
- Model/provider: OpenAI-compatible onboarding probe
- Integration/channel (if any): CLI onboarding
- Relevant config (redacted): targeted fixture/test doubles only

### Steps

1. Run the custom onboarding compatibility probe against an OpenAI-compatible backend that rejects `max_tokens=1`.
2. Run `pnpm test:serial src/commands/onboard-custom.test.ts`.
3. Verify the probe now uses `max_tokens=16`.

### Expected

- The compatibility probe uses a small but broadly accepted token cap and valid providers pass the probe.

### Actual

- Before the fix, the 1-token probe could produce a false negative during onboarding.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test:serial src/commands/onboard-custom.test.ts`.
- Edge cases checked: OpenAI-compatible providers with stricter minimum token validation.
- What you did **not** verify: a live matrix of third-party providers beyond the targeted test coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: narrow fix may miss adjacent provider-specific edge cases not covered by the focused regression.
  - Mitigation: keep the patch scoped and ship targeted regression coverage for the implicated path only.
