### PR TITLE
fix: serialize oauth refresh across agents

### DIFF
--- a/src/agents/auth-profiles/oauth.cross-agent-refresh-lock.test.ts
+++ b/src/agents/auth-profiles/oauth.cross-agent-refresh-lock.test.ts
@@ -1,0 +1,198 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureEnv } from "../../test-utils/env.js";
+
+const { getOAuthApiKeyMock } = vi.hoisted(() => ({
+  getOAuthApiKeyMock: vi.fn(),
+}));
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: getOAuthApiKeyMock,
+  getOAuthProviders: () => [
+    {
+      id: "openai-codex",
+      envApiKey: "OPENAI_API_KEY",
+      oauthTokenEnv: "OPENAI_OAUTH_TOKEN",
+    },
+  ],
+}));
+
+import { resolveApiKeyForProfile } from "./oauth.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStore,
+  saveAuthProfileStore,
+} from "./store.js";
+import type { AuthProfileStore } from "./types.js";
+
+function createExpiredOauthStore(params: {
+  profileId: string;
+  provider: string;
+  access: string;
+  refresh: string;
+  expires: number;
+}): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      [params.profileId]: {
+        type: "oauth",
+        provider: params.provider,
+        access: params.access,
+        refresh: params.refresh,
+        expires: params.expires,
+      },
+    },
+  };
+}
+
+describe("cross-agent OAuth refresh serialization", () => {
+  const envSnapshot = captureEnv([
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_AGENT_DIR",
+    "PI_CODING_AGENT_DIR",
+  ]);
+
+  let tempRoot = "";
+  let mainAgentDir = "";
+  let operatorAgentDir = "";
+  let selfAnalysisAgentDir = "";
+
+  beforeEach(async () => {
+    getOAuthApiKeyMock.mockReset();
+    clearRuntimeAuthProfileStoreSnapshots();
+
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cross-agent-refresh-"));
+    mainAgentDir = path.join(tempRoot, "agents", "main", "agent");
+    operatorAgentDir = path.join(tempRoot, "agents", "operator", "agent");
+    selfAnalysisAgentDir = path.join(tempRoot, "agents", "self-analysis", "agent");
+    await fs.mkdir(mainAgentDir, { recursive: true });
+    await fs.mkdir(operatorAgentDir, { recursive: true });
+    await fs.mkdir(selfAnalysisAgentDir, { recursive: true });
+
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+    process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+  });
+
+  afterEach(async () => {
+    clearRuntimeAuthProfileStoreSnapshots();
+    envSnapshot.restore();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  async function resolveFromAgent(agentDir: string, profileId: string) {
+    return await resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(agentDir),
+      profileId,
+      agentDir,
+    });
+  }
+
+  it("serializes refresh across agents and syncs the winning credentials back to main", async () => {
+    const profileId = "openai-codex:default";
+    const expiredAt = Date.now() - 60_000;
+    const refreshedAt = Date.now() + 60 * 60 * 1000;
+    const staleRefresh = "stale-refresh-token";
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        access: "main-stale-access",
+        refresh: staleRefresh,
+        expires: expiredAt,
+      }),
+      mainAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        access: "operator-stale-access",
+        refresh: staleRefresh,
+        expires: expiredAt,
+      }),
+      operatorAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        access: "self-analysis-stale-access",
+        refresh: staleRefresh,
+        expires: expiredAt,
+      }),
+      selfAnalysisAgentDir,
+    );
+
+    let releaseFirstRefresh: (() => void) | null = null;
+    getOAuthApiKeyMock.mockImplementationOnce(async () => {
+      return await new Promise((resolve) => {
+        releaseFirstRefresh = () => {
+          resolve({
+            apiKey: "fresh-access-token",
+            newCredentials: {
+              access: "fresh-access-token",
+              refresh: "fresh-refresh-token",
+              expires: refreshedAt,
+            },
+          });
+        };
+      });
+    });
+    getOAuthApiKeyMock.mockImplementation(async () => {
+      throw new Error("refresh should only run once");
+    });
+
+    const operatorResolve = resolveFromAgent(operatorAgentDir, profileId);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const selfAnalysisResolve = resolveFromAgent(selfAnalysisAgentDir, profileId);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(releaseFirstRefresh).not.toBeNull();
+    releaseFirstRefresh?.();
+
+    const [operatorResult, selfAnalysisResult] = await Promise.all([
+      operatorResolve,
+      selfAnalysisResolve,
+    ]);
+
+    expect(operatorResult).toEqual({
+      apiKey: "fresh-access-token",
+      provider: "openai-codex",
+      email: undefined,
+    });
+    expect(selfAnalysisResult).toEqual({
+      apiKey: "fresh-access-token",
+      provider: "openai-codex",
+      email: undefined,
+    });
+    expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
+
+    const mainStore = JSON.parse(
+      await fs.readFile(path.join(mainAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    const selfAnalysisStore = JSON.parse(
+      await fs.readFile(path.join(selfAnalysisAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+
+    expect(mainStore.profiles[profileId]).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "fresh-access-token",
+      refresh: "fresh-refresh-token",
+      expires: refreshedAt,
+    });
+    expect(selfAnalysisStore.profiles[profileId]).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "fresh-access-token",
+      refresh: "fresh-refresh-token",
+      expires: refreshedAt,
+    });
+  });
+});

