### PR TITLE
fix(config): restore Telegram native commands under auto defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Secrets/plugins/status: align SecretRef inspect-vs-strict handling across plugin preload, read-only status/agents surfaces, and runtime auth paths so unresolved refs no longer crash read-only CLI flows while runtime-required non-env refs stay strict. (#66818) Thanks @joshavant.
 - Memory/dreaming: stop ordinary transcripts that merely quote the dream-diary prompt from being classified as internal dreaming runs and silently dropped from session recall ingestion. (#66852) Thanks @gumadeiras.
 - Telegram/documents: sanitize binary reply context and ZIP-like archive extraction so `.epub` and `.mobi` uploads can no longer leak raw binary into prompt context through reply metadata or archive-to-`text/plain` coercion. (#66877) Thanks @martinfrancois.
+- Telegram/native commands: restore plugin-registry-backed auto defaults for native commands and native skills so Telegram slash commands keep registering when `commands.native` and `commands.nativeSkills` stay on `auto`. (#66843) Thanks @kashevk0.
 
 ## 2026.4.14
 

--- a/src/config/commands.test.ts
+++ b/src/config/commands.test.ts
@@ -56,6 +56,17 @@ beforeEach(() => {
           },
         },
       },
+      {
+        pluginId: "demo-channel",
+        source: "test",
+        plugin: {
+          ...createChannelTestPluginBase({ id: "demo-channel" }),
+          commands: {
+            nativeCommandsAutoEnabled: true,
+            nativeSkillsAutoEnabled: true,
+          },
+        },
+      },
     ]),
   );
 });
@@ -117,6 +128,21 @@ describe("resolveNativeCommandsEnabled", () => {
     expect(resolveNativeCommandsEnabled({ providerId: "slack", globalSetting: "auto" })).toBe(
       false,
     );
+  });
+
+  it("uses the plugin registry for auto defaults even when chat-channel normalization misses", () => {
+    expect(
+      resolveNativeCommandsEnabled({
+        providerId: "demo-channel",
+        globalSetting: "auto",
+      }),
+    ).toBe(true);
+    expect(
+      resolveNativeSkillsEnabled({
+        providerId: "demo-channel",
+        globalSetting: "auto",
+      }),
+    ).toBe(true);
   });
 
   it("honors explicit provider/global booleans", () => {

--- a/src/config/commands.test.ts
+++ b/src/config/commands.test.ts
@@ -115,6 +115,15 @@ describe("resolveNativeSkillsEnabled", () => {
       }),
     ).toBe(false);
   });
