### PR TITLE
fix: suppress commentary text in live gateway surfaces

### DIFF
--- a/docs/diagnostics/commentary-phase-chat-leak.md
+++ b/docs/diagnostics/commentary-phase-chat-leak.md
@@ -1,0 +1,91 @@
+# Commentary-Phase Chat Leak Investigation
+
+## Summary
+
+Commentary-phase assistant text is supposed to be replay/debug context, not user-visible chat output.
+Current OpenClaw code mostly treats it that way, but two live broadcast surfaces bypass the phase-aware filters:
+
+1. `chat` live events in `src/gateway/server-chat.ts`
+2. `session.message` transcript update events in `src/gateway/server-session-events.ts`
+
+That matches the reported symptom: a transcript entry can contain commentary text plus a tool call in the same assistant turn, and that commentary text can still show up in chat even though history endpoints hide it.
+
+## What Commentary Means
+
+Current architecture treats assistant `phase` / `textSignature.phase` as semantic metadata on assistant text blocks:
+
+- `commentary` means interim assistant narration/replay text, often before a tool call.
+- `final_answer` means the user-visible answer text.
+
+The shared extraction helpers make that contract explicit:
+
+- `resolveAssistantMessagePhase()` infers a message phase from `message.phase` or `textSignature.phase` metadata in text blocks. See `src/shared/chat-message-content.ts:64`.
+- `extractAssistantVisibleText()` prefers `final_answer` text and otherwise only returns unphased legacy text. Commentary-only text is intentionally excluded. See `src/shared/chat-message-content.ts:182`.
+
+## Exact Persistence Path
+
+For OpenAI Responses / WebSocket turns, commentary metadata is preserved on the stored assistant message:
+
+1. `buildAssistantMessageFromResponse()` converts model output items into an assistant transcript message. Commentary text is stored as `content[]` text blocks with `textSignature` carrying `{ phase: "commentary" }`, and tool calls are stored in the same assistant message as `toolCall` blocks. See `src/agents/openai-ws-message-conversion.ts:465`.
+2. The embedded runner uses a guarded `SessionManager.appendMessage(...)` wrapper.
+3. `installSessionToolResultGuard()` appends the final assistant message verbatim and immediately emits `emitSessionTranscriptUpdate({ message: finalMessage, ... })`. No commentary stripping happens there. See `src/agents/session-tool-result-guard.ts:171` and `src/agents/session-tool-result-guard.ts:247`.
+
+So the transcript entry itself legitimately contains commentary text plus tool calls. That is not the bug by itself.
+
+## Where Suppression Already Works
+
+The phase-aware filtering exists and is already used in history-style surfaces:
+
+- `sanitizeChatHistoryMessages()` drops assistant messages whose resolved phase is `commentary`, and strips commentary text blocks when explicit phased blocks are present. See `src/gateway/server-methods/chat.ts:691` and `src/gateway/server-methods/chat.ts:936`.
+- `buildSessionHistorySnapshot()` always runs `sanitizeChatHistoryMessages(...)` before returning messages. See `src/gateway/session-history-state.ts:96`.
+- `sessions-history-http` also uses the same sanitized state for inline SSE `message` updates. See `src/gateway/sessions-history-http.ts:227`.
+- Existing tests already prove this contract for `chat.history`. See `src/gateway/server.chat.gateway-server-chat.test.ts:545` and `src/gateway/server-methods/server-methods.test.ts:266`.
+- The embedded reply stream used for actual reply delivery also suppresses commentary before emitting assistant deltas/finals. See `src/agents/pi-embedded-subscribe.handlers.messages.ts:217`, `src/agents/pi-embedded-subscribe.handlers.messages.ts:303`, and `src/agents/pi-embedded-subscribe.handlers.messages.ts:456`.
+
+## Where It Actually Leaks
+
+### 1. Live `chat` stream
+
+`createAgentEventHandler()` forwards any assistant event with `evt.data.text` into `emitChatDelta(...)` without checking `evt.data.phase`.
+
+See `src/gateway/server-chat.ts:983`.
+
+That means commentary-phase assistant events can become live user-visible `chat` deltas/finals if any upstream emitter includes `phase: "commentary"` alongside `text`.
+
+### 2. `session.message` transcript broadcast
+
+`createTranscriptUpdateBroadcastHandler()` forwards `update.message` directly as a `session.message` event after attaching only sequence/id metadata.
+
+See `src/gateway/server-session-events.ts:83`.
+
+Unlike history endpoints, this path does not run `sanitizeChatHistoryMessages(...)`, `resolveAssistantMessagePhase(...)`, or `extractAssistantVisibleText(...)`.
+
+So when the session manager emits a transcript update for an assistant message containing commentary text plus tool calls, subscribers can receive the raw commentary text and render it directly.
+
+## Likely Root Cause
+
+The bug is inconsistent filtering across surfaces, not incorrect transcript storage.
+
+OpenClaw intentionally preserves commentary-phase text in the transcript for replay/context continuity. The leak happens later because some live broadcast paths still treat raw assistant text as user-visible text:
+
+- `server-chat` trusts `evt.data.text` and ignores `evt.data.phase`
+- `server-session-events` trusts `update.message` and skips transcript sanitization
+
+In other words, commentary is modeled correctly, persisted correctly, and filtered correctly in history endpoints, but not normalized at every live fan-out boundary.
+
+## Most Likely Safe Fix Shape
+
+The obvious safe fix is to make the live fan-out boundaries reuse the same phase-aware rules already used elsewhere:
+
+1. In `src/gateway/server-chat.ts`, ignore assistant events whose `evt.data.phase === "commentary"` before calling `emitChatDelta(...)` / emitting final chat text.
+2. In `src/gateway/server-session-events.ts`, sanitize `update.message` before broadcasting `session.message`, ideally by reusing the same history sanitization/extraction helpers.
+3. Add regression tests for an assistant turn that contains:
+   - a commentary text block with `textSignature.phase = "commentary"`
+   - a `toolCall` in the same assistant message
+   - a live `chat`/`session.message` subscriber
+
+## Conclusion
+
+The reported leak is plausible in current code.
+
+The most likely root cause is that commentary-phase text is preserved in the transcript for replay, but `server-chat` and `server-session-events` still expose raw assistant text without applying the phase-aware visibility contract already enforced by `chat.history`, `sessions-history-http`, and the embedded reply stream.

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -215,6 +215,63 @@ describe("agent event handler", () => {
     nowSpy?.mockRestore();
   });
 
