### PR TITLE
fix(agents): recognize billing-cooldown skip messages as billing errors

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -233,6 +233,20 @@ describe("isBillingErrorMessage", () => {
       expect(classifyFailoverReason(sample, { provider: "anthropic" })).toBe("billing");
     }
   });
+
+  it("classifies internally-generated billing-cooldown skip messages as billing (#66314)", () => {
+    // model-fallback.ts emits these when all profiles are in billing cooldown
+    const samples = [
+      "Provider anthropic has billing issue (skipping all models)",
+      "Provider openai has billing issue (skipping all models)",
+      "Provider google has billing issue (skipping all models)",
+    ];
+
+    for (const sample of samples) {
+      expect(isBillingErrorMessage(sample)).toBe(true);
+      expect(classifyFailoverReason(sample, { provider: "anthropic" })).toBe("billing");
+    }
+  });
 });
 
 describe("isCloudCodeAssistFormatError", () => {

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -133,6 +133,8 @@ const ERROR_PATTERNS = {
     /out of extra usage/i,
     /draw from your extra usage/i,
     /extra usage is required(?: for long context requests)?/i,
+    // Internally-generated message when all profiles are in billing cooldown (#66314)
+    "has billing issue",
     // Z.ai: error 1311 = model not included in current subscription plan (#48988)
     ZAI_BILLING_CODE_1311_RE,
   ],


### PR DESCRIPTION
Fixes #66314

## Problem

When all model-fallback candidates are skipped due to billing cooldown, users see a generic `"Something went wrong"` instead of the proper billing error message.

**Trace:**

1. A billing error causes a profile to enter cooldown with `reason: "billing"`
2. On the next request, `model-fallback.ts` skips all candidates and emits:
   ```
   Provider anthropic has billing issue (skipping all models)
   ```
3. `formatAssistantErrorText()` → `isBillingErrorMessage()` → **returns `false`**
4. The message falls through to the generic error path

`isBillingErrorMessage` returned `false` because:
- No 402/payment/credits keyword is present
- `BILLING_ERROR_HEAD_RE` anchors to messages starting with `"billing"` or `"error"`, but this message starts with `"Provider"`

## Fix

Add `"has billing issue"` to `ERROR_PATTERNS.billing` in `failover-matches.ts`.

The substring `has ${inferredReason} issue` is the exact template used by `model-fallback.ts` (lines 592 and 611). It is specific to this internal code path and will not produce false positives against real provider API responses.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-helpers/failover-matches.ts` | Add `"has billing issue"` to `ERROR_PATTERNS.billing` |
| `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` | Add test covering the three provider variants emitted by `model-fallback.ts` |

## Test plan

- [ ] `pnpm test src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` — new test case passes
- [ ] Existing billing/auth false-positive tests remain green (the new pattern only touches billing classification)
- [ ] With an Anthropic OAuth account that has exhausted extra usage, the next agent turn shows `BILLING_ERROR_USER_MESSAGE` instead of the generic error