### PR TITLE
fix: honor cfg-compatible capability provider resolution before partial active registries

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -201,7 +201,7 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
   });
 
-  it("keeps active capability providers even when cfg is passed", () => {
+  it("keeps active capability providers even when cfg is passed and the active registry is compatible", () => {
     const active = createEmptyPluginRegistry();
     active.speechProviders.push({
       pluginId: "microsoft",
@@ -220,8 +220,16 @@ describe("resolvePluginCapabilityProviders", () => {
         }),
       },
     } as never);
+    const compatConfig = {
+      messages: { tts: { provider: "edge" } },
+      plugins: { entries: { microsoft: { enabled: true } } },
+    } as OpenClawConfig;
+    mocks.withBundledPluginEnablementCompat.mockReturnValue(compatConfig);
+    mocks.withBundledPluginVitestCompat.mockReturnValue(compatConfig);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
-      params === undefined ? active : createEmptyPluginRegistry(),
+      params === undefined || JSON.stringify(params) === JSON.stringify({ config: compatConfig })
+        ? active
+        : createEmptyPluginRegistry(),
     );
 
     const providers = resolvePluginCapabilityProviders({
@@ -231,9 +239,68 @@ describe("resolvePluginCapabilityProviders", () => {
 
     expectResolvedCapabilityProviderIds(providers, ["microsoft"]);
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
-    expect(mocks.resolveRuntimePluginRegistry).not.toHaveBeenCalledWith({
-      config: expect.anything(),
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({ config: compatConfig });
+  });
+
+  it("prefers cfg-compatible capability resolution over a partial active registry", () => {
+    const active = createEmptyPluginRegistry();
+    active.speechProviders.push({
+      pluginId: "openai",
+      pluginName: "openai",
+      source: "test",
+      provider: {
+        id: "openai",
+        label: "openai",
+        isConfigured: () => true,
+        synthesize: async () => ({
+          audioBuffer: Buffer.from("x"),
+          outputFormat: "mp3",
+          voiceCompatible: false,
+          fileExtension: ".mp3",
+        }),
+      },
+    } as never);
+
+    const compatConfig = {
+      messages: { tts: { provider: "microsoft" } },
+      plugins: { entries: { microsoft: { enabled: true } } },
+    } as OpenClawConfig;
+    const compatRegistry = createEmptyPluginRegistry();
+    compatRegistry.speechProviders.push({
+      pluginId: "microsoft",
+      pluginName: "microsoft",
+      source: "test",
+      provider: {
+        id: "microsoft",
+        label: "microsoft",
+        aliases: ["edge"],
+        isConfigured: () => true,
+        synthesize: async () => ({
+          audioBuffer: Buffer.from("x"),
+          outputFormat: "mp3",
+          voiceCompatible: false,
+          fileExtension: ".mp3",
+        }),
+      },
+    } as never);
+    setBundledCapabilityFixture("speechProviders");
+    mocks.withBundledPluginEnablementCompat.mockReturnValue(compatConfig);
+    mocks.withBundledPluginVitestCompat.mockReturnValue(compatConfig);
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined
+        ? active
+        : JSON.stringify(params) === JSON.stringify({ config: compatConfig })
+          ? compatRegistry
+          : createEmptyPluginRegistry(),
+    );
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "speechProviders",
+      cfg: { messages: { tts: { provider: "microsoft" } } } as OpenClawConfig,
     });
+
+    expectResolvedCapabilityProviderIds(providers, ["microsoft"]);
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({ config: compatConfig });
   });
 
   it.each([

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -84,13 +84,19 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
 }): CapabilityProviderForKey<K>[] {
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
-  if (activeProviders.length > 0) {
+
+  if (params.cfg === undefined && activeProviders.length > 0) {
     return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }
+
   const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
   const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
   const registry = resolveRuntimePluginRegistry(loadOptions);
-  return (registry?.[params.key] ?? []).map(
-    (entry) => entry.provider,
-  ) as CapabilityProviderForKey<K>[];
+  const resolvedProviders = registry?.[params.key] ?? [];
+
+  if (resolvedProviders.length > 0) {
+    return resolvedProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+  }
+
+  return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
 }

--- a/src/tts/provider-registry.test.ts
+++ b/src/tts/provider-registry.test.ts
@@ -126,6 +126,38 @@ describe("speech provider registry", () => {
     });
   });
 
+  it("uses cfg-compatible speech providers when the active registry is partial", () => {
+    resolveRuntimePluginRegistryMock.mockImplementation((params?: unknown) =>
+      params === undefined
+        ? {
+            ...createEmptyPluginRegistry(),
+            speechProviders: [
+              {
+                pluginId: "test-openai",
+                source: "test",
+                provider: createSpeechProvider("openai"),
+              },
+            ],
+          }
+        : {
+            ...createEmptyPluginRegistry(),
+            speechProviders: [
+              {
+                pluginId: "test-microsoft",
+                source: "test",
+                provider: createSpeechProvider("microsoft", ["edge"]),
+              },
+            ],
+          },
+    );
+
+    const cfg = { messages: { tts: { provider: "microsoft" } } } as OpenClawConfig;
+
+    expect(listSpeechProviders(cfg).map((provider) => provider.id)).toEqual(["microsoft"]);
+    expect(getSpeechProvider("microsoft", cfg)?.id).toBe("microsoft");
+    expect(getSpeechProvider("edge", cfg)?.id).toBe("microsoft");
+  });
+
   it("returns no providers when neither plugins nor active registry provide speech support", () => {
     expect(listSpeechProviders()).toEqual([]);
     expect(getSpeechProvider("demo-speech")).toBeUndefined();


### PR DESCRIPTION
This patch fixes cfg-aware capability provider resolution for plugin-backed registries.

Root cause:
`resolvePluginCapabilityProviders(...)` returned active runtime capability providers too early whenever the active list was non-empty. When `cfg` was present, that could suppress resolution through the cfg-compatible runtime/plugin load context. In practice, a partial active `speechProviders` registry could hide providers that were available through the correct cfg-shaped registry, including the Microsoft speech provider used by the TTS path.

Fix:
- preserve the existing fast path when `cfg` is not provided
- when `cfg` is provided, resolve capability providers from the cfg-compatible registry first
- fall back to active providers only if cfg-compatible resolution returns nothing

Why this is safe:
- no Microsoft-specific special casing
- no changes to Telegram/chat wrapper logic
- no broader TTS redesign
- no behavior change for callers that do not provide `cfg`

Validation:
- direct targeted tests pass in:
  - `src/plugins/capability-provider-runtime.test.ts`
  - `src/tts/provider-registry.test.ts`

Note on speech-core extension tests:
`extensions/speech-core/src/tts.test.ts` currently hangs under the existing extensions Vitest harness, and the hang reproduces on baseline test content without this patch. That issue is treated as pre-existing harness/test infrastructure behavior and is intentionally left out of this PR’s scope.
