### PR TITLE
feat(telegram): add health check watchdog for long-polling connections

### DIFF
--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -4,6 +4,7 @@ import {
   isRecoverableTelegramNetworkError,
   isTelegramRateLimitError,
   isSafeToRetrySendError,
+  isStaleConnectionError,
   isTelegramClientRejection,
   isTelegramPollingNetworkError,
   isTelegramServerError,
@@ -255,5 +256,117 @@ describe("isTelegramClientRejection", () => {
     const inner = Object.assign(new Error("Forbidden"), { error_code: 403 });
     const outer = Object.assign(new Error("wrapped"), { cause: inner });
     expect(isTelegramClientRejection(outer)).toBe(true);
+  });
+});
+
+describe("isStaleConnectionError", () => {
+  it.each([
+    ["ECONNRESET", "read ECONNRESET"],
+    ["ETIMEDOUT", "connect ETIMEDOUT"],
+    ["UND_ERR_SOCKET", "socket error"],
+    ["EPIPE", "write EPIPE"],
+    ["ECONNABORTED", "connection aborted"],
+    ["UND_ERR_HEADERS_TIMEOUT", "headers timeout"],
+    ["UND_ERR_BODY_TIMEOUT", "body timeout"],
+    ["UND_ERR_ABORTED", "aborted"],
+    ["ERR_NETWORK", "network error"],
+  ])("detects post-connect error code %s as stale", (code, message) => {
+    expect(isStaleConnectionError(errorWithCode(message, code))).toBe(true);
+  });
+
+  it.each([
+    ["ECONNREFUSED", "connect ECONNREFUSED"],
+    ["ENOTFOUND", "getaddrinfo ENOTFOUND"],
+    ["EAI_AGAIN", "getaddrinfo EAI_AGAIN"],
+    ["ENETUNREACH", "connect ENETUNREACH"],
+    ["EHOSTUNREACH", "connect EHOSTUNREACH"],
+    ["UND_ERR_CONNECT_TIMEOUT", "connect timeout"],
+  ])("does NOT treat connect-time error code %s as stale", (code, message) => {
+    // Connect-time failures mean the health-check probe failed to open a new
+    // connection; the existing long-poll socket may still be healthy.
+    expect(isStaleConnectionError(errorWithCode(message, code))).toBe(false);
+  });
+
+  it("detects our own health check timeout as stale", () => {
+    expect(isStaleConnectionError(new Error("Health check timeout"))).toBe(true);
+  });
+
+  it("detects fetch failed as stale", () => {
+    expect(isStaleConnectionError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  it("detects socket hang up as stale", () => {
+    expect(isStaleConnectionError(new Error("socket hang up"))).toBe(true);
+  });
+
+  it("does NOT treat HTTP 504 Gateway Timeout as stale", () => {
+    // 504 means the Telegram server responded -- TCP connection is alive
+    const err = Object.assign(new Error("Gateway Timeout"), { error_code: 504 });
+    expect(isStaleConnectionError(err)).toBe(false);
+    // Verify it IS recoverable (it should still be retried, just not treated as stale)
+    expect(isRecoverableTelegramNetworkError(err, { context: "polling" })).toBe(true);
+  });
+
+  it("does NOT treat HTTP 502 Bad Gateway as stale", () => {
+    const err = Object.assign(new Error("Bad Gateway"), { error_code: 502 });
+    expect(isStaleConnectionError(err)).toBe(false);
+  });
+
+  it("does NOT treat HTTP 429 Too Many Requests as stale", () => {
+    const err = Object.assign(new Error("Too Many Requests: retry after 30"), { error_code: 429 });
+    expect(isStaleConnectionError(err)).toBe(false);
+  });
+
+  it("does NOT treat HTTP 500 Internal Server Error as stale", () => {
+    const err = Object.assign(new Error("Internal Server Error"), { error_code: 500 });
+    expect(isStaleConnectionError(err)).toBe(false);
+  });
+
+  it("detects connection error nested in cause chain", () => {
+    const root = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+    const wrapped = Object.assign(new TypeError("fetch failed"), { cause: root });
+    expect(isStaleConnectionError(wrapped)).toBe(true);
+  });
+
+  it("does NOT treat HTTP error wrapped in HttpError as stale", () => {
+    // Grammy wraps API errors in HttpError with .error property
+    const inner = Object.assign(new Error("Gateway Timeout"), { error_code: 504 });
+    const outer = Object.assign(new Error("Network request for 'getMe' failed!"), {
+      name: "HttpError",
+      error: inner,
+    });
+    expect(isStaleConnectionError(outer)).toBe(false);
+  });
+
+  it.each([["ENOTFOUND"], ["ECONNREFUSED"], ["EAI_AGAIN"], ["UND_ERR_CONNECT_TIMEOUT"]])(
+    "does NOT treat fetch-failed wrapper with nested connect-time code %s as stale",
+    (code) => {
+      // A health-check probe that fails to open a new connection surfaces as
+      // TypeError("fetch failed") wrapping a cause whose `code` is a connect-time
+      // failure. The existing long-poll socket may still be healthy, so we must
+      // not classify this as a stale connection.
+      const cause = Object.assign(new Error(`connect ${code}`), { code });
+      const wrapped = Object.assign(new TypeError("fetch failed"), { cause });
+      expect(isStaleConnectionError(wrapped)).toBe(false);
+    },
+  );
+
+  it("does NOT treat self-induced AbortError as stale", () => {
+    // polling-session aborts in-flight fetches itself during stall recovery
+    // and forced restarts. The resulting AbortError on a pending health-check
+    // getMe must not be misclassified as a broken socket.
+    const err = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+    });
+    expect(isStaleConnectionError(err)).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isStaleConnectionError(null)).toBe(false);
+    expect(isStaleConnectionError(undefined)).toBe(false);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isStaleConnectionError(new Error("invalid token"))).toBe(false);
   });
 });

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -232,6 +232,150 @@ export function isTelegramClientRejection(err: unknown): boolean {
   return hasTelegramErrorCode(err, (code) => code >= 400 && code < 500);
 }
 
