### PR TITLE
fix(telegram): add null safety to .trim() calls in setup flow

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -515,7 +515,7 @@ async function resolveTelegramTargets(params: {
     cfg: params.cfg,
     accountId: params.accountId,
   });
-  const token = account.token.trim();
+  const token = (account.token ?? "").trim();
   if (!token) {
     return params.inputs.map((input) => ({
       input,
@@ -731,8 +731,8 @@ export const telegramPlugin = createChatChannelPlugin({
       detectLegacyStateMigrations: ({ cfg, env }) =>
         detectTelegramLegacyStateMigrations({ cfg, env }),
       onAccountConfigChanged: async ({ prevCfg, nextCfg, accountId }) => {
-        const previousToken = resolveTelegramAccount({ cfg: prevCfg, accountId }).token.trim();
-        const nextToken = resolveTelegramAccount({ cfg: nextCfg, accountId }).token.trim();
+        const previousToken = (resolveTelegramAccount({ cfg: prevCfg, accountId }).token ?? "").trim();
+        const nextToken = (resolveTelegramAccount({ cfg: nextCfg, accountId }).token ?? "").trim();
         if (previousToken !== nextToken) {
           const { deleteTelegramUpdateOffset } = await import("../update-offset-runtime-api.js");
           await deleteTelegramUpdateOffset({ accountId });

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -229,7 +229,7 @@ export async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig)
     for (const accountId of resolverAccountIds) {
       try {
         const account = resolveTelegramAccount({ cfg: resolvedConfig, accountId });
-        const token = account.token.trim();
+        const token = (account.token ?? "").trim();
         if (!token) {
           continue;
         }

--- a/extensions/telegram/src/setup-core.ts
+++ b/extensions/telegram/src/setup-core.ts
@@ -33,6 +33,9 @@ export const TELEGRAM_USER_ID_HELP_LINES = [
 ];
 
 export function normalizeTelegramAllowFromInput(raw: string): string {
+  if (raw == null) {
+    return "";
+  }
   return raw
     .trim()
     .replace(/^(telegram|tg):/i, "")

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -986,12 +986,10 @@ export async function promptSingleChannelToken(params: {
   inputPrompt: string;
 }): Promise<{ useEnv: boolean; token: string | null }> {
   const promptToken = async (): Promise<string> =>
-    (
-      await params.prompter.text({
-        message: params.inputPrompt,
-        validate: (value) => (value?.trim() ? undefined : "Required"),
-      })
-    ).trim();
+    (await params.prompter.text({
+      message: params.inputPrompt,
+      validate: (value) => (value?.trim() ? undefined : "Required"),
+    }) ?? "").trim();
 
   if (params.canUseEnv) {
     const keepEnv = await params.prompter.confirm({

--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -455,7 +455,7 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
               });
             },
           });
-          const trimmedValue = rawValue.trim();
+          const trimmedValue = (rawValue ?? "").trim();
           if (!trimmedValue && textInput.required === false) {
             if (textInput.applyEmptyValue) {
               next = await applyWizardTextInputValue({


### PR DESCRIPTION
## Summary

Fixes #66619 — Telegram channel setup crashes with `TypeError: Cannot read properties of undefined (reading 'trim')` immediately after the DM policy warning banner.

## What & Why

Multiple `.trim()` calls in the Telegram setup flow assume their operand is always a string. At runtime, these values can be `undefined` when the setup wizard encounters edge cases — e.g., a freshly initialized config with no token yet resolved, or a prompter returning `undefined`.

The previous refactoring in `96fe85fb` ("refactor: dedupe telegram trimmed readers") replaced *some* `.trim()` calls with `normalizeOptionalString()` but missed several call sites that still called `.trim()` directly on potentially-undefined values.

## Changes

| File | Change |
|------|--------|
| `extensions/telegram/src/setup-core.ts` | Guard `normalizeTelegramAllowFromInput` against `null`/`undefined` raw input |
| `extensions/telegram/src/channel.ts` | Use `(account.token ?? "").trim()` for 2 call sites where `account.token` may be undefined |
| `extensions/telegram/src/doctor.ts` | Use `(account.token ?? "").trim()` for 1 call site |
| `src/channels/plugins/setup-wizard-helpers.ts` | Use `(result ?? "").trim()` for `prompter.text()` result |
| `src/channels/plugins/setup-wizard.ts` | Use `(rawValue ?? "").trim()` for text input result |

## Reproduction

1. Install openclaw v2026.4.14
2. Run through Telegram channel setup
3. Error is thrown after the DM policy warning banner

## Workaround

Roll back to `2026.4.5`: `npm install -g openclaw@2026.4.5`

## AI-Assisted

- **AI-assisted**: Yes
- **Degree of testing**: Lightly tested (syntax validation passed; full `pnpm build && pnpm check && pnpm test` not available due to missing esbuild platform binary)
- **Tool**: Qoder AI coding assistant
- **I understand what the code does**: Yes — each change adds a null coalescing fallback (`?? ""`) or explicit null guard before calling `.trim()`, ensuring the operation is safe even when the operand is `undefined` at runtime.