### PR TITLE
fix(reply): resolve active channel/account SecretRefs in reply runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/MCP loopback: switch the `/mcp` bearer comparison from plain `!==` to constant-time `safeEqualSecret` (matching the convention every other auth surface in the codebase uses), and reject non-loopback browser-origin requests via `checkBrowserOrigin` before the auth gate runs. Loopback origins (`127.0.0.1:*`, `localhost:*`, same-origin) still go through, including the `localhost`↔`127.0.0.1` host mismatch that browsers flag as `Sec-Fetch-Site: cross-site`. (#66665) Thanks @eleqtrizit.
 - Auto-reply/billing: classify pure billing cooldown fallback summaries from structured fallback reasons so users see billing guidance instead of the generic failure reply. (#66363) Thanks @Rohan5commit.
 - Agents/fallback: preserve the original prompt body on model fallback retries with session history so the retrying model keeps the active task instead of only seeing a generic continue message. (#66029) Thanks @WuKongAI-CMU.
+- Reply/secrets: resolve active reply channel/account SecretRefs before reply-run message-action discovery so channel token SecretRefs (for example Discord) do not degrade into discovery-time unresolved-secret failures. (#66796) Thanks @joshavant.
 
 ## 2026.4.14
 

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -136,7 +136,13 @@ describe("runReplyAgent runtime config", () => {
     ).rejects.toBe(sentinelError);
 
     expect(followupRun.run.config).toBe(freshCfg);
-    expect(resolveQueuedReplyExecutionConfigMock).toHaveBeenCalledWith(staleCfg);
+    expect(resolveQueuedReplyExecutionConfigMock).toHaveBeenCalledWith(
+      staleCfg,
+      expect.objectContaining({
+        originatingChannel: "telegram",
+        messageProvider: "telegram",
+      }),
+    );
     expect(resolveReplyToModeMock).toHaveBeenCalledWith(freshCfg, "telegram", "default", "dm");
     expect(createReplyMediaPathNormalizerMock).toHaveBeenCalledWith({
       cfg: freshCfg,

--- a/src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+const hoisted = vi.hoisted(() => ({
+  resolveCommandSecretRefsViaGatewayMock: vi.fn(),
+  getScopedChannelsCommandSecretTargetsMock: vi.fn(),
+}));
+
+vi.mock("../../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: (...args: unknown[]) =>
+    hoisted.resolveCommandSecretRefsViaGatewayMock(...args),
+}));
+
+vi.mock("../../cli/command-secret-targets.js", () => ({
+  getAgentRuntimeCommandSecretTargetIds: () => new Set(["skills.entries.*.apiKey"]),
+  getScopedChannelsCommandSecretTargets: (...args: unknown[]) =>
+    hoisted.getScopedChannelsCommandSecretTargetsMock(...args),
+}));
+
+const { resolveQueuedReplyExecutionConfig } = await import("./agent-runner-utils.js");
+const { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =
+  await import("../../config/config.js");
+
+describe("resolveQueuedReplyExecutionConfig channel scope", () => {
+  beforeEach(() => {
+    clearRuntimeConfigSnapshot();
+    hoisted.resolveCommandSecretRefsViaGatewayMock
+      .mockReset()
+      .mockImplementation(async ({ config }) => ({
+        resolvedConfig: config,
+        diagnostics: [],
+        targetStatesByPath: {},
+        hadUnresolvedTargets: false,
+      }));
+    hoisted.getScopedChannelsCommandSecretTargetsMock.mockReset().mockReturnValue({
+      targetIds: new Set(["channels.discord.token"]),
+      allowedPaths: new Set(["channels.discord.token", "channels.discord.accounts.work.token"]),
+    });
+  });
+
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("resolves base runtime targets, then active channel/account targets from originating context", async () => {
+    const sourceConfig = { source: true } as unknown as OpenClawConfig;
+    const baseResolved = { baseResolved: true } as unknown as OpenClawConfig;
+    const scopedResolved = { scopedResolved: true } as unknown as OpenClawConfig;
+    hoisted.resolveCommandSecretRefsViaGatewayMock
+      .mockResolvedValueOnce({
+        resolvedConfig: baseResolved,
+        diagnostics: [],
+        targetStatesByPath: {},
+        hadUnresolvedTargets: false,
+      })
+      .mockResolvedValueOnce({
+        resolvedConfig: scopedResolved,
+        diagnostics: [],
+        targetStatesByPath: {},
+        hadUnresolvedTargets: false,
+      });
+
+    const resolved = await resolveQueuedReplyExecutionConfig(sourceConfig, {
+      originatingChannel: "discord",
+      messageProvider: "slack",
+      originatingAccountId: "work",
+      agentAccountId: "default",
+    });
+
+    expect(resolved).toBe(scopedResolved);
+    expect(hoisted.resolveCommandSecretRefsViaGatewayMock).toHaveBeenCalledTimes(2);
+    const baseCall = hoisted.resolveCommandSecretRefsViaGatewayMock.mock.calls[0]?.[0] as {
+      config: OpenClawConfig;
+      commandName: string;
+      targetIds: Set<string>;
+    };
+    expect(baseCall.config).toBe(sourceConfig);
+    expect(baseCall.commandName).toBe("reply");
+    expect(baseCall.targetIds).toEqual(new Set(["skills.entries.*.apiKey"]));
+    expect(hoisted.getScopedChannelsCommandSecretTargetsMock).toHaveBeenCalledWith({
+      config: baseResolved,
+      channel: "discord",
+      accountId: "work",
+    });
+    const scopedCall = hoisted.resolveCommandSecretRefsViaGatewayMock.mock.calls[1]?.[0] as {
+      config: OpenClawConfig;
+      commandName: string;
+      targetIds: Set<string>;
+      allowedPaths?: Set<string>;
+    };
+    expect(scopedCall.config).toBe(baseResolved);
+    expect(scopedCall.commandName).toBe("reply");
+    expect(scopedCall.targetIds).toEqual(new Set(["channels.discord.token"]));
+    expect(scopedCall.allowedPaths).toEqual(
+      new Set(["channels.discord.token", "channels.discord.accounts.work.token"]),
+    );
+  });
+
+  it("falls back to messageProvider and agentAccountId when originating values are missing", async () => {
+    const sourceConfig = { source: true } as unknown as OpenClawConfig;
+
+    await resolveQueuedReplyExecutionConfig(sourceConfig, {
+      messageProvider: "discord",
+      agentAccountId: "ops",
+    });
+
+    expect(hoisted.getScopedChannelsCommandSecretTargetsMock).toHaveBeenCalledWith({
+      config: sourceConfig,
+      channel: "discord",
+      accountId: "ops",
+    });
+  });
+
+  it("skips scoped channel resolution when no active channel can be resolved", async () => {
+    const sourceConfig = { source: true } as unknown as OpenClawConfig;
+
+    const resolved = await resolveQueuedReplyExecutionConfig(sourceConfig);
+
+    expect(resolved).toBe(sourceConfig);
+    expect(hoisted.resolveCommandSecretRefsViaGatewayMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.getScopedChannelsCommandSecretTargetsMock).not.toHaveBeenCalled();
+  });
+
+  it("prefers the runtime snapshot as the base config for secret resolution", async () => {
+    const sourceConfig = { source: true } as unknown as OpenClawConfig;
+    const runtimeConfig = { runtime: true } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+    hoisted.getScopedChannelsCommandSecretTargetsMock.mockReturnValue({
+      targetIds: new Set<string>(),
+    });
+
+    await resolveQueuedReplyExecutionConfig(sourceConfig, {
+      messageProvider: "discord",
+    });
+
+    const baseCall = hoisted.resolveCommandSecretRefsViaGatewayMock.mock.calls[0]?.[0] as {
+      config: OpenClawConfig;
+      commandName: string;
+    };
+    expect(baseCall.config).toBe(runtimeConfig);
+    expect(baseCall.commandName).toBe("reply");
+    expect(hoisted.getScopedChannelsCommandSecretTargetsMock).toHaveBeenCalledWith({
+      config: runtimeConfig,
+      channel: "discord",
+      accountId: undefined,
+    });
+  });
+});

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -6,7 +6,11 @@ import type {
 } from "../../channels/plugins/types.public.js";
 import { normalizeAnyChannelId, normalizeChannelId } from "../../channels/registry.js";
 import { resolveCommandSecretRefsViaGateway } from "../../cli/command-secret-gateway.js";
-import { getAgentRuntimeCommandSecretTargetIds } from "../../cli/command-secret-targets.js";
+import {
+  getAgentRuntimeCommandSecretTargetIds,
+  getScopedChannelsCommandSecretTargets,
+} from "../../cli/command-secret-targets.js";
+import { resolveMessageSecretScope } from "../../cli/message-secret-scope.js";
 import { getRuntimeConfigSnapshot, type OpenClawConfig } from "../../config/config.js";
 import {
   normalizeOptionalLowercaseString,
@@ -32,6 +36,12 @@ export function resolveQueuedReplyRuntimeConfig(config: OpenClawConfig): OpenCla
 
 export async function resolveQueuedReplyExecutionConfig(
   config: OpenClawConfig,
+  params?: {
+    originatingChannel?: string;
+    messageProvider?: string;
+    originatingAccountId?: string;
+    agentAccountId?: string;
+  },
 ): Promise<OpenClawConfig> {
   const runtimeConfig = resolveQueuedReplyRuntimeConfig(config);
   const { resolvedConfig } = await resolveCommandSecretRefsViaGateway({
@@ -39,7 +49,34 @@ export async function resolveQueuedReplyExecutionConfig(
     commandName: "reply",
     targetIds: getAgentRuntimeCommandSecretTargetIds(),
   });
-  return resolvedConfig ?? runtimeConfig;
+  const baseResolvedConfig = resolvedConfig ?? runtimeConfig;
+
+  const scope = resolveMessageSecretScope({
+    channel: params?.originatingChannel,
+    fallbackChannel: params?.messageProvider,
+    accountId: params?.originatingAccountId,
+    fallbackAccountId: params?.agentAccountId,
+  });
+  if (!scope.channel) {
+    return baseResolvedConfig;
+  }
+
+  const scopedTargets = getScopedChannelsCommandSecretTargets({
+    config: baseResolvedConfig,
+    channel: scope.channel,
+    accountId: scope.accountId,
+  });
+  if (scopedTargets.targetIds.size === 0) {
+    return baseResolvedConfig;
+  }
+
+  const scopedResolved = await resolveCommandSecretRefsViaGateway({
+    config: baseResolvedConfig,
+    commandName: "reply",
+    targetIds: scopedTargets.targetIds,
+    ...(scopedTargets.allowedPaths ? { allowedPaths: scopedTargets.allowedPaths } : {}),
+  });
+  return scopedResolved.resolvedConfig ?? baseResolvedConfig;
 }
 
 /**

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1013,7 +1013,12 @@ export async function runReplyAgent(params: {
     return undefined;
   }
 
-  followupRun.run.config = await resolveQueuedReplyExecutionConfig(followupRun.run.config);
+  followupRun.run.config = await resolveQueuedReplyExecutionConfig(followupRun.run.config, {
+    originatingChannel: sessionCtx.OriginatingChannel,
+    messageProvider: followupRun.run.messageProvider,
+    originatingAccountId: followupRun.originatingAccountId,
+    agentAccountId: followupRun.run.agentAccountId,
+  });
 
   const replyToChannel = resolveOriginMessageProvider({
     originatingChannel: sessionCtx.OriginatingChannel,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -283,6 +283,30 @@ async function loadFreshFollowupRunnerModuleForTest() {
   }));
   vi.doMock("../../cli/command-secret-targets.js", () => ({
     getAgentRuntimeCommandSecretTargetIds: () => new Set(["skills.entries."]),
+    getScopedChannelsCommandSecretTargets: ({
+      channel,
+      accountId,
+    }: {
+      channel?: string;
+      accountId?: string;
+    }) => {
+      const normalizedChannel = channel?.trim() ?? "";
+      if (!normalizedChannel) {
+        return { targetIds: new Set<string>() };
+      }
+      const targetIds = new Set<string>([`channels.${normalizedChannel}.token`]);
+      const normalizedAccountId = accountId?.trim() ?? "";
+      if (!normalizedAccountId) {
+        return { targetIds };
+      }
+      return {
+        targetIds,
+        allowedPaths: new Set<string>([
+          `channels.${normalizedChannel}.token`,
+          `channels.${normalizedChannel}.accounts.${normalizedAccountId}.token`,
+        ]),
+      };
+    },
   }));
   ({ createFollowupRunner } = await import("./followup-runner.js"));
   ({ clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -12,6 +12,10 @@ const routeReplyMock = vi.fn();
 const isRoutableChannelMock = vi.fn();
 const runPreflightCompactionIfNeededMock = vi.fn();
 const resolveCommandSecretRefsViaGatewayMock = vi.fn();
+const resolveQueuedReplyExecutionConfigMock = vi.fn();
+let resolveQueuedReplyExecutionConfigActual:
+  | (typeof import("./agent-runner-utils.js"))["resolveQueuedReplyExecutionConfig"]
+  | undefined;
 let createFollowupRunner: typeof import("./followup-runner.js").createFollowupRunner;
 let clearRuntimeConfigSnapshot: typeof import("../../config/config.js").clearRuntimeConfigSnapshot;
 let loadSessionStore: typeof import("../../config/sessions/store.js").loadSessionStore;
@@ -277,6 +281,21 @@ async function loadFreshFollowupRunnerModuleForTest() {
     isRoutableChannel: (...args: unknown[]) => isRoutableChannelMock(...args),
     routeReply: (...args: unknown[]) => routeReplyMock(...args),
   }));
+  vi.doMock("./agent-runner-utils.js", async () => {
+    const actual =
+      await vi.importActual<typeof import("./agent-runner-utils.js")>("./agent-runner-utils.js");
+    resolveQueuedReplyExecutionConfigActual = actual.resolveQueuedReplyExecutionConfig;
+    resolveQueuedReplyExecutionConfigMock.mockImplementation(
+      async (...args: Parameters<typeof actual.resolveQueuedReplyExecutionConfig>) =>
+        await actual.resolveQueuedReplyExecutionConfig(...args),
+    );
+    return {
+      ...actual,
+      resolveQueuedReplyExecutionConfig: (
+        ...args: Parameters<typeof actual.resolveQueuedReplyExecutionConfig>
+      ) => resolveQueuedReplyExecutionConfigMock(...args),
+    };
+  });
   vi.doMock("../../cli/command-secret-gateway.js", () => ({
     resolveCommandSecretRefsViaGateway: (...args: unknown[]) =>
       resolveCommandSecretRefsViaGatewayMock(...args),
@@ -338,6 +357,15 @@ beforeEach(() => {
   compactEmbeddedPiSessionMock.mockReset();
   runPreflightCompactionIfNeededMock.mockReset();
   resolveCommandSecretRefsViaGatewayMock.mockReset();
+  resolveQueuedReplyExecutionConfigMock.mockReset();
+  const resolveQueuedReplyExecutionConfig = resolveQueuedReplyExecutionConfigActual;
+  if (!resolveQueuedReplyExecutionConfig) {
+    throw new Error("resolveQueuedReplyExecutionConfig mock not initialized");
+  }
+  resolveQueuedReplyExecutionConfigMock.mockImplementation(
+    async (...args: Parameters<typeof resolveQueuedReplyExecutionConfig>) =>
+      await resolveQueuedReplyExecutionConfig(...args),
+  );
   runPreflightCompactionIfNeededMock.mockImplementation(
     async (params: { sessionEntry?: SessionEntry }) => params.sessionEntry,
   );
@@ -536,6 +564,39 @@ describe("createFollowupRunner runtime config", () => {
         }
       | undefined;
     expect(call?.config).toBe(runtimeConfig);
+  });
+
+  it("passes queued origin scope into queued execution-config resolution", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+    const sourceConfig: OpenClawConfig = {};
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "openai/gpt-5.4",
+    });
+    const queued = createQueuedRun({
+      originatingChannel: "discord",
+      originatingAccountId: "work",
+      run: {
+        config: sourceConfig,
+        provider: "openai",
+        model: "gpt-5.4",
+        messageProvider: "discord",
+        agentAccountId: "bot-account",
+      },
+    });
+
+    await runner(queued);
+
+    expect(resolveQueuedReplyExecutionConfigMock).toHaveBeenCalledWith(sourceConfig, {
+      originatingChannel: "discord",
+      messageProvider: "discord",
+      originatingAccountId: "work",
+      agentAccountId: "bot-account",
+    });
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -135,7 +135,12 @@ export function createFollowupRunner(params: {
   };
 
   return async (queued: FollowupRun) => {
-    queued.run.config = await resolveQueuedReplyExecutionConfig(queued.run.config);
+    queued.run.config = await resolveQueuedReplyExecutionConfig(queued.run.config, {
+      originatingChannel: queued.originatingChannel,
+      messageProvider: queued.run.messageProvider,
+      originatingAccountId: queued.originatingAccountId,
+      agentAccountId: queued.run.agentAccountId,
+    });
     const replySessionKey = queued.run.sessionKey ?? sessionKey;
     const runtimeConfig = resolveQueuedReplyRuntimeConfig(queued.run.config);
     const effectiveQueued =


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: reply-run secret resolution only requested base agent runtime targets, so `channels.*` SecretRefs (for the active reply channel) could remain unresolved during agent tool discovery.
- Why it matters: Discord message-action discovery can throw on unresolved token SecretRefs, causing noisy `[message-action-discovery]` errors and degraded/incomplete turns even when channel status/probe looks healthy.
- What changed: reply execution now performs a second, scoped channel/account SecretRef resolution pass for the active reply context (`originatingChannel` > `messageProvider`, `originatingAccountId` > `agentAccountId`).
- What did NOT change (scope boundary): no global expansion of agent runtime secret target scope; no feature flags; no plugin-specific behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveQueuedReplyExecutionConfig` only resolved `getAgentRuntimeCommandSecretTargetIds()` targets. By default that excludes `channels.*`, so active channel SecretRefs could remain raw in reply runs.
- Missing detection / guardrail: no reply-runtime test asserted that active channel/account SecretRefs are resolved before message tool schema/action discovery.
- Contributing context (if known): Discord token resolution intentionally fails closed on unresolved SecretRefs; message-action discovery catches/logs that failure.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts`
  - `src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts`
  - `src/auto-reply/reply/followup-runner.test.ts`
- Scenario the test should lock in:
  - reply runtime resolves base targets and then active channel/account targets (scoped) before tool discovery paths consume config.
- Why this is the smallest reliable guardrail:
  - it validates the exact resolver seam and callsites used by both direct and queued reply paths without broad unrelated runtime dependencies.
- Existing test that already covers this (if any):
  - `extensions/discord/src/token.test.ts` already asserts unresolved Discord SecretRefs throw in strict token resolution.
- If no new test is added, why not:
  - N/A (new tests added).

## User-visible / Behavior Changes

- Active reply channel/account SecretRefs are resolved before reply-run tool discovery.
- If the active reply channel/account SecretRef is unresolved, reply runs fail earlier and explicitly (hard-fail), instead of degrading into discovery-time errors.

## Diagram (if applicable)

```text
Before:
reply run -> resolve base runtime secrets only -> message tool discovery -> discord token SecretRef still raw -> discovery error log

After:
reply run -> resolve base runtime secrets -> resolve active channel/account secrets (scoped) -> message tool discovery uses resolved token -> no unresolved SecretRef discovery error
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
  - No
- Secrets/tokens handling changed? (`Yes/No`)
  - Yes
- New/changed network calls? (`Yes/No`)
  - No
- Command/tool execution surface changed? (`Yes/No`)
  - No
- Data access scope changed? (`Yes/No`)
  - No
- If any `Yes`, explain risk + mitigation:
  - Secret-resolution behavior changed for reply runs: active channel/account scopes are now resolved strictly before execution. Mitigated by scoped target/allowedPaths selection and regression tests.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v24.14.1, pnpm
- Model/provider: OpenAI `gpt-5.4` (invalid API key used intentionally to end run quickly)
- Integration/channel (if any): Discord
- Relevant config (redacted): `channels.discord.token` configured as `env:default:DISCORD_BOT_TOKEN` SecretRef

### Steps

1. Configure Discord token as SecretRef object in runtime config.
2. Run embedded reply path with active Discord context without scoped reply secret resolution (control).
3. Run same path with `resolveQueuedReplyExecutionConfig(...)` scoped channel/account resolution first.

### Expected

- Control: unresolved SecretRef discovery error is logged.
- Fixed path: no unresolved SecretRef discovery error for Discord message-action discovery.

### Actual

- Control produced:
  - `[message-action-discovery] discord.actions.describeMessageTool failed: ... unresolved SecretRef "env:default:DISCORD_BOT_TOKEN"`
- Fixed path produced:
  - resolved Discord token type became string
  - zero unresolved discovery errors captured

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - direct reply path now passes active scope into `resolveQueuedReplyExecutionConfig`
  - queued followup path now passes active scope into `resolveQueuedReplyExecutionConfig`
  - scoped channel/account resolver pass executes and applies `allowedPaths` when account is known
  - manual control-vs-fixed repro for Discord SecretRef discovery behavior
- Edge cases checked:
  - missing active channel skips scoped pass
  - fallback to `messageProvider`/`agentAccountId` when originating values are missing
  - runtime snapshot remains preferred base config input
- What you did **not** verify:
  - full live Discord gateway send roundtrip with production credentials

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
  - Yes
- Config/env changes? (`Yes/No`)
  - No
- Migration needed? (`Yes/No`)
  - No
- If yes, exact upgrade steps:
  - N/A

## Risks and Mitigations

- Risk:
  - Runs can fail earlier for unresolved active channel/account SecretRefs that previously degraded later.
  - Mitigation:
    - this is intentional hard-fail behavior for active reply routing correctness; scope is limited to active channel/account only.
- Risk:
  - Future changes could accidentally broaden scoped resolution.
  - Mitigation:
    - dedicated scoped-resolution tests assert channel/account targeting and no-op behavior when no active channel is resolved.
