### PR TITLE
fix(cli): unwrap nested claude result json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@ Docs: https://docs.openclaw.ai
 - Codex: consume unauthorized bound conversation inbound claims before they can fall through to other claim handlers or enqueue Codex turns. (#71702) Thanks @vincentkoc.
 - Codex media understanding: require approval-checked app-server image turns while explicitly declining tool, file, permission, and elicitation approval requests for the bounded image worker. (#71703) Thanks @vincentkoc.
 - Agents/Claude CLI: allow large live `stream-json` JSONL lines up to the existing per-turn raw limit, preventing large Telegram, WebChat, MCP, and image turns from aborting on the old stdout buffer cap. Fixes #71793, #71080, and #70766. (#71897) Thanks @chacher86, @shivamgrover21, and @tpjordan.
+- Agents/Claude CLI: unwrap nested Claude result envelopes in CLI JSON output so delegated agent responses surface as final text instead of raw result JSON. (#66819) Thanks @mraleko.
 
 ## 2026.4.24
 

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -125,6 +125,33 @@ describe("parseCliJson", () => {
     });
   });
 
+  it("unwraps nested Claude result JSON from JSON output", () => {
+    const result = parseCliJson(
+      JSON.stringify({
+        session_id: "session-nested-json",
+        result: JSON.stringify({
+          type: "result",
+          result: JSON.stringify({
+            type: "result",
+            subtype: "success",
+            result: "actual response text",
+          }),
+        }),
+      }),
+      {
+        command: "claude",
+        output: "json",
+        sessionIdFields: ["session_id"],
+      },
+    );
+
+    expect(result).toEqual({
+      text: "actual response text",
+      sessionId: "session-nested-json",
+      usage: undefined,
+    });
+  });
+
   it("parses nested OpenAI-style cached token details from CLI json payloads", () => {
     const result = parseCliJson(
       JSON.stringify({
@@ -292,6 +319,38 @@ describe("parseCliJsonl", () => {
         cacheWrite: undefined,
         total: undefined,
       },
+    });
+  });
+
+  it("unwraps nested Claude agent result JSON from stream-json output", () => {
+    const result = parseCliJsonl(
+      [
+        JSON.stringify({ type: "init", session_id: "session-nested-jsonl" }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-nested-jsonl",
+          result: JSON.stringify({
+            type: "result",
+            result: JSON.stringify({
+              type: "result",
+              subtype: "success",
+              result: "actual response text",
+            }),
+          }),
+        }),
+      ].join("\n"),
+      {
+        command: "claude",
+        output: "jsonl",
+        sessionIdFields: ["session_id"],
+      },
+      "claude-cli",
+    );
+
+    expect(result).toEqual({
+      text: "actual response text",
+      sessionId: "session-nested-jsonl",
+      usage: undefined,
     });
   });
 

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -143,11 +143,40 @@ describe("parseCliJson", () => {
         output: "json",
         sessionIdFields: ["session_id"],
       },
+      "claude-cli",
     );
 
     expect(result).toEqual({
       text: "actual response text",
       sessionId: "session-nested-json",
+      usage: undefined,
+    });
+  });
+
+  it("does not unwrap nested result-shaped JSON for non-claude json backends", () => {
+    const nestedResult = JSON.stringify({
+      type: "result",
+      result: JSON.stringify({
+        type: "result",
+        result: "actual response text",
+      }),
+    });
+    const result = parseCliJson(
+      JSON.stringify({
+        session_id: "gemini-session-nested-json",
+        result: nestedResult,
+      }),
+      {
+        command: "gemini",
+        output: "json",
+        sessionIdFields: ["session_id"],
+      },
+      "gemini",
+    );
+
+    expect(result).toEqual({
+      text: nestedResult,
+      sessionId: "gemini-session-nested-json",
       usage: undefined,
     });
   });

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -193,6 +193,31 @@ function collectCliText(value: unknown): string {
   return "";
 }
 
