### PR TITLE
fix(pre-commit): fall back to corepack-managed pnpm

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -73,7 +73,14 @@ if [[ -f "$ROOT_DIR/package.json" ]] && [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; the
       if [[ "$docs_only" == true ]]; then
         echo "Docs-only staged changes detected: skipping pnpm check in pre-commit hook."
       else
-        pnpm check
+        if command -v pnpm >/dev/null 2>&1; then
+          pnpm check
+        elif command -v corepack >/dev/null 2>&1; then
+          corepack pnpm check
+        else
+          echo "Neither pnpm nor corepack is available on PATH; cannot run pre-commit pnpm check." >&2
+          exit 1
+        fi
       fi
       ;;
   esac

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -108,4 +108,35 @@ describe("git-hooks/pre-commit (integration)", () => {
 
     expect(output).toContain("FAST_COMMIT enabled: skipping pnpm check in pre-commit hook.");
   });
+
+  it("falls back to corepack pnpm when pnpm is not directly on PATH", () => {
+    const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-corepack-");
+    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
+
+    const fakeBinDir = installPreCommitFixture(dir);
+    writeFileSync(path.join(dir, "package.json"), '{"name":"tmp"}\n', "utf8");
+    writeFileSync(path.join(dir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf8");
+
+    const markerFile = path.join(dir, "corepack-ran.txt");
+    writeExecutable(
+      fakeBinDir,
+      "corepack",
+      `#!/usr/bin/env bash
+[ "$1" = "pnpm" ] || exit 90
+[ "$2" = "check" ] || exit 91
+echo ok > "${markerFile}"
+exit 0
+`,
+    );
+
+    writeFileSync(path.join(dir, "tracked.txt"), "hello\n", "utf8");
+    run(dir, "git", ["add", "--", "tracked.txt"]);
+
+    run(dir, "bash", ["git-hooks/pre-commit"], {
+      PATH: `${fakeBinDir}:/usr/bin:/bin`,
+    });
+
+    const marker = run(dir, "cat", [markerFile]);
+    expect(marker).toBe("ok");
+  });
 });

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempRepoRoot } from "./helpers/temp-repo.js";
@@ -136,7 +136,7 @@ exit 0
       PATH: `${fakeBinDir}:/usr/bin:/bin`,
     });
 
-    const marker = run(dir, "cat", [markerFile]);
+    const marker = readFileSync(markerFile, "utf8").trim();
     expect(marker).toBe("ok");
   });
 });

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempRepoRoot } from "./helpers/temp-repo.js";
@@ -136,6 +136,7 @@ exit 0
       PATH: `${fakeBinDir}:/usr/bin:/bin`,
     });
 
+    expect(existsSync(markerFile)).toBe(true);
     const marker = readFileSync(markerFile, "utf8").trim();
     expect(marker).toBe("ok");
   });

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -132,10 +132,11 @@ exit 0
     writeFileSync(path.join(dir, "tracked.txt"), "hello\n", "utf8");
     run(dir, "git", ["add", "--", "tracked.txt"]);
 
