### PR TITLE
fix(agents): handle OpenRouter reasoning_details in stream parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Secrets/plugins/status: align SecretRef inspect-vs-strict handling across plugin preload, read-only status/agents surfaces, and runtime auth paths so unresolved refs no longer crash read-only CLI flows while runtime-required non-env refs stay strict. (#66818) Thanks @joshavant.
 - Memory/dreaming: stop ordinary transcripts that merely quote the dream-diary prompt from being classified as internal dreaming runs and silently dropped from session recall ingestion. (#66852) Thanks @gumadeiras.
 - Telegram/documents: sanitize binary reply context and ZIP-like archive extraction so `.epub` and `.mobi` uploads can no longer leak raw binary into prompt context through reply metadata or archive-to-`text/plain` coercion. (#66877) Thanks @martinfrancois.
+- Agents/OpenAI completions stream: read reasoning out of the OpenRouter-style `reasoning_details` array (e.g. `{ type: "reasoning.text", text, index }`) in addition to the existing `reasoning_content`/`reasoning`/`reasoning_text` string fields so Qwen3 responses via OpenRouter no longer fail assistant turns with `payloads=0` when the model emits reasoning through `reasoning_details`. (#66833)
 
 ## 2026.4.14
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1727,4 +1727,212 @@ describe("openai transport stream", () => {
       false,
     );
   });
+
+  it("treats OpenRouter reasoning_details array as streamed thinking content", async () => {
+    const model = {
+      id: "qwen/qwen3-235b-a22b",
+      name: "Qwen3 235B A22B",
+      api: "openai-completions",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 256000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const output = {
+      role: "assistant" as const,
+      content: [] as Array<Record<string, unknown>>,
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    const emittedEvents: Array<Record<string, unknown>> = [];
+    const stream = {
+      push: (event: unknown) => {
+        emittedEvents.push(event as Record<string, unknown>);
+      },
+    };
+
+    const mockChunks = [
+      {
+        id: "chatcmpl-reasoning-details",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: "assistant" as const,
+              reasoning_details: [
+                { type: "reasoning.text", text: "Thinking ", format: "unknown", index: 0 },
+              ],
+            },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-reasoning-details",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              reasoning_details: [
+                { type: "reasoning.text", text: "about it.", format: "unknown", index: 0 },
+              ],
+            },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-reasoning-details",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: { content: "Final answer." },
+            logprobs: null,
+            finish_reason: "stop" as const,
+          },
+        ],
+      },
+    ] as const;
+
+    async function* mockStream() {
+      for (const chunk of mockChunks) {
+        yield chunk as never;
+      }
+    }
+
+    await __testing.processOpenAICompletionsStream(mockStream(), output as never, model, stream);
+
+    const thinkingBlocks = output.content.filter(
+      (block) => (block as { type?: string }).type === "thinking",
+    );
+    const textBlocks = output.content.filter(
+      (block) => (block as { type?: string }).type === "text",
+    );
+    expect(thinkingBlocks).toHaveLength(1);
+    expect((thinkingBlocks[0] as { thinking: string }).thinking).toBe("Thinking about it.");
+    expect((thinkingBlocks[0] as { thinkingSignature?: string }).thinkingSignature).toBe(
+      "reasoning_details",
+    );
+    expect(textBlocks).toHaveLength(1);
+    expect((textBlocks[0] as { text: string }).text).toBe("Final answer.");
+    expect(output.stopReason).toBe("stop");
+    expect(
+      emittedEvents.some((event) => (event as { type?: string }).type === "thinking_start"),
+    ).toBe(true);
+    expect(
+      emittedEvents.filter((event) => (event as { type?: string }).type === "thinking_delta"),
+    ).toHaveLength(2);
+  });
+
+  it("ignores empty reasoning_details entries so streams with no reasoning text fall through", async () => {
+    const model = {
+      id: "qwen/qwen3-32b",
+      name: "Qwen3 32B",
+      api: "openai-completions",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const output = {
+      role: "assistant" as const,
+      content: [] as Array<Record<string, unknown>>,
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    const stream = { push: () => {} };
+
+    const mockChunks = [
+      {
+        id: "chatcmpl-empty-details",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              reasoning_details: [
+                { type: "reasoning.text", text: "", format: "unknown", index: 0 },
+              ],
+            },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-empty-details",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: { content: "Hello." },
+            logprobs: null,
+            finish_reason: "stop" as const,
+          },
+        ],
+      },
+    ] as const;
+
+    async function* mockStream() {
+      for (const chunk of mockChunks) {
+        yield chunk as never;
+      }
+    }
+
+    await __testing.processOpenAICompletionsStream(mockStream(), output as never, model, stream);
+
+    expect(output.content.some((block) => (block as { type?: string }).type === "thinking")).toBe(
+      false,
+    );
+    const textBlock = output.content.find((block) => (block as { type?: string }).type === "text");
+    expect(textBlock).toBeDefined();
+    expect((textBlock as { text: string }).text).toBe("Hello.");
+  });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2035,4 +2035,143 @@ describe("openai transport stream", () => {
     expect((toolCallBlock as { id: string; name: string }).name).toBe("get_weather");
     expect((toolCallBlock as { arguments: { city?: string } }).arguments.city).toBe("Paris");
   });
