### PR TITLE
fix(openai): clarify provider setup wizard hint

### DIFF
--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -206,7 +206,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
           choiceLabel: "OpenAI API key",
           groupId: "openai",
           groupLabel: "OpenAI",
-          groupHint: "Codex OAuth + API key",
+          groupHint: "Direct OpenAI API key",
         },
       }),
     ],

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -19,7 +19,7 @@
       "choiceHint": "Browser sign-in",
       "groupId": "openai",
       "groupLabel": "OpenAI",
-      "groupHint": "Codex OAuth + API key"
+      "groupHint": "Direct OpenAI API key"
     },
     {
       "provider": "openai",

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -28,7 +28,7 @@
       "choiceLabel": "OpenAI API key",
       "groupId": "openai",
       "groupLabel": "OpenAI",
-      "groupHint": "Codex OAuth + API key",
+      "groupHint": "Direct OpenAI API key",
       "optionKey": "openaiApiKey",
       "cliFlag": "--openai-api-key",
       "cliOption": "--openai-api-key <key>",

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -509,6 +509,44 @@ describe("buildAuthChoiceOptions", () => {
     expect(ollamaGroup?.options.some((opt) => opt.value === "ollama")).toBe(true);
   });
 
+  it("uses the direct API key hint for the OpenAI group when api-key auth is the primary setup option", () => {
+    resolveManifestProviderAuthChoices.mockReturnValue([
+      {
+        pluginId: "openai",
+        providerId: "openai",
+        methodId: "oauth",
+        choiceId: "openai-codex",
+        choiceLabel: "OpenAI Codex (ChatGPT OAuth)",
+        groupId: "openai",
+        groupLabel: "OpenAI",
+        groupHint: "Codex OAuth + API key",
+      },
+      {
+        pluginId: "openai",
+        providerId: "openai",
+        methodId: "api-key",
+        choiceId: "openai-api-key",
+        choiceLabel: "OpenAI API key",
+        groupId: "openai",
+        groupLabel: "OpenAI",
+        groupHint: "Direct OpenAI API key",
+      },
+    ]);
+
+    const { groups } = buildAuthChoiceGroups({
+      store: EMPTY_STORE,
+      includeSkip: false,
+    });
+    const openAiGroup = groups.find((group) => group.value === "openai");
+
+    expect(openAiGroup).toBeDefined();
+    expect(openAiGroup?.hint).toBe("Direct OpenAI API key");
+    expect(openAiGroup?.options.map((option) => option.value)).toEqual([
+      "openai-api-key",
+      "openai-codex",
+    ]);
+  });
+
   it("hides image-generation-only providers from the interactive auth picker", () => {
     resolveManifestProviderAuthChoices.mockReturnValue([
       {


### PR DESCRIPTION
Summary
This updates the OpenAI provider setup hint so the plain OpenAI API key option is described as a direct API-key flow instead of "Codex OAuth + API key".

Why
The previous hint was misleading for the standard OpenAI API key path and made the interactive setup flow harder to understand.

Changes
- rename the OpenAI group hint in the provider manifest and runtime provider definition
- add coverage for the OpenAI auth-choice group hint and option ordering

Testing
- node node_modules/vitest/vitest.mjs run src/commands/auth-choice-options.test.ts