+function unwrapNestedCliResultText(raw: string): string {
+  let text = raw;
+  for (let depth = 0; depth < 8; depth += 1) {
+    const trimmed = text.trim();
+    if (!trimmed.startsWith("{")) {
+      return text;
+    }
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (
+        !isRecord(parsed) ||
+        typeof parsed.type !== "string" ||
+        parsed.type !== "result" ||
+        typeof parsed.result !== "string"
+      ) {
+        return text;
+      }
+      text = parsed.result;
+    } catch {
+      return text;
+    }
+  }
+  return text;
+}
+
 function collectExplicitCliErrorText(parsed: Record<string, unknown>): string {
   const nested = readNestedErrorMessage(parsed);
   if (nested) {
@@ -260,7 +285,7 @@ export function parseCliJson(raw: string, backend: CliBackendConfig): CliOutput 
       collectCliText(parsed.result) ||
       collectCliText(parsed.response) ||
       collectCliText(parsed);
-    const trimmedText = nextText.trim();
+    const trimmedText = unwrapNestedCliResultText(nextText).trim();
     if (trimmedText) {
       text = trimmedText;
       sawStructuredOutput = true;
@@ -292,7 +317,7 @@ function parseClaudeCliJsonlResult(params: {
     params.parsed.type === "result" &&
     typeof params.parsed.result === "string"
   ) {
-    const resultText = params.parsed.result.trim();
+    const resultText = unwrapNestedCliResultText(params.parsed.result).trim();
     if (resultText) {
       return { text: resultText, sessionId: params.sessionId, usage: params.usage };
     }

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -267,14 +267,10 @@ function pickCliSessionId(
 }
 
 function shouldUnwrapNestedCliResultText(params: {
-  backend: CliBackendConfig;
   providerId?: string;
   parsed: Record<string, unknown>;
 }): boolean {
-  const isClaudeBackend =
-    (params.providerId && isClaudeCliProvider(params.providerId)) ||
-    /^claude(?:$|[\\/-])/i.test(params.backend.command.trim());
-  if (!isClaudeBackend) {
+  if (!params.providerId || !isClaudeCliProvider(params.providerId)) {
     return false;
   }
   return !Object.hasOwn(params.parsed, "type") || params.parsed.type === "result";
@@ -304,7 +300,7 @@ export function parseCliJson(
       collectCliText(parsed.response) ||
       collectCliText(parsed);
     const trimmedText = (
-      shouldUnwrapNestedCliResultText({ backend, providerId, parsed })
+      shouldUnwrapNestedCliResultText({ providerId, parsed })
         ? unwrapNestedCliResultText(nextText)
         : nextText
     ).trim();

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -266,7 +266,25 @@ function pickCliSessionId(
   return undefined;
 }
 
-export function parseCliJson(raw: string, backend: CliBackendConfig): CliOutput | null {
+function shouldUnwrapNestedCliResultText(params: {
+  backend: CliBackendConfig;
+  providerId?: string;
+  parsed: Record<string, unknown>;
+}): boolean {
+  const isClaudeBackend =
+    (params.providerId && isClaudeCliProvider(params.providerId)) ||
+    /^claude(?:$|[\\/-])/i.test(params.backend.command.trim());
+  if (!isClaudeBackend) {
+    return false;
+  }
+  return !Object.hasOwn(params.parsed, "type") || params.parsed.type === "result";
+}
+
+export function parseCliJson(
+  raw: string,
+  backend: CliBackendConfig,
+  providerId?: string,
+): CliOutput | null {
   const parsedRecords = parseJsonRecordCandidates(raw);
   if (parsedRecords.length === 0) {
     return null;
@@ -285,7 +303,11 @@ export function parseCliJson(raw: string, backend: CliBackendConfig): CliOutput 
       collectCliText(parsed.result) ||
       collectCliText(parsed.response) ||
       collectCliText(parsed);
-    const trimmedText = unwrapNestedCliResultText(nextText).trim();
+    const trimmedText = (
+      shouldUnwrapNestedCliResultText({ backend, providerId, parsed })
+        ? unwrapNestedCliResultText(nextText)
+        : nextText
+    ).trim();
     if (trimmedText) {
       text = trimmedText;
       sawStructuredOutput = true;
@@ -509,7 +531,7 @@ export function parseCliOutput(params: {
     );
   }
   return (
-    parseCliJson(params.raw, params.backend) ?? {
+    parseCliJson(params.raw, params.backend, params.providerId) ?? {
       text: params.raw.trim(),
       sessionId: params.fallbackSessionId,
     }


### PR DESCRIPTION
## Summary

- Problem: Claude Code sub-agent results can arrive as nested stringified `{ "type": "result", "result": "..." }` payloads, and OpenClaw forwards that raw JSON string to delivery channels instead of the inner text.
- Why it matters: users see leaked tool/result JSON in Telegram or other channels instead of the actual assistant reply.
- What changed: recursively unwrap nested Claude result JSON before returning final text from both the JSON and stream-json parsers, and add focused regression tests for both paths.
- What did NOT change (scope boundary): streaming delta parsing, provider routing, and non-result JSON payload handling.
- AI-assisted: built with Hermes and locally validated with targeted tests.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66743
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the CLI output parser stopped after extracting the outer Claude `result` string, even when that string itself was another serialized Claude `result` payload from a sub-agent/tool handoff.
- Missing detection / guardrail: there was no regression test covering nested result JSON on the final-output path.
- Contributing context (if known): Claude Code Agent tool results can be nested more than once before the final delivery text is chosen.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/cli-output.test.ts`
- Scenario the test should lock in: nested Claude `{ type: "result", result: "..." }` payloads unwrap to the innermost plain text for both JSON and stream-json output modes.
- Why this is the smallest reliable guardrail: the bug is isolated to final CLI output parsing, so parser-level tests cover it without requiring a live Claude CLI run.
- Existing test that already covers this (if any): existing `parseCliJsonl` tests covered only single-layer result payloads.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Claude Code sub-agent replies now deliver the actual inner response text instead of a raw nested JSON payload.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node + pnpm workspace checkout
- Model/provider: `claude-cli`
- Integration/channel (if any): final CLI output parsing for Claude Code Agent results
- Relevant config (redacted): targeted parser fixtures only

### Steps

1. Feed `parseCliJson` a Claude result whose `result` field is another stringified Claude result payload.
2. Feed `parseCliJsonl` a Claude stream-json `type: "result"` event with the same nested shape.
3. Verify both parsers return only the innermost plain-text response.

### Expected

- Nested Claude result payloads unwrap to the actual response text before delivery.

### Actual

- Before the fix, the outer parser returned the nested JSON string verbatim.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/agents/cli-output.test.ts`
- Edge cases checked: nested result JSON in both `parseCliJson` and Claude stream-json `parseCliJsonl` paths.
- What you did **not** verify: live Telegram delivery against a real Claude Code runtime.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: an arbitrary JSON string that happens to look like a Claude `type: "result"` payload could now be unwrapped.
  - Mitigation: the unwrap is limited to nested objects with the exact Claude result shape and only runs on final text extraction paths.
