### PR TITLE
fix(status): quiet read-only plugin registry loads on v2026.4.14

### DIFF
--- a/extensions/openai/base-url.test.ts
+++ b/extensions/openai/base-url.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOpenAIApiBaseUrl,
+  isOpenAICodexBaseUrl,
+  OPENAI_API_BASE_URL,
+  resolveConfiguredOpenAIBaseUrl,
+} from "./base-url.js";
+
+describe("openai base url helpers", () => {
+  it("resolves the configured provider base url or falls back to the native default", () => {
+    expect(resolveConfiguredOpenAIBaseUrl(undefined)).toBe(OPENAI_API_BASE_URL);
+    expect(
+      resolveConfiguredOpenAIBaseUrl({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: " https://proxy.example.com/v1 ",
+            },
+          },
+        },
+      } as never),
+    ).toBe("https://proxy.example.com/v1");
+  });
+
+  it("detects native OpenAI API and Codex routes without treating proxies as native", () => {
+    expect(isOpenAIApiBaseUrl("https://api.openai.com")).toBe(true);
+    expect(isOpenAIApiBaseUrl("https://api.openai.com/v1")).toBe(true);
+    expect(isOpenAIApiBaseUrl("https://proxy.example.com/v1")).toBe(false);
+
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api")).toBe(true);
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/")).toBe(true);
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/api")).toBe(false);
+  });
+});

--- a/extensions/openai/base-url.ts
+++ b/extensions/openai/base-url.ts
@@ -1,0 +1,24 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+
+export const OPENAI_API_BASE_URL = "https://api.openai.com/v1";
+
+export function resolveConfiguredOpenAIBaseUrl(cfg: OpenClawConfig | undefined): string {
+  return normalizeOptionalString(cfg?.models?.providers?.openai?.baseUrl) ?? OPENAI_API_BASE_URL;
+}
+
+export function isOpenAIApiBaseUrl(baseUrl?: string): boolean {
+  const trimmed = normalizeOptionalString(baseUrl);
+  if (!trimmed) {
+    return false;
+  }
+  return /^https?:\/\/api\.openai\.com(?:\/v1)?\/?$/i.test(trimmed);
+}
+
+export function isOpenAICodexBaseUrl(baseUrl?: string): boolean {
+  const trimmed = normalizeOptionalString(baseUrl);
+  if (!trimmed) {
+    return false;
+  }
+  return /^https?:\/\/chatgpt\.com\/backend-api\/?$/i.test(trimmed);
+}

