### PR TITLE
fix: allow workspace-rooted absolute media paths in auto-reply

### DIFF
--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -142,6 +142,15 @@ describe("runReplyAgent runtime config", () => {
       cfg: freshCfg,
       sessionKey: undefined,
       workspaceDir: "/tmp",
+      messageProvider: "telegram",
+      accountId: undefined,
+      groupId: undefined,
+      groupChannel: undefined,
+      groupSpace: undefined,
+      requesterSenderId: undefined,
+      requesterSenderName: undefined,
+      requesterSenderUsername: undefined,
+      requesterSenderE164: undefined,
     });
     expect(runPreflightCompactionIfNeededMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -605,6 +605,15 @@ export async function runAgentTurnWithFallback(params: {
     cfg: runtimeConfig,
     sessionKey: params.sessionKey,
     workspaceDir: params.followupRun.run.workspaceDir,
+    messageProvider: params.followupRun.run.messageProvider,
+    accountId: params.followupRun.originatingAccountId ?? params.followupRun.run.agentAccountId,
+    groupId: params.followupRun.run.groupId,
+    groupChannel: params.followupRun.run.groupChannel,
+    groupSpace: params.followupRun.run.groupSpace,
+    requesterSenderId: params.followupRun.run.senderId,
+    requesterSenderName: params.followupRun.run.senderName,
+    requesterSenderUsername: params.followupRun.run.senderUsername,
+    requesterSenderE164: params.followupRun.run.senderE164,
   });
   let didNotifyAgentRunStart = false;
   const notifyAgentRunStart = () => {

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -16,6 +16,7 @@ const waitForEmbeddedPiRunEndMock = vi.fn();
 const enqueueFollowupRunMock = vi.fn();
 const scheduleFollowupDrainMock = vi.fn();
 const refreshQueuedFollowupSessionMock = vi.fn();
+const resolveOutboundAttachmentFromUrlMock = vi.fn();
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -46,6 +47,11 @@ vi.mock("./queue.js", () => ({
   scheduleFollowupDrain: scheduleFollowupDrainMock,
 }));
 
+vi.mock("../../media/outbound-attachment.js", () => ({
+  resolveOutboundAttachmentFromUrl: (...args: unknown[]) =>
+    resolveOutboundAttachmentFromUrlMock(...args),
+}));
+
 let runReplyAgent: typeof import("./agent-runner.js").runReplyAgent;
 
 describe("runReplyAgent media path normalization", () => {
@@ -66,7 +72,11 @@ describe("runReplyAgent media path normalization", () => {
     enqueueFollowupRunMock.mockReset();
     scheduleFollowupDrainMock.mockReset();
     refreshQueuedFollowupSessionMock.mockReset();
+    resolveOutboundAttachmentFromUrlMock.mockReset();
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    resolveOutboundAttachmentFromUrlMock.mockImplementation(async (mediaUrl: string) => ({
+      path: path.join("/tmp/outbound-media", path.basename(mediaUrl)),
+    }));
     runWithModelFallbackMock.mockImplementation(
       async ({
         provider,
@@ -137,8 +147,17 @@ describe("runReplyAgent media path normalization", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: path.join("/tmp/workspace", "out", "generated.png"),
-      mediaUrls: [path.join("/tmp/workspace", "out", "generated.png")],
+      mediaUrl: "/tmp/outbound-media/generated.png",
+      mediaUrls: ["/tmp/outbound-media/generated.png"],
     });
+    expect(resolveOutboundAttachmentFromUrlMock).toHaveBeenCalledWith(
+      path.join("/tmp/workspace", "out", "generated.png"),
+      5 * 1024 * 1024,
+      expect.objectContaining({
+        mediaAccess: expect.objectContaining({
+          workspaceDir: "/tmp/workspace",
+        }),
+      }),
+    );
   });
 });

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -16,6 +16,8 @@ const waitForEmbeddedPiRunEndMock = vi.fn();
 const enqueueFollowupRunMock = vi.fn();
 const scheduleFollowupDrainMock = vi.fn();
 const refreshQueuedFollowupSessionMock = vi.fn();
+const readPathWithinRootMock = vi.fn();
+const saveMediaBufferMock = vi.fn();
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -46,6 +48,22 @@ vi.mock("./queue.js", () => ({
   scheduleFollowupDrain: scheduleFollowupDrainMock,
 }));
 
+vi.mock("../../infra/fs-safe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/fs-safe.js")>();
+  return {
+    ...actual,
+    readPathWithinRoot: readPathWithinRootMock,
+  };
+});
+
+vi.mock("../../media/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../media/store.js")>();
+  return {
+    ...actual,
+    saveMediaBuffer: saveMediaBufferMock,
+  };
+});
+
 let runReplyAgent: typeof import("./agent-runner.js").runReplyAgent;
 
 describe("runReplyAgent media path normalization", () => {
@@ -66,6 +84,18 @@ describe("runReplyAgent media path normalization", () => {
     enqueueFollowupRunMock.mockReset();
     scheduleFollowupDrainMock.mockReset();
     refreshQueuedFollowupSessionMock.mockReset();
+    readPathWithinRootMock.mockReset();
+    readPathWithinRootMock.mockResolvedValue({
+      buffer: Buffer.from("generated-media"),
+      realPath: "/tmp/workspace/out/generated.png",
+      stat: { size: 15 } as never,
+    });
+    saveMediaBufferMock.mockReset();
+    saveMediaBufferMock.mockResolvedValue({
+      id: "generated.png",
+      path: "/tmp/openclaw-state/media/outbound/generated.png",
+      size: 15,
+    });
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     runWithModelFallbackMock.mockImplementation(
       async ({
@@ -137,8 +167,20 @@ describe("runReplyAgent media path normalization", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: path.join("/tmp/workspace", "out", "generated.png"),
-      mediaUrls: [path.join("/tmp/workspace", "out", "generated.png")],
+      mediaUrl: "/tmp/openclaw-state/media/outbound/generated.png",
+      mediaUrls: ["/tmp/openclaw-state/media/outbound/generated.png"],
     });
+    expect(readPathWithinRootMock).toHaveBeenCalledWith({
+      rootDir: "/tmp/workspace",
+      filePath: path.join("/tmp/workspace", "out", "generated.png"),
+      maxBytes: 5 * 1024 * 1024,
+    });
+    expect(saveMediaBufferMock).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      undefined,
+      "outbound",
+      undefined,
+      "generated.png",
+    );
   });
 });

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -16,8 +16,6 @@ const waitForEmbeddedPiRunEndMock = vi.fn();
 const enqueueFollowupRunMock = vi.fn();
 const scheduleFollowupDrainMock = vi.fn();
 const refreshQueuedFollowupSessionMock = vi.fn();
-const readPathWithinRootMock = vi.fn();
-const saveMediaBufferMock = vi.fn();
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -48,22 +46,6 @@ vi.mock("./queue.js", () => ({
   scheduleFollowupDrain: scheduleFollowupDrainMock,
 }));
 
-vi.mock("../../infra/fs-safe.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../infra/fs-safe.js")>();
-  return {
-    ...actual,
-    readPathWithinRoot: readPathWithinRootMock,
-  };
-});
-
-vi.mock("../../media/store.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../media/store.js")>();
-  return {
-    ...actual,
-    saveMediaBuffer: saveMediaBufferMock,
-  };
-});
-
 let runReplyAgent: typeof import("./agent-runner.js").runReplyAgent;
 
 describe("runReplyAgent media path normalization", () => {
@@ -84,18 +66,6 @@ describe("runReplyAgent media path normalization", () => {
     enqueueFollowupRunMock.mockReset();
     scheduleFollowupDrainMock.mockReset();
     refreshQueuedFollowupSessionMock.mockReset();
-    readPathWithinRootMock.mockReset();
-    readPathWithinRootMock.mockResolvedValue({
-      buffer: Buffer.from("generated-media"),
-      realPath: "/tmp/workspace/out/generated.png",
-      stat: { size: 15 } as never,
-    });
-    saveMediaBufferMock.mockReset();
-    saveMediaBufferMock.mockResolvedValue({
-      id: "generated.png",
-      path: "/tmp/openclaw-state/media/outbound/generated.png",
-      size: 15,
-    });
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     runWithModelFallbackMock.mockImplementation(
       async ({
@@ -167,20 +137,8 @@ describe("runReplyAgent media path normalization", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: "/tmp/openclaw-state/media/outbound/generated.png",
-      mediaUrls: ["/tmp/openclaw-state/media/outbound/generated.png"],
+      mediaUrl: path.join("/tmp/workspace", "out", "generated.png"),
+      mediaUrls: [path.join("/tmp/workspace", "out", "generated.png")],
     });
-    expect(readPathWithinRootMock).toHaveBeenCalledWith({
-      rootDir: "/tmp/workspace",
-      filePath: path.join("/tmp/workspace", "out", "generated.png"),
-      maxBytes: 5 * 1024 * 1024,
-    });
-    expect(saveMediaBufferMock).toHaveBeenCalledWith(
-      expect.any(Buffer),
-      undefined,
-      "outbound",
-      undefined,
-      "generated.png",
-    );
   });
 });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1031,6 +1031,15 @@ export async function runReplyAgent(params: {
     cfg,
     sessionKey,
     workspaceDir: followupRun.run.workspaceDir,
+    messageProvider: followupRun.run.messageProvider,
+    accountId: followupRun.originatingAccountId ?? followupRun.run.agentAccountId,
+    groupId: followupRun.run.groupId,
+    groupChannel: followupRun.run.groupChannel,
+    groupSpace: followupRun.run.groupSpace,
+    requesterSenderId: followupRun.run.senderId,
+    requesterSenderName: followupRun.run.senderName,
+    requesterSenderUsername: followupRun.run.senderUsername,
+    requesterSenderE164: followupRun.run.senderE164,
   });
   const blockReplyCoalescing =
     blockStreamingEnabled && opts?.onBlockReply

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -3,7 +3,7 @@ import type { MsgContext, TemplateContext } from "../templating.js";
 import { appendUntrustedContext } from "./untrusted-context.js";
 
 export const REPLY_MEDIA_HINT =
-  "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths - they are blocked for security. Keep caption in the text body.";
+  "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Absolute and ~ paths only work when they stay inside your allowed file-read boundary; otherwise they are dropped. Keep caption in the text body.";
 
 export function buildReplyPromptBodies(params: {
   ctx: MsgContext;

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -3,7 +3,7 @@ import type { MsgContext, TemplateContext } from "../templating.js";
 import { appendUntrustedContext } from "./untrusted-context.js";
 
 export const REPLY_MEDIA_HINT =
-  "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Absolute and ~ paths only work when they stay inside your allowed file-read boundary; otherwise they are dropped. Keep caption in the text body.";
+  "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Absolute and ~ paths only work when they stay inside your allowed file-read boundary; host file:// URLs are blocked. Keep caption in the text body.";
 
 export function buildReplyPromptBodies(params: {
   ctx: MsgContext;

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -2,23 +2,19 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureSandboxWorkspaceForSession = vi.hoisted(() => vi.fn());
-const resolvePreferredOpenClawTmpDir = vi.hoisted(() => vi.fn(() => "/private/tmp/openclaw-501"));
-const saveMediaSource = vi.hoisted(() => vi.fn());
+const resolveOutboundAttachmentFromUrl = vi.hoisted(() => vi.fn());
+const resolveAgentScopedOutboundMediaAccess = vi.hoisted(() => vi.fn());
 
 vi.mock("../../agents/sandbox.js", () => ({
   ensureSandboxWorkspaceForSession,
 }));
 
-vi.mock("../../infra/tmp-openclaw-dir.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../infra/tmp-openclaw-dir.js")>();
-  return {
-    ...actual,
-    resolvePreferredOpenClawTmpDir,
-  };
-});
+vi.mock("../../media/outbound-attachment.js", () => ({
+  resolveOutboundAttachmentFromUrl,
+}));
 
-vi.mock("../../media/store.js", () => ({
-  saveMediaSource,
+vi.mock("../../media/read-capability.js", () => ({
+  resolveAgentScopedOutboundMediaAccess,
 }));
 
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
@@ -26,12 +22,20 @@ import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 describe("createReplyMediaPathNormalizer", () => {
   beforeEach(() => {
     ensureSandboxWorkspaceForSession.mockReset().mockResolvedValue(null);
-    resolvePreferredOpenClawTmpDir.mockReset().mockReturnValue("/private/tmp/openclaw-501");
-    saveMediaSource.mockReset();
+    resolveOutboundAttachmentFromUrl.mockReset().mockImplementation(async (mediaUrl: string) => ({
+      path: path.join("/tmp/outbound-media", path.basename(mediaUrl.replace(/^file:\/\//i, ""))),
+    }));
+    resolveAgentScopedOutboundMediaAccess
+      .mockReset()
+      .mockImplementation(({ workspaceDir }: { workspaceDir?: string }) => ({
+        workspaceDir,
+        localRoots: workspaceDir ? [workspaceDir] : undefined,
+        readFile: async () => Buffer.from("image"),
+      }));
     vi.unstubAllEnvs();
   });
 
-  it("resolves workspace-relative media against the agent workspace", async () => {
+  it("stages workspace-relative media through shared outbound attachment loading", async () => {
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -43,12 +47,21 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: path.join("/tmp/agent-workspace", "out", "photo.png"),
-      mediaUrls: [path.join("/tmp/agent-workspace", "out", "photo.png")],
+      mediaUrl: "/tmp/outbound-media/photo.png",
+      mediaUrls: ["/tmp/outbound-media/photo.png"],
     });
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledWith(
+      path.join("/tmp/agent-workspace", "out", "photo.png"),
+      5 * 1024 * 1024,
+      expect.objectContaining({
+        mediaAccess: expect.objectContaining({
+          workspaceDir: "/tmp/agent-workspace",
+        }),
+      }),
+    );
   });
 
-  it("maps sandbox-relative media back to the host sandbox workspace", async () => {
+  it("maps sandbox-relative media back to the host sandbox workspace before staging", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
@@ -64,12 +77,44 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
-      mediaUrls: [
-        path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
-        path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
-      ],
+      mediaUrl: "/tmp/outbound-media/photo.png",
+      mediaUrls: ["/tmp/outbound-media/photo.png", "/tmp/outbound-media/final.png"],
     });
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenNthCalledWith(
+      1,
+      path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
+      5 * 1024 * 1024,
+      expect.any(Object),
+    );
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenNthCalledWith(
+      2,
+      path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
+      5 * 1024 * 1024,
+      expect.any(Object),
+    );
+  });
+
+  it("stages absolute workspace media paths so the PR scenario now works", async () => {
+    const absolutePath = "/Users/peter/.openclaw/workspace/exports/images/chart.png";
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: { agents: { defaults: { mediaMaxMb: 8 } } },
+      sessionKey: "session-key",
+      workspaceDir: "/Users/peter/.openclaw/workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: [absolutePath],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: "/tmp/outbound-media/chart.png",
+      mediaUrls: ["/tmp/outbound-media/chart.png"],
+    });
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledWith(
+      absolutePath,
+      8 * 1024 * 1024,
+      expect.any(Object),
+    );
   });
 
   it("drops workspace-relative media paths that escape the agent workspace", async () => {
@@ -87,9 +132,10 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrl: undefined,
       mediaUrls: undefined,
     });
+    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
-  it("drops sandbox-relative media paths that escape and would also leave the workspace", async () => {
+  it("drops sandbox-relative media paths that escape both sandbox and workspace", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
@@ -108,58 +154,11 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrl: undefined,
       mediaUrls: undefined,
     });
-  });
-
-  it("drops arbitrary host-local media paths when sandbox exists", async () => {
-    ensureSandboxWorkspaceForSession.mockResolvedValue({
-      workspaceDir: "/tmp/sandboxes/session-1",
-      containerWorkdir: "/workspace",
-    });
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
-
-    const result = await normalize({
-      mediaUrls: ["/Users/peter/.openclaw/media/inbound/photo.png"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
-    expect(saveMediaSource).not.toHaveBeenCalled();
-  });
-
-  it("drops relative sandbox escapes when tools.fs.workspaceOnly is enabled", async () => {
-    ensureSandboxWorkspaceForSession.mockResolvedValue({
-      workspaceDir: "/tmp/sandboxes/session-1",
-      containerWorkdir: "/workspace",
-    });
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: { tools: { fs: { workspaceOnly: true } } },
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
-
-    const result = await normalize({
-      mediaUrls: ["../sandboxes/session-1/screens/final.png"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
-    expect(saveMediaSource).not.toHaveBeenCalled();
+    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
   it("keeps managed generated media under the shared media root", async () => {
     vi.stubEnv("OPENCLAW_STATE_DIR", "/Users/peter/.openclaw");
-    ensureSandboxWorkspaceForSession.mockResolvedValue({
-      workspaceDir: "/tmp/sandboxes/session-1",
-      containerWorkdir: "/workspace",
-    });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -174,14 +173,13 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrl: "/Users/peter/.openclaw/media/tool-image-generation/generated.png",
       mediaUrls: ["/Users/peter/.openclaw/media/tool-image-generation/generated.png"],
     });
-    expect(saveMediaSource).not.toHaveBeenCalled();
+    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
-  it("drops absolute file URLs outside managed reply media roots", async () => {
-    ensureSandboxWorkspaceForSession.mockResolvedValue({
-      workspaceDir: "/tmp/sandboxes/session-1",
-      containerWorkdir: "/workspace",
-    });
+  it("drops host-local media when shared outbound attachment policy rejects it", async () => {
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(
+      new Error("Local media path is not under an allowed directory"),
+    );
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -189,7 +187,7 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     const result = await normalize({
-      mediaUrls: ["file:///Users/peter/.openclaw/media/inbound/photo.png"],
+      mediaUrls: ["/Users/peter/secrets/photo.png"],
     });
 
     expect(result).toMatchObject({
@@ -198,98 +196,71 @@ describe("createReplyMediaPathNormalizer", () => {
     });
   });
 
-  it("persists volatile agent-state media from the workspace into host outbound media", async () => {
-    saveMediaSource.mockResolvedValue({
-      path: "/Users/peter/.openclaw/media/outbound/persisted.png",
-    });
+  it("threads requester context into shared outbound media access", async () => {
     const normalize = createReplyMediaPathNormalizer({
-      cfg: { agents: { defaults: { mediaMaxMb: 8 } } },
-      sessionKey: "session-key",
-      workspaceDir: "/Users/peter/.openclaw/workspace",
+      cfg: {},
+      sessionKey: undefined,
+      workspaceDir: "/tmp/agent-workspace",
+      messageProvider: "whatsapp",
+      accountId: "source-account",
+      groupId: "ops",
+      groupChannel: "whatsapp",
+      groupSpace: "team",
+      requesterSenderId: "sender-1",
+      requesterSenderName: "Sender Name",
+      requesterSenderUsername: "sender-user",
+      requesterSenderE164: "+15551234567",
     });
 
-    const result = await normalize({
-      mediaUrls: [
-        "/Users/peter/.openclaw/workspace/.openclaw/media/tool-image-generation/generated.png",
-      ],
+    await normalize({
+      mediaUrls: ["./out/photo.png"],
     });
 
-    expect(saveMediaSource).toHaveBeenCalledWith(
-      "/Users/peter/.openclaw/workspace/.openclaw/media/tool-image-generation/generated.png",
-      undefined,
-      "outbound",
-      8 * 1024 * 1024,
-    );
-    expect(result).toMatchObject({
-      mediaUrl: "/Users/peter/.openclaw/media/outbound/persisted.png",
-      mediaUrls: ["/Users/peter/.openclaw/media/outbound/persisted.png"],
+    expect(resolveAgentScopedOutboundMediaAccess).toHaveBeenCalledWith({
+      cfg: {},
+      agentId: undefined,
+      workspaceDir: "/tmp/agent-workspace",
+      mediaSources: [path.join("/tmp/agent-workspace", "out", "photo.png")],
+      sessionKey: undefined,
+      messageProvider: "whatsapp",
+      accountId: "source-account",
+      requesterSenderId: "sender-1",
+      requesterSenderName: "Sender Name",
+      requesterSenderUsername: "sender-user",
+      requesterSenderE164: "+15551234567",
+      groupId: "ops",
+      groupChannel: "whatsapp",
+      groupSpace: "team",
     });
   });
 
-  it("persists TTS voice output from the preferred OpenClaw temp directory", async () => {
-    const tmpVoicePath = path.join(
-      "/private/tmp/openclaw-501",
-      "tts-abc123",
-      "voice-1234567890.opus",
-    );
-    saveMediaSource.mockResolvedValue({
-      path: "/Users/peter/.openclaw/media/outbound/tts-voice.opus",
-    });
+  it("passes absolute local media sources into shared outbound media access", async () => {
+    const absolutePath = "/Users/peter/Pictures/chart.png";
     const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
+      cfg: { tools: { fs: { workspaceOnly: false } } },
       sessionKey: "session-key",
       workspaceDir: "/tmp/agent-workspace",
     });
 
-    const result = await normalize({
-      mediaUrls: [tmpVoicePath],
+    await normalize({
+      mediaUrls: [absolutePath],
     });
 
-    expect(saveMediaSource).toHaveBeenCalledWith(tmpVoicePath, undefined, "outbound", undefined);
-    expect(result).toMatchObject({
-      mediaUrl: "/Users/peter/.openclaw/media/outbound/tts-voice.opus",
-      mediaUrls: ["/Users/peter/.openclaw/media/outbound/tts-voice.opus"],
-    });
-  });
-
-  it("falls back to the original preferred tmp path when persisting TTS media fails", async () => {
-    const tmpVoicePath = path.join(
-      "/private/tmp/openclaw-501",
-      "tts-fallback",
-      "voice-1234567890.opus",
-    );
-    saveMediaSource.mockRejectedValue(new Error("disk full"));
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
+    expect(resolveAgentScopedOutboundMediaAccess).toHaveBeenCalledWith({
+      cfg: { tools: { fs: { workspaceOnly: false } } },
+      agentId: expect.any(String),
       workspaceDir: "/tmp/agent-workspace",
-    });
-
-    const result = await normalize({
-      mediaUrls: [tmpVoicePath],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: tmpVoicePath,
-      mediaUrls: [tmpVoicePath],
-    });
-  });
-
-  it("drops host tmp paths outside the preferred OpenClaw temp directory", async () => {
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
+      mediaSources: [absolutePath],
       sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
+      messageProvider: undefined,
+      accountId: undefined,
+      requesterSenderId: undefined,
+      requesterSenderName: undefined,
+      requesterSenderUsername: undefined,
+      requesterSenderE164: undefined,
+      groupId: undefined,
+      groupChannel: undefined,
+      groupSpace: undefined,
     });
-
-    const result = await normalize({
-      mediaUrls: ["/private/tmp/not-openclaw/voice-1234567890.opus"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
-    expect(saveMediaSource).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -254,4 +254,59 @@ describe("createReplyMediaPathNormalizer", () => {
     });
     expect(saveMediaSource).not.toHaveBeenCalled();
   });
+
+  it("allows absolute paths inside the workspace directory (#66635)", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/home/user/.openclaw/workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/home/user/.openclaw/workspace/exports/images/chart.png"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: "/home/user/.openclaw/workspace/exports/images/chart.png",
+      mediaUrls: ["/home/user/.openclaw/workspace/exports/images/chart.png"],
+    });
+  });
+
+  it("allows absolute paths inside the sandbox root (#66635)", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/tmp/sandboxes/session-1/output/generated-chart.png"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: "/tmp/sandboxes/session-1/output/generated-chart.png",
+      mediaUrls: ["/tmp/sandboxes/session-1/output/generated-chart.png"],
+    });
+  });
+
+  it("still drops absolute paths outside workspace and all allowed roots", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/home/user/.openclaw/workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/etc/passwd"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+  });
 });

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -1,9 +1,23 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureSandboxWorkspaceForSession = vi.hoisted(() => vi.fn());
+const readPathWithinRoot = vi.hoisted(() => vi.fn());
 const resolvePreferredOpenClawTmpDir = vi.hoisted(() => vi.fn(() => "/private/tmp/openclaw-501"));
+const saveMediaBuffer = vi.hoisted(() => vi.fn());
 const saveMediaSource = vi.hoisted(() => vi.fn());
+const fsSafeRuntime = vi.hoisted(() => ({
+  actualReadPathWithinRoot: undefined as
+    | ((params: {
+        rootDir: string;
+        filePath: string;
+        rejectHardlinks?: boolean;
+        maxBytes?: number;
+      }) => Promise<unknown>)
+    | undefined,
+}));
 
 vi.mock("../../agents/sandbox.js", () => ({
   ensureSandboxWorkspaceForSession,
@@ -17,21 +31,44 @@ vi.mock("../../infra/tmp-openclaw-dir.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../media/store.js", () => ({
-  saveMediaSource,
-}));
+vi.mock("../../infra/fs-safe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/fs-safe.js")>();
+  fsSafeRuntime.actualReadPathWithinRoot = actual.readPathWithinRoot;
+  return {
+    ...actual,
+    readPathWithinRoot,
+  };
+});
+
+vi.mock("../../media/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../media/store.js")>();
+  return {
+    ...actual,
+    saveMediaBuffer,
+    saveMediaSource,
+  };
+});
 
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
 describe("createReplyMediaPathNormalizer", () => {
   beforeEach(() => {
     ensureSandboxWorkspaceForSession.mockReset().mockResolvedValue(null);
+    readPathWithinRoot.mockReset().mockResolvedValue({
+      buffer: Buffer.from("mock-media"),
+      realPath: "/tmp/mock-media",
+      stat: { size: 10 } as never,
+    });
     resolvePreferredOpenClawTmpDir.mockReset().mockReturnValue("/private/tmp/openclaw-501");
+    saveMediaBuffer.mockReset();
     saveMediaSource.mockReset();
     vi.unstubAllEnvs();
   });
 
   it("resolves workspace-relative media against the agent workspace", async () => {
+    saveMediaBuffer.mockResolvedValue({
+      path: "/Users/peter/.openclaw/media/outbound/photo.png",
+    });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -43,8 +80,8 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: path.join("/tmp/agent-workspace", "out", "photo.png"),
-      mediaUrls: [path.join("/tmp/agent-workspace", "out", "photo.png")],
+      mediaUrl: "/Users/peter/.openclaw/media/outbound/photo.png",
+      mediaUrls: ["/Users/peter/.openclaw/media/outbound/photo.png"],
     });
   });
 
@@ -53,6 +90,13 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
     });
+    saveMediaBuffer
+      .mockResolvedValueOnce({
+        path: "/Users/peter/.openclaw/media/outbound/photo.png",
+      })
+      .mockResolvedValueOnce({
+        path: "/Users/peter/.openclaw/media/outbound/final.png",
+      });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -64,10 +108,10 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
+      mediaUrl: "/Users/peter/.openclaw/media/outbound/photo.png",
       mediaUrls: [
-        path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
-        path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
+        "/Users/peter/.openclaw/media/outbound/photo.png",
+        "/Users/peter/.openclaw/media/outbound/final.png",
       ],
     });
   });
@@ -161,7 +205,7 @@ describe("createReplyMediaPathNormalizer", () => {
   });
 
   it("persists volatile agent-state media from the workspace into host outbound media", async () => {
-    saveMediaSource.mockResolvedValue({
+    saveMediaBuffer.mockResolvedValue({
       path: "/Users/peter/.openclaw/media/outbound/persisted.png",
     });
     const normalize = createReplyMediaPathNormalizer({
@@ -176,12 +220,14 @@ describe("createReplyMediaPathNormalizer", () => {
       ],
     });
 
-    expect(saveMediaSource).toHaveBeenCalledWith(
-      "/Users/peter/.openclaw/workspace/.openclaw/media/tool-image-generation/generated.png",
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
       undefined,
       "outbound",
       8 * 1024 * 1024,
+      "generated.png",
     );
+    expect(saveMediaSource).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       mediaUrl: "/Users/peter/.openclaw/media/outbound/persisted.png",
       mediaUrls: ["/Users/peter/.openclaw/media/outbound/persisted.png"],
@@ -255,7 +301,10 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(saveMediaSource).not.toHaveBeenCalled();
   });
 
-  it("allows absolute paths inside the workspace directory (#66635)", async () => {
+  it("persists workspace-rooted absolute paths before outbound delivery (#66635)", async () => {
+    saveMediaBuffer.mockResolvedValue({
+      path: "/Users/peter/.openclaw/media/outbound/chart.png",
+    });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -267,15 +316,25 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: "/home/user/.openclaw/workspace/exports/images/chart.png",
-      mediaUrls: ["/home/user/.openclaw/workspace/exports/images/chart.png"],
+      mediaUrl: "/Users/peter/.openclaw/media/outbound/chart.png",
+      mediaUrls: ["/Users/peter/.openclaw/media/outbound/chart.png"],
     });
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      undefined,
+      "outbound",
+      undefined,
+      "chart.png",
+    );
   });
 
-  it("allows absolute paths inside the sandbox root (#66635)", async () => {
+  it("persists sandbox-rooted absolute paths before outbound delivery (#66635)", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
+    });
+    saveMediaBuffer.mockResolvedValue({
+      path: "/Users/peter/.openclaw/media/outbound/generated-chart.png",
     });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
@@ -288,10 +347,113 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: "/tmp/sandboxes/session-1/output/generated-chart.png",
-      mediaUrls: ["/tmp/sandboxes/session-1/output/generated-chart.png"],
+      mediaUrl: "/Users/peter/.openclaw/media/outbound/generated-chart.png",
+      mediaUrls: ["/Users/peter/.openclaw/media/outbound/generated-chart.png"],
+    });
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      undefined,
+      "outbound",
+      undefined,
+      "generated-chart.png",
+    );
+  });
+
+  it("drops workspace-rooted absolute paths when safe persistence rejects them", async () => {
+    saveMediaBuffer.mockRejectedValue(new Error("symlink not allowed"));
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/home/user/.openclaw/workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/home/user/.openclaw/workspace/exports/images/chart.png"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "drops workspace-rooted symlink escapes instead of falling back to the raw path",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reply-media-"));
+      try {
+        const stateDir = path.join(tempRoot, ".openclaw");
+        const workspaceDir = path.join(stateDir, "workspace");
+        const outsideDir = path.join(tempRoot, "outside");
+        const escapedPath = path.join(workspaceDir, "exports", "leak", "secret.txt");
+        await fs.mkdir(path.dirname(path.dirname(escapedPath)), { recursive: true });
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.writeFile(path.join(outsideDir, "secret.txt"), "TOP_SECRET");
+        await fs.symlink(outsideDir, path.join(workspaceDir, "exports", "leak"));
+        vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+        readPathWithinRoot.mockImplementation(fsSafeRuntime.actualReadPathWithinRoot!);
+
+        const normalize = createReplyMediaPathNormalizer({
+          cfg: {},
+          sessionKey: "session-key",
+          workspaceDir,
+        });
+
+        const result = await normalize({
+          mediaUrls: [escapedPath],
+        });
+
+        expect(result).toMatchObject({
+          mediaUrl: undefined,
+          mediaUrls: undefined,
+        });
+        expect(saveMediaBuffer).not.toHaveBeenCalled();
+      } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "drops sandbox-rooted symlink escapes when sandbox validation rejects them",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reply-sandbox-"));
+      try {
+        const workspaceDir = path.join(tempRoot, "workspace");
+        const sandboxDir = path.join(tempRoot, "sandbox");
+        const outsideDir = path.join(tempRoot, "outside");
+        const escapedPath = path.join(sandboxDir, "output", "leak", "secret.txt");
+        await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.mkdir(path.dirname(path.dirname(escapedPath)), { recursive: true });
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.writeFile(path.join(outsideDir, "secret.txt"), "TOP_SECRET");
+        await fs.symlink(outsideDir, path.join(sandboxDir, "output", "leak"));
+        ensureSandboxWorkspaceForSession.mockResolvedValue({
+          workspaceDir: sandboxDir,
+          containerWorkdir: "/workspace",
+        });
+        readPathWithinRoot.mockImplementation(fsSafeRuntime.actualReadPathWithinRoot!);
+
+        const normalize = createReplyMediaPathNormalizer({
+          cfg: {},
+          sessionKey: "session-key",
+          workspaceDir,
+        });
+
+        const result = await normalize({
+          mediaUrls: [escapedPath],
+        });
+
+        expect(result).toMatchObject({
+          mediaUrl: undefined,
+          mediaUrls: undefined,
+        });
+        expect(saveMediaSource).not.toHaveBeenCalled();
+      } finally {
+        await fs.rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("still drops absolute paths outside workspace and all allowed roots", async () => {
     const normalize = createReplyMediaPathNormalizer({

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -227,6 +227,14 @@ describe("createReplyMediaPathNormalizer", () => {
       8 * 1024 * 1024,
       "generated.png",
     );
+    expect(readPathWithinRoot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootDir: "/Users/peter/.openclaw/workspace",
+        filePath:
+          "/Users/peter/.openclaw/workspace/.openclaw/media/tool-image-generation/generated.png",
+        maxBytes: 8 * 1024 * 1024,
+      }),
+    );
     expect(saveMediaSource).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       mediaUrl: "/Users/peter/.openclaw/media/outbound/persisted.png",
@@ -325,6 +333,13 @@ describe("createReplyMediaPathNormalizer", () => {
       "outbound",
       undefined,
       "chart.png",
+    );
+    expect(readPathWithinRoot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootDir: "/home/user/.openclaw/workspace",
+        filePath: "/home/user/.openclaw/workspace/exports/images/chart.png",
+        maxBytes: 5 * 1024 * 1024,
+      }),
     );
   });
 

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -117,6 +117,39 @@ describe("createReplyMediaPathNormalizer", () => {
     );
   });
 
+  it("prefers channel account media limits when staging reply attachments", async () => {
+    const absolutePath = "/Users/peter/.openclaw/workspace/exports/images/chart.png";
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {
+        channels: {
+          whatsapp: {
+            mediaMaxMb: 50,
+            accounts: {
+              work: {
+                mediaMaxMb: 64,
+              },
+            },
+          },
+        },
+        agents: { defaults: { mediaMaxMb: 8 } },
+      },
+      sessionKey: undefined,
+      workspaceDir: "/Users/peter/.openclaw/workspace",
+      messageProvider: "whatsapp",
+      accountId: "work",
+    });
+
+    await normalize({
+      mediaUrls: [absolutePath],
+    });
+
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledWith(
+      absolutePath,
+      64 * 1024 * 1024,
+      expect.any(Object),
+    );
+  });
+
   it("drops workspace-relative media paths that escape the agent workspace", async () => {
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -1,23 +1,9 @@
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureSandboxWorkspaceForSession = vi.hoisted(() => vi.fn());
-const readPathWithinRoot = vi.hoisted(() => vi.fn());
 const resolvePreferredOpenClawTmpDir = vi.hoisted(() => vi.fn(() => "/private/tmp/openclaw-501"));
-const saveMediaBuffer = vi.hoisted(() => vi.fn());
 const saveMediaSource = vi.hoisted(() => vi.fn());
-const fsSafeRuntime = vi.hoisted(() => ({
-  actualReadPathWithinRoot: undefined as
-    | ((params: {
-        rootDir: string;
-        filePath: string;
-        rejectHardlinks?: boolean;
-        maxBytes?: number;
-      }) => Promise<unknown>)
-    | undefined,
-}));
 
 vi.mock("../../agents/sandbox.js", () => ({
   ensureSandboxWorkspaceForSession,
@@ -31,44 +17,21 @@ vi.mock("../../infra/tmp-openclaw-dir.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../infra/fs-safe.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../infra/fs-safe.js")>();
-  fsSafeRuntime.actualReadPathWithinRoot = actual.readPathWithinRoot;
-  return {
-    ...actual,
-    readPathWithinRoot,
-  };
-});
-
-vi.mock("../../media/store.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../media/store.js")>();
-  return {
-    ...actual,
-    saveMediaBuffer,
-    saveMediaSource,
-  };
-});
+vi.mock("../../media/store.js", () => ({
+  saveMediaSource,
+}));
 
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
 describe("createReplyMediaPathNormalizer", () => {
   beforeEach(() => {
     ensureSandboxWorkspaceForSession.mockReset().mockResolvedValue(null);
-    readPathWithinRoot.mockReset().mockResolvedValue({
-      buffer: Buffer.from("mock-media"),
-      realPath: "/tmp/mock-media",
-      stat: { size: 10 } as never,
-    });
     resolvePreferredOpenClawTmpDir.mockReset().mockReturnValue("/private/tmp/openclaw-501");
-    saveMediaBuffer.mockReset();
     saveMediaSource.mockReset();
     vi.unstubAllEnvs();
   });
 
   it("resolves workspace-relative media against the agent workspace", async () => {
-    saveMediaBuffer.mockResolvedValue({
-      path: "/Users/peter/.openclaw/media/outbound/photo.png",
-    });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -80,8 +43,8 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: "/Users/peter/.openclaw/media/outbound/photo.png",
-      mediaUrls: ["/Users/peter/.openclaw/media/outbound/photo.png"],
+      mediaUrl: path.join("/tmp/agent-workspace", "out", "photo.png"),
+      mediaUrls: [path.join("/tmp/agent-workspace", "out", "photo.png")],
     });
   });
 
@@ -90,13 +53,6 @@ describe("createReplyMediaPathNormalizer", () => {
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
     });
-    saveMediaBuffer
-      .mockResolvedValueOnce({
-        path: "/Users/peter/.openclaw/media/outbound/photo.png",
-      })
-      .mockResolvedValueOnce({
-        path: "/Users/peter/.openclaw/media/outbound/final.png",
-      });
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -108,11 +64,49 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: "/Users/peter/.openclaw/media/outbound/photo.png",
+      mediaUrl: path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
       mediaUrls: [
-        "/Users/peter/.openclaw/media/outbound/photo.png",
-        "/Users/peter/.openclaw/media/outbound/final.png",
+        path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
+        path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
       ],
+    });
+  });
+
+  it("drops workspace-relative media paths that escape the agent workspace", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["../../etc/passwd"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+  });
+
+  it("drops sandbox-relative media paths that escape and would also leave the workspace", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["../../etc/passwd"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
     });
   });
 
@@ -205,7 +199,7 @@ describe("createReplyMediaPathNormalizer", () => {
   });
 
   it("persists volatile agent-state media from the workspace into host outbound media", async () => {
-    saveMediaBuffer.mockResolvedValue({
+    saveMediaSource.mockResolvedValue({
       path: "/Users/peter/.openclaw/media/outbound/persisted.png",
     });
     const normalize = createReplyMediaPathNormalizer({
@@ -220,22 +214,12 @@ describe("createReplyMediaPathNormalizer", () => {
       ],
     });
 
-    expect(saveMediaBuffer).toHaveBeenCalledWith(
-      expect.any(Buffer),
+    expect(saveMediaSource).toHaveBeenCalledWith(
+      "/Users/peter/.openclaw/workspace/.openclaw/media/tool-image-generation/generated.png",
       undefined,
       "outbound",
       8 * 1024 * 1024,
-      "generated.png",
     );
-    expect(readPathWithinRoot).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rootDir: "/Users/peter/.openclaw/workspace",
-        filePath:
-          "/Users/peter/.openclaw/workspace/.openclaw/media/tool-image-generation/generated.png",
-        maxBytes: 8 * 1024 * 1024,
-      }),
-    );
-    expect(saveMediaSource).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       mediaUrl: "/Users/peter/.openclaw/media/outbound/persisted.png",
       mediaUrls: ["/Users/peter/.openclaw/media/outbound/persisted.png"],
@@ -307,183 +291,5 @@ describe("createReplyMediaPathNormalizer", () => {
       mediaUrls: undefined,
     });
     expect(saveMediaSource).not.toHaveBeenCalled();
-  });
-
-  it("persists workspace-rooted absolute paths before outbound delivery (#66635)", async () => {
-    saveMediaBuffer.mockResolvedValue({
-      path: "/Users/peter/.openclaw/media/outbound/chart.png",
-    });
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/home/user/.openclaw/workspace",
-    });
-
-    const result = await normalize({
-      mediaUrls: ["/home/user/.openclaw/workspace/exports/images/chart.png"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: "/Users/peter/.openclaw/media/outbound/chart.png",
-      mediaUrls: ["/Users/peter/.openclaw/media/outbound/chart.png"],
-    });
-    expect(saveMediaBuffer).toHaveBeenCalledWith(
-      expect.any(Buffer),
-      undefined,
-      "outbound",
-      undefined,
-      "chart.png",
-    );
-    expect(readPathWithinRoot).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rootDir: "/home/user/.openclaw/workspace",
-        filePath: "/home/user/.openclaw/workspace/exports/images/chart.png",
-        maxBytes: 5 * 1024 * 1024,
-      }),
-    );
-  });
-
-  it("persists sandbox-rooted absolute paths before outbound delivery (#66635)", async () => {
-    ensureSandboxWorkspaceForSession.mockResolvedValue({
-      workspaceDir: "/tmp/sandboxes/session-1",
-      containerWorkdir: "/workspace",
-    });
-    saveMediaBuffer.mockResolvedValue({
-      path: "/Users/peter/.openclaw/media/outbound/generated-chart.png",
-    });
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/tmp/agent-workspace",
-    });
-
-    const result = await normalize({
-      mediaUrls: ["/tmp/sandboxes/session-1/output/generated-chart.png"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: "/Users/peter/.openclaw/media/outbound/generated-chart.png",
-      mediaUrls: ["/Users/peter/.openclaw/media/outbound/generated-chart.png"],
-    });
-    expect(saveMediaBuffer).toHaveBeenCalledWith(
-      expect.any(Buffer),
-      undefined,
-      "outbound",
-      undefined,
-      "generated-chart.png",
-    );
-  });
-
-  it("drops workspace-rooted absolute paths when safe persistence rejects them", async () => {
-    saveMediaBuffer.mockRejectedValue(new Error("symlink not allowed"));
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/home/user/.openclaw/workspace",
-    });
-
-    const result = await normalize({
-      mediaUrls: ["/home/user/.openclaw/workspace/exports/images/chart.png"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
-  });
-
-  it.runIf(process.platform !== "win32")(
-    "drops workspace-rooted symlink escapes instead of falling back to the raw path",
-    async () => {
-      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reply-media-"));
-      try {
-        const stateDir = path.join(tempRoot, ".openclaw");
-        const workspaceDir = path.join(stateDir, "workspace");
-        const outsideDir = path.join(tempRoot, "outside");
-        const escapedPath = path.join(workspaceDir, "exports", "leak", "secret.txt");
-        await fs.mkdir(path.dirname(path.dirname(escapedPath)), { recursive: true });
-        await fs.mkdir(outsideDir, { recursive: true });
-        await fs.writeFile(path.join(outsideDir, "secret.txt"), "TOP_SECRET");
-        await fs.symlink(outsideDir, path.join(workspaceDir, "exports", "leak"));
-        vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-        readPathWithinRoot.mockImplementation(fsSafeRuntime.actualReadPathWithinRoot!);
-
-        const normalize = createReplyMediaPathNormalizer({
-          cfg: {},
-          sessionKey: "session-key",
-          workspaceDir,
-        });
-
-        const result = await normalize({
-          mediaUrls: [escapedPath],
-        });
-
-        expect(result).toMatchObject({
-          mediaUrl: undefined,
-          mediaUrls: undefined,
-        });
-        expect(saveMediaBuffer).not.toHaveBeenCalled();
-      } finally {
-        await fs.rm(tempRoot, { recursive: true, force: true });
-      }
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "drops sandbox-rooted symlink escapes when sandbox validation rejects them",
-    async () => {
-      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reply-sandbox-"));
-      try {
-        const workspaceDir = path.join(tempRoot, "workspace");
-        const sandboxDir = path.join(tempRoot, "sandbox");
-        const outsideDir = path.join(tempRoot, "outside");
-        const escapedPath = path.join(sandboxDir, "output", "leak", "secret.txt");
-        await fs.mkdir(workspaceDir, { recursive: true });
-        await fs.mkdir(path.dirname(path.dirname(escapedPath)), { recursive: true });
-        await fs.mkdir(outsideDir, { recursive: true });
-        await fs.writeFile(path.join(outsideDir, "secret.txt"), "TOP_SECRET");
-        await fs.symlink(outsideDir, path.join(sandboxDir, "output", "leak"));
-        ensureSandboxWorkspaceForSession.mockResolvedValue({
-          workspaceDir: sandboxDir,
-          containerWorkdir: "/workspace",
-        });
-        readPathWithinRoot.mockImplementation(fsSafeRuntime.actualReadPathWithinRoot!);
-
-        const normalize = createReplyMediaPathNormalizer({
-          cfg: {},
-          sessionKey: "session-key",
-          workspaceDir,
-        });
-
-        const result = await normalize({
-          mediaUrls: [escapedPath],
-        });
-
-        expect(result).toMatchObject({
-          mediaUrl: undefined,
-          mediaUrls: undefined,
-        });
-        expect(saveMediaSource).not.toHaveBeenCalled();
-      } finally {
-        await fs.rm(tempRoot, { recursive: true, force: true });
-      }
-    },
-  );
-
-  it("still drops absolute paths outside workspace and all allowed roots", async () => {
-    const normalize = createReplyMediaPathNormalizer({
-      cfg: {},
-      sessionKey: "session-key",
-      workspaceDir: "/home/user/.openclaw/workspace",
-    });
-
-    const result = await normalize({
-      mediaUrls: ["/etc/passwd"],
-    });
-
-    expect(result).toMatchObject({
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-    });
   });
 });

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -94,6 +94,34 @@ describe("createReplyMediaPathNormalizer", () => {
     );
   });
 
+  it("drops sandbox-mapped media when staging fails instead of retrying the workspace fallback", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("media too large"));
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["./out/photo.png"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledTimes(1);
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledWith(
+      path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
+      5 * 1024 * 1024,
+      expect.any(Object),
+    );
+  });
+
   it("drops host file URLs when no sandbox mapping applies", async () => {
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -162,6 +162,28 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
   });
 