+  it("suppresses commentary-phase assistant text but still emits later final_answer text", () => {
+    const { broadcast, nodeSendToSession, chatRunState, handler, nowSpy } = createHarness({
+      now: 1_250,
+    });
+    chatRunState.registry.add("run-commentary", {
+      sessionKey: "session-commentary",
+      clientRunId: "client-commentary",
+    });
+
+    handler({
+      runId: "run-commentary",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: {
+        text: "Checking thread context before I answer.",
+        delta: "Checking thread context before I answer.",
+        phase: "commentary",
+      },
+    });
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(0);
+
+    handler({
+      runId: "run-commentary",
+      seq: 2,
+      stream: "assistant",
+      ts: Date.now(),
+      data: {
+        text: "Final answer",
+        delta: "Final answer",
+        phase: "final_answer",
+      },
+    });
+    emitLifecycleEnd(handler, "run-commentary", 3);
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(2);
+    expect(chatCalls.map(([, payload]) => (payload as { state?: string }).state)).toEqual([
+      "delta",
+      "final",
+    ]);
+    expect(
+      chatCalls.every(([, payload]) => {
+        const text = (payload as { message?: { content?: Array<{ text?: string }> } }).message
+          ?.content?.[0]?.text;
+        return !text || !text.includes("Checking thread context");
+      }),
+    ).toBe(true);
+    const finalPayload = chatCalls.at(-1)?.[1] as {
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(finalPayload.message?.content?.[0]?.text).toBe("Final answer");
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(2);
+    nowSpy?.mockRestore();
+  });
+
   it.each([" NO_REPLY  ", " ANNOUNCE_SKIP ", " REPLY_SKIP "])(
     "does not emit chat delta for suppressed control text %s",
     (replyText) => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -980,7 +980,14 @@ export function createAgentEventHandler({
           isToolEvent ? { ...toolPayload, ...buildSessionEventSnapshot(sessionKey) } : agentPayload,
         );
       }
-      if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
+      const assistantPhase =
+        evt.stream === "assistant" && typeof evt.data?.phase === "string" ? evt.data.phase : "";
+      if (
+        !isAborted &&
+        evt.stream === "assistant" &&
+        assistantPhase !== "commentary" &&
+        typeof evt.data?.text === "string"
+      ) {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text, evt.data.delta);
       }
     }

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  attachOpenClawTranscriptMeta: vi.fn(),
+  loadGatewaySessionRow: vi.fn(),
+  loadSessionEntry: vi.fn(),
+  readSessionMessages: vi.fn(),
+  resolveSessionKeyForTranscriptFile: vi.fn(),
+}));
+
+vi.mock("./session-transcript-key.js", () => ({
+  resolveSessionKeyForTranscriptFile: mocks.resolveSessionKeyForTranscriptFile,
+}));
+
+vi.mock("./session-utils.js", () => ({
+  attachOpenClawTranscriptMeta: mocks.attachOpenClawTranscriptMeta,
+  loadGatewaySessionRow: mocks.loadGatewaySessionRow,
+  loadSessionEntry: mocks.loadSessionEntry,
+  readSessionMessages: mocks.readSessionMessages,
+}));
+
+import { createTranscriptUpdateBroadcastHandler } from "./server-session-events.js";
+
+describe("createTranscriptUpdateBroadcastHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveSessionKeyForTranscriptFile.mockReturnValue("agent:main:main");
+    mocks.loadSessionEntry.mockReturnValue({
+      entry: {
+        sessionId: "sess-main",
+        sessionFile: "/tmp/sess-main.jsonl",
+      },
+      storePath: "/tmp/sessions.json",
+    });
+    mocks.readSessionMessages.mockReturnValue([{}, {}]);
+    mocks.loadGatewaySessionRow.mockReturnValue({
+      sessionId: "sess-main",
+      updatedAt: 123,
+      kind: "agent",
+      label: "Main",
+    });
+    mocks.attachOpenClawTranscriptMeta.mockImplementation(
+      (message: Record<string, unknown>, meta: Record<string, unknown>) => ({
+        ...message,
+        openclawMeta: meta,
+      }),
+    );
+  });
+
+  function createHarness() {
+    const broadcastToConnIds = vi.fn();
+    const sessionEventSubscribers = {
+      getAll: vi.fn(() => new Set(["conn-event"])),
+    };
+    const sessionMessageSubscribers = {
+      get: vi.fn((sessionKey: string) =>
+        sessionKey === "agent:main:main" ? new Set(["conn-message"]) : new Set<string>(),
+      ),
+    };
+    return {
+      broadcastToConnIds,
+      handler: createTranscriptUpdateBroadcastHandler({
+        broadcastToConnIds,
+        sessionEventSubscribers,
+        sessionMessageSubscribers,
+      }),
+      sessionEventSubscribers,
+      sessionMessageSubscribers,
+    };
+  }
+
+  it("suppresses commentary-only assistant transcript updates from session.message", () => {
+    const { broadcastToConnIds, handler } = createHarness();
+
+    handler({
+      sessionFile: "/tmp/sess-main.jsonl",
+      sessionKey: "agent:main:main",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Thinking out loud",
+            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+          },
+        ],
+        timestamp: 1,
+      },
+      messageId: "msg-commentary",
+    });
+
+    expect(mocks.attachOpenClawTranscriptMeta).not.toHaveBeenCalled();
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
+    expect(broadcastToConnIds.mock.calls[0]?.[0]).toBe("sessions.changed");
+    expect(broadcastToConnIds.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        phase: "message",
+        messageId: "msg-commentary",
+        messageSeq: 2,
+      }),
+    );
+    expect(Array.from(broadcastToConnIds.mock.calls[0]?.[2] as Set<string>)).toEqual([
+      "conn-event",
+    ]);
+  });
+
+  it("suppresses mixed commentary transcript updates from session.message", () => {
+    const { broadcastToConnIds, handler } = createHarness();
+
+    handler({
+      sessionFile: "/tmp/sess-main.jsonl",
+      sessionKey: "agent:main:main",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Checking logs before I call the tool.",
+            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+          },
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "read",
+            arguments: { path: "README.md" },
+          },
+        ],
+        timestamp: 1,
+      },
+      messageId: "msg-commentary-tool",
+    });
+
+    expect(mocks.attachOpenClawTranscriptMeta).not.toHaveBeenCalled();
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
+    expect(broadcastToConnIds.mock.calls[0]?.[0]).toBe("sessions.changed");
+    expect(broadcastToConnIds.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        messageId: "msg-commentary-tool",
+        messageSeq: 2,
+        phase: "message",
+      }),
+    );
+    expect(Array.from(broadcastToConnIds.mock.calls[0]?.[2] as Set<string>)).toEqual([
+      "conn-event",
+    ]);
+  });
+});

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -5,6 +5,7 @@ import type {
   SessionEventSubscriberRegistry,
   SessionMessageSubscriberRegistry,
 } from "./server-chat.js";
