### PR TITLE
fix: replace source-tree-relative runtime import in session-status-tool

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -250,7 +250,7 @@ vi.mock("../plugins/providers.runtime.js", () => ({
 vi.mock("../agents/auth-profiles.js", createAuthProfilesModuleMock);
 vi.mock("../agents/model-auth.js", createModelAuthModuleMock);
 vi.mock("../infra/provider-usage.js", createProviderUsageModuleMock);
-vi.mock("./tools/session-status.runtime.js", createCommandsStatusRuntimeModuleMock);
+vi.mock("../auto-reply/reply/commands-status.runtime.js", createCommandsStatusRuntimeModuleMock);
 vi.mock("../auto-reply/group-activation.js", () => ({
   normalizeGroupActivation: (value: unknown) => value ?? "always",
 }));

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -22,7 +22,7 @@ import {
 } from "../../routing/session-key.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
-import type { BuildStatusTextParams } from "../../status/status-text.types.js";
+import { buildStatusText } from "../../auto-reply/reply/commands-status.runtime.js";
 import { buildTaskStatusSnapshotForRelatedSessionKeyForOwner } from "../../tasks/task-owner-access.js";
 import { formatTaskStatusDetail, formatTaskStatusTitle } from "../../tasks/task-status.js";
 import { loadModelCatalog } from "../model-catalog.js";
@@ -57,17 +57,6 @@ const SessionStatusToolSchema = Type.Object({
   model: Type.Optional(Type.String()),
 });
 
-type CommandsStatusRuntimeModule = {
-  buildStatusText: (params: BuildStatusTextParams) => Promise<string>;
-};
-
-let commandsStatusRuntimePromise: Promise<CommandsStatusRuntimeModule> | null = null;
-
-function loadCommandsStatusRuntime(): Promise<CommandsStatusRuntimeModule> {
-  commandsStatusRuntimePromise ??=
-    import("./session-status.runtime.js") as Promise<CommandsStatusRuntimeModule>;
-  return commandsStatusRuntimePromise;
-}
 
 function resolveSessionEntry(params: {
   store: Record<string, SessionEntry>;
@@ -543,7 +532,6 @@ export function createSessionStatusTool(opts?: {
         relatedSessionKey: resolved.key,
         callerOwnerKey: visibilityRequesterKey,
       });
-      const { buildStatusText } = await loadCommandsStatusRuntime();
       const statusText = await buildStatusText({
         cfg,
         sessionEntry: statusSessionEntry,


### PR DESCRIPTION
## Problem
The `session_status` tool crashes with:
```
Cannot find module '/Users/xxxx/auto-reply/reply/commands-status.runtime.js'
```

## Root Cause
`session-status-tool.ts` used `importRuntimeModule(import.meta.url, ["../../auto-reply/reply/commands-status.runtime", ".js"])` — a source-tree-relative path from `src/agents/tools/` to `src/auto-reply/reply/`. After bundling, `import.meta.url` points to the chunk in `dist/`, so `../../` resolves outside the project root entirely.

## Fix
Replace the lazy `importRuntimeModule` call with a direct static import of `buildStatusText` from the runtime re-export. The bundler correctly resolves static imports regardless of output chunk placement.

## Testing
- `pnpm build` passes
- Lint and type checks pass
- Verified dist output now has `import "./commands-status.runtime-CM2-NZvk.js"` instead of the broken runtime-relative path