### PR TITLE
fix(ui): keep exec approval popup within viewport on long commands

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2995,6 +2995,10 @@ td.data-table-key-col {
   border-radius: var(--radius-lg);
   padding: 20px;
   animation: scale-in 0.2s var(--ease-out);
+  max-height: calc(100dvh - 48px); /* overlay has 24px padding top + bottom */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .exec-approval-header {
@@ -3034,6 +3038,8 @@ td.data-table-key-col {
   white-space: pre-wrap;
   font-family: var(--mono);
   font-size: 13px;
+  max-height: 40vh;
+  overflow-y: auto;
 }
 
 .exec-approval-meta {
@@ -3066,6 +3072,7 @@ td.data-table-key-col {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 /* ===========================================
@@ -4369,13 +4376,10 @@ details[open] > .ov-expandable-toggle::after {
   .exec-approval-card {
     padding: 16px;
     max-height: 90dvh;
-    display: flex;
-    flex-direction: column;
   }
 
   .exec-approval-actions {
     flex-direction: column;
-    flex-shrink: 0;
   }
 
   .exec-approval-actions .btn {


### PR DESCRIPTION
## Summary

Fixes #66403 — exec approval popup can push action buttons below the viewport when the command preview is long.

The mobile responsive styles already had the correct fix (`max-height`, `display: flex; flex-direction: column`, `overflow-y: auto` on the command block). This PR promotes the same pattern to the base desktop styles so it applies on all viewports.

**Changes to `ui/src/styles/components.css`:**

- `.exec-approval-card`: add `max-height: calc(100dvh - 48px)`, `display: flex; flex-direction: column;`, `overflow: hidden` — caps the card to the visible viewport (48px accounts for the overlay's `24px` top + bottom padding)
- `.exec-approval-command`: add `max-height: 40vh; overflow-y: auto;` — long commands scroll within the card instead of stretching it
- `.exec-approval-actions`: add `flex-shrink: 0` — buttons are always pinned at the bottom, never compressed off-screen
- Mobile overrides: remove `display: flex; flex-direction: column` from `.exec-approval-card` and `flex-shrink: 0` from `.exec-approval-actions` since they are now in the base rule (keeping `max-height: 90dvh` override for mobile)

## Test plan

- [ ] Trigger an exec approval with a long multiline command in Control UI
- [ ] Verify the popup stays within the viewport and the command area scrolls
- [ ] Verify Allow once / Always allow / Deny buttons are always reachable without changing zoom
- [ ] Verify short commands still render normally (no layout change for typical commands)
- [ ] Verify mobile layout is unchanged