### PR TITLE
Agents: add lean local model mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Docs/showcase: add a scannable hero, complete section jump links, and a responsive video grid for community examples. (#48493) Thanks @jchopard69.
+- Agents/local models: add `agents.defaults.localModelMode: "lean"` to drop heavyweight default tools like `browser`, `cron`, and `message`, reducing prompt size for weaker local-model setups without changing the normal path. Thanks @ImLukeF.
 
 ### Fixes
 

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -166,8 +166,8 @@ Compatibility notes for stricter OpenAI-compatible backends:
   backend works for tiny direct `/v1/chat/completions` calls but fails on normal
   OpenClaw agent turns, first try
   `agents.defaults.localModelMode: "lean"` to drop heavyweight default tools
-  like `browser`, `cron`, and `message`, then try
-  `models.providers.<provider>.models[].compat.supportsTools: false` first.
+  like `browser`, `cron`, and `message`; if that still fails, try
+  `models.providers.<provider>.models[].compat.supportsTools: false`.
 - If the backend still fails only on larger OpenClaw runs, the remaining issue
   is usually upstream model/server capacity or a backend bug, not OpenClaw's
   transport layer.

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -164,7 +164,9 @@ Compatibility notes for stricter OpenAI-compatible backends:
 - Some smaller or stricter local backends are unstable with OpenClaw's full
   agent-runtime prompt shape, especially when tool schemas are included. If the
   backend works for tiny direct `/v1/chat/completions` calls but fails on normal
-  OpenClaw agent turns, try
+  OpenClaw agent turns, first try
+  `agents.defaults.localModelMode: "lean"` to drop heavyweight default tools
+  like `browser`, `cron`, and `message`, then try
   `models.providers.<provider>.models[].compat.supportsTools: false` first.
 - If the backend still fails only on larger OpenClaw runs, the remaining issue
   is usually upstream model/server capacity or a backend bug, not OpenClaw's

--- a/src/agents/models-config.providers.google-antigravity.test.ts
+++ b/src/agents/models-config.providers.google-antigravity.test.ts
@@ -70,7 +70,7 @@ describe("google-antigravity provider normalization", () => {
 });
 
 describe("google-vertex provider normalization", () => {
-  it("leaves google-vertex provider catalogs unchanged because model-id normalization happens later", () => {
+  it("normalizes gemini flash-lite IDs for google-vertex providers", () => {
     const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
     const providers = {
       "google-vertex": buildProvider(["gemini-3.1-flash-lite", "gemini-3-flash-preview"], {
@@ -81,11 +81,24 @@ describe("google-vertex provider normalization", () => {
 
     const normalized = normalizeProviders({ providers, agentDir });
 
-    expect(normalized).toBe(providers);
+    expect(normalized).not.toBe(providers);
     expect(normalized?.["google-vertex"]?.models.map((model) => model.id)).toEqual([
-      "gemini-3.1-flash-lite",
+      "gemini-3.1-flash-lite-preview",
       "gemini-3-flash-preview",
     ]);
     expect(normalized?.openai).toBe(providers.openai);
+  });
+
+  it("returns original providers object when no google-vertex IDs need normalization", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const providers = {
+      "google-vertex": buildProvider(["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview"], {
+        api: undefined,
+      }),
+    };
+
+    const normalized = normalizeProviders({ providers, agentDir });
+
+    expect(normalized).toBe(providers);
   });
 });

--- a/src/agents/models-config.providers.google-antigravity.test.ts
+++ b/src/agents/models-config.providers.google-antigravity.test.ts
@@ -70,7 +70,7 @@ describe("google-antigravity provider normalization", () => {
 });
 
 describe("google-vertex provider normalization", () => {
-  it("normalizes gemini flash-lite IDs for google-vertex providers", () => {
+  it("leaves google-vertex provider catalogs unchanged because model-id normalization happens later", () => {
     const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
     const providers = {
       "google-vertex": buildProvider(["gemini-3.1-flash-lite", "gemini-3-flash-preview"], {
@@ -81,24 +81,11 @@ describe("google-vertex provider normalization", () => {
 
     const normalized = normalizeProviders({ providers, agentDir });
 
-    expect(normalized).not.toBe(providers);
+    expect(normalized).toBe(providers);
     expect(normalized?.["google-vertex"]?.models.map((model) => model.id)).toEqual([
-      "gemini-3.1-flash-lite-preview",
+      "gemini-3.1-flash-lite",
       "gemini-3-flash-preview",
     ]);
     expect(normalized?.openai).toBe(providers.openai);
-  });
-
-  it("returns original providers object when no google-vertex IDs need normalization", () => {
-    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
-    const providers = {
-      "google-vertex": buildProvider(["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview"], {
-        api: undefined,
-      }),
-    };
-
-    const normalized = normalizeProviders({ providers, agentDir });
-
-    expect(normalized).toBe(providers);
   });
 });

--- a/src/agents/pi-tools.model-provider-collision.test.ts
+++ b/src/agents/pi-tools.model-provider-collision.test.ts
@@ -115,4 +115,56 @@ describe("applyModelProviderToolPolicy", () => {
 
     expect(toolNames(filtered)).toEqual(["read", "web_search", "exec"]);
   });
+
+  it("drops heavyweight tools when lean local-model mode is enabled", () => {
+    const filtered = __testing.applyModelProviderToolPolicy(
+      [
+        { name: "read" },
+        { name: "browser" },
+        { name: "cron" },
+        { name: "message" },
+        { name: "exec" },
+      ] as unknown as AnyAgentTool[],
+      {
+        config: {
+          agents: {
+            defaults: {
+              localModelMode: "lean",
+            },
+          },
+        },
+        modelProvider: "openai",
+        modelApi: "openai-responses",
+        modelId: "gpt-5.4",
+      },
+    );
+
+    expect(toolNames(filtered)).toEqual(["read", "exec"]);
+  });
+
+  it("keeps heavyweight tools when lean local-model mode is not enabled", () => {
+    const filtered = __testing.applyModelProviderToolPolicy(
+      [
+        { name: "read" },
+        { name: "browser" },
+        { name: "cron" },
+        { name: "message" },
+        { name: "exec" },
+      ] as unknown as AnyAgentTool[],
+      {
+        config: {
+          agents: {
+            defaults: {
+              localModelMode: "default",
+            },
+          },
+        },
+        modelProvider: "openai",
+        modelApi: "openai-responses",
+        modelId: "gpt-5.4",
+      },
+    );
+
+    expect(toolNames(filtered)).toEqual(["read", "browser", "cron", "message", "exec"]);
+  });
 });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -131,6 +131,11 @@ function applyModelProviderToolPolicy(
     modelCompat?: ModelCompatConfig;
   },
 ): AnyAgentTool[] {
+  if (params?.config?.agents?.defaults?.localModelMode === "lean") {
+    const leanDeny = new Set(["browser", "cron", "message"]);
+    tools = tools.filter((tool) => !leanDeny.has(tool.name));
+  }
+
   if (
     shouldSuppressManagedWebSearchTool({
       config: params?.config,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -3243,6 +3243,21 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 description:
                   "Max total characters across all injected workspace bootstrap files (default: 150000).",
               },
+              localModelMode: {
+                anyOf: [
+                  {
+                    type: "string",
+                    const: "default",
+                  },
+                  {
+                    type: "string",
+                    const: "lean",
+                  },
+                ],
+                title: "Local Model Mode",
+                description:
+                  'Local-model prompt profile: "default" keeps the standard tool surface, while "lean" drops heavyweight non-essential tools for smaller or weaker models.',
+              },
               bootstrapPromptTruncationWarning: {
                 anyOf: [
                   {
@@ -24512,6 +24527,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       label: "Bootstrap Total Max Chars",
       help: "Max total characters across all injected workspace bootstrap files (default: 150000).",
       tags: ["performance"],
+    },
+    "agents.defaults.localModelMode": {
+      label: "Local Model Mode",
+      help: 'Local-model prompt profile: "default" keeps the standard tool surface, while "lean" drops heavyweight non-essential tools for smaller or weaker models.',
+      tags: ["advanced"],
     },
     "agents.defaults.bootstrapPromptTruncationWarning": {
       label: "Bootstrap Prompt Truncation Warning",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -848,6 +848,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
   "agents.defaults.bootstrapTotalMaxChars":
     "Max total characters across all injected workspace bootstrap files (default: 150000).",
+  "agents.defaults.localModelMode":
+    'Local-model prompt profile: "default" keeps the standard tool surface, while "lean" drops heavyweight non-essential tools for smaller or weaker models.',
   "agents.defaults.bootstrapPromptTruncationWarning":
     'Inject agent-visible warning text when bootstrap files are truncated: "off", "once" (default), or "always".',
   "agents.defaults.startupContext":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -343,6 +343,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.contextInjection": "Context Injection",
   "agents.defaults.bootstrapMaxChars": "Bootstrap Max Chars",
   "agents.defaults.bootstrapTotalMaxChars": "Bootstrap Total Max Chars",
+  "agents.defaults.localModelMode": "Local Model Mode",
   "agents.defaults.bootstrapPromptTruncationWarning": "Bootstrap Prompt Truncation Warning",
   "agents.defaults.startupContext": "Startup Context",
   "agents.defaults.startupContext.enabled": "Enable Startup Context",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -13,6 +13,7 @@ import type { MemorySearchConfig } from "./types.tools.js";
 
 export type AgentContextInjection = "always" | "continuation-skip";
 export type EmbeddedPiExecutionContract = "default" | "strict-agentic";
+export type LocalModelMode = "default" | "lean";
 
 export type AgentModelEntryConfig = {
   alias?: string;
@@ -198,6 +199,12 @@ export type AgentDefaultsConfig = {
   bootstrapMaxChars?: number;
   /** Max total chars across all injected bootstrap files (default: 150000). */
   bootstrapTotalMaxChars?: number;
+  /**
+   * Optional local-model prompt profile:
+   * - default: keep the standard tool surface
+   * - lean: drop heavyweight non-essential tools for smaller or weaker models
+   */
+  localModelMode?: LocalModelMode;
   /**
    * Agent-visible bootstrap truncation warning mode:
    * - off: do not inject warning text

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -52,6 +52,7 @@ export const AgentDefaultsSchema = z
     contextInjection: z.union([z.literal("always"), z.literal("continuation-skip")]).optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
+    localModelMode: z.union([z.literal("default"), z.literal("lean")]).optional(),
     bootstrapPromptTruncationWarning: z
       .union([z.literal("off"), z.literal("once"), z.literal("always")])
       .optional(),


### PR DESCRIPTION
## Summary
- add `agents.defaults.localModelMode` with `"default" | "lean"`
- make `"lean"` drop heavyweight default tools (`browser`, `cron`, `message`) before request assembly
- document the setting for local-model troubleshooting and update generated config schema artifacts

## Why
Some weaker local/self-hosted models cope badly with OpenClaw's full default tool surface because the tool schemas alone consume a lot of prompt budget. This keeps the normal path unchanged and gives users an explicit smaller prompt profile when they need it.

In a local context report check against `ollama/qwen3:8b`, the tracked prompt estimate dropped from `66,838` chars to `50,819` chars, and the tool-schema portion dropped from `25,538` chars to `10,438` chars.

## Testing
- `pnpm test src/agents/pi-tools.model-provider-collision.test.ts`
- `pnpm test src/config/schema.help.quality.test.ts src/config/schema.base.generated.test.ts`
- `pnpm config:docs:check`
- `pnpm config:schema:check`
- `pnpm check`
- `pnpm build`