### PR TITLE
fix: remove info.id mismatch validation in context engine registry

### DIFF
--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -771,30 +771,6 @@ describe("Invalid engine fallback", () => {
     );
   });
 
-  it("rejects resolved engines whose info.id mismatches the registered id", async () => {
-    const engineId = `mismatched-info-id-${Date.now().toString(36)}`;
-    registerContextEngine(
-      engineId,
-      () =>
-        ({
-          info: { id: "legacy", name: "Broken Engine" },
-          async ingest() {
-            return { ingested: false };
-          },
-          async assemble({ messages }: { messages: AgentMessage[] }) {
-            return { messages, estimatedTokens: 0 };
-          },
-          async compact() {
-            return { ok: true, compacted: false };
-          },
-        }) as unknown as ContextEngine,
-    );
-
-    await expect(resolveContextEngine(configWithSlot(engineId))).rejects.toThrow(
-      `Context engine "${engineId}" factory returned an invalid ContextEngine: info.id must match registered id "${engineId}".`,
-    );
-  });
-
   it("rejects resolved engines that omit required lifecycle methods", async () => {
     const engineId = `invalid-methods-${Date.now().toString(36)}`;
     registerContextEngine(

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -413,8 +413,6 @@ function describeResolvedContextEngineContractError(
     const infoId = typeof infoRecord.id === "string" ? infoRecord.id.trim() : "";
     if (!infoId) {
       issues.push("missing info.id");
-    } else if (infoId !== engineId) {
-      issues.push(`info.id must match registered id "${engineId}"`);
     }
     if (typeof infoRecord.name !== "string" || !infoRecord.name.trim()) {
       issues.push("missing info.name");


### PR DESCRIPTION
## Summary

The validation added in #63222 that `info.id` must match the registered engine ID is **too strict** and breaks external plugins (e.g. `lossless-claw`) that have always worked with a different `info.id` than their registry key.

## Root Cause

In , the check:
```ts
else if (infoId !== engineId) {
  issues.push(`info.id must match registered id "${engineId}"`);
}
```

was rejecting any context engine factory that returned an `info.id` not equal to the registry key. This breaks plugins that register under one ID (e.g., `"lossless-claw"` ) but internally set `info.id` to a different value.

## Why This Is Wrong

The `info.id` field is **informational**. The registry key is what matters for lookups and routing. The only downstream usage of `info.id` in  is:

```ts
includeMemorySection: !params.contextEngine || params.contextEngine.info.id === "legacy",
```

This is non-critical behavior (memory section inclusion). A mismatch here doesn't cause system-wide failure.

## Fix

Remove the `infoId !== engineId` check while keeping validation for genuinely missing `info.id` (empty string) and missing `info.name`.

## Testing

```bash
pnpm test -- src/context-engine/context-engine.test.ts
```

All 35 tests pass (removed the now-invalid test that expected mismatch rejection).

## Issue

Fixes #66601