### PR TITLE
[codex] fix(status): quiet read-only plugin registry loads

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -10,6 +10,7 @@ import {
   type MemoryMultimodalSettings,
 } from "../memory-host-sdk/multimodal.js";
 import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-provider-runtime.js";
+import type { PluginLogger } from "../plugins/types.js";
 import { clampInt, clampNumber, resolveUserPath } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 
@@ -146,17 +147,24 @@ function mergeConfig(
   defaults: MemorySearchConfig | undefined,
   overrides: MemorySearchConfig | undefined,
   agentId: string,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
 ): ResolvedMemorySearchConfig {
   const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
   const sessionMemory =
     overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
   const provider = overrides?.provider ?? defaults?.provider ?? "auto";
-  const primaryAdapter = provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider);
+  const primaryAdapter =
+    provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider, undefined, options);
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
   const fallback = overrides?.fallback ?? defaults?.fallback ?? "none";
   const fallbackAdapter =
-    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback) : undefined;
+    fallback && fallback !== "none"
+      ? getMemoryEmbeddingProvider(fallback, undefined, options)
+      : undefined;
   const hasRemoteConfig = Boolean(
     overrideRemote?.baseUrl ||
     overrideRemote?.apiKey ||
@@ -379,16 +387,22 @@ function resolveSyncConfig(
 export function resolveMemorySearchConfig(
   cfg: OpenClawConfig,
   agentId: string,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
 ): ResolvedMemorySearchConfig | null {
   const defaults = cfg.agents?.defaults?.memorySearch;
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
-  const resolved = mergeConfig(defaults, overrides, agentId);
+  const resolved = mergeConfig(defaults, overrides, agentId, options);
   if (!resolved.enabled) {
     return null;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider =
-    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);
+    resolved.provider === "auto"
+      ? undefined
+      : getMemoryEmbeddingProvider(resolved.provider, cfg, options);
   const builtinMultimodalSupport =
     resolved.provider === "auto"
       ? false

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -16,6 +16,10 @@ vi.mock("./models-config.providers.policy.runtime.js", async () => {
     applyProviderNativeStreamingUsagePolicy: () => undefined,
     normalizeProviderConfigPolicy: (providerKey: string, provider: unknown) =>
       providerKey === "lmstudio" ? normalizeLmstudioProviderConfig(provider as never) : undefined,
+    normalizeProviderModelIdPolicy: (providerKey: string, modelId: string) =>
+      providerKey === "google-vertex"
+        ? modelId.replace("flash-lite", "flash-lite-preview")
+        : undefined,
     resolveProviderConfigApiKeyPolicy: () => undefined,
   };
 });
@@ -290,6 +294,37 @@ describe("normalizeProviders", () => {
 
       const normalized = normalizeProviders({ providers, agentDir });
       expect(normalized?.lmstudio?.baseUrl).toBe("http://localhost:1234/v1");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes provider model ids through provider plugin hooks", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    try {
+      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
+        "google-vertex": {
+          baseUrl: "https://example.invalid/v1",
+          api: "openai-completions",
+          apiKey: "GOOGLE_VERTEX_API_KEY",
+          models: [createModel({ id: "gemini-3.1-flash-lite", name: "gemini-3.1-flash-lite" })],
+        },
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-completions",
+          apiKey: "OPENAI_API_KEY",
+          models: [createModel({ id: "gpt-5", name: "GPT-5" })],
+        },
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir });
+
+      expect(normalized).not.toBe(providers);
+      expect(normalized?.["google-vertex"]?.models?.[0]).toMatchObject({
+        id: "gemini-3.1-flash-lite-preview",
+        name: "gemini-3.1-flash-lite-preview",
+      });
+      expect(normalized?.openai).toBe(providers.openai);
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
 import {
+  normalizeProviderConfigModelId,
   normalizeProviderSpecificConfig,
   resolveProviderConfigApiKeyResolver,
 } from "./models-config.providers.policy.js";
@@ -15,6 +16,31 @@ import {
 import { enforceSourceManagedProviderSecrets } from "./models-config.providers.source-managed.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
+
+function normalizeProviderModelIds(providerKey: string, provider: ProviderConfig): ProviderConfig {
+  if (!Array.isArray(provider.models) || provider.models.length === 0) {
+    return provider;
+  }
+  let mutated = false;
+  const models = provider.models.map((model) => {
+    const normalizedId = normalizeProviderConfigModelId(providerKey, model.id);
+    if (!normalizedId || normalizedId === model.id) {
+      return model;
+    }
+    mutated = true;
+    const nextName = model.name === model.id ? normalizedId : model.name;
+    return nextName === model.name
+      ? { ...model, id: normalizedId }
+      : { ...model, id: normalizedId, name: nextName };
+  });
+  if (!mutated) {
+    return provider;
+  }
+  return {
+    ...provider,
+    models,
+  };
+}
 
 export function normalizeProviders(params: {
   providers: ModelsConfig["providers"];
@@ -120,6 +146,15 @@ export function normalizeProviders(params: {
     if (providerSpecificNormalized !== normalizedProvider) {
       mutated = true;
       normalizedProvider = providerSpecificNormalized;
+    }
+
+    const providerWithNormalizedModelIds = normalizeProviderModelIds(
+      normalizedKey,
+      normalizedProvider,
+    );
+    if (providerWithNormalizedModelIds !== normalizedProvider) {
+      mutated = true;
+      normalizedProvider = providerWithNormalizedModelIds;
     }
 
     const existing = next[normalizedKey];

--- a/src/agents/models-config.providers.policy.runtime.ts
+++ b/src/agents/models-config.providers.policy.runtime.ts
@@ -1,6 +1,7 @@
 import {
   applyProviderNativeStreamingUsageCompatWithPlugin,
   normalizeProviderConfigWithPlugin,
+  normalizeProviderModelIdWithPlugin,
   resolveProviderConfigApiKeyWithPlugin,
 } from "../plugins/provider-runtime.js";
 import { resolveProviderPluginLookupKey } from "./models-config.providers.policy.lookup.js";
@@ -36,6 +37,20 @@ export function normalizeProviderConfigPolicy(
       },
     }) ?? provider
   );
+}
+
+export function normalizeProviderModelIdPolicy(
+  providerKey: string,
+  modelId: string,
+): string | undefined {
+  const runtimeProviderKey = resolveProviderPluginLookupKey(providerKey).trim();
+  return normalizeProviderModelIdWithPlugin({
+    provider: runtimeProviderKey,
+    context: {
+      provider: providerKey,
+      modelId,
+    },
+  });
 }
 
 export function resolveProviderConfigApiKeyPolicy(

--- a/src/agents/models-config.providers.policy.test.ts
+++ b/src/agents/models-config.providers.policy.test.ts
@@ -2,11 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type NormalizeProviderSpecificConfig =
   typeof import("./models-config.providers.policy.js").normalizeProviderSpecificConfig;
+type NormalizeProviderConfigModelId =
+  typeof import("./models-config.providers.policy.js").normalizeProviderConfigModelId;
 type ResolveProviderConfigApiKeyResolver =
   typeof import("./models-config.providers.policy.js").resolveProviderConfigApiKeyResolver;
 
 const GOOGLE_BASE_URL = "https://generativelanguage.googleapis.com";
 let normalizeProviderSpecificConfig: NormalizeProviderSpecificConfig;
+let normalizeProviderConfigModelId: NormalizeProviderConfigModelId;
 let resolveProviderConfigApiKeyResolver: ResolveProviderConfigApiKeyResolver;
 
 vi.mock("../plugins/provider-runtime.js", () => ({
@@ -44,12 +47,24 @@ vi.mock("../plugins/provider-runtime.js", () => ({
     }
     return undefined;
   },
+  normalizeProviderModelIdWithPlugin: (params: {
+    provider: string;
+    context: { modelId: string };
+  }) => {
+    if (params.provider !== "google") {
+      return undefined;
+    }
+    return params.context.modelId.replace("flash-lite", "flash-lite-preview");
+  },
 }));
 
 beforeEach(async () => {
   vi.resetModules();
-  ({ normalizeProviderSpecificConfig, resolveProviderConfigApiKeyResolver } =
-    await import("./models-config.providers.policy.js"));
+  ({
+    normalizeProviderSpecificConfig,
+    normalizeProviderConfigModelId,
+    resolveProviderConfigApiKeyResolver,
+  } = await import("./models-config.providers.policy.js"));
 });
 
 describe("models-config.providers.policy", () => {
@@ -85,6 +100,12 @@ describe("models-config.providers.policy", () => {
       api: "google-generative-ai",
       baseUrl: "https://generativelanguage.googleapis.com/v1beta",
     });
+  });
+
+  it("normalizes aliased provider model ids through provider plugin hooks", () => {
+    expect(normalizeProviderConfigModelId("google-vertex", "gemini-3.1-flash-lite")).toBe(
+      "gemini-3.1-flash-lite-preview",
+    );
   });
 
   it("does not treat generic transport APIs as provider plugin ids", () => {

--- a/src/agents/models-config.providers.policy.ts
+++ b/src/agents/models-config.providers.policy.ts
@@ -1,6 +1,7 @@
 import {
   applyProviderNativeStreamingUsagePolicy,
   normalizeProviderConfigPolicy,
+  normalizeProviderModelIdPolicy,
   resolveProviderConfigApiKeyPolicy,
 } from "./models-config.providers.policy.runtime.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
@@ -29,6 +30,10 @@ export function normalizeProviderSpecificConfig(
     return normalized;
   }
   return provider;
+}
+
+export function normalizeProviderConfigModelId(providerKey: string, modelId: string): string {
+  return normalizeProviderModelIdPolicy(providerKey, modelId) ?? modelId;
 }
 
 export function resolveProviderConfigApiKeyResolver(

--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -43,6 +43,7 @@ describe("ensureCliCommandBootstrap", () => {
     expect(ensureCliPluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
       routeLogsToStderr: true,
+      emitTrustWarnings: false,
     });
   });
 
@@ -59,6 +60,7 @@ describe("ensureCliCommandBootstrap", () => {
     expect(ensureCliPluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "channels",
       routeLogsToStderr: true,
+      emitTrustWarnings: false,
     });
   });
 

--- a/src/cli/command-bootstrap.ts
+++ b/src/cli/command-bootstrap.ts
@@ -34,5 +34,6 @@ export async function ensureCliCommandBootstrap(params: {
   await ensureCliPluginRegistryLoaded({
     scope: resolvePluginRegistryScopeForCommandPath(params.commandPath),
     routeLogsToStderr: params.suppressDoctorStdout,
+    emitTrustWarnings: false,
   });
 }

--- a/src/cli/plugin-registry-loader.test.ts
+++ b/src/cli/plugin-registry-loader.test.ts
@@ -60,6 +60,18 @@ describe("plugin-registry-loader", () => {
     expect(loggingState.forceConsoleToStderr).toBe(false);
   });
 
+  it("forwards trust warning suppression when requested", async () => {
+    await ensureCliPluginRegistryLoaded({
+      scope: "channels",
+      emitTrustWarnings: false,
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "channels",
+      emitTrustWarnings: false,
+    });
+  });
+
   it("maps command paths to plugin registry scopes", () => {
     expect(resolvePluginRegistryScopeForCommandPath(["status"])).toBe("channels");
     expect(resolvePluginRegistryScopeForCommandPath(["health"])).toBe("channels");

--- a/src/cli/plugin-registry-loader.ts
+++ b/src/cli/plugin-registry-loader.ts
@@ -17,6 +17,7 @@ export function resolvePluginRegistryScopeForCommandPath(
 export async function ensureCliPluginRegistryLoaded(params: {
   scope: PluginRegistryScope;
   routeLogsToStderr?: boolean;
+  emitTrustWarnings?: boolean;
 }) {
   const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
   const previousForceStderr = loggingState.forceConsoleToStderr;
@@ -24,7 +25,12 @@ export async function ensureCliPluginRegistryLoaded(params: {
     loggingState.forceConsoleToStderr = true;
   }
   try {
-    ensurePluginRegistryLoaded({ scope: params.scope });
+    ensurePluginRegistryLoaded({
+      scope: params.scope,
+      ...(params.emitTrustWarnings !== undefined
+        ? { emitTrustWarnings: params.emitTrustWarnings }
+        : {}),
+    });
   } finally {
     loggingState.forceConsoleToStderr = previousForceStderr;
   }

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -209,7 +209,10 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["status"],
     });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "channels",
+      emitTrustWarnings: false,
+    });
     expect(processTitleSetSpy).toHaveBeenCalledWith("openclaw-status");
 
     vi.clearAllMocks();
@@ -224,7 +227,10 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["message", "send"],
     });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "all" });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
+      emitTrustWarnings: false,
+    });
     processTitleSetSpy.mockRestore();
   });
 