--- a/extensions/openai/shared.ts
+++ b/extensions/openai/shared.ts
@@ -1,4 +1,3 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { findCatalogTemplate } from "openclaw/plugin-sdk/provider-catalog-shared";
 import {
   cloneFirstTemplateModel,
@@ -6,7 +5,12 @@ import {
   type ProviderPlugin,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { buildProviderStreamFamilyHooks } from "openclaw/plugin-sdk/provider-stream-family";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import {
+  isOpenAIApiBaseUrl,
+  isOpenAICodexBaseUrl,
+  OPENAI_API_BASE_URL,
+  resolveConfiguredOpenAIBaseUrl,
+} from "./base-url.js";
 import { buildOpenAIReplayPolicy } from "./replay-policy.js";
 import {
   resolveOpenAITransportTurnState,
@@ -31,33 +35,12 @@ type SyntheticOpenAIModelCatalogEntry = {
   cost?: SyntheticOpenAIModelCatalogCost;
 };
 
-export const OPENAI_API_BASE_URL = "https://api.openai.com/v1";
 export const OPENAI_RESPONSES_STREAM_HOOKS = buildProviderStreamFamilyHooks(
   "openai-responses-defaults",
 );
 
 export function toOpenAIDataUrl(buffer: Buffer, mimeType: string): string {
   return `data:${mimeType};base64,${buffer.toString("base64")}`;
-}
-
-export function resolveConfiguredOpenAIBaseUrl(cfg: OpenClawConfig | undefined): string {
-  return normalizeOptionalString(cfg?.models?.providers?.openai?.baseUrl) ?? OPENAI_API_BASE_URL;
-}
-
-export function isOpenAIApiBaseUrl(baseUrl?: string): boolean {
-  const trimmed = normalizeOptionalString(baseUrl);
-  if (!trimmed) {
-    return false;
-  }
-  return /^https?:\/\/api\.openai\.com(?:\/v1)?\/?$/i.test(trimmed);
-}
-
-export function isOpenAICodexBaseUrl(baseUrl?: string): boolean {
-  const trimmed = normalizeOptionalString(baseUrl);
-  if (!trimmed) {
-    return false;
-  }
-  return /^https?:\/\/chatgpt\.com\/backend-api\/?$/i.test(trimmed);
 }
 
 function hasSupportedOpenAIResponsesTransport(
@@ -139,4 +122,12 @@ export function buildOpenAISyntheticCatalogEntry(
   };
 }
 
-export { cloneFirstTemplateModel, findCatalogTemplate, matchesExactOrPrefix };
+export {
+  cloneFirstTemplateModel,
+  findCatalogTemplate,
+  isOpenAIApiBaseUrl,
+  isOpenAICodexBaseUrl,
+  matchesExactOrPrefix,
+  OPENAI_API_BASE_URL,
+  resolveConfiguredOpenAIBaseUrl,
+};

--- a/extensions/openai/transport-policy.ts
+++ b/extensions/openai/transport-policy.ts
@@ -6,7 +6,7 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
-import { isOpenAIApiBaseUrl, isOpenAICodexBaseUrl } from "./shared.js";
+import { isOpenAIApiBaseUrl, isOpenAICodexBaseUrl } from "./base-url.js";
 
 const DEFAULT_OPENAI_WS_DEGRADE_COOLDOWN_MS = 60_000;
 const AZURE_PROVIDER_IDS = new Set(["azure-openai", "azure-openai-responses"]);

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -10,6 +10,7 @@ import {
   type MemoryMultimodalSettings,
 } from "../memory-host-sdk/multimodal.js";
 import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-provider-runtime.js";
+import type { PluginLogger } from "../plugins/types.js";
 import { clampInt, clampNumber, resolveUserPath } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 
@@ -146,17 +147,24 @@ function mergeConfig(
   defaults: MemorySearchConfig | undefined,
   overrides: MemorySearchConfig | undefined,
   agentId: string,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
 ): ResolvedMemorySearchConfig {
   const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
   const sessionMemory =
     overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
   const provider = overrides?.provider ?? defaults?.provider ?? "auto";
-  const primaryAdapter = provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider);
+  const primaryAdapter =
+    provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider, undefined, options);
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
   const fallback = overrides?.fallback ?? defaults?.fallback ?? "none";
   const fallbackAdapter =
-    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback) : undefined;
+    fallback && fallback !== "none"
+      ? getMemoryEmbeddingProvider(fallback, undefined, options)
+      : undefined;
   const hasRemoteConfig = Boolean(
     overrideRemote?.baseUrl ||
     overrideRemote?.apiKey ||
@@ -379,16 +387,22 @@ function resolveSyncConfig(
 export function resolveMemorySearchConfig(
   cfg: OpenClawConfig,
   agentId: string,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
 ): ResolvedMemorySearchConfig | null {
   const defaults = cfg.agents?.defaults?.memorySearch;
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
-  const resolved = mergeConfig(defaults, overrides, agentId);
+  const resolved = mergeConfig(defaults, overrides, agentId, options);
   if (!resolved.enabled) {
     return null;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider =
-    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);
+    resolved.provider === "auto"
+      ? undefined
+      : getMemoryEmbeddingProvider(resolved.provider, cfg, options);
   const builtinMultimodalSupport =
     resolved.provider === "auto"
       ? false

--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -43,6 +43,7 @@ describe("ensureCliCommandBootstrap", () => {
     expect(ensureCliPluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "all",
       routeLogsToStderr: true,
+      emitTrustWarnings: false,
     });
   });
 
@@ -59,6 +60,7 @@ describe("ensureCliCommandBootstrap", () => {
     expect(ensureCliPluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "channels",
       routeLogsToStderr: true,
+      emitTrustWarnings: false,
     });
   });
 

--- a/src/cli/command-bootstrap.ts
+++ b/src/cli/command-bootstrap.ts
@@ -34,5 +34,6 @@ export async function ensureCliCommandBootstrap(params: {
   await ensureCliPluginRegistryLoaded({
     scope: resolvePluginRegistryScopeForCommandPath(params.commandPath),
     routeLogsToStderr: params.suppressDoctorStdout,
+    emitTrustWarnings: false,
   });
 }

--- a/src/cli/plugin-registry-loader.test.ts
+++ b/src/cli/plugin-registry-loader.test.ts
@@ -60,6 +60,18 @@ describe("plugin-registry-loader", () => {
     expect(loggingState.forceConsoleToStderr).toBe(false);
   });
 
+  it("forwards trust warning suppression when requested", async () => {
+    await ensureCliPluginRegistryLoaded({
+      scope: "channels",
+      emitTrustWarnings: false,
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "channels",
+      emitTrustWarnings: false,
+    });
+  });
+
   it("maps command paths to plugin registry scopes", () => {
     expect(resolvePluginRegistryScopeForCommandPath(["status"])).toBe("channels");
     expect(resolvePluginRegistryScopeForCommandPath(["health"])).toBe("channels");

--- a/src/cli/plugin-registry-loader.ts
+++ b/src/cli/plugin-registry-loader.ts
@@ -17,6 +17,7 @@ export function resolvePluginRegistryScopeForCommandPath(
 export async function ensureCliPluginRegistryLoaded(params: {
   scope: PluginRegistryScope;
   routeLogsToStderr?: boolean;
+  emitTrustWarnings?: boolean;
 }) {
   const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
   const previousForceStderr = loggingState.forceConsoleToStderr;
@@ -24,7 +25,12 @@ export async function ensureCliPluginRegistryLoaded(params: {
     loggingState.forceConsoleToStderr = true;
   }
   try {
-    ensurePluginRegistryLoaded({ scope: params.scope });
+    ensurePluginRegistryLoaded({
+      scope: params.scope,
+      ...(params.emitTrustWarnings !== undefined
+        ? { emitTrustWarnings: params.emitTrustWarnings }
+        : {}),
+    });
   } finally {
     loggingState.forceConsoleToStderr = previousForceStderr;
   }

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -117,7 +117,9 @@ async function resolveStatusAllLocalDiagnosis(params: {
           }
         })()
       : null;
-  const pluginCompatibility = buildPluginCompatibilityNotices({ config: overview.cfg });
+  const pluginCompatibility = buildPluginCompatibilityNotices({
+    config: overview.sourceConfig,
+  });
 
   return {
     configPath,

--- a/src/commands/status.scan-memory.test.ts
+++ b/src/commands/status.scan-memory.test.ts
@@ -50,7 +50,9 @@ describe("status.scan-memory", () => {
       requireDefaultStore,
     });
 
-    expect(mocks.resolveSharedMemoryStatusSnapshot).toHaveBeenCalledWith({
+    const snapshotArgs = mocks.resolveSharedMemoryStatusSnapshot.mock.calls[0]?.[0];
+
+    expect(snapshotArgs).toEqual({
       cfg: { agents: {} },
       agentStatus: {
         defaultId: "main",
@@ -69,9 +71,20 @@ describe("status.scan-memory", () => {
         ],
       },
       memoryPlugin: { enabled: true, slot: "memory-core" },
-      resolveMemoryConfig: mocks.resolveMemorySearchConfig,
+      resolveMemoryConfig: expect.any(Function),
       getMemorySearchManager: mocks.getMemorySearchManager,
       requireDefaultStore,
+    });
+
+    expect(snapshotArgs.resolveMemoryConfig({ agents: {} }, "main")).toBeUndefined();
+    expect(mocks.resolveMemorySearchConfig).toHaveBeenCalledWith({ agents: {} }, "main", {
+      emitTrustWarnings: false,
+      logger: expect.objectContaining({
+        info: expect.any(Function),
+        warn: expect.any(Function),
+        error: expect.any(Function),
+        debug: expect.any(Function),
+      }),
     });
   });
 });

--- a/src/commands/status.scan-memory.ts
+++ b/src/commands/status.scan-memory.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
+import type { PluginLogger } from "../plugins/types.js";
 import type { getAgentLocalStatuses as getAgentLocalStatusesFn } from "./status.agent-local.js";
 import {
   resolveSharedMemoryStatusSnapshot,
@@ -17,6 +18,15 @@ let statusScanDepsRuntimeModulePromise:
 function loadStatusScanDepsRuntimeModule() {
   statusScanDepsRuntimeModulePromise ??= import("./status.scan.deps.runtime.js");
   return statusScanDepsRuntimeModulePromise;
+}
+
+function createQuietStatusMemoryLogger(): PluginLogger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
 }
 
 export function resolveDefaultMemoryStorePath(agentId: string): string {
@@ -34,7 +44,11 @@ export async function resolveStatusMemoryStatusSnapshot(params: {
     cfg: params.cfg,
     agentStatus: params.agentStatus,
     memoryPlugin: params.memoryPlugin,
-    resolveMemoryConfig: resolveMemorySearchConfig,
+    resolveMemoryConfig: (cfg, agentId) =>
+      resolveMemorySearchConfig(cfg, agentId, {
+        emitTrustWarnings: false,
+        logger: createQuietStatusMemoryLogger(),
+      }),
     getMemorySearchManager,
     requireDefaultStore: params.requireDefaultStore,
   });

--- a/src/commands/status.scan.test.ts
+++ b/src/commands/status.scan.test.ts
@@ -91,6 +91,23 @@ describe("scanStatus", () => {
     );
   });
 
+  it("uses sourceConfig for plugin compatibility checks in text status output", async () => {
+    configureScanStatus({
+      sourceConfig: createStatusScanConfig({
+        marker: "source",
+      }),
+      resolvedConfig: createStatusScanConfig({
+        marker: "resolved",
+      }),
+    });
+
+    await scanStatus({ json: false }, {} as never);
+
+    expect(mocks.buildPluginCompatibilityNotices).toHaveBeenCalledWith({
+      config: expect.objectContaining({ marker: "source" }),
+    });
+  });
+
   it("skips channel plugin preload for status --json with no channel config", async () => {
     configureScanStatus({
       sourceConfig: createStatusScanConfig({

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -59,7 +59,9 @@ export async function scanStatus(
       });
 
       progress.setLabel("Checking plugins…");
-      const pluginCompatibility = buildPluginCompatibilityNotices({ config: overview.cfg });
+      const pluginCompatibility = buildPluginCompatibilityNotices({
+        config: overview.sourceConfig,
+      });
       progress.tick();
 
       progress.setLabel("Checking memory and sessions…");

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -310,4 +310,24 @@ describe("resolvePluginCapabilityProviders", () => {
     });
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({ config: compatConfig });
   });
+
+  it("forwards trust warning suppression when loading compatibility providers", () => {
+    const { cfg, enablementCompat } = createCompatChainConfig();
+    setBundledCapabilityFixture("speechProviders");
+    mocks.withBundledPluginEnablementCompat.mockReturnValue(enablementCompat);
+    mocks.withBundledPluginVitestCompat.mockReturnValue(enablementCompat);
+
+    expectNoResolvedCapabilityProviders(
+      resolvePluginCapabilityProviders({
+        key: "speechProviders",
+        cfg,
+        emitTrustWarnings: false,
+      }),
+    );
+
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
+      config: enablementCompat,
+      emitTrustWarnings: false,
+    });
+  });
 });

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -7,6 +7,7 @@ import {
 import { resolveRuntimePluginRegistry } from "./loader.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginRegistry } from "./registry-types.js";
+import type { PluginLogger } from "./types.js";
 
 type CapabilityProviderRegistryKey =
   | "memoryEmbeddingProviders"
@@ -81,6 +82,8 @@ function resolveCapabilityProviderConfig(params: {
 export function resolvePluginCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
   key: K;
   cfg?: OpenClawConfig;
+  emitTrustWarnings?: boolean;
+  logger?: PluginLogger;
 }): CapabilityProviderForKey<K>[] {
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
@@ -88,7 +91,16 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }
   const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
-  const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
+  const loadOptions =
+    compatConfig === undefined
+      ? undefined
+      : {
+          config: compatConfig,
+          ...(params.emitTrustWarnings !== undefined
+            ? { emitTrustWarnings: params.emitTrustWarnings }
+            : {}),
+          ...(params.logger ? { logger: params.logger } : {}),
+        };
   const registry = resolveRuntimePluginRegistry(loadOptions);
   return (registry?.[params.key] ?? []).map(
     (entry) => entry.provider,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -126,6 +126,7 @@ export type PluginLoadOptions = {
   activate?: boolean;
   loadModules?: boolean;
   throwOnLoadError?: boolean;
+  emitTrustWarnings?: boolean;
 };
 
 const CLI_METADATA_ENTRY_BASENAMES = [
@@ -1176,6 +1177,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const validateOnly = options.mode === "validate";
   const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
   const cacheEnabled = options.cache !== false;
+  const emitTrustWarnings = options.emitTrustWarnings ?? shouldActivate;
   if (cacheEnabled) {
     const cached = getCachedPluginRegistry(cacheKey);
     if (cached) {
@@ -1328,7 +1330,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     });
     pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
     warnWhenAllowlistIsOpen({
-      emitWarning: shouldActivate,
+      emitWarning: emitTrustWarnings,
       logger,
       pluginsEnabled: normalized.enabled,
       allow: normalized.allow,
@@ -1881,7 +1883,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       registry,
       provenance,
       allowlist: normalized.allow,
-      emitWarning: shouldActivate,
+      emitWarning: emitTrustWarnings,
       logger,
       env,
     });

--- a/src/plugins/memory-embedding-provider-runtime.test.ts
+++ b/src/plugins/memory-embedding-provider-runtime.test.ts
@@ -60,6 +60,22 @@ describe("memory embedding provider runtime resolution", () => {
     expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledTimes(2);
   });
 
+  it("forwards trust warning suppression to capability fallback resolution", () => {
+    mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("ollama")]);
+
+    expect(
+      runtimeModule.getMemoryEmbeddingProvider("ollama", undefined, {
+        emitTrustWarnings: false,
+      })?.id,
+    ).toBe("ollama");
+
+    expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledWith({
+      key: "memoryEmbeddingProviders",
+      cfg: undefined,
+      emitTrustWarnings: false,
+    });
+  });
+
   it("does not consult capability fallback once runtime adapters are registered", () => {
     registerMemoryEmbeddingProvider({
       id: "openai",

--- a/src/plugins/memory-embedding-provider-runtime.ts
+++ b/src/plugins/memory-embedding-provider-runtime.ts
@@ -5,6 +5,7 @@ import {
   listRegisteredMemoryEmbeddingProviders,
   type MemoryEmbeddingProviderAdapter,
 } from "./memory-embedding-providers.js";
+import type { PluginLogger } from "./types.js";
 
 export { listRegisteredMemoryEmbeddingProviders };
 
@@ -13,6 +14,10 @@ export function listRegisteredMemoryEmbeddingProviderAdapters(): MemoryEmbedding
 }
 export function listMemoryEmbeddingProviders(
   cfg?: OpenClawConfig,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
 ): MemoryEmbeddingProviderAdapter[] {
   const registered = listRegisteredMemoryEmbeddingProviderAdapters();
   if (registered.length > 0) {
@@ -21,12 +26,20 @@ export function listMemoryEmbeddingProviders(
   return resolvePluginCapabilityProviders({
     key: "memoryEmbeddingProviders",
     cfg,
+    ...(options?.emitTrustWarnings !== undefined
+      ? { emitTrustWarnings: options.emitTrustWarnings }
+      : {}),
+    ...(options?.logger ? { logger: options.logger } : {}),
   });
 }
 
 export function getMemoryEmbeddingProvider(
   id: string,
   cfg?: OpenClawConfig,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
 ): MemoryEmbeddingProviderAdapter | undefined {
   const registered = getRegisteredMemoryEmbeddingProvider(id);
   if (registered) {
@@ -35,5 +48,5 @@ export function getMemoryEmbeddingProvider(
   if (listRegisteredMemoryEmbeddingProviders().length > 0) {
     return undefined;
   }
-  return listMemoryEmbeddingProviders(cfg).find((adapter) => adapter.id === id);
+  return listMemoryEmbeddingProviders(cfg, options).find((adapter) => adapter.id === id);
 }

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -159,6 +159,24 @@ describe("memory runtime auto-enable loading", () => {
     await expectAutoEnabledMemoryRuntimeCase({ run, expectedResult });
   });
 
+  it("suppresses trust warnings when status probes bootstrap memory runtime", async () => {
+    const { rawConfig, autoEnabledConfig } = setAutoEnabledMemoryRuntime();
+
+    await getActiveMemorySearchManager({
+      cfg: rawConfig as never,
+      agentId: "main",
+      purpose: "status",
+    });
+
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: autoEnabledConfig,
+        activationSourceConfig: rawConfig,
+        emitTrustWarnings: false,
+      }),
+    );
+  });
+
   it.each([
     {
       name: "does not bootstrap the memory runtime just to close managers",

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -5,14 +5,38 @@ import {
   buildPluginRuntimeLoadOptions,
   resolvePluginRuntimeLoadContext,
 } from "./runtime/load-context.js";
+import type { PluginLogger } from "./types.js";
 
-function ensureMemoryRuntime(cfg?: OpenClawConfig) {
+function createQuietMemoryRuntimeLogger(): PluginLogger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
+function ensureMemoryRuntime(
+  cfg?: OpenClawConfig,
+  options?: {
+    emitTrustWarnings?: boolean;
+    logger?: PluginLogger;
+  },
+) {
   const current = getMemoryRuntime();
   if (current || !cfg) {
     return current;
   }
   resolveRuntimePluginRegistry(
-    buildPluginRuntimeLoadOptions(resolvePluginRuntimeLoadContext({ config: cfg })),
+    buildPluginRuntimeLoadOptions(
+      resolvePluginRuntimeLoadContext({
+        config: cfg,
+        ...(options?.logger ? { logger: options.logger } : {}),
+      }),
+      options?.emitTrustWarnings !== undefined
+        ? { emitTrustWarnings: options.emitTrustWarnings }
+        : {},
+    ),
   );
   return getMemoryRuntime();
 }
@@ -22,7 +46,15 @@ export async function getActiveMemorySearchManager(params: {
   agentId: string;
   purpose?: "default" | "status";
 }) {
-  const runtime = ensureMemoryRuntime(params.cfg);
+  const runtime = ensureMemoryRuntime(
+    params.cfg,
+    params.purpose === "status"
+      ? {
+          emitTrustWarnings: false,
+          logger: createQuietMemoryRuntimeLogger(),
+        }
+      : {},
+  );
   if (!runtime) {
     return { manager: null, error: "memory plugin unavailable" };
   }

--- a/src/plugins/runtime/metadata-registry-loader.test.ts
+++ b/src/plugins/runtime/metadata-registry-loader.test.ts
@@ -92,4 +92,18 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
       }),
     );
   });
+
+  it("forwards trust warning suppression to metadata snapshots", () => {
+    loadPluginMetadataRegistrySnapshot({
+      config: { plugins: {} },
+      emitTrustWarnings: false,
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emitTrustWarnings: false,
+        mode: "validate",
+      }),
+    );
+  });
 });

--- a/src/plugins/runtime/metadata-registry-loader.ts
+++ b/src/plugins/runtime/metadata-registry-loader.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadOpenClawPlugins } from "../loader.js";
 import { hasExplicitPluginIdScope } from "../plugin-scope.js";
 import type { PluginRegistry } from "../registry.js";
+import type { PluginLogger } from "../types.js";
 import { buildPluginRuntimeLoadOptions, resolvePluginRuntimeLoadContext } from "./load-context.js";
 
 export function loadPluginMetadataRegistrySnapshot(options?: {
@@ -9,8 +10,10 @@ export function loadPluginMetadataRegistrySnapshot(options?: {
   activationSourceConfig?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   workspaceDir?: string;
+  logger?: PluginLogger;
   onlyPluginIds?: string[];
   loadModules?: boolean;
+  emitTrustWarnings?: boolean;
 }): PluginRegistry {
   const context = resolvePluginRuntimeLoadContext(options);
 
@@ -21,6 +24,9 @@ export function loadPluginMetadataRegistrySnapshot(options?: {
       activate: false,
       mode: "validate",
       loadModules: options?.loadModules,
+      ...(options?.emitTrustWarnings !== undefined
+        ? { emitTrustWarnings: options.emitTrustWarnings }
+        : {}),
       ...(hasExplicitPluginIdScope(options?.onlyPluginIds)
         ? { onlyPluginIds: options?.onlyPluginIds }
         : {}),

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -238,6 +238,22 @@ describe("ensurePluginRegistryLoaded", () => {
     );
   });
 
+  it("forwards trust warning suppression for read-only preloads", () => {
+    mocks.resolveConfiguredChannelPluginIds.mockReturnValue(["demo-channel"]);
+
+    ensurePluginRegistryLoaded({
+      scope: "configured-channels",
+      config: { channels: { demo: { enabled: true } } } as never,
+      emitTrustWarnings: false,
+    });
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emitTrustWarnings: false,
+      }),
+    );
+  });
+
   it("does not forward empty channel scopes for broad channel loads", () => {
     mocks.resolveChannelPluginIds.mockReturnValue([]);
 

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -79,6 +79,7 @@ export function ensurePluginRegistryLoaded(options?: {
   activationSourceConfig?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: string[];
+  emitTrustWarnings?: boolean;
 }): void {
   const scope = options?.scope ?? "all";
   const requestedPluginIds = normalizePluginIdScope(options?.onlyPluginIds);
@@ -144,6 +145,9 @@ export function ensurePluginRegistryLoaded(options?: {
         shouldForwardChannelScope({ scope, scopedLoad }) ||
         hasNonEmptyPluginIdScope(expectedChannelPluginIds)
           ? { onlyPluginIds: expectedChannelPluginIds }
+          : {}),
+        ...(options?.emitTrustWarnings !== undefined
+          ? { emitTrustWarnings: options.emitTrustWarnings }
           : {}),
       },
     ),

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -538,6 +538,42 @@ describe("plugin status reports", () => {
     );
   });
 
+  it("suppresses trust warnings while building full plugin diagnostics", () => {
+    setSinglePluginLoadResult(createPluginRecord({ id: "demo" }));
+
+    buildPluginDiagnosticsReport({ config: {} });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emitTrustWarnings: false,
+        logger: expect.objectContaining({
+          info: expect.any(Function),
+          warn: expect.any(Function),
+          error: expect.any(Function),
+          debug: expect.any(Function),
+        }),
+      }),
+    );
+  });
+
+  it("suppresses trust warnings while building metadata-only plugin reports", () => {
+    setSinglePluginLoadResult(createPluginRecord({ id: "demo" }));
+
+    buildPluginSnapshotReport({ config: {} });
+
+    expect(loadPluginMetadataRegistrySnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emitTrustWarnings: false,
+        logger: expect.objectContaining({
+          info: expect.any(Function),
+          warn: expect.any(Function),
+          error: expect.any(Function),
+          debug: expect.any(Function),
+        }),
+      }),
+    );
+  });
+
   it("marks errored plugin modules as imported when full diagnostics already evaluated them", () => {
     setPluginLoadResult({
       plugins: [createPluginRecord({ id: "broken-plugin", status: "error" })],

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -22,7 +22,7 @@ import {
 } from "./runtime/load-context.js";
 import { loadPluginMetadataRegistrySnapshot } from "./runtime/metadata-registry-loader.js";
 import { hasKind } from "./slots.js";
-import type { PluginHookName } from "./types.js";
+import type { PluginHookName, PluginLogger } from "./types.js";
 
 export type PluginStatusReport = PluginRegistry & {
   workspaceDir?: string;
@@ -152,14 +152,25 @@ type PluginReportParams = {
   env?: NodeJS.ProcessEnv;
 };
 
+function createQuietPluginStatusLogger(): PluginLogger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
 function buildPluginReport(
   params: PluginReportParams | undefined,
   loadModules: boolean,
 ): PluginStatusReport {
+  const logger = createQuietPluginStatusLogger();
   const baseContext = resolvePluginRuntimeLoadContext({
     config: params?.config ?? loadConfig(),
     env: params?.env,
     workspaceDir: params?.workspaceDir,
+    logger,
   });
   const workspaceDir = baseContext.workspaceDir ?? resolveDefaultAgentWorkspaceDir();
   const context =
@@ -202,6 +213,7 @@ function buildPluginReport(
           loadModules,
           activate: false,
           cache: false,
+          emitTrustWarnings: false,
         }),
       )
     : loadPluginMetadataRegistrySnapshot({
@@ -209,7 +221,9 @@ function buildPluginReport(
         activationSourceConfig: rawConfig,
         workspaceDir,
         env: params?.env,
+        logger,
         loadModules: false,
+        emitTrustWarnings: false,
       });
   const importedPluginIds = new Set([
     ...(loadModules


### PR DESCRIPTION
## Summary
- carry forward the read-only plugin registry quieting fix onto the v2026.4.14 release line
- keep text status and doctor plugin inspection paths from leaking trust/provenance chatter
- keep status memory/provider fallback probes quiet while preserving real diagnostics and compatibility reporting
- break the `extensions/openai/shared.ts <-> transport-policy.ts` runtime import cycle exposed by current `main` CI

## Context
- This supersedes the older v2026.4.12-based PR for the same status/doctor noise issue.
- The release branch already contains part of the quiet-runtime plumbing; this PR completes the remaining status/memory fallback path so local installs do not regress when upgrading to 2026.4.14.
- After rebasing onto current `main`, the upstream merge commit inherited a pre-existing OpenAI runtime import cycle; this PR now fixes that cycle in the same branch so `check:import-cycles` is green again.

## Testing
- node scripts/test-projects.mjs src/cli/command-bootstrap.test.ts src/cli/plugin-registry-loader.test.ts src/plugins/runtime/runtime-registry-loader.test.ts src/plugins/runtime/metadata-registry-loader.test.ts src/plugins/status.test.ts src/commands/status.scan.test.ts src/commands/status.scan-memory.test.ts src/plugins/memory-runtime.test.ts src/plugins/capability-provider-runtime.test.ts src/plugins/memory-embedding-provider-runtime.test.ts
- pnpm check:import-cycles
- pnpm vitest run extensions/openai/base-url.test.ts extensions/openai/transport-policy.test.ts extensions/openai/openai-provider.test.ts extensions/openai/openai-codex-provider.test.ts
- pnpm check
- pnpm build
- node dist/index.js status
- node dist/index.js doctor --non-interactive
- node dist/index.js channels status --probe
- node dist/index.js gateway status
