### PR TITLE
fix(reply): keep implicit threading when replyToCurrent defaults false

### DIFF
--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -75,14 +75,16 @@ export function createBlockReplyDeliveryHandler(params: {
       return;
     }
 
+    // Only skip implicit threading when replyToCurrent is explicitly false via a reply tag.
+    // When replyToCurrent defaults to false (no tag present), implicit threading should still work.
+    const explicitOptOut = payload.replyToCurrent === false && payload.replyToTag;
+
     const taggedPayload = applyReplyTagsToPayload(
       {
         ...payload,
         text,
         mediaUrl: payload.mediaUrl ?? payload.mediaUrls?.[0],
-        replyToId:
-          payload.replyToId ??
-          (payload.replyToCurrent === false ? undefined : params.currentMessageId),
+        replyToId: payload.replyToId ?? (explicitOptOut ? undefined : params.currentMessageId),
       },
       params.currentMessageId,
     );

--- a/src/auto-reply/reply/reply-payloads-base.ts
+++ b/src/auto-reply/reply/reply-payloads-base.ts
@@ -36,9 +36,13 @@ function resolveReplyThreadingForPayload(params: {
     params.replyThreading,
   );
 
+  // Only skip implicit threading when replyToCurrent is explicitly false via a reply tag.
+  // When replyToCurrent defaults to false (no tag present), implicit threading should still work.
+  const explicitOptOut = params.payload.replyToCurrent === false && params.payload.replyToTag;
+
   let resolved: ReplyPayload =
     params.payload.replyToId ||
-    params.payload.replyToCurrent === false ||
+    explicitOptOut ||
     !implicitReplyToId ||
     !allowImplicitReplyToCurrentMessage
       ? params.payload

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -368,6 +368,32 @@ describe("applyReplyThreading auto-threading", () => {
     expect(result).toHaveLength(1);
     expect(result[0].replyToId).toBe("mm-post-abc123");
   });
+
+  it("preserves implicit threading when replyToCurrent defaults to false (no tag)", () => {
+    // Fix for #66540: When replyToCurrent is false but no reply tag was present,
+    // implicit threading should still work (this is the default case)
+    const result = applyReplyThreading({
+      payloads: [{ text: "hello", replyToCurrent: false }], // Default false, no replyToTag
+      replyToMode: "all",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBe("42");
+  });
+
+  it("blocks implicit threading when replyToCurrent is explicitly false via tag", () => {
+    // When replyToCurrent is false AND replyToTag is true, it means an explicit opt-out
+    // (e.g., [[reply_to_none]] tag was parsed)
+    const result = applyReplyThreading({
+      payloads: [{ text: "hello", replyToCurrent: false, replyToTag: true }],
+      replyToMode: "all",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBeUndefined();
+  });
 });
 
 const baseRun: SubagentRunRecord = {


### PR DESCRIPTION
Fixes issue where implicit threading was lost when replyToCurrent defaults to false.

## Problem
- When replyToCurrent defaults false, implicit threading context was not preserved
- Messages lost their thread association in conversations

## Solution  
- Modified conversation binding to maintain implicit threading
- Ensures thread context is preserved across message exchanges
- Maintains backward compatibility with existing behavior

Fixes #66540