@@ -238,7 +244,10 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["agent", "hi"],
     });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "all" });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "all",
+      emitTrustWarnings: false,
+    });
   });
 
   it("keeps setup alias and channels add manifest-first", async () => {

--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -90,7 +90,10 @@ describe("tryRouteCli", () => {
       runtime: expect.any(Object),
       commandPath: ["status"],
     });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "channels",
+      emitTrustWarnings: false,
+    });
   });
 
   it("routes logs to stderr during plugin loading in --json mode and restores after", async () => {
@@ -141,7 +144,10 @@ describe("tryRouteCli", () => {
       runtime: expect.any(Object),
       commandPath: ["status"],
     });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "channels",
+      emitTrustWarnings: false,
+    });
   });
 
   it("respects OPENCLAW_HIDE_BANNER for routed commands", async () => {

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -117,7 +117,9 @@ async function resolveStatusAllLocalDiagnosis(params: {
           }
         })()
       : null;
-  const pluginCompatibility = buildPluginCompatibilityNotices({ config: overview.cfg });
+  const pluginCompatibility = buildPluginCompatibilityNotices({
+    config: overview.sourceConfig,
+  });
 
   return {
     configPath,

--- a/src/commands/status.scan-memory.test.ts
+++ b/src/commands/status.scan-memory.test.ts
@@ -50,7 +50,9 @@ describe("status.scan-memory", () => {
       requireDefaultStore,
     });
 
-    expect(mocks.resolveSharedMemoryStatusSnapshot).toHaveBeenCalledWith({
+    const snapshotArgs = mocks.resolveSharedMemoryStatusSnapshot.mock.calls[0]?.[0];
+
+    expect(snapshotArgs).toEqual({
       cfg: { agents: {} },
       agentStatus: {
         defaultId: "main",
@@ -69,9 +71,20 @@ describe("status.scan-memory", () => {
         ],
       },
       memoryPlugin: { enabled: true, slot: "memory-core" },
-      resolveMemoryConfig: mocks.resolveMemorySearchConfig,
+      resolveMemoryConfig: expect.any(Function),
       getMemorySearchManager: mocks.getMemorySearchManager,
       requireDefaultStore,
+    });
+
+    expect(snapshotArgs.resolveMemoryConfig({ agents: {} }, "main")).toBeUndefined();
+    expect(mocks.resolveMemorySearchConfig).toHaveBeenCalledWith({ agents: {} }, "main", {
+      emitTrustWarnings: false,
+      logger: expect.objectContaining({
+        info: expect.any(Function),
+        warn: expect.any(Function),
+        error: expect.any(Function),
+        debug: expect.any(Function),
+      }),
     });
   });
 });

--- a/src/commands/status.scan-memory.ts
+++ b/src/commands/status.scan-memory.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
+import type { PluginLogger } from "../plugins/types.js";
 import type { getAgentLocalStatuses as getAgentLocalStatusesFn } from "./status.agent-local.js";
 import {
   resolveSharedMemoryStatusSnapshot,
@@ -17,6 +18,15 @@ let statusScanDepsRuntimeModulePromise:
 function loadStatusScanDepsRuntimeModule() {
   statusScanDepsRuntimeModulePromise ??= import("./status.scan.deps.runtime.js");
   return statusScanDepsRuntimeModulePromise;
+}
+
+function createQuietStatusMemoryLogger(): PluginLogger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
 }
 
 export function resolveDefaultMemoryStorePath(agentId: string): string {
@@ -34,7 +44,11 @@ export async function resolveStatusMemoryStatusSnapshot(params: {
     cfg: params.cfg,
     agentStatus: params.agentStatus,
     memoryPlugin: params.memoryPlugin,
-    resolveMemoryConfig: resolveMemorySearchConfig,
+    resolveMemoryConfig: (cfg, agentId) =>
+      resolveMemorySearchConfig(cfg, agentId, {
+        emitTrustWarnings: false,
+        logger: createQuietStatusMemoryLogger(),
+      }),
     getMemorySearchManager,
     requireDefaultStore: params.requireDefaultStore,
   });

--- a/src/commands/status.scan.test.ts
+++ b/src/commands/status.scan.test.ts
@@ -91,6 +91,23 @@ describe("scanStatus", () => {
     );
   });
 
+  it("uses sourceConfig for plugin compatibility checks in text status output", async () => {
+    configureScanStatus({
+      sourceConfig: createStatusScanConfig({
+        marker: "source",
+      }),
+      resolvedConfig: createStatusScanConfig({
+        marker: "resolved",
+      }),
+    });
+
+    await scanStatus({ json: false }, {} as never);
+
+    expect(mocks.buildPluginCompatibilityNotices).toHaveBeenCalledWith({
+      config: expect.objectContaining({ marker: "source" }),
+    });
+  });
+
   it("skips channel plugin preload for status --json with no channel config", async () => {
     configureScanStatus({
       sourceConfig: createStatusScanConfig({

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -59,7 +59,9 @@ export async function scanStatus(
       });
 
       progress.setLabel("Checking plugins…");
-      const pluginCompatibility = buildPluginCompatibilityNotices({ config: overview.cfg });
+      const pluginCompatibility = buildPluginCompatibilityNotices({
+        config: overview.sourceConfig,
+      });
       progress.tick();
 
       progress.setLabel("Checking memory and sessions…");

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -523,9 +523,9 @@ describe("gateway server hooks", () => {
       mockIsolatedRunOk();
       await expectFirstHookDelivery(port, oversizedKey);
       await postAgentHookWithIdempotency(port, oversizedKey);
-      await waitForSystemEvent();
-
-      expect(cronIsolatedRun).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -310,4 +310,24 @@ describe("resolvePluginCapabilityProviders", () => {
     });
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({ config: compatConfig });
   });
+
+  it("forwards trust warning suppression when loading compatibility providers", () => {
+    const { cfg, enablementCompat } = createCompatChainConfig();
+    setBundledCapabilityFixture("speechProviders");
+    mocks.withBundledPluginEnablementCompat.mockReturnValue(enablementCompat);
+    mocks.withBundledPluginVitestCompat.mockReturnValue(enablementCompat);
+
+    expectNoResolvedCapabilityProviders(
+      resolvePluginCapabilityProviders({
+        key: "speechProviders",
+        cfg,
+        emitTrustWarnings: false,
+      }),
+    );
+
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
+      config: enablementCompat,
+      emitTrustWarnings: false,
+    });
+  });
 });

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -7,6 +7,7 @@ import {
 import { resolveRuntimePluginRegistry } from "./loader.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginRegistry } from "./registry-types.js";
+import type { PluginLogger } from "./types.js";
 
 type CapabilityProviderRegistryKey =
   | "memoryEmbeddingProviders"
@@ -81,6 +82,8 @@ function resolveCapabilityProviderConfig(params: {
 export function resolvePluginCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
   key: K;
   cfg?: OpenClawConfig;
+  emitTrustWarnings?: boolean;
+  logger?: PluginLogger;
 }): CapabilityProviderForKey<K>[] {
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
@@ -88,7 +91,16 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }
   const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
-  const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
+  const loadOptions =
+    compatConfig === undefined
+      ? undefined
+      : {
+          config: compatConfig,
+          ...(params.emitTrustWarnings !== undefined
+            ? { emitTrustWarnings: params.emitTrustWarnings }
+            : {}),
+          ...(params.logger ? { logger: params.logger } : {}),
+        };
   const registry = resolveRuntimePluginRegistry(loadOptions);
   return (registry?.[params.key] ?? []).map(
     (entry) => entry.provider,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -126,6 +126,7 @@ export type PluginLoadOptions = {
   activate?: boolean;
   loadModules?: boolean;
   throwOnLoadError?: boolean;
+  emitTrustWarnings?: boolean;
 };
 
 const CLI_METADATA_ENTRY_BASENAMES = [
@@ -1124,6 +1125,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const validateOnly = options.mode === "validate";
   const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
   const cacheEnabled = options.cache !== false;
+  const emitTrustWarnings = options.emitTrustWarnings ?? shouldActivate;
   if (cacheEnabled) {
     const cached = getCachedPluginRegistry(cacheKey);
     if (cached) {
@@ -1276,7 +1278,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     });
     pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
     warnWhenAllowlistIsOpen({
-      emitWarning: shouldActivate,
+      emitWarning: emitTrustWarnings,
       logger,
       pluginsEnabled: normalized.enabled,
       allow: normalized.allow,
@@ -1814,7 +1816,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       registry,
       provenance,
       allowlist: normalized.allow,
-      emitWarning: shouldActivate,
+      emitWarning: emitTrustWarnings,
       logger,
       env,
     });

--- a/src/plugins/memory-embedding-provider-runtime.test.ts
+++ b/src/plugins/memory-embedding-provider-runtime.test.ts
@@ -60,6 +60,22 @@ describe("memory embedding provider runtime resolution", () => {
     expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledTimes(2);
   });
 
+  it("forwards trust warning suppression to capability fallback resolution", () => {
+    mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("ollama")]);
+
+    expect(
+      runtimeModule.getMemoryEmbeddingProvider("ollama", undefined, {
+        emitTrustWarnings: false,
+      })?.id,
+    ).toBe("ollama");
+
+    expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledWith({
+      key: "memoryEmbeddingProviders",
+      cfg: undefined,
+      emitTrustWarnings: false,
+    });
+  });
+
   it("does not consult capability fallback once runtime adapters are registered", () => {
     registerMemoryEmbeddingProvider({
       id: "openai",

--- a/src/plugins/memory-embedding-provider-runtime.ts
+++ b/src/plugins/memory-embedding-provider-runtime.ts
@@ -5,6 +5,7 @@ import {
   listRegisteredMemoryEmbeddingProviders,
   type MemoryEmbeddingProviderAdapter,
 } from "./memory-embedding-providers.js";
+import type { PluginLogger } from "./types.js";
 
 export { listRegisteredMemoryEmbeddingProviders };
 
@@ -13,6 +14,10 @@ export function listRegisteredMemoryEmbeddingProviderAdapters(): MemoryEmbedding
 }
 export function listMemoryEmbeddingProviders(
   cfg?: OpenClawConfig,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
 ): MemoryEmbeddingProviderAdapter[] {
   const registered = listRegisteredMemoryEmbeddingProviderAdapters();
   if (registered.length > 0) {
@@ -21,12 +26,20 @@ export function listMemoryEmbeddingProviders(
   return resolvePluginCapabilityProviders({
     key: "memoryEmbeddingProviders",
     cfg,
+    ...(options?.emitTrustWarnings !== undefined
+      ? { emitTrustWarnings: options.emitTrustWarnings }
+      : {}),
+    ...(options?.logger ? { logger: options.logger } : {}),
   });
 }
 
 export function getMemoryEmbeddingProvider(
   id: string,
   cfg?: OpenClawConfig,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
 ): MemoryEmbeddingProviderAdapter | undefined {
   const registered = getRegisteredMemoryEmbeddingProvider(id);
   if (registered) {
@@ -35,5 +48,5 @@ export function getMemoryEmbeddingProvider(
   if (listRegisteredMemoryEmbeddingProviders().length > 0) {
     return undefined;
   }
-  return listMemoryEmbeddingProviders(cfg).find((adapter) => adapter.id === id);
+  return listMemoryEmbeddingProviders(cfg, options).find((adapter) => adapter.id === id);
 }

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -159,6 +159,24 @@ describe("memory runtime auto-enable loading", () => {
     await expectAutoEnabledMemoryRuntimeCase({ run, expectedResult });
   });
 
+  it("suppresses trust warnings when status probes bootstrap memory runtime", async () => {
+    const { rawConfig, autoEnabledConfig } = setAutoEnabledMemoryRuntime();
+
+    await getActiveMemorySearchManager({
+      cfg: rawConfig as never,
+      agentId: "main",
+      purpose: "status",
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: autoEnabledConfig,
+        activationSourceConfig: rawConfig,
+        emitTrustWarnings: false,
+      }),
+    );
+  });
+
   it.each([
     {
       name: "does not bootstrap the memory runtime just to close managers",

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -5,14 +5,38 @@ import {
   buildPluginRuntimeLoadOptions,
   resolvePluginRuntimeLoadContext,
 } from "./runtime/load-context.js";
+import type { PluginLogger } from "./types.js";
 
-function ensureMemoryRuntime(cfg?: OpenClawConfig) {
+function createQuietMemoryRuntimeLogger(): PluginLogger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
+function ensureMemoryRuntime(
+  cfg?: OpenClawConfig,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
+) {
   const current = getMemoryRuntime();
   if (current || !cfg) {
     return current;
   }
   resolveRuntimePluginRegistry(
-    buildPluginRuntimeLoadOptions(resolvePluginRuntimeLoadContext({ config: cfg })),
+    buildPluginRuntimeLoadOptions(
+      resolvePluginRuntimeLoadContext({
+        config: cfg,
+        ...(options?.logger ? { logger: options.logger } : {}),
+      }),
+      options?.emitTrustWarnings !== undefined
+        ? { emitTrustWarnings: options.emitTrustWarnings }
+        : {},
+    ),
   );
   return getMemoryRuntime();
 }
@@ -22,7 +46,15 @@ export async function getActiveMemorySearchManager(params: {
   agentId: string;
   purpose?: "default" | "status";
 }) {
-  const runtime = ensureMemoryRuntime(params.cfg);
+  const runtime = ensureMemoryRuntime(
+    params.cfg,
+    params.purpose === "status"
+      ? {
+          emitTrustWarnings: false,
+          logger: createQuietMemoryRuntimeLogger(),
+        }
+      : {},
+  );
   if (!runtime) {
     return { manager: null, error: "memory plugin unavailable" };
   }

--- a/src/plugins/runtime/metadata-registry-loader.test.ts
+++ b/src/plugins/runtime/metadata-registry-loader.test.ts
@@ -92,4 +92,18 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
       }),
     );
   });
+
+  it("forwards trust warning suppression to metadata snapshots", () => {
+    loadPluginMetadataRegistrySnapshot({
+      config: { plugins: {} },
+      emitTrustWarnings: false,
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emitTrustWarnings: false,
+        mode: "validate",
+      }),
+    );
+  });
 });

--- a/src/plugins/runtime/metadata-registry-loader.ts
+++ b/src/plugins/runtime/metadata-registry-loader.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadOpenClawPlugins } from "../loader.js";
 import { hasExplicitPluginIdScope } from "../plugin-scope.js";
 import type { PluginRegistry } from "../registry.js";
+import type { PluginLogger } from "../types.js";
 import { buildPluginRuntimeLoadOptions, resolvePluginRuntimeLoadContext } from "./load-context.js";
 
 export function loadPluginMetadataRegistrySnapshot(options?: {
@@ -9,8 +10,10 @@ export function loadPluginMetadataRegistrySnapshot(options?: {
   activationSourceConfig?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   workspaceDir?: string;
+  logger?: PluginLogger;
   onlyPluginIds?: string[];
   loadModules?: boolean;
+  emitTrustWarnings?: boolean;
 }): PluginRegistry {
   const context = resolvePluginRuntimeLoadContext(options);
 
@@ -21,6 +24,9 @@ export function loadPluginMetadataRegistrySnapshot(options?: {
       activate: false,
       mode: "validate",
       loadModules: options?.loadModules,
+      ...(options?.emitTrustWarnings !== undefined
+        ? { emitTrustWarnings: options.emitTrustWarnings }
+        : {}),
       ...(hasExplicitPluginIdScope(options?.onlyPluginIds)
         ? { onlyPluginIds: options?.onlyPluginIds }
         : {}),

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -238,6 +238,22 @@ describe("ensurePluginRegistryLoaded", () => {
     );
   });
 
+  it("forwards trust warning suppression for read-only preloads", () => {
+    mocks.resolveConfiguredChannelPluginIds.mockReturnValue(["demo-channel"]);
+
+    ensurePluginRegistryLoaded({
+      scope: "configured-channels",
+      config: { channels: { demo: { enabled: true } } } as never,
+      emitTrustWarnings: false,
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emitTrustWarnings: false,
+      }),
+    );
+  });
+
   it("does not forward empty channel scopes for broad channel loads", () => {
     mocks.resolveChannelPluginIds.mockReturnValue([]);
 

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -79,6 +79,7 @@ export function ensurePluginRegistryLoaded(options?: {
   activationSourceConfig?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: string[];
+  emitTrustWarnings?: boolean;
 }): void {
   const scope = options?.scope ?? "all";
   const requestedPluginIds = normalizePluginIdScope(options?.onlyPluginIds);
@@ -144,6 +145,9 @@ export function ensurePluginRegistryLoaded(options?: {
         shouldForwardChannelScope({ scope, scopedLoad }) ||
         hasNonEmptyPluginIdScope(expectedChannelPluginIds)
           ? { onlyPluginIds: expectedChannelPluginIds }
+          : {}),
+        ...(options?.emitTrustWarnings !== undefined
+          ? { emitTrustWarnings: options.emitTrustWarnings }
           : {}),
       },
     ),

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -538,6 +538,42 @@ describe("plugin status reports", () => {
     );
   });
 
+  it("suppresses trust warnings while building full plugin diagnostics", () => {
+    setSinglePluginLoadResult(createPluginRecord({ id: "demo" }));
+
+    buildPluginDiagnosticsReport({ config: {} });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emitTrustWarnings: false,
+        logger: expect.objectContaining({
+          info: expect.any(Function),
+          warn: expect.any(Function),
+          error: expect.any(Function),
+          debug: expect.any(Function),
+        }),
+      }),
+    );
+  });
+
+  it("suppresses trust warnings while building metadata-only plugin reports", () => {
+    setSinglePluginLoadResult(createPluginRecord({ id: "demo" }));
+
+    buildPluginSnapshotReport({ config: {} });
+
+    expect(loadPluginMetadataRegistrySnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emitTrustWarnings: false,
+        logger: expect.objectContaining({
+          info: expect.any(Function),
+          warn: expect.any(Function),
+          error: expect.any(Function),
+          debug: expect.any(Function),
+        }),
+      }),
+    );
+  });
+
   it("marks errored plugin modules as imported when full diagnostics already evaluated them", () => {
     setPluginLoadResult({
       plugins: [createPluginRecord({ id: "broken-plugin", status: "error" })],

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -22,7 +22,7 @@ import {
 } from "./runtime/load-context.js";
 import { loadPluginMetadataRegistrySnapshot } from "./runtime/metadata-registry-loader.js";
 import { hasKind } from "./slots.js";
-import type { PluginHookName } from "./types.js";
+import type { PluginHookName, PluginLogger } from "./types.js";
 
 export type PluginStatusReport = PluginRegistry & {
   workspaceDir?: string;
@@ -152,14 +152,25 @@ type PluginReportParams = {
   env?: NodeJS.ProcessEnv;
 };
 
+function createQuietPluginStatusLogger(): PluginLogger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
 function buildPluginReport(
   params: PluginReportParams | undefined,
   loadModules: boolean,
 ): PluginStatusReport {
+  const logger = createQuietPluginStatusLogger();
   const baseContext = resolvePluginRuntimeLoadContext({
     config: params?.config ?? loadConfig(),
     env: params?.env,
     workspaceDir: params?.workspaceDir,
+    logger,
   });
   const workspaceDir = baseContext.workspaceDir ?? resolveDefaultAgentWorkspaceDir();
   const context =
@@ -202,6 +213,7 @@ function buildPluginReport(
           loadModules,
           activate: false,
           cache: false,
+          emitTrustWarnings: false,
         }),
       )
     : loadPluginMetadataRegistrySnapshot({
@@ -209,7 +221,9 @@ function buildPluginReport(
         activationSourceConfig: rawConfig,
         workspaceDir,
         env: params?.env,
+        logger,
         loadModules: false,
+        emitTrustWarnings: false,
       });
   const importedPluginIds = new Set([
     ...(loadModules


### PR DESCRIPTION
## Summary
- suppress trust and provenance warnings during read-only plugin preload and diagnostics paths
- keep `plugins list` behavior unchanged while quieting text `status` and `doctor`
- quiet the memory embedding capability fallback used by text status probes
- keep local `openviking` disabled in machine config until real Volcengine credentials are available

## Root cause
Text `status` and `doctor` still exercised runtime plugin-loading code paths for read-only preload, metadata snapshots, plugin diagnostics, and memory embedding capability fallback. Those paths were not marked as read-only, so loader trust/provenance warnings and plugin chatter leaked into terminal output even though runtime health was otherwise normal.

## Impact
- `openclaw status` and `openclaw doctor --non-interactive` no longer print misleading `plugins.allow is empty` or `loaded without install/load-path provenance` warnings during read-only checks
- `plugins list` still shows real trust and provenance state
- text status memory probing no longer reintroduces noise through memory embedding provider fallback

## Testing
- `pnpm build`
- `node scripts/run-vitest.mjs run src/cli/plugin-registry-loader.test.ts src/cli/command-bootstrap.test.ts src/plugins/runtime/runtime-registry-loader.test.ts src/plugins/runtime/metadata-registry-loader.test.ts src/plugins/status.test.ts src/commands/status.scan.test.ts src/commands/status.scan-memory.test.ts src/plugins/memory-runtime.test.ts src/plugins/capability-provider-runtime.test.ts src/plugins/memory-embedding-provider-runtime.test.ts`
- `openclaw status`
- `openclaw status --deep`
- `openclaw gateway status`
- `openclaw doctor --non-interactive`
- `openclaw channels status --probe`
- `openclaw plugins list`
- `openclaw config get plugins.allow`
