### PR TITLE
fix(reply): keep implicit threading when replyToCurrent defaults false

### DIFF
--- a/src/auto-reply/reply/reply-payloads-base.ts
+++ b/src/auto-reply/reply/reply-payloads-base.ts
@@ -37,10 +37,7 @@ function resolveReplyThreadingForPayload(params: {
   );
 
   let resolved: ReplyPayload =
-    params.payload.replyToId ||
-    params.payload.replyToCurrent === false ||
-    !implicitReplyToId ||
-    !allowImplicitReplyToCurrentMessage
+    params.payload.replyToId || !implicitReplyToId || !allowImplicitReplyToCurrentMessage
       ? params.payload
       : { ...params.payload, replyToId: implicitReplyToId };
 

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -268,6 +268,18 @@ describe("applyReplyThreading auto-threading", () => {
     expect(result[1].replyToId).toBe("42");
   });
 
+  it("does not treat replyToCurrent: false as an explicit opt-out of implicit threading", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "hello", replyToCurrent: false }],
+      replyToMode: "all",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBe("42");
+    expect(result[0].replyToCurrent).toBe(false);
+  });
+
   it("strips replyToId when mode is 'off'", () => {
     const result = applyReplyThreading({
       payloads: [{ text: "A" }],


### PR DESCRIPTION
## Summary

- Problem: implicit reply threading treated `replyToCurrent: false` as an explicit opt-out, even though that value is the default parse result when no `[[reply_to_current]]` tag is present.
- Why it matters: threaded channels can silently lose `replyToId` and fall back to plain replies when payloads carry the default flag.
- What changed: removed the false-default veto from `resolveReplyThreadingForPayload` and added a regression test for payloads that arrive with `replyToCurrent: false`.
- What did NOT change (scope boundary): followup queue routing semantics, channel-specific transport logic, and directive parsing defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66540
- Related #66540
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveReplyThreadingForPayload` treated `replyToCurrent === false` as an explicit opt-out, but `parseInlineDirectives` emits `false` by default when there is no reply tag.
- Missing detection / guardrail: nearby threading tests covered implicit threading and explicit tags, but not the default-false payload shape.
- Contributing context (if known): this mostly affects paths where payloads are normalized before threading and keep the default `replyToCurrent` value.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/reply-plumbing.test.ts`
- Scenario the test should lock in: a payload with `replyToCurrent: false` and no explicit `replyToId` should still receive the implicit `currentMessageId` when reply threading is enabled.
- Why this is the smallest reliable guardrail: it exercises the shared threading helper directly, which is where the regression lives.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Channels that rely on threaded replies no longer lose the implicit `replyToId` just because a payload carried the default `replyToCurrent: false` value.

## Diagram (if applicable)

```text
Before:
[payload with replyToCurrent:false] -> shared threading helper -> implicit replyToId blocked

After:
[payload with replyToCurrent:false] -> shared threading helper -> implicit replyToId preserved -> threaded reply delivered
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime/container: Node 22 / Bun
- Model/provider: N/A
- Integration/channel (if any): shared reply threading path
- Relevant config (redacted): default reply threading test fixtures

### Steps

1. Build a reply payload with `text: \"hello\"`, `replyToCurrent: false`, and no explicit `replyToId`.
2. Call `applyReplyThreading` with `replyToMode: \"all\"` and `currentMessageId: \"42\"`.
3. Inspect the resolved payload.

### Expected

- The payload keeps implicit threading and resolves `replyToId` to `42`.

### Actual

- Before this change, the shared helper left `replyToId` unset because it treated the default `false` flag as an explicit opt-out.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: direct helper repro for implicit threading with and without `replyToCurrent: false`; narrow test run for `src/auto-reply/reply/reply-plumbing.test.ts` and `src/auto-reply/reply/followup-delivery.test.ts`.
- Edge cases checked: explicit `[[reply_to_current]]` coverage remained green; followup delivery tests remained green.
- What you did **not** verify: live channel roundtrips on a real threaded integration.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: payloads that intentionally relied on `replyToCurrent: false` as an opt-out could now thread implicitly.
  - Mitigation: the codebase already models explicit opt-in via reply tags and explicit `replyToId`; the regression test locks in that the default parse value is not treated as an explicit opt-out.

## AI Assistance

- AI assistance: used for implementation and test authoring; the change and verification steps above were reviewed before opening this PR.
- Testing level: repo pre-commit checks passed during commit, plus targeted reply-threading tests were run locally.

Made with [Cursor](https://cursor.com)