### PR TITLE
test(codex): cover exact gpt-5.4 registry upgrades

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -43,6 +43,7 @@ import {
   buildOpenAICodexForwardCompatExpectation,
   makeModel,
   mockDiscoveredModel,
+  OPENAI_CODEX_TEMPLATE_MODEL,
   mockOpenAICodexTemplateModel,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
@@ -825,6 +826,71 @@ describe("resolveModel", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
+  });
+
+  it("upgrades stale exact openai-codex gpt-5.4 registry metadata via forward-compat", () => {
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider !== "openai-codex") {
+          return null;
+        }
+        if (modelId === "gpt-5.4") {
+          return {
+            ...OPENAI_CODEX_TEMPLATE_MODEL,
+            id: "gpt-5.4",
+            name: "GPT-5.4",
+            contextWindow: 272000,
+          };
+        }
+        if (modelId === "gpt-5.3-codex") {
+          return {
+            ...OPENAI_CODEX_TEMPLATE_MODEL,
+            id: "gpt-5.3-codex",
+            name: "GPT-5.3 Codex",
+          };
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModelForTest("openai-codex", "gpt-5.4", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      contextWindow: 1_050_000,
+      maxTokens: 128000,
+    });
+  });
+
+  it("does not downgrade exact openai-codex gpt-5.3-codex registry metadata", () => {
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider !== "openai-codex") {
+          return null;
+        }
+        if (modelId === "gpt-5.3-codex") {
+          return {
+            ...OPENAI_CODEX_TEMPLATE_MODEL,
+            id: "gpt-5.3-codex",
+            name: "GPT-5.3 Codex",
+            contextWindow: 272000,
+          };
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModelForTest("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+      contextWindow: 272000,
+      maxTokens: 128000,
+    });
   });
 
   it("canonicalizes the legacy openai-codex gpt-5.4-codex alias at runtime", () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: exact-row OpenAI Codex registry upgrade behavior for `gpt-5.4` was not locked down with focused regression coverage.
- Why it matters: the current runtime behavior is subtle, and future refactors can silently regress exact-row upgrade or downgrade semantics.
- What changed: add focused regression coverage for exact `gpt-5.4` registry upgrades and ensure nearby exact legacy rows do not get downgraded.
- What did NOT change (scope boundary): no runtime behavior changed in this replacement; this is a guardrail PR on top of current main behavior.
- Supersedes #41343.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #41343
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A. Current main already contains the runtime behavior; the missing piece here is regression coverage for the exact-row upgrade contract.
- Missing detection / guardrail: there was no focused test proving exact `openai-codex/gpt-5.4` rows upgrade correctly while adjacent exact rows stay untouched.
- Contributing context (if known): the original PR aged badly because the runtime fix landed elsewhere, but the coverage gap remained.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: src/agents/pi-embedded-runner/model.test.ts
- Scenario the test should lock in: exact `gpt-5.4` rows upgrade through forward-compat resolution while exact `gpt-5.3-codex` rows are not downgraded.
- Why this is the smallest reliable guardrail: the current behavior is fully observable in the model-resolution test surface with no extra runtime setup.
- Existing test that already covers this (if any): adjacent model-resolution coverage existed, but not this exact-row pair of invariants.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None. This replacement PR adds regression coverage only.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / `pnpm test:serial`
- Model/provider: OpenAI Codex exact-row model resolution
- Integration/channel (if any): PI embedded runner model resolution
- Relevant config (redacted): targeted fixture/test doubles only

### Steps

1. Run the exact-row model-resolution coverage on current main behavior.
2. Execute `pnpm test:serial src/agents/pi-embedded-runner/model.test.ts`.
3. Verify exact `gpt-5.4` rows upgrade and exact `gpt-5.3-codex` rows do not downgrade.

### Expected

- Current forward-compat behavior stays locked in for exact `gpt-5.4` rows without regressing nearby exact legacy rows.

### Actual

- Without this coverage, the behavior could regress silently in future refactors.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test:serial src/agents/pi-embedded-runner/model.test.ts`.
- Edge cases checked: exact `gpt-5.4` upgrade and no-downgrade behavior for exact `gpt-5.3-codex` rows.
- What you did **not** verify: additional live Codex provider behavior outside the focused regression test.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: narrow fix may miss adjacent provider-specific edge cases not covered by the focused regression.
  - Mitigation: keep the patch scoped and ship targeted regression coverage for the implicated path only.
