### PR TITLE
fix: add root transcript fallback for drifted agent sessions

### DIFF
--- a/src/gateway/session-transcript-files.fs.test.ts
+++ b/src/gateway/session-transcript-files.fs.test.ts
@@ -9,6 +9,26 @@ import {
 } from "./session-transcript-files.fs.js";
 import { readSessionMessages } from "./session-utils.fs.js";
 
+function hasAssistantTextMessage(
+  value: unknown,
+): value is { content: Array<{ type: string; text: string }> } {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const content = Reflect.get(value, "content");
+  if (!Array.isArray(content) || content.length === 0) {
+    return false;
+  }
+  const first = content[0];
+  if (!first || typeof first !== "object") {
+    return false;
+  }
+  return (
+    typeof Reflect.get(first, "text") === "string" &&
+    typeof Reflect.get(first, "type") === "string"
+  );
+}
+
 describe("session transcript root fallback", () => {
   const fixture = useTempSessionsFixture("session-transcript-files-");
   const sessionId = "12345678-1234-4123-8123-1234567890ab";
@@ -54,9 +74,14 @@ describe("session transcript root fallback", () => {
     );
 
     const messages = readSessionMessages(sessionId, storePath, sessionsPath);
+    const firstMessage = messages[0];
 
     expect(messages).toHaveLength(1);
-    expect((messages[0] as any).content[0].text).toBe("ROOT_FALLBACK_OK");
+    expect(hasAssistantTextMessage(firstMessage)).toBe(true);
+    if (!hasAssistantTextMessage(firstMessage)) {
+      throw new Error("expected assistant text message");
+    }
+    expect(firstMessage.content[0]?.text).toBe("ROOT_FALLBACK_OK");
   });
 
   it("archives the root transcript in the drift case", () => {
@@ -70,11 +95,16 @@ describe("session transcript root fallback", () => {
       sessionFile: sessionsPath,
       reason: "deleted",
     });
+    const [archivedEntry] = archived;
 
     expect(archived).toHaveLength(1);
-    expect(archived[0]?.sourcePath).toBe(rootPath);
-    expect(archived[0]?.archivedPath).toMatch(/\.deleted\./);
+    expect(archivedEntry?.sourcePath).toBe(rootPath);
+    expect(archivedEntry?.archivedPath).toMatch(/\.deleted\./);
     expect(fs.existsSync(rootPath)).toBe(false);
-    expect(fs.existsSync(archived[0]!.archivedPath)).toBe(true);
+    expect(archivedEntry).toBeDefined();
+    if (!archivedEntry) {
+      throw new Error("expected archived transcript entry");
+    }
+    expect(fs.existsSync(archivedEntry.archivedPath)).toBe(true);
   });
 });

