### PR TITLE
feat(tools): add model_spawn tool — live session model switch and parallel ephemeral spawns

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -666,6 +666,16 @@
         "cleanup"
       ]
     },
+    "model_spawn": {
+      "emoji": "🔀",
+      "title": "Model Spawn",
+      "detailKeys": [
+        "mode",
+        "model",
+        "task",
+        "cleanup"
+      ]
+    },
     "subagents": {
       "emoji": "🤖",
       "title": "Subagents",

--- a/docs/tools/model-spawn.md
+++ b/docs/tools/model-spawn.md
@@ -1,0 +1,273 @@
+---
+title: Model Spawn
+description: Spawn one or more model instances for inference tasks — in-place session switch or isolated ephemeral runs.
+---
+
+# `model_spawn` Tool Specification
+
+**Version**: 1.0  
+**Tool name**: `model_spawn`  
+**Implemented in**: OpenClaw (TypeScript), zeroclaw (Rust, in design)
+
+---
+
+## Overview
+
+`model_spawn` gives the LLM direct control over model selection at inference time. It has two modes:
+
+| Mode    | What it does                                         | Context                                        |
+| ------- | ---------------------------------------------------- | ---------------------------------------------- |
+| `live`  | Switch the current session to a different model      | Preserved — prior conversation carries forward |
+| `spawn` | Run one or more tasks in isolated ephemeral sessions | Isolated — each spawn gets a clean context     |
+
+`spawn` mode supports both **single-model delegation** (route a task to the best model for it) and **parallel multi-model execution** (send the same or different tasks to multiple models concurrently, for specialization or comparison).
+
+---
+
+## Schema (canonical)
+
+```json
+{
+  "name": "model_spawn",
+  "parameters": {
+    "type": "object",
+    "required": ["mode"],
+    "properties": {
+      "mode": {
+        "type": "string",
+        "enum": ["live", "spawn"],
+        "description": "live=in-place session model switch (context preserved). spawn=isolated ephemeral run(s)."
+      },
+      "model": {
+        "type": "string",
+        "description": "Full provider/model spec, e.g. \"together/MiniMaxAI/MiniMax-M2.7\". Required for live mode and single-model spawn."
+      },
+      "task": {
+        "type": "string",
+        "description": "Task prompt. Required for single spawn. Serves as default for spawns[] entries that omit their own task."
+      },
+      "context": {
+        "type": "string",
+        "description": "Context prepended to task. Used for single spawn or as default for spawns[] entries."
+      },
+      "spawns": {
+        "type": "array",
+        "maxItems": 10,
+        "description": "Multi-model parallel execution. Each entry runs in its own isolated session concurrently.",
+        "items": {
+          "type": "object",
+          "required": ["model"],
+          "properties": {
+            "model": { "type": "string", "description": "Model for this spawn." },
+            "task": {
+              "type": "string",
+              "description": "Task for this spawn. Falls back to top-level task."
+            },
+            "label": { "type": "string", "description": "Human label for this spawn's result." },
+            "context": {
+              "type": "string",
+              "description": "Context for this spawn. Falls back to top-level context."
+            }
+          }
+        }
+      },
+      "cleanup": {
+        "type": "string",
+        "enum": ["delete", "keep"],
+        "description": "Session cleanup after spawn. Default: \"delete\" (ephemeral)."
+      },
+      "timeout_seconds": {
+        "type": "number",
+        "minimum": 0,
+        "description": "Per-spawn run timeout in seconds."
+      }
+    }
+  }
+}
+```
+
+**Mutual exclusion**: `model` (top-level) and `spawns[]` are mutually exclusive. Use one or the other in `spawn` mode, not both.
+
+---
+
+## Response schema (canonical)
+
+### `live` mode
+
+```json
+{
+  "status":       "ok" | "error",
+  "mode":         "live",
+  "model":        "provider/model-id",
+  "provider":     "provider",
+  "modelId":      "model-id",
+  "switchPending": true,
+  "note":         "human-readable status"
+}
+```
+
+### `spawn` mode — single
+
+```json
+{
+  "mode":   "spawn",
+  "multi":  false,
+  "model":  "provider/model-id",
+  "status": "accepted" | "error",
+  ...spawnSubagentResult
+}
+```
+
+### `spawn` mode — multi
+
+```json
+{
+  "mode":    "spawn",
+  "multi":   true,
+  "count":   3,
+  "results": [
+    {
+      "label":  "MiniMax summary",
+      "index":  0,
+      "model":  "together/MiniMaxAI/MiniMax-M2.7",
+      "status": "accepted",
+      ...
+    },
+    { "label": "Kimi reasoning", "index": 1, ... },
+    { "label": "GLM analysis",   "index": 2, ... }
+  ]
+}
+```
+
+---
+
+## Usage examples
+
+### Live switch (context preserved)
+
+```json
+{
+  "mode": "live",
+  "model": "together/zai-org/GLM-5"
+}
+```
+
+Switch to GLM-5 for the remainder of this session. Prior conversation is not affected.
+
+---
+
+### Single spawn (task delegation)
+
+```json
+{
+  "mode": "spawn",
+  "model": "together/MiniMaxAI/MiniMax-M2.7",
+  "task": "Summarize the Q1 2026 10-K executive section in 200 words.",
+  "cleanup": "delete"
+}
+```
+
+Run a single task on MiniMax. The parent session's model is unchanged.
+
+---
+
+### Multi-model parallel specialization
+
+Each model gets a different subtask it's best suited for:
+
+```json
+{
+  "mode": "spawn",
+  "spawns": [
+    {
+      "model": "together/MiniMaxAI/MiniMax-M2.7",
+      "task": "Extract all numerical metrics from the following 10-K text: ...",
+      "label": "metric-extraction"
+    },
+    {
+      "model": "together/zai-org/GLM-5",
+      "task": "Identify regulatory risk factors and rate severity 1-5: ...",
+      "label": "risk-analysis"
+    },
+    {
+      "model": "groq/moonshotai/kimi-k2-instruct-0905",
+      "task": "Compare this company's guidance to analyst consensus: ...",
+      "label": "guidance-comparison"
+    }
+  ],
+  "cleanup": "delete",
+  "timeout_seconds": 120
+}
+```
+
+All three spawns run concurrently. Results are collected and returned as `results[]`.
+
+---
+
+### Multi-model comparison (same task, different models)
+
+```json
+{
+  "mode": "spawn",
+  "task": "Write a one-paragraph investment thesis for NVDA based on Q1 2026 earnings.",
+  "spawns": [
+    { "model": "together/MiniMaxAI/MiniMax-M2.7", "label": "minimax" },
+    { "model": "together/zai-org/GLM-5", "label": "glm5" },
+    { "model": "xai/grok-4-1-fast", "label": "grok" }
+  ]
+}
+```
+
+Top-level `task` is shared across all entries. Results returned for comparison.
+
+---
+
+## Decision guide: when to use each mode
+
+| Situation                                                                                                  | Recommended mode                                  |
+| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| The current conversation would be better served by a different model going forward                         | `live`                                            |
+| A single subtask needs a specialized model (e.g. a coding model for code gen, a reasoning model for logic) | `spawn` + single `model`                          |
+| Multiple subtasks need different specialist models simultaneously                                          | `spawn` + `spawns[]`                              |
+| A/B model comparison on the same prompt                                                                    | `spawn` + `spawns[]` with shared top-level `task` |
+| You need the child session to persist after the run                                                        | `spawn` + `cleanup="keep"`                        |
+
+---
+
+## Implementation notes (conformant systems)
+
+### `live` mode requirements
+
+The system must:
+
+1. Parse `model` as `<provider>/<model-id>` (split on first `/`)
+2. Set a session-scoped model override that takes effect on the **next clean turn boundary**, not immediately mid-inference
+3. Preserve full prior conversation context — the override applies to future turns only
+4. **Not** persist the override to global config — it is session-scoped
+
+### `spawn` mode requirements
+
+The system must:
+
+1. Create a new isolated session (no prior conversation context injected)
+2. Use the specified model for that session's inference
+3. Return when the task completes (or times out)
+4. If `cleanup="delete"` (default), destroy the session record after completion
+5. For `spawns[]`, run all entries **concurrently** (not sequentially) and collect results
+
+### `spawns[]` fallback rules
+
+- If a spawn entry omits `task`: use top-level `task`. Error if top-level `task` is also absent.
+- If a spawn entry omits `context`: use top-level `context` (if any). No error if both are absent.
+- If a spawn entry omits `label`: use the entry's `model` value as the label.
+
+---
+
+## Conformance across systems
+
+| System   | `live` mode                                      | `spawn` single                              | `spawn` multi                     |
+| -------- | ------------------------------------------------ | ------------------------------------------- | --------------------------------- |
+| OpenClaw | ✅ `liveModelSwitchPending` + session store      | ✅ `spawnSubagentDirect`                    | ✅ `Promise.all`                  |
+| zeroclaw | 🔧 Needs `pending_model_switch` in session state | 🔧 Needs inline `model` param on `delegate` | 🔧 Needs `spawns[]` on `delegate` |
+
+See `ZEROCLAW_MODEL_SPAWN_DESIGN.md` in the InvestorClaw repo for the zeroclaw implementation spec.

--- a/docs/tools/model-spawn.md
+++ b/docs/tools/model-spawn.md
@@ -52,7 +52,7 @@ description: Spawn one or more model instances for inference tasks — in-place 
       },
       "spawns": {
         "type": "array",
-        "maxItems": 10,
+        "maxItems": 5,
         "description": "Multi-model parallel execution. Each entry runs in its own isolated session concurrently.",
         "items": {
           "type": "object",

--- a/docs/tools/model-spawn.md
+++ b/docs/tools/model-spawn.md
@@ -265,9 +265,9 @@ The system must:
 
 ## Conformance across systems
 
-| System   | `live` mode                                      | `spawn` single                              | `spawn` multi                     |
-| -------- | ------------------------------------------------ | ------------------------------------------- | --------------------------------- |
-| OpenClaw | ✅ `liveModelSwitchPending` + session store      | ✅ `spawnSubagentDirect`                    | ✅ `Promise.all`                  |
-| zeroclaw | 🔧 Needs `pending_model_switch` in session state | 🔧 Needs inline `model` param on `delegate` | 🔧 Needs `spawns[]` on `delegate` |
+| System   | `live` mode                                   | `spawn` single                                    | `spawn` multi               |
+| -------- | --------------------------------------------- | ------------------------------------------------- | --------------------------- |
+| OpenClaw | ✅ `liveModelSwitchPending` + session store   | ✅ `spawnSubagentDirect`                          | ✅ `Promise.all`            |
+| zeroclaw | ✅ `MODEL_SWITCH_REQUEST` global + agent loop | ✅ `create_provider_with_options` + `simple_chat` | ✅ `futures_util::join_all` |
 
 See `ZEROCLAW_MODEL_SPAWN_DESIGN.md` in the InvestorClaw repo for the zeroclaw implementation spec.

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -21,6 +21,7 @@ import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageGenerateTool } from "./tools/image-generate-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
 import { createMessageTool } from "./tools/message-tool.js";
+import { createModelSpawnTool } from "./tools/model-spawn-tool.js";
 import { createMusicGenerateTool } from "./tools/music-generate-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
@@ -290,6 +291,17 @@ export function createOpenClawTools(
       agentGroupSpace: options?.agentGroupSpace,
       sandboxed: options?.sandboxed,
       requesterAgentIdOverride: options?.requesterAgentIdOverride,
+      workspaceDir: spawnWorkspaceDir,
+    }),
+    createModelSpawnTool({
+      agentSessionKey: options?.agentSessionKey,
+      agentChannel: options?.agentChannel,
+      agentAccountId: options?.agentAccountId,
+      agentTo: options?.agentTo,
+      agentThreadId: options?.agentThreadId,
+      agentGroupId: options?.agentGroupId,
+      agentGroupChannel: options?.agentGroupChannel,
+      agentGroupSpace: options?.agentGroupSpace,
       workspaceDir: spawnWorkspaceDir,
     }),
     createSubagentsTool({

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -302,6 +302,7 @@ export function createOpenClawTools(
       agentGroupId: options?.agentGroupId,
       agentGroupChannel: options?.agentGroupChannel,
       agentGroupSpace: options?.agentGroupSpace,
+      requesterAgentIdOverride: options?.requesterAgentIdOverride,
       workspaceDir: spawnWorkspaceDir,
     }),
     createSubagentsTool({

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -438,6 +438,11 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "Sub-agent",
       detailKeys: ["label", "task", "agentId", "model", "thinking", "runTimeoutSeconds", "cleanup"],
     },
+    model_spawn: {
+      emoji: "🔀",
+      title: "Model Spawn",
+      detailKeys: ["mode", "model", "task", "cleanup"],
+    },
     subagents: {
       emoji: "🤖",
       title: "Subagents",

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -13,6 +13,7 @@ const MUTATING_TOOL_NAMES = new Set([
   "process",
   "message",
   "sessions_spawn",
+  "model_spawn",
   "sessions_send",
   "cron",
   "gateway",

--- a/src/agents/tools/model-spawn-tool.test.ts
+++ b/src/agents/tools/model-spawn-tool.test.ts
@@ -1,0 +1,379 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── hoisted mocks ──────────────────────────────────────────────────────────────
+const hoisted = vi.hoisted(() => {
+  const spawnMock = vi.fn();
+  const loadSessionStore = vi.fn();
+  const resolveStorePath = vi.fn();
+  const updateSessionStore = vi.fn();
+  const resolveAgentIdFromSessionKey = vi.fn();
+  const applyModelOverrideToSessionEntry = vi.fn();
+  const resolveMainSessionAlias = vi.fn();
+  const resolveInternalSessionKey = vi.fn();
+  return {
+    spawnMock,
+    loadSessionStore,
+    resolveStorePath,
+    updateSessionStore,
+    resolveAgentIdFromSessionKey,
+    applyModelOverrideToSessionEntry,
+    resolveMainSessionAlias,
+    resolveInternalSessionKey,
+  };
+});
+
+vi.mock("../subagent-spawn.js", () => ({
+  spawnSubagentDirect: (...args: unknown[]) => hoisted.spawnMock(...args),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: (...args: unknown[]) => hoisted.loadSessionStore(...args),
+  resolveStorePath: (...args: unknown[]) => hoisted.resolveStorePath(...args),
+  updateSessionStore: (...args: unknown[]) => hoisted.updateSessionStore(...args),
+}));
+
+vi.mock("../../routing/session-key.js", () => ({
+  resolveAgentIdFromSessionKey: (...args: unknown[]) =>
+    hoisted.resolveAgentIdFromSessionKey(...args),
+}));
+
+vi.mock("../../sessions/model-overrides.js", () => ({
+  applyModelOverrideToSessionEntry: (...args: unknown[]) =>
+    hoisted.applyModelOverrideToSessionEntry(...args),
+}));
+
+vi.mock("./sessions-helpers.js", () => ({
+  resolveMainSessionAlias: (...args: unknown[]) => hoisted.resolveMainSessionAlias(...args),
+  resolveInternalSessionKey: (...args: unknown[]) => hoisted.resolveInternalSessionKey(...args),
+}));
+
+// ── import under test ──────────────────────────────────────────────────────────
+let createModelSpawnTool: typeof import("./model-spawn-tool.js").createModelSpawnTool;
+
+describe("model_spawn tool", () => {
+  beforeAll(async () => {
+    ({ createModelSpawnTool } = await import("./model-spawn-tool.js"));
+  });
+
+  beforeEach(() => {
+    hoisted.spawnMock.mockReset().mockResolvedValue({ status: "ok", output: "done" });
+    hoisted.loadSessionStore.mockReset().mockReturnValue({
+      "agent:main:main": { providerOverride: "openai", modelOverride: "gpt-4o" },
+    });
+    hoisted.resolveStorePath.mockReset().mockReturnValue("/tmp/sessions.json");
+    hoisted.updateSessionStore.mockReset().mockResolvedValue(undefined);
+    hoisted.resolveAgentIdFromSessionKey.mockReset().mockReturnValue("main");
+    hoisted.applyModelOverrideToSessionEntry.mockReset().mockReturnValue({ updated: true });
+    hoisted.resolveMainSessionAlias
+      .mockReset()
+      .mockReturnValue({ mainKey: "main", alias: "agent:main:main", scope: "per-sender" });
+    hoisted.resolveInternalSessionKey.mockReset().mockReturnValue("agent:main:main");
+  });
+
+  // ── live mode ──────────────────────────────────────────────────────────────
+
+  describe("live mode", () => {
+    it("writes model switch to session store and returns switchPending: true", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      const result = await tool.execute("call-1", {
+        mode: "live",
+        model: "together/MiniMaxAI/MiniMax-M2.7",
+      });
+
+      expect(hoisted.applyModelOverrideToSessionEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selection: { provider: "together", model: "MiniMaxAI/MiniMax-M2.7", isDefault: false },
+          selectionSource: "user",
+          markLiveSwitchPending: true,
+        }),
+      );
+      expect(hoisted.updateSessionStore).toHaveBeenCalledWith(
+        "/tmp/sessions.json",
+        expect.any(Function),
+      );
+      const details = result.details as Record<string, unknown>;
+      expect(details).toMatchObject({
+        status: "ok",
+        mode: "live",
+        switchPending: true,
+      });
+    });
+
+    it("returns switchPending: false and skips store write when model already active", async () => {
+      hoisted.applyModelOverrideToSessionEntry.mockReturnValue({ updated: false });
+
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      const result = await tool.execute("call-2", {
+        mode: "live",
+        model: "together/MiniMaxAI/MiniMax-M2.7",
+      });
+
+      expect(hoisted.updateSessionStore).not.toHaveBeenCalled();
+      const details = result.details as Record<string, unknown>;
+      expect(details).toMatchObject({
+        status: "ok",
+        mode: "live",
+        switchPending: false,
+      });
+    });
+
+    it("returns error result (not throw) when no session key", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "" });
+
+      const result = await tool.execute("call-3", {
+        mode: "live",
+        model: "together/MiniMaxAI/MiniMax-M2.7",
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details).toMatchObject({ status: "error" });
+      expect(hoisted.updateSessionStore).not.toHaveBeenCalled();
+    });
+
+    it("returns error result when no store path", async () => {
+      hoisted.resolveStorePath.mockReturnValue(undefined);
+
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      const result = await tool.execute("call-4", {
+        mode: "live",
+        model: "together/MiniMaxAI/MiniMax-M2.7",
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details).toMatchObject({ status: "error" });
+    });
+
+    it("returns error result when session not found in store", async () => {
+      hoisted.loadSessionStore.mockReturnValue({});
+
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      const result = await tool.execute("call-5", {
+        mode: "live",
+        model: "together/MiniMaxAI/MiniMax-M2.7",
+      });
+
+      const details = result.details as Record<string, unknown>;
+      expect(details).toMatchObject({ status: "error" });
+    });
+
+    it("throws ToolInputError for invalid model format (no slash)", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      await expect(
+        tool.execute("call-6", {
+          mode: "live",
+          model: "no-slash-model",
+        }),
+      ).rejects.toThrow("model must include a provider prefix");
+    });
+
+    it("uses requesterAgentIdOverride over session key parsing when provided", async () => {
+      const tool = createModelSpawnTool({
+        agentSessionKey: "agent:main:main",
+        requesterAgentIdOverride: "cron-agent",
+      });
+
+      await tool.execute("call-7", {
+        mode: "live",
+        model: "together/MiniMaxAI/MiniMax-M2.7",
+      });
+
+      expect(hoisted.resolveStorePath).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ agentId: "cron-agent" }),
+      );
+      expect(hoisted.resolveAgentIdFromSessionKey).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── spawn single ───────────────────────────────────────────────────────────
+
+  describe("spawn single", () => {
+    it("calls spawnSubagentDirect with correct task/model/cleanup/timeout", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      await tool.execute("call-s1", {
+        mode: "spawn",
+        model: "together/MiniMaxAI/MiniMax-M2.7",
+        task: "summarize this document",
+        cleanup: "keep",
+        timeout_seconds: 30,
+      });
+
+      expect(hoisted.spawnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: "summarize this document",
+          model: "together/MiniMaxAI/MiniMax-M2.7",
+          cleanup: "keep",
+          runTimeoutSeconds: 30,
+          expectsCompletionMessage: true,
+        }),
+        expect.objectContaining({
+          agentSessionKey: "agent:main:main",
+        }),
+      );
+    });
+
+    it("prepends context to task when both provided", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      await tool.execute("call-s2", {
+        mode: "spawn",
+        model: "together/MiniMaxAI/MiniMax-M2.7",
+        task: "analyze the code",
+        context: "You are a code reviewer",
+      });
+
+      expect(hoisted.spawnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: "You are a code reviewer\n\nanalyze the code",
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("throws ToolInputError when model is missing", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      await expect(
+        tool.execute("call-s3", {
+          mode: "spawn",
+          task: "do something",
+        }),
+      ).rejects.toThrow("model is required for single spawn mode");
+    });
+
+    it("throws ToolInputError when task is missing", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      await expect(
+        tool.execute("call-s4", {
+          mode: "spawn",
+          model: "together/MiniMaxAI/MiniMax-M2.7",
+        }),
+      ).rejects.toThrow("task is required for spawn mode");
+    });
+  });
+
+  // ── spawn multi ────────────────────────────────────────────────────────────
+
+  describe("spawn multi (spawns[])", () => {
+    it("runs all entries and results array has label/index/model per entry", async () => {
+      hoisted.spawnMock
+        .mockResolvedValueOnce({ status: "ok", output: "result-a" })
+        .mockResolvedValueOnce({ status: "ok", output: "result-b" });
+
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      const result = await tool.execute("call-m1", {
+        mode: "spawn",
+        spawns: [
+          { model: "openai/gpt-5.4", task: "task-a", label: "GPT" },
+          { model: "together/MiniMaxAI/MiniMax-M2.7", task: "task-b", label: "MiniMax" },
+        ],
+      });
+
+      const details = result.details as {
+        results: Array<{ label: string; index: number; model: string }>;
+      };
+      expect(details.results).toHaveLength(2);
+      expect(details.results[0]).toMatchObject({ label: "GPT", index: 0, model: "openai/gpt-5.4" });
+      expect(details.results[1]).toMatchObject({
+        label: "MiniMax",
+        index: 1,
+        model: "together/MiniMaxAI/MiniMax-M2.7",
+      });
+    });
+
+    it("per-entry omitted task inherits top-level task", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      await tool.execute("call-m2", {
+        mode: "spawn",
+        task: "shared task",
+        spawns: [{ model: "openai/gpt-5.4" }],
+      });
+
+      expect(hoisted.spawnMock).toHaveBeenCalledWith(
+        expect.objectContaining({ task: "shared task" }),
+        expect.any(Object),
+      );
+    });
+
+    it("per-entry omitted context inherits top-level context", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      await tool.execute("call-m3", {
+        mode: "spawn",
+        task: "do work",
+        context: "You are an expert",
+        spawns: [{ model: "openai/gpt-5.4" }],
+      });
+
+      expect(hoisted.spawnMock).toHaveBeenCalledWith(
+        expect.objectContaining({ task: "You are an expert\n\ndo work" }),
+        expect.any(Object),
+      );
+    });
+
+    it("one entry error doesn't discard other results (Promise.allSettled)", async () => {
+      hoisted.spawnMock
+        .mockResolvedValueOnce({ status: "ok", output: "good" })
+        .mockRejectedValueOnce(new Error("spawn failed"));
+
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      const result = await tool.execute("call-m4", {
+        mode: "spawn",
+        spawns: [
+          { model: "openai/gpt-5.4", task: "task-a" },
+          { model: "together/broken-model", task: "task-b" },
+        ],
+      });
+
+      const details = result.details as {
+        results: Array<{ status: string; error?: string; output?: string }>;
+      };
+      expect(details.results).toHaveLength(2);
+      expect(details.results[0]).toMatchObject({ status: "ok" });
+      expect(details.results[1]).toMatchObject({ status: "error", error: "spawn failed" });
+    });
+  });
+
+  // ── mutual exclusion & invalid mode ────────────────────────────────────────
+
+  describe("validation", () => {
+    it("throws ToolInputError when top-level model and spawns[] are both provided", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      await expect(
+        tool.execute("call-v1", {
+          mode: "spawn",
+          model: "openai/gpt-5.4",
+          spawns: [{ model: "together/MiniMaxAI/MiniMax-M2.7", task: "test" }],
+        }),
+      ).rejects.toThrow(
+        "Provide either a top-level model (single spawn) or a spawns array (multi-spawn), not both",
+      );
+    });
+
+    it("throws ToolInputError for invalid mode", async () => {
+      const tool = createModelSpawnTool({ agentSessionKey: "agent:main:main" });
+
+      await expect(
+        tool.execute("call-v2", {
+          mode: "invalid",
+          model: "openai/gpt-5.4",
+        }),
+      ).rejects.toThrow('mode must be "live" or "spawn"');
+    });
+  });
+});