--- a/src/agents/auth-profiles/oauth.cross-agent-refresh-lock.test.ts
+++ b/src/agents/auth-profiles/oauth.cross-agent-refresh-lock.test.ts
@@ -148,9 +148,11 @@ describe("cross-agent OAuth refresh serialization", () => {
     });
 
     const operatorResolve = resolveFromAgent(operatorAgentDir, profileId);
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await vi.waitFor(() => {
+      expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
+      expect(releaseFirstRefresh).not.toBeNull();
+    });
     const selfAnalysisResolve = resolveFromAgent(selfAnalysisAgentDir, profileId);
-    await new Promise((resolve) => setTimeout(resolve, 25));
 
     expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
     expect(releaseFirstRefresh).not.toBeNull();
@@ -176,11 +178,21 @@ describe("cross-agent OAuth refresh serialization", () => {
     const mainStore = JSON.parse(
       await fs.readFile(path.join(mainAgentDir, "auth-profiles.json"), "utf8"),
     ) as AuthProfileStore;
+    const operatorStore = JSON.parse(
+      await fs.readFile(path.join(operatorAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
     const selfAnalysisStore = JSON.parse(
       await fs.readFile(path.join(selfAnalysisAgentDir, "auth-profiles.json"), "utf8"),
     ) as AuthProfileStore;
 
     expect(mainStore.profiles[profileId]).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "fresh-access-token",
+      refresh: "fresh-refresh-token",
+      expires: refreshedAt,
+    });
+    expect(operatorStore.profiles[profileId]).toMatchObject({
       type: "oauth",
       provider: "openai-codex",
       access: "fresh-access-token",

--- a/src/agents/auth-profiles/oauth.cross-agent-refresh-lock.test.ts
+++ b/src/agents/auth-profiles/oauth.cross-agent-refresh-lock.test.ts
@@ -23,9 +23,17 @@ import { resolveApiKeyForProfile } from "./oauth.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
+  replaceRuntimeAuthProfileStoreSnapshots,
   saveAuthProfileStore,
 } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
+
+function createStore(profiles: AuthProfileStore["profiles"]): AuthProfileStore {
+  return {
+    version: 1,
+    profiles,
+  };
+}
 
 function createExpiredOauthStore(params: {
   profileId: string;
@@ -34,18 +42,15 @@ function createExpiredOauthStore(params: {
   refresh: string;
   expires: number;
 }): AuthProfileStore {
-  return {
-    version: 1,
-    profiles: {
-      [params.profileId]: {
-        type: "oauth",
-        provider: params.provider,
-        access: params.access,
-        refresh: params.refresh,
-        expires: params.expires,
-      },
+  return createStore({
+    [params.profileId]: {
+      type: "oauth",
+      provider: params.provider,
+      access: params.access,
+      refresh: params.refresh,
+      expires: params.expires,
     },
-  };
+  });
 }
 
 describe("cross-agent OAuth refresh serialization", () => {
@@ -200,6 +205,146 @@ describe("cross-agent OAuth refresh serialization", () => {
       expires: refreshedAt,
     });
     expect(selfAnalysisStore.profiles[profileId]).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "fresh-access-token",
+      refresh: "fresh-refresh-token",
+      expires: refreshedAt,
+    });
+  });
+
+  it("reloads the main store from disk before syncing refreshed credentials", async () => {
+    const profileId = "openai-codex:default";
+    const expiredAt = Date.now() - 60_000;
+    const refreshedAt = Date.now() + 60 * 60 * 1000;
+
+    saveAuthProfileStore(
+      createStore({
+        [profileId]: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "main-stale-access",
+          refresh: "main-stale-refresh",
+          expires: expiredAt,
+        },
+        "anthropic:default": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "sk-main-only",
+        },
+      }),
+      mainAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        access: "operator-stale-access",
+        refresh: "operator-stale-refresh",
+        expires: expiredAt,
+      }),
+      operatorAgentDir,
+    );
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir: mainAgentDir,
+        store: createExpiredOauthStore({
+          profileId,
+          provider: "openai-codex",
+          access: "snapshot-stale-access",
+          refresh: "snapshot-stale-refresh",
+          expires: expiredAt,
+        }),
+      },
+    ]);
+
+    getOAuthApiKeyMock.mockResolvedValue({
+      apiKey: "fresh-access-token",
+      newCredentials: {
+        access: "fresh-access-token",
+        refresh: "fresh-refresh-token",
+        expires: refreshedAt,
+      },
+    });
+
+    await expect(resolveFromAgent(operatorAgentDir, profileId)).resolves.toEqual({
+      apiKey: "fresh-access-token",
+      provider: "openai-codex",
+      email: undefined,
+    });
+
+    const mainStore = JSON.parse(
+      await fs.readFile(path.join(mainAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+
+    expect(mainStore.profiles[profileId]).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "fresh-access-token",
+      refresh: "fresh-refresh-token",
+      expires: refreshedAt,
+    });
+    expect(mainStore.profiles["anthropic:default"]).toEqual({
+      type: "api_key",
+      provider: "anthropic",
+      key: "sk-main-only",
+    });
+  });
+
+  it("skips syncing refreshed credentials when the main profile contract diverged", async () => {
+    const profileId = "openai-codex:default";
+    const expiredAt = Date.now() - 60_000;
+    const refreshedAt = Date.now() + 60 * 60 * 1000;
+
+    saveAuthProfileStore(
+      createStore({
+        [profileId]: {
+          type: "token",
+          provider: "openai-codex",
+          token: "main-static-token",
+        },
+      }),
+      mainAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        access: "operator-stale-access",
+        refresh: "operator-stale-refresh",
+        expires: expiredAt,
+      }),
+      operatorAgentDir,
+    );
+
+    getOAuthApiKeyMock.mockResolvedValue({
+      apiKey: "fresh-access-token",
+      newCredentials: {
+        access: "fresh-access-token",
+        refresh: "fresh-refresh-token",
+        expires: refreshedAt,
+      },
+    });
+
+    await expect(resolveFromAgent(operatorAgentDir, profileId)).resolves.toEqual({
+      apiKey: "fresh-access-token",
+      provider: "openai-codex",
+      email: undefined,
+    });
+
+    const mainStore = JSON.parse(
+      await fs.readFile(path.join(mainAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    const operatorStore = JSON.parse(
+      await fs.readFile(path.join(operatorAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+
+    expect(mainStore.profiles[profileId]).toEqual({
+      type: "token",
+      provider: "openai-codex",
+      token: "main-static-token",
+    });
+    expect(operatorStore.profiles[profileId]).toMatchObject({
       type: "oauth",
       provider: "openai-codex",
       access: "fresh-access-token",

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   getOAuthApiKey,
   getOAuthProviders,
@@ -5,15 +6,18 @@ import {
   type OAuthProvider,
 } from "@mariozechner/pi-ai/oauth";
 import { loadConfig } from "../../config/config.js";
+import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { withFileLock } from "../../infra/file-lock.js";
+import { enqueueKeyedTask } from "../../plugin-sdk/keyed-async-queue.js";
 import {
   formatProviderAuthProfileApiKeyWithPlugin,
   refreshProviderOAuthCredentialWithPlugin,
 } from "../../plugins/provider-runtime.runtime.js";
 import { resolveSecretRefString, type SecretRefResolveCache } from "../../secrets/resolve.js";
+import { resolveProcessScopedMap } from "../../shared/process-scoped-map.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
 import { writeCodexCliCredentials } from "../cli-credentials.js";
@@ -55,6 +59,9 @@ function listOAuthProviderIds(): string[] {
 }
 
 const OAUTH_PROVIDER_IDS = new Set<string>(listOAuthProviderIds());
+const OAUTH_REFRESH_TAILS = resolveProcessScopedMap<Promise<void>>(
+  Symbol.for("openclaw.authProfiles.oauthRefreshTails"),
+);
 
 const isOAuthProvider = (provider: string): provider is OAuthProvider =>
   OAUTH_PROVIDER_IDS.has(provider);
@@ -183,8 +190,8 @@ function adoptNewerMainOAuthCredential(params: {
   store: AuthProfileStore;
   profileId: string;
   agentDir?: string;
-  cred: OAuthCredentials & { type: "oauth"; provider: string; email?: string };
-}): (OAuthCredentials & { type: "oauth"; provider: string; email?: string }) | null {
+  cred: OAuthCredential;
+}): OAuthCredential | null {
   if (!params.agentDir) {
     return null;
   }
@@ -216,6 +223,49 @@ function adoptNewerMainOAuthCredential(params: {
   return null;
 }
 
+function resolveOAuthRefreshCoordinationPath(profileId: string): string {
+  const normalizedProfileId = profileId.replace(/[^a-zA-Z0-9._-]+/g, "_");
+  return path.join(resolveStateDir(), "locks", "oauth-refresh", normalizedProfileId);
+}
+
+async function syncRefreshedOAuthCredentialToMainAgent(params: {
+  profileId: string;
+  agentDir?: string;
+  credentials: OAuthCredential;
+}): Promise<void> {
+  if (!params.agentDir) {
+    return;
+  }
+
+  const authPath = resolveAuthStorePath(params.agentDir);
+  const mainAuthPath = resolveAuthStorePath();
+  if (authPath === mainAuthPath) {
+    return;
+  }
+
+  ensureAuthStoreFile(mainAuthPath);
+  await withFileLock(mainAuthPath, AUTH_STORE_LOCK_OPTIONS, async () => {
+    const mainStore = ensureAuthProfileStore(undefined);
+    const existing = mainStore.profiles[params.profileId];
+    if (
+      existing?.type === "oauth" &&
+      existing.provider === params.credentials.provider &&
+      Number.isFinite(existing.expires) &&
+      existing.expires > params.credentials.expires
+    ) {
+      return;
+    }
+
+    mainStore.profiles[params.profileId] = { ...params.credentials };
+    saveAuthProfileStore(mainStore, undefined);
+    log.info("synced refreshed OAuth credentials to main agent", {
+      profileId: params.profileId,
+      agentDir: params.agentDir,
+      expires: new Date(params.credentials.expires).toISOString(),
+    });
+  });
+}
+
 async function refreshOAuthTokenWithLock(params: {
   profileId: string;
   agentDir?: string;
@@ -223,120 +273,167 @@ async function refreshOAuthTokenWithLock(params: {
   const authPath = resolveAuthStorePath(params.agentDir);
   ensureAuthStoreFile(authPath);
 
-  return await withFileLock(authPath, AUTH_STORE_LOCK_OPTIONS, async () => {
-    // Locked refresh must bypass runtime snapshots so we can adopt fresher
-    // on-disk credentials written by another refresh attempt.
-    const store = loadAuthProfileStoreForSecretsRuntime(params.agentDir);
-    const cred = store.profiles[params.profileId];
-    if (!cred || cred.type !== "oauth") {
-      return null;
-    }
+  return await enqueueKeyedTask({
+    tails: OAUTH_REFRESH_TAILS,
+    key: params.profileId,
+    task: async () => {
+      return await withFileLock(
+        resolveOAuthRefreshCoordinationPath(params.profileId),
+        AUTH_STORE_LOCK_OPTIONS,
+        async () => {
+          return await withFileLock(authPath, AUTH_STORE_LOCK_OPTIONS, async () => {
+            // Locked refresh must bypass runtime snapshots so we can adopt fresher
+            // on-disk credentials written by another refresh attempt.
+            const store = loadAuthProfileStoreForSecretsRuntime(params.agentDir);
+            const cred = store.profiles[params.profileId];
+            if (!cred || cred.type !== "oauth") {
+              return null;
+            }
 
-    if (Date.now() < cred.expires) {
-      return {
-        apiKey: await buildOAuthApiKey(cred.provider, cred),
-        newCredentials: cred,
-      };
-    }
+            const activeCred =
+              adoptNewerMainOAuthCredential({
+                store,
+                profileId: params.profileId,
+                agentDir: params.agentDir,
+                cred,
+              }) ?? cred;
 
-    const externallyManaged = readManagedExternalCliCredential({
-      profileId: params.profileId,
-      credential: cred,
-    });
-    if (externallyManaged) {
-      if (!areOAuthCredentialsEquivalent(cred, externallyManaged)) {
-        store.profiles[params.profileId] = externallyManaged;
-        saveAuthProfileStore(store, params.agentDir);
-      }
-      if (Date.now() < externallyManaged.expires) {
-        return {
-          apiKey: await buildOAuthApiKey(externallyManaged.provider, externallyManaged),
-          newCredentials: externallyManaged,
-        };
-      }
-      if (externallyManaged.managedBy === "codex-cli") {
-        const pluginRefreshed = await refreshProviderOAuthCredentialWithPlugin({
-          provider: externallyManaged.provider,
-          context: externallyManaged,
-        });
-        if (pluginRefreshed) {
-          const refreshedCredentials: OAuthCredential = {
-            ...externallyManaged,
-            ...pluginRefreshed,
-            type: "oauth",
-            managedBy: "codex-cli",
-          };
-          if (!writeCodexCliCredentials(refreshedCredentials)) {
-            log.warn("failed to persist refreshed codex credentials back to Codex storage", {
+            if (Date.now() < activeCred.expires) {
+              return {
+                apiKey: await buildOAuthApiKey(activeCred.provider, activeCred),
+                newCredentials: activeCred,
+              };
+            }
+
+            const externallyManaged = readManagedExternalCliCredential({
               profileId: params.profileId,
+              credential: activeCred,
             });
-          }
-          store.profiles[params.profileId] = refreshedCredentials;
-          saveAuthProfileStore(store, params.agentDir);
-          return {
-            apiKey: await buildOAuthApiKey(refreshedCredentials.provider, refreshedCredentials),
-            newCredentials: refreshedCredentials,
-          };
-        }
-      }
-      throw new Error(
-        `${externallyManaged.managedBy} credential is expired; refresh it in the external CLI and retry.`,
-      );
-    }
-    if (cred.managedBy) {
-      throw new Error(
-        `${cred.managedBy} credential is unavailable; re-authenticate in the external CLI and retry.`,
-      );
-    }
+            if (externallyManaged) {
+              if (!areOAuthCredentialsEquivalent(activeCred, externallyManaged)) {
+                store.profiles[params.profileId] = externallyManaged;
+                saveAuthProfileStore(store, params.agentDir);
+              }
+              if (Date.now() < externallyManaged.expires) {
+                return {
+                  apiKey: await buildOAuthApiKey(externallyManaged.provider, externallyManaged),
+                  newCredentials: externallyManaged,
+                };
+              }
+              if (externallyManaged.managedBy === "codex-cli") {
+                const pluginRefreshed = await refreshProviderOAuthCredentialWithPlugin({
+                  provider: externallyManaged.provider,
+                  context: externallyManaged,
+                });
+                if (pluginRefreshed) {
+                  const refreshedCredentials: OAuthCredential = {
+                    ...externallyManaged,
+                    ...pluginRefreshed,
+                    type: "oauth",
+                    managedBy: "codex-cli",
+                  };
+                  if (!writeCodexCliCredentials(refreshedCredentials)) {
+                    log.warn(
+                      "failed to persist refreshed codex credentials back to Codex storage",
+                      {
+                        profileId: params.profileId,
+                      },
+                    );
+                  }
+                  store.profiles[params.profileId] = refreshedCredentials;
+                  saveAuthProfileStore(store, params.agentDir);
+                  await syncRefreshedOAuthCredentialToMainAgent({
+                    profileId: params.profileId,
+                    agentDir: params.agentDir,
+                    credentials: refreshedCredentials,
+                  });
+                  return {
+                    apiKey: await buildOAuthApiKey(
+                      refreshedCredentials.provider,
+                      refreshedCredentials,
+                    ),
+                    newCredentials: refreshedCredentials,
+                  };
+                }
+              }
+              throw new Error(
+                `${externallyManaged.managedBy} credential is expired; refresh it in the external CLI and retry.`,
+              );
+            }
+            if (activeCred.managedBy) {
+              throw new Error(
+                `${activeCred.managedBy} credential is unavailable; re-authenticate in the external CLI and retry.`,
+              );
+            }
 
-    const pluginRefreshed = await refreshProviderOAuthCredentialWithPlugin({
-      provider: cred.provider,
-      context: cred,
-    });
-    if (pluginRefreshed) {
-      const refreshedCredentials: OAuthCredential = {
-        ...cred,
-        ...pluginRefreshed,
-        type: "oauth",
-      };
-      store.profiles[params.profileId] = refreshedCredentials;
-      saveAuthProfileStore(store, params.agentDir);
-      return {
-        apiKey: await buildOAuthApiKey(cred.provider, refreshedCredentials),
-        newCredentials: refreshedCredentials,
-      };
-    }
-
-    const oauthCreds: Record<string, OAuthCredentials> = { [cred.provider]: cred };
-    const result =
-      cred.provider === "chutes"
-        ? await (async () => {
-            const newCredentials = await refreshChutesTokens({
-              credential: cred,
+            const pluginRefreshed = await refreshProviderOAuthCredentialWithPlugin({
+              provider: activeCred.provider,
+              context: activeCred,
             });
-            return { apiKey: newCredentials.access, newCredentials };
-          })()
-        : await (async () => {
-            const oauthProvider = resolveOAuthProvider(cred.provider);
-            if (!oauthProvider) {
+            if (pluginRefreshed) {
+              const refreshedCredentials: OAuthCredential = {
+                ...activeCred,
+                ...pluginRefreshed,
+                type: "oauth",
+              };
+              store.profiles[params.profileId] = refreshedCredentials;
+              saveAuthProfileStore(store, params.agentDir);
+              await syncRefreshedOAuthCredentialToMainAgent({
+                profileId: params.profileId,
+                agentDir: params.agentDir,
+                credentials: refreshedCredentials,
+              });
+              return {
+                apiKey: await buildOAuthApiKey(activeCred.provider, refreshedCredentials),
+                newCredentials: refreshedCredentials,
+              };
+            }
+
+            const oauthCreds: Record<string, OAuthCredentials> = {
+              [activeCred.provider]: activeCred,
+            };
+            const result =
+              activeCred.provider === "chutes"
+                ? await (async () => {
+                    const newCredentials = await refreshChutesTokens({
+                      credential: activeCred,
+                    });
+                    return { apiKey: newCredentials.access, newCredentials };
+                  })()
+                : await (async () => {
+                    const oauthProvider = resolveOAuthProvider(activeCred.provider);
+                    if (!oauthProvider) {
+                      return null;
+                    }
+                    if (typeof getOAuthApiKey !== "function") {
+                      return null;
+                    }
+                    return await getOAuthApiKey(oauthProvider, oauthCreds);
+                  })();
+            if (!result) {
               return null;
             }
-            if (typeof getOAuthApiKey !== "function") {
-              return null;
-            }
-            return await getOAuthApiKey(oauthProvider, oauthCreds);
-          })();
-    if (!result) {
-      return null;
-    }
-    store.profiles[params.profileId] = {
-      ...cred,
-      ...result.newCredentials,
-      type: "oauth",
-    };
-    saveAuthProfileStore(store, params.agentDir);
+            const syncedCredentials: OAuthCredential = {
+              ...activeCred,
+              ...result.newCredentials,
+              type: "oauth",
+            };
+            store.profiles[params.profileId] = syncedCredentials;
+            saveAuthProfileStore(store, params.agentDir);
+            await syncRefreshedOAuthCredentialToMainAgent({
+              profileId: params.profileId,
+              agentDir: params.agentDir,
+              credentials: syncedCredentials,
+            });
 
-    return result;
+            return {
+              apiKey: result.apiKey,
+              newCredentials: syncedCredentials,
+            };
+          });
+        },
+      );
+    },
   });
 }
 

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -177,6 +177,34 @@ async function loadFreshStoredOAuthCredential(params: {
   return reloaded;
 }
 
+function normalizeOAuthProfileContractValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function hasMatchingOAuthProfileSyncContract(params: {
+  existing: AuthProfileStore["profiles"][string] | undefined;
+  expected: OAuthCredential;
+}): boolean {
+  const { existing, expected } = params;
+  if (existing?.type !== "oauth") {
+    return false;
+  }
+  return (
+    existing.provider === expected.provider &&
+    normalizeOAuthProfileContractValue(existing.managedBy) ===
+      normalizeOAuthProfileContractValue(expected.managedBy) &&
+    normalizeOAuthProfileContractValue(existing.clientId) ===
+      normalizeOAuthProfileContractValue(expected.clientId) &&
+    normalizeOAuthProfileContractValue(existing.enterpriseUrl) ===
+      normalizeOAuthProfileContractValue(expected.enterpriseUrl) &&
+    normalizeOAuthProfileContractValue(existing.projectId) ===
+      normalizeOAuthProfileContractValue(expected.projectId) &&
+    normalizeOAuthProfileContractValue(existing.accountId) ===
+      normalizeOAuthProfileContractValue(expected.accountId)
+  );
+}
+
 type ResolveApiKeyForProfileParams = {
   cfg?: OpenClawConfig;
   store: AuthProfileStore;
@@ -231,6 +259,7 @@ function resolveOAuthRefreshCoordinationPath(profileId: string): string {
 async function syncRefreshedOAuthCredentialToMainAgent(params: {
   profileId: string;
   agentDir?: string;
+  sourceCredential: OAuthCredential;
   credentials: OAuthCredential;
 }): Promise<void> {
   if (!params.agentDir) {
@@ -245,18 +274,35 @@ async function syncRefreshedOAuthCredentialToMainAgent(params: {
 
   ensureAuthStoreFile(mainAuthPath);
   await withFileLock(mainAuthPath, AUTH_STORE_LOCK_OPTIONS, async () => {
-    const mainStore = ensureAuthProfileStore(undefined);
+    // Reload the main store from disk while holding the lock so we never sync
+    // refreshed credentials back onto a stale runtime snapshot.
+    const mainStore = loadAuthProfileStoreForSecretsRuntime(undefined);
     const existing = mainStore.profiles[params.profileId];
     if (
-      existing?.type === "oauth" &&
-      existing.provider === params.credentials.provider &&
-      Number.isFinite(existing.expires) &&
-      existing.expires > params.credentials.expires
+      existing?.type !== "oauth" ||
+      !hasMatchingOAuthProfileSyncContract({
+        existing,
+        expected: params.sourceCredential,
+      })
     ) {
+      log.info("skipped syncing refreshed OAuth credentials to main agent", {
+        profileId: params.profileId,
+        agentDir: params.agentDir,
+        reason: "profile_contract_diverged",
+        mainType: existing?.type,
+        mainProvider: existing?.provider,
+        sourceProvider: params.sourceCredential.provider,
+      });
+      return;
+    }
+    if (Number.isFinite(existing.expires) && existing.expires > params.credentials.expires) {
       return;
     }
 
-    mainStore.profiles[params.profileId] = { ...params.credentials };
+    mainStore.profiles[params.profileId] = {
+      ...existing,
+      ...params.credentials,
+    };
     saveAuthProfileStore(mainStore, undefined);
     log.info("synced refreshed OAuth credentials to main agent", {
       profileId: params.profileId,
@@ -345,6 +391,7 @@ async function refreshOAuthTokenWithLock(params: {
                   await syncRefreshedOAuthCredentialToMainAgent({
                     profileId: params.profileId,
                     agentDir: params.agentDir,
+                    sourceCredential: externallyManaged,
                     credentials: refreshedCredentials,
                   });
                   return {
@@ -381,6 +428,7 @@ async function refreshOAuthTokenWithLock(params: {
               await syncRefreshedOAuthCredentialToMainAgent({
                 profileId: params.profileId,
                 agentDir: params.agentDir,
+                sourceCredential: activeCred,
                 credentials: refreshedCredentials,
               });
               return {
@@ -423,6 +471,7 @@ async function refreshOAuthTokenWithLock(params: {
             await syncRefreshedOAuthCredentialToMainAgent({
               profileId: params.profileId,
               agentDir: params.agentDir,
+              sourceCredential: activeCred,
               credentials: syncedCredentials,
             });
 


### PR DESCRIPTION
$## Summary
- serialize OAuth refresh work per profile within a process and across agents using a shared state-dir file lock
- adopt fresher main-agent OAuth credentials inside the refresh critical section and sync successful secondary-agent refreshes back to main auth state
- add a regression test covering two secondary agents racing the same expired OAuth profile

## Patch scope
- src/agents/auth-profiles/oauth.ts
- src/agents/auth-profiles/oauth.cross-agent-refresh-lock.test.ts

## Validation
- rebased/cherry-picked the accepted source commit `4987addcd1eeaf2f3b31ab793d7921dbd1bf975d` onto current `main`
- attempted delegated targeted validation command, but this isolated worktree is using a linked stale dependency tree and local rerun is blocked by environment issues:
  - `pnpm vitest run ...` hit a Vitest project-config startup error
  - `pnpm vitest --config test/vitest/vitest.agents.config.ts run ...` hit `TypeError: Class extends value undefined is not a constructor or null` from `test/non-isolated-runner.ts`
- upstream CI should run on the pushed branch with the correct dependency set