### PR TITLE
fix(memory-flush): allow additional write paths beyond daily notes

### DIFF
--- a/extensions/memory-core/src/flush-plan.ts
+++ b/extensions/memory-core/src/flush-plan.ts
@@ -128,12 +128,23 @@ export function buildMemoryFlushPlan(
     ),
   );
 
+  const additionalWritePaths: string[] = [];
+  const resolvedPrompt = appendCurrentTimeLine(
+    promptBase.replaceAll("YYYY-MM-DD", dateStamp),
+    timeLine,
+  );
+  const resolvedSystemPrompt = systemPrompt.replaceAll("YYYY-MM-DD", dateStamp);
+  if (resolvedPrompt.includes("SESSION_HANDOFF") || resolvedSystemPrompt.includes("SESSION_HANDOFF")) {
+    additionalWritePaths.push("SESSION_HANDOFF.md");
+  }
+
   return {
     softThresholdTokens,
     forceFlushTranscriptBytes,
     reserveTokensFloor,
-    prompt: appendCurrentTimeLine(promptBase.replaceAll("YYYY-MM-DD", dateStamp), timeLine),
-    systemPrompt: systemPrompt.replaceAll("YYYY-MM-DD", dateStamp),
+    prompt: resolvedPrompt,
+    systemPrompt: resolvedSystemPrompt,
     relativePath,
+    additionalWritePaths,
   };
 }

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -30,6 +30,8 @@ export type RunEmbeddedPiAgentParams = {
   trigger?: EmbeddedRunTrigger;
   /** Relative workspace path that memory-triggered writes are allowed to append to. */
   memoryFlushWritePath?: string;
+  /** Additional relative paths the memory flush agent may overwrite. */
+  memoryFlushAdditionalWritePaths?: string[];
   /** Delivery target (e.g. telegram:group:123:topic:456) for topic/thread routing. */
   messageTo?: string;
   /** Thread/topic identifier for routing replies to the originating thread. */

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -446,6 +446,7 @@ export function resolveToolPathAgainstWorkspaceRoot(params: {
 type MemoryFlushAppendOnlyWriteOptions = {
   root: string;
   relativePath: string;
+  additionalWritePaths?: string[];
   containerWorkdir?: string;
   sandbox?: {
     root: string;
@@ -540,9 +541,14 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
   options: MemoryFlushAppendOnlyWriteOptions,
 ): AnyAgentTool {
   const allowedAbsolutePath = path.resolve(options.root, options.relativePath);
+  const additionalAbsoluteMap = new Map<string, string>();
+  for (const rel of options.additionalWritePaths ?? []) {
+    additionalAbsoluteMap.set(path.resolve(options.root, rel), rel);
+  }
+  const allAllowedRelative = [options.relativePath, ...additionalAbsoluteMap.values()];
   return {
     ...tool,
-    description: `${tool.description} During memory flush, this tool may only append to ${options.relativePath}.`,
+    description: `${tool.description} During memory flush, this tool may only write to ${allAllowedRelative.join(", ")}.`,
     execute: async (toolCallId, args, signal, onUpdate) => {
       const record = getToolParamsRecord(args);
       assertRequiredParams(record, REQUIRED_PARAM_GROUPS.write, tool.name);
@@ -558,27 +564,45 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
         root: options.root,
         containerWorkdir: options.containerWorkdir,
       });
-      if (resolvedPath !== allowedAbsolutePath) {
-        throw new Error(
-          `Memory flush writes are restricted to ${options.relativePath}; use that path only.`,
-        );
+
+      if (resolvedPath === allowedAbsolutePath) {
+        await appendMemoryFlushContent({
+          absolutePath: allowedAbsolutePath,
+          root: options.root,
+          relativePath: options.relativePath,
+          content,
+          sandbox: options.sandbox,
+          signal,
+        });
+        return {
+          content: [{ type: "text", text: `Appended content to ${options.relativePath}.` }],
+          details: {
+            path: options.relativePath,
+            appendOnly: true,
+          },
+        };
       }
 
-      await appendMemoryFlushContent({
-        absolutePath: allowedAbsolutePath,
-        root: options.root,
-        relativePath: options.relativePath,
-        content,
-        sandbox: options.sandbox,
-        signal,
-      });
-      return {
-        content: [{ type: "text", text: `Appended content to ${options.relativePath}.` }],
-        details: {
-          path: options.relativePath,
-          appendOnly: true,
-        },
-      };
+      const additionalRelative = additionalAbsoluteMap.get(resolvedPath);
+      if (additionalRelative !== undefined) {
+        await writeFileWithinRoot({
+          rootDir: options.root,
+          relativePath: additionalRelative,
+          data: content,
+          mkdir: true,
+        });
+        return {
+          content: [{ type: "text", text: `Wrote content to ${additionalRelative}.` }],
+          details: {
+            path: additionalRelative,
+            appendOnly: false,
+          },
+        };
+      }
+
+      throw new Error(
+        `Memory flush writes are restricted to ${allAllowedRelative.join(", ")}; use those paths only.`,
+      );
     },
   };
 }

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -260,6 +260,8 @@ export function createOpenClawCodingTools(options?: {
   trigger?: string;
   /** Relative workspace path that memory-triggered writes may append to. */
   memoryFlushWritePath?: string;
+  /** Additional relative paths the memory flush agent may overwrite. */
+  memoryFlushAdditionalWritePaths?: string[];
   agentDir?: string;
   workspaceDir?: string;
   /**
@@ -331,6 +333,9 @@ export function createOpenClawCodingTools(options?: {
     throw new Error("memoryFlushWritePath required for memory-triggered tool runs");
   }
   const memoryFlushWritePath = isMemoryFlushRun ? options.memoryFlushWritePath : undefined;
+  const memoryFlushAdditionalWritePaths = isMemoryFlushRun
+    ? options?.memoryFlushAdditionalWritePaths
+    : undefined;
   const {
     agentId,
     globalPolicy,
@@ -612,6 +617,7 @@ export function createOpenClawCodingTools(options?: {
               wrapToolMemoryFlushAppendOnlyWrite(tool, {
                 root: sandboxRoot ?? workspaceRoot,
                 relativePath: memoryFlushWritePath,
+                additionalWritePaths: memoryFlushAdditionalWritePaths,
                 containerWorkdir: sandbox?.containerWorkdir,
                 sandbox:
                   sandboxRoot && sandboxFsBridge

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -71,6 +71,7 @@ export type MemoryFlushPlan = {
   prompt: string;
   systemPrompt: string;
   relativePath: string;
+  additionalWritePaths: string[];
 };
 
 export type MemoryFlushPlanResolver = (params: {


### PR DESCRIPTION
## Summary

The memory flush sandbox restricts tool writes to a single path (`memory/YYYY-MM-DD.md`), but the default flush prompt instructs writing to `SESSION_HANDOFF.md` as well. This causes the handoff write to fail silently during compaction, breaking session continuity.

## Changes

- **`extensions/memory-core/src/flush-plan.ts`**: `buildMemoryFlushPlan()` now detects `SESSION_HANDOFF` references in the resolved prompt/system prompt and returns `additionalWritePaths`
- **`src/agents/pi-tools.read.ts`**: `wrapToolMemoryFlushAppendOnlyWrite()` accepts an array of additional paths with full overwrite (not append-only) access via `writeFileWithinRoot`
- **`src/agents/pi-tools.ts`**: Threads `memoryFlushAdditionalWritePaths` through `createOpenClawCodingTools`
- **`src/agents/pi-embedded-runner/run/params.ts`**: Adds `memoryFlushAdditionalWritePaths` to `RunEmbeddedPiAgentParams`
- **`src/plugins/memory-state.ts`**: `MemoryFlushPlan` type gains `additionalWritePaths: string[]`

## Design Decisions

- Additional paths use **full overwrite** (`writeFileWithinRoot`) rather than append, since `SESSION_HANDOFF.md` is meant to be replaced each flush cycle
- Detection is prompt-based (checks for `SESSION_HANDOFF` in resolved prompt text), keeping it backward-compatible — existing configs without the handoff instruction see no behavior change
- The approach is generic: `additionalWritePaths` can support future multi-file flush scenarios beyond just SESSION_HANDOFF

## Testing

Tested against a live OpenClaw deployment with `memoryFlush.enabled: true` and `softThresholdTokens: 8000`. Before fix: SESSION_HANDOFF.md write fails with sandbox error. After fix: both `memory/YYYY-MM-DD.md` (append) and `SESSION_HANDOFF.md` (overwrite) succeed during flush.

Fixes #66612