### PR TITLE
Plugins: expose native messageId on message_sent hook event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - macOS/gateway: add `screen.snapshot` support for macOS app nodes, including runtime plumbing, default macOS allowlisting, and docs for monitor preview flows. (#67954) Thanks @BunsDev.
+- Plugins/message_sent: expose the native channel `messageId` on the plugin SDK `message_sent` hook event (`toPluginMessageSentEvent`) so plugins can match responses, react to bot-sent messages, and audit outbound deliveries without patching compiled chunks. (#66729)
+- Docs/showcase: add a scannable hero, complete section jump links, and a responsive video grid for community examples. (#48493) Thanks @jchopard69.
+- Agents/local models: add `agents.defaults.localModelMode: "lean"` to drop heavyweight default tools like `browser`, `cron`, and `message`, reducing prompt size for weaker local-model setups without changing the normal path. Thanks @ImLukeF.
 
 ### Fixes
 

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -251,6 +251,7 @@ describe("message hook mappers", () => {
       content: "reply",
       success: false,
       error: "network error",
+      messageId: "out-1",
     });
     expect(toInternalMessageSentContext(canonical)).toEqual({
       to: "demo-chat:chat:456",
@@ -263,6 +264,38 @@ describe("message hook mappers", () => {
       messageId: "out-1",
       isGroup: true,
       groupId: "demo-chat:chat:456",
+    });
+  });
+
+  it("omits messageId from plugin sent event when not provided", () => {
+    const canonical = buildCanonicalSentMessageHookContext({
+      to: "demo-chat:chat:456",
+      content: "reply",
+      success: true,
+      channelId: "demo-chat",
+    });
+
+    expect(toPluginMessageSentEvent(canonical)).toEqual({
+      to: "demo-chat:chat:456",
+      content: "reply",
+      success: true,
+    });
+  });
+
+  it("exposes native messageId on successful plugin sent events", () => {
+    const canonical = buildCanonicalSentMessageHookContext({
+      to: "demo-chat:chat:456",
+      content: "reply",
+      success: true,
+      channelId: "demo-chat",
+      messageId: "native-msg-42",
+    });
+
+    expect(toPluginMessageSentEvent(canonical)).toEqual({
+      to: "demo-chat:chat:456",
+      content: "reply",
+      success: true,
+      messageId: "native-msg-42",
     });
   });
 });

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -307,6 +307,7 @@ export function toPluginMessageSentEvent(
     content: canonical.content,
     success: canonical.success,
     ...(canonical.error ? { error: canonical.error } : {}),
+    ...(canonical.messageId ? { messageId: canonical.messageId } : {}),
   };
 }
 

--- a/src/plugins/hook-message.types.ts
+++ b/src/plugins/hook-message.types.ts
@@ -54,4 +54,5 @@ export type PluginHookMessageSentEvent = {
   content: string;
   success: boolean;
   error?: string;
+  messageId?: string;
 };


### PR DESCRIPTION
## Summary

- **Problem:** `toPluginMessageSentEvent` strips `messageId` from the canonical sent context before dispatching the `message_sent` plugin hook, even though the channel already returned a native message id (already present on `canonical.messageId` and on the internal `toInternalMessageSentContext`). Plugins that want to react to, audit, or correlate with the just-sent message have to patch compiled JS chunks on every upgrade.
- **Why it matters:** Unblocks canary/health-check plugins, reaction plugins, and audit/logging plugins that need the native platform id of a message the bot just sent. Matches the internal hook context, which already carries `messageId`.
- **What changed:** Added optional `messageId?: string` to `PluginHookMessageSentEvent`; `toPluginMessageSentEvent` now forwards `canonical.messageId` when the channel provided one (conditional spread so the shape stays unchanged when the channel did not return an id). Covered by mapper tests.
- **What did NOT change (scope boundary):** No changes to hook dispatch/ordering, no changes to channel adapters, no change to the internal `toInternalMessageSentContext` (already correct), and the plugin-sdk API baseline (`pnpm plugin-sdk:api:check`) still passes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature

## Scope (select all touched areas)

- [x] API / contracts
- [x] Integrations

## Linked Issue/PR

- Closes #66729
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `toPluginMessageSentEvent` was introduced as a minimal plugin-facing projection of `CanonicalSentMessageHookContext`. It omitted `messageId` while the internal variant (`toInternalMessageSentContext`) retained it, so plugin SDK consumers lost the native id at the hook boundary.
- Missing detection / guardrail: The mapper test only asserted fields it cared about at the time — `messageId` was never explicitly exercised for the plugin path, so the asymmetry with the internal path went unnoticed.
- Contributing context: `canonical.messageId` has existed on `CanonicalSentMessageHookContext` the whole time — this is purely a projection bug, not a plumbing bug.

## Regression Test Plan

- Coverage level:
  - [x] Unit test
- Target test or file: `src/hooks/message-hook-mappers.test.ts`
- Scenario the test locks in:
  - `toPluginMessageSentEvent` includes `messageId` when the canonical context has one.
  - `toPluginMessageSentEvent` omits `messageId` entirely when the canonical context does not have one (so the event shape stays minimal for adapters that do not return an id).
- Why this is the smallest reliable guardrail: The bug is a pure projection issue; a unit test on the mapper catches both the regression and any future drift between the plugin and internal sent events.

## User-visible / Behavior Changes

Plugin authors listening on `message_sent` will now receive the native channel `messageId` on the event object when the underlying adapter returned one. The field is optional, so existing plugins that do not read it are unaffected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — the id was already present on the internal hook context and on `canonical`; this change only re-exposes it on the plugin-facing projection. No new data crosses a trust boundary.

## Repro + Verification

### Environment

- OS: macOS 26.4.1 (arm64)
- Runtime/container: Node 22, pnpm 10.32.1 (per repo `packageManager`)

### Steps

1. Register a plugin with a `message_sent` hook and log the incoming event.
2. Have the bot send a message through any channel that returns a native id (WhatsApp / Telegram / Discord).
3. Inspect the event object in the plugin.

### Expected

- `event.messageId` is the native channel id of the message that was just sent.

### Actual (before this PR)

- `event.messageId` is `undefined`; plugins have to patch compiled chunks of `message-hook-mappers` to recover it.

## Evidence

- `pnpm vitest run src/hooks/message-hook-mappers.test.ts` → 10/10 passing (existing 8 + 2 new).
- `pnpm vitest run src/plugins/wired-hooks-message.test.ts` → 4/4 passing (no regression on dispatch-side type usage).
- `pnpm plugin-sdk:api:check` → baseline unchanged.

## Human Verification (required)

- Verified scenarios: Focused unit runs listed above; manually inspected the diff vs `toInternalMessageSentContext` to confirm field-level parity for `messageId`.
- Edge cases checked:
  - `messageId` absent on the canonical context → plugin event stays minimal (no `messageId` key at all — test covers this).
  - `messageId` present → plugin event carries it.
  - Error path (`success: false`) still carries `error` alongside `messageId`.
- What I did not verify: End-to-end wire through a live channel adapter (no live channel creds in this environment). The canonical contexts already carry `messageId` per the existing mappers and tests, so the remaining wiring is already exercised upstream of the hook boundary.

## Compatibility / Migration

- Backward compatible? Yes — the new field is optional and the type only gains a property.
- Config/env changes? No.
- Migration needed? No.

## Risks and Mitigations

- Risk: Plugins that were working around the bug by reading `messageId` from elsewhere continue to work but now have the field natively; no action required. Mitigation: field is additive and optional.