### PR TITLE
fix: forward toolsAllow through embedded runner call chain

### DIFF
--- a/src/agents/pi-embedded-runner/run.tools-allow-forwarding.test.ts
+++ b/src/agents/pi-embedded-runner/run.tools-allow-forwarding.test.ts
@@ -1,0 +1,64 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+
+describe("runEmbeddedPiAgent toolsAllow forwarding", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+  });
+
+  it("forwards toolsAllow to the attempt when set", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-tools-allow-forward",
+      toolsAllow: ["exec", "read"],
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolsAllow: ["exec", "read"],
+      }),
+    );
+  });
+
+  it("forwards undefined toolsAllow when not set (backward compat)", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-tools-allow-undefined",
+    });
+
+    const params = mockedRunEmbeddedAttempt.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(params.toolsAllow).toBeUndefined();
+  });
+
+  it("forwards an empty toolsAllow array without coercing to undefined", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-tools-allow-empty",
+      toolsAllow: [],
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolsAllow: [],
+      }),
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -660,6 +660,7 @@ export async function runEmbeddedPiAgent(
             imageOrder: params.imageOrder,
             clientTools: params.clientTools,
             disableTools: params.disableTools,
+            toolsAllow: params.toolsAllow,
             provider,
             modelId,
             model: applyAuthHeaderOverride(


### PR DESCRIPTION
## Summary

- `runEmbeddedPiAgent` accepts a `toolsAllow` parameter but never forwarded it to `runEmbeddedAttemptWithBackend`, causing sub-agents to receive the full ~37k-token tool list instead of a filtered ~3k-token subset
- Added the missing `toolsAllow: params.toolsAllow` to the params object in `run.ts` line 663
- The attempt layer (`attempt.ts`) already handles `toolsAllow` correctly for both tool filtering (lines 542-544) and prompt mode optimization (lines 708-710) -- it just never received the value

## The bug

When a caller sets `toolsAllow: ["exec", "read"]` on `runEmbeddedPiAgent`, the orchestration layer (`run.ts`) builds a ~90-field params object for `runEmbeddedAttemptWithBackend` but omits `toolsAllow`. The attempt layer has the filtering logic but always sees `undefined`, so every sub-agent gets ALL tools. This causes 10x token bloat and 30s timeouts on constrained runs.

## Fix

One line: `toolsAllow: params.toolsAllow,` added to the params object at the call site.

## Test plan

- [x] New test: `toolsAllow` is forwarded when set (non-empty array)
- [x] New test: `toolsAllow` remains `undefined` when not set (backward compat)
- [x] New test: empty `toolsAllow` array is forwarded without coercion
- [x] Existing overflow compaction tests pass (13/13)
- [x] Existing attempt tests pass (95/95)
- [x] Pre-commit hooks pass (type check, lint, import cycles, conflict markers)

Fixes #66581
Complementary to #60842 (config-level allowlist operates at a different layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)