### PR TITLE
fix(gateway): increase chat.history limit from 1000 to 2000

### DIFF
--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -26,7 +26,7 @@ export const LogsTailResultSchema = Type.Object(
 export const ChatHistoryParamsSchema = Type.Object(
   {
     sessionKey: NonEmptyString,
-    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+    limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 2000 })),
     maxChars: Type.Optional(Type.Integer({ minimum: 1, maximum: 500_000 })),
   },
   { additionalProperties: false },

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1622,7 +1622,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       provider: resolvedSessionModel.provider,
       localMessages,
     });
-    const hardMax = 1000;
+    const hardMax = 2000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
     const max = Math.min(hardMax, requested);


### PR DESCRIPTION
   ## Description

   Fix chat.history API rejecting limit=2000 with INVALID_REQUEST error, causing silent failures and lost conversation context.

   ## Root Cause

   The schema validation in `ChatHistoryParamsSchema` capped the limit parameter at 1000, but clients (like Feishu channel integration) were requesting limit=2000. This caused the server to reject the request before the actual limit-clamping logic could handle it.

   ## Solution

   - Increased `ChatHistoryParamsSchema` maximum limit from 1000 to 2000
   - Synced server-side `hardMax` constant from 1000 to 2000
   - Maintains backward compatibility (default limit still 200)

   ## Testing

   - [x] Code changes validated
   - [ ] Tests need to pass on CI
   - [ ] Manual testing with Feishu channel integration recommended

   ## Related Issues

   Closes #66573