### PR TITLE
feat: bridge external MCP servers to CLI backends via bundleExternalMcp

### DIFF
--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -25,6 +25,7 @@ export type ResolvedCliBackend = {
   config: CliBackendConfig;
   bundleMcp: boolean;
   bundleMcpMode?: CliBundleMcpMode;
+  bundleExternalMcp?: boolean;
   pluginId?: string;
   transformSystemPrompt?: CliBackendPlugin["transformSystemPrompt"];
   textTransforms?: PluginTextTransforms;
@@ -46,6 +47,7 @@ export function normalizeClaudeBackendConfig(config: CliBackendConfig): CliBacke
 type FallbackCliBackendPolicy = {
   bundleMcp: boolean;
   bundleMcpMode?: CliBundleMcpMode;
+  bundleExternalMcp?: boolean;
   baseConfig?: CliBackendConfig;
   normalizeConfig?: (config: CliBackendConfig) => CliBackendConfig;
   transformSystemPrompt?: CliBackendPlugin["transformSystemPrompt"];
@@ -79,6 +81,7 @@ function resolveSetupCliBackendPolicy(provider: string): FallbackCliBackendPolic
       entry.backend.bundleMcpMode,
       entry.backend.bundleMcp === true,
     ),
+    bundleExternalMcp: entry.backend.bundleExternalMcp,
     baseConfig: entry.backend.config,
     normalizeConfig: entry.backend.normalizeConfig,
     transformSystemPrompt: entry.backend.transformSystemPrompt,
@@ -212,6 +215,7 @@ export function resolveCliBackendConfig(
         registered.bundleMcpMode,
         registered.bundleMcp === true,
       ),
+      bundleExternalMcp: registered.bundleExternalMcp,
       pluginId: registered.pluginId,
       transformSystemPrompt: registered.transformSystemPrompt,
       textTransforms: mergePluginTextTransforms(runtimeTextTransforms, registered.textTransforms),
@@ -235,6 +239,7 @@ export function resolveCliBackendConfig(
       config: { ...baseConfig, command },
       bundleMcp: fallbackPolicy.bundleMcp,
       bundleMcpMode: fallbackPolicy.bundleMcpMode,
+      bundleExternalMcp: fallbackPolicy.bundleExternalMcp,
       transformSystemPrompt: fallbackPolicy.transformSystemPrompt,
       textTransforms: mergePluginTextTransforms(
         runtimeTextTransforms,
@@ -257,6 +262,7 @@ export function resolveCliBackendConfig(
     config: { ...config, command },
     bundleMcp: fallbackPolicy?.bundleMcp === true,
     bundleMcpMode: fallbackPolicy?.bundleMcpMode,
+    bundleExternalMcp: fallbackPolicy?.bundleExternalMcp,
     transformSystemPrompt: fallbackPolicy?.transformSystemPrompt,
     textTransforms: mergePluginTextTransforms(
       runtimeTextTransforms,

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -314,18 +314,24 @@ async function prepareModeSpecificBundleMcpConfig(params: {
  * These are "external" MCP servers configured by the user at the gateway level.
  */
 function extractExternalMcpConfig(config?: OpenClawConfig): BundleMcpConfig {
-  const servers = (config as Record<string, unknown> | undefined)?.mcp as
-    | Record<string, unknown>
-    | undefined;
-  const serverMap = servers?.servers as Record<string, Record<string, unknown>> | undefined;
-  if (!serverMap || typeof serverMap !== "object") {
+  const cfg = config as Record<string, unknown> | undefined;
+  const mcp = cfg?.mcp;
+  if (!isRecord(mcp)) {
+    return { mcpServers: {} };
+  }
+  const serverMap = mcp.servers;
+  if (!isRecord(serverMap)) {
     return { mcpServers: {} };
   }
   const result: Record<string, BundleMcpServerConfig> = {};
   for (const [name, server] of Object.entries(serverMap)) {
-    if (!server || typeof server !== "object") continue;
-    if ((server as Record<string, unknown>).enabled === false) continue;
-    const { enabled, ...rest } = server as Record<string, unknown>;
+    if (!isRecord(server)) {
+      continue;
+    }
+    if (server.enabled === false) {
+      continue;
+    }
+    const { enabled: _enabled, ...rest } = server;
     result[name] = rest;
   }
   return { mcpServers: result };

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -314,25 +314,17 @@ async function prepareModeSpecificBundleMcpConfig(params: {
  * These are "external" MCP servers configured by the user at the gateway level.
  */
 function extractExternalMcpConfig(config?: OpenClawConfig): BundleMcpConfig {
-  const cfg = config as Record<string, unknown> | undefined;
-  const mcp = cfg?.mcp;
-  if (!isRecord(mcp)) {
-    return { mcpServers: {} };
-  }
-  const serverMap = mcp.servers;
-  if (!isRecord(serverMap)) {
+  const serverMap = config?.mcp?.servers;
+  if (!serverMap) {
     return { mcpServers: {} };
   }
   const result: Record<string, BundleMcpServerConfig> = {};
   for (const [name, server] of Object.entries(serverMap)) {
-    if (!isRecord(server)) {
-      continue;
-    }
     if (server.enabled === false) {
       continue;
     }
-    const { enabled: _enabled, ...rest } = server;
-    result[name] = rest;
+    const { enabled: _enabled, ...rest } = server as Record<string, unknown>;
+    result[name] = rest as BundleMcpServerConfig;
   }
   return { mcpServers: result };
 }
@@ -378,11 +370,13 @@ export async function prepareCliBundleMcpConfig(params: {
   }
   mergedConfig = applyMergePatch(mergedConfig, bundleConfig.config) as BundleMcpConfig;
 
-  // Merge external MCP servers from openclaw.json mcp.servers (default: on when bundleMcp is on)
+  // Include external MCP servers from openclaw.json mcp.servers (default: on when bundleMcp is on).
+  // External servers replace same-name bundled servers wholesale to avoid stale field collisions
+  // when transports differ (e.g. bundled stdio vs external HTTP).
   if (params.bundleExternalMcp !== false) {
     const externalMcp = extractExternalMcpConfig(params.config);
-    if (Object.keys(externalMcp.mcpServers).length > 0) {
-      mergedConfig = applyMergePatch(mergedConfig, externalMcp) as BundleMcpConfig;
+    for (const [name, server] of Object.entries(externalMcp.mcpServers)) {
+      mergedConfig.mcpServers[name] = server;
     }
   }
 

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -309,9 +309,32 @@ async function prepareModeSpecificBundleMcpConfig(params: {
   };
 }
 
+/**
+ * Extract enabled MCP servers from the openclaw.json `mcp.servers` config.
+ * These are "external" MCP servers configured by the user at the gateway level.
+ */
+function extractExternalMcpConfig(config?: OpenClawConfig): BundleMcpConfig {
+  const servers = (config as Record<string, unknown> | undefined)?.mcp as
+    | Record<string, unknown>
+    | undefined;
+  const serverMap = servers?.servers as Record<string, Record<string, unknown>> | undefined;
+  if (!serverMap || typeof serverMap !== "object") {
+    return { mcpServers: {} };
+  }
+  const result: Record<string, BundleMcpServerConfig> = {};
+  for (const [name, server] of Object.entries(serverMap)) {
+    if (!server || typeof server !== "object") continue;
+    if ((server as Record<string, unknown>).enabled === false) continue;
+    const { enabled, ...rest } = server as Record<string, unknown>;
+    result[name] = rest;
+  }
+  return { mcpServers: result };
+}
+
 export async function prepareCliBundleMcpConfig(params: {
   enabled: boolean;
   mode?: CliBundleMcpMode;
+  bundleExternalMcp?: boolean;
   backend: CliBackendConfig;
   workspaceDir: string;
   config?: OpenClawConfig;
@@ -348,6 +371,15 @@ export async function prepareCliBundleMcpConfig(params: {
     params.warn?.(`bundle MCP skipped for ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
   mergedConfig = applyMergePatch(mergedConfig, bundleConfig.config) as BundleMcpConfig;
+
+  // Merge external MCP servers from openclaw.json mcp.servers (default: on when bundleMcp is on)
+  if (params.bundleExternalMcp !== false) {
+    const externalMcp = extractExternalMcpConfig(params.config);
+    if (Object.keys(externalMcp.mcpServers).length > 0) {
+      mergedConfig = applyMergePatch(mergedConfig, externalMcp) as BundleMcpConfig;
+    }
+  }
+
   if (params.additionalConfig) {
     mergedConfig = applyMergePatch(mergedConfig, params.additionalConfig) as BundleMcpConfig;
   }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -130,6 +130,7 @@ export async function prepareCliRunContext(
   const preparedBackend = await prepareCliBundleMcpConfig({
     enabled: backendResolved.bundleMcp,
     mode: backendResolved.bundleMcpMode,
+    bundleExternalMcp: backendResolved.bundleExternalMcp ?? backendResolved.bundleMcp,
     backend: backendResolved.config,
     workspaceDir,
     config: params.config,

--- a/src/config/types.mcp.ts
+++ b/src/config/types.mcp.ts
@@ -17,6 +17,8 @@ export type McpServerConfig = {
   headers?: Record<string, string | number | boolean>;
   /** Optional connection timeout in milliseconds. */
   connectionTimeoutMs?: number;
+  /** When false, the server is excluded from bundled MCP configs for CLI backends. */
+  enabled?: boolean;
   [key: string]: unknown;
 };
 

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -56,6 +56,14 @@ export type CliBackendPlugin = {
    */
   bundleMcpMode?: CliBundleMcpMode;
   /**
+   * Whether to include external MCP servers from `openclaw.json` `mcp.servers`
+   * in the bundled MCP config passed to the CLI subprocess.
+   *
+   * Defaults to `true` when `bundleMcp` is enabled. Set to `false` to only
+   * include plugin-based MCP servers.
+   */
+  bundleExternalMcp?: boolean;
+  /**
    * Optional config normalizer applied after user overrides merge.
    *
    * Use this for backend-specific compatibility rewrites when old config


### PR DESCRIPTION
## Summary
- When `bundleMcp` is enabled for a CLI backend (e.g. claude-cli), external MCP servers defined in `openclaw.json` under `mcp.servers` are now included in the bundled MCP config passed to the CLI subprocess
- Previously, only plugin-based MCP servers were bridged. User-configured servers like `chrome-devtools` were visible to the gateway but invisible to CLI backends
- New `bundleExternalMcp` option defaults to `true` when `bundleMcp` is enabled; servers with `enabled: false` are excluded

## Motivation
Users configuring MCP servers in `openclaw.json` (e.g. Chrome DevTools MCP for browser automation via CDP relay) expect those tools to be available to their agent. With `claude-cli` as the backend, the `bundleMcp` bridge only included plugin-bundle MCP servers, leaving external servers inaccessible.

## Changes
- `src/plugins/cli-backend.types.ts` - Add `bundleExternalMcp` type definition
- `src/agents/cli-backends.ts` - Propagate through resolved backend types
- `src/agents/cli-runner/bundle-mcp.ts` - Add `extractExternalMcpConfig()` to read enabled servers from `mcp.servers` and merge into bundled MCP config
- `src/agents/cli-runner/prepare.ts` - Pass `bundleExternalMcp` flag

## Test plan
- [x] Configure `mcp.servers.chrome-devtools` in `openclaw.json`
- [x] Start gateway with `claude-cli/opus` backend
- [x] Verified all 30 chrome-devtools tools visible to CLI subprocess
- [x] Agent successfully used chrome-devtools tools (screenshots, accessibility tree)