### PR TITLE
fix(node-host): allow absolute-path native binaries through approval binder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/security: enforce `localRoots` containment on the webchat audio embedding path. (#67298) Thanks @pgondhi987.
 - Webchat/security: reject remote-host `file://` URLs in the media embedding path. (#67293) Thanks @pgondhi987.
 - Dreaming/memory-core: use the ingestion day, not the source file day, for daily recall dedupe so repeat sweeps of the same daily note can increment `dailyCount` across days instead of stalling at `1`. (#67091) Thanks @Bartok9.
+- Node-host/tools.exec: let approval binding distinguish known native binaries from mutable shell payload files, while still fail-closing unknown or racy file probes so absolute-path node-host commands like `/usr/bin/whoami` no longer get rejected as unsafe interpreter/runtime commands. (#66731) Thanks @tmimmanuel.
 
 ## 2026.4.14
 

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { formatExecCommand } from "../infra/system-run-command.js";
 import {
   buildSystemRunApprovalPlan,
@@ -845,6 +845,50 @@ describe("hardenApprovedExecutionPaths", () => {
       fileName: "mz-script",
       body: "MZ not really a PE file\n",
     });
+  });
+
+  it("keeps fail-closed behavior for unknown NUL-bearing headers", () => {
+    expectShellPayloadApprovalDenied({
+      tmpPrefix: "openclaw-shell-nul-header-binding-",
+      fileName: "nul-script",
+      body: "SAFE\u0000maybe-binary\n",
+    });
+  });
+
+  it("keeps fail-closed behavior when the shell payload probe stops seeing a file", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-race-binding-"));
+    try {
+      const scriptPath = path.join(tmp, "run.sh");
+      fs.writeFileSync(scriptPath, "#!/bin/sh\necho SAFE\n");
+      fs.chmodSync(scriptPath, 0o755);
+      const realStatSync = fs.statSync;
+      let targetStatCalls = 0;
+      const statSyncSpy = vi.spyOn(fs, "statSync").mockImplementation((pathLike, options) => {
+        const targetPath = typeof pathLike === "string" ? pathLike : pathLike.toString();
+        if (targetPath === scriptPath) {
+          targetStatCalls += 1;
+          if (targetStatCalls === 2) {
+            return realStatSync(tmp, options);
+          }
+        }
+        return realStatSync(pathLike, options);
+      });
+      try {
+        const prepared = buildSystemRunApprovalPlan({
+          command: ["/bin/sh", "-lc", scriptPath],
+          rawCommand: scriptPath,
+          cwd: tmp,
+        });
+        expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
+      } finally {
+        statSyncSpy.mockRestore();
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it.each(unsafeRuntimeInvocationCases)("$name", (testCase) => {

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -122,6 +122,19 @@ function withFakeRuntimeBins<T>(params: {
   }
 }
 
+function resolveNativeBinaryFixturePath(): string {
+  for (const candidate of ["/bin/ls", "/usr/bin/ls", "/bin/echo", "/usr/bin/printf"]) {
+    try {
+      if (fs.statSync(candidate).isFile()) {
+        return candidate;
+      }
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("expected a native binary fixture path");
+}
+
 function expectMutableFileOperandApprovalPlan(fixture: ScriptOperandFixture, cwd: string) {
   const prepared = buildSystemRunApprovalPlan({
     command: fixture.command,
@@ -773,9 +786,10 @@ describe("hardenApprovedExecutionPaths", () => {
     if (process.platform === "win32") {
       return;
     }
+    const binaryPath = resolveNativeBinaryFixturePath();
     const prepared = buildSystemRunApprovalPlan({
-      command: ["/bin/sh", "-lc", process.execPath],
-      rawCommand: process.execPath,
+      command: ["/bin/sh", "-lc", binaryPath],
+      rawCommand: binaryPath,
       cwd: process.cwd(),
     });
     expect(prepared.ok).toBe(true);

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -823,6 +823,27 @@ describe("hardenApprovedExecutionPaths", () => {
     expect(prepared.plan.mutableFileOperand).toBeUndefined();
   });
 
+  it("keeps fail-closed behavior for relative native-binary shell payloads", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-relative-binary-binding-"));
+    try {
+      const binaryPath = resolveNativeBinaryFixturePath();
+      const relativeBinaryPath = path.join(tmp, "tool");
+      fs.copyFileSync(binaryPath, relativeBinaryPath);
+      fs.chmodSync(relativeBinaryPath, 0o755);
+      const prepared = buildSystemRunApprovalPlan({
+        command: ["/bin/sh", "-lc", "./tool"],
+        rawCommand: "./tool",
+        cwd: tmp,
+      });
+      expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("keeps fail-closed behavior for shell payloads that invoke mutable script files", () => {
     expectShellPayloadApprovalDenied({
       tmpPrefix: "openclaw-shell-script-binding-",

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -865,6 +865,35 @@ describe("hardenApprovedExecutionPaths", () => {
     }
   });
 
+  it("keeps fail-closed behavior for symlinked binaries with writable targets", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-symlink-binary-binding-"));
+    const stableDir = path.join(tmp, "stable");
+    const mutableDir = path.join(tmp, "mutable");
+    try {
+      const binaryPath = resolveNativeBinaryFixturePath();
+      fs.mkdirSync(stableDir);
+      fs.mkdirSync(mutableDir);
+      const targetBinaryPath = path.join(mutableDir, "tool");
+      const symlinkPath = path.join(stableDir, "tool");
+      fs.copyFileSync(binaryPath, targetBinaryPath);
+      fs.chmodSync(targetBinaryPath, 0o755);
+      fs.symlinkSync(targetBinaryPath, symlinkPath);
+      fs.chmodSync(stableDir, 0o555);
+      const prepared = buildSystemRunApprovalPlan({
+        command: ["/bin/sh", "-lc", symlinkPath],
+        rawCommand: symlinkPath,
+        cwd: tmp,
+      });
+      expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
+    } finally {
+      fs.chmodSync(stableDir, 0o755);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("keeps fail-closed behavior for shell payloads that invoke mutable script files", () => {
     expectShellPayloadApprovalDenied({
       tmpPrefix: "openclaw-shell-script-binding-",

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -769,6 +769,82 @@ describe("hardenApprovedExecutionPaths", () => {
     );
   });
 
+  it("allows shell payloads that invoke absolute-path native binaries", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const prepared = buildSystemRunApprovalPlan({
+      command: ["/bin/sh", "-lc", process.execPath],
+      rawCommand: process.execPath,
+      cwd: process.cwd(),
+    });
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) {
+      throw new Error("unreachable");
+    }
+    expect(prepared.plan.mutableFileOperand).toBeUndefined();
+  });
+
+  it("keeps fail-closed behavior for shell payloads that invoke mutable script files", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-script-binding-"));
+    try {
+      const scriptPath = path.join(tmp, "run.sh");
+      fs.writeFileSync(scriptPath, "#!/bin/sh\necho SAFE\n");
+      fs.chmodSync(scriptPath, 0o755);
+      const prepared = buildSystemRunApprovalPlan({
+        command: ["/bin/sh", "-lc", scriptPath],
+        rawCommand: scriptPath,
+        cwd: tmp,
+      });
+      expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps fail-closed behavior for empty shell payload files", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-empty-binding-"));
+    try {
+      const scriptPath = path.join(tmp, "empty");
+      fs.writeFileSync(scriptPath, "");
+      fs.chmodSync(scriptPath, 0o755);
+      const prepared = buildSystemRunApprovalPlan({
+        command: ["/bin/sh", "-lc", scriptPath],
+        rawCommand: scriptPath,
+        cwd: tmp,
+      });
+      expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat weak MZ text headers as native binaries", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-mz-text-binding-"));
+    try {
+      const scriptPath = path.join(tmp, "mz-script");
+      fs.writeFileSync(scriptPath, "MZ not really a PE file\n");
+      fs.chmodSync(scriptPath, 0o755);
+      const prepared = buildSystemRunApprovalPlan({
+        command: ["/bin/sh", "-lc", scriptPath],
+        rawCommand: scriptPath,
+        cwd: tmp,
+      });
+      expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it.each(unsafeRuntimeInvocationCases)("$name", (testCase) => {
     withFakeRuntimeBin({
       binName: testCase.binName,

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -135,6 +135,30 @@ function resolveNativeBinaryFixturePath(): string {
   throw new Error("expected a native binary fixture path");
 }
 
+function expectShellPayloadApprovalDenied(params: {
+  tmpPrefix: string;
+  fileName: string;
+  body: string;
+}) {
+  if (process.platform === "win32") {
+    return;
+  }
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), params.tmpPrefix));
+  try {
+    const scriptPath = path.join(tmp, params.fileName);
+    fs.writeFileSync(scriptPath, params.body);
+    fs.chmodSync(scriptPath, 0o755);
+    const prepared = buildSystemRunApprovalPlan({
+      command: ["/bin/sh", "-lc", scriptPath],
+      rawCommand: scriptPath,
+      cwd: tmp,
+    });
+    expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 function expectMutableFileOperandApprovalPlan(fixture: ScriptOperandFixture, cwd: string) {
   const prepared = buildSystemRunApprovalPlan({
     command: fixture.command,
@@ -800,63 +824,27 @@ describe("hardenApprovedExecutionPaths", () => {
   });
 
   it("keeps fail-closed behavior for shell payloads that invoke mutable script files", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-script-binding-"));
-    try {
-      const scriptPath = path.join(tmp, "run.sh");
-      fs.writeFileSync(scriptPath, "#!/bin/sh\necho SAFE\n");
-      fs.chmodSync(scriptPath, 0o755);
-      const prepared = buildSystemRunApprovalPlan({
-        command: ["/bin/sh", "-lc", scriptPath],
-        rawCommand: scriptPath,
-        cwd: tmp,
-      });
-      expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
+    expectShellPayloadApprovalDenied({
+      tmpPrefix: "openclaw-shell-script-binding-",
+      fileName: "run.sh",
+      body: "#!/bin/sh\necho SAFE\n",
+    });
   });
 
   it("keeps fail-closed behavior for empty shell payload files", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-empty-binding-"));
-    try {
-      const scriptPath = path.join(tmp, "empty");
-      fs.writeFileSync(scriptPath, "");
-      fs.chmodSync(scriptPath, 0o755);
-      const prepared = buildSystemRunApprovalPlan({
-        command: ["/bin/sh", "-lc", scriptPath],
-        rawCommand: scriptPath,
-        cwd: tmp,
-      });
-      expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
+    expectShellPayloadApprovalDenied({
+      tmpPrefix: "openclaw-shell-empty-binding-",
+      fileName: "empty",
+      body: "",
+    });
   });
 
   it("does not treat weak MZ text headers as native binaries", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-mz-text-binding-"));
-    try {
-      const scriptPath = path.join(tmp, "mz-script");
-      fs.writeFileSync(scriptPath, "MZ not really a PE file\n");
-      fs.chmodSync(scriptPath, 0o755);
-      const prepared = buildSystemRunApprovalPlan({
-        command: ["/bin/sh", "-lc", scriptPath],
-        rawCommand: scriptPath,
-        cwd: tmp,
-      });
-      expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
+    expectShellPayloadApprovalDenied({
+      tmpPrefix: "openclaw-shell-mz-text-binding-",
+      fileName: "mz-script",
+      body: "MZ not really a PE file\n",
+    });
   });
 
   it.each(unsafeRuntimeInvocationCases)("$name", (testCase) => {

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -844,6 +844,27 @@ describe("hardenApprovedExecutionPaths", () => {
     }
   });
 
+  it("keeps fail-closed behavior for writable absolute native-binary shell payloads", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-shell-absolute-binary-binding-"));
+    try {
+      const binaryPath = resolveNativeBinaryFixturePath();
+      const copiedBinaryPath = path.join(tmp, "tool");
+      fs.copyFileSync(binaryPath, copiedBinaryPath);
+      fs.chmodSync(copiedBinaryPath, 0o755);
+      const prepared = buildSystemRunApprovalPlan({
+        command: ["/bin/sh", "-lc", copiedBinaryPath],
+        rawCommand: copiedBinaryPath,
+        cwd: tmp,
+      });
+      expect(prepared).toEqual(DENIED_RUNTIME_APPROVAL);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("keeps fail-closed behavior for shell payloads that invoke mutable script files", () => {
     expectShellPayloadApprovalDenied({
       tmpPrefix: "openclaw-shell-script-binding-",

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -315,7 +315,7 @@ function isLikelyScriptLikePathSync(targetPath: string): boolean {
   try {
     stat = fs.statSync(targetPath);
   } catch {
-    return false;
+    return true;
   }
   if (!stat.isFile()) {
     return false;

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -294,7 +294,11 @@ function isKnownBinaryExecutableHeader(buffer: Buffer): boolean {
     (buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xce])) ||
       buffer.subarray(0, 4).equals(Buffer.from([0xce, 0xfa, 0xed, 0xfe])) ||
       buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xcf])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xcf, 0xfa, 0xed, 0xfe])))
+      buffer.subarray(0, 4).equals(Buffer.from([0xcf, 0xfa, 0xed, 0xfe])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xca, 0xfe, 0xba, 0xbe])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xbe, 0xba, 0xfe, 0xca])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xca, 0xfe, 0xba, 0xbf])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xbf, 0xba, 0xfe, 0xca])))
   ) {
     return true;
   }
@@ -317,7 +321,7 @@ function isLikelyScriptLikePathSync(targetPath: string): boolean {
     return true;
   }
   if (!stat.isFile()) {
-    return false;
+    return true;
   }
   let header: Buffer;
   try {
@@ -341,7 +345,7 @@ function isLikelyScriptLikePathSync(targetPath: string): boolean {
   if (isKnownBinaryExecutableHeader(header)) {
     return false;
   }
-  return !header.includes(0);
+  return true;
 }
 
 function unwrapArgvForMutableOperand(argv: string[]): {

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -285,6 +285,52 @@ function resolvesToExistingFileSync(rawOperand: string, cwd: string | undefined)
   }
 }
 
+function isKnownBinaryExecutableHeader(buffer: Buffer): boolean {
+  return (
+    buffer.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46])) ||
+    buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xce])) ||
+    buffer.subarray(0, 4).equals(Buffer.from([0xce, 0xfa, 0xed, 0xfe])) ||
+    buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xcf])) ||
+    buffer.subarray(0, 4).equals(Buffer.from([0xcf, 0xfa, 0xed, 0xfe])) ||
+    buffer.subarray(0, 2).equals(Buffer.from([0x4d, 0x5a]))
+  );
+}
+
+function isLikelyScriptLikePathSync(targetPath: string): boolean {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(targetPath);
+  } catch {
+    return false;
+  }
+  if (!stat.isFile()) {
+    return false;
+  }
+  let header: Buffer;
+  try {
+    const fd = fs.openSync(targetPath, "r");
+    try {
+      header = Buffer.alloc(256);
+      const bytesRead = fs.readSync(fd, header, 0, header.length, 0);
+      header = header.subarray(0, bytesRead);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return true;
+  }
+  if (header.length === 0) {
+    return false;
+  }
+  if (header.subarray(0, 2).equals(Buffer.from("#!"))) {
+    return true;
+  }
+  if (isKnownBinaryExecutableHeader(header)) {
+    return false;
+  }
+  return !header.includes(0);
+}
+
 function unwrapArgvForMutableOperand(argv: string[]): {
   argv: string[];
   baseIndex: number;
@@ -832,7 +878,10 @@ function shellPayloadNeedsStableBinding(shellCommand: string, cwd: string | unde
     return true;
   }
   const firstToken = readTrimmedArgToken(argv, 0);
-  return resolvesToExistingFileSync(firstToken, cwd);
+  if (!resolvesToExistingFileSync(firstToken, cwd)) {
+    return false;
+  }
+  return isLikelyScriptLikePathSync(path.resolve(cwd ?? process.cwd(), firstToken));
 }
 
 function requiresStableInterpreterApprovalBindingWithShellCommand(params: {

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -286,17 +286,31 @@ function resolvesToExistingFileSync(rawOperand: string, cwd: string | undefined)
 }
 
 function isKnownBinaryExecutableHeader(buffer: Buffer): boolean {
+  if (buffer.length >= 4 && buffer.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))) {
+    return true;
+  }
+  if (
+    buffer.length >= 4 &&
+    (buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xce])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xce, 0xfa, 0xed, 0xfe])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xcf])) ||
+      buffer.subarray(0, 4).equals(Buffer.from([0xcf, 0xfa, 0xed, 0xfe])))
+  ) {
+    return true;
+  }
+  if (buffer.length < 0x40 || !buffer.subarray(0, 2).equals(Buffer.from([0x4d, 0x5a]))) {
+    return false;
+  }
+  const peOffset = buffer.readUInt32LE(0x3c);
   return (
-    buffer.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46])) ||
-    buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xce])) ||
-    buffer.subarray(0, 4).equals(Buffer.from([0xce, 0xfa, 0xed, 0xfe])) ||
-    buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xcf])) ||
-    buffer.subarray(0, 4).equals(Buffer.from([0xcf, 0xfa, 0xed, 0xfe])) ||
-    buffer.subarray(0, 2).equals(Buffer.from([0x4d, 0x5a]))
+    peOffset >= 0 &&
+    peOffset <= buffer.length - 4 &&
+    buffer.subarray(peOffset, peOffset + 4).equals(Buffer.from([0x50, 0x45, 0x00, 0x00]))
   );
 }
 
 function isLikelyScriptLikePathSync(targetPath: string): boolean {
+  // Stat defensively in case a future caller has not already confirmed the file exists.
   let stat: fs.Stats;
   try {
     stat = fs.statSync(targetPath);
@@ -310,7 +324,7 @@ function isLikelyScriptLikePathSync(targetPath: string): boolean {
   try {
     const fd = fs.openSync(targetPath, "r");
     try {
-      header = Buffer.alloc(256);
+      header = Buffer.alloc(1024);
       const bytesRead = fs.readSync(fd, header, 0, header.length, 0);
       header = header.subarray(0, bytesRead);
     } finally {
@@ -320,7 +334,7 @@ function isLikelyScriptLikePathSync(targetPath: string): boolean {
     return true;
   }
   if (header.length === 0) {
-    return false;
+    return true;
   }
   if (header.subarray(0, 2).equals(Buffer.from("#!"))) {
     return true;

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -901,7 +901,15 @@ function shellPayloadNeedsStableBinding(shellCommand: string, cwd: string | unde
   if (!path.isAbsolute(firstToken)) {
     return true;
   }
-  return isLikelyScriptLikePathSync(path.resolve(cwd ?? process.cwd(), firstToken));
+  const resolvedPath = path.resolve(cwd ?? process.cwd(), firstToken);
+  if (
+    isWritableByCurrentProcessSync(resolvedPath) ||
+    isWritableByCurrentProcessSync(path.dirname(resolvedPath)) ||
+    hasMutableSymlinkPathComponentSync(resolvedPath)
+  ) {
+    return true;
+  }
+  return isLikelyScriptLikePathSync(resolvedPath);
 }
 
 function requiresStableInterpreterApprovalBindingWithShellCommand(params: {

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -249,6 +249,27 @@ function hasMutableSymlinkPathComponentSync(targetPath: string): boolean {
   return false;
 }
 
+function pathLooksMutableForShellPayloadSync(targetPath: string): boolean {
+  if (
+    isWritableByCurrentProcessSync(targetPath) ||
+    isWritableByCurrentProcessSync(path.dirname(targetPath)) ||
+    hasMutableSymlinkPathComponentSync(targetPath)
+  ) {
+    return true;
+  }
+  let realPath: string;
+  try {
+    realPath = fs.realpathSync(targetPath);
+  } catch {
+    return true;
+  }
+  return (
+    isWritableByCurrentProcessSync(realPath) ||
+    isWritableByCurrentProcessSync(path.dirname(realPath)) ||
+    hasMutableSymlinkPathComponentSync(realPath)
+  );
+}
+
 function shouldPinExecutableForApproval(params: {
   shellCommand: string | null;
   wrapperChain: string[] | undefined;
@@ -902,11 +923,7 @@ function shellPayloadNeedsStableBinding(shellCommand: string, cwd: string | unde
     return true;
   }
   const resolvedPath = path.resolve(cwd ?? process.cwd(), firstToken);
-  if (
-    isWritableByCurrentProcessSync(resolvedPath) ||
-    isWritableByCurrentProcessSync(path.dirname(resolvedPath)) ||
-    hasMutableSymlinkPathComponentSync(resolvedPath)
-  ) {
+  if (pathLooksMutableForShellPayloadSync(resolvedPath)) {
     return true;
   }
   return isLikelyScriptLikePathSync(resolvedPath);

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -310,7 +310,6 @@ function isKnownBinaryExecutableHeader(buffer: Buffer): boolean {
 }
 
 function isLikelyScriptLikePathSync(targetPath: string): boolean {
-  // Stat defensively in case a future caller has not already confirmed the file exists.
   let stat: fs.Stats;
   try {
     stat = fs.statSync(targetPath);

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -898,6 +898,9 @@ function shellPayloadNeedsStableBinding(shellCommand: string, cwd: string | unde
   if (!resolvesToExistingFileSync(firstToken, cwd)) {
     return false;
   }
+  if (!path.isAbsolute(firstToken)) {
+    return true;
+  }
   return isLikelyScriptLikePathSync(path.resolve(cwd ?? process.cwd(), firstToken));
 }
 


### PR DESCRIPTION
## Summary

Fix the node-host approval binder so absolute-path native binaries are not rejected as unsafe interpreter/runtime commands.

Before this change, `tools.exec` with `host=node` could fail for commands like `/usr/bin/whoami` because the shell-payload binder treated any existing file at argv[0] as requiring stable script-style binding. That was correct for mutable scripts, but wrong for native binaries.

This patch keeps the fail-closed behavior for likely script files while allowing native executables through without requiring a mutable file operand.

Fixes #66524.

## What changed

- updated `src/node-host/invoke-system-run-plan.ts`
- refined `shellPayloadNeedsStableBinding()` to distinguish:
  - script-like file payloads that should stay fail-closed
  - native binaries that should be allowed
- added lightweight executable header detection for ELF, Mach-O, and PE/COFF
- added regression tests in `src/node-host/invoke-system-run-plan.test.ts` for:
  - `/bin/sh -lc /usr/bin/whoami` succeeds
  - `/bin/sh -lc <script-path>` still fails closed

## Why

The previous logic rejected all shell payloads whose first token resolved to an existing file, which unintentionally blocked absolute-path binaries on node hosts. The `env /usr/bin/whoami` workaround reported in #66524 demonstrated that the rejection was overly broad.

This change narrows the rejection surface to mutable script-like targets rather than all file-backed commands.

## Risk

Low to medium.

The patch only affects the shell-payload stable-binding heuristic. It preserves the existing stricter behavior for script/interpreter cases and does not change allowlist, approval, or execution policy flows.

## Testing

Added regression tests for:
- absolute-path native binary payloads
- script-path payloads that must remain fail-closed

Local verification:
- `git diff --check` passed

