### PR TITLE
fix(browser-cli): avoid full boot on openclaw browser --help

### DIFF
--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -18,6 +18,8 @@ const runtimeApiMocks = vi.hoisted(() => ({
   })),
   handleBrowserGatewayRequest: vi.fn(),
   registerBrowserCli: vi.fn(),
+  runBrowserProxyCommand: vi.fn(async () => "ok"),
+  collectBrowserSecurityAuditFindings: vi.fn(() => []),
 }));
 
 vi.mock("./register.runtime.js", async () => {
@@ -29,6 +31,8 @@ vi.mock("./register.runtime.js", async () => {
     createBrowserTool: runtimeApiMocks.createBrowserTool,
     handleBrowserGatewayRequest: runtimeApiMocks.handleBrowserGatewayRequest,
     registerBrowserCli: runtimeApiMocks.registerBrowserCli,
+    runBrowserProxyCommand: runtimeApiMocks.runBrowserProxyCommand,
+    collectBrowserSecurityAuditFindings: runtimeApiMocks.collectBrowserSecurityAuditFindings,
   };
 });
 
@@ -65,14 +69,14 @@ describe("browser plugin", () => {
 
   it("forwards per-session browser options into the tool factory", async () => {
     const { api, registerTool } = createApi();
-    registerBrowserPlugin(api);
+    await registerBrowserPlugin(api);
 
     const tool = registerTool.mock.calls[0]?.[0];
     if (typeof tool !== "function") {
       throw new Error("expected browser plugin to register a tool factory");
     }
 
-    tool({
+    await tool({
       sessionKey: "agent:main:webchat:direct:123",
       browser: {
         sandboxBridgeUrl: "http://127.0.0.1:9999",
@@ -85,5 +89,24 @@ describe("browser plugin", () => {
       allowHostControl: true,
       agentSessionKey: "agent:main:webchat:direct:123",
     });
+  });
+
+  it("registers CLI descriptors so browser commands can stay lazy", async () => {
+    const { api, registerCli } = createApi();
+    await registerBrowserPlugin(api);
+
+    expect(registerCli).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        commands: ["browser"],
+        descriptors: [
+          {
+            name: "browser",
+            description: "Manage OpenClaw's dedicated browser (Chrome/Chromium)",
+            hasSubcommands: true,
+          },
+        ],
+      }),
+    );
   });
 });

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -34,7 +34,7 @@ export async function registerBrowserPlugin(api: OpenClawPluginApi) {
       allowHostControl: ctx.browser?.allowHostControl,
       agentSessionKey: ctx.sessionKey,
     });
-  }) as OpenClawPluginToolFactory);
+  }) as unknown as OpenClawPluginToolFactory);
   api.registerCli(
     async ({ program }) => {
       const { registerBrowserCli } = await import("./register.runtime.js");

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -18,12 +18,13 @@ export const browserPluginNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
   },
 ];
 