+import { sanitizeChatHistoryMessages } from "./server-methods/chat.js";
 import { resolveSessionKeyForTranscriptFile } from "./session-transcript-key.js";
 import {
   attachOpenClawTranscriptMeta,
@@ -16,6 +17,18 @@ import {
 
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
+
+function sanitizeTranscriptUpdateMessage(message: unknown): Record<string, unknown> | null {
+  const [sanitizedMessage] = sanitizeChatHistoryMessages([message]);
+  if (
+    !sanitizedMessage ||
+    typeof sanitizedMessage !== "object" ||
+    Array.isArray(sanitizedMessage)
+  ) {
+    return null;
+  }
+  return sanitizedMessage as Record<string, unknown>;
+}
 
 function buildGatewaySessionSnapshot(params: {
   sessionRow: GatewaySessionRow | null | undefined;
@@ -108,22 +121,25 @@ export function createTranscriptUpdateBroadcastHandler(params: {
       sessionRow: loadGatewaySessionRow(sessionKey),
       includeSession: true,
     });
-    const message = attachOpenClawTranscriptMeta(update.message, {
-      ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
-      ...(typeof messageSeq === "number" ? { seq: messageSeq } : {}),
-    });
-    params.broadcastToConnIds(
-      "session.message",
-      {
-        sessionKey,
-        message,
-        ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
-        ...(typeof messageSeq === "number" ? { messageSeq } : {}),
-        ...sessionSnapshot,
-      },
-      connIds,
-      { dropIfSlow: true },
-    );
+    const sanitizedMessage = sanitizeTranscriptUpdateMessage(update.message);
+    if (sanitizedMessage) {
+      const message = attachOpenClawTranscriptMeta(sanitizedMessage, {
+        ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
+        ...(typeof messageSeq === "number" ? { seq: messageSeq } : {}),
+      });
+      params.broadcastToConnIds(
+        "session.message",
+        {
+          sessionKey,
+          message,
+          ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
+          ...(typeof messageSeq === "number" ? { messageSeq } : {}),
+          ...sessionSnapshot,
+        },
+        connIds,
+        { dropIfSlow: true },
+      );
+    }
 
     const sessionEventConnIds = params.sessionEventSubscribers.getAll();
     if (sessionEventConnIds.size === 0) {


### PR DESCRIPTION
## What
This PR stops live gateway broadcasts from surfacing commentary-phase assistant text in user-visible chat and transcript subscription updates, while leaving transcript persistence unchanged.

## Why
A commentary-phase assistant turn was being rebroadcast raw through live chat and `session.message` paths, which allowed internal reasoning/commentary text to leak into user-visible surfaces.

## Changes
- Skip commentary deltas in live chat fan-out
- Sanitize transcript updates before session.message broadcast
- Add live chat commentary regression test
- Add session.message broadcast suppression tests
- Include the investigation note for clawdbot-b90

## Testing
- `pnpm test src/gateway/server-chat.agent-events.test.ts`
- `pnpm test src/gateway/server-session-events.test.ts`