### PR TITLE
Gateway: avoid duplicate schtasks restart on Windows (#52044)

### DIFF
--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -9,6 +9,7 @@ import {
   schtasksResponses,
   withWindowsEnv,
   writeGatewayScript,
+  writeGatewayScriptWithNoRespawn,
 } from "./test-helpers/schtasks-fixtures.js";
 const findVerifiedGatewayListenerPidsOnPortSync = vi.hoisted(() =>
   vi.fn<(port: number) => number[]>(() => []),
@@ -170,7 +171,8 @@ describe("Scheduled Task stop/restart cleanup", () => {
 
   it("kills lingering verified gateway listeners and waits for port release before restart", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
-      pushSuccessfulSchtasksResponses(4);
+      const schtasksOkCount = process.platform === "win32" ? 3 : 4;
+      pushSuccessfulSchtasksResponses(schtasksOkCount);
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([5151]);
       inspectPortUsage
         .mockResolvedValueOnce(busyPortUsage(5151))
@@ -183,11 +185,35 @@ describe("Scheduled Task stop/restart cleanup", () => {
       expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(GATEWAY_PORT);
       expectGatewayTermination(5151);
       expect(inspectPortUsage).toHaveBeenCalledTimes(2);
-      expect(schtasksCalls.at(-1)).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+      const expectedLast =
+        process.platform === "win32"
+          ? (["/End", "/TN", "OpenClaw Gateway"] as const)
+          : (["/Run", "/TN", "OpenClaw Gateway"] as const);
+      expect(schtasksCalls.at(-1)).toEqual(expectedLast);
     });
   });
 
-  it("throws when /Run fails during restart", async () => {
+  it.skipIf(process.platform !== "win32")(
+    "runs schtasks /Run on win32 when staged script sets OPENCLAW_NO_RESPAWN",
+    async () => {
+      await withWindowsEnv("openclaw-win-stop-norespawn-", async ({ env }) => {
+        await writeGatewayScriptWithNoRespawn(env, GATEWAY_PORT);
+        const stdout = new PassThrough();
+        pushSuccessfulSchtasksResponses(4);
+        findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([5151]);
+        inspectPortUsage
+          .mockResolvedValueOnce(busyPortUsage(5151))
+          .mockResolvedValueOnce(freePortUsage());
+
+        await expect(restartScheduledTask({ env, stdout })).resolves.toEqual({
+          outcome: "completed",
+        });
+        expect(schtasksCalls.at(-1)).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+      });
+    },
+  );
+
+  it.skipIf(process.platform === "win32")("throws when /Run fails during restart", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
       schtasksResponses.push(
         { ...SUCCESS_RESPONSE },

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -6,7 +6,10 @@ import { findVerifiedGatewayListenerPidsOnPortSync } from "../infra/gateway-proc
 import { inspectPortUsage } from "../infra/ports.js";
 import { getWindowsInstallRoots } from "../infra/windows-install-roots.js";
 import { killProcessTree } from "../process/kill-tree.js";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalLowercaseString,
+} from "../shared/string-coerce.js";
 import { sleep } from "../utils.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
@@ -26,6 +29,11 @@ import type {
   GatewayServiceRenderArgs,
   GatewayServiceRestartResult,
 } from "./service-types.js";
+
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  const normalized = normalizeOptionalLowercaseString(value);
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
 
 function resolveTaskName(env: GatewayServiceEnv): string {
   const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
@@ -806,7 +814,19 @@ export async function restartScheduledTask({
       }
     }
   }
-  await runScheduledTaskOrThrow(taskName);
+  // Windows: avoid a second schtasks /Run here. The gateway run-loop triggers
+  // relaunchGatewayScheduledTask on supervised shutdown; CLI /Run races that path
+  // and can spawn duplicate task instances (#52044). When OPENCLAW_NO_RESPAWN is
+  // set in the staged task script, full-process supervised relaunch is skipped, so
+  // we must still kick the task immediately from the CLI.
+  let shouldRunTaskImmediately = process.platform !== "win32";
+  if (process.platform === "win32") {
+    const staged = await readScheduledTaskCommand(effectiveEnv).catch(() => null);
+    shouldRunTaskImmediately = isTruthyEnvFlag(staged?.environment?.OPENCLAW_NO_RESPAWN);
+  }
+  if (shouldRunTaskImmediately) {
+    await runScheduledTaskOrThrow(taskName);
+  }
   stdout.write(`${formatLine("Restarted Scheduled Task", taskName)}\n`);
   return { outcome: "completed" };
 }

--- a/src/daemon/test-helpers/schtasks-fixtures.ts
+++ b/src/daemon/test-helpers/schtasks-fixtures.ts
@@ -55,3 +55,23 @@ export async function writeGatewayScript(
     "utf8",
   );
 }
+
+/** Staged script with OPENCLAW_NO_RESPAWN so CLI restart must schtasks /Run (#52044). */
+export async function writeGatewayScriptWithNoRespawn(
+  env: Record<string, string>,
+  port = Number(env.OPENCLAW_GATEWAY_PORT || "18789"),
+) {
+  const scriptPath = resolveTaskScriptPath(env);
+  await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+  await fs.writeFile(
+    scriptPath,
+    [
+      "@echo off",
+      `set "OPENCLAW_GATEWAY_PORT=${port}"`,
+      'set "OPENCLAW_NO_RESPAWN=1"',
+      `"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\steipete\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" gateway --port ${port}`,
+      "",
+    ].join("\r\n"),
+    "utf8",
+  );
+}


### PR DESCRIPTION
## Summary
- avoid issuing a second `schtasks /Run` during Windows scheduled-task restart when the supervised gateway shutdown path will relaunch the task itself
- keep the existing CLI `/Run` fallback when the staged task script opts into `OPENCLAW_NO_RESPAWN=1`
- add regression coverage for the Windows default path and the `OPENCLAW_NO_RESPAWN` exception

## Test plan
- [x] `pnpm test src/daemon/schtasks.stop.test.ts src/infra/process-respawn.test.ts src/daemon/schtasks.startup-fallback.test.ts`