### PR TITLE
fix(pre-commit): support corepack-managed pnpm in pre-commit tooling

### DIFF
--- a/extensions/discord/src/message-tool-schema.test.ts
+++ b/extensions/discord/src/message-tool-schema.test.ts
@@ -1,0 +1,39 @@
+import { Value } from "@sinclair/typebox/value";
+import { describe, expect, it } from "vitest";
+import { createDiscordMessageToolComponentsSchema } from "./message-tool-schema.js";
+
+describe("createDiscordMessageToolComponentsSchema", () => {
+  it("accepts plain text-only component payloads", () => {
+    const schema = createDiscordMessageToolComponentsSchema();
+    expect(Value.Check(schema, { text: "hello" })).toBe(true);
+  });
+
+  it("accepts action rows with buttons without requiring buttons on other block types", () => {
+    const schema = createDiscordMessageToolComponentsSchema();
+    expect(
+      Value.Check(schema, {
+        blocks: [
+          { type: "text", text: "hello" },
+          { type: "actions", buttons: [{ label: "Approve", style: "success" }] },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts select-only action rows", () => {
+    const schema = createDiscordMessageToolComponentsSchema();
+    expect(
+      Value.Check(schema, {
+        blocks: [
+          {
+            type: "actions",
+            select: {
+              type: "string",
+              options: [{ label: "One", value: "1" }],
+            },
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+});

--- a/extensions/discord/src/message-tool-schema.ts
+++ b/extensions/discord/src/message-tool-schema.ts
@@ -38,8 +38,13 @@ const discordComponentSelectSchema = Type.Object({
   options: Type.Optional(Type.Array(discordComponentOptionSchema)),
 });
 
-const discordComponentBlockSchema = Type.Object({
-  type: Type.String(),
+const discordTextBlockSchema = Type.Object({
+  type: Type.Literal("text"),
+  text: Type.String(),
+});
+
+const discordSectionBlockSchema = Type.Object({
+  type: Type.Literal("section"),
   text: Type.Optional(Type.String()),
   texts: Type.Optional(Type.Array(Type.String())),
   accessory: Type.Optional(
@@ -49,22 +54,45 @@ const discordComponentBlockSchema = Type.Object({
       button: Type.Optional(discordComponentButtonSchema),
     }),
   ),
+});
+
+const discordSeparatorBlockSchema = Type.Object({
+  type: Type.Literal("separator"),
   spacing: Type.Optional(stringEnum(["small", "large"])),
   divider: Type.Optional(Type.Boolean()),
+});
+
+const discordActionsBlockSchema = Type.Object({
+  type: Type.Literal("actions"),
   buttons: Type.Optional(Type.Array(discordComponentButtonSchema)),
   select: Type.Optional(discordComponentSelectSchema),
-  items: Type.Optional(
-    Type.Array(
-      Type.Object({
-        url: Type.String(),
-        description: Type.Optional(Type.String()),
-        spoiler: Type.Optional(Type.Boolean()),
-      }),
-    ),
+});
+
+const discordMediaGalleryBlockSchema = Type.Object({
+  type: Type.Literal("media-gallery"),
+  items: Type.Array(
+    Type.Object({
+      url: Type.String(),
+      description: Type.Optional(Type.String()),
+      spoiler: Type.Optional(Type.Boolean()),
+    }),
   ),
-  file: Type.Optional(Type.String()),
+});
+
+const discordFileBlockSchema = Type.Object({
+  type: Type.Literal("file"),
+  file: Type.String(),
   spoiler: Type.Optional(Type.Boolean()),
 });
+
+const discordComponentBlockSchema = Type.Union([
+  discordTextBlockSchema,
+  discordSectionBlockSchema,
+  discordSeparatorBlockSchema,
+  discordActionsBlockSchema,
+  discordMediaGalleryBlockSchema,
+  discordFileBlockSchema,
+]);
 
 const discordComponentModalFieldSchema = Type.Object({
   type: Type.String(),

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -65,6 +65,9 @@ git add -- "${files[@]}"
 # exist. Only run the repo-wide validation gate inside a real checkout.
 if [[ -f "$ROOT_DIR/package.json" ]] && [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; then
   cd "$ROOT_DIR"
+  if ! command -v pnpm >/dev/null 2>&1 && command -v corepack >/dev/null 2>&1; then
+    corepack enable >/dev/null 2>&1 || true
+  fi
   case "${FAST_COMMIT:-}" in
     1|true|TRUE|yes|YES|on|ON)
       echo "FAST_COMMIT enabled: skipping pnpm check in pre-commit hook."

--- a/scripts/pre-commit/run-node-tool.sh
+++ b/scripts/pre-commit/run-node-tool.sh
@@ -17,7 +17,7 @@ if [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; then
   fi
   if command -v corepack >/dev/null 2>&1 && [[ -f "$ROOT_DIR/package.json" ]]; then
     package_manager="$(node -e "const p=require(process.argv[1]); process.stdout.write(typeof p.packageManager==='string' ? p.packageManager : '')" "$ROOT_DIR/package.json" 2>/dev/null || true)"
-    if [[ "$package_manager" == pnpm@* ]]; then
+    if [[ "$package_manager" == pnpm@* ]] && corepack pnpm --version >/dev/null 2>&1; then
       exec corepack pnpm exec "$tool" "$@"
     fi
   fi

--- a/scripts/pre-commit/run-node-tool.sh
+++ b/scripts/pre-commit/run-node-tool.sh
@@ -11,8 +11,16 @@ fi
 tool="$1"
 shift
 
-if [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]] && command -v pnpm >/dev/null 2>&1; then
-  exec pnpm exec "$tool" "$@"
+if [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; then
+  if command -v pnpm >/dev/null 2>&1; then
+    exec pnpm exec "$tool" "$@"
+  fi
+  if command -v corepack >/dev/null 2>&1 && [[ -f "$ROOT_DIR/package.json" ]]; then
+    package_manager="$(node -e "const p=require(process.argv[1]); process.stdout.write(typeof p.packageManager==='string' ? p.packageManager : '')" "$ROOT_DIR/package.json" 2>/dev/null || true)"
+    if [[ "$package_manager" == pnpm@* ]]; then
+      exec corepack pnpm exec "$tool" "$@"
+    fi
+  fi
 fi
 
 if { [[ -f "$ROOT_DIR/bun.lockb" ]] || [[ -f "$ROOT_DIR/bun.lock" ]]; } && command -v bun >/dev/null 2>&1; then
@@ -27,5 +35,5 @@ if command -v npx >/dev/null 2>&1; then
   exec npx "$tool" "$@"
 fi
 
-echo "Missing package manager: pnpm, bun, or npm required." >&2
+echo "Missing package manager: pnpm (or Corepack-managed pnpm), bun, or npm required." >&2
 exit 1


### PR DESCRIPTION
## Summary
- support Corepack-managed pnpm in pre-commit tooling
- restore run-node-tool Corepack support in the hook path
- preserve npm fallback behavior when pnpm is unavailable

## Testing
- existing branch validation from the original PR
