### PR TITLE
fix(memory): recognize ollama as valid embedding provider

### DIFF
--- a/src/plugins/memory-embedding-provider-runtime.test.ts
+++ b/src/plugins/memory-embedding-provider-runtime.test.ts
@@ -60,14 +60,25 @@ describe("memory embedding provider runtime resolution", () => {
     expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledTimes(2);
   });
 
-  it("does not consult capability fallback once runtime adapters are registered", () => {
+  it("does not consult capability fallback for a provider that is already registered", () => {
     registerMemoryEmbeddingProvider({
       id: "openai",
       create: async () => ({ provider: null }),
     });
     mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("ollama")]);
 
-    expect(runtimeModule.getMemoryEmbeddingProvider("ollama")).toBeUndefined();
+    expect(runtimeModule.getMemoryEmbeddingProvider("openai")?.id).toBe("openai");
     expect(mocks.resolvePluginCapabilityProviders).not.toHaveBeenCalled();
+  });
+
+  it("falls back to capability providers for an unregistered id even when other providers are registered (#66688)", () => {
+    registerMemoryEmbeddingProvider({
+      id: "openai",
+      create: async () => ({ provider: null }),
+    });
+    mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("ollama")]);
+
+    expect(runtimeModule.getMemoryEmbeddingProvider("ollama")?.id).toBe("ollama");
+    expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalled();
   });
 });

--- a/src/plugins/memory-embedding-provider-runtime.ts
+++ b/src/plugins/memory-embedding-provider-runtime.ts
@@ -32,8 +32,12 @@ export function getMemoryEmbeddingProvider(
   if (registered) {
     return registered.adapter;
   }
-  if (listRegisteredMemoryEmbeddingProviders().length > 0) {
-    return undefined;
-  }
-  return listMemoryEmbeddingProviders(cfg).find((adapter) => adapter.id === id);
+  // Even when other providers are already registered, the requested provider
+  // may live in a plugin that hasn't loaded yet.  Fall through to the plugin
+  // capability system so that bundled plugins (e.g. ollama) are discovered.
+  const pluginProviders = resolvePluginCapabilityProviders({
+    key: "memoryEmbeddingProviders",
+    cfg,
+  });
+  return pluginProviders.find((adapter) => adapter.id === id);
 }


### PR DESCRIPTION
## Summary
- Fixes #66688 — `openclaw memory index` fails with "Unknown memory embedding provider: ollama"
- The `getMemoryEmbeddingProvider()` had a short-circuit guard: when any providers were already registered in the runtime map, it returned `undefined` for providers not in that map, without falling through to the plugin capability system
- This meant ollama (which loads via a bundled plugin) was never discovered when other providers like `openai` or `local` were already registered

## Changes
- Removed the short-circuit guard in `memory-embedding-provider-runtime.ts`
- Now always consults `resolvePluginCapabilityProviders()` when requested ID is not in the registered map
- Updated existing test that encoded the buggy behavior
- Added regression test tagged with #66688

## Test plan
- [ ] `pnpm test` passes for memory embedding provider tests
- [ ] Verify `openclaw memory index` works with ollama provider configured

🤖 Generated with [Claude Code](https://claude.ai/code)