+
+  it("preserves an active tool_call id/name when a later chunk adds reasoning_details + arg continuation", async () => {
+    const model = {
+      id: "qwen/qwen3-235b-a22b",
+      name: "Qwen3 235B A22B",
+      api: "openai-completions",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 256000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const output = {
+      role: "assistant" as const,
+      content: [] as Array<Record<string, unknown>>,
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    const stream = { push: () => {} };
+
+    // Chunk 1 opens a tool_call with id+name and partial args.
+    // Chunk 2 has BOTH non-empty reasoning_details AND a tool_call continuation
+    //   (OpenAI-style delta: no `id`/`name`, only more arguments). Before the
+    //   fix, reasoning_details finalized the tool_call block and the
+    //   continuation opened a new tool_call with empty id/name — producing
+    //   malformed, split tool-call state.
+    // Chunk 3 closes the stream with finish_reason: "tool_calls".
+    const mockChunks = [
+      {
+        id: "chatcmpl-split-tool-call",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: "assistant" as const,
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_split",
+                  type: "function" as const,
+                  function: { name: "get_weather", arguments: '{"city":"' },
+                },
+              ],
+            },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-split-tool-call",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              reasoning_details: [
+                { type: "reasoning.text", text: "Finalizing args.", format: "unknown", index: 0 },
+              ],
+              tool_calls: [
+                {
+                  index: 0,
+                  // No id/name — this is a continuation of the active call.
+                  function: { arguments: 'Paris"}' },
+                },
+              ],
+            },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-split-tool-call",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: { tool_calls: [] as never[] },
+            logprobs: null,
+            finish_reason: "tool_calls" as const,
+          },
+        ],
+      },
+    ] as const;
+
+    async function* mockStream() {
+      for (const chunk of mockChunks) {
+        yield chunk as never;
+      }
+    }
+
+    await __testing.processOpenAICompletionsStream(mockStream(), output as never, model, stream);
+
+    const toolCallBlocks = output.content.filter(
+      (block) => (block as { type?: string }).type === "toolCall",
+    );
+    // The active tool-call must remain a single block carrying full id/name
+    // and the concatenated arguments — not be split across two toolCall blocks.
+    expect(toolCallBlocks).toHaveLength(1);
+    const toolCallBlock = toolCallBlocks[0] as {
+      id: string;
+      name: string;
+      arguments: { city?: string };
+      partialArgs: string;
+    };
+    expect(toolCallBlock.id).toBe("call_split");
+    expect(toolCallBlock.name).toBe("get_weather");
+    expect(toolCallBlock.partialArgs).toBe('{"city":"Paris"}');
+    expect(toolCallBlock.arguments.city).toBe("Paris");
+
+    const thinkingBlock = output.content.find(
+      (block) => (block as { type?: string }).type === "thinking",
+    );
+    expect(thinkingBlock).toBeDefined();
+    expect((thinkingBlock as { thinking: string }).thinking).toBe("Finalizing args.");
+  });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1935,4 +1935,104 @@ describe("openai transport stream", () => {
     expect(textBlock).toBeDefined();
     expect((textBlock as { text: string }).text).toBe("Hello.");
   });
