### PR TITLE
fix(gateway): register chat run on agent start and enable provider hooks during model warmup #66470

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2151,6 +2151,10 @@ export const chatHandlers: GatewayRequestHandlers = {
           imageOrder: imageOrder.length > 0 ? imageOrder : undefined,
           onAgentRunStart: (runId) => {
             agentRunStarted = true;
+            context.addChatRun(runId, {
+              sessionKey: p.sessionKey,
+              clientRunId,
+            });
             void emitUserTranscriptUpdate();
             const connId = typeof client?.connId === "string" ? client.connId : undefined;
             const wantsToolEvents = hasGatewayClientCap(

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -75,7 +75,7 @@ async function prewarmConfiguredPrimaryModel(params: {
   try {
     await ensureOpenClawModelsJson(params.cfg, agentDir);
     const resolved = resolveModel(provider, model, agentDir, params.cfg, {
-      skipProviderRuntimeHooks: true,
+      skipProviderRuntimeHooks: false,
     });
     if (!resolved.model) {
       throw new Error(

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -85,7 +85,7 @@ describe("gateway startup primary model warmup", () => {
 
     expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(cfg, "/tmp/agent");
     expect(resolveModelMock).toHaveBeenCalledWith("openai-codex", "gpt-5.4", "/tmp/agent", cfg, {
-      skipProviderRuntimeHooks: true,
+      skipProviderRuntimeHooks: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- Problem: With `codex/gpt-5.4`, the TUI/webchat remains in "pondering" for ~39 seconds after the backend has already written the assistant reply. Additionally, gateway startup logs `Unknown model: codex/gpt-5.4` during warmup.
- Why it matters: Interactive Codex sessions appear hung or much slower than actual completion time, degrading UX for all TUI/webchat users on affected providers.
- What changed: (1) `chat.send` in `chat.ts` now calls `context.addChatRun()` inside `onAgentRunStart` to register the agent run ID with the chat event system, matching the pattern used by `server-node-events.ts` and `agent.ts`. (2) `server-startup-post-attach.ts` sets `skipProviderRuntimeHooks: false` so provider-registered models like `codex/gpt-5.4` are resolved correctly during warmup.
- What did NOT change (scope boundary): No changes to agent execution, session management, delivery routing, or any other gateway method. The chat abort, history, and inject handlers are untouched.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #(insert issue number)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: (1) `chat.send` never called `addChatRun()` to register the agent's run ID with the chat run registry. Other ingress paths (`server-node-events.ts` for voice, `agent.ts` for main/global sessions) do call it. Without this registration, the TUI never receives the "final" chat event for the run, causing it to hang in "pondering" until timeout. (2) `prewarmConfiguredPrimaryModel` passed `skipProviderRuntimeHooks: true`, which skips provider plugin hooks that register dynamic model IDs like `codex/gpt-5.4`, causing `resolveModel` to fail with "Unknown model".
- Missing detection / guardrail: No test asserting that `chat.send` registers runs via `addChatRun`. The warmup test asserted `skipProviderRuntimeHooks: true` as expected behavior.
- Contributing context (if known): The codex provider registers its models through runtime hooks. Skipping those hooks at warmup was intentional for static-only resolution but became a bug when dynamic providers were added.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-startup.test.ts`
- Scenario the test should lock in: Warmup calls `resolveModel` with `skipProviderRuntimeHooks: false` so dynamic provider models resolve correctly.
- Why this is the smallest reliable guardrail: The warmup test directly asserts the options passed to `resolveModel`.
- Existing test that already covers this (if any): Updated existing `"prewarms an explicit configured primary model"` test.
- If no new test is added, why not: The `addChatRun` fix in `chat.ts` is in async orchestration code that requires a full gateway harness to test properly; existing `server-chat.agent-events.test.ts` and `server-node-events.test.ts` pass and cover the surrounding patterns.

## User-visible / Behavior Changes
TUI/webchat sessions using `codex/gpt-5.4` (and other provider-hook-registered models) will now render the final reply immediately after the backend completes, instead of hanging in "pondering". The `startup model warmup failed` log warning for these models is also eliminated.

## Diagram (if applicable)
```text
Before:
[chat.send] -> [agent runs, writes reply] -> [TUI waits for "final" event] -> [timeout ~39s] -> [render]

After:
[chat.send] -> [onAgentRunStart: addChatRun()] -> [agent runs, writes reply] -> [TUI receives "final" event] -> [render immediately]
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: Ubuntu 24.04.4 LTS on WSL / Windows 11
- Runtime/container: Node.js / npm global
- Model/provider: codex/gpt-5.4 via openclaw -> codex app-server
- Integration/channel (if any): TUI / webchat
- Relevant config (redacted): default model set to `codex/gpt-5.4`

### Steps
1. Configure `codex/gpt-5.4` as default model
2. Start gateway, observe startup logs
3. Send a trivial prompt via TUI, observe response latency

### Expected
- No warmup error in startup logs
- TUI renders reply immediately after backend completion

### Actual
- `startup model warmup failed for codex/gpt-5.4: Error: Unknown model: codex/gpt-5.4`
- TUI stuck in "pondering" ~39 seconds after reply written to session file

## Evidence
- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

6/6 startup tests pass after updating assertion. `server-node-events.test.ts` and `server-chat.agent-events.test.ts` pass with zero regressions.

## Human Verification (required)
- Verified scenarios: Warmup test updated and passing; chat agent events tests passing; node events tests passing
- Edge cases checked: Voice ingress path (already calls `addChatRun`), main/global session path (already calls `addChatRun`), non-PI runtimes (warmup still skipped correctly)
- What you did **not** verify: Live TUI session with a running codex/gpt-5.4 instance (no API key available)

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Enabling provider runtime hooks during warmup could slow gateway startup if a provider hook is slow or fails.
  - Mitigation: The warmup is already wrapped in a try/catch that logs warnings and continues. Slow hooks only delay startup, not block it.
- Risk: `addChatRun` in `chat.send` could cause duplicate registrations if `onAgentRunStart` fires multiple times.
  - Mitigation: `addChatRun` is idempotent (map set by runId), and `onAgentRunStart` fires once per dispatch.