### PR TITLE
fix(heartbeat): relay exec payload in prompts

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -70,6 +70,12 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("Session history looks corrupted");
     expect(result).toContain("/new");
   });
+  it("returns a recovery hint for replay-invalid connection mismatch errors", () => {
+    const msg = makeAssistantError("401 input item ID does not belong to this connection");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Session history or replay state is invalid");
+    expect(result).toContain("/new");
+  });
   it("handles JSON-wrapped role errors", () => {
     const msg = makeAssistantError('{"error":{"message":"400 Incorrect role information"}}');
     const result = formatAssistantErrorText(msg);

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1175,6 +1175,9 @@ describe("classifyProviderRuntimeFailureKind", () => {
     expect(classifyProviderRuntimeFailureKind("tool_use.input: Field required")).toBe(
       "replay_invalid",
     );
+    expect(
+      classifyProviderRuntimeFailureKind("401 input item ID does not belong to this connection"),
+    ).toBe("replay_invalid");
   });
 
   it("does not classify generic config errors that mention proxy settings as proxy failures", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -320,7 +320,7 @@ const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host
 const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
 const REPLAY_INVALID_RE =
-  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b/i;
+  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b/i;
 

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -47,18 +47,29 @@ describe("heartbeat event prompts", () => {
   it.each([
     {
       name: "builds user-relay exec prompt by default",
-      opts: undefined,
-      expected: ["Please relay the command output to the user", "If it failed"],
+      events: ["Exec completed (rapid-br, code 0) :: temp/news/raw-latest.md written"],
+      expected: [
+        "temp/news/raw-latest.md written",
+        "Please relay the command output to the user",
+        "If it failed",
+      ],
       unexpected: ["Handle the result internally"],
     },
     {
       name: "builds internal-only exec prompt when delivery is disabled",
+      events: ["Exec completed (rapid-br, code 0) :: temp/news/raw-latest.md written"],
       opts: { deliverToUser: false },
-      expected: ["Handle the result internally"],
+      expected: ["temp/news/raw-latest.md written", "Handle the result internally"],
       unexpected: ["Please relay the command output to the user"],
     },
-  ])("$name", ({ opts, expected, unexpected }) => {
-    const prompt = buildExecEventPrompt(opts);
+    {
+      name: "falls back to a generic exec prompt when payload is empty",
+      events: ["   "],
+      expected: ["shown in the system messages above"],
+      unexpected: ["temp/news/raw-latest.md written"],
+    },
+  ])("$name", ({ events, opts, expected, unexpected }) => {
+    const prompt = buildExecEventPrompt(events, opts);
     for (const part of expected) {
       expect(prompt).toContain(part);
     }

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -38,16 +38,36 @@ export function buildCronEventPrompt(
   );
 }
 
-export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string {
+export function buildExecEventPrompt(
+  pendingEvents: string[],
+  opts?: { deliverToUser?: boolean },
+): string {
   const deliverToUser = opts?.deliverToUser ?? true;
-  if (!deliverToUser) {
+  const eventText = pendingEvents.join("\n").trim();
+  if (!eventText) {
+    if (!deliverToUser) {
+      return (
+        "An async command you ran earlier has completed. The result is shown in the system messages above. " +
+        "Handle the result internally. Do not relay it to the user unless explicitly requested."
+      );
+    }
     return (
       "An async command you ran earlier has completed. The result is shown in the system messages above. " +
-      "Handle the result internally. Do not relay it to the user unless explicitly requested."
+      "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
+      "If it failed, explain what went wrong."
+    );
+  }
+  if (!deliverToUser) {
+    return (
+      "An async command you ran earlier has completed. The result is:\n\n" +
+      eventText +
+      "\n\nHandle the result internally. Do not relay it to the user unless explicitly requested."
     );
   }
   return (
-    "An async command you ran earlier has completed. The result is shown in the system messages above. " +
+    "An async command you ran earlier has completed. The result is:\n\n" +
+    eventText +
+    "\n\n" +
     "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
     "If it failed, explain what went wrong."
   );

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -466,6 +466,11 @@ describe("Ghost reminder bug (issue #13317)", () => {
       });
 
       expect(result.status).toBe("ran");
+      expect(getReplySpy).toHaveBeenCalledTimes(1);
+      const calledCtx = getReplySpy.mock.calls[0]?.[0] as { Body?: string } | undefined;
+      expect(calledCtx?.Body).toContain("Exec completed (review-run, code 0)");
+      expect(calledCtx?.Body).toContain("The result is:");
+      expect(calledCtx?.Body).toContain("Please relay the command output to the user");
       expect(sendTelegram).toHaveBeenCalledTimes(1);
       expect(sendTelegram).toHaveBeenCalledWith(
         "telegram:-1003774691294:topic:47",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -628,7 +628,8 @@ function resolveHeartbeatRunPrompt(params: {
         isCronSystemEvent(event.text),
     )
     .map((event) => event.text);
-  const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);
+  const execEvents = pendingEvents.filter(isExecCompletionEvent);
+  const hasExecCompletion = execEvents.length > 0;
   const hasCronEvents = cronEvents.length > 0;
 
   // If tasks are defined, build a batched prompt with due tasks
@@ -667,7 +668,7 @@ After completing all due tasks, reply HEARTBEAT_OK.`;
 
   // Fallback to original behavior
   const basePrompt = hasExecCompletion
-    ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
+    ? buildExecEventPrompt(execEvents, { deliverToUser: params.canRelayToUser })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);


### PR DESCRIPTION
Fixes #66487

### Claim
Heartbeat exec-event prompts now include the real exec completion payload before asking the model to relay it.

### Evidence
- unit coverage for payload + empty fallback in `heartbeat-events-filter.test.ts`
- runner-level regression verifies the heartbeat prompt body includes the exec completion text
- local validation harness passed: `node_modules/.bin/tsx .tmp-heartbeat-exec-check.ts`

### Checks
- `git diff --check`
