### PR TITLE
fix(codex): keep auth read diagnostics off stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
-- OpenAI Codex/auth: keep malformed Codex CLI auth-file diagnostics on the debug logger instead of stdout so interactive command output stays clean while auth read failures remain traceable. (#65893) Thanks @SimbaKingjoe and @vincentkoc.
+- OpenAI Codex/auth: keep malformed Codex CLI auth-file diagnostics on the debug logger instead of stdout so interactive command output stays clean while auth read failures remain traceable. (#66451) Thanks @SimbaKingjoe.
 
 ## 2026.4.14-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
+- OpenAI Codex/auth: keep malformed Codex CLI auth-file diagnostics on the debug logger instead of stdout so interactive command output stays clean while auth read failures remain traceable. (#65893) Thanks @SimbaKingjoe and @vincentkoc.
 
 ## 2026.4.14-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@ Docs: https://docs.openclaw.ai
 - Media-understanding/proxy env: auto-upgrade provider HTTP helper requests to trusted env-proxy mode only when `HTTP_PROXY`/`HTTPS_PROXY` is active and the target is not bypassed by `NO_PROXY`, so remote media-understanding and transcription requests stop failing local DNS pre-resolution in proxy-only environments without widening SSRF bypasses. (#52162) Thanks @mjamiv and @vincentkoc.
 - Browser: keep loopback CDP readiness checks reachable under strict SSRF defaults so OpenClaw can reconnect to locally started managed Chrome. (#66354) Thanks @hxy91819.
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
+- OpenAI Codex/auth: keep malformed Codex CLI auth-file diagnostics on the debug logger instead of stdout so interactive command output stays clean while auth read failures remain traceable. (#66451) Thanks @SimbaKingjoe.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
-- OpenAI Codex/auth: keep malformed Codex CLI auth-file diagnostics on the debug logger instead of stdout so interactive command output stays clean while auth read failures remain traceable. (#66451) Thanks @SimbaKingjoe.
 
 ## 2026.4.14-beta.1
 

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -22,9 +22,15 @@ const runtimeMocks = vi.hoisted(() => ({
   refreshOpenAICodexToken: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
-  ensureGlobalUndiciEnvProxyDispatcher: runtimeMocks.ensureGlobalUndiciEnvProxyDispatcher,
-}));
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    ensureGlobalUndiciEnvProxyDispatcher: runtimeMocks.ensureGlobalUndiciEnvProxyDispatcher,
+  };
+});
 
 vi.mock("@mariozechner/pi-ai/oauth", async () => {
   const actual = await vi.importActual<typeof import("@mariozechner/pi-ai/oauth")>(

--- a/extensions/openai/openai-codex-cli-auth.test.ts
+++ b/extensions/openai/openai-codex-cli-auth.test.ts
@@ -1,5 +1,16 @@
 import fs from "node:fs";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  createSubsystemLogger: () => ({
+    debug: runtimeMocks.debug,
+  }),
+}));
+
 import {
   OPENAI_CODEX_DEFAULT_PROFILE_ID,
   readOpenAICodexCliOAuthProfile,
@@ -12,6 +23,10 @@ function buildJwt(payload: Record<string, unknown>) {
 }
 
 describe("readOpenAICodexCliOAuthProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -79,5 +94,34 @@ describe("readOpenAICodexCliOAuthProfile", () => {
     });
 
     expect(parsed).toBeNull();
+  });
+
+  it("returns null without logging when the Codex CLI auth file is missing", () => {
+    const error = Object.assign(new Error("missing"), {
+      code: "ENOENT",
+    });
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw error;
+    });
+
+    const parsed = readOpenAICodexCliOAuthProfile({
+      store: { version: 1, profiles: {} },
+    });
+
+    expect(parsed).toBeNull();
+    expect(runtimeMocks.debug).not.toHaveBeenCalled();
+  });
+
+  it("logs debug output through the runtime logger for other auth read failures", () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue("{");
+
+    const parsed = readOpenAICodexCliOAuthProfile({
+      store: { version: 1, profiles: {} },
+    });
+
+    expect(parsed).toBeNull();
+    expect(runtimeMocks.debug).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to read auth file:"),
+    );
   });
 });

--- a/extensions/openai/openai-codex-cli-auth.test.ts
+++ b/extensions/openai/openai-codex-cli-auth.test.ts
@@ -112,7 +112,7 @@ describe("readOpenAICodexCliOAuthProfile", () => {
     expect(runtimeMocks.debug).not.toHaveBeenCalled();
   });
 
