### PR TITLE
fix(agents): don't misclassify AbortError as timeout in hasTimeoutHint

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -197,6 +197,11 @@ function hasTimeoutHint(err: unknown): boolean {
   if (readErrorName(err) === "TimeoutError") {
     return true;
   }
+  // AbortError is a distinct error type (cancellation), not a timeout.
+  // Don't classify AbortErrors as timeouts based on message patterns alone.
+  if (readErrorName(err) === "AbortError") {
+    return false;
+  }
   const message = getErrorMessage(err);
   return Boolean(message && isTimeoutErrorMessage(message));
 }


### PR DESCRIPTION
## Summary

**Issue:** #66561 — openai-codex SSE stream begins, but embedded run aborts locally and is surfaced as timeout (408)

**Root Cause:** `hasTimeoutHint()` in `src/agents/failover-error.ts` was incorrectly classifying `AbortError` as a timeout based on message patterns (e.g. "stream aborted" matching timeout patterns). Upstream had already responded (first byte at 12:03:01.557) but the client aborted, and the error was misclassified as a 408 timeout, triggering incorrect failover logic.

**Fix:** Add an explicit `AbortError` check in `hasTimeoutHint()` to return `false` immediately, preventing message-based timeout pattern matching from incorrectly classifying `AbortError` as a timeout.

```typescript
// Before
if (readErrorName(err) === "TimeoutError") {
  return true;
}
const message = getErrorMessage(err);
return Boolean(message && isTimeoutErrorMessage(message));

// After
if (readErrorName(err) === "TimeoutError") {
  return true;
}
// AbortError is a distinct error type (cancellation), not a timeout.
// Don't classify AbortErrors as timeouts based on message patterns alone.
if (readErrorName(err) === "AbortError") {
  return false;
}
const message = getErrorMessage(err);
return Boolean(message && isTimeoutErrorMessage(message));
```

**Testing:**
- `failover-error.test.ts` — 51 tests pass ✓
- `isbillingerrormessage.test.ts` — pass ✓
- `llm-idle-timeout.test.ts` — pass ✓

Closes #66561