### PR TITLE
fix(wizard): avoid setup crash on missing provider ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Video generation/live tests: bound provider polling for live video smoke, default to the fast non-FAL text-to-video path, and use a one-second lobster prompt so release validation no longer waits indefinitely on slow provider queues.
 - Memory-core/QMD `memory_get`: reject reads of arbitrary workspace markdown paths and only allow canonical memory files (`MEMORY.md`, `memory.md`, `DREAMS.md`, `dreams.md`, `memory/**`) plus exact paths of active indexed QMD workspace documents, so the QMD memory backend can no longer be used as a generic workspace-file read shim that bypasses `read` tool-policy denials. (#66026) Thanks @eleqtrizit.
 - Cron/agents: forward embedded-run tool policy and internal event params into the attempt layer so `--tools` allowlists, cron-owned message-tool suppression, explicit message targeting, and command-path internal events all take effect at runtime again. (#62675) Thanks @hexsprite.
+- Setup/providers: guard preferred-provider lookup during setup so malformed plugin metadata with a missing provider id no longer crashes the wizard with `Cannot read properties of undefined (reading 'trim')`. (#66649) Thanks @Tianworld.
 
 ## 2026.4.14
 

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -278,7 +278,7 @@ describe("runSetupWizard", () => {
     return dir;
   }
 
-  it("does not crash when provider entries are missing ids (defensive trim)", async () => {
+  it("does not crash when preferred-provider lookup sees a provider without an id", async () => {
     setupChannels.mockClear();
     readConfigFileSnapshot.mockResolvedValueOnce({
       path: "/tmp/.openclaw/openclaw.json",
@@ -301,7 +301,6 @@ describe("runSetupWizard", () => {
     const caseDir = await makeCaseDir("provider-missing-id-");
     const select = vi.fn(async ({ message }: WizardSelectParams<unknown>) => {
       if (message === "Select setup mode") return "quickstart";
-      if (message === "Select provider authentication") return "skip";
       if (message === "Select channel (QuickStart)") return "__skip__";
       if (message === "How do you want to hatch your bot?") return "skip";
       return "skip";
@@ -315,7 +314,7 @@ describe("runSetupWizard", () => {
         {
           acceptRisk: true,
           flow: "quickstart",
-          authChoice: "skip",
+          authChoice: "ollama",
           installDaemon: false,
           skipProviders: false,
           skipSkills: true,
@@ -328,8 +327,10 @@ describe("runSetupWizard", () => {
         prompter,
       ),
     ).resolves.toBeUndefined();
-
-    // Avoid leaking call counts into later tests in this file.
+    expect(resolvePreferredProviderForAuthChoice).toHaveBeenCalledWith(
+      expect.objectContaining({ choice: "ollama" }),
+    );
+    expect(resolvePluginProvidersRuntime).toHaveBeenCalled();
     setupChannels.mockClear();
   });
 

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -278,6 +278,61 @@ describe("runSetupWizard", () => {
     return dir;
   }
 
+  it("does not crash when provider entries are missing ids (defensive trim)", async () => {
+    setupChannels.mockClear();
+    readConfigFileSnapshot.mockResolvedValueOnce({
+      path: "/tmp/.openclaw/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      resolved: {},
+      valid: true,
+      config: {},
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    });
+    resolvePreferredProviderForAuthChoice.mockResolvedValueOnce("demo-provider");
+    resolvePluginProvidersRuntime.mockReturnValueOnce([
+      { id: undefined } as unknown as { id: string },
+      { id: "demo-provider", wizard: { setup: {} } } as unknown as { id: string },
+    ]);
+
+    const caseDir = await makeCaseDir("provider-missing-id-");
+    const select = vi.fn(async ({ message }: WizardSelectParams<unknown>) => {
+      if (message === "Select setup mode") return "quickstart";
+      if (message === "Select provider authentication") return "skip";
+      if (message === "Select channel (QuickStart)") return "__skip__";
+      if (message === "How do you want to hatch your bot?") return "skip";
+      return "skip";
+    }) as unknown as WizardPrompter["select"];
+    const confirm = vi.fn(async () => true) as unknown as WizardPrompter["confirm"];
+    const prompter = buildWizardPrompter({ select, confirm });
+    const runtime = createRuntime({ throwsOnExit: true });
+
+    await expect(
+      runSetupWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          authChoice: "skip",
+          installDaemon: false,
+          skipProviders: false,
+          skipSkills: true,
+          skipSearch: true,
+          skipChannels: false,
+          skipUi: true,
+          workspace: caseDir,
+        },
+        runtime,
+        prompter,
+      ),
+    ).resolves.toBeUndefined();
+
+    // Avoid leaking call counts into later tests in this file.
+    setupChannels.mockClear();
+  });
+
   it("exits when config is invalid", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce({
       path: "/tmp/.openclaw/openclaw.json",

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -58,13 +58,15 @@ async function resolveAuthChoiceModelSelectionPolicy(params: {
   });
   const matchedProvider =
     resolvedChoice?.provider ??
-    (preferredProvider
-      ? providers.find((provider) => {
-          const providerId = typeof provider?.id === "string" ? provider.id.trim() : "";
-          const preferredId = preferredProvider?.trim() ?? "";
-          return Boolean(providerId) && Boolean(preferredId) && providerId === preferredId;
-        })
-      : undefined);
+    (() => {
+      const preferredId = preferredProvider?.trim();
+      if (!preferredId) {
+        return undefined;
+      }
+      return providers.find(
+        (provider) => typeof provider.id === "string" && provider.id.trim() === preferredId,
+      );
+    })();
   const setupPolicy =
     resolvedChoice?.wizard?.modelSelection ?? matchedProvider?.wizard?.setup?.modelSelection;
 

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -59,7 +59,11 @@ async function resolveAuthChoiceModelSelectionPolicy(params: {
   const matchedProvider =
     resolvedChoice?.provider ??
     (preferredProvider
-      ? providers.find((provider) => provider.id.trim() === preferredProvider.trim())
+      ? providers.find((provider) => {
+          const providerId = typeof provider?.id === "string" ? provider.id.trim() : "";
+          const preferredId = preferredProvider?.trim() ?? "";
+          return Boolean(providerId) && Boolean(preferredId) && providerId === preferredId;
+        })
       : undefined);
   const setupPolicy =
     resolvedChoice?.wizard?.modelSelection ?? matchedProvider?.wizard?.setup?.modelSelection;


### PR DESCRIPTION
﻿## Summary

Prevent setup wizard crashes when provider plugin metadata is incomplete.

The setup flow compares provider ids using `.trim()`; if a provider entry is missing `id`, it crashed with `TypeError: Cannot read properties of undefined (reading 'trim')`.

- Guard provider id comparisons when selecting the preferred provider for an auth choice.
- Add regression coverage.

Fixes #66641.
Fixes #66619.

## Test plan

- `pnpm exec vitest run src/wizard/setup.test.ts`
