### PR TITLE
fix(plugins): enable DuckDuckGo web search provider by default

### DIFF
--- a/extensions/duckduckgo/openclaw.plugin.json
+++ b/extensions/duckduckgo/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "duckduckgo",
+  "enabledByDefault": true,
   "uiHints": {
     "webSearch.region": {
       "label": "DuckDuckGo Region",

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -28,6 +28,41 @@ describe("web tools defaults", () => {
     expect(tool).toBeNull();
   });
 
+  it("returns web_search when a keyless provider is in the active registry (enabledByDefault)", () => {
+    // Simulates enabledByDefault: true loading DuckDuckGo into the active registry at startup.
+    // When no config is passed, createWebSearchTool uses the active registry directly.
+    const registry = createEmptyPluginRegistry();
+    registry.webSearchProviders.push({
+      pluginId: "duckduckgo",
+      pluginName: "DuckDuckGo",
+      source: "bundled",
+      provider: {
+        id: "duckduckgo",
+        label: "DuckDuckGo Search (experimental)",
+        hint: "Free web search fallback with no API key required",
+        requiresCredential: false,
+        envVars: [],
+        placeholder: "(no key needed)",
+        signupUrl: "https://duckduckgo.com/",
+        autoDetectOrder: 100,
+        credentialPath: "",
+        inactiveSecretPaths: [],
+        getCredentialValue: () => "",
+        setCredentialValue: () => {},
+        createTool: () => ({
+          description: "Search the web using DuckDuckGo.",
+          parameters: {},
+          execute: async () => ({}),
+        }),
+      },
+    });
+    setActivePluginRegistry(registry);
+
+    const tool = createWebSearchTool();
+
+    expect(tool?.name).toBe("web_search");
+  });
+
   it("uses runtime-only web_search providers when runtime metadata is present", async () => {
     const registry = createEmptyPluginRegistry();
     registry.webSearchProviders.push({


### PR DESCRIPTION
## Summary

- DuckDuckGo is a keyless bundled web search provider (no API key required), but it was never included in the active plugin registry at startup because bundled plugins are **disabled by default** unless `enabledByDefault: true` is set in their manifest.
- On fresh installs without going through the wizard, `web_search` was missing from agent tool lists entirely.
- This adds `"enabledByDefault": true` to `extensions/duckduckgo/openclaw.plugin.json` so DuckDuckGo is activated via the standard bundled-default-enablement path on startup.

## Root cause

`src/plugins/config-policy.ts` line 199–207 shows that bundled plugins without `enabledByDefault: true` fall through to `"bundled (disabled by default)"`. The compat mechanism (`withBundledPluginEnablementCompat`) correctly enables DuckDuckGo in per-request tool resolution snapshots, but the **main active registry** loaded at server startup never included DuckDuckGo, leaving `createWebSearchTool` unable to resolve a provider when no compat snapshot was available.

## Fix

- `extensions/duckduckgo/openclaw.plugin.json`: add `"enabledByDefault": true`
- `src/agents/tools/web-tools.enabled-defaults.test.ts`: add test verifying a keyless provider in the active registry produces a `web_search` tool (simulating the `enabledByDefault` load path)

## Opt-out

Users who want to disable DuckDuckGo can set `plugins.entries.duckduckgo.enabled: false` or add `duckduckgo` to `plugins.deny`. Explicit disablement is checked before the `enabledByDefault` path in the loader.

## Test plan

- [ ] Run `pnpm test src/agents/tools/web-tools.enabled-defaults.test.ts` — new test passes
- [ ] Run `pnpm test src/plugins/contracts/web-search-provider.duckduckgo.contract.test.ts` — contract still passes
- [ ] Run `pnpm test src/plugins/contracts/bundled-web-search.duckduckgo.contract.test.ts` — fast-path contract still passes
- [ ] Verify fresh install: `web_search` appears in agent tool list without any explicit plugin config
- [ ] Verify opt-out: setting `plugins.entries.duckduckgo.enabled: false` removes `web_search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)