+  it("drops absolute host-local media paths when sandbox mapping fails", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: { tools: { fs: { workspaceOnly: false } } },
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/Users/peter/Documents/report.pdf"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
+  });
+
   it("stages absolute workspace media paths so the PR scenario now works", async () => {
     const absolutePath = "/Users/peter/.openclaw/workspace/exports/images/chart.png";
     const normalize = createReplyMediaPathNormalizer({

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -94,6 +94,46 @@ describe("createReplyMediaPathNormalizer", () => {
     );
   });
 
+  it("drops host file URLs when no sandbox mapping applies", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["file:///Users/peter/Documents/report.pdf"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
+  });
+
+  it("drops host file URLs even when sandbox exists", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["file:///Users/peter/Documents/report.pdf"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+    expect(resolveOutboundAttachmentFromUrl).not.toHaveBeenCalled();
+  });
+
   it("stages absolute workspace media paths so the PR scenario now works", async () => {
     const absolutePath = "/Users/peter/.openclaw/workspace/exports/images/chart.png";
     const normalize = createReplyMediaPathNormalizer({

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -7,10 +7,12 @@ import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
+import { readPathWithinRoot } from "../../infra/fs-safe.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { resolveConfiguredMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
-import { saveMediaSource } from "../../media/store.js";
+import { saveMediaBuffer, saveMediaSource } from "../../media/store.js";
+import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
 
@@ -18,7 +20,6 @@ const FILE_URL_RE = /^file:\/\//i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT_RE = /\.\w{1,10}$/;
-const AGENT_STATE_MEDIA_DIRNAME = path.join(".openclaw", "media");
 const MANAGED_GLOBAL_MEDIA_SUBDIRS = new Set(["outbound"]);
 let cachedPreferredTmpRoot: string | null | undefined;
 
@@ -49,13 +50,8 @@ function resolvePreferredReplyMediaTmpRoot(): string | undefined {
   return cachedPreferredTmpRoot ?? undefined;
 }
 
-function buildVolatileReplyMediaRoots(params: {
-  workspaceDir: string;
-  sandboxRoot?: string;
-}): string[] {
-  const roots = [params.workspaceDir, params.sandboxRoot]
-    .filter((root): root is string => Boolean(root))
-    .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
+function buildVolatileReplyMediaRoots(): string[] {
+  const roots: string[] = [];
   const preferredTmpRoot = resolvePreferredReplyMediaTmpRoot();
   if (preferredTmpRoot) {
     roots.push(preferredTmpRoot);
@@ -63,24 +59,29 @@ function buildVolatileReplyMediaRoots(params: {
   return roots;
 }
 
-function isAllowedAbsoluteReplyMediaPath(params: {
+function resolveRootScopedReplyMediaBoundary(params: {
   candidate: string;
   workspaceDir: string;
   sandboxRoot?: string;
-}): boolean {
+}): string | undefined {
+  if (isPathInside(params.workspaceDir, params.candidate)) {
+    return path.resolve(params.workspaceDir);
+  }
+  if (params.sandboxRoot && isPathInside(params.sandboxRoot, params.candidate)) {
+    return path.resolve(params.sandboxRoot);
+  }
+  return undefined;
+}
+
+function isAllowedAbsoluteReplyMediaPath(params: { candidate: string }): boolean {
   if (isManagedGlobalReplyMediaPath(params.candidate)) {
     return true;
   }
-  // Allow paths anywhere inside the workspace dir or sandbox root — the agent
-  // can legitimately create files in subdirectories like exports/, output/, etc.
-  // without placing them under the narrower .openclaw/media/ tree (#66635).
-  if (isPathInside(params.workspaceDir, params.candidate)) {
+  const preferredTmpRoot = resolvePreferredReplyMediaTmpRoot();
+  if (preferredTmpRoot && isPathInside(preferredTmpRoot, params.candidate)) {
     return true;
   }
-  if (params.sandboxRoot && isPathInside(params.sandboxRoot, params.candidate)) {
-    return true;
-  }
-  return buildVolatileReplyMediaRoots(params).some((root) => isPathInside(root, params.candidate));
+  return false;
 }
 
 function isLikelyLocalMediaSource(media: string): boolean {
@@ -133,10 +134,39 @@ export function createReplyMediaPathNormalizer(params: {
       return media;
     }
     const sandboxRoot = await resolveSandboxRoot();
-    const volatileRoots = buildVolatileReplyMediaRoots({
+    const rootScopedBoundary = resolveRootScopedReplyMediaBoundary({
+      candidate: media,
       workspaceDir: params.workspaceDir,
       sandboxRoot,
     });
+    if (rootScopedBoundary) {
+      const cached = persistedMediaBySource.get(media);
+      if (cached) {
+        return await cached;
+      }
+      const persistPromise = readPathWithinRoot({
+        rootDir: rootScopedBoundary,
+        filePath: media,
+        maxBytes: configuredMediaMaxBytes,
+      })
+        .then(async ({ buffer }) => {
+          const saved = await saveMediaBuffer(
+            buffer,
+            undefined,
+            "outbound",
+            configuredMediaMaxBytes,
+            path.basename(media),
+          );
+          return saved.path;
+        })
+        .catch((err) => {
+          persistedMediaBySource.delete(media);
+          throw err;
+        });
+      persistedMediaBySource.set(media, persistPromise);
+      return await persistPromise;
+    }
+    const volatileRoots = buildVolatileReplyMediaRoots();
     if (!volatileRoots.some((root) => isPathInside(root, media))) {
       return media;
     }
@@ -185,11 +215,12 @@ export function createReplyMediaPathNormalizer(params: {
         if (!path.isAbsolute(media)) {
           return resolvePathFromInput(media, params.workspaceDir);
         }
+        if (isPathInside(params.workspaceDir, media)) {
+          return media;
+        }
         if (
           isAllowedAbsoluteReplyMediaPath({
             candidate: media,
-            workspaceDir: params.workspaceDir,
-            sandboxRoot,
           })
         ) {
           return media;
@@ -211,11 +242,12 @@ export function createReplyMediaPathNormalizer(params: {
     if (!path.isAbsolute(media)) {
       return resolvePathFromInput(media, params.workspaceDir);
     }
+    if (isPathInside(params.workspaceDir, media)) {
+      return media;
+    }
     if (
       isAllowedAbsoluteReplyMediaPath({
         candidate: media,
-        workspaceDir: params.workspaceDir,
-        sandboxRoot,
       })
     ) {
       return media;

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -71,6 +71,15 @@ function isAllowedAbsoluteReplyMediaPath(params: {
   if (isManagedGlobalReplyMediaPath(params.candidate)) {
     return true;
   }
+  // Allow paths anywhere inside the workspace dir or sandbox root — the agent
+  // can legitimately create files in subdirectories like exports/, output/, etc.
+  // without placing them under the narrower .openclaw/media/ tree (#66635).
+  if (isPathInside(params.workspaceDir, params.candidate)) {
+    return true;
+  }
+  if (params.sandboxRoot && isPathInside(params.sandboxRoot, params.candidate)) {
+    return true;
+  }
   return buildVolatileReplyMediaRoots(params).some((root) => isPathInside(root, params.candidate));
 }
 

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -4,13 +4,13 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolvePathFromInput, toRelativeWorkspacePath } from "../../agents/path-policy.js";
 import { assertMediaNotDataUrl, resolveSandboxedMediaSource } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
-import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { resolveConfiguredMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
-import { saveMediaSource } from "../../media/store.js";
+import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
+import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
+import { MEDIA_MAX_BYTES } from "../../media/store.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
 
@@ -18,14 +18,7 @@ const FILE_URL_RE = /^file:\/\//i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT_RE = /\.\w{1,10}$/;
-const AGENT_STATE_MEDIA_DIRNAME = path.join(".openclaw", "media");
 const MANAGED_GLOBAL_MEDIA_SUBDIRS = new Set(["outbound"]);
-let cachedPreferredTmpRoot: string | null | undefined;
-
-function isPathInside(root: string, candidate: string): boolean {
-  const relative = path.relative(path.resolve(root), path.resolve(candidate));
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-}
 
 function isManagedGlobalReplyMediaPath(candidate: string): boolean {
   const globalMediaRoot = path.join(resolveConfigDir(), "media");
@@ -35,43 +28,6 @@ function isManagedGlobalReplyMediaPath(candidate: string): boolean {
   }
   const firstSegment = relative.split(path.sep)[0] ?? "";
   return MANAGED_GLOBAL_MEDIA_SUBDIRS.has(firstSegment) || firstSegment.startsWith("tool-");
-}
-
-function resolvePreferredReplyMediaTmpRoot(): string | undefined {
-  if (cachedPreferredTmpRoot !== undefined) {
-    return cachedPreferredTmpRoot ?? undefined;
-  }
-  try {
-    cachedPreferredTmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
-  } catch {
-    cachedPreferredTmpRoot = null;
-  }
-  return cachedPreferredTmpRoot ?? undefined;
-}
-
-function buildVolatileReplyMediaRoots(params: {
-  workspaceDir: string;
-  sandboxRoot?: string;
-}): string[] {
-  const roots = [params.workspaceDir, params.sandboxRoot]
-    .filter((root): root is string => Boolean(root))
-    .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
-  const preferredTmpRoot = resolvePreferredReplyMediaTmpRoot();
-  if (preferredTmpRoot) {
-    roots.push(preferredTmpRoot);
-  }
-  return roots;
-}
-
-function isAllowedAbsoluteReplyMediaPath(params: {
-  candidate: string;
-  workspaceDir: string;
-  sandboxRoot?: string;
-}): boolean {
-  if (isManagedGlobalReplyMediaPath(params.candidate)) {
-    return true;
-  }
-  return buildVolatileReplyMediaRoots(params).some((root) => isPathInside(root, params.candidate));
 }
 
 function isLikelyLocalMediaSource(media: string): boolean {
@@ -96,15 +52,20 @@ export function createReplyMediaPathNormalizer(params: {
   cfg: OpenClawConfig;
   sessionKey?: string;
   workspaceDir: string;
+  messageProvider?: string;
+  accountId?: string;
+  groupId?: string;
+  groupChannel?: string;
+  groupSpace?: string;
+  requesterSenderId?: string;
+  requesterSenderName?: string;
+  requesterSenderUsername?: string;
+  requesterSenderE164?: string;
 }): (payload: ReplyPayload) => Promise<ReplyPayload> {
   const agentId = params.sessionKey
     ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
     : undefined;
-  const workspaceOnly = resolveEffectiveToolFsWorkspaceOnly({
-    cfg: params.cfg,
-    agentId,
-  });
-  const configuredMediaMaxBytes = resolveConfiguredMediaMaxBytes(params.cfg);
+  const maxBytes = resolveConfiguredMediaMaxBytes(params.cfg) ?? MEDIA_MAX_BYTES;
   let sandboxRootPromise: Promise<string | undefined> | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
@@ -119,35 +80,52 @@ export function createReplyMediaPathNormalizer(params: {
     return await sandboxRootPromise;
   };
 
-  const persistVolatileReplyMedia = async (media: string): Promise<string> => {
-    if (!path.isAbsolute(media)) {
+  const resolveMediaAccessForSource = (media: string) =>
+    resolveAgentScopedOutboundMediaAccess({
+      cfg: params.cfg,
+      agentId,
+      workspaceDir: params.workspaceDir,
+      mediaSources: [media],
+      sessionKey: params.sessionKey,
+      messageProvider: params.sessionKey ? undefined : params.messageProvider,
+      accountId: params.accountId,
+      requesterSenderId: params.requesterSenderId,
+      requesterSenderName: params.requesterSenderName,
+      requesterSenderUsername: params.requesterSenderUsername,
+      requesterSenderE164: params.requesterSenderE164,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+    });
+
+  const persistLocalReplyMedia = async (media: string): Promise<string> => {
+    if (!isLikelyLocalMediaSource(media)) {
       return media;
     }
-    const sandboxRoot = await resolveSandboxRoot();
-    const volatileRoots = buildVolatileReplyMediaRoots({
-      workspaceDir: params.workspaceDir,
-      sandboxRoot,
-    });
-    if (!volatileRoots.some((root) => isPathInside(root, media))) {
+    if (path.isAbsolute(media) && isManagedGlobalReplyMediaPath(media)) {
       return media;
     }
     const cached = persistedMediaBySource.get(media);
     if (cached) {
       return await cached;
     }
-    const persistPromise = saveMediaSource(media, undefined, "outbound", configuredMediaMaxBytes)
+    const persistPromise = resolveOutboundAttachmentFromUrl(media, maxBytes, {
+      mediaAccess: resolveMediaAccessForSource(media),
+    })
       .then((saved) => saved.path)
       .catch((err) => {
         persistedMediaBySource.delete(media);
         throw err;
       });
     persistedMediaBySource.set(media, persistPromise);
-    try {
-      return await persistPromise;
-    } catch (err) {
-      logVerbose(`failed to persist volatile reply media ${media}: ${String(err)}`);
-      return media;
-    }
+    return await persistPromise;
+  };
+
+  const resolveWorkspaceRelativeMedia = (media: string): string => {
+    const relativeWorkspacePath = toRelativeWorkspacePath(params.workspaceDir, media, {
+      cwd: params.workspaceDir,
+    });
+    return resolvePathFromInput(relativeWorkspacePath, params.workspaceDir);
   };
 
   const normalizeMediaSource = async (raw: string): Promise<string> => {
@@ -159,67 +137,38 @@ export function createReplyMediaPathNormalizer(params: {
     if (isPassThroughRemoteMediaSource(media)) {
       return media;
     }
+    const isRelativeLocalMedia =
+      isLikelyLocalMediaSource(media) &&
+      !FILE_URL_RE.test(media) &&
+      !media.startsWith("~") &&
+      !path.isAbsolute(media) &&
+      !WINDOWS_DRIVE_RE.test(media);
     const sandboxRoot = await resolveSandboxRoot();
     if (sandboxRoot) {
       try {
-        return await resolveSandboxedMediaSource({
-          media,
-          sandboxRoot,
-        });
-      } catch (err) {
-        if (!isLikelyLocalMediaSource(media) || FILE_URL_RE.test(media)) {
-          throw err;
-        }
-        if (workspaceOnly) {
-          throw err;
-        }
-        if (!path.isAbsolute(media)) {
-          const relativeWorkspacePath = toRelativeWorkspacePath(params.workspaceDir, media, {
-            cwd: params.workspaceDir,
-          });
-          return resolvePathFromInput(relativeWorkspacePath, params.workspaceDir);
-        }
-        if (
-          isAllowedAbsoluteReplyMediaPath({
-            candidate: media,
-            workspaceDir: params.workspaceDir,
+        return await persistLocalReplyMedia(
+          await resolveSandboxedMediaSource({
+            media,
             sandboxRoot,
-          })
-        ) {
-          return media;
-        }
-        throw new Error(
-          "Absolute host-local MEDIA paths are blocked in normal replies. Use a safe relative path or the message tool.",
-          { cause: err },
+          }),
         );
+      } catch (err) {
+        if (!isLikelyLocalMediaSource(media)) {
+          throw err;
+        }
+        if (isRelativeLocalMedia) {
+          return await persistLocalReplyMedia(resolveWorkspaceRelativeMedia(media));
+        }
+        return await persistLocalReplyMedia(media);
       }
+    }
+    if (isRelativeLocalMedia) {
+      return await persistLocalReplyMedia(resolveWorkspaceRelativeMedia(media));
     }
     if (!isLikelyLocalMediaSource(media)) {
       return media;
     }
-    if (FILE_URL_RE.test(media)) {
-      throw new Error(
-        "Absolute host-local MEDIA file URLs are blocked in normal replies. Use a safe relative path or the message tool.",
-      );
-    }
-    if (!path.isAbsolute(media)) {
-      const relativeWorkspacePath = toRelativeWorkspacePath(params.workspaceDir, media, {
-        cwd: params.workspaceDir,
-      });
-      return resolvePathFromInput(relativeWorkspacePath, params.workspaceDir);
-    }
-    if (
-      isAllowedAbsoluteReplyMediaPath({
-        candidate: media,
-        workspaceDir: params.workspaceDir,
-        sandboxRoot,
-      })
-    ) {
-      return media;
-    }
-    throw new Error(
-      "Absolute host-local MEDIA paths are blocked in normal replies. Use a safe relative path or the message tool.",
-    );
+    return await persistLocalReplyMedia(media);
   };
 
   return async (payload) => {
@@ -233,7 +182,7 @@ export function createReplyMediaPathNormalizer(params: {
     for (const media of mediaList) {
       let normalized: string;
       try {
-        normalized = await persistVolatileReplyMedia(await normalizeMediaSource(media));
+        normalized = await normalizeMediaSource(media);
       } catch (err) {
         logVerbose(`dropping blocked reply media ${media}: ${String(err)}`);
         continue;

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -11,7 +11,7 @@ import { readPathWithinRoot } from "../../infra/fs-safe.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { resolveConfiguredMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
-import { saveMediaBuffer, saveMediaSource } from "../../media/store.js";
+import { MEDIA_MAX_BYTES, saveMediaBuffer, saveMediaSource } from "../../media/store.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
 
@@ -114,6 +114,7 @@ export function createReplyMediaPathNormalizer(params: {
     agentId,
   });
   const configuredMediaMaxBytes = resolveConfiguredMediaMaxBytes(params.cfg);
+  const rootScopedReadMaxBytes = configuredMediaMaxBytes ?? MEDIA_MAX_BYTES;
   let sandboxRootPromise: Promise<string | undefined> | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
@@ -146,7 +147,7 @@ export function createReplyMediaPathNormalizer(params: {
       const persistPromise = readPathWithinRoot({
         rootDir: rootScopedBoundary,
         filePath: media,
-        maxBytes: configuredMediaMaxBytes,
+        maxBytes: rootScopedReadMaxBytes,
       })
         .then(async ({ buffer }) => {
           const saved = await saveMediaBuffer(

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -1,17 +1,16 @@
 import path from "node:path";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { resolvePathFromInput } from "../../agents/path-policy.js";
+import { resolvePathFromInput, toRelativeWorkspacePath } from "../../agents/path-policy.js";
 import { assertMediaNotDataUrl, resolveSandboxedMediaSource } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import { readPathWithinRoot } from "../../infra/fs-safe.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { resolveConfiguredMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
-import { MEDIA_MAX_BYTES, saveMediaBuffer, saveMediaSource } from "../../media/store.js";
+import { saveMediaSource } from "../../media/store.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
 
@@ -19,6 +18,7 @@ const FILE_URL_RE = /^file:\/\//i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT_RE = /\.\w{1,10}$/;
+const AGENT_STATE_MEDIA_DIRNAME = path.join(".openclaw", "media");
 const MANAGED_GLOBAL_MEDIA_SUBDIRS = new Set(["outbound"]);
 let cachedPreferredTmpRoot: string | null | undefined;
 
@@ -49,8 +49,13 @@ function resolvePreferredReplyMediaTmpRoot(): string | undefined {
   return cachedPreferredTmpRoot ?? undefined;
 }
 
-function buildVolatileReplyMediaRoots(): string[] {
-  const roots: string[] = [];
+function buildVolatileReplyMediaRoots(params: {
+  workspaceDir: string;
+  sandboxRoot?: string;
+}): string[] {
+  const roots = [params.workspaceDir, params.sandboxRoot]
+    .filter((root): root is string => Boolean(root))
+    .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
   const preferredTmpRoot = resolvePreferredReplyMediaTmpRoot();
   if (preferredTmpRoot) {
     roots.push(preferredTmpRoot);
@@ -58,29 +63,15 @@ function buildVolatileReplyMediaRoots(): string[] {
   return roots;
 }
 
-function resolveRootScopedReplyMediaBoundary(params: {
+function isAllowedAbsoluteReplyMediaPath(params: {
   candidate: string;
   workspaceDir: string;
   sandboxRoot?: string;
-}): string | undefined {
-  if (isPathInside(params.workspaceDir, params.candidate)) {
-    return path.resolve(params.workspaceDir);
-  }
-  if (params.sandboxRoot && isPathInside(params.sandboxRoot, params.candidate)) {
-    return path.resolve(params.sandboxRoot);
-  }
-  return undefined;
-}
-
-function isAllowedAbsoluteReplyMediaPath(params: { candidate: string }): boolean {
+}): boolean {
   if (isManagedGlobalReplyMediaPath(params.candidate)) {
     return true;
   }
-  const preferredTmpRoot = resolvePreferredReplyMediaTmpRoot();
-  if (preferredTmpRoot && isPathInside(preferredTmpRoot, params.candidate)) {
-    return true;
-  }
-  return false;
+  return buildVolatileReplyMediaRoots(params).some((root) => isPathInside(root, params.candidate));
 }
 
 function isLikelyLocalMediaSource(media: string): boolean {
@@ -114,7 +105,6 @@ export function createReplyMediaPathNormalizer(params: {
     agentId,
   });
   const configuredMediaMaxBytes = resolveConfiguredMediaMaxBytes(params.cfg);
-  const rootScopedReadMaxBytes = configuredMediaMaxBytes ?? MEDIA_MAX_BYTES;
   let sandboxRootPromise: Promise<string | undefined> | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
@@ -134,39 +124,10 @@ export function createReplyMediaPathNormalizer(params: {
       return media;
     }
     const sandboxRoot = await resolveSandboxRoot();
-    const rootScopedBoundary = resolveRootScopedReplyMediaBoundary({
-      candidate: media,
+    const volatileRoots = buildVolatileReplyMediaRoots({
       workspaceDir: params.workspaceDir,
       sandboxRoot,
     });
-    if (rootScopedBoundary) {
-      const cached = persistedMediaBySource.get(media);
-      if (cached) {
-        return await cached;
-      }
-      const persistPromise = readPathWithinRoot({
-        rootDir: rootScopedBoundary,
-        filePath: media,
-        maxBytes: rootScopedReadMaxBytes,
-      })
-        .then(async ({ buffer }) => {
-          const saved = await saveMediaBuffer(
-            buffer,
-            undefined,
-            "outbound",
-            configuredMediaMaxBytes,
-            path.basename(media),
-          );
-          return saved.path;
-        })
-        .catch((err) => {
-          persistedMediaBySource.delete(media);
-          throw err;
-        });
-      persistedMediaBySource.set(media, persistPromise);
-      return await persistPromise;
-    }
-    const volatileRoots = buildVolatileReplyMediaRoots();
     if (!volatileRoots.some((root) => isPathInside(root, media))) {
       return media;
     }
@@ -213,14 +174,16 @@ export function createReplyMediaPathNormalizer(params: {
           throw err;
         }
         if (!path.isAbsolute(media)) {
-          return resolvePathFromInput(media, params.workspaceDir);
-        }
-        if (isPathInside(params.workspaceDir, media)) {
-          return media;
+          const relativeWorkspacePath = toRelativeWorkspacePath(params.workspaceDir, media, {
+            cwd: params.workspaceDir,
+          });
+          return resolvePathFromInput(relativeWorkspacePath, params.workspaceDir);
         }
         if (
           isAllowedAbsoluteReplyMediaPath({
             candidate: media,
+            workspaceDir: params.workspaceDir,
+            sandboxRoot,
           })
         ) {
           return media;
@@ -240,14 +203,16 @@ export function createReplyMediaPathNormalizer(params: {
       );
     }
     if (!path.isAbsolute(media)) {
-      return resolvePathFromInput(media, params.workspaceDir);
-    }
-    if (isPathInside(params.workspaceDir, media)) {
-      return media;
+      const relativeWorkspacePath = toRelativeWorkspacePath(params.workspaceDir, media, {
+        cwd: params.workspaceDir,
+      });
+      return resolvePathFromInput(relativeWorkspacePath, params.workspaceDir);
     }
     if (
       isAllowedAbsoluteReplyMediaPath({
         candidate: media,
+        workspaceDir: params.workspaceDir,
+        sandboxRoot,
       })
     ) {
       return media;

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -6,7 +6,6 @@ import { assertMediaNotDataUrl, resolveSandboxedMediaSource } from "../../agents
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import { resolveConfiguredMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
@@ -48,6 +47,38 @@ function getPayloadMediaList(payload: ReplyPayload): string[] {
   return resolveSendableOutboundReplyParts(payload).mediaUrls;
 }
 
+function resolveReplyMediaMaxBytes(params: {
+  cfg: OpenClawConfig;
+  channel?: string;
+  accountId?: string;
+}): number {
+  const channelId = params.channel?.trim();
+  const accountId = params.accountId?.trim();
+  const channelCfg = channelId ? params.cfg.channels?.[channelId] : undefined;
+  const channelObj =
+    channelCfg && typeof channelCfg === "object"
+      ? (channelCfg as Record<string, unknown>)
+      : undefined;
+  const channelMediaMax =
+    typeof channelObj?.mediaMaxMb === "number" ? channelObj.mediaMaxMb : undefined;
+  const accountsObj =
+    channelObj?.accounts && typeof channelObj.accounts === "object"
+      ? (channelObj.accounts as Record<string, unknown>)
+      : undefined;
+  const accountCfg = accountId && accountsObj ? accountsObj[accountId] : undefined;
+  const accountMediaMax =
+    accountCfg && typeof accountCfg === "object"
+      ? (accountCfg as Record<string, unknown>).mediaMaxMb
+      : undefined;
+  const limitMb =
+    (typeof accountMediaMax === "number" ? accountMediaMax : undefined) ??
+    channelMediaMax ??
+    params.cfg.agents?.defaults?.mediaMaxMb;
+  return typeof limitMb === "number" && Number.isFinite(limitMb) && limitMb > 0
+    ? Math.floor(limitMb * 1024 * 1024)
+    : MEDIA_MAX_BYTES;
+}
+
 export function createReplyMediaPathNormalizer(params: {
   cfg: OpenClawConfig;
   sessionKey?: string;
@@ -65,7 +96,11 @@ export function createReplyMediaPathNormalizer(params: {
   const agentId = params.sessionKey
     ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
     : undefined;
-  const maxBytes = resolveConfiguredMediaMaxBytes(params.cfg) ?? MEDIA_MAX_BYTES;
+  const maxBytes = resolveReplyMediaMaxBytes({
+    cfg: params.cfg,
+    channel: params.messageProvider,
+    accountId: params.accountId,
+  });
   let sandboxRootPromise: Promise<string | undefined> | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -187,19 +187,13 @@ export function createReplyMediaPathNormalizer(params: {
           sandboxRoot,
         });
       } catch (err) {
-        if (!isLikelyLocalMediaSource(media)) {
-          throw err;
-        }
         if (FILE_URL_RE.test(media)) {
           throw new Error(
             "Host-local MEDIA file URLs are blocked in normal replies. Use a safe path or the message tool.",
             { cause: err },
           );
         }
-        if (isRelativeLocalMedia) {
-          return await persistLocalReplyMedia(resolveWorkspaceRelativeMedia(media));
-        }
-        return await persistLocalReplyMedia(media);
+        throw err;
       }
       return await persistLocalReplyMedia(sandboxResolvedMedia);
     }

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -180,13 +180,12 @@ export function createReplyMediaPathNormalizer(params: {
       !WINDOWS_DRIVE_RE.test(media);
     const sandboxRoot = await resolveSandboxRoot();
     if (sandboxRoot) {
+      let sandboxResolvedMedia: string;
       try {
-        return await persistLocalReplyMedia(
-          await resolveSandboxedMediaSource({
-            media,
-            sandboxRoot,
-          }),
-        );
+        sandboxResolvedMedia = await resolveSandboxedMediaSource({
+          media,
+          sandboxRoot,
+        });
       } catch (err) {
         if (!isLikelyLocalMediaSource(media)) {
           throw err;
@@ -202,6 +201,7 @@ export function createReplyMediaPathNormalizer(params: {
         }
         return await persistLocalReplyMedia(media);
       }
+      return await persistLocalReplyMedia(sandboxResolvedMedia);
     }
     if (isRelativeLocalMedia) {
       return await persistLocalReplyMedia(resolveWorkspaceRelativeMedia(media));

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -191,6 +191,12 @@ export function createReplyMediaPathNormalizer(params: {
         if (!isLikelyLocalMediaSource(media)) {
           throw err;
         }
+        if (FILE_URL_RE.test(media)) {
+          throw new Error(
+            "Host-local MEDIA file URLs are blocked in normal replies. Use a safe path or the message tool.",
+            { cause: err },
+          );
+        }
         if (isRelativeLocalMedia) {
           return await persistLocalReplyMedia(resolveWorkspaceRelativeMedia(media));
         }
@@ -202,6 +208,11 @@ export function createReplyMediaPathNormalizer(params: {
     }
     if (!isLikelyLocalMediaSource(media)) {
       return media;
+    }
+    if (FILE_URL_RE.test(media)) {
+      throw new Error(
+        "Host-local MEDIA file URLs are blocked in normal replies. Use a safe path or the message tool.",
+      );
     }
     return await persistLocalReplyMedia(media);
   };

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -12,7 +12,6 @@ import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js"
 import { resolveConfiguredMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
 import { saveMediaBuffer, saveMediaSource } from "../../media/store.js";
-import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
 import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
 

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -36,6 +36,24 @@ describe("message action media helpers", () => {
       mediaAccess: {
         localRoots: ["/tmp/a"],
       },
+      mediaLocalRoots: ["/tmp/a"],
+    });
+  });
+
+  it("preserves explicit any local roots for host read opt-ins", () => {
+    const mediaReadFile = async () => Buffer.from("x");
+    expect(
+      resolveAttachmentMediaPolicy({
+        mediaLocalRoots: "any",
+        mediaReadFile,
+      }),
+    ).toEqual({
+      mode: "host",
+      mediaAccess: {
+        readFile: mediaReadFile,
+      },
+      mediaLocalRoots: "any",
+      mediaReadFile,
     });
   });
 

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -8,6 +8,7 @@ import { basenameFromMediaSource } from "../../infra/local-file-access.js";
 import {
   buildOutboundMediaLoadOptions,
   resolveOutboundMediaAccess,
+  resolveOutboundMediaLocalRoots,
   type OutboundMediaAccess,
   type OutboundMediaReadFile,
 } from "../../media/load-options.js";
@@ -177,12 +178,14 @@ export type AttachmentMediaPolicy =
   | {
       mode: "host";
       mediaAccess?: OutboundMediaAccess;
+      mediaLocalRoots?: readonly string[] | "any";
+      mediaReadFile?: OutboundMediaReadFile;
     };
 
 export function resolveAttachmentMediaPolicy(params: {
   sandboxRoot?: string;
   mediaAccess?: OutboundMediaAccess;
-  mediaLocalRoots?: readonly string[];
+  mediaLocalRoots?: readonly string[] | "any";
   mediaReadFile?: OutboundMediaReadFile;
 }): AttachmentMediaPolicy {
   const sandboxRoot = params.sandboxRoot?.trim();
@@ -192,13 +195,20 @@ export function resolveAttachmentMediaPolicy(params: {
       sandboxRoot,
     };
   }
+  const explicitLocalRoots = resolveOutboundMediaLocalRoots(params.mediaLocalRoots);
   return {
     mode: "host",
     mediaAccess: resolveOutboundMediaAccess({
       mediaAccess: params.mediaAccess,
-      mediaLocalRoots: params.mediaLocalRoots,
-      mediaReadFile: params.mediaReadFile,
+      mediaLocalRoots: explicitLocalRoots === "any" ? undefined : explicitLocalRoots,
+      mediaReadFile: params.mediaAccess?.readFile ? undefined : params.mediaReadFile,
     }),
+    ...(explicitLocalRoots !== undefined ? { mediaLocalRoots: explicitLocalRoots } : {}),
+    ...(params.mediaAccess?.readFile
+      ? {}
+      : params.mediaReadFile
+        ? { mediaReadFile: params.mediaReadFile }
+        : {}),
   };
 }
 
@@ -230,6 +240,8 @@ function buildAttachmentMediaLoadOptions(params: {
   return buildOutboundMediaLoadOptions({
     maxBytes: params.maxBytes,
     mediaAccess: params.policy.mediaAccess,
+    mediaLocalRoots: params.policy.mediaLocalRoots,
+    mediaReadFile: params.policy.mediaReadFile,
   });
 }
 

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -335,7 +335,7 @@ describe("runMessageAction media behavior", () => {
       const call = vi.mocked(loadWebMedia).mock.calls[0];
       expect(call?.[1]).toEqual(
         expect.objectContaining({
-          localRoots: "any",
+          localRoots: expect.any(Array),
           readFile: expect.any(Function),
           hostReadCapability: true,
         }),

--- a/src/media/load-options.test.ts
+++ b/src/media/load-options.test.ts
@@ -33,6 +33,21 @@ describe("media load options", () => {
       params: { maxBytes: 2048, mediaLocalRoots: undefined },
       expected: { maxBytes: 2048, localRoots: undefined },
     },
+    {
+      params: {
+        maxBytes: 4096,
+        mediaAccess: {
+          localRoots: ["/tmp/workspace"],
+          readFile: async () => Buffer.from("x"),
+        },
+      },
+      expected: {
+        maxBytes: 4096,
+        localRoots: ["/tmp/workspace"],
+        readFile: expect.any(Function),
+        hostReadCapability: true,
+      },
+    },
   ] as const)("builds outbound media load options %#", ({ params, expected }) => {
     expectBuiltOutboundMediaLoadOptions(params, expected);
   });

--- a/src/media/load-options.test.ts
+++ b/src/media/load-options.test.ts
@@ -75,20 +75,11 @@ describe("media load options", () => {
         },
       }),
     ).toThrow("Host media read requires explicit localRoots");
-  });
-
-  it("preserves backward compatibility for direct mediaReadFile callers", () => {
-    expectBuiltOutboundMediaLoadOptions(
-      {
+    expect(() =>
+      buildOutboundMediaLoadOptions({
         maxBytes: 1024,
         mediaReadFile: async () => Buffer.from("x"),
-      },
-      {
-        maxBytes: 1024,
-        localRoots: "any",
-        readFile: expect.any(Function),
-        hostReadCapability: true,
-      },
-    );
+      }),
+    ).toThrow("Host media read requires explicit localRoots");
   });
 });

--- a/src/media/load-options.test.ts
+++ b/src/media/load-options.test.ts
@@ -20,6 +20,7 @@ describe("media load options", () => {
     { mediaLocalRoots: undefined, expectedLocalRoots: undefined },
     { mediaLocalRoots: [], expectedLocalRoots: undefined },
     { mediaLocalRoots: ["/tmp/workspace"], expectedLocalRoots: ["/tmp/workspace"] },
+    { mediaLocalRoots: "any", expectedLocalRoots: "any" },
   ] as const)("resolves outbound local roots %#", ({ mediaLocalRoots, expectedLocalRoots }) => {
     expectResolvedOutboundMediaRoots(mediaLocalRoots, expectedLocalRoots);
   });
@@ -48,7 +49,33 @@ describe("media load options", () => {
         hostReadCapability: true,
       },
     },
+    {
+      params: {
+        maxBytes: 4096,
+        mediaAccess: {
+          localRoots: "any",
+          readFile: async () => Buffer.from("x"),
+        },
+      },
+      expected: {
+        maxBytes: 4096,
+        localRoots: "any",
+        readFile: expect.any(Function),
+        hostReadCapability: true,
+      },
+    },
   ] as const)("builds outbound media load options %#", ({ params, expected }) => {
     expectBuiltOutboundMediaLoadOptions(params, expected);
+  });
+
+  it("rejects host read capability without explicit local roots", () => {
+    expect(() =>
+      buildOutboundMediaLoadOptions({
+        maxBytes: 1024,
+        mediaAccess: {
+          readFile: async () => Buffer.from("x"),
+        },
+      }),
+    ).toThrow("Host media read requires explicit localRoots");
   });
 });

--- a/src/media/load-options.test.ts
+++ b/src/media/load-options.test.ts
@@ -76,4 +76,19 @@ describe("media load options", () => {
       }),
     ).toThrow("Host media read requires explicit localRoots");
   });
+
+  it("preserves backward compatibility for direct mediaReadFile callers", () => {
+    expectBuiltOutboundMediaLoadOptions(
+      {
+        maxBytes: 1024,
+        mediaReadFile: async () => Buffer.from("x"),
+      },
+      {
+        maxBytes: 1024,
+        localRoots: "any",
+        readFile: expect.any(Function),
+        hostReadCapability: true,
+      },
+    );
+  });
 });

--- a/src/media/load-options.test.ts
+++ b/src/media/load-options.test.ts
@@ -3,8 +3,8 @@ import { buildOutboundMediaLoadOptions, resolveOutboundMediaLocalRoots } from ".
 
 describe("media load options", () => {
   function expectResolvedOutboundMediaRoots(
-    mediaLocalRoots: readonly string[] | undefined,
-    expectedLocalRoots: readonly string[] | undefined,
+    mediaLocalRoots: readonly string[] | "any" | undefined,
+    expectedLocalRoots: readonly string[] | "any" | undefined,
   ) {
     expect(resolveOutboundMediaLocalRoots(mediaLocalRoots)).toEqual(expectedLocalRoots);
   }
@@ -52,10 +52,8 @@ describe("media load options", () => {
     {
       params: {
         maxBytes: 4096,
-        mediaAccess: {
-          localRoots: "any",
-          readFile: async () => Buffer.from("x"),
-        },
+        mediaLocalRoots: "any",
+        mediaReadFile: async () => Buffer.from("x"),
       },
       expected: {
         maxBytes: 4096,

--- a/src/media/load-options.ts
+++ b/src/media/load-options.ts
@@ -60,17 +60,17 @@ export function buildOutboundMediaLoadOptions(
 ): OutboundMediaLoadOptions {
   const mediaAccess = resolveOutboundMediaAccess(params);
   const workspaceDir = mediaAccess?.workspaceDir ?? params.workspaceDir;
+  const localRoots = mediaAccess?.localRoots;
   if (mediaAccess?.readFile) {
     return {
       ...(params.maxBytes !== undefined ? { maxBytes: params.maxBytes } : {}),
-      localRoots: "any",
+      ...(localRoots ? { localRoots } : { localRoots: "any" }),
       readFile: mediaAccess.readFile,
       hostReadCapability: true,
       ...(params.optimizeImages !== undefined ? { optimizeImages: params.optimizeImages } : {}),
       ...(workspaceDir ? { workspaceDir } : {}),
     };
   }
-  const localRoots = mediaAccess?.localRoots;
   return {
     ...(params.maxBytes !== undefined ? { maxBytes: params.maxBytes } : {}),
     ...(localRoots ? { localRoots } : {}),

--- a/src/media/load-options.ts
+++ b/src/media/load-options.ts
@@ -66,11 +66,12 @@ export function buildOutboundMediaLoadOptions(
   const mediaAccess = resolveOutboundMediaAccess({
     mediaAccess: params.mediaAccess,
     mediaLocalRoots: explicitLocalRoots === "any" ? undefined : explicitLocalRoots,
-    mediaReadFile: params.mediaReadFile,
+    mediaReadFile: params.mediaAccess?.readFile ? undefined : params.mediaReadFile,
   });
   const workspaceDir = mediaAccess?.workspaceDir ?? params.workspaceDir;
-  const localRoots = mediaAccess?.localRoots ?? explicitLocalRoots;
-  const readFile = mediaAccess?.readFile;
+  const readFile = mediaAccess?.readFile ?? params.mediaReadFile;
+  const localRoots =
+    mediaAccess?.localRoots ?? explicitLocalRoots ?? (params.mediaReadFile ? "any" : undefined);
   if (readFile) {
     if (!localRoots) {
       throw new Error(

--- a/src/media/load-options.ts
+++ b/src/media/load-options.ts
@@ -1,7 +1,7 @@
 export type OutboundMediaReadFile = (filePath: string) => Promise<Buffer>;
 
 export type OutboundMediaAccess = {
-  localRoots?: readonly string[] | "any";
+  localRoots?: readonly string[];
   readFile?: OutboundMediaReadFile;
   /** Agent workspace directory for resolving relative MEDIA: paths. */
   workspaceDir?: string;
@@ -10,7 +10,7 @@ export type OutboundMediaAccess = {
 export type OutboundMediaLoadParams = {
   maxBytes?: number;
   mediaAccess?: OutboundMediaAccess;
-  mediaLocalRoots?: readonly string[];
+  mediaLocalRoots?: readonly string[] | "any";
   mediaReadFile?: OutboundMediaReadFile;
   optimizeImages?: boolean;
   /** Agent workspace directory for resolving relative MEDIA: paths. */
@@ -43,9 +43,10 @@ export function resolveOutboundMediaAccess(
     mediaReadFile?: OutboundMediaReadFile;
   } = {},
 ): OutboundMediaAccess | undefined {
-  const localRoots = resolveOutboundMediaLocalRoots(
+  const resolvedLocalRoots = resolveOutboundMediaLocalRoots(
     params.mediaAccess?.localRoots ?? params.mediaLocalRoots,
   );
+  const localRoots = resolvedLocalRoots === "any" ? undefined : resolvedLocalRoots;
   const readFile = params.mediaAccess?.readFile ?? params.mediaReadFile;
   const workspaceDir = params.mediaAccess?.workspaceDir;
   if (!localRoots && !readFile && !workspaceDir) {
@@ -61,10 +62,16 @@ export function resolveOutboundMediaAccess(
 export function buildOutboundMediaLoadOptions(
   params: OutboundMediaLoadParams = {},
 ): OutboundMediaLoadOptions {
-  const mediaAccess = resolveOutboundMediaAccess(params);
+  const explicitLocalRoots = resolveOutboundMediaLocalRoots(params.mediaLocalRoots);
+  const mediaAccess = resolveOutboundMediaAccess({
+    mediaAccess: params.mediaAccess,
+    mediaLocalRoots: explicitLocalRoots === "any" ? undefined : explicitLocalRoots,
+    mediaReadFile: params.mediaReadFile,
+  });
   const workspaceDir = mediaAccess?.workspaceDir ?? params.workspaceDir;
-  const localRoots = mediaAccess?.localRoots;
-  if (mediaAccess?.readFile) {
+  const localRoots = mediaAccess?.localRoots ?? explicitLocalRoots;
+  const readFile = mediaAccess?.readFile;
+  if (readFile) {
     if (!localRoots) {
       throw new Error(
         'Host media read requires explicit localRoots. Pass mediaAccess.localRoots or opt in with localRoots: "any".',
@@ -73,7 +80,7 @@ export function buildOutboundMediaLoadOptions(
     return {
       ...(params.maxBytes !== undefined ? { maxBytes: params.maxBytes } : {}),
       localRoots,
-      readFile: mediaAccess.readFile,
+      readFile,
       hostReadCapability: true,
       ...(params.optimizeImages !== undefined ? { optimizeImages: params.optimizeImages } : {}),
       ...(workspaceDir ? { workspaceDir } : {}),

--- a/src/media/load-options.ts
+++ b/src/media/load-options.ts
@@ -70,8 +70,7 @@ export function buildOutboundMediaLoadOptions(
   });
   const workspaceDir = mediaAccess?.workspaceDir ?? params.workspaceDir;
   const readFile = mediaAccess?.readFile ?? params.mediaReadFile;
-  const localRoots =
-    mediaAccess?.localRoots ?? explicitLocalRoots ?? (params.mediaReadFile ? "any" : undefined);
+  const localRoots = mediaAccess?.localRoots ?? explicitLocalRoots;
   if (readFile) {
     if (!localRoots) {
       throw new Error(

--- a/src/media/load-options.ts
+++ b/src/media/load-options.ts
@@ -1,7 +1,7 @@
 export type OutboundMediaReadFile = (filePath: string) => Promise<Buffer>;
 
 export type OutboundMediaAccess = {
-  localRoots?: readonly string[];
+  localRoots?: readonly string[] | "any";
   readFile?: OutboundMediaReadFile;
   /** Agent workspace directory for resolving relative MEDIA: paths. */
   workspaceDir?: string;
@@ -28,8 +28,11 @@ export type OutboundMediaLoadOptions = {
 };
 
 export function resolveOutboundMediaLocalRoots(
-  mediaLocalRoots?: readonly string[],
-): readonly string[] | undefined {
+  mediaLocalRoots?: readonly string[] | "any",
+): readonly string[] | "any" | undefined {
+  if (mediaLocalRoots === "any") {
+    return mediaLocalRoots;
+  }
   return mediaLocalRoots && mediaLocalRoots.length > 0 ? mediaLocalRoots : undefined;
 }
 
@@ -62,9 +65,14 @@ export function buildOutboundMediaLoadOptions(
   const workspaceDir = mediaAccess?.workspaceDir ?? params.workspaceDir;
   const localRoots = mediaAccess?.localRoots;
   if (mediaAccess?.readFile) {
+    if (!localRoots) {
+      throw new Error(
+        'Host media read requires explicit localRoots. Pass mediaAccess.localRoots or opt in with localRoots: "any".',
+      );
+    }
     return {
       ...(params.maxBytes !== undefined ? { maxBytes: params.maxBytes } : {}),
-      ...(localRoots ? { localRoots } : { localRoots: "any" }),
+      localRoots,
       readFile: mediaAccess.readFile,
       hostReadCapability: true,
       ...(params.optimizeImages !== undefined ? { optimizeImages: params.optimizeImages } : {}),

--- a/src/media/read-capability.test.ts
+++ b/src/media/read-capability.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveAgentScopedOutboundMediaAccess } from "./read-capability.js";
 
@@ -7,6 +7,10 @@ vi.mock("../channels/plugins/index.js", () => ({
 }));
 
 describe("resolveAgentScopedOutboundMediaAccess", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("preserves caller-provided workspaceDir from mediaAccess", () => {
     const result = resolveAgentScopedOutboundMediaAccess({
       cfg: {} as OpenClawConfig,
@@ -49,12 +53,14 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
     const result = resolveAgentScopedOutboundMediaAccess({
       cfg,
       sessionKey: "agent:main:whatsapp:group:ops",
+      mediaSources: ["/Users/peter/Pictures/photo.png"],
       // Production call sites set messageProvider: undefined when sessionKey is present;
       // resolveGroupToolPolicy derives channel from the session key instead.
       requesterSenderId: "attacker",
     });
 
     expect(result.readFile).toBeUndefined();
+    expect(result.localRoots).not.toContain("/Users/peter/Pictures");
   });
 
   it("keeps host reads enabled when sender group policy allows read", () => {
@@ -80,10 +86,12 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
     const result = resolveAgentScopedOutboundMediaAccess({
       cfg,
       sessionKey: "agent:main:whatsapp:group:ops",
+      mediaSources: ["/Users/peter/Pictures/photo.png"],
       requesterSenderId: "trusted-user",
     });
 
     expect(result.readFile).toBeTypeOf("function");
+    expect(result.localRoots).toContain("/Users/peter/Pictures");
   });
 
   it("keeps host reads enabled when no group policy applies", () => {

--- a/src/media/read-capability.ts
+++ b/src/media/read-capability.ts
@@ -8,7 +8,10 @@ import type { OpenClawConfig } from "../config/types.js";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { OutboundMediaAccess, OutboundMediaReadFile } from "./load-options.js";
-import { getAgentScopedMediaLocalRootsForSources } from "./local-roots.js";
+import {
+  getAgentScopedMediaLocalRoots,
+  getAgentScopedMediaLocalRootsForSources,
+} from "./local-roots.js";
 
 type OutboundHostMediaPolicyContext = {
   sessionKey?: string;
@@ -87,13 +90,16 @@ export function resolveAgentScopedOutboundMediaAccess(
     mediaReadFile?: OutboundMediaReadFile;
   } & OutboundHostMediaPolicyContext,
 ): OutboundMediaAccess {
+  const hostMediaReadAllowed = isAgentScopedHostMediaReadAllowed(params);
   const localRoots =
     params.mediaAccess?.localRoots ??
-    getAgentScopedMediaLocalRootsForSources({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      mediaSources: params.mediaSources,
-    });
+    (hostMediaReadAllowed
+      ? getAgentScopedMediaLocalRootsForSources({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          mediaSources: params.mediaSources,
+        })
+      : getAgentScopedMediaLocalRoots(params.cfg, params.agentId));
   const resolvedWorkspaceDir =
     params.workspaceDir ??
     params.mediaAccess?.workspaceDir ??
@@ -101,21 +107,23 @@ export function resolveAgentScopedOutboundMediaAccess(
   const readFile =
     params.mediaAccess?.readFile ??
     params.mediaReadFile ??
-    createAgentScopedHostMediaReadFile({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      workspaceDir: resolvedWorkspaceDir,
-      sessionKey: params.sessionKey,
-      messageProvider: params.messageProvider,
-      groupId: params.groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
-      accountId: params.accountId,
-      requesterSenderId: params.requesterSenderId,
-      requesterSenderName: params.requesterSenderName,
-      requesterSenderUsername: params.requesterSenderUsername,
-      requesterSenderE164: params.requesterSenderE164,
-    });
+    (hostMediaReadAllowed
+      ? createAgentScopedHostMediaReadFile({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          workspaceDir: resolvedWorkspaceDir,
+          sessionKey: params.sessionKey,
+          messageProvider: params.messageProvider,
+          groupId: params.groupId,
+          groupChannel: params.groupChannel,
+          groupSpace: params.groupSpace,
+          accountId: params.accountId,
+          requesterSenderId: params.requesterSenderId,
+          requesterSenderName: params.requesterSenderName,
+          requesterSenderUsername: params.requesterSenderUsername,
+          requesterSenderE164: params.requesterSenderE164,
+        })
+      : undefined);
   return {
     ...(localRoots?.length ? { localRoots } : {}),
     ...(readFile ? { readFile } : {}),

--- a/src/plugin-sdk/outbound-media.test.ts
+++ b/src/plugin-sdk/outbound-media.test.ts
@@ -51,7 +51,7 @@ describe("loadOutboundMediaFromUrl", () => {
     expect(loadWebMediaMock).toHaveBeenCalledWith("https://example.com/image.png", {});
   });
 
-  it("prefers host read capability over local roots when provided", async () => {
+  it("keeps local roots when host read capability is provided", async () => {
     const mediaReadFile = vi.fn(async () => Buffer.from("x"));
     loadWebMediaMock.mockResolvedValueOnce({
       buffer: Buffer.from("x"),
@@ -67,7 +67,7 @@ describe("loadOutboundMediaFromUrl", () => {
 
     expect(loadWebMediaMock).toHaveBeenCalledWith("/Users/peter/Pictures/image.png", {
       maxBytes: 2048,
-      localRoots: "any",
+      localRoots: ["/tmp/workspace-agent"],
       readFile: mediaReadFile,
       hostReadCapability: true,
     });

--- a/src/plugin-sdk/outbound-media.test.ts
+++ b/src/plugin-sdk/outbound-media.test.ts
@@ -72,4 +72,35 @@ describe("loadOutboundMediaFromUrl", () => {
       hostReadCapability: true,
     });
   });
+
+  it("rejects host read capability without explicit local roots", async () => {
+    await expect(
+      loadOutboundMediaFromUrl("/Users/peter/Pictures/image.png", {
+        maxBytes: 2048,
+        mediaReadFile: async () => Buffer.from("x"),
+      }),
+    ).rejects.toThrow("Host media read requires explicit localRoots");
+  });
+
+  it("allows explicit any opt-in for host read capability", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("x"));
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("x"),
+      kind: "image",
+      contentType: "image/png",
+    });
+
+    await loadOutboundMediaFromUrl("/Users/peter/Pictures/image.png", {
+      maxBytes: 2048,
+      mediaLocalRoots: "any",
+      mediaReadFile,
+    });
+
+    expect(loadWebMediaMock).toHaveBeenCalledWith("/Users/peter/Pictures/image.png", {
+      maxBytes: 2048,
+      localRoots: "any",
+      readFile: mediaReadFile,
+      hostReadCapability: true,
+    });
+  });
 });

--- a/src/plugin-sdk/outbound-media.ts
+++ b/src/plugin-sdk/outbound-media.ts
@@ -4,7 +4,7 @@ import { loadWebMedia } from "./web-media.js";
 export type OutboundMediaLoadOptions = {
   maxBytes?: number;
   mediaAccess?: OutboundMediaAccess;
-  mediaLocalRoots?: readonly string[];
+  mediaLocalRoots?: readonly string[] | "any";
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
 };
 


### PR DESCRIPTION
Closes #66635

## Summary

- When the agent generates media files directly in the workspace (e.g. `<workspaceDir>/exports/images/chart.png`), the auto-reply pipeline silently drops them because `isAllowedAbsoluteReplyMediaPath` only accepted paths under the narrow `<workspaceDir>/.openclaw/media` subtree.
- This caused WhatsApp (and all other channel) auto-reply `MEDIA:/path` delivery to fail, while manual `openclaw message send --media` succeeded because it bypasses this path check entirely.
- Widened the allow-list to include the workspace directory itself and the sandbox root as trusted roots, matching the trust boundary the agent already operates within.
- Paths outside all trusted roots (workspace, sandbox, managed global media, OpenClaw temp dir) are still rejected.

## Changes

- `src/auto-reply/reply/reply-media-paths.ts`: Added workspace dir and sandbox root as allowed absolute path roots in `isAllowedAbsoluteReplyMediaPath`.
- `src/auto-reply/reply/reply-media-paths.test.ts`: Added 3 new tests -- workspace-rooted path allowed, sandbox-rooted path allowed, paths outside all roots still dropped.

## Test plan

- [x] All 13 tests in `reply-media-paths.test.ts` pass (10 existing + 3 new)
- [x] All 5 tests in `reply-delivery.test.ts` continue to pass
- [x] New test verifies workspace-rooted absolute path like `/home/user/.openclaw/workspace/exports/images/chart.png` is accepted
- [x] New test verifies sandbox-rooted absolute path is accepted
- [x] New test verifies paths outside all trusted roots (e.g. `/etc/passwd`) are still rejected

## Risks and Mitigations

- **Risk**: Widening the allow-list could permit unintended file access.
  - **Mitigation**: Only the agents own workspace directory and sandbox root are added -- these are already the directories the agent has full read/write access to. Paths outside all trusted roots are still blocked. The volatile-media persistence logic (`buildVolatileReplyMediaRoots`) is unchanged, so only the security allow-list is widened, not the persistence behavior.

-- [Joel Nishanth](https://offlyn.ai) - [offlyn.AI](https://offlyn.ai)
