### PR TITLE
fix: guard against undefined path in formatDocsLink

### DIFF
--- a/src/terminal/links.ts
+++ b/src/terminal/links.ts
@@ -9,11 +9,13 @@ export function formatDocsLink(
   label?: string,
   opts?: { fallback?: string; force?: boolean },
 ): string {
-  const trimmed = path.trim();
-  const docsRoot = resolveDocsRoot();
+  const trimmed = (path ?? "").trim();
+  if (!trimmed) {
+    return opts?.fallback ?? label ?? "";
+  }
   const url = trimmed.startsWith("http")
     ? trimmed
-    : `${docsRoot}${trimmed.startsWith("/") ? trimmed : `/${trimmed}`}`;
+    : `${resolveDocsRoot()}${trimmed.startsWith("/") ? trimmed : `/${trimmed}`}`;
   return formatTerminalLink(label ?? url, url, {
     fallback: opts?.fallback ?? url,
     force: opts?.force,


### PR DESCRIPTION
## Summary
Fix TypeError crash in `openclaw configure` and onboarding when channel docs path is undefined.

## Root Cause
`formatChannelSelectionLine` passes `meta.docsPath` to `formatDocsLink`, but `docsPath` can be undefined for some channels. `formatDocsLink` calls `path.trim()` on the undefined value, throwing `TypeError: Cannot read properties of undefined (reading 'trim')`.

## Fix
Added nullish coalescing guard `(path ?? "")` and early return with fallback when trimmed result is empty.

## Test Plan
- [ ] `openclaw configure` wizard no longer crashes on channels without docsPath
- [ ] Onboarding channel selection no longer crashes
- [ ] Existing formatDocsLink callers continue to work

Closes openclaw#66718
Closes openclaw#66693