-  it("logs debug output through the runtime logger for other auth read failures", () => {
+  it("logs a sanitized code for invalid auth JSON", () => {
     vi.spyOn(fs, "readFileSync").mockReturnValue("{");
 
     const parsed = readOpenAICodexCliOAuthProfile({
@@ -121,7 +121,28 @@ describe("readOpenAICodexCliOAuthProfile", () => {
 
     expect(parsed).toBeNull();
     expect(runtimeMocks.debug).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to read auth file:"),
+      "Failed to read Codex CLI auth file (code=INVALID_JSON)",
+    );
+  });
+
+  it("does not leak auth file paths in debug logs for filesystem failures", () => {
+    const error = Object.assign(
+      new Error("EACCES: permission denied, open '/Users/alice/.codex/auth.json'"),
+      {
+        code: "EACCES",
+      },
+    );
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw error;
+    });
+
+    const parsed = readOpenAICodexCliOAuthProfile({
+      store: { version: 1, profiles: {} },
+    });
+
+    expect(parsed).toBeNull();
+    expect(runtimeMocks.debug).toHaveBeenCalledWith(
+      "Failed to read Codex CLI auth file (code=EACCES)",
     );
   });
 });

--- a/extensions/openai/openai-codex-cli-auth.ts
+++ b/extensions/openai/openai-codex-cli-auth.ts
@@ -45,15 +45,18 @@ function readCodexCliAuthFile(env: NodeJS.ProcessEnv): CodexCliAuthFile | null {
     const parsed = JSON.parse(raw);
     return parsed && typeof parsed === "object" ? (parsed as CodexCliAuthFile) : null;
   } catch (error) {
-    if (error instanceof Error) {
-      const code = "code" in error ? (error as NodeJS.ErrnoException).code : undefined;
-      if (code === "ENOENT") {
-        return null;
-      }
-      log.debug(`Failed to read auth file: ${error.message}`);
-    } else {
-      log.debug(`Failed to read auth file: ${String(error)}`);
+    const code =
+      error instanceof SyntaxError
+        ? "INVALID_JSON"
+        : error instanceof Error && "code" in error
+          ? (error as NodeJS.ErrnoException).code
+          : undefined;
+    if (code === "ENOENT") {
+      return null;
     }
+    log.debug(
+      `Failed to read Codex CLI auth file (code=${typeof code === "string" ? code : "UNKNOWN"})`,
+    );
     return null;
   }
 }

--- a/extensions/openai/openai-codex-cli-auth.ts
+++ b/extensions/openai/openai-codex-cli-auth.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { AuthProfileStore, OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import { resolveRequiredHomeDir } from "openclaw/plugin-sdk/provider-auth";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
   resolveCodexAccessTokenExpiry,
   resolveCodexAuthIdentity,
@@ -9,6 +10,7 @@ import {
 import { trimNonEmptyString } from "./openai-codex-shared.js";
 
 const PROVIDER_ID = "openai-codex";
+const log = createSubsystemLogger("openai/codex-cli-auth");
 
 export const CODEX_CLI_PROFILE_ID = `${PROVIDER_ID}:codex-cli`;
 export const OPENAI_CODEX_DEFAULT_PROFILE_ID = `${PROVIDER_ID}:default`;
@@ -42,7 +44,16 @@ function readCodexCliAuthFile(env: NodeJS.ProcessEnv): CodexCliAuthFile | null {
     const raw = fs.readFileSync(authPath, "utf8");
     const parsed = JSON.parse(raw);
     return parsed && typeof parsed === "object" ? (parsed as CodexCliAuthFile) : null;
-  } catch {
+  } catch (error) {
+    if (error instanceof Error) {
+      const code = "code" in error ? (error as NodeJS.ErrnoException).code : undefined;
+      if (code === "ENOENT") {
+        return null;
+      }
+      log.debug(`Failed to read auth file: ${error.message}`);
+    } else {
+      log.debug(`Failed to read auth file: ${String(error)}`);
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: malformed Codex CLI auth-file reads could print diagnostics to stdout.
- Why it matters: interactive command output gets polluted even though the auth failure is only diagnostic context.
- What changed: keep malformed-auth diagnostics on the debug logger, keep missing auth files silent, retain test coverage, and add the missing changelog entry.
- What did NOT change (scope boundary): no auth format migration or login flow behavior changed.
- Supersedes #65893.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #65893
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Codex CLI auth helper surfaced non-ENOENT read/parse failures through stdout instead of the logger path intended for diagnostics.
- Missing detection / guardrail: coverage did not lock in the stdout-vs-debug distinction for malformed auth-file reads.
- Contributing context (if known): this path sits on an interactive command boundary where stdout cleanliness matters.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: extensions/openai/openai-codex-cli-auth.test.ts
- Scenario the test should lock in: malformed auth reads use debug logging, while missing auth files still return null quietly.
- Why this is the smallest reliable guardrail: the bug is isolated to the helper that reads and reports auth-file failures.
- Existing test that already covers this (if any): adjacent auth helper coverage existed, but not the stdout leakage regression.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Interactive Codex-related command output stays clean while malformed-auth diagnostics remain available on debug logs.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / `pnpm test:serial`
- Model/provider: OpenAI Codex auth helper
- Integration/channel (if any): Codex CLI auth
- Relevant config (redacted): targeted fixture/test doubles only

### Steps

1. Make the Codex auth file unreadable or malformed in the targeted fixture.
2. Run `pnpm test:serial extensions/openai/openai-codex-cli-auth.test.ts`.
3. Verify the helper logs debug diagnostics without writing to stdout, and ENOENT still returns null silently.

### Expected

- Malformed auth-file reads stay on debug logging only; missing files remain quiet.

### Actual

- Before the fix, malformed auth-file failures could write directly to stdout.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test:serial extensions/openai/openai-codex-cli-auth.test.ts`.
- Edge cases checked: ENOENT handling versus malformed/auth parse failures.
- What you did **not** verify: live Codex CLI auth state outside the targeted helper tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: narrow fix may miss adjacent provider-specific edge cases not covered by the focused regression.
  - Mitigation: keep the patch scoped and ship targeted regression coverage for the implicated path only.