+
+  it("still processes tool_calls when a chunk also carries reasoning_details", async () => {
+    const model = {
+      id: "qwen/qwen3-235b-a22b",
+      name: "Qwen3 235B A22B",
+      api: "openai-completions",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 256000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const output = {
+      role: "assistant" as const,
+      content: [] as Array<Record<string, unknown>>,
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+
+    const stream = { push: () => {} };
+
+    const mockChunks = [
+      {
+        id: "chatcmpl-reasoning-and-tool",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: "assistant" as const,
+              reasoning_details: [
+                { type: "reasoning.text", text: "Planning call.", format: "unknown", index: 0 },
+              ],
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_1",
+                  type: "function" as const,
+                  function: { name: "get_weather", arguments: '{"city":"Paris"}' },
+                },
+              ],
+            },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-reasoning-and-tool",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: model.id,
+        choices: [
+          {
+            index: 0,
+            delta: { tool_calls: [] as never[] },
+            logprobs: null,
+            finish_reason: "tool_calls" as const,
+          },
+        ],
+      },
+    ] as const;
+
+    async function* mockStream() {
+      for (const chunk of mockChunks) {
+        yield chunk as never;
+      }
+    }
+
+    await __testing.processOpenAICompletionsStream(mockStream(), output as never, model, stream);
+
+    const thinkingBlock = output.content.find(
+      (block) => (block as { type?: string }).type === "thinking",
+    );
+    const toolCallBlock = output.content.find(
+      (block) => (block as { type?: string }).type === "toolCall",
+    );
+    expect(thinkingBlock).toBeDefined();
+    expect((thinkingBlock as { thinking: string }).thinking).toBe("Planning call.");
+    expect(toolCallBlock).toBeDefined();
+    expect((toolCallBlock as { id: string; name: string }).id).toBe("call_1");
+    expect((toolCallBlock as { id: string; name: string }).name).toBe("get_weather");
+    expect((toolCallBlock as { arguments: { city?: string } }).arguments.city).toBe("Paris");
+  });
 });

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1127,6 +1127,44 @@ async function processOpenAICompletionsStream(
       });
       continue;
     }
+    // OpenRouter returns Qwen3-style thinking as an array of reasoning_details
+    // entries ({ type: "reasoning.text", text, ... }) instead of a top-level
+    // reasoning_content string. Without this, streams that carry reasoning in
+    // reasoning_details produce zero assistant content blocks and the turn
+    // fails with `payloads=0`.
+    const reasoningDetails = (choice.delta as Record<string, unknown>).reasoning_details;
+    if (Array.isArray(reasoningDetails)) {
+      let reasoningDelta = "";
+      for (const entry of reasoningDetails) {
+        if (!entry || typeof entry !== "object") {
+          continue;
+        }
+        const text = (entry as Record<string, unknown>).text;
+        if (typeof text === "string" && text.length > 0) {
+          reasoningDelta += text;
+        }
+      }
+      if (reasoningDelta.length > 0) {
+        if (!currentBlock || currentBlock.type !== "thinking") {
+          finishCurrentBlock();
+          currentBlock = {
+            type: "thinking",
+            thinking: "",
+            thinkingSignature: "reasoning_details",
+          };
+          output.content.push(currentBlock);
+          stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+        }
+        currentBlock.thinking += reasoningDelta;
+        stream.push({
+          type: "thinking_delta",
+          contentIndex: blockIndex(),
+          delta: reasoningDelta,
+          partial: output,
+        });
+        continue;
+      }
+    }
     if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
       for (const toolCall of choice.delta.tool_calls) {
         if (

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1131,7 +1131,9 @@ async function processOpenAICompletionsStream(
     // entries ({ type: "reasoning.text", text, ... }) instead of a top-level
     // reasoning_content string. Without this, streams that carry reasoning in
     // reasoning_details produce zero assistant content blocks and the turn
-    // fails with `payloads=0`.
+    // fails with `payloads=0`. Falls through to the tool_calls branch below so
+    // a chunk that carries both reasoning_details and tool_calls still lands
+    // tool-call id/argument fragments (regression noted during review).
     const reasoningDetails = (choice.delta as Record<string, unknown>).reasoning_details;
     if (Array.isArray(reasoningDetails)) {
       let reasoningDelta = "";
@@ -1162,7 +1164,6 @@ async function processOpenAICompletionsStream(
           delta: reasoningDelta,
           partial: output,
         });
-        continue;
       }
     }
     if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1127,45 +1127,13 @@ async function processOpenAICompletionsStream(
       });
       continue;
     }
