### PR TITLE
feat(codex): add gpt-5.4-pro forward compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- OpenAI Codex/models: add forward-compat support for `gpt-5.4-pro`, including Codex pricing/limits and list/status visibility before the upstream catalog catches up. (#63447) Thanks @jepson-liu and @vincentkoc.
+- OpenAI Codex/models: add forward-compat support for `gpt-5.4-pro`, including Codex pricing/limits and list/status visibility before the upstream catalog catches up. (#66453) Thanks @jepson-liu.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- OpenAI Codex/models: add forward-compat support for `gpt-5.4-pro`, including Codex pricing/limits and list/status visibility before the upstream catalog catches up. (#63447) Thanks @jepson-liu and @vincentkoc.
+
 ### Fixes
 
 - Agents/Ollama: forward the configured embedded-run timeout into the global undici stream timeout tuning so slow local Ollama runs no longer inherit the default stream cutoff instead of the operator-set run timeout. (#63175) Thanks @mindcraftreader and @vincentkoc.

--- a/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
+++ b/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
@@ -145,7 +145,9 @@ describe("discord native /think autocomplete", () => {
     providerThinkingMocks.resolveProviderBinaryThinking.mockReturnValue(undefined);
     providerThinkingMocks.resolveProviderDefaultThinkingLevel.mockReturnValue(undefined);
     providerThinkingMocks.resolveProviderXHighThinking.mockImplementation(({ provider, context }) =>
-      provider === "openai-codex" && context.modelId === "gpt-5.4" ? true : undefined,
+      provider === "openai-codex" && ["gpt-5.4", "gpt-5.4-pro"].includes(context.modelId)
+        ? true
+        : undefined,
     );
     buildModelsProviderDataMock.mockResolvedValue({
       byProvider: new Map<string, Set<string>>(),
@@ -172,7 +174,9 @@ describe("discord native /think autocomplete", () => {
     providerThinkingMocks.resolveProviderDefaultThinkingLevel.mockReturnValue(undefined);
     providerThinkingMocks.resolveProviderXHighThinking.mockReset();
     providerThinkingMocks.resolveProviderXHighThinking.mockImplementation(({ provider, context }) =>
-      provider === "openai-codex" && context.modelId === "gpt-5.4" ? true : undefined,
+      provider === "openai-codex" && ["gpt-5.4", "gpt-5.4-pro"].includes(context.modelId)
+        ? true
+        : undefined,
     );
     fs.mkdirSync(path.dirname(STORE_PATH), { recursive: true });
     fs.writeFileSync(

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -264,6 +264,7 @@ describe("openai codex provider", () => {
         id: "gpt-5.4",
         contextWindow: 1_050_000,
         contextTokens: 272_000,
+        cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
       }),
     );
     expect(entries).toContainEqual(
@@ -271,12 +272,14 @@ describe("openai codex provider", () => {
         id: "gpt-5.4-pro",
         contextWindow: 1_050_000,
         contextTokens: 272_000,
+        cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
       }),
     );
     expect(entries).toContainEqual(
       expect.objectContaining({
         id: "gpt-5.4-mini",
         contextWindow: 272_000,
+        cost: { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
       }),
     );
   });

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -134,6 +134,42 @@ describe("openai codex provider", () => {
     });
   });
 
+  it("resolves gpt-5.4-pro with pro pricing and codex-sized limits", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.resolveDynamicModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.4-pro",
+      modelRegistry: {
+        find: (providerId: string, modelId: string) => {
+          if (providerId === "openai-codex" && modelId === "gpt-5.3-codex") {
+            return {
+              id: "gpt-5.3-codex",
+              name: "gpt-5.3-codex",
+              provider: "openai-codex",
+              api: "openai-codex-responses",
+              baseUrl: "https://chatgpt.com/backend-api",
+              reasoning: true,
+              input: ["text", "image"] as const,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 272_000,
+              maxTokens: 128_000,
+            };
+          }
+          return undefined;
+        },
+      } as never,
+    });
+
+    expect(model).toMatchObject({
+      id: "gpt-5.4-pro",
+      contextWindow: 1_050_000,
+      contextTokens: 272_000,
+      maxTokens: 128_000,
+      cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
+    });
+  });
+
   it("resolves the legacy gpt-5.4-codex alias to canonical gpt-5.4", () => {
     const provider = buildOpenAICodexProviderPlugin();
 
@@ -226,6 +262,13 @@ describe("openai codex provider", () => {
     expect(entries).toContainEqual(
       expect.objectContaining({
         id: "gpt-5.4",
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+      }),
+    );
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        id: "gpt-5.4-pro",
         contextWindow: 1_050_000,
         contextTokens: 272_000,
       }),

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -284,6 +284,33 @@ describe("openai codex provider", () => {
     );
   });
 
+  it("augments gpt-5.4-pro from catalog gpt-5.4 when legacy codex rows are absent", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const entries = provider.augmentModelCatalog?.({
+      env: process.env,
+      entries: [
+        {
+          id: "gpt-5.4",
+          name: "gpt-5.4",
+          provider: "openai-codex",
+          reasoning: true,
+          input: ["text", "image"],
+          contextWindow: 272_000,
+        },
+      ],
+    } as never);
+
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        id: "gpt-5.4-pro",
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
+      }),
+    );
+  });
+
   it("canonicalizes legacy gpt-5.4-codex models during resolved-model normalization", () => {
     const provider = buildOpenAICodexProviderPlugin();
 

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -170,6 +170,45 @@ describe("openai codex provider", () => {
     });
   });
 
