### PR TITLE
fix(agents): add diagnostic info to agents_list and sessions_spawn

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -463,9 +463,14 @@ export async function spawnSubagentDirect(
     );
     if (!allowAny && !allowSet.has(normalizedTargetId)) {
       const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
+      // Include hint when no agents are allowlisted to help diagnose config issues.
+      const hint =
+        allowSet.size === 0
+          ? ` Set subagents.allowAgents on "${requesterAgentId}" or agents.defaults.subagents.allowAgents. Use agents_list to check config.`
+          : "";
       return {
         status: "forbidden",
-        error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
+        error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText}).${hint}`,
       };
     }
   }

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -1,11 +1,11 @@
 import { Type } from "@sinclair/typebox";
-import { loadConfig } from "../../config/config.js";
+import { loadConfig, resolveConfigPath } from "../../config/config.js";
 import {
   DEFAULT_AGENT_ID,
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
-import { resolveAgentConfig } from "../agent-scope.js";
+import { listAgentIds, resolveAgentConfig } from "../agent-scope.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult } from "./common.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-helpers.js";
@@ -91,10 +91,33 @@ export function createAgentsListTool(opts?: {
         configured: configuredIds.includes(id),
       }));
 
+      // Include diagnostic info when no agents are allowlisted beyond the requester.
+      // This helps users diagnose config issues when agents.list or allowAgents is missing.
+      const hasExplicitAllowlist = allowAgents.length > 0;
+      const requesterConfigured = resolveAgentConfig(cfg, requesterAgentId) !== undefined;
+      const configuredAgentCount = configuredIds.length;
+
       return jsonResult({
         requester: requesterAgentId,
         allowAny,
         agents,
+        // Diagnostic fields to help debug config issues (only when relevant)
+        ...(hasExplicitAllowlist
+          ? {}
+          : {
+              diagnostic: {
+                configPath: resolveConfigPath(),
+                requesterConfigured,
+                configuredAgentCount,
+                configuredAgentIds: configuredAgentCount > 0 ? listAgentIds(cfg) : [],
+                hint:
+                  !requesterConfigured && configuredAgentCount === 0
+                    ? "No agents configured in agents.list. Check that your config file is loaded from the expected path."
+                    : !hasExplicitAllowlist
+                      ? `No allowAgents configured for "${requesterAgentId}". Set subagents.allowAgents on this agent or agents.defaults.subagents.allowAgents.`
+                      : undefined,
+              },
+            }),
       });
     },
   };


### PR DESCRIPTION
## Summary

Fixes #41463

When `agents_list` returns no spawnable agents or `sessions_spawn` fails with `(allowed: none)`, users have no way to diagnose whether the issue is:

1. Config not loading from expected path
2. `agents.list` not configured  
3. `subagents.allowAgents` not set

## Changes

### `agents_list` tool
- Added `diagnostic` object to output when no `allowAgents` is configured
- Includes: `configPath`, `requesterConfigured`, `configuredAgentCount`, `configuredAgentIds`
- Provides helpful `hint` explaining what might be wrong

### `sessions_spawn` tool  
- Improved error message when `allowAgents` is empty
- Points users to set `subagents.allowAgents` on the agent or `agents.defaults.subagents.allowAgents`
- Suggests using `agents_list` to check config

## Example Output

When `/agents` returns `(none)`, users now see:

```json
{
  "requester": "main",
  "allowAny": false,
  "agents": [{"id": "main", "configured": false}],
  "diagnostic": {
    "configPath": "/home/user/.openclaw/openclaw.json",
    "requesterConfigured": false,
    "configuredAgentCount": 0,
    "configuredAgentIds": [],
    "hint": "No agents configured in agents.list. Check that your config file is loaded from the expected path."
  }
}
```

## Testing

- All existing tests pass
- `pnpm test src/agents/openclaw-tools.agents.test.ts` ✅
- `pnpm test src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts` ✅