### PR TITLE
fix(control-ui): show configured thinkingDefault in dropdown

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -684,14 +684,32 @@ function resolveChatThinkingSelectState(state: AppViewState): ChatThinkingSelect
       ? (normalizeThinkLevel(persisted) ?? persisted.trim())
       : "";
   const { provider, model } = resolveThinkingTargetModel(state);
+  const configuredDefaultRaw = (() => {
+    const cfg = state.configSnapshot?.config;
+    if (!cfg || typeof cfg !== "object" || Array.isArray(cfg)) {
+      return undefined;
+    }
+    const agents = (cfg as Record<string, unknown>)["agents"];
+    if (!agents || typeof agents !== "object" || Array.isArray(agents)) {
+      return undefined;
+    }
+    const defaults = (agents as Record<string, unknown>)["defaults"];
+    if (!defaults || typeof defaults !== "object" || Array.isArray(defaults)) {
+      return undefined;
+    }
+    const thinkingDefault = (defaults as Record<string, unknown>)["thinkingDefault"];
+    return typeof thinkingDefault === "string" ? thinkingDefault : undefined;
+  })();
+  const configuredDefault = normalizeThinkLevel(configuredDefaultRaw);
   const defaultLevel =
-    provider && model
+    configuredDefault ??
+    (provider && model
       ? resolveThinkingDefaultForModel({
           provider,
           model,
           catalog: state.chatModelCatalog ?? [],
         })
-      : "off";
+      : "off");
   return {
     currentOverride,
     defaultLabel: `Default (${defaultLevel})`,


### PR DESCRIPTION
﻿## Summary

The WebChat thinking dropdown always showed `Default (low)` for reasoning models, even when the user configured `agents.defaults.thinkingDefault` to something else (e.g. `adaptive`).

This change reads `agents.defaults.thinkingDefault` from the loaded config snapshot (when present) and uses it for the default label.

Fixes #66607.

## Test plan

- Manual: set `agents.defaults.thinkingDefault=adaptive`, open Control UI WebChat, verify dropdown shows `Default (adaptive)` when no per-session override is set.
