### PR TITLE
fix(agents): honor explicit strict-agentic execution contract for all providers

### DIFF
--- a/src/agents/execution-contract.test.ts
+++ b/src/agents/execution-contract.test.ts
@@ -171,7 +171,7 @@ describe("resolveEffectiveExecutionContract", () => {
       ).toBe("default");
     });
 
-    it("collapses explicit strict-agentic to default on an unsupported lane", () => {
+    it("honors explicit strict-agentic on unsupported providers", () => {
       const config: OpenClawConfig = {
         agents: {
           defaults: {
@@ -187,7 +187,26 @@ describe("resolveEffectiveExecutionContract", () => {
           provider: unsupportedProvider,
           modelId: "claude-opus-4-6",
         }),
-      ).toBe("default");
+      ).toBe("strict-agentic");
+    });
+
+    it("honors explicit strict-agentic for LM Studio with local models", () => {
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            embeddedPi: {
+              executionContract: "strict-agentic",
+            },
+          },
+        },
+      };
+      expect(
+        resolveEffectiveExecutionContract({
+          config,
+          provider: "lmstudio",
+          modelId: "qwen/qwen3.5-35b-a3b",
+        }),
+      ).toBe("strict-agentic");
     });
   });
 

--- a/src/agents/execution-contract.ts
+++ b/src/agents/execution-contract.ts
@@ -59,27 +59,21 @@ export function isStrictAgenticSupportedProviderModel(params: {
 /**
  * Returns the effective execution contract for an embedded Pi run.
  *
- * strict-agentic is a GPT-5-family openai/openai-codex-only runtime contract,
- * so an unsupported provider/model pair always collapses to `"default"`
- * regardless of what the caller passed or what config says — the contract
- * is inert off-provider. Within the supported lane, the behavior matrix is:
+ * The behavior matrix is:
  *
- * - Supported provider/model + explicit `"strict-agentic"` in config
- *   (defaults or per-agent override) ⇒ `"strict-agentic"`.
- * - Supported provider/model + explicit `"default"` in config ⇒ `"default"`
- *   (opt-out honored).
- * - Supported provider/model + unspecified ⇒ `"strict-agentic"` so the
- *   no-stall completion-gate criterion applies to out-of-the-box GPT-5 runs
- *   without requiring every user to set the flag.
- * - Unsupported provider/model (anything that is not openai or openai-codex
- *   with a gpt-5-family model id) ⇒ `"default"`, even when the config
- *   explicitly sets `"strict-agentic"`. The retry guard and blocked-exit
- *   helpers all check this lane again, so an explicit `"strict-agentic"`
- *   on an unsupported lane is a no-op rather than a hard failure.
+ * - Explicit `"strict-agentic"` in config (defaults or per-agent override)
+ *   ⇒ `"strict-agentic"` regardless of provider. This lets non-OpenAI
+ *   providers (LM Studio, Ollama, etc.) opt in to the planning-only retry
+ *   guard and completion-gate behavior.
+ * - Explicit `"default"` in config ⇒ `"default"` (opt-out honored).
+ * - Supported provider/model (GPT-5-family on openai/openai-codex) +
+ *   unspecified ⇒ `"strict-agentic"` so out-of-the-box GPT-5 runs get
+ *   the no-stall completion-gate without requiring manual opt-in.
+ * - Unsupported provider/model + unspecified ⇒ `"default"`.
  *
- * This means explicit opt-out still works, but the gate criterion
- * "GPT-5.4 no longer stalls after planning" now covers unconfigured
- * installations, not only users who opted in manually.
+ * This means explicit opt-in/out always wins, auto-activation covers
+ * unconfigured GPT-5 installations, and other providers can opt in
+ * when the operator knows their model benefits from the retry guard.
  */
 export function resolveEffectiveExecutionContract(params: {
   config?: OpenClawConfig;
@@ -94,22 +88,24 @@ export function resolveEffectiveExecutionContract(params: {
     agentId: params.agentId ?? undefined,
   });
   const explicit = resolveAgentExecutionContract(params.config, sessionAgentId);
-  // strict-agentic is a GPT-5-family openai/openai-codex runtime contract
-  // regardless of whether it was set explicitly or auto-activated. On an
-  // unsupported provider/model pair the contract is inert either way, so
-  // the effective value collapses to "default".
+  // Explicit opt-in is honored regardless of provider — this lets non-OpenAI
+  // providers (LM Studio, Ollama, etc.) benefit from the planning-only retry
+  // guard when the operator deliberately configures strict-agentic.
+  if (explicit === "strict-agentic") {
+    return "strict-agentic";
+  }
+  // Explicit opt-out is always honored.
+  if (explicit === "default") {
+    return "default";
+  }
+  // Auto-activate for supported GPT-5-family provider/model pairs when the
+  // config is unspecified, so out-of-the-box GPT-5 runs get the no-stall
+  // completion-gate without requiring manual opt-in.
   const supported = isStrictAgenticSupportedProviderModel({
     provider: params.provider,
     modelId: params.modelId,
   });
-  if (!supported) {
-    return "default";
-  }
-  if (explicit === "default") {
-    return "default";
-  }
-  // Explicit strict-agentic OR unspecified-but-supported → strict-agentic.
-  return "strict-agentic";
+  return supported ? "strict-agentic" : "default";
 }
 
 export function isStrictAgenticExecutionContractActive(params: {

--- a/src/agents/openclaw-tools.registration.ts
+++ b/src/agents/openclaw-tools.registration.ts
@@ -1,5 +1,8 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { isStrictAgenticExecutionContractActive } from "./execution-contract.js";
+import {
+  isStrictAgenticExecutionContractActive,
+  isStrictAgenticSupportedProviderModel,
+} from "./execution-contract.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 export function collectPresentOpenClawTools(
@@ -19,11 +22,20 @@ export function isUpdatePlanToolEnabledForOpenClawTools(params: {
   if (configured !== undefined) {
     return configured;
   }
-  return isStrictAgenticExecutionContractActive({
-    config: params.config,
-    sessionKey: params.agentSessionKey,
-    agentId: params.agentId,
-    provider: params.modelProvider,
-    modelId: params.modelId,
-  });
+  // Auto-enable update_plan only for supported provider/model combinations
+  // where strict-agentic is active. Operators on other providers can use
+  // tools.experimental.planTool: true to force-enable.
+  return (
+    isStrictAgenticExecutionContractActive({
+      config: params.config,
+      sessionKey: params.agentSessionKey,
+      agentId: params.agentId,
+      provider: params.modelProvider,
+      modelId: params.modelId,
+    }) &&
+    isStrictAgenticSupportedProviderModel({
+      provider: params.modelProvider,
+      modelId: params.modelId,
+    })
+  );
 }

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -670,6 +670,49 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(instruction).toContain("Do not recap or restate the plan");
   });
 
+  it("enables planning-only retry for non-OpenAI providers with strict-agentic contract", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      provider: "lmstudio",
+      modelId: "qwen/qwen3.5-35b-a3b",
+      executionContract: "strict-agentic",
+      prompt: "Run the morning research pipeline.",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
+      }),
+    });
+
+    expect(retryInstruction).toContain("Do not restate the plan");
+  });
+
+  it("does not enable planning-only retry for non-OpenAI providers with default contract", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      provider: "lmstudio",
+      modelId: "qwen/qwen3.5-35b-a3b",
+      executionContract: "default",
+      prompt: "Run the morning research pipeline.",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
+      }),
+    });
+
+    expect(retryInstruction).toBeNull();
+  });
+
+  it("enables ack-turn fast-path for non-OpenAI providers with strict-agentic contract", () => {
+    const instruction = resolveAckExecutionFastPathInstruction({
+      provider: "lmstudio",
+      modelId: "qwen/qwen3.5-35b-a3b",
+      executionContract: "strict-agentic",
+      prompt: "go ahead",
+    });
+
+    expect(instruction).toContain("Do not recap or restate the plan");
+  });
+
   it("extracts structured steps from planning-only narration", () => {
     expect(
       extractPlanningOnlyPlanDetails(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -473,6 +473,7 @@ export async function runEmbeddedPiAgent(
       const ackExecutionFastPathInstruction = resolveAckExecutionFastPathInstruction({
         provider,
         modelId,
+        executionContract: configuredExecutionContract,
         prompt: params.prompt,
       });
       let rateLimitProfileRotations = 0;
@@ -1675,6 +1676,7 @@ export async function runEmbeddedPiAgent(
           const nextPlanningOnlyRetryInstruction = resolvePlanningOnlyRetryInstruction({
             provider,
             modelId,
+            executionContract: configuredExecutionContract,
             prompt: params.prompt,
             aborted,
             timedOut,
@@ -1683,6 +1685,7 @@ export async function runEmbeddedPiAgent(
           const nextReasoningOnlyRetryInstruction = resolveReasoningOnlyRetryInstruction({
             provider: activeErrorContext.provider,
             modelId: activeErrorContext.model,
+            executionContract: configuredExecutionContract,
             aborted,
             timedOut,
             attempt,
@@ -1690,6 +1693,7 @@ export async function runEmbeddedPiAgent(
           const nextEmptyResponseRetryInstruction = resolveEmptyResponseRetryInstruction({
             provider: activeErrorContext.provider,
             modelId: activeErrorContext.model,
+            executionContract: configuredExecutionContract,
             payloadCount,
             aborted,
             timedOut,

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -278,6 +278,7 @@ function isEmptyResponseAssistantTurn(params: {
 export function resolveReasoningOnlyRetryInstruction(params: {
   provider?: string;
   modelId?: string;
+  executionContract?: string;
   aborted: boolean;
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
@@ -298,6 +299,7 @@ export function resolveReasoningOnlyRetryInstruction(params: {
     !shouldApplyPlanningOnlyRetryGuard({
       provider: params.provider,
       modelId: params.modelId,
+      executionContract: params.executionContract,
     })
   ) {
     return null;
@@ -320,6 +322,7 @@ export function resolveReasoningOnlyRetryInstruction(params: {
 export function resolveEmptyResponseRetryInstruction(params: {
   provider?: string;
   modelId?: string;
+  executionContract?: string;
   payloadCount: number;
   aborted: boolean;
   timedOut: boolean;
@@ -341,6 +344,7 @@ export function resolveEmptyResponseRetryInstruction(params: {
     !shouldApplyPlanningOnlyRetryGuard({
       provider: params.provider,
       modelId: params.modelId,
+      executionContract: params.executionContract,
     })
   ) {
     return null;
@@ -361,7 +365,11 @@ export function resolveEmptyResponseRetryInstruction(params: {
 function shouldApplyPlanningOnlyRetryGuard(params: {
   provider?: string;
   modelId?: string;
+  executionContract?: string;
 }): boolean {
+  if (params.executionContract === "strict-agentic") {
+    return true;
+  }
   return isStrictAgenticSupportedProviderModel({
     provider: params.provider,
     modelId: params.modelId,
@@ -400,12 +408,14 @@ function isLikelyActionableUserPrompt(text: string): boolean {
 export function resolveAckExecutionFastPathInstruction(params: {
   provider?: string;
   modelId?: string;
+  executionContract?: string;
   prompt: string;
 }): string | null {
   if (
     !shouldApplyPlanningOnlyRetryGuard({
       provider: params.provider,
       modelId: params.modelId,
+      executionContract: params.executionContract,
     }) ||
     !isLikelyExecutionAckPrompt(params.prompt)
   ) {
@@ -518,6 +528,7 @@ export function resolvePlanningOnlyRetryLimit(
 export function resolvePlanningOnlyRetryInstruction(params: {
   provider?: string;
   modelId?: string;
+  executionContract?: string;
   prompt?: string;
   aborted: boolean;
   timedOut: boolean;
@@ -534,6 +545,7 @@ export function resolvePlanningOnlyRetryInstruction(params: {
     !shouldApplyPlanningOnlyRetryGuard({
       provider: params.provider,
       modelId: params.modelId,
+      executionContract: params.executionContract,
     }) ||
     (typeof params.prompt === "string" && !isLikelyActionableUserPrompt(params.prompt)) ||
     params.aborted ||

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -251,8 +251,8 @@ export type AgentDefaultsConfig = {
     projectSettingsPolicy?: "trusted" | "sanitize" | "ignore";
     /**
      * Embedded Pi execution contract:
-     * - default: keep the standard runner behavior
-     * - strict-agentic: on OpenAI/OpenAI Codex GPT-5-family runs, keep acting until hitting a real blocker
+     * - default: keep the standard runner behavior (auto-detects GPT-5-family for planning-only retry)
+     * - strict-agentic: keep acting until hitting a real blocker (works with any provider)
      */
     executionContract?: EmbeddedPiExecutionContract;
   };


### PR DESCRIPTION
## Problem

`executionContract: "strict-agentic"` is a user-facing config option, but it is silently ignored for any provider that isn't OpenAI/GPT-5. `resolveEffectiveExecutionContract()` collapses non-OpenAI providers to `"default"` *before* checking the explicit config value, and `shouldApplyPlanningOnlyRetryGuard()` delegates to `isStrictAgenticSupportedProviderModel()` which rejects non-OpenAI providers unconditionally.

This means operators running LM Studio, Ollama, or other OpenAI-compatible providers cannot opt in to the planning-only retry guard — their model narrates a plan ("I'll read the file next…") and the runner treats that as a completed turn.

## Root cause

In `resolveEffectiveExecutionContract()`, the provider-support check runs first:

```typescript
if (!supported) {
  return "default";  // explicit config never reached
}
```

The auto-detection logic (GPT-5 on openai/openai-codex → auto-activate) was correct, but it blocked explicit opt-in for other providers.

## Fix

**`execution-contract.ts`** — check explicit config *before* provider support:

```
Explicit strict-agentic + any provider       → strict-agentic  (NEW)
Explicit default + any provider              → default         (unchanged)
Unspecified + GPT-5-family                   → strict-agentic  (auto-detect, unchanged)
Unspecified + other provider                 → default         (unchanged)
```

**`incomplete-turn.ts`** — add `executionContract` param to `shouldApplyPlanningOnlyRetryGuard()`. When `"strict-agentic"`, return `true` before the provider check. Threaded through all 4 callers: `resolvePlanningOnlyRetryInstruction`, `resolveReasoningOnlyRetryInstruction`, `resolveEmptyResponseRetryInstruction`, `resolveAckExecutionFastPathInstruction`.

**`run.ts`** — pass `configuredExecutionContract` (the raw config value, not the auto-detected `executionContract`) to the guard functions. This ensures auto-detected strict-agentic on GPT-5 does *not* bypass the response-provider mismatch check in the reasoning-only and empty-response guards — only explicit operator intent does.

**`types.agent-defaults.ts`** — update JSDoc to reflect that `strict-agentic` works with any provider.

## Behavioral summary

| Scenario | Before | After |
|----------|--------|-------|
| GPT-5 + unspecified config | strict-agentic (auto) | **unchanged** |
| GPT-5 + explicit `"strict-agentic"` | strict-agentic | **unchanged** |
| GPT-5 + explicit `"default"` | default (opt-out) | **unchanged** |
| LM Studio + explicit `"strict-agentic"` | **silently collapsed to default** | **strict-agentic** |
| LM Studio + unspecified config | default | **unchanged** |
| GPT-5 auto-detect + response-provider mismatch | no retry (provider check) | **unchanged** |

No change for users who haven't set `executionContract`. No change to auto-detection behavior.

## Test plan

- [x] Updated existing `execution-contract.test.ts` — explicit strict-agentic on unsupported providers now returns `"strict-agentic"` (was `"default"`)
- [x] Added `execution-contract.test.ts` case for LM Studio + explicit strict-agentic
- [x] Added 3 `run.incomplete-turn.test.ts` unit tests: LM Studio planning-only retry (strict-agentic vs default), ack fast-path with strict-agentic
- [x] All 66 existing + new tests pass
- [x] Existing provider-mismatch integration test still passes (auto-detected contract does not bypass response-provider check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)