+/**
+ * Error codes that indicate a broken/stale *existing* TCP connection rather than
+ * a failure to establish a new connection.
+ *
+ * Excludes connect-time codes (ENOTFOUND, ECONNREFUSED, EAI_AGAIN, ENETUNREACH,
+ * EHOSTUNREACH) because those only mean the health-check probe could not open a
+ * new connection -- the current long-poll socket may still be healthy.
+ */
+const STALE_CONNECTION_ERROR_CODES = new Set([
+  "ECONNRESET", // Existing connection reset by peer
+  "EPIPE", // Write to a broken pipe/socket
+  "ETIMEDOUT", // Existing connection timed out
+  "ESOCKETTIMEDOUT", // Socket-level timeout on existing connection
+  "UND_ERR_HEADERS_TIMEOUT", // Undici headers timeout on existing connection
+  "UND_ERR_BODY_TIMEOUT", // Undici body timeout on existing connection
+  "UND_ERR_SOCKET", // Undici socket error on existing connection
+  "UND_ERR_ABORTED", // Undici aborted (e.g. socket closed mid-stream)
+  "ECONNABORTED", // Connection aborted
+  "ERR_NETWORK", // Generic network failure
+  // UND_ERR_CONNECT_TIMEOUT excluded: indicates a TCP connect-phase timeout in the
+  // health-check probe, not a broken existing long-poll socket.
+]);
+
+/**
+ * Error names that indicate stale/broken connections (not connect-time failures).
+ *
+ * AbortError is intentionally excluded: polling-session aborts in-flight fetches
+ * itself via fetchAbortController.abort() during stall recovery and forced
+ * restarts, so treating self-induced AbortError on a pending health-check getMe
+ * as a stale-connection signal would misclassify our own teardown path.
+ */
+const STALE_CONNECTION_ERROR_NAMES = new Set([
+  "TimeoutError",
+  "HeadersTimeoutError",
+  "BodyTimeoutError",
+  // ConnectTimeoutError excluded: could mean the probe failed to connect,
+  // not that the existing polling socket is stale.
+]);
+
+/**
+ * Error codes that indicate a connect-time failure rather than a broken existing
+ * socket. If any candidate in the error graph carries one of these, the failure
+ * is treated as "could not open a new connection" and NOT classified as a stale
+ * existing connection. This lets broad wrappers like TypeError("fetch failed")
+ * with nested cause.code=ENOTFOUND / ECONNREFUSED fall through without forcing
+ * a polling restart.
+ */
+const CONNECT_TIME_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ENETUNREACH",
+  "EHOSTUNREACH",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
+
+/**
+ * Connection-level message snippets for stale-connection detection.
+ * Intentionally excludes the broad "timeout" / "timed out" snippets from
+ * RECOVERABLE_MESSAGE_SNIPPETS because those match HTTP timeout responses
+ * (e.g. 504 Gateway Timeout) where the server actually responded.
+ * Also excludes "getaddrinfo" since DNS failures are connect-time errors.
+ */
+const STALE_CONNECTION_MESSAGE_SNIPPETS = [
+  "undici",
+  "network error",
+  "network request",
+  "client network socket disconnected",
+  "socket hang up",
+  "health check timeout",
+];
+
+/**
+ * Returns true when the error indicates a dead or stale TCP connection rather than
+ * a Telegram API-level HTTP error response or a connect-time failure.
+ *
+ * Key distinction 1: an HTTP 504 Gateway Timeout (or any other HTTP status error) means
+ * the server actually responded -- the underlying TCP link is alive and the health-check
+ * watchdog should NOT treat it as a stale socket.  Only connection-level failures
+ * (ECONNRESET, ETIMEDOUT, socket hang up, fetch failed, our own "Health check timeout",
+ * etc.) indicate that the TCP connection itself is dead or unusable.
+ *
+ * Key distinction 2: connect-time failures (ENOTFOUND, ECONNREFUSED, EAI_AGAIN) only
+ * mean the health-check probe could not open a *new* connection.  The existing
+ * long-poll socket may still be healthy, so these should NOT trigger a restart.
+ *
+ * Used by the health-check watchdog so it does not force-restart polling sessions
+ * during transient Telegram-side outages or DNS blips.
+ */
+export function isStaleConnectionError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+  // If the error carries a Telegram HTTP error_code, the server responded --
+  // the connection is alive regardless of the status code (429, 5xx, etc.).
+  if (hasTelegramErrorCode(err, () => true)) {
+    return false;
+  }
+
+  // Pre-scan for connect-time codes anywhere in the error graph. A broad
+  // wrapper like TypeError("fetch failed") whose `cause.code` is ENOTFOUND /
+  // ECONNREFUSED / EAI_AGAIN is a probe-side failure to open a new connection,
+  // not evidence that the existing long-poll socket is dead. We must check
+  // this before the outer message matches "fetch failed" / "network request".
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    const code = normalizeCode(getErrorCode(candidate));
+    if (code && CONNECT_TIME_ERROR_CODES.has(code)) {
+      return false;
+    }
+  }
+
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    // Skip candidates that are themselves Telegram HTTP error objects
+    if (
+      candidate &&
+      typeof candidate === "object" &&
+      "error_code" in candidate &&
+      typeof (candidate as { error_code: unknown }).error_code === "number"
+    ) {
+      continue;
+    }
+
+    const code = normalizeCode(getErrorCode(candidate));
+    if (code && STALE_CONNECTION_ERROR_CODES.has(code)) {
+      return true;
+    }
+
+    const name = readErrorName(candidate);
+    if (name && STALE_CONNECTION_ERROR_NAMES.has(name)) {
+      return true;
+    }
+
+    const message = formatErrorMessage(candidate).trim().toLowerCase();
+    if (message && ALWAYS_RECOVERABLE_MESSAGES.has(message)) {
+      return true;
+    }
+    if (message && STALE_CONNECTION_MESSAGE_SNIPPETS.some((snippet) => message.includes(snippet))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function isRecoverableTelegramNetworkError(
   err: unknown,
   options: { context?: TelegramNetworkErrorContext; allowMessageMatch?: boolean } = {},

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const runMock = vi.hoisted(() => vi.fn());
 const createTelegramBotMock = vi.hoisted(() => vi.fn());
 const isRecoverableTelegramNetworkErrorMock = vi.hoisted(() => vi.fn(() => true));
+const isStaleConnectionErrorMock = vi.hoisted(() => vi.fn(() => true));
 const computeBackoffMock = vi.hoisted(() => vi.fn(() => 0));
 const sleepWithAbortMock = vi.hoisted(() => vi.fn(async () => undefined));
 
@@ -16,6 +17,7 @@ vi.mock("./bot.js", () => ({
 
 vi.mock("./network-errors.js", () => ({
   isRecoverableTelegramNetworkError: isRecoverableTelegramNetworkErrorMock,
+  isStaleConnectionError: isStaleConnectionErrorMock,
 }));
 
 vi.mock("./api-logging.js", () => ({
@@ -58,11 +60,44 @@ function installPollingStallWatchdogHarness(
     return 1 as unknown as ReturnType<typeof setInterval>;
   });
   const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
-  const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((fn) => {
-    void Promise.resolve().then(() => (fn as () => void)());
-    return 1 as unknown as ReturnType<typeof setTimeout>;
+  // Track pending timeouts so clearTimeout can actually suppress the callback.
+  // Without this the health-check's inner HEALTH_CHECK_TIMEOUT_MS timer leaks
+  // unhandled "Health check timeout" rejections after the finally-block clears it.
+  //
+  // We also skip auto-firing timers whose delay exceeds STALL_HARNESS_AUTO_FIRE_MAX_MS.
+  // The stall watchdog and its forced-cycle fallback use short delays (<=15s), but
+  // the health-check interval is 120s. Auto-firing the health-check timer would
+  // run the watchdog concurrently with the stall-watchdog path and corrupt
+  // expectations. Long timers still register a handle for clearTimeout, so teardown
+  // behaves correctly.
+  const STALL_HARNESS_AUTO_FIRE_MAX_MS = 30_000;
+  let nextTimerHandle = 1;
+  const pendingTimers = new Map<number, () => void>();
+  const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((fn, delayMs) => {
+    const handle = nextTimerHandle++;
+    const cb = fn as () => void;
+    const delay = typeof delayMs === "number" ? delayMs : 0;
+    if (delay > STALL_HARNESS_AUTO_FIRE_MAX_MS) {
+      // Retain the handle so clearTimeout remains consistent, but never fire.
+      pendingTimers.set(handle, () => {});
+      return handle as unknown as ReturnType<typeof setTimeout>;
+    }
+    pendingTimers.set(handle, cb);
+    void Promise.resolve().then(() => {
+      const pending = pendingTimers.get(handle);
+      if (!pending) {
+        return;
+      }
+      pendingTimers.delete(handle);
+      pending();
+    });
+    return handle as unknown as ReturnType<typeof setTimeout>;
   });
-  const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => {});
+  const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation((handle) => {
+    if (typeof handle === "number") {
+      pendingTimers.delete(handle);
+    }
+  });
   const dateNowSpy = vi.spyOn(Date, "now");
   for (const value of dateNowSequence) {
     dateNowSpy.mockImplementationOnce(() => value);

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -28,6 +28,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   computeBackoff: computeBackoffMock,
   formatDurationPrecise: vi.fn((ms: number) => `${ms}ms`),
   sleepWithAbort: sleepWithAbortMock,
+  logVerbose: vi.fn(),
 }));
 
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -2,6 +2,7 @@ import { type RunOptions, run } from "@grammyjs/runner";
 import {
   computeBackoff,
   formatDurationPrecise,
+  logVerbose,
   sleepWithAbort,
 } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -9,7 +10,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtim
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { type TelegramTransport } from "./fetch.js";
-import { isRecoverableTelegramNetworkError } from "./network-errors.js";
+import { isRecoverableTelegramNetworkError, isStaleConnectionError } from "./network-errors.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
 
 const TELEGRAM_POLL_RESTART_POLICY = {
@@ -22,6 +23,14 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
+
+/**
+ * Health check interval: how often to ping Telegram API to detect stale connections.
+ * After inactivity, NAT/firewalls may silently drop TCP connections, causing the
+ * long-polling socket to hang indefinitely. This watchdog detects and recovers from that.
+ */
+const HEALTH_CHECK_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
+const HEALTH_CHECK_TIMEOUT_MS = 10 * 1000; // 10 seconds
 
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -290,6 +299,7 @@ export class TelegramPollingSession {
     }
     let stopPromise: Promise<void> | undefined;
     let stalledRestart = false;
+    let staleConnectionDetected = false;
     let forceCycleTimer: ReturnType<typeof setTimeout> | undefined;
     let forceCycleResolve: (() => void) | undefined;
     const forceCyclePromise = new Promise<void>((resolve) => {
@@ -373,11 +383,110 @@ export class TelegramPollingSession {
       }
     }, POLL_WATCHDOG_INTERVAL_MS);
 
+    // Health check watchdog: periodically ping Telegram API to detect stale connections.
+    // If the connection is dead (NAT timeout, firewall drop), the health check will fail
+    // and we'll restart the runner.
+    // Uses a self-scheduling loop instead of setInterval to prevent overlapping checks
+    // when a health check takes longer than the interval period.
+    // healthCheckStopped guards against a concurrent in-flight check scheduling a new
+    // timer after stopHealthCheck() has been called (e.g., during runner teardown).
+    let healthCheckStopped = false;
+    let healthCheckTimer: ReturnType<typeof setTimeout> | undefined;
+    let healthCheckTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const startHealthCheck = () => {
+      const scheduleNext = () => {
+        healthCheckTimer = setTimeout(async () => {
+          if (healthCheckStopped || this.opts.abortSignal?.aborted) {
+            return;
+          }
+          try {
+            const timeoutPromise = new Promise<never>((_, reject) => {
+              healthCheckTimeoutHandle = setTimeout(
+                () => reject(new Error("Health check timeout")),
+                HEALTH_CHECK_TIMEOUT_MS,
+              );
+            });
+            try {
+              await Promise.race([bot.api.getMe(), timeoutPromise]);
+            } finally {
+              if (healthCheckTimeoutHandle) {
+                clearTimeout(healthCheckTimeoutHandle);
+                healthCheckTimeoutHandle = undefined;
+              }
+            }
+            logVerbose("[telegram] Health check passed");
+          } catch (err) {
+            if (healthCheckStopped || this.opts.abortSignal?.aborted) {
+              return;
+            }
+            // Distinguish connection/network errors from HTTP API responses (429, 5xx).
+            // A Telegram HTTP error (e.g. 504 Gateway Timeout) means the server
+            // responded -- the TCP connection is alive.  Only actual connection-level
+            // failures (ECONNRESET, socket hang up, our own health-check timeout, etc.)
+            // should trigger a stale-connection restart.
+            if (isStaleConnectionError(err)) {
+              staleConnectionDetected = true;
+              this.opts.log(
+                `[telegram] Health check failed (stale connection detected): ${formatErrorMessage(err)}; restarting polling...`,
+              );
+              void stopRunner();
+              // Arm the forced-cycle fallback so runner.task() cannot hang
+              // indefinitely if a slow/hung update handler blocks runner.stop().
+              if (!forceCycleTimer) {
+                forceCycleTimer = setTimeout(() => {
+                  if (this.opts.abortSignal?.aborted) {
+                    return;
+                  }
+                  this.opts.log(
+                    `[telegram] Polling runner stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)} (stale connection restart); forcing restart cycle.`,
+                  );
+                  forceCycleResolve?.();
+                }, POLL_STOP_GRACE_MS);
+              }
+              return; // Don't schedule next check; runner restart will create a new watchdog
+            }
+            // Transient API error (e.g. 429 rate-limit, 5xx server error) --
+            // log and reschedule; no restart needed.
+            this.opts.log(
+              `[telegram] Health check transient error: ${formatErrorMessage(err)}; will retry at next interval.`,
+            );
+          }
+          // Only reschedule if watchdog is still active (not torn down mid-check).
+          if (!healthCheckStopped) {
+            scheduleNext();
+          }
+        }, HEALTH_CHECK_INTERVAL_MS);
+      };
+      scheduleNext();
+    };
+
+    const stopHealthCheck = () => {
+      healthCheckStopped = true;
+      if (healthCheckTimer) {
+        clearTimeout(healthCheckTimer);
+        healthCheckTimer = undefined;
+      }
+      // Clear the inner timeout handle to avoid keeping the event loop alive
+      // for up to HEALTH_CHECK_TIMEOUT_MS after teardown.
+      if (healthCheckTimeoutHandle) {
+        clearTimeout(healthCheckTimeoutHandle);
+        healthCheckTimeoutHandle = undefined;
+      }
+    };
+
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+    startHealthCheck();
     try {
       await Promise.race([runner.task(), forceCyclePromise]);
       if (this.opts.abortSignal?.aborted) {
         return "exit";
+      }
+      if (staleConnectionDetected) {
+        // Runner was stopped due to health check failure; continue to restart
+        // without backoff since this is a controlled recovery restart.
+        this.#forceRestarted = false;
+        this.#restartAttempts = 0;
+        return "continue";
       }
       const reason = stalledRestart
         ? "polling stall detected"
@@ -419,6 +528,7 @@ export class TelegramPollingSession {
       return shouldRestart ? "continue" : "exit";
     } finally {
       clearInterval(watchdog);
+      stopHealthCheck();
       if (forceCycleTimer) {
         clearTimeout(forceCycleTimer);
       }

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -227,9 +227,20 @@ export class TelegramPollingSession {
     let inFlightGetUpdates = 0;
     let _stopSequenceLogged = false;
     let stallDiagLoggedAt = 0;
+    // Counter of in-flight watchdog health-check probes. When > 0, the API
+    // middleware skips its liveness-bookkeeping path so the probe cannot
+    // refresh the signals that the stall watchdog relies on. Otherwise a
+    // periodic getMe() probe would keep `apiElapsed` from crossing the
+    // restart threshold even for a genuinely stuck getUpdates loop, which
+    // would defeat the stall-recovery path instead of recovering it.
+    let healthCheckProbesInFlight = 0;
 
     bot.api.config.use(async (prev, method, payload, signal) => {
       if (method !== "getUpdates") {
+        if (healthCheckProbesInFlight > 0) {
+          // Pass through without updating liveness counters.
+          return await prev(method, payload, signal);
+        }
         const startedAt = Date.now();
         const callId = nextInFlightApiCallId;
         nextInFlightApiCallId += 1;
@@ -406,9 +417,11 @@ export class TelegramPollingSession {
                 HEALTH_CHECK_TIMEOUT_MS,
               );
             });
+            healthCheckProbesInFlight += 1;
             try {
               await Promise.race([bot.api.getMe(), timeoutPromise]);
             } finally {
+              healthCheckProbesInFlight -= 1;
               if (healthCheckTimeoutHandle) {
                 clearTimeout(healthCheckTimeoutHandle);
                 healthCheckTimeoutHandle = undefined;

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -429,6 +429,10 @@ export class TelegramPollingSession {
               this.opts.log(
                 `[telegram] Health check failed (stale connection detected): ${formatErrorMessage(err)}; restarting polling...`,
               );
+              // Force transport rebuild: a stuck proxy/agent socket inside the
+              // current dispatcher would otherwise be reused on the next cycle
+              // and keep failing the same way.
+              this.#transportState.markDirty();
               void stopRunner();
               // Arm the forced-cycle fallback so runner.task() cannot hang
               // indefinitely if a slow/hung update handler blocks runner.stop().


### PR DESCRIPTION
## Summary

Add a health-check watchdog that detects silently-stalled Telegram long-polling connections and restarts them. The watchdog runs on a timer, compares `lastGetUpdatesAt` against a configurable threshold, and if `getUpdates` hasn't made progress in that window it stops the runner/bot and lets the outer supervisor reconnect.

## Why

Telegram long-polling can get stuck silently — the socket stays open but no updates arrive — and without a watchdog the bot goes quiet until manually restarted.

## How it works

- Watchdog timer compares `lastGetUpdatesAt` and `lastApiActivityAt` against a configurable stall threshold.
- **Distinguish stale connections from HTTP errors** so a transient 429 or 5xx from Telegram doesn't fake a restart signal. `isStaleConnectionError` pre-scans nested `cause.code` for connect-time errors (ENOTFOUND/ECONNREFUSED/EAI_AGAIN/ENETUNREACH/EHOSTUNREACH/UND_ERR_CONNECT_TIMEOUT) before message matching.
- `AbortError` is NOT treated as a stale-connection signal — it's usually a self-induced abort during stall recovery, not evidence of a stall.
- Track `lastApiActivityAt` via a bot API middleware: any successful non-`getUpdates` call (sendMessage, etc.) proves the TCP/TLS path is alive, so we don't restart just because `getUpdates` happens to be quiet on a low-traffic chat.
- In-flight non-`getUpdates` calls count as liveness **only if they started within the stall threshold** — a `sendMessage` stuck past the threshold is itself evidence of a stall and should trigger restart.
- Forced-cycle fallback: watchdog also triggers when the runner appears idle even without network activity signals.

## Test plan

- [x] `pnpm check` — clean
- [x] `extensions/telegram/src/polling-session.test.ts` + `network-errors.test.ts` — 81 tests, incl.:
  - Recent `sendMessage` success suppresses restart despite stale `getUpdates`
  - In-flight send within threshold suppresses restart
  - In-flight send stuck past threshold triggers restart
  - HTTP errors don't fake a restart signal
  - Nested `cause.code` connect-time errors short-circuit stale-detection
  - Forced-cycle fallback

Supersedes #33557 (stale after multiple review rounds). All actionable Codex/Greptile feedback from that PR is addressed here.