-    // OpenRouter returns Qwen3-style thinking as an array of reasoning_details
-    // entries ({ type: "reasoning.text", text, ... }) instead of a top-level
-    // reasoning_content string. Without this, streams that carry reasoning in
-    // reasoning_details produce zero assistant content blocks and the turn
-    // fails with `payloads=0`. Falls through to the tool_calls branch below so
-    // a chunk that carries both reasoning_details and tool_calls still lands
-    // tool-call id/argument fragments (regression noted during review).
-    const reasoningDetails = (choice.delta as Record<string, unknown>).reasoning_details;
-    if (Array.isArray(reasoningDetails)) {
-      let reasoningDelta = "";
-      for (const entry of reasoningDetails) {
-        if (!entry || typeof entry !== "object") {
-          continue;
-        }
-        const text = (entry as Record<string, unknown>).text;
-        if (typeof text === "string" && text.length > 0) {
-          reasoningDelta += text;
-        }
-      }
-      if (reasoningDelta.length > 0) {
-        if (!currentBlock || currentBlock.type !== "thinking") {
-          finishCurrentBlock();
-          currentBlock = {
-            type: "thinking",
-            thinking: "",
-            thinkingSignature: "reasoning_details",
-          };
-          output.content.push(currentBlock);
-          stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
-        }
-        currentBlock.thinking += reasoningDelta;
-        stream.push({
-          type: "thinking_delta",
-          contentIndex: blockIndex(),
-          delta: reasoningDelta,
-          partial: output,
-        });
-      }
-    }
+    // Process tool_calls before reasoning_details so a chunk that carries both
+    // an active tool-call continuation (where OpenAI-style deltas often omit
+    // `id`/`name` after the opening fragment) and non-empty reasoning_details
+    // still appends the continuation to the live tool-call block first. If we
+    // finished the tool-call block to open a thinking block first, the
+    // continuation would start a fresh toolCall with empty id/name and split
+    // one logical call into two blocks with malformed arguments.
     if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
       for (const toolCall of choice.delta.tool_calls) {
         if (
@@ -1203,6 +1171,45 @@ async function processOpenAICompletionsStream(
             partial: output,
           });
         }