+  it("resolves gpt-5.4-pro from a gpt-5.4 runtime template when legacy codex rows are absent", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.resolveDynamicModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.4-pro",
+      modelRegistry: {
+        find: (providerId: string, modelId: string) => {
+          if (providerId === "openai-codex" && modelId === "gpt-5.4") {
+            return {
+              id: "gpt-5.4",
+              name: "gpt-5.4",
+              provider: "openai-codex",
+              api: "openai-codex-responses",
+              baseUrl: "https://chatgpt.com/backend-api",
+              reasoning: true,
+              input: ["text", "image"] as const,
+              cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+              contextWindow: 1_050_000,
+              contextTokens: 272_000,
+              maxTokens: 128_000,
+            };
+          }
+          return undefined;
+        },
+      } as never,
+    });
+
+    expect(model).toMatchObject({
+      id: "gpt-5.4-pro",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      contextWindow: 1_050_000,
+      contextTokens: 272_000,
+      maxTokens: 128_000,
+      cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
+    });
+  });
+
   it("resolves the legacy gpt-5.4-codex alias to canonical gpt-5.4", () => {
     const provider = buildOpenAICodexProviderPlugin();
 

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -67,6 +67,11 @@ const OPENAI_CODEX_GPT_54_MINI_COST = {
   cacheWrite: 0,
 } as const;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
+/** Legacy codex rows first; fall back to catalog `gpt-5.4` when the API omits 5.3/5.2. */
+const OPENAI_CODEX_GPT_54_CATALOG_SYNTH_TEMPLATE_MODEL_IDS = [
+  ...OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS,
+  OPENAI_CODEX_GPT_54_MODEL_ID,
+] as const;
 const OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
   "gpt-5.1-codex-mini",
@@ -359,7 +364,7 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
       const gpt54Template = findCatalogTemplate({
         entries: ctx.entries,
         providerId: PROVIDER_ID,
-        templateIds: OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS,
+        templateIds: OPENAI_CODEX_GPT_54_CATALOG_SYNTH_TEMPLATE_MODEL_IDS,
       });
       const gpt54MiniTemplate = findCatalogTemplate({
         entries: ctx.entries,

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -378,6 +378,7 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
           input: ["text", "image"],
           contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
           contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
+          cost: OPENAI_CODEX_GPT_54_COST,
         }),
         buildOpenAISyntheticCatalogEntry(gpt54Template, {
           id: OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
@@ -385,12 +386,14 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
           input: ["text", "image"],
           contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
           contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
+          cost: OPENAI_CODEX_GPT_54_PRO_COST,
         }),
         buildOpenAISyntheticCatalogEntry(gpt54MiniTemplate, {
           id: OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
           reasoning: true,
           input: ["text", "image"],
           contextWindow: OPENAI_CODEX_GPT_54_MINI_CONTEXT_TOKENS,
+          cost: OPENAI_CODEX_GPT_54_MINI_COST,
         }),
         buildOpenAISyntheticCatalogEntry(sparkTemplate, {
           id: OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -142,7 +142,7 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
   let templateIds: readonly string[];
   let patch: Parameters<typeof cloneFirstTemplateModel>[0]["patch"];
   if (lower === OPENAI_CODEX_GPT_54_MODEL_ID || lower === OPENAI_CODEX_GPT_54_LEGACY_MODEL_ID) {
-    templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
+    templateIds = OPENAI_CODEX_GPT_54_CATALOG_SYNTH_TEMPLATE_MODEL_IDS;
     patch = {
       contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
       contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
@@ -150,7 +150,7 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
       cost: OPENAI_CODEX_GPT_54_COST,
     };
   } else if (lower === OPENAI_CODEX_GPT_54_PRO_MODEL_ID) {
-    templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
+    templateIds = OPENAI_CODEX_GPT_54_CATALOG_SYNTH_TEMPLATE_MODEL_IDS;
     patch = {
       contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
       contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -42,6 +42,7 @@ const PROVIDER_ID = "openai-codex";
 const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT_54_LEGACY_MODEL_ID = "gpt-5.4-codex";
+const OPENAI_CODEX_GPT_54_PRO_MODEL_ID = "gpt-5.4-pro";
 const OPENAI_CODEX_GPT_54_MINI_MODEL_ID = "gpt-5.4-mini";
 const OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS = 272_000;
@@ -51,6 +52,12 @@ const OPENAI_CODEX_GPT_54_COST = {
   input: 2.5,
   output: 15,
   cacheRead: 0.25,
+  cacheWrite: 0,
+} as const;
+const OPENAI_CODEX_GPT_54_PRO_COST = {
+  input: 30,
+  output: 180,
+  cacheRead: 0,
   cacheWrite: 0,
 } as const;
 const OPENAI_CODEX_GPT_54_MINI_COST = {
@@ -72,6 +79,7 @@ const OPENAI_CODEX_GPT_53_SPARK_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 const OPENAI_CODEX_XHIGH_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
+  OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
   OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
   OPENAI_CODEX_GPT_53_MODEL_ID,
   OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
@@ -80,6 +88,7 @@ const OPENAI_CODEX_XHIGH_MODEL_IDS = [
 ] as const;
 const OPENAI_CODEX_MODERN_MODEL_IDS = [
   OPENAI_CODEX_GPT_54_MODEL_ID,
+  OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
   OPENAI_CODEX_GPT_54_MINI_MODEL_ID,
   "gpt-5.2",
   "gpt-5.2-codex",
@@ -134,6 +143,14 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
       contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
       maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
       cost: OPENAI_CODEX_GPT_54_COST,
+    };
+  } else if (lower === OPENAI_CODEX_GPT_54_PRO_MODEL_ID) {
+    templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
+    patch = {
+      contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
+      contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
+      maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+      cost: OPENAI_CODEX_GPT_54_PRO_COST,
     };
   } else if (lower === OPENAI_CODEX_GPT_54_MINI_MODEL_ID) {
     templateIds = OPENAI_CODEX_GPT_54_MINI_TEMPLATE_MODEL_IDS;
@@ -306,9 +323,13 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
     supportsXHighThinking: ({ modelId }) =>
       matchesExactOrPrefix(modelId, OPENAI_CODEX_XHIGH_MODEL_IDS),
     isModernModelRef: ({ modelId }) => matchesExactOrPrefix(modelId, OPENAI_CODEX_MODERN_MODEL_IDS),
-    preferRuntimeResolvedModel: (ctx) =>
-      normalizeProviderId(ctx.provider) === PROVIDER_ID &&
-      ctx.modelId.trim().toLowerCase() === OPENAI_CODEX_GPT_54_MODEL_ID,
+    preferRuntimeResolvedModel: (ctx) => {
+      if (normalizeProviderId(ctx.provider) !== PROVIDER_ID) {
+        return false;
+      }
+      const id = ctx.modelId.trim().toLowerCase();
+      return id === OPENAI_CODEX_GPT_54_MODEL_ID || id === OPENAI_CODEX_GPT_54_PRO_MODEL_ID;
+    },
     buildReplayPolicy: buildOpenAIReplayPolicy,
     prepareExtraParams: (ctx) => {
       const transport = ctx.extraParams?.transport;
@@ -353,6 +374,13 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
       return [
         buildOpenAISyntheticCatalogEntry(gpt54Template, {
           id: OPENAI_CODEX_GPT_54_MODEL_ID,
+          reasoning: true,
+          input: ["text", "image"],
+          contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,
+          contextTokens: OPENAI_CODEX_GPT_54_DEFAULT_CONTEXT_TOKENS,
+        }),
+        buildOpenAISyntheticCatalogEntry(gpt54Template, {
+          id: OPENAI_CODEX_GPT_54_PRO_MODEL_ID,
           reasoning: true,
           input: ["text", "image"],
           contextWindow: OPENAI_CODEX_GPT_54_NATIVE_CONTEXT_TOKENS,

--- a/extensions/openai/shared.ts
+++ b/extensions/openai/shared.ts
@@ -6,6 +6,13 @@ import {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 
+type SyntheticOpenAIModelCatalogCost = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+};
+
 type SyntheticOpenAIModelCatalogEntry = {
   provider: string;
   id: string;
@@ -14,6 +21,7 @@ type SyntheticOpenAIModelCatalogEntry = {
   input?: ("text" | "image")[];
   contextWindow?: number;
   contextTokens?: number;
+  cost?: SyntheticOpenAIModelCatalogCost;
 };
 
 export const OPENAI_API_BASE_URL = "https://api.openai.com/v1";
@@ -50,6 +58,7 @@ export function buildOpenAISyntheticCatalogEntry(
     input: readonly ("text" | "image")[];
     contextWindow: number;
     contextTokens?: number;
+    cost?: SyntheticOpenAIModelCatalogCost;
   },
 ): SyntheticOpenAIModelCatalogEntry | undefined {
   if (!template) {
@@ -63,6 +72,7 @@ export function buildOpenAISyntheticCatalogEntry(
     input: [...entry.input],
     contextWindow: entry.contextWindow,
     ...(entry.contextTokens === undefined ? {} : { contextTokens: entry.contextTokens }),
+    ...(entry.cost === undefined ? {} : { cost: entry.cost }),
   };
 }
 

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -401,7 +401,8 @@ describe("isModernModelRef", () => {
       provider === "openai" &&
       ["gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini", "gpt-5.4-nano"].includes(context.modelId)
         ? true
-        : provider === "openai-codex" && ["gpt-5.4", "gpt-5.4-mini"].includes(context.modelId)
+        : provider === "openai-codex" &&
+            ["gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini"].includes(context.modelId)
           ? true
           : provider === "opencode" && ["claude-opus-4-6", "gemini-3-pro"].includes(context.modelId)
             ? true
@@ -415,6 +416,7 @@ describe("isModernModelRef", () => {
     expect(isModernModelRef({ provider: "openai", id: "gpt-5.4-mini" })).toBe(true);
     expect(isModernModelRef({ provider: "openai", id: "gpt-5.4-nano" })).toBe(true);
     expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4" })).toBe(true);
+    expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4-pro" })).toBe(true);
     expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4-mini" })).toBe(true);
     expect(isModernModelRef({ provider: "opencode", id: "claude-opus-4-6" })).toBe(true);
     expect(isModernModelRef({ provider: "opencode", id: "gemini-3-pro" })).toBe(true);

--- a/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
@@ -185,16 +185,16 @@ function buildDynamicModel(
       const isLegacyGpt54Alias = lower === "gpt-5.4-codex";
       const template =
         lower === "gpt-5.4" || isLegacyGpt54Alias || lower === "gpt-5.4-pro"
-          ? findTemplate(params, "openai-codex", ["gpt-5.4", "gpt-5.4"])
+          ? findTemplate(params, "openai-codex", ["gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex"])
           : lower === "gpt-5.4-mini"
             ? findTemplate(params, "openai-codex", [
                 "gpt-5.4",
                 "gpt-5.1-codex-mini",
                 "gpt-5.3-codex",
-                "gpt-5.4",
+                "gpt-5.2-codex",
               ])
             : lower === "gpt-5.3-codex-spark"
-              ? findTemplate(params, "openai-codex", ["gpt-5.4", "gpt-5.4"])
+              ? findTemplate(params, "openai-codex", ["gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex"])
               : findTemplate(params, "openai-codex", ["gpt-5.4"]);
       const fallback = {
         provider: "openai-codex",

--- a/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
@@ -184,7 +184,7 @@ function buildDynamicModel(
     case "openai-codex": {
       const isLegacyGpt54Alias = lower === "gpt-5.4-codex";
       const template =
-        lower === "gpt-5.4" || isLegacyGpt54Alias
+        lower === "gpt-5.4" || isLegacyGpt54Alias || lower === "gpt-5.4-pro"
           ? findTemplate(params, "openai-codex", ["gpt-5.4", "gpt-5.4"])
           : lower === "gpt-5.4-mini"
             ? findTemplate(params, "openai-codex", [
@@ -215,6 +215,22 @@ function buildDynamicModel(
             api: "openai-codex-responses",
             baseUrl: OPENAI_CODEX_BASE_URL,
             cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+            contextWindow: 1_050_000,
+            contextTokens: 272_000,
+            maxTokens: 128_000,
+          },
+          fallback,
+        );
+      }
+      if (lower === "gpt-5.4-pro") {
+        return cloneTemplate(
+          template,
+          modelId,
+          {
+            provider: "openai-codex",
+            api: "openai-codex-responses",
+            baseUrl: OPENAI_CODEX_BASE_URL,
+            cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 },
             contextWindow: 1_050_000,
             contextTokens: 272_000,
             maxTokens: 128_000,

--- a/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
@@ -39,6 +39,7 @@ export const DEFAULT_TEST_MODEL_CATALOG: Array<{
   { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", provider: "openai" },
   { id: "gpt-5.4-nano", name: "GPT-5.4 Nano", provider: "openai" },
   { id: "gpt-5.4", name: "GPT-5.4 (Codex)", provider: "openai-codex" },
+  { id: "gpt-5.4-pro", name: "GPT-5.4 Pro (Codex)", provider: "openai-codex" },
   { id: "gpt-5.4-mini", name: "GPT-5.4 Mini (Codex)", provider: "openai-codex" },
   { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
 ];
@@ -55,6 +56,7 @@ const OPENAI_XHIGH_MODEL_IDS = [
 
 const OPENAI_CODEX_XHIGH_MODEL_IDS = [
   "gpt-5.4",
+  "gpt-5.4-pro",
   "gpt-5.4-mini",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -85,7 +85,7 @@ describe("listThinkingLevels", () => {
     providerRuntimeMocks.resolveProviderXHighThinking.mockImplementation(({ provider, context }) =>
       (provider === "openai" && ["gpt-5.4", "gpt-5.4", "gpt-5.4-pro"].includes(context.modelId)) ||
       (provider === "openai-codex" &&
-        ["gpt-5.4", "gpt-5.4", "gpt-5.3-codex-spark"].includes(context.modelId)) ||
+        ["gpt-5.4", "gpt-5.4-pro", "gpt-5.3-codex-spark"].includes(context.modelId)) ||
       (provider === "github-copilot" && ["gpt-5.4", "gpt-5.4"].includes(context.modelId))
         ? true
         : undefined,
@@ -94,6 +94,7 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("openai-codex", "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels("openai-codex", "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels("openai-codex", "gpt-5.3-codex-spark")).toContain("xhigh");
+    expect(listThinkingLevels("openai-codex", "gpt-5.4-pro")).toContain("xhigh");
     expect(listThinkingLevels("openai", "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels("openai", "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels("openai", "gpt-5.4-pro")).toContain("xhigh");

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -19,6 +19,12 @@ const OPENAI_CODEX_MINI_MODEL = {
   contextWindow: 272_000,
 };
 
+const OPENAI_CODEX_PRO_MODEL = {
+  ...OPENAI_CODEX_MODEL,
+  id: "gpt-5.4-pro",
+  name: "GPT-5.4 Pro",
+};
+
 const OPENAI_CODEX_53_MODEL = {
   ...OPENAI_CODEX_MODEL,
   id: "gpt-5.4",
@@ -232,6 +238,35 @@ describe("modelsListCommand forward-compat", () => {
       expect(codexMini).toBeTruthy();
       expect(codexMini?.missing).toBe(false);
       expect(codexMini?.tags).not.toContain("missing");
+    });
+
+    it("does not mark configured codex gpt-5.4-pro as missing when forward-compat can build a fallback", async () => {
+      mocks.resolveConfiguredEntries.mockReturnValueOnce({
+        entries: [
+          {
+            key: "openai-codex/gpt-5.4-pro",
+            ref: { provider: "openai-codex", model: "gpt-5.4-pro" },
+            tags: new Set(["configured"]),
+            aliases: [],
+          },
+        ],
+      });
+      mocks.resolveModelWithRegistry.mockReturnValueOnce({ ...OPENAI_CODEX_PRO_MODEL });
+      const runtime = createRuntime();
+
+      await modelsListCommand({ json: true }, runtime as never);
+
+      expect(mocks.printModelTable).toHaveBeenCalled();
+      const rows = lastPrintedRows<{
+        key: string;
+        tags: string[];
+        missing: boolean;
+      }>();
+
+      const codexPro = rows.find((row) => row.key === "openai-codex/gpt-5.4-pro");
+      expect(codexPro).toBeTruthy();
+      expect(codexPro?.missing).toBe(false);
+      expect(codexPro?.tags).not.toContain("missing");
     });
 
     it("passes source config to model registry loading for persistence safety", async () => {

--- a/src/plugins/provider-runtime.test-support.ts
+++ b/src/plugins/provider-runtime.test-support.ts
@@ -14,6 +14,7 @@ export const expectedAugmentedOpenaiCodexCatalogEntries = [
   { provider: "openai", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
   { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
   { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+  { provider: "openai-codex", id: "gpt-5.4-pro", name: "gpt-5.4-pro" },
   { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
   {
     provider: "openai-codex",

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -132,6 +132,7 @@ function createOpenAiCatalogProviderPlugin(
       { provider: "openai", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
       { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
       { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
+      { provider: "openai-codex", id: "gpt-5.4-pro", name: "gpt-5.4-pro" },
       { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
       {
         provider: "openai-codex",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenAI Codex forward-compat handling covered `gpt-5.4` but not `gpt-5.4-pro`, so newer runtime/catalog combinations could hide or under-spec the model.
- Why it matters: users can have a working `gpt-5.4-pro` runtime before the upstream catalog catches up, but the model is missing pricing/limits/list visibility.
- What changed: add `gpt-5.4-pro` forward-compat synthesis, preserve legacy alias handling, wire pricing/limits, extend list/status coverage, and carry the missing changelog entry.
- What did NOT change (scope boundary): no broader Codex catalog refactor or unrelated provider default changes.
- Supersedes #63447.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #63447
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the forward-compat synthesis/template path only modeled `gpt-5.4`, leaving `gpt-5.4-pro` without the same fallback metadata path.
- Missing detection / guardrail: there was no focused provider/list/status coverage for `gpt-5.4-pro` when the upstream catalog row is absent.
- Contributing context (if known): Codex model catalogs often lag real runtime availability during rollouts.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: extensions/openai/openai-codex-provider.test.ts and related list/status forward-compat tests
- Scenario the test should lock in: `gpt-5.4-pro` remains visible and correctly annotated even when only template/fallback metadata is available.
- Why this is the smallest reliable guardrail: the failure spans provider augmentation plus list/status presentation, and the targeted test slice covers exactly those seams.
- Existing test that already covers this (if any): existing `gpt-5.4` forward-compat coverage was adjacent but incomplete for `gpt-5.4-pro`.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`gpt-5.4-pro` now shows up with sane Codex pricing/limits and forward-compat behavior before the upstream catalog row lands.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / `pnpm test:serial`
- Model/provider: OpenAI Codex model catalog
- Integration/channel (if any): Codex provider and model listing surfaces
- Relevant config (redacted): targeted fixture/test doubles only

### Steps

1. Run the Codex provider/list/status tests with a catalog state that lacks a concrete `gpt-5.4-pro` row.
2. Execute `pnpm test:serial extensions/openai/openai-codex-provider.test.ts src/commands/models/list.list-command.forward-compat.test.ts src/auto-reply/thinking.test.ts extensions/discord/src/monitor/native-command.think-autocomplete.test.ts src/agents/model-compat.test.ts src/plugins/provider-runtime.test.ts`.
3. Verify `gpt-5.4-pro` is synthesized with the expected metadata and remains visible across the affected surfaces.

### Expected

- `gpt-5.4-pro` is present with stable pricing/limit metadata and forward-compat behavior.

### Actual

- Before the fix, the model could be absent or under-specified when the upstream catalog lagged.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test:serial extensions/openai/openai-codex-provider.test.ts src/commands/models/list.list-command.forward-compat.test.ts src/auto-reply/thinking.test.ts extensions/discord/src/monitor/native-command.think-autocomplete.test.ts src/agents/model-compat.test.ts src/plugins/provider-runtime.test.ts`.
- Edge cases checked: legacy `gpt-5.4-codex` alias handling and fallback-cost synthesis when only template metadata is available.
- What you did **not** verify: live upstream Codex catalog rollouts beyond the targeted provider/list/status coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: narrow fix may miss adjacent provider-specific edge cases not covered by the focused regression.
  - Mitigation: keep the patch scoped and ship targeted regression coverage for the implicated path only.
