### PR TITLE
fix: guard against undefined path in formatDocsLink

### DIFF
--- a/src/terminal/links.ts
+++ b/src/terminal/links.ts
@@ -9,7 +9,7 @@ export function formatDocsLink(
   label?: string,
   opts?: { fallback?: string; force?: boolean },
 ): string {
-  const trimmed = path.trim();
+  const trimmed = (path ?? "").trim();
   const docsRoot = resolveDocsRoot();
   const url = trimmed.startsWith("http")
     ? trimmed


### PR DESCRIPTION
## Summary
Fixes TypeError crash in `openclaw configure` wizard when channel doc links are undefined.

## Root Cause
`formatDocsLink()` in `src/terminal/links.ts` called `path.trim()` without checking if `path` is undefined. When a channel's `meta.docsPath` is not set, this crashes the configure wizard.

## Fix
Changed `path.trim()` to `(path ?? "").trim()` — returns empty string fallback, allowing the function to continue gracefully.

## Test Plan
- [ ] Unit tests pass
- [ ] `openclaw configure` wizard no longer crashes on channels with missing docsPath

Closes openclaw#66718