### PR TITLE
Fix manage flags section

### DIFF
--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -189,13 +189,13 @@ himalaya message delete 42
 Add flag:
 
 ```bash
-himalaya flag add 42 --flag seen
+himalaya flag add 42 seen
 ```
 
 Remove flag:
 
 ```bash
-himalaya flag remove 42 --flag seen
+himalaya flag remove 42 seen
 ```
 
 ## Multiple Accounts


### PR DESCRIPTION
Removed invalid '--flag' option from manage flags section in skill.

This flag seems to be outdated (or halluzinated) and throws an error on a fresh install.

## Summary

```sh
root@agent:~# himalaya flag add 2 --flag seen
error: unexpected argument '--flag' found

  tip: to pass '--flag' as a value, use '-- --flag'

Usage: himalaya flag add <ID-OR-FLAG>...

For more information, try '--help'.

root@agent:~# himalaya flag add 2 seen
Flag(s) seen successfully added!
```

**I didn't check other commands/arguments yet.**

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra