### PR TITLE
fix(telegram): honor agent defaults in model picker

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -374,12 +374,15 @@ export const registerTelegramHandlers = ({
         model: `${provider}/${model}`,
       };
     }
-    const modelCfg = runtimeCfg.agents?.defaults?.model;
+    const resolvedDefault = resolveDefaultModelForAgent({
+      cfg: runtimeCfg,
+      agentId: route.agentId,
+    });
     return {
       agentId: route.agentId,
       sessionEntry: entry,
       sessionKey,
-      model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary,
+      model: `${resolvedDefault.provider}/${resolvedDefault.model}`,
     };
   };
 

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -1051,6 +1051,75 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("marks the agent-level default model as current in the Telegram picker", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    editMessageTextSpy.mockClear();
+
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: "openai-codex/gpt-5.4",
+          models: {
+            "openai-codex/gpt-5.4": {},
+            "venice/zai-org-glm-4.7": {},
+          },
+        },
+        list: [
+          {
+            id: "household",
+            default: true,
+            model: "venice/zai-org-glm-4.7",
+          },
+        ],
+      },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    };
+
+    loadConfig.mockReturnValue(config);
+    createTelegramBot({
+      token: "tok",
+      config,
+    });
+    const callbackHandler = onSpy.mock.calls.find(
+      (call) => call[0] === "callback_query",
+    )?.[1] as (ctx: Record<string, unknown>) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-model-agent-default-1",
+        data: "mdl_list_venice_1",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 18,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
+    expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+    const [, , , params] = editMessageTextSpy.mock.calls[0] ?? [];
+    expect(params).toEqual({
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: "zai-org-glm-4.7 ✓", callback_data: "mdl_sel_venice/zai-org-glm-4.7" }],
+          [{ text: "<< Back", callback_data: "mdl_back" }],
+        ],
+      },
+    });
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-agent-default-1");
+  });
+
   it("persists non-default model override using fresh config, not stale startup snapshot", async () => {
     // Regression: the callback handler used the startup `cfg` snapshot for
     // store path and default-model resolution.  If the config was reloaded


### PR DESCRIPTION
## Summary
- use `resolveDefaultModelForAgent({ cfg, agentId })` when Telegram reconstructs session state for model-picker callbacks without a stored override
- add a regression test covering an agent-level default that differs from the global default

## Problem
When a Telegram conversation had no stored model override yet, `resolveTelegramSessionState()` fell back to `cfg.agents.defaults.model` directly. That meant the model picker treated the global default as the current model even when the routed agent had its own default model.

In practice, the picker opened on the right provider list but failed to mark the agent's actual default with `✓`, which is misleading before the first override is ever written.

## Testing
- `pnpm exec vitest run extensions/telegram/src/bot.test.ts -t "marks the agent-level default model as current in the Telegram picker"`
- `pnpm test:extension telegram`
- `pnpm tsgo` *(still reports 5 pre-existing unrelated errors; none are introduced by this diff)*

## Note
- Separate issue observed in bundled `channel.runtime-DuOrY50k.js:3264` affecting the Tlon "Generated by" footer. Not addressed here.