-    run(dir, "bash", ["git-hooks/pre-commit"], {
+    const output = run(dir, "bash", ["git-hooks/pre-commit"], {
       PATH: `${fakeBinDir}:/usr/bin:/bin`,
     });
 
+    expect(output).not.toContain("Neither pnpm nor corepack is available on PATH");
     expect(existsSync(markerFile)).toBe(true);
     const marker = readFileSync(markerFile, "utf8").trim();
     expect(marker).toBe("ok");


### PR DESCRIPTION
## Summary
- update  to run 
> openclaw@2026.4.14 check /Users/pica/.openclaw/workspace-builder/repos/openclaw
> pnpm check:no-conflict-markers && pnpm tool-display:check && pnpm check:host-env-policy:swift && pnpm check:import-cycles && pnpm check:madge-import-cycles && pnpm tsgo && node scripts/prepare-extension-package-boundary-artifacts.mjs && pnpm lint && pnpm lint:webhook:no-low-level-body-read && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope


> openclaw@2026.4.14 check:no-conflict-markers /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node scripts/check-no-conflict-markers.mjs


> openclaw@2026.4.14 tool-display:check /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node --import tsx scripts/tool-display.ts --check

tool-display snapshot is up to date

> openclaw@2026.4.14 check:host-env-policy:swift /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node scripts/generate-host-env-security-policy-swift.mjs --check

OK apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift

> openclaw@2026.4.14 check:import-cycles /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node --import tsx scripts/check-import-cycles.ts

Import cycle check: 0 runtime value cycle(s).

> openclaw@2026.4.14 check:madge-import-cycles /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node --import tsx scripts/check-madge-import-cycles.ts

 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1. when Version 10.32.1
Usage: pnpm [command] [flags]
       pnpm [ -h | --help | -v | --version ]

These are common pnpm commands used in various situations, use 'pnpm help -a' to list all commands

Manage your dependencies:
      add                  Installs a package and any packages that it depends
                           on. By default, any new package is installed as a
                           prod dependency
   i, install              Install all dependencies for a project
  ln, link                 Connect the local project to another one
  rm, remove               Removes packages from node_modules and from the
                           project's package.json
      unlink               Unlinks a package. Like yarn unlink but pnpm
                           re-installs the dependency after removing the
                           external link
  up, update               Updates packages to their latest version based on the
                           specified range

Review your dependencies:
      audit                Checks for known security issues with the installed
                           packages
  ls, list                 Print all the versions of packages that are
                           installed, as well as their dependencies, in a
                           tree-structure
      outdated             Check for outdated packages
      why                  Shows all packages that depend on the specified
                           package

Run your scripts:
      create               Create a project from a "create-*" or "@foo/create-*"
                           starter kit
      dlx                  Fetches a package from the registry without
                           installing it as a dependency, hot loads it, and runs
                           whatever default command binary it exposes
      exec                 Executes a shell command in scope of a project
      run                  Runs a defined package script

Other:
   c, config               Manage the pnpm configuration files
      init                 Create a package.json file
      publish              Publishes a package to the registry
      self-update          Updates pnpm to the latest version

Options:
  -r, --recursive          Run the command for each project in the workspace. exists, otherwise fall back to 
> openclaw@2026.4.14 check /Users/pica/.openclaw/workspace-builder/repos/openclaw
> pnpm check:no-conflict-markers && pnpm tool-display:check && pnpm check:host-env-policy:swift && pnpm check:import-cycles && pnpm check:madge-import-cycles && pnpm tsgo && node scripts/prepare-extension-package-boundary-artifacts.mjs && pnpm lint && pnpm lint:webhook:no-low-level-body-read && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope


> openclaw@2026.4.14 check:no-conflict-markers /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node scripts/check-no-conflict-markers.mjs


> openclaw@2026.4.14 tool-display:check /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node --import tsx scripts/tool-display.ts --check

tool-display snapshot is up to date

> openclaw@2026.4.14 check:host-env-policy:swift /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node scripts/generate-host-env-security-policy-swift.mjs --check

OK apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift

> openclaw@2026.4.14 check:import-cycles /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node --import tsx scripts/check-import-cycles.ts

Import cycle check: 0 runtime value cycle(s).

> openclaw@2026.4.14 check:madge-import-cycles /Users/pica/.openclaw/workspace-builder/repos/openclaw
> node --import tsx scripts/check-madge-import-cycles.ts

 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
- fail with a clear error message only when neither Version 10.32.1
Usage: pnpm [command] [flags]
       pnpm [ -h | --help | -v | --version ]

These are common pnpm commands used in various situations, use 'pnpm help -a' to list all commands

Manage your dependencies:
      add                  Installs a package and any packages that it depends
                           on. By default, any new package is installed as a
                           prod dependency
   i, install              Install all dependencies for a project
  ln, link                 Connect the local project to another one
  rm, remove               Removes packages from node_modules and from the
                           project's package.json
      unlink               Unlinks a package. Like yarn unlink but pnpm
                           re-installs the dependency after removing the
                           external link
  up, update               Updates packages to their latest version based on the
                           specified range

Review your dependencies:
      audit                Checks for known security issues with the installed
                           packages
  ls, list                 Print all the versions of packages that are
                           installed, as well as their dependencies, in a
                           tree-structure
      outdated             Check for outdated packages
      why                  Shows all packages that depend on the specified
                           package

Run your scripts:
      create               Create a project from a "create-*" or "@foo/create-*"
                           starter kit
      dlx                  Fetches a package from the registry without
                           installing it as a dependency, hot loads it, and runs
                           whatever default command binary it exposes
      exec                 Executes a shell command in scope of a project
      run                  Runs a defined package script

Other:
   c, config               Manage the pnpm configuration files
      init                 Create a package.json file
      publish              Publishes a package to the registry
      self-update          Updates pnpm to the latest version

Options:
  -r, --recursive          Run the command for each project in the workspace. nor Corepack - 0.34.0

  $ corepack <command>

General commands

  corepack cache clean
    Cleans Corepack cache

  corepack disable [--install-directory #0] ...
    Remove the Corepack shims from the install directory

  corepack enable [--install-directory #0] ...
    Add the Corepack shims to the install directory

  corepack install
    Install the package manager configured in the local project

  corepack install <-g,--global> [--cache-only] ...
    Install package managers on the system

  corepack pack [--json] [-o,--output #0] ...
    Store package managers in a tarball

  corepack up
    Update the package manager used in the current project

  corepack use <pattern>
    Define the package manager to use for the current project

You can also print more details about any of these commands by calling them with 
the `-h,--help` flag right after the command name. is available
- keep existing  and docs-only skip behavior unchanged

## Tests
- 
[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/Users/pica/.openclaw/workspace-builder/repos/openclaw[39m

 [32m✓[39m [30m[46m tooling [49m[39m ../git-hooks-pre-commit.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 978[2mms[22m[39m
     [33m[2m✓[22m[39m falls back to corepack pnpm when pnpm is not directly on PATH [33m 558[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m3 passed[39m[22m[90m (3)[39m
[2m   Start at [22m 04:08:39
[2m   Duration [22m 1.06s[2m (transform 30ms, setup 23ms, import 2ms, tests 978ms, environment 0ms)[22m
- added integration coverage: 

Fixes #66695