--- a/src/agents/tools/model-spawn-tool.ts
+++ b/src/agents/tools/model-spawn-tool.ts
@@ -1,0 +1,289 @@
+import { Type } from "@sinclair/typebox";
+import { loadConfig } from "../../config/config.js";
+import { loadSessionStore, resolveStorePath, updateSessionStore } from "../../config/sessions.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import { optionalStringEnum, stringEnum } from "../schema/typebox.js";
+import type { SpawnedToolContext } from "../spawned-context.js";
+import { spawnSubagentDirect } from "../subagent-spawn.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam, ToolInputError } from "./common.js";
+import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
+
+const MODEL_SPAWN_MODES = ["live", "spawn"] as const;
+
+// Maximum concurrent spawns for multi-model parallel execution.
+const MAX_PARALLEL_SPAWNS = 10;
+
+const SpawnEntrySchema = Type.Object({
+  model: Type.String({
+    description:
+      'Full model spec for this spawn, e.g. "together/MiniMaxAI/MiniMax-M2.7". Required per-entry when no top-level model is set.',
+  }),
+  task: Type.Optional(
+    Type.String({
+      description: "Task for this spawn. Falls back to the top-level task when omitted.",
+    }),
+  ),
+  label: Type.Optional(
+    Type.String({
+      description: "Human-readable label for this spawn's result.",
+    }),
+  ),
+  context: Type.Optional(
+    Type.String({
+      description:
+        "Context prepended to this spawn's task. Falls back to the top-level context when omitted.",
+    }),
+  ),
+});
+
+const ModelSpawnToolSchema = Type.Object({
+  mode: stringEnum(MODEL_SPAWN_MODES, {
+    description:
+      "live=switch the current session model in-place (context preserved, takes effect next clean turn). spawn=run one or more tasks in isolated ephemeral sessions, each on a specified model (context isolated, sessions cleaned up by default).",
+  }),
+  model: Type.Optional(
+    Type.String({
+      description:
+        'Model for live mode, or for a single-model spawn. Full provider/model spec, e.g. "together/MiniMaxAI/MiniMax-M2.7". Omit when using the spawns array.',
+    }),
+  ),
+  task: Type.Optional(
+    Type.String({
+      description:
+        "Task to run. Required for single-model spawn mode. Serves as the default task for entries in the spawns array that do not specify their own.",
+    }),
+  ),
+  context: Type.Optional(
+    Type.String({
+      description:
+        "Context to prepend to the task. Used for single-model spawn, or as default for spawns array entries.",
+    }),
+  ),
+  spawns: Type.Optional(
+    Type.Array(SpawnEntrySchema, {
+      minItems: 1,
+      maxItems: MAX_PARALLEL_SPAWNS,
+      description:
+        "Spawn multiple models concurrently, each in its own isolated session. All spawns run in parallel and results are collected. Use for model specialization (route different subtasks to the best model for each) or model comparison (run the same task across multiple models).",
+    }),
+  ),
+  cleanup: optionalStringEnum(["delete", "keep"] as const, {
+    description:
+      'Session cleanup after spawn completes. Defaults to "delete" for ephemeral isolation.',
+  }),
+  timeout_seconds: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      description: "Timeout in seconds per spawn.",
+    }),
+  ),
+});
+
+export function createModelSpawnTool(
+  opts?: {
+    agentSessionKey?: string;
+    agentChannel?: GatewayMessageChannel;
+    agentAccountId?: string;
+    agentTo?: string;
+    agentThreadId?: string | number;
+  } & SpawnedToolContext,
+): AnyAgentTool {
+  return {
+    label: "Model Spawn",
+    name: "model_spawn",
+    description:
+      'Spawn models for inference tasks. mode="live": switch the current session\'s model in-place (context preserved, takes effect next turn). mode="spawn": run one or more tasks in ephemeral isolated sessions — pass a single model+task for focused delegation, or a spawns[] array to run multiple models concurrently for specialization or comparison.',
+    parameters: ModelSpawnToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const mode = params.mode === "live" || params.mode === "spawn" ? params.mode : undefined;
+      if (!mode) {
+        throw new ToolInputError('mode must be "live" or "spawn".');
+      }
+
+      // ── live mode ────────────────────────────────────────────────────────────
+      if (mode === "live") {
+        const modelRaw = readStringParam(params, "model", { required: true });
+        if (!modelRaw?.trim()) {
+          throw new ToolInputError("model is required for live mode.");
+        }
+        const model = modelRaw.trim();
+        const slashIdx = model.indexOf("/");
+        if (slashIdx < 1) {
+          throw new ToolInputError(
+            'model must include a provider prefix, e.g. "together/MiniMaxAI/MiniMax-M2.7".',
+          );
+        }
+        const provider = model.slice(0, slashIdx);
+        const modelId = model.slice(slashIdx + 1);
+        if (!modelId) {
+          throw new ToolInputError(
+            'model must be in "provider/model-id" format, e.g. "together/MiniMaxAI/MiniMax-M2.7".',
+          );
+        }
+
+        const sessionKey = opts?.agentSessionKey?.trim();
+        if (!sessionKey) {
+          return jsonResult({
+            status: "error",
+            error:
+              "live mode requires an active named session. Cannot switch models outside a session context.",
+          });
+        }
+
+        const cfg = loadConfig();
+        const agentId = resolveAgentIdFromSessionKey(sessionKey);
+        const storePath = resolveStorePath(cfg.session?.store, { agentId });
+        if (!storePath) {
+          return jsonResult({
+            status: "error",
+            error: "Unable to resolve session store path for live model switch.",
+          });
+        }
+
+        const store = loadSessionStore(storePath);
+        const { mainKey, alias } = resolveMainSessionAlias(cfg);
+        const internalKey = resolveInternalSessionKey({ key: sessionKey, alias, mainKey });
+        const entry = store[internalKey];
+        if (!entry) {
+          return jsonResult({
+            status: "error",
+            error: `Session not found: ${sessionKey}. Cannot perform live model switch.`,
+          });
+        }
+
+        const nextEntry = { ...entry };
+        const { updated } = applyModelOverrideToSessionEntry({
+          entry: nextEntry,
+          selection: { provider, model: modelId, isDefault: false },
+          selectionSource: "user",
+          markLiveSwitchPending: true,
+        });
+
+        if (updated) {
+          await updateSessionStore(storePath, (s) => {
+            s[internalKey] = nextEntry;
+          });
+        }
+
+        return jsonResult({
+          status: "ok",
+          mode: "live",
+          model,
+          provider,
+          modelId,
+          switchPending: updated,
+          note: updated
+            ? `Model switch to ${model} queued. Takes effect at the next clean turn boundary.`
+            : `Model ${model} is already active for this session; no change was made.`,
+        });
+      }
+
+      // ── spawn mode ───────────────────────────────────────────────────────────
+      const rawSpawns = Array.isArray(params.spawns) ? params.spawns : undefined;
+      const topModel = readStringParam(params, "model");
+      const topTask = readStringParam(params, "task");
+      const topContext = readStringParam(params, "context");
+      const cleanup =
+        params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "delete";
+      const timeoutSeconds =
+        typeof params.timeout_seconds === "number" && Number.isFinite(params.timeout_seconds)
+          ? Math.max(0, Math.floor(params.timeout_seconds))
+          : undefined;
+
+      if (rawSpawns && rawSpawns.length > 0 && topModel?.trim()) {
+        throw new ToolInputError(
+          "Provide either a top-level model (single spawn) or a spawns array (multi-spawn), not both.",
+        );
+      }
+
+      const spawnCtx = {
+        agentSessionKey: opts?.agentSessionKey,
+        agentChannel: opts?.agentChannel,
+        agentAccountId: opts?.agentAccountId,
+        agentTo: opts?.agentTo,
+        agentThreadId: opts?.agentThreadId,
+        agentGroupId: opts?.agentGroupId,
+        agentGroupChannel: opts?.agentGroupChannel,
+        agentGroupSpace: opts?.agentGroupSpace,
+        workspaceDir: opts?.workspaceDir,
+      } as const;
+
+      // ── multi-model parallel spawn ───────────────────────────────────────────
+      if (rawSpawns && rawSpawns.length > 0) {
+        type SpawnEntry = { model?: unknown; task?: unknown; label?: unknown; context?: unknown };
+        const entries = rawSpawns as SpawnEntry[];
+
+        const spawnPromises = entries.map(async (entry, idx) => {
+          const entryModel = typeof entry.model === "string" ? entry.model.trim() : "";
+          const entryTask = (typeof entry.task === "string" ? entry.task : (topTask ?? "")).trim();
+          const entryContext = (
+            typeof entry.context === "string" ? entry.context : (topContext ?? "")
+          ).trim();
+          const entryLabel =
+            typeof entry.label === "string" && entry.label.trim()
+              ? entry.label.trim()
+              : entryModel || `spawn[${idx}]`;
+
+          if (!entryModel) {
+            return { label: entryLabel, index: idx, status: "error", error: "model is required" };
+          }
+          if (!entryTask) {
+            return {
+              label: entryLabel,
+              index: idx,
+              status: "error",
+              error: "task is required (provide per-entry or as top-level default)",
+            };
+          }
+
+          const fullTask = entryContext ? `${entryContext}\n\n${entryTask}` : entryTask;
+          const result = await spawnSubagentDirect(
+            {
+              task: fullTask,
+              model: entryModel,
+              cleanup,
+              runTimeoutSeconds: timeoutSeconds,
+              expectsCompletionMessage: true,
+            },
+            spawnCtx,
+          );
+          return { label: entryLabel, index: idx, model: entryModel, ...result };
+        });
+
+        const results = await Promise.all(spawnPromises);
+        return jsonResult({ mode: "spawn", multi: true, count: results.length, results });
+      }
+
+      // ── single-model spawn ───────────────────────────────────────────────────
+      if (!topModel?.trim()) {
+        throw new ToolInputError(
+          "model is required for single spawn mode. Provide model for a single spawn or spawns[] for multi-model.",
+        );
+      }
+      if (!topTask?.trim()) {
+        throw new ToolInputError("task is required for spawn mode.");
+      }
+
+      const fullTask = topContext?.trim()
+        ? `${topContext.trim()}\n\n${topTask.trim()}`
+        : topTask.trim();
+
+      const result = await spawnSubagentDirect(
+        {
+          task: fullTask,
+          model: topModel.trim(),
+          cleanup,
+          runTimeoutSeconds: timeoutSeconds,
+          expectsCompletionMessage: true,
+        },
+        spawnCtx,
+      );
+
+      return jsonResult({ mode: "spawn", multi: false, model: topModel.trim(), ...result });
+    },
+  };
+}

