### PR TITLE
fix: redact device token from rotate response

### DIFF
--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -347,7 +347,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       {
         deviceId,
         role: entry.role,
-        token: entry.token,
+        token: "[REDACTED]",
         scopes: entry.scopes,
         rotatedAtMs: entry.rotatedAtMs ?? entry.createdAtMs,
       },


### PR DESCRIPTION
## Summary
Prevents plaintext device tokens from being returned in `device.token.rotate\* gateway RPC responses.

## Root Cause
`device.token.rotate\* in `src/gateway/server-methods/devices.ts\* returned the full plaintext bearer token in the success payload. This exposed credentials to websocket traffic, browser devtools, client logs, session transcripts, and proxy instrumentation.

## Fix
Return `[REDACTED]\* instead of the raw token value. The rotation still succeeds server-side; the caller knows the rotation was requested. Clients that need the token can retrieve it through secure out-of-band mechanisms.

Closes openclaw#66773