--- a/src/gateway/session-transcript-files.fs.test.ts
+++ b/src/gateway/session-transcript-files.fs.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { useTempSessionsFixture } from "../config/sessions/test-helpers.js";
+import { resolveSessionTranscriptPathInDir } from "../config/sessions/paths.js";
+import {
+  archiveSessionTranscriptsDetailed,
+  resolveSessionTranscriptCandidates,
+} from "./session-transcript-files.fs.js";
+import { readSessionMessages } from "./session-utils.fs.js";
+
+describe("session transcript root fallback", () => {
+  const fixture = useTempSessionsFixture("session-transcript-files-");
+  const sessionId = "12345678-1234-4123-8123-1234567890ab";
+
+  function paths() {
+    const sessionsDir = fixture.sessionsDir();
+    const agentDir = path.dirname(sessionsDir);
+    return {
+      storePath: fixture.storePath(),
+      sessionsDir,
+      agentDir,
+      sessionsPath: resolveSessionTranscriptPathInDir(sessionId, sessionsDir),
+      rootPath: resolveSessionTranscriptPathInDir(sessionId, agentDir),
+    };
+  }
+
+  it("includes root fallback for agent store paths", () => {
+    const { storePath, sessionsPath, rootPath } = paths();
+
+    const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionsPath);
+
+    expect(candidates[0]).toBe(sessionsPath);
+    expect(candidates).toContain(rootPath);
+    expect(candidates.indexOf(rootPath)).toBeGreaterThan(candidates.indexOf(sessionsPath));
+  });
+
+  it("reads messages from root fallback when sessions path is missing", () => {
+    const { storePath, sessionsPath, rootPath } = paths();
+
+    fs.writeFileSync(
+      rootPath,
+      [
+        JSON.stringify({ type: "session", id: sessionId }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "ROOT_FALLBACK_OK" }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const messages = readSessionMessages(sessionId, storePath, sessionsPath);
+
+    expect(messages).toHaveLength(1);
+    expect((messages[0] as any).content[0].text).toBe("ROOT_FALLBACK_OK");
+  });
+
+  it("archives the root transcript in the drift case", () => {
+    const { storePath, sessionsPath, rootPath } = paths();
+
+    fs.writeFileSync(rootPath, '{"type":"session","id":"' + sessionId + '"}\n', "utf-8");
+
+    const archived = archiveSessionTranscriptsDetailed({
+      sessionId,
+      storePath,
+      sessionFile: sessionsPath,
+      reason: "deleted",
+    });
+
+    expect(archived).toHaveLength(1);
+    expect(archived[0]?.sourcePath).toBe(rootPath);
+    expect(archived[0]?.archivedPath).toMatch(/\.deleted\./);
+    expect(fs.existsSync(rootPath)).toBe(false);
+    expect(fs.existsSync(archived[0]!.archivedPath)).toBe(true);
+  });
+});

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -7,6 +7,7 @@ import {
   type SessionArchiveReason,
 } from "../config/sessions/artifacts.js";
 import {
+  resolveAgentsDirFromSessionStorePath,
   resolveSessionFilePath,
   resolveSessionTranscriptPath,
   resolveSessionTranscriptPathInDir,
@@ -67,6 +68,36 @@ function canonicalizePathForComparison(filePath: string): string {
   }
 }
 
+function resolveAgentRootDirFromStorePath(storePath: string): string | undefined {
+  const agentsDir = resolveAgentsDirFromSessionStorePath(storePath);
+  if (!agentsDir) {
+    return undefined;
+  }
+  const sessionsDir = path.dirname(path.resolve(storePath));
+  if (path.basename(sessionsDir) !== "sessions") {
+    return undefined;
+  }
+  const agentDir = path.dirname(sessionsDir);
+  const agentId = path.basename(agentDir);
+  if (!agentId) {
+    return undefined;
+  }
+  return path.join(agentsDir, agentId);
+}
+
+function resolveAgentRootDirFromAgentId(sessionId: string, agentId?: string): string | undefined {
+  if (!agentId?.trim()) {
+    return undefined;
+  }
+  try {
+    const sessionPath = resolveSessionTranscriptPath(sessionId, agentId);
+    const sessionsDir = path.dirname(sessionPath);
+    return path.dirname(sessionsDir);
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveSessionTranscriptCandidates(
   sessionId: string,
   storePath: string | undefined,
@@ -75,6 +106,9 @@ export function resolveSessionTranscriptCandidates(
 ): string[] {
   const candidates: string[] = [];
   const sessionFileState = classifySessionTranscriptCandidate(sessionId, sessionFile);
+  const rootFallbackDir =
+    (storePath ? resolveAgentRootDirFromStorePath(storePath) : undefined) ??
+    resolveAgentRootDirFromAgentId(sessionId, agentId);
   const pushCandidate = (resolve: () => string): void => {
     try {
       candidates.push(resolve());
@@ -91,6 +125,9 @@ export function resolveSessionTranscriptCandidates(
       );
     }
     pushCandidate(() => resolveSessionTranscriptPathInDir(sessionId, sessionsDir));
+    if (rootFallbackDir) {
+      pushCandidate(() => resolveSessionTranscriptPathInDir(sessionId, rootFallbackDir));
+    }
     if (sessionFile && sessionFileState === "stale") {
       pushCandidate(() =>
         resolveSessionFilePath(sessionId, { sessionFile }, { sessionsDir, agentId }),
@@ -111,6 +148,9 @@ export function resolveSessionTranscriptCandidates(
 
   if (agentId) {
     pushCandidate(() => resolveSessionTranscriptPath(sessionId, agentId));
+    if (rootFallbackDir) {
+      pushCandidate(() => resolveSessionTranscriptPathInDir(sessionId, rootFallbackDir));
+    }
     if (sessionFile && sessionFileState === "stale") {
       pushCandidate(() => resolveSessionFilePath(sessionId, { sessionFile }, { agentId }));
     }

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -11,6 +11,7 @@ import {
   resolveSessionFilePath,
   resolveSessionTranscriptPath,
   resolveSessionTranscriptPathInDir,
+  resolveSessionTranscriptsDirForAgent,
 } from "../config/sessions/paths.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 
@@ -69,30 +70,19 @@ function canonicalizePathForComparison(filePath: string): string {
 }
 
 function resolveAgentRootDirFromStorePath(storePath: string): string | undefined {
-  const agentsDir = resolveAgentsDirFromSessionStorePath(storePath);
-  if (!agentsDir) {
+  if (!resolveAgentsDirFromSessionStorePath(storePath)) {
     return undefined;
   }
   const sessionsDir = path.dirname(path.resolve(storePath));
-  if (path.basename(sessionsDir) !== "sessions") {
-    return undefined;
-  }
-  const agentDir = path.dirname(sessionsDir);
-  const agentId = path.basename(agentDir);
-  if (!agentId) {
-    return undefined;
-  }
-  return path.join(agentsDir, agentId);
+  return path.dirname(sessionsDir);
 }
 
-function resolveAgentRootDirFromAgentId(sessionId: string, agentId?: string): string | undefined {
+function resolveAgentRootDirFromAgentId(agentId?: string): string | undefined {
   if (!agentId?.trim()) {
     return undefined;
   }
   try {
-    const sessionPath = resolveSessionTranscriptPath(sessionId, agentId);
-    const sessionsDir = path.dirname(sessionPath);
-    return path.dirname(sessionsDir);
+    return path.dirname(resolveSessionTranscriptsDirForAgent(agentId));
   } catch {
     return undefined;
   }
@@ -108,7 +98,7 @@ export function resolveSessionTranscriptCandidates(
   const sessionFileState = classifySessionTranscriptCandidate(sessionId, sessionFile);
   const rootFallbackDir =
     (storePath ? resolveAgentRootDirFromStorePath(storePath) : undefined) ??
-    resolveAgentRootDirFromAgentId(sessionId, agentId);
+    resolveAgentRootDirFromAgentId(agentId);
   const pushCandidate = (resolve: () => string): void => {
     try {
       candidates.push(resolve());


### PR DESCRIPTION
## Summary
- add a root transcript fallback for agent-scoped session stores when the normal `sessions/` candidate is missing
- keep the normal `.../agents/<agent>/sessions/<sessionId>.jsonl` path first
- only add the fallback `.../agents/<agent>/<sessionId>.jsonl` after the normal candidate
- cover the drift case with a focused gateway test

## Why
We hit a real drift case for a long-lived `main` session where:
- the session store still pointed to `~/.openclaw/agents/main/sessions/<sessionId>.jsonl`
- that file no longer existed
- the real live transcript existed at `~/.openclaw/agents/main/<sessionId>.jsonl`

That broke both:
- `readSessionMessages(...)` (returned 0 messages for the live session)
- transcript archiving on delete/reset (the real root file was left behind)

## Approach
This keeps the current candidate order conservative:
1. normal `sessions/` path
2. root fallback under `agents/<agent>/`
3. existing stale/legacy fallbacks

So the normal green path stays unchanged, while the drifted main-agent case becomes readable/archiveable again.

## Tests
- added `src/gateway/session-transcript-files.fs.test.ts`
  - includes root fallback in candidate resolution for agent stores
  - reads messages from the root fallback when the `sessions/` path is missing
  - archives the root transcript in the drift case
- re-ran existing regression coverage:
  - `src/gateway/session-transcript-key.test.ts`

## Verification
Ran:
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/session-transcript-files.fs.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/session-transcript-key.test.ts src/gateway/session-transcript-files.fs.test.ts`