+      }
+    }
+    // OpenRouter returns Qwen3-style thinking as an array of reasoning_details
+    // entries ({ type: "reasoning.text", text, ... }) instead of a top-level
+    // reasoning_content string. Without this, streams that carry reasoning in
+    // reasoning_details produce zero assistant content blocks and the turn
+    // fails with `payloads=0`. Runs after the tool_calls branch above so a
+    // chunk that carries both still preserves any active tool-call block
+    // before a new thinking block is opened.
+    const reasoningDetails = (choice.delta as Record<string, unknown>).reasoning_details;
+    if (Array.isArray(reasoningDetails)) {
+      let reasoningDelta = "";
+      for (const entry of reasoningDetails) {
+        if (!entry || typeof entry !== "object") {
+          continue;
+        }
+        const text = (entry as Record<string, unknown>).text;
+        if (typeof text === "string" && text.length > 0) {
+          reasoningDelta += text;
+        }
+      }
+      if (reasoningDelta.length > 0) {
+        if (!currentBlock || currentBlock.type !== "thinking") {
+          finishCurrentBlock();
+          currentBlock = {
+            type: "thinking",
+            thinking: "",
+            thinkingSignature: "reasoning_details",
+          };
+          output.content.push(currentBlock);
+          stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+        }
+        currentBlock.thinking += reasoningDelta;
+        stream.push({
+          type: "thinking_delta",
+          contentIndex: blockIndex(),
+          delta: reasoningDelta,
+          partial: output,
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary

- Problem: OpenRouter-served Qwen3 streams emit thinking/reasoning inside a `reasoning_details` array (entries like `{ type: "reasoning.text", text, index }`), but the OpenAI-completions stream parser only reads reasoning out of the top-level string fields `reasoning_content` / `reasoning` / `reasoning_text`.
- Why it matters: because no content or reasoning block is assembled from `reasoning_details`, the assistant turn completes with `payloads=0` and the user sees `⚠️ Agent couldn't generate a response. Please try again.` — even though the provider returned a valid response.
- What changed: after the existing string reasoning-field branch in `processOpenAICompletionsStream`, pick up `choice.delta.reasoning_details` when it is an array, concatenate each entry's `text` field, and stream it into a `thinking` block the same way as the existing reasoning fields. Two regression tests lock the new branch in: one that assembles multi-chunk `reasoning_details` deltas plus a text delta into `thinking` + `text` blocks, and one that confirms empty `reasoning_details` entries do not open a spurious thinking block when only a `content` delta follows.
- What did NOT change (scope boundary): this PR does not touch OpenRouter request wrapping (`createOpenRouterWrapper`), request-side `reasoning`/`exclude` behavior, the OpenAI Responses transport, any non-completions stream, or the thinking-block schema / sanitization logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66833
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `processOpenAICompletionsStream` only checks `reasoning_content` / `reasoning` / `reasoning_text` on `choice.delta`. OpenRouter's Qwen3 responses (and other OpenRouter models that use `reasoning_details`) put the reasoning text inside an array of entries keyed by `type: "reasoning.text"` with a `text` field, which the parser never reads. With no text `content` delta and no recognized reasoning field, `output.content` stays empty and the runtime surfaces `payloads=0`.
- Missing detection / guardrail: no coverage exercised the OpenRouter `reasoning_details` shape on the OpenAI-completions stream.
- Contributing context (if known): OpenRouter passes Qwen3's native response through verbatim; the reporter confirmed (issue #66833) that a direct OpenRouter call returns `content` + `reasoning_details`, but the OpenClaw gateway path consistently hits `payloads=0`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-transport-stream.test.ts` (two new tests that exercise `__testing.processOpenAICompletionsStream`).
- Scenario the test should lock in: (1) a stream that sends two `reasoning_details` entries across chunks followed by a `content` delta assembles into one `thinking` block (`Thinking about it.`) plus one `text` block (`Final answer.`) and emits `thinking_start` + two `thinking_delta` events; (2) a stream whose only `reasoning_details` entry has empty `text` does NOT open a thinking block when the following chunk only carries a `content` delta.
- Why this is the smallest reliable guardrail: the failure is in the stream-chunk reducer itself, so direct tests against `processOpenAICompletionsStream` are enough — no transport/network harness needed.
- Existing test that already covers this (if any): none — existing reasoning tests exercise the string-shaped `reasoning_content` / `reasoning` / `reasoning_text` branch only.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

OpenRouter-routed Qwen3 sessions (and any OpenAI-completions stream that emits `reasoning_details`) now complete turns normally instead of failing with `⚠️ Agent couldn't generate a response.`, and the model's reasoning text is preserved as a `thinking` block with `thinkingSignature: "reasoning_details"` (consistent with how the existing reasoning fields tag their thinking blocks).

## Diagram (if applicable)

```text
Before:
[OpenRouter Qwen3 stream]
  delta: { reasoning_details: [{ type: "reasoning.text", text: "..." }] }
  delta: { content: "..." }  // optional
-> reducer only inspects reasoning_content / reasoning / reasoning_text
-> no thinking block, no text block from reasoning_details
-> output.content = [] -> payloads=0 -> "Agent couldn't generate a response"

After:
[OpenRouter Qwen3 stream]
  delta: { reasoning_details: [{ type: "reasoning.text", text: "..." }] }
  delta: { content: "..." }
-> reducer also reads reasoning_details[].text, concatenates, and emits a thinking block
-> text deltas still build a text block as before
-> output.content = [ thinking, text ] -> turn completes normally
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local validation); issue reported on macOS arm64 and reproduces on any host running OpenClaw 2026.4.14 against an OpenRouter Qwen3 model.
- Runtime/container: Node.js 22 / pnpm workspace.
- Model/provider: `openrouter/qwen/qwen3-235b-a22b` (and other Qwen3 OpenRouter variants).
- Integration/channel (if any): agent message path going through the OpenAI-completions stream transport.
- Relevant config (redacted): `model: "openrouter/qwen/qwen3-235b-a22b"` on a standard agent; no special reasoning overrides required.

### Steps

1. Configure an agent with `model: "openrouter/qwen/qwen3-235b-a22b"` and send any user message.
2. Observe on `main` that the turn completes with `incomplete turn detected: ... stopReason=stop payloads=0` and the UI surfaces the "Agent couldn't generate a response" warning.
3. With this PR applied, the same turn assembles a `thinking` block from the streamed `reasoning_details` entries and, if the model also emits `content`, a normal `text` block — no `payloads=0` failure.

### Expected

- Turns against OpenRouter Qwen3 complete with at least one assistant content block and surface the model's reasoning (and text, when present) instead of failing with `payloads=0`.

### Actual

- Before this PR: `payloads=0`, "Agent couldn't generate a response" user-visible error, content dropped silently.
- After this PR: thinking block captures `reasoning_details` text; text block captures any `content` delta; turn completes normally.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added two direct unit tests against `__testing.processOpenAICompletionsStream` that (a) feed two-chunk `reasoning_details` plus a final `content` delta and assert a single `thinking` block, a single `text` block, and the expected thinking/text event emissions, and (b) feed a single empty-`text` `reasoning_details` entry plus a `content` delta and assert that no thinking block is opened. Ran `node scripts/test-projects.mjs src/agents/openai-transport-stream.test.ts` locally: 54/54 tests pass.
- Edge cases checked: non-array `reasoning_details` is ignored; array entries without a string `text` field contribute nothing; empty concatenated text does not open a thinking block (the reducer continues on to tool_calls / next chunk); `thinkingSignature` is set to `"reasoning_details"` so consumers can distinguish it from the existing string-field branches.
- What you did **not** verify: I did not run a live OpenRouter Qwen3 request in this session.

## Review Conversations

- [x] I will reply to and resolve every bot review conversation I address in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk: If another OpenAI-compatible provider sends `reasoning_details` with a different semantic shape, we would fold its reasoning text into a thinking block rather than drop it.
  - Mitigation: we only read the string `text` field of each entry and only open a thinking block when the concatenated text is non-empty; the change is strictly additive to the existing string-field branch and does not alter behavior for providers that never emit `reasoning_details`.
- Risk: `reasoning_details` entries whose `text` is already partial (e.g. cumulative) could be double-counted.
  - Mitigation: the OpenAI/OpenRouter streaming contract is delta-based across chunks, consistent with how `reasoning_content` is already appended; this PR follows the same append pattern.

## AI Assistance

- AI-assisted: Yes (Claude)
- Testing degree: Fully tested for the affected stream reducer branch
- Prompt/session summary: Identified issue #66833 as a freshly reported, source-documented bug with no active competing PR, traced the reducer at `src/agents/openai-transport-stream.ts` to the existing `reasoningFields` branch, added a strictly-additive `reasoning_details` branch that follows the same thinking-block/event-emission pattern, then wrote two direct unit tests against `__testing.processOpenAICompletionsStream` and confirmed the focused suite passes locally.
- Understanding confirmation: I understand this change only widens the completions stream reducer's reasoning-field recognition to include OpenRouter's `reasoning_details` array shape; it does not change request-side OpenRouter wrapping, the Responses transport, or any thinking-block downstream consumer.

## Verification Commands

- `node scripts/test-projects.mjs src/agents/openai-transport-stream.test.ts` → `Test Files 1 passed (1) / Tests 54 passed (54)`
- `pnpm exec oxlint src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts` → `Found 0 warnings and 0 errors.`
- `pnpm format src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts` → clean
- `pnpm exec tsgo --noEmit` → clean
- `git diff --check` → clean