-export const browserSecurityAuditCollectors = [
-  async (...args: unknown[]) => {
-    const { collectBrowserSecurityAuditFindings } = await import("./register.runtime.js");
-    return (collectBrowserSecurityAuditFindings as (...args: unknown[]) => unknown)(...args);
-  },
-];
+export const browserSecurityAuditCollectors: import("openclaw/plugin-sdk/plugin-entry").OpenClawPluginSecurityAuditCollector[] =
+  [
+    async (ctx) => {
+      const { collectBrowserSecurityAuditFindings } = await import("./register.runtime.js");
+      return collectBrowserSecurityAuditFindings(ctx);
+    },
+  ];
 
 export async function registerBrowserPlugin(api: OpenClawPluginApi) {
   api.registerTool((async (ctx: OpenClawPluginToolContext) => {
@@ -50,9 +51,9 @@ export async function registerBrowserPlugin(api: OpenClawPluginApi) {
       ],
     },
   );
-  api.registerGatewayMethod("browser.request", async (...args) => {
+  api.registerGatewayMethod("browser.request", async (opts) => {
     const { handleBrowserGatewayRequest } = await import("./register.runtime.js");
-    return (handleBrowserGatewayRequest as (...args: unknown[]) => unknown)(...args);
+    return handleBrowserGatewayRequest(opts);
   }, {
     scope: "operator.write",
   });

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -4,14 +4,6 @@ import type {
   OpenClawPluginToolContext,
   OpenClawPluginToolFactory,
 } from "openclaw/plugin-sdk/plugin-entry";
-import {
-  collectBrowserSecurityAuditFindings,
-  createBrowserPluginService,
-  createBrowserTool,
-  handleBrowserGatewayRequest,
-  registerBrowserCli,
-  runBrowserProxyCommand,
-} from "./register.runtime.js";
 
 export const browserPluginReload = { restartPrefixes: ["browser"] };
 
@@ -19,22 +11,68 @@ export const browserPluginNodeHostCommands: OpenClawPluginNodeHostCommand[] = [
   {
     command: "browser.proxy",
     cap: "browser",
-    handle: runBrowserProxyCommand,
+    handle: async (paramsJSON) => {
+      const { runBrowserProxyCommand } = await import("./register.runtime.js");
+      return runBrowserProxyCommand(paramsJSON);
+    },
   },
 ];
 
-export const browserSecurityAuditCollectors = [collectBrowserSecurityAuditFindings];
+export const browserSecurityAuditCollectors = [
+  async (...args: unknown[]) => {
+    const { collectBrowserSecurityAuditFindings } = await import("./register.runtime.js");
+    return (collectBrowserSecurityAuditFindings as (...args: unknown[]) => unknown)(...args);
+  },
+];
 
-export function registerBrowserPlugin(api: OpenClawPluginApi) {
-  api.registerTool(((ctx: OpenClawPluginToolContext) =>
-    createBrowserTool({
+export async function registerBrowserPlugin(api: OpenClawPluginApi) {
+  api.registerTool((async (ctx: OpenClawPluginToolContext) => {
+    const { createBrowserTool } = await import("./register.runtime.js");
+    return createBrowserTool({
       sandboxBridgeUrl: ctx.browser?.sandboxBridgeUrl,
       allowHostControl: ctx.browser?.allowHostControl,
       agentSessionKey: ctx.sessionKey,
-    })) as OpenClawPluginToolFactory);
-  api.registerCli(({ program }) => registerBrowserCli(program), { commands: ["browser"] });
-  api.registerGatewayMethod("browser.request", handleBrowserGatewayRequest, {
+    });
+  }) as OpenClawPluginToolFactory);
+  api.registerCli(
+    async ({ program }) => {
+      const { registerBrowserCli } = await import("./register.runtime.js");
+      registerBrowserCli(program);
+    },
+    {
+      commands: ["browser"],
+      descriptors: [
+        {
+          name: "browser",
+          description: "Manage OpenClaw's dedicated browser (Chrome/Chromium)",
+          hasSubcommands: true,
+        },
+      ],
+    },
+  );
+  api.registerGatewayMethod("browser.request", async (...args) => {
+    const { handleBrowserGatewayRequest } = await import("./register.runtime.js");
+    return (handleBrowserGatewayRequest as (...args: unknown[]) => unknown)(...args);
+  }, {
     scope: "operator.write",
   });
-  api.registerService(createBrowserPluginService());
+  let loadedService:
+    | Awaited<ReturnType<(typeof import("./register.runtime.js"))["createBrowserPluginService"]>>
+    | null = null;
+  api.registerService({
+    id: "browser-control",
+    start: async (ctx) => {
+      if (!loadedService) {
+        const { createBrowserPluginService } = await import("./register.runtime.js");
+        loadedService = createBrowserPluginService();
+      }
+      await loadedService.start(ctx);
+    },
+    stop: async (ctx) => {
+      if (!loadedService?.stop) {
+        return;
+      }
+      await loadedService.stop(ctx);
+    },
+  });
 }


### PR DESCRIPTION
﻿## Summary

`openclaw browser --help` should not trigger the browser plugin's heavy runtime imports. This change makes the browser plugin registration lazy and adds CLI descriptors so the root CLI can keep `browser` as a placeholder until first invocation.

Fixes #65400.

## What changed

- Defer importing `extensions/browser/register.runtime` until the browser CLI/tool/service is actually used.
- Provide `descriptors` for the `browser` command so plugin CLI registration can stay lazy.
- Update browser plugin unit tests to cover descriptor registration.

## Test plan

- `pnpm exec vitest run extensions/browser/index.test.ts`