+
+  it("uses the plugin registry for auto defaults even when chat-channel normalization misses", () => {
+    expect(
+      resolveNativeSkillsEnabled({
+        providerId: "demo-channel",
+        globalSetting: "auto",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("resolveNativeCommandsEnabled", () => {
@@ -133,12 +142,6 @@ describe("resolveNativeCommandsEnabled", () => {
   it("uses the plugin registry for auto defaults even when chat-channel normalization misses", () => {
     expect(
       resolveNativeCommandsEnabled({
-        providerId: "demo-channel",
-        globalSetting: "auto",
-      }),
-    ).toBe(true);
-    expect(
-      resolveNativeSkillsEnabled({
         providerId: "demo-channel",
         globalSetting: "auto",
       }),

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -1,6 +1,5 @@
-import { getChannelPlugin } from "../channels/plugins/index.js";
+import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
-import { normalizeChannelId } from "../channels/registry.js";
 import type { NativeCommandsSetting } from "./types.js";
 export { isCommandFlagEnabled, isRestartEnabled, type CommandFlagKey } from "./commands.flags.js";
 


### PR DESCRIPTION
## Summary

- Problem: Telegram native slash commands stopped registering when `commands.native` and `commands.nativeSkills` were left on the default `"auto"` behavior.
- Why it matters: the Telegram `/` menu became empty and native command handling stopped working even though the Telegram plugin still advertised native command auto support.
- What changed: `src/config/commands.ts` now normalizes provider IDs through the plugin-registry path before resolving native command and native skill auto defaults, and `src/config/commands.test.ts` adds a regression test for that path.
- What did NOT change (scope boundary): this does not add a Telegram-specific hardcode, does not change config defaults, and does not modify command implementations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66756
- Related #62508
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveNativeCommandsEnabled()` and `resolveNativeSkillsEnabled()` normalized provider IDs through `../channels/registry.js`, while plugin lookup used the plugin-registry path. In the affected bundle, that normalization path failed to recognize Telegram, so auto resolution returned `false` too early.
- Missing detection / guardrail: there was no regression test for a provider that is resolvable by the plugin registry but missed by the narrower normalization path.
- Contributing context (if known): this surfaced as a Telegram regression on `2026.4.14`, where native command auto support still existed in the plugin but command registration fell through to disabled. This is distinct from the Telegram command-sync/cache symptom family addressed in other work such as `#66730`; this PR fixes the config-side auto-default resolution path in `src/config/commands.ts`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/commands.test.ts`
- Scenario the test should lock in: when a provider is present in the plugin registry and its commands and skills are auto-enabled there, `resolveNativeCommandsEnabled()` and `resolveNativeSkillsEnabled()` should stay enabled under `globalSetting: "auto"`.
- Why this is the smallest reliable guardrail: the bug is in config-resolution logic, so a focused unit regression catches it without needing a full Telegram runtime harness.
- Existing test that already covers this (if any): none found
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram native slash commands stay enabled under the default `auto` path for affected providers instead of being incorrectly disabled.

## Diagram (if applicable)

```text
Before:
Telegram provider -> registry normalization misses provider -> auto resolves false -> native commands do not register

After:
Telegram provider -> plugin-registry normalization resolves provider -> auto resolves true -> native commands register
```

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - This restores intended native command and native skill exposure for providers that already advertise auto support.
  - It does not add new command implementations or widen data access.
  - Risk is limited by aligning normalization with the same plugin-registry-backed path already used for plugin lookup.

## Repro + Verification

### Environment

- OS: macOS for local validation, with the original user-visible regression reported on Telegram in OpenClaw `2026.4.14`
- Runtime/container: source checkout plus local installed OpenClaw bundle analysis
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `commands.native: "auto"`, `commands.nativeSkills: "auto"`

### Steps

1. Leave native commands and native skills on `auto`.
2. Use the affected bundle where Telegram is missing from the older normalization path.
3. Observe Telegram native command auto resolution fall back to disabled even though the plugin registry still exposes Telegram native auto support.

### Expected

- Telegram native commands remain enabled when the plugin registry marks them auto-enabled.

### Actual

- Auto resolution returned `false` early, which disabled Telegram native commands.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - confirmed the affected normalization path could miss Telegram while plugin auto support still existed
  - ran the targeted regression test:
    - `corepack pnpm exec vitest run --config test/vitest/vitest.runtime-config.config.ts src/config/commands.test.ts`
    - result: `1` file passed, `9` tests passed
  - ran:
    - `corepack pnpm build` ✅
    - `corepack pnpm check` ✅
    - `corepack pnpm check:docs` ✅
- Edge cases checked:
  - both `resolveNativeCommandsEnabled()`
  - and `resolveNativeSkillsEnabled()`
- What you did **not** verify:
  - a fully green `pnpm test` run on this host, because the repo-wide suite surfaced unrelated failures outside touched files (for example `src/gateway/control-ui.http.test.ts`, `src/agents/tools/image-tool.test.ts`, `extensions/signal/src/install-signal-cli.test.ts`) and also hit a worker OOM during the broader run
  - end-to-end Telegram verification on this source branch

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - providers previously dropped by the narrower normalization path will now inherit plugin-registry auto defaults
  - Mitigation:
    - that is the intended behavior,
    - the fix keeps normalization aligned with plugin lookup,
    - and the regression test covers both native commands and native skills

## AI Assistance

- AI-assisted: Yes
- Tooling used: OpenClaw / Codex-assisted workflow
- Testing degree: targeted regression validated locally; broader local gate attempted (`build`, `check`, and `check:docs` passed, repo-wide `test` was not green on this host outside the touched files)
- I understand what the code does: Yes
- Prompts/session logs: available on request
- `codex review --base origin/main`: attempted via `npm exec @openai/codex -- review --base origin/main`, but local Codex auth on this host returned `401 Unauthorized`
