### PR TITLE
Gateway: avoid spurious Windows restart on unknown listener stale (#52044)

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -4,6 +4,7 @@ import { captureEnv } from "../../test-utils/env.js";
 type RestartHealthSnapshot = {
   healthy: boolean;
   staleGatewayPids: number[];
+  verifiedStaleGatewayPids: number[];
   runtime: { status?: string };
   portUsage: { port: number; status: string; listeners: []; hints: []; errors?: string[] };
   waitOutcome?: string;
@@ -190,6 +191,7 @@ describe("runDaemonRestart health checks", () => {
     waitForGatewayHealthyRestart.mockResolvedValue({
       healthy: true,
       staleGatewayPids: [],
+      verifiedStaleGatewayPids: [],
       runtime: { status: "running" },
       portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
     });
@@ -227,12 +229,14 @@ describe("runDaemonRestart health checks", () => {
     const unhealthy: RestartHealthSnapshot = {
       healthy: false,
       staleGatewayPids: [1993],
+      verifiedStaleGatewayPids: [1993],
       runtime: { status: "stopped" },
       portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
     };
     const healthy: RestartHealthSnapshot = {
       healthy: true,
       staleGatewayPids: [],
+      verifiedStaleGatewayPids: [],
       runtime: { status: "running" },
       portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
     };
@@ -251,6 +255,7 @@ describe("runDaemonRestart health checks", () => {
     const unhealthy: RestartHealthSnapshot = {
       healthy: false,
       staleGatewayPids: [1993],
+      verifiedStaleGatewayPids: [1993],
       runtime: { status: "stopped" },
       portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
     };
@@ -267,10 +272,12 @@ describe("runDaemonRestart health checks", () => {
   });
 
   it("fails restart when gateway remains unhealthy after the full timeout", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     const { formatCliCommand } = await import("../command-format.js");
     const unhealthy: RestartHealthSnapshot = {
       healthy: false,
       staleGatewayPids: [],
+      verifiedStaleGatewayPids: [],
       runtime: { status: "stopped" },
       portUsage: { port: 18789, status: "free", listeners: [], hints: [] },
       waitOutcome: "timeout",
@@ -315,6 +322,7 @@ describe("runDaemonRestart health checks", () => {
     const unhealthy: RestartHealthSnapshot = {
       healthy: false,
       staleGatewayPids: [],
+      verifiedStaleGatewayPids: [],
       runtime: { status: "stopped" },
       portUsage: { port: 18789, status: "free", listeners: [], hints: [] },
       waitOutcome: "stopped-free",

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -246,15 +246,17 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         includeUnknownListenersAsStale: process.platform === "win32",
       });
 
-      if (!health.healthy && health.staleGatewayPids.length > 0) {
-        const staleMsg = `Found stale gateway process(es): ${health.staleGatewayPids.join(", ")}.`;
+      // Windows unknown-listener fallback can mark PIDs as stale for diagnostics without
+      // classifying them as gateway; do not kill/restart on that alone (#52044).
+      if (!health.healthy && health.verifiedStaleGatewayPids.length > 0) {
+        const staleMsg = `Found stale gateway process(es): ${health.verifiedStaleGatewayPids.join(", ")}.`;
         warnings.push(staleMsg);
         if (!json) {
           defaultRuntime.log(theme.warn(staleMsg));
           defaultRuntime.log(theme.muted("Stopping stale process(es) and retrying restart..."));
         }
 
-        await terminateStaleGatewayPids(health.staleGatewayPids);
+        await terminateStaleGatewayPids(health.verifiedStaleGatewayPids);
         const retryRestart = await service.restart({ env: process.env, stdout });
         if (retryRestart.outcome === "scheduled") {
           return retryRestart;

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -143,6 +143,7 @@ describe("inspectGatewayRestart", () => {
 
     expect(snapshot.healthy).toBe(true);
     expect(snapshot.staleGatewayPids).toEqual([]);
+    expect(snapshot.verifiedStaleGatewayPids).toEqual([]);
   });
 
   it("marks non-owned gateway listener pids as stale while runtime is running", async () => {
@@ -158,6 +159,7 @@ describe("inspectGatewayRestart", () => {
 
     expect(snapshot.healthy).toBe(false);
     expect(snapshot.staleGatewayPids).toEqual([9000]);
+    expect(snapshot.verifiedStaleGatewayPids).toEqual([9000]);
   });
 
   it("treats unknown listeners as stale on Windows when enabled", async () => {
@@ -167,6 +169,7 @@ describe("inspectGatewayRestart", () => {
     });
 
     expect(snapshot.staleGatewayPids).toEqual([10920]);
+    expect(snapshot.verifiedStaleGatewayPids).toEqual([]);
   });
 
   it("does not treat unknown listeners as stale when fallback is disabled", async () => {
@@ -176,6 +179,7 @@ describe("inspectGatewayRestart", () => {
     });
 
     expect(snapshot.staleGatewayPids).toEqual([]);
+    expect(snapshot.verifiedStaleGatewayPids).toEqual([]);
   });
 
   it("does not apply unknown-listener fallback while runtime is running", async () => {
@@ -185,6 +189,7 @@ describe("inspectGatewayRestart", () => {
     });
 
     expect(snapshot.staleGatewayPids).toEqual([]);
+    expect(snapshot.verifiedStaleGatewayPids).toEqual([]);
   });
 
   it("does not treat known non-gateway listeners as stale in fallback mode", async () => {
@@ -203,6 +208,7 @@ describe("inspectGatewayRestart", () => {
     });
 
     expect(snapshot.staleGatewayPids).toEqual([]);
+    expect(snapshot.verifiedStaleGatewayPids).toEqual([]);
   });
 
   it("uses a local gateway probe when ownership is ambiguous", async () => {
@@ -237,6 +243,7 @@ describe("inspectGatewayRestart", () => {
 
     expect(snapshot.healthy).toBe(true);
     expect(snapshot.staleGatewayPids).toEqual([]);
+    expect(snapshot.verifiedStaleGatewayPids).toEqual([]);
   });
 
   it("treats auth-closed probe as healthy gateway reachability", async () => {
@@ -268,9 +275,12 @@ describe("inspectGatewayRestart", () => {
 
     expect(snapshot.healthy).toBe(true);
     expect(probeGateway).not.toHaveBeenCalled();
+    expect(snapshot.staleGatewayPids).toEqual([]);
+    expect(snapshot.verifiedStaleGatewayPids).toEqual([]);
   });
 
   it("annotates stopped-free early exits with the actual elapsed time", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     const snapshot = await waitForStoppedFreeGatewayRestart();
 
     expect(snapshot).toMatchObject({
@@ -296,6 +306,35 @@ describe("inspectGatewayRestart", () => {
       elapsedMs: 92_500,
     });
     expect(sleep).toHaveBeenCalledTimes(185);
+  });
+
+  it("does not early-exit restart wait on Windows unknown-only stale listeners", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    classifyPortListener.mockReturnValue("unknown");
+    const service = makeGatewayService({ status: "stopped" });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 10920, command: "unknown" }],
+      hints: [],
+    });
+    probeGateway.mockResolvedValue({
+      ok: false,
+      close: null,
+    });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service,
+      port: 18789,
+      attempts: 4,
+      delayMs: 10,
+      includeUnknownListenersAsStale: true,
+    });
+
+    expect(snapshot.waitOutcome).toBe("timeout");
+    expect(snapshot.staleGatewayPids).toEqual([10920]);
+    expect(snapshot.verifiedStaleGatewayPids).toEqual([]);
   });
 
   it("annotates timeout waits when the health loop exhausts all attempts", async () => {

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -29,6 +29,8 @@ export type GatewayRestartSnapshot = {
   portUsage: PortUsage;
   healthy: boolean;
   staleGatewayPids: number[];
+  /** PIDs classified as gateway listeners that are stale; excludes Windows unknown-listener fallback. */
+  verifiedStaleGatewayPids: number[];
   waitOutcome?: GatewayRestartWaitOutcome;
   elapsedMs?: number;
 };
@@ -143,6 +145,7 @@ export async function inspectGatewayRestart(params: {
           portUsage,
           healthy: true,
           staleGatewayPids: [],
+          verifiedStaleGatewayPids: [],
         };
       }
     } catch {
@@ -183,9 +186,9 @@ export async function inspectGatewayRestart(params: {
       // best-effort probe
     }
   }
-  const staleGatewayPids = Array.from(
-    new Set([
-      ...gatewayListeners
+  const verifiedStaleGatewayPids = Array.from(
+    new Set(
+      gatewayListeners
         .filter((listener) => Number.isFinite(listener.pid))
         .filter((listener) => {
           if (!running) {
@@ -197,17 +200,19 @@ export async function inspectGatewayRestart(params: {
           return !listenerOwnedByRuntimePid({ listener, runtimePid });
         })
         .map((listener) => listener.pid as number),
-      ...fallbackListenerPids.filter(
-        (pid) => runtime.pid == null || pid !== runtime.pid || !running,
-      ),
-    ]),
+    ),
   );
+  const fallbackStalePids = fallbackListenerPids.filter(
+    (pid) => runtime.pid == null || pid !== runtime.pid || !running,
+  );
+  const staleGatewayPids = Array.from(new Set([...verifiedStaleGatewayPids, ...fallbackStalePids]));
 
   return {
     runtime,
     portUsage,
     healthy,
     staleGatewayPids,
+    verifiedStaleGatewayPids,
   };
 }
 
@@ -266,7 +271,7 @@ export async function waitForGatewayHealthyRestart(params: {
     if (snapshot.healthy) {
       return withWaitContext(snapshot, "healthy", attempt * delayMs);
     }
-    if (snapshot.staleGatewayPids.length > 0 && snapshot.runtime.status !== "running") {
+    if (snapshot.verifiedStaleGatewayPids.length > 0 && snapshot.runtime.status !== "running") {
       return withWaitContext(snapshot, "stale-pids", attempt * delayMs);
     }
     if (shouldEarlyExitStoppedFree(snapshot, attempt, minAttemptForEarlyExit)) {

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -33,6 +33,7 @@ const inspectGatewayRestart = vi.fn<(opts?: unknown) => Promise<GatewayRestartSn
     portUsage: { port: 19001, status: "busy", listeners: [], hints: [] },
     healthy: true,
     staleGatewayPids: [],
+    verifiedStaleGatewayPids: [],
   }),
 );
 const serviceReadCommand = vi.fn<
@@ -553,6 +554,7 @@ describe("gatherDaemonStatus", () => {
       },
       healthy: false,
       staleGatewayPids: [9000],
+      verifiedStaleGatewayPids: [9000],
     });
 
     const status = await gatherDaemonStatus({

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -28,6 +28,9 @@ const serviceReadRuntime = vi.fn();
 const inspectPortUsage = vi.fn();
 const classifyPortListener = vi.fn();
 const formatPortDiagnostics = vi.fn();
+const waitForGatewayHealthyRestart = vi.fn();
+const terminateStaleGatewayPids = vi.fn();
+const renderRestartDiagnostics = vi.fn();
 const pathExists = vi.fn();
 const syncPluginsForUpdateChannel = vi.fn();
 const updateNpmInstalledPlugins = vi.fn();
@@ -159,6 +162,12 @@ vi.mock("../infra/ports.js", () => ({
   inspectPortUsage: (...args: unknown[]) => inspectPortUsage(...args),
   classifyPortListener: (...args: unknown[]) => classifyPortListener(...args),
   formatPortDiagnostics: (...args: unknown[]) => formatPortDiagnostics(...args),
+}));
+
+vi.mock("./daemon-cli/restart-health.js", () => ({
+  waitForGatewayHealthyRestart: (...args: unknown[]) => waitForGatewayHealthyRestart(...args),
+  terminateStaleGatewayPids: (...args: unknown[]) => terminateStaleGatewayPids(...args),
+  renderRestartDiagnostics: (...args: unknown[]) => renderRestartDiagnostics(...args),
 }));
 
 vi.mock("./update-cli/restart-helper.js", () => ({
@@ -433,6 +442,15 @@ describe("update-cli", () => {
     });
     classifyPortListener.mockReturnValue("gateway");
     formatPortDiagnostics.mockReturnValue(["Port 18789 is already in use."]);
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: true,
+      staleGatewayPids: [],
+      verifiedStaleGatewayPids: [],
+      runtime: { status: "running", pid: 4242 },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
+    terminateStaleGatewayPids.mockResolvedValue([]);
+    renderRestartDiagnostics.mockReturnValue(["Port 18789 is already in use."]);
     pathExists.mockResolvedValue(false);
     syncPluginsForUpdateChannel.mockResolvedValue({
       changed: false,
@@ -1577,6 +1595,60 @@ describe("update-cli", () => {
       },
     },
   ] as const)("updateCommand service refresh behavior: $name", runUpdateCliScenario);
+
+  it("does not re-restart after update when only diagnostic stale pids are present", async () => {
+    vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
+    serviceLoaded.mockResolvedValue(true);
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: false,
+      staleGatewayPids: [10920],
+      verifiedStaleGatewayPids: [],
+      runtime: { status: "stopped" },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
+    vi.mocked(defaultRuntime.log).mockClear();
+
+    await updateCommand({});
+
+    expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
+    expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
+    expect(runDaemonRestart).not.toHaveBeenCalled();
+    const logLines = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    expect(logLines.some((line) => line.includes("Found stale gateway process(es) after restart"))).toBe(
+      false,
+    );
+    expect(logLines).toContain("Gateway did not become healthy after restart.");
+  });
+
+  it("cleans verified stale pids after update and retries the daemon restart once", async () => {
+    vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
+    serviceLoaded.mockResolvedValue(true);
+    waitForGatewayHealthyRestart
+      .mockResolvedValueOnce({
+        healthy: false,
+        staleGatewayPids: [10920],
+        verifiedStaleGatewayPids: [10920],
+        runtime: { status: "stopped" },
+        portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+      })
+      .mockResolvedValueOnce({
+        healthy: true,
+        staleGatewayPids: [],
+        verifiedStaleGatewayPids: [],
+        runtime: { status: "running", pid: 4242 },
+        portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+      });
+    terminateStaleGatewayPids.mockResolvedValue([10920]);
+    vi.mocked(defaultRuntime.log).mockClear();
+
+    await updateCommand({});
+
+    expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(2);
+    expect(terminateStaleGatewayPids).toHaveBeenCalledWith([10920]);
+    expect(runDaemonRestart).toHaveBeenCalledTimes(1);
+    const logLines = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    expect(logLines).toContain("Daemon restart completed.");
+  });
 
   it.each([
     {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -784,15 +784,15 @@ async function maybeRestartService(params: {
           service,
           port: params.gatewayPort,
         });
-        if (!health.healthy && health.staleGatewayPids.length > 0) {
+        if (!health.healthy && health.verifiedStaleGatewayPids.length > 0) {
           if (!params.opts.json) {
             defaultRuntime.log(
               theme.warn(
-                `Found stale gateway process(es) after restart: ${health.staleGatewayPids.join(", ")}. Cleaning up...`,
+                `Found stale gateway process(es) after restart: ${health.verifiedStaleGatewayPids.join(", ")}. Cleaning up...`,
               ),
             );
           }
-          await terminateStaleGatewayPids(health.staleGatewayPids);
+          await terminateStaleGatewayPids(health.verifiedStaleGatewayPids);
           await runDaemonRestart();
           health = await waitForGatewayHealthyRestart({
             service,


### PR DESCRIPTION
## Summary
- split restart health into `staleGatewayPids` (diagnostics, includes Windows unknown-listener fallback) vs `verifiedStaleGatewayPids` (gateway-classified, actionable listeners)
- only early-exit the restart wait and only kill/retry when verified stale PIDs exist, avoiding a third `service.restart()` from `postRestartCheck` on Windows (#52044)
- align `update-cli` restart follow-up with the same rule and add regression coverage for diagnostic-only vs verified stale PID handling
- fix stopped-free timing test to pin non-Windows platform so expectations are stable on Windows hosts

## Test plan
- [x] `pnpm test src/cli/update-cli.test.ts -t "does not re-restart after update|cleans verified stale pids after update"`
- [x] `pnpm test src/cli/daemon-cli/restart-health.test.ts src/cli/daemon-cli/lifecycle.test.ts src/cli/daemon-cli/status.gather.test.ts`

## Notes
- The broader `src/cli/update-cli.test.ts` file still has an unrelated Windows portable-Git PATH test that is noisy on this host; the new restart-follow-up coverage passes.
