### PR TITLE
fix(memory): preserve embedding proxy provider prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Ollama/OpenAI-compat: send `stream_options.include_usage` for Ollama streaming completions so local Ollama runs report real usage instead of falling back to bogus prompt-token counts that trigger premature compaction. (#64568) Thanks @xchunzhao and @vincentkoc.
 - Doctor/plugins: cache external `preferOver` catalog lookups within each plugin auto-enable pass so large `agents.list` configs no longer peg CPU and repeatedly reread plugin catalogs during doctor/plugins resolution. (#66246) Thanks @yfge.
 - GitHub Copilot/thinking: allow `github-copilot/gpt-5.4` to use `xhigh` reasoning so Copilot GPT-5.4 matches the rest of the GPT-5.4 family. (#50168) Thanks @jakepresent and @vincentkoc.
+- Memory/embeddings: preserve non-OpenAI provider prefixes when normalizing OpenAI-compatible embedding model refs so proxy-backed memory providers stop failing with `Unknown memory embedding provider`. (#66452) Thanks @jlapenna.
 - Agents/local models: clarify low-context preflight hints for self-hosted models, point config-backed caps at the relevant OpenClaw setting, and stop suggesting larger models when `agents.defaults.contextTokens` is the real limit. (#66236) Thanks @ImLukeF.
 - Browser/SSRF: restore hostname navigation under the default browser SSRF policy while keeping explicit strict mode reachable from config, and keep managed loopback CDP `/json/new` fallback requests on the local CDP control policy so browser follow-up fixes stop regressing normal navigation or self-blocking local CDP control. (#66386) Thanks @obviyus.
 - Models/Codex: canonicalize the legacy `openai-codex/gpt-5.4-codex` runtime alias to `openai-codex/gpt-5.4` while still honoring alias-specific and canonical per-model overrides. (#43060) Thanks @Sapientropic and @vincentkoc.
@@ -29,7 +30,6 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
-- Memory/embeddings: preserve non-OpenAI provider prefixes when normalizing OpenAI-compatible embedding model refs so proxy-backed memory providers stop failing with `Unknown memory embedding provider`. (#66452) Thanks @jlapenna.
 
 ## 2026.4.14-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
-- Memory/embeddings: preserve non-OpenAI provider prefixes when normalizing OpenAI-compatible embedding model refs so proxy-backed memory providers stop failing with `Unknown memory embedding provider`. (#66190) Thanks @jlapenna and @vincentkoc.
+- Memory/embeddings: preserve non-OpenAI provider prefixes when normalizing OpenAI-compatible embedding model refs so proxy-backed memory providers stop failing with `Unknown memory embedding provider`. (#66452) Thanks @jlapenna.
 
 ## 2026.4.14-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: compact engine-owned sessions from the first tool-loop delta and preserve ingest fallback when `afterTurn` is absent, so long-running tool loops can stay bounded without dropping engine state. (#63555) Thanks @Bikkies.
 - Discord/native commands: return the real status card for native `/status` interactions instead of falling through to the synthetic `✅ Done.` ack when the generic dispatcher produces no visible reply. (#54629) Thanks @tkozzer and @vincentkoc.
 - Hooks/Ollama: let LLM-backed session-memory slug generation honor an explicit `agents.defaults.timeoutSeconds` override instead of always aborting after 15 seconds, so slow local Ollama runs stop silently dropping back to generic filenames. (#66237) Thanks @dmak and @vincentkoc.
+- Memory/embeddings: preserve non-OpenAI provider prefixes when normalizing OpenAI-compatible embedding model refs so proxy-backed memory providers stop failing with `Unknown memory embedding provider`. (#66190) Thanks @jlapenna and @vincentkoc.
 
 ## 2026.4.14-beta.1
 

--- a/src/memory-host-sdk/host/embeddings-openai.test.ts
+++ b/src/memory-host-sdk/host/embeddings-openai.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_OPENAI_EMBEDDING_MODEL, normalizeOpenAiModel } from "./embeddings-openai.js";
+
+describe("normalizeOpenAiModel", () => {
+  it("returns the default model when input is blank", () => {
+    expect(normalizeOpenAiModel("")).toBe(DEFAULT_OPENAI_EMBEDDING_MODEL);
+    expect(normalizeOpenAiModel("   ")).toBe(DEFAULT_OPENAI_EMBEDDING_MODEL);
+  });
+
+  it("strips the openai/ prefix", () => {
+    expect(normalizeOpenAiModel("openai/text-embedding-3-small")).toBe("text-embedding-3-small");
+    expect(normalizeOpenAiModel("openai/text-embedding-ada-002")).toBe("text-embedding-ada-002");
+  });
+
+  it("preserves explicit third-party provider prefixes", () => {
+    expect(normalizeOpenAiModel("spark/text-embedding-3-small")).toBe(
+      "spark/text-embedding-3-small",
+    );
+    expect(normalizeOpenAiModel("litellm/azure/ada-002")).toBe("litellm/azure/ada-002");
+  });
+
+  it("preserves unprefixed model ids", () => {
+    expect(normalizeOpenAiModel("text-embedding-3-large")).toBe("text-embedding-3-large");
+  });
+});

--- a/src/memory-host-sdk/host/embeddings-openai.ts
+++ b/src/memory-host-sdk/host/embeddings-openai.ts
@@ -1,6 +1,6 @@
+import { parseStaticModelRef } from "../../agents/model-ref-shared.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { OPENAI_DEFAULT_EMBEDDING_MODEL } from "../../plugins/provider-model-defaults.js";
-import { normalizeEmbeddingModelWithPrefixes } from "./embeddings-model-normalize.js";
 import {
   createRemoteEmbeddingProvider,
   resolveRemoteEmbeddingClient,
@@ -24,11 +24,12 @@ const OPENAI_MAX_INPUT_TOKENS: Record<string, number> = {
 };
 
 export function normalizeOpenAiModel(model: string): string {
-  return normalizeEmbeddingModelWithPrefixes({
-    model,
-    defaultModel: DEFAULT_OPENAI_EMBEDDING_MODEL,
-    prefixes: ["openai/"],
-  });
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return DEFAULT_OPENAI_EMBEDDING_MODEL;
+  }
+  const parsed = parseStaticModelRef(trimmed, "openai");
+  return parsed && parsed.provider === "openai" ? parsed.model : trimmed;
 }
 
 export async function createOpenAiEmbeddingProvider(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: static embedding model refs routed through proxy providers could lose their provider prefix and get rewritten as raw OpenAI refs.
- Why it matters: memory embedding requests can silently switch providers or break when users rely on proxy-prefixed model refs like `spark/...` or `litellm/...`.
- What changed: parse static embedding model refs with provider-aware logic so non-OpenAI prefixes survive, add focused regression coverage, and carry the missing changelog entry.
- What did NOT change (scope boundary): no broader embedding provider selection or memory indexing policy changed.
- Supersedes #66190.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #66190
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: embedding model normalization treated static refs as OpenAI-native too early and discarded third-party provider prefixes.
- Missing detection / guardrail: there was no focused test for prefixed static embedding refs flowing through the OpenAI embedding host path.
- Contributing context (if known): memory setups frequently proxy embeddings through LiteLLM, Spark, and similar provider prefixes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: src/memory-host-sdk/host/embeddings-openai.test.ts
- Scenario the test should lock in: provider-prefixed static embedding refs are preserved instead of being collapsed to `openai/...`.
- Why this is the smallest reliable guardrail: the failure is contained in static model-ref parsing for the embedding host path.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Memory embeddings now preserve configured proxy-provider prefixes instead of silently rewriting them to OpenAI.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / `pnpm test:serial`
- Model/provider: Memory embeddings via proxy providers
- Integration/channel (if any): Memory host SDK
- Relevant config (redacted): targeted fixture/test doubles only

### Steps

1. Configure memory embeddings with a provider-prefixed static model ref such as `spark/text-embedding-3-large`.
2. Run `pnpm test:serial src/memory-host-sdk/host/embeddings-openai.test.ts`.
3. Verify the resolved embedding model keeps the original provider prefix.

### Expected

- The provider-prefixed static ref remains provider-prefixed through embedding host resolution.

### Actual

- Before the fix, the prefix could be dropped and rewritten as an OpenAI ref.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test:serial src/memory-host-sdk/host/embeddings-openai.test.ts`.
- Edge cases checked: non-OpenAI provider prefixes on static embedding refs.
- What you did **not** verify: live remote embedding calls through every supported proxy provider.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: narrow fix may miss adjacent provider-specific edge cases not covered by the focused regression.
  - Mitigation: keep the patch scoped and ship targeted regression coverage for the implicated path only.