--- a/src/agents/tools/model-spawn-tool.ts
+++ b/src/agents/tools/model-spawn-tool.ts
@@ -169,6 +169,10 @@ export function createModelSpawnTool(
           selection: { provider, model: modelId, isDefault: false },
           selectionSource: "user",
           markLiveSwitchPending: true,
+          // Preserve the existing auth profile override so an LLM-initiated model
+          // switch does not silently clear a user-configured auth profile.
+          profileOverride: entry.authProfileOverride,
+          profileOverrideSource: entry.authProfileOverrideSource === "auto" ? "auto" : "user",
         });
 
         if (updated) {

--- a/src/agents/tools/model-spawn-tool.ts
+++ b/src/agents/tools/model-spawn-tool.ts
@@ -89,6 +89,8 @@ export function createModelSpawnTool(
     agentAccountId?: string;
     agentTo?: string;
     agentThreadId?: string | number;
+    /** Explicit agent ID override for cron/hook sessions where session key parsing may not work. */
+    requesterAgentIdOverride?: string;
   } & SpawnedToolContext,
 ): AnyAgentTool {
   return {
@@ -209,6 +211,7 @@ export function createModelSpawnTool(
         agentGroupId: opts?.agentGroupId,
         agentGroupChannel: opts?.agentGroupChannel,
         agentGroupSpace: opts?.agentGroupSpace,
+        requesterAgentIdOverride: opts?.requesterAgentIdOverride,
         workspaceDir: opts?.workspaceDir,
       } as const;
 
@@ -241,20 +244,37 @@ export function createModelSpawnTool(
           }
 
           const fullTask = entryContext ? `${entryContext}\n\n${entryTask}` : entryTask;
-          const result = await spawnSubagentDirect(
-            {
-              task: fullTask,
+          try {
+            const result = await spawnSubagentDirect(
+              {
+                task: fullTask,
+                model: entryModel,
+                cleanup,
+                runTimeoutSeconds: timeoutSeconds,
+                expectsCompletionMessage: true,
+              },
+              spawnCtx,
+            );
+            return { label: entryLabel, index: idx, model: entryModel, ...result };
+          } catch (err) {
+            return {
+              label: entryLabel,
+              index: idx,
               model: entryModel,
-              cleanup,
-              runTimeoutSeconds: timeoutSeconds,
-              expectsCompletionMessage: true,
-            },
-            spawnCtx,
-          );
-          return { label: entryLabel, index: idx, model: entryModel, ...result };
+              status: "error" as const,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
         });
 
-        const results = await Promise.all(spawnPromises);
+        // Use allSettled so an unexpected rejection in any promise does not discard
+        // results from already-completed spawns.
+        const settled = await Promise.allSettled(spawnPromises);
+        const results = settled.map((r) =>
+          r.status === "fulfilled"
+            ? r.value
+            : { status: "error" as const, error: String(r.reason) },
+        );
         return jsonResult({ mode: "spawn", multi: true, count: results.length, results });
       }
 

--- a/src/agents/tools/model-spawn-tool.ts
+++ b/src/agents/tools/model-spawn-tool.ts
@@ -14,7 +14,11 @@ import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-h
 const MODEL_SPAWN_MODES = ["live", "spawn"] as const;
 
 // Maximum concurrent spawns for multi-model parallel execution.
-const MAX_PARALLEL_SPAWNS = 10;
+// Capped at 5 to stay within the default maxChildrenPerAgent limit.
+// Note: countActiveRunsForSession is checked inside spawnSubagentDirect, so all
+// concurrent spawns pass the gate before any sibling registers — proper enforcement
+// requires a pre-flight batch-reservation API in the runtime.
+const MAX_PARALLEL_SPAWNS = 5;
 
 const SpawnEntrySchema = Type.Object({
   model: Type.String({
@@ -137,7 +141,9 @@ export function createModelSpawnTool(
         }
 
         const cfg = loadConfig();
-        const agentId = resolveAgentIdFromSessionKey(sessionKey);
+        // Prefer the explicit override (cron/hook contexts) before falling back to key parsing.
+        const agentId =
+          opts?.requesterAgentIdOverride?.trim() || resolveAgentIdFromSessionKey(sessionKey);
         const storePath = resolveStorePath(cfg.session?.store, { agentId });
         if (!storePath) {
           return jsonResult({

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -23,6 +23,8 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
   "apply_patch",
   // Session orchestration — spawning agents remotely is RCE
   "sessions_spawn",
+  // Model-spawn can run spawn mode via spawnSubagentDirect — same RCE surface as sessions_spawn
+  "model_spawn",
   // Cross-session injection — message injection across sessions
   "sessions_send",
   // Persistent automation control plane — can create/update/remove scheduled runs


### PR DESCRIPTION
## Summary

- Adds `model_spawn` LLM-callable tool implementing the canonical spec in `docs/tools/model-spawn.md`
- **`live` mode**: switches the current session's model in-place (context preserved, takes effect at the next clean turn boundary via `liveModelSwitchPending` + session store)
- **`spawn` single**: delegates one task to a specified model in an ephemeral isolated session via `spawnSubagentDirect`
- **`spawn` multi**: fans out up to 10 tasks concurrently across different models via `Promise.all` — supports both model specialization (different subtasks to different models) and model comparison (same task across multiple models)
- Replaces the narrower `model_switch` tool (live-switch only, no spawn capability)
- Canonical spec (`docs/tools/model-spawn.md`) is language-agnostic; a conformant Rust implementation for zeroclaw is being submitted in parallel to zeroclaw-labs/zeroclaw

## Files changed

| File | Change |
|------|--------|
| `src/agents/tools/model-spawn-tool.ts` | New tool implementation |
| `src/agents/openclaw-tools.ts` | Register `model_spawn`, remove `model_switch` |
| `src/agents/tool-display-config.ts` | Add display metadata (required by pre-commit hook) |
| `apps/shared/OpenClawKit/Resources/tool-display.json` | Regenerated snapshot |
| `docs/tools/model-spawn.md` | Canonical spec (shared with zeroclaw) |

## Schema

```json
{
  "mode": "live" | "spawn",
  "model": "provider/model-id",        // live or single spawn
  "task": "...",                        // single spawn or default for spawns[]
  "context": "...",                     // optional, prepended to task
  "spawns": [                           // multi-model parallel execution
    { "model": "...", "task": "...", "label": "...", "context": "..." }
  ],
  "cleanup": "delete" | "keep",        // default: "delete"
  "timeout_seconds": 120
}
```

## Test plan

- [ ] `live` mode: verify `liveModelSwitchPending` is set in session store; next turn uses new model
- [ ] `spawn` single: task runs in isolated session on specified model; parent session model unchanged
- [ ] `spawn` multi: all entries run concurrently; results array contains one entry per spawn with label/index/model/status/output
- [ ] `spawns[]` fallback: per-entry omitted `task` inherits top-level `task`; per-entry omitted `context` inherits top-level `context`
- [ ] Mutual exclusion: providing both top-level `model` and `spawns[]` returns an error
- [ ] `cleanup="keep"`: session persists after spawn completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)