### PR TITLE
fix: preserve runtime token budget in deferred context-engine maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Agents/fallback: preserve the original prompt body on model fallback retries with session history so the retrying model keeps the active task instead of only seeing a generic continue message. (#66029) Thanks @WuKongAI-CMU.
 - Reply/secrets: resolve active reply channel/account SecretRefs before reply-run message-action discovery so channel token SecretRefs (for example Discord) do not degrade into discovery-time unresolved-secret failures. (#66796) Thanks @joshavant.
 - Agents/Anthropic: ignore non-positive Anthropic Messages token overrides and fail locally when no positive token budget remains, so invalid `max_tokens` values no longer reach the provider API. (#66664) thanks @jalehman
+- Agents/context engines: preserve prompt-only token counts, not full request totals, when deferred maintenance reuses after-turn runtime context so background compaction bookkeeping matches the active prompt window. (#66820) thanks @jalehman.
 
 ## 2026.4.14
 

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.test.ts
@@ -424,7 +424,11 @@ describe("runContextEngineMaintenance", () => {
           sessionKey,
           sessionFile: "/tmp/session.jsonl",
           reason: "turn",
-          runtimeContext: { workspaceDir: "/tmp/workspace" },
+          runtimeContext: {
+            workspaceDir: "/tmp/workspace",
+            tokenBudget: 2048,
+            currentTokenCount: 1536,
+          },
         });
 
         expect(result).toBeUndefined();
@@ -453,6 +457,8 @@ describe("runContextEngineMaintenance", () => {
           runtimeContext: expect.objectContaining({
             workspaceDir: "/tmp/workspace",
             allowDeferredCompactionExecution: true,
+            tokenBudget: 2048,
+            currentTokenCount: 1536,
           }),
         });
 

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -226,6 +226,8 @@ export function buildAfterTurnRuntimeContext(params: {
   >;
   workspaceDir: string;
   agentDir: string;
+  tokenBudget?: number;
+  currentTokenCount?: number;
   promptCache?: ContextEnginePromptCacheInfo;
 }): ContextEngineRuntimeContext {
   return {
@@ -252,6 +254,16 @@ export function buildAfterTurnRuntimeContext(params: {
       extraSystemPrompt: params.attempt.extraSystemPrompt,
       ownerNumbers: params.attempt.ownerNumbers,
     }),
+    ...(typeof params.tokenBudget === "number" &&
+      Number.isFinite(params.tokenBudget) &&
+      params.tokenBudget > 0
+      ? { tokenBudget: Math.floor(params.tokenBudget) }
+      : {}),
+    ...(typeof params.currentTokenCount === "number" &&
+      Number.isFinite(params.currentTokenCount) &&
+      params.currentTokenCount > 0
+      ? { currentTokenCount: Math.floor(params.currentTokenCount) }
+      : {}),
     ...(params.promptCache ? { promptCache: params.promptCache } : {}),
   };
 }

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -14,6 +14,8 @@ import {
   runAttemptContextEngineBootstrap,
 } from "./attempt.context-engine-helpers.js";
 import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
   createContextEngineBootstrapAndAssemble,
   expectCalledWithSessionKey,
   getHoisted,
@@ -109,6 +111,7 @@ async function finalizeTurn(
 
 describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   const sessionKey = "agent:main:discord:channel:test-ctx-engine";
+  const tempPaths: string[] = [];
   beforeEach(() => {
     resetEmbeddedAttemptHarness();
     clearMemoryPluginState();
@@ -116,6 +119,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   });
 
   afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
     clearMemoryPluginState();
     vi.restoreAllMocks();
   });
@@ -391,6 +395,59 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
         previousCacheRead: 5000,
         cacheRead: 2000,
         changes: expect.arrayContaining([expect.objectContaining({ code: "systemPrompt" })]),
+      }),
+    );
+  });
+
+  it("derives deferred maintenance currentTokenCount from prompt-only usage", async () => {
+    const afterTurn = vi.fn(
+      async (_params: {
+        runtimeContext?: {
+          currentTokenCount?: number;
+          promptCache?: { lastCallUsage?: { total?: number } };
+        };
+      }) => {},
+    );
+
+    await createContextEngineAttemptRunner({
+      sessionKey,
+      tempPaths,
+      contextEngine: {
+        assemble: async ({ messages }) => ({
+          messages,
+          estimatedTokens: 1,
+        }),
+        afterTurn,
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          {
+            role: "assistant",
+            content: "done",
+            timestamp: 2,
+            usage: {
+              input: 10,
+              output: 5,
+              cacheRead: 40,
+              cacheWrite: 2,
+              total: 57,
+            },
+          } as unknown as AgentMessage,
+        ];
+      },
+    });
+
+    expect(afterTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeContext: expect.objectContaining({
+          currentTokenCount: 52,
+          promptCache: expect.objectContaining({
+            lastCallUsage: expect.objectContaining({
+              total: 57,
+            }),
+          }),
+        }),
       }),
     );
   });

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -2836,6 +2836,8 @@ describe("buildAfterTurnRuntimeContext", () => {
       },
       workspaceDir: "/tmp/workspace",
       agentDir: "/tmp/agent",
+      tokenBudget: 1050000,
+      currentTokenCount: 232393,
     });
 
     expect(legacy).toMatchObject({
@@ -2844,6 +2846,8 @@ describe("buildAfterTurnRuntimeContext", () => {
       model: "gpt-5.4",
       workspaceDir: "/tmp/workspace",
       agentDir: "/tmp/agent",
+      tokenBudget: 1050000,
+      currentTokenCount: 232393,
     });
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -887,6 +887,7 @@ export async function runEmbeddedAttempt(
           attempt: params,
           workspaceDir: effectiveWorkspace,
           agentDir,
+          tokenBudget: params.contextTokenBudget,
         }),
         runMaintenance: async (contextParams) =>
           await runContextEngineMaintenance({
@@ -2201,10 +2202,18 @@ export async function runEmbeddedAttempt(
 
         // Let the active context engine run its post-turn lifecycle.
         if (params.contextEngine) {
+          const runtimeCurrentTokenCount =
+            typeof lastCallUsage?.total === "number" &&
+            Number.isFinite(lastCallUsage.total) &&
+            lastCallUsage.total > 0
+              ? Math.floor(lastCallUsage.total)
+              : undefined;
           const afterTurnRuntimeContext = buildAfterTurnRuntimeContext({
             attempt: params,
             workspaceDir: effectiveWorkspace,
             agentDir,
+            tokenBudget: params.contextTokenBudget,
+            currentTokenCount: runtimeCurrentTokenCount,
             promptCache,
           });
           await finalizeAttemptContextEngineTurn({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -116,7 +116,7 @@ import {
   resolveTranscriptPolicy,
   shouldAllowProviderOwnedThinkingReplay,
 } from "../../transcript-policy.js";
-import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
+import { derivePromptTokens, normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
@@ -2202,12 +2202,7 @@ export async function runEmbeddedAttempt(
 
         // Let the active context engine run its post-turn lifecycle.
         if (params.contextEngine) {
-          const runtimeCurrentTokenCount =
-            typeof lastCallUsage?.total === "number" &&
-            Number.isFinite(lastCallUsage.total) &&
-            lastCallUsage.total > 0
-              ? Math.floor(lastCallUsage.total)
-              : undefined;
+          const runtimeCurrentTokenCount = derivePromptTokens(lastCallUsage);
           const afterTurnRuntimeContext = buildAfterTurnRuntimeContext({
             attempt: params,
             workspaceDir: effectiveWorkspace,

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -140,6 +140,10 @@ export type ContextEngineRuntimeContext = Record<string, unknown> & {
    * consuming deferred compaction debt.
    */
   allowDeferredCompactionExecution?: boolean;
+  /** Runtime-resolved context window budget for the active model call. */
+  tokenBudget?: number;
+  /** Best-effort current prompt/context token estimate for this turn. */
+  currentTokenCount?: number;
   /** Optional prompt-cache telemetry for cache-aware engines. */
   promptCache?: ContextEnginePromptCacheInfo;
   /**


### PR DESCRIPTION
## Summary

- Problem: deferred context-engine maintenance rebuilt `runtimeContext` without the active model's token budget, so maintenance fell back to a synthetic default budget instead of the real one from the turn that queued the work.
- Why it matters: background maintenance could make prompt-size and compaction decisions against the wrong window, causing unnecessary maintenance pressure and inconsistent behavior between inline turn handling and deferred maintenance.
- What changed: `buildAfterTurnRuntimeContext()` now carries forward `tokenBudget`, and it also forwards a best-effort `currentTokenCount` when the latest call usage total is available; deferred maintenance tests now lock in those fields.
- What did NOT change (scope boundary): this does not change maintenance policy, cache heuristics, or compaction thresholds; it only preserves runtime context fidelity between the foreground turn path and the deferred maintenance path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the runtime context builder used after a turn did not preserve `contextTokenBudget`, so deferred maintenance later ran with no budget in `runtimeContext` and fell back to the context engine's internal default.
- Missing detection / guardrail: tests covered direct `afterTurn()` token budget wiring but did not assert that deferred maintenance received the same runtime budget context.
- Contributing context (if known): deferred maintenance reuses the stored runtime context instead of the direct `afterTurn()` call arguments, so omissions in the runtime-context shape only show up once work is replayed later.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/context-engine-maintenance.test.ts` and `src/agents/pi-embedded-runner/run/attempt.test.ts`
- Scenario the test should lock in: the runtime context produced after a turn includes `tokenBudget` and `currentTokenCount`, and deferred maintenance receives those same values when it invokes the context engine.
- Why this is the smallest reliable guardrail: the bug is in the runtime-context handoff layer, so unit tests on the builder and maintenance caller exercise the exact omission without needing a full provider-backed run.
- Existing test that already covers this (if any): direct `afterTurn()` budget handling was already exercised indirectly; the deferred maintenance path was not.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[turn completes with real model budget]
  -> [runtimeContext drops tokenBudget]
  -> [deferred maintenance runs later]
  -> [maintenance falls back to synthetic budget]

After:
[turn completes with real model budget]
  -> [runtimeContext preserves tokenBudget/currentTokenCount]
  -> [deferred maintenance runs later]
  -> [maintenance evaluates against the same budget context]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Vitest
- Model/provider: N/A
- Integration/channel (if any): embedded runner / context engine
- Relevant config (redacted): defaults

### Steps

1. Build the post-turn runtime context for a turn with a non-default `contextTokenBudget`.
2. Queue deferred context-engine maintenance using that runtime context.
3. Inspect the arguments passed into `maintain()`.

### Expected

- Deferred maintenance receives the same runtime `tokenBudget` as the completed turn, plus `currentTokenCount` when available.

### Actual

- Before this change, deferred maintenance received no `tokenBudget` in `runtimeContext` and relied on the engine fallback.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran the targeted unit tests for the after-turn runtime-context builder and deferred context-engine maintenance handoff; verified the new fields are present and forwarded.
- Edge cases checked: `currentTokenCount` is only included when a finite positive total is available; existing runtime-context fields remain intact.
- What you did **not** verify: a full end-to-end provider-backed run in a live OpenClaw session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: `currentTokenCount` could be stale or absent on some runs.
  - Mitigation: it is passed as best-effort metadata only when a finite positive total is already available; maintenance still behaves as before when it is missing.
