### PR TITLE
fix: return 1M context tokens for Anthropic Opus/Sonnet 4 without context1m config

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -400,7 +400,7 @@ export function resolveContextTokensForModel(params: {
   const explicitProvider = params.provider?.trim();
   if (ref) {
     const modelParams = resolveConfiguredModelParams(params.cfg, ref.provider, ref.model);
-    if (modelParams?.context1m === true && isAnthropic1MModel(ref.provider, ref.model)) {
+    if (isAnthropic1MModel(ref.provider, ref.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
     }
     // Only do the config direct scan when the caller explicitly passed a


### PR DESCRIPTION
## Summary
Fixes incorrect 200k context limit display for Anthropic Claude Opus 4 and Sonnet 4 models in `/status\* and Control UI.

## Root Cause
`resolveContextTokensForModel()\* in `src/agents/context.ts\* required BOTH `context1m: true\* in config AND `isAnthropic1MModel()\* to return 1M tokens. Users without the explicit config flag got the 200k default fallback even though the model is correctly identified as 1M-capable.

## Fix
Removed the `context1m: true\* config requirement. When `isAnthropic1MModel()\* returns true (model ID starts with `claude-opus-4\* or `claude-sonnet-4\*), return `ANTHROPIC_CONTEXT_1M_TOKENS\* unconditionally. The model identification is already sufficient — the config flag is redundant.

## Test Plan
- [ ] Unit tests pass
- [ ] `openclaw models list\* shows 977k for claude-opus-4-6
- [ ] `/status\* shows correct ~1M context limit without `context1m: true\* config

Closes openclaw#66766