### PR TITLE
memory: block dreaming self-ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Video generation/live tests: bound provider polling for live video smoke, default to the fast non-FAL text-to-video path, and use a one-second lobster prompt so release validation no longer waits indefinitely on slow provider queues.
+- Memory/dreaming: stop ordinary transcripts that merely quote the dream-diary prompt from being classified as internal dreaming runs and silently dropped from session recall ingestion. (#66852) Thanks @gumadeiras.
 - Memory-core/QMD `memory_get`: reject reads of arbitrary workspace markdown paths and only allow canonical memory files (`MEMORY.md`, `memory.md`, `DREAMS.md`, `dreams.md`, `memory/**`) plus exact paths of active indexed QMD workspace documents, so the QMD memory backend can no longer be used as a generic workspace-file read shim that bypasses `read` tool-policy denials. (#66026) Thanks @eleqtrizit.
 - Cron/agents: forward embedded-run tool policy and internal event params into the attempt layer so `--tools` allowlists, cron-owned message-tool suppression, explicit message targeting, and command-path internal events all take effect at runtime again. (#62675) Thanks @hexsprite.
 - Setup/providers: guard preferred-provider lookup during setup so malformed plugin metadata with a missing provider id no longer crashes the wizard with `Cannot read properties of undefined (reading 'trim')`. (#66649) Thanks @Tianworld.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Video generation/live tests: bound provider polling for live video smoke, default to the fast non-FAL text-to-video path, and use a one-second lobster prompt so release validation no longer waits indefinitely on slow provider queues.
-- Memory/dreaming: stop ordinary transcripts that merely quote the dream-diary prompt from being classified as internal dreaming runs and silently dropped from session recall ingestion. (#66852) Thanks @gumadeiras.
 - Memory-core/QMD `memory_get`: reject reads of arbitrary workspace markdown paths and only allow canonical memory files (`MEMORY.md`, `memory.md`, `DREAMS.md`, `dreams.md`, `memory/**`) plus exact paths of active indexed QMD workspace documents, so the QMD memory backend can no longer be used as a generic workspace-file read shim that bypasses `read` tool-policy denials. (#66026) Thanks @eleqtrizit.
 - Cron/agents: forward embedded-run tool policy and internal event params into the attempt layer so `--tools` allowlists, cron-owned message-tool suppression, explicit message targeting, and command-path internal events all take effect at runtime again. (#62675) Thanks @hexsprite.
 - Setup/providers: guard preferred-provider lookup during setup so malformed plugin metadata with a missing provider id no longer crashes the wizard with `Cannot read properties of undefined (reading 'trim')`. (#66649) Thanks @Tianworld.
@@ -114,6 +113,7 @@ Docs: https://docs.openclaw.ai
 - CLI/approvals: raise the default `openclaw approvals get` gateway timeout and report config-load timeouts explicitly, so slow hosts stop showing a misleading `Config unavailable.` note when the approvals snapshot succeeds but the follow-up config RPC needs more time. (#66239) Thanks @neeravmakwana.
 - Media/store: honor configured agent media limits when saving generated media and persisting outbound reply media, so the store no longer hard-stops those flows at 5 MB before the configured limit applies. (#66229) Thanks @neeravmakwana and @vincentkoc.
 - Plugins/setup-entry: preserve separate setup-entry secrets exports when loading bundled setup-runtime channels, so setup-mode flows keep the channel secret contract for split plugin + secrets entrypoints. (#66261) Thanks @hxy91819.
+- Memory/dreaming: stop ordinary transcripts that merely quote the dream-diary prompt from being classified as internal dreaming runs and silently dropped from session recall ingestion. (#66852) Thanks @gumadeiras.
 
 ## 2026.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engines: preserve prompt-only token counts, not full request totals, when deferred maintenance reuses after-turn runtime context so background compaction bookkeeping matches the active prompt window. (#66820) thanks @jalehman.
 - BlueBubbles/inbound: add a persistent file-backed GUID dedupe so MessagePoller webhook replays after BB Server restart or reconnect no longer cause the agent to re-reply to already-handled messages. (#19176, #12053, #66816) Thanks @omarshahine.
 - Secrets/plugins/status: align SecretRef inspect-vs-strict handling across plugin preload, read-only status/agents surfaces, and runtime auth paths so unresolved refs no longer crash read-only CLI flows while runtime-required non-env refs stay strict. (#66818) Thanks @joshavant.
+- Memory/dreaming: stop ordinary transcripts that merely quote the dream-diary prompt from being classified as internal dreaming runs and silently dropped from session recall ingestion. (#66852) Thanks @gumadeiras.
 
 ## 2026.4.14
 
@@ -113,7 +114,6 @@ Docs: https://docs.openclaw.ai
 - CLI/approvals: raise the default `openclaw approvals get` gateway timeout and report config-load timeouts explicitly, so slow hosts stop showing a misleading `Config unavailable.` note when the approvals snapshot succeeds but the follow-up config RPC needs more time. (#66239) Thanks @neeravmakwana.
 - Media/store: honor configured agent media limits when saving generated media and persisting outbound reply media, so the store no longer hard-stops those flows at 5 MB before the configured limit applies. (#66229) Thanks @neeravmakwana and @vincentkoc.
 - Plugins/setup-entry: preserve separate setup-entry secrets exports when loading bundled setup-runtime channels, so setup-mode flows keep the channel secret contract for split plugin + secrets entrypoints. (#66261) Thanks @hxy91819.
-- Memory/dreaming: stop ordinary transcripts that merely quote the dream-diary prompt from being classified as internal dreaming runs and silently dropped from session recall ingestion. (#66852) Thanks @gumadeiras.
 
 ## 2026.4.12
 

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -80,6 +80,9 @@ After each phase has enough material, `memory-core` runs a best-effort backgroun
 subagent turn (using the default runtime model) and appends a short diary entry.
 
 This diary is for human reading in the Dreams UI, not a promotion source.
+Dreaming-generated diary/report artifacts are excluded from short-term
+promotion. Only grounded memory snippets are eligible to promote into
+`MEMORY.md`.
 
 There is also a grounded historical backfill lane for review and recovery work:
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -796,9 +796,11 @@ describe("memory-core dreaming phases", () => {
         { trigger: "heartbeat", workspaceDir },
       );
 
-      expect(readFileSpy.mock.calls.some(([target]) => String(target) === transcriptPath)).toBe(
-        false,
-      );
+      expect(
+        readFileSpy.mock.calls.some(
+          ([target]) => typeof target === "string" && target === transcriptPath,
+        ),
+      ).toBe(false);
       readFileSpy.mockRestore();
     } finally {
       vi.restoreAllMocks();

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -713,8 +713,8 @@ describe("memory-core dreaming phases", () => {
     expect(Object.keys(sessionIngestion.files)).toHaveLength(1);
     expect(Object.values(sessionIngestion.files)).toEqual([
       expect.objectContaining({
-        lineCount: 2,
-        lastContentLine: 2,
+        lineCount: 0,
+        lastContentLine: 0,
         contentHash: expect.any(String),
       }),
     ]);

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -720,6 +720,92 @@ describe("memory-core dreaming phases", () => {
     ]);
   });
 
+  it("does not reread unchanged dreaming-generated transcripts after checkpointing skip state", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-narrative.jsonl");
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "custom",
+          customType: "openclaw:bootstrap-context:full",
+          data: {
+            runId: "dreaming-narrative-light-1775894400455",
+            sessionId: "dream-session-1",
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:01:00.000Z",
+            content: [
+              { type: "text", text: "Write a dream diary entry from these memory fragments." },
+            ],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const mtime = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, mtime, mtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+          list: [{ id: "main", workspace: workspaceDir }],
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+
+      const readFileSpy = vi.spyOn(fs, "readFile");
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+
+      expect(readFileSpy.mock.calls.some(([target]) => String(target) === transcriptPath)).toBe(
+        false,
+      );
+      readFileSpy.mockRestore();
+    } finally {
+      vi.restoreAllMocks();
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("dedupes reset/deleted session archives instead of double-ingesting", async () => {
     const workspaceDir = await createDreamingWorkspace();
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -739,10 +739,7 @@ async function collectSessionIngestionBatches(params: {
       mtimeMs: Math.floor(Math.max(0, stat.mtimeMs)),
       size: Math.floor(Math.max(0, stat.size)),
     };
-    const cursorAtEnd =
-      previous !== undefined &&
-      previous.lineCount > 0 &&
-      previous.lastContentLine >= previous.lineCount;
+    const cursorAtEnd = previous !== undefined && previous.lastContentLine >= previous.lineCount;
     const unchanged =
       Boolean(previous) &&
       previous.mtimeMs === fingerprint.mtimeMs &&

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -262,6 +262,36 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("keeps ordinary snippets that only quote dreaming prompt markers", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "debug note",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 1,
+            endLine: 1,
+            score: 0.75,
+            snippet:
+              "Debug note: quote Write a dream diary entry from these memory fragments for docs, but do not use dreaming-narrative-like labels in production.",
+          },
+        ],
+      });
+
+      const store = JSON.parse(
+        await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8"),
+      ) as { entries: Record<string, { snippet: string }> };
+      expect(Object.values(store.entries)).toEqual([
+        expect.objectContaining({
+          snippet:
+            "Debug note: quote Write a dream diary entry from these memory fragments for docs, but do not use dreaming-narrative-like labels in production.",
+        }),
+      ]);
+    });
+  });
+
   it("records recalls and ranks candidates with weighted scores", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({
@@ -1059,6 +1089,22 @@ describe("short-term promotion", () => {
     expect(
       __testing.isContaminatedDreamingSnippet(
         "([ Candidate: Default to action. confidence: 0.76 evidence: memory/.dreams/session-corpus/2026-04-08.txt:1-1 recalls: 3 status: staged",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat ordinary candidate notes with daily-memory evidence as contaminated", () => {
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "Candidate: move backups weekly. confidence: 0.76 evidence: memory/2026-04-08.md:1-1",
+      ),
+    ).toBe(false);
+  });
+
+  it("treats transcript-style dreaming prompt echoes as contaminated", () => {
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "[main/dreaming-narrative-light.jsonl#L1] Write a dream diary entry from these memory fragments:",
       ),
     ).toBe(true);
   });

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -203,6 +203,33 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("ignores contaminated dreaming snippets when recording short-term recalls", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "action preference",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 1,
+            endLine: 1,
+            score: 0.92,
+            snippet:
+              "Candidate: Default to action. confidence: 0.76 evidence: memory/.dreams/session-corpus/2026-04-08.txt:1-1 recalls: 3 status: staged",
+          },
+        ],
+      });
+
+      expect(
+        JSON.parse(await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8")),
+      ).toMatchObject({
+        version: 1,
+        entries: {},
+      });
+    });
+  });
+
   it("records recalls and ranks candidates with weighted scores", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({
@@ -940,6 +967,54 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("does not rank contaminated dreaming snippets from an existing short-term store", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const storePath = resolveShortTermRecallStorePath(workspaceDir);
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            version: 1,
+            updatedAt: "2026-04-04T00:00:00.000Z",
+            entries: {
+              contaminated: {
+                key: "contaminated",
+                path: "memory/2026-04-03.md",
+                startLine: 1,
+                endLine: 1,
+                source: "memory",
+                snippet:
+                  "Reflections: Theme: assistant. confidence: 1.00 evidence: memory/.dreams/session-corpus/2026-04-08.txt:2-2 recalls: 4 status: staged",
+                recallCount: 4,
+                dailyCount: 0,
+                groundedCount: 0,
+                totalScore: 3.6,
+                maxScore: 0.95,
+                firstRecalledAt: "2026-04-03T00:00:00.000Z",
+                lastRecalledAt: "2026-04-04T00:00:00.000Z",
+                queryHashes: ["a", "b"],
+                recallDays: ["2026-04-03", "2026-04-04"],
+                conceptTags: ["assistant"],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(ranked).toEqual([]);
+    });
+  });
+
   it("skips direct candidates that exceed maxAgeDays during apply", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const applied = await applyShortTermPromotions({
@@ -966,6 +1041,53 @@ describe("short-term promotion", () => {
             score: 0.95,
             recallDays: ["2026-04-01", "2026-04-02"],
             conceptTags: ["expired"],
+            components: {
+              frequency: 1,
+              relevance: 1,
+              diversity: 1,
+              recency: 1,
+              consolidation: 1,
+              conceptual: 1,
+            },
+          },
+        ],
+      });
+
+      expect(applied.applied).toBe(0);
+      await expect(
+        fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
+  it("does not append contaminated dreaming snippets during direct apply", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        candidates: [
+          {
+            key: "memory:memory/2026-04-03.md:1:1",
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            source: "memory",
+            snippet:
+              "Candidate: Default to action. confidence: 0.76 evidence: memory/.dreams/session-corpus/2026-04-08.txt:1-1 recalls: 3 status: staged",
+            recallCount: 4,
+            avgScore: 0.97,
+            maxScore: 0.97,
+            uniqueQueries: 2,
+            firstRecalledAt: "2026-04-03T00:00:00.000Z",
+            lastRecalledAt: "2026-04-04T00:00:00.000Z",
+            ageDays: 0,
+            score: 0.99,
+            recallDays: ["2026-04-03", "2026-04-04"],
+            conceptTags: ["assistant"],
             components: {
               frequency: 1,
               relevance: 1,

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1055,6 +1055,14 @@ describe("short-term promotion", () => {
     ).toBe(true);
   });
 
+  it("treats bracket-prefixed dreaming snippets as contaminated", () => {
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "([ Candidate: Default to action. confidence: 0.76 evidence: memory/.dreams/session-corpus/2026-04-08.txt:1-1 recalls: 3 status: staged",
+      ),
+    ).toBe(true);
+  });
+
   it("skips direct candidates that exceed maxAgeDays during apply", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const applied = await applyShortTermPromotions({

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1104,7 +1104,7 @@ describe("short-term promotion", () => {
   it("treats transcript-style dreaming prompt echoes as contaminated", () => {
     expect(
       __testing.isContaminatedDreamingSnippet(
-        "[main/dreaming-narrative-light.jsonl#L1] Write a dream diary entry from these memory fragments:",
+        "[main/dreaming-narrative-light.jsonl#L1] User: Write a dream diary entry from these memory fragments:",
       ),
     ).toBe(true);
   });

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -230,6 +230,38 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("ignores bullet-prefixed dreaming snippets when recording short-term recalls", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "action preference",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 1,
+            endLine: 5,
+            score: 0.92,
+            snippet: [
+              "- Candidate: Default to action.",
+              "  - confidence: 0.76",
+              "  - evidence: memory/.dreams/session-corpus/2026-04-08.txt:1-1",
+              "  - recalls: 3",
+              "  - status: staged",
+            ].join("\n"),
+          },
+        ],
+      });
+
+      expect(
+        JSON.parse(await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8")),
+      ).toMatchObject({
+        version: 1,
+        entries: {},
+      });
+    });
+  });
+
   it("records recalls and ranks candidates with weighted scores", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({
@@ -1013,6 +1045,14 @@ describe("short-term promotion", () => {
 
       expect(ranked).toEqual([]);
     });
+  });
+
+  it("treats diff-prefixed dreaming snippets as contaminated", () => {
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "@@ -1,1 - Candidate: Default to action. confidence: 0.76 evidence: memory/.dreams/session-corpus/2026-04-08.txt:1-1 recalls: 3 status: staged",
+      ),
+    ).toBe(true);
   });
 
   it("skips direct candidates that exceed maxAgeDays during apply", async () => {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -39,10 +39,6 @@ const PHASE_SIGNAL_LIGHT_BOOST_MAX = 0.06;
 const PHASE_SIGNAL_REM_BOOST_MAX = 0.09;
 const PHASE_SIGNAL_HALF_LIFE_DAYS = 14;
 const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
-const DREAMING_CANDIDATE_LEAD_RE =
-  /^(?:[-*+>]\s+|@@\s*-\d+(?:,\d+)?\s+[-*+]\s+|[([]\s*)*Candidate:/i;
-const DREAMING_REFLECTION_LEAD_RE =
-  /^(?:[-*+>]\s+|@@\s*-\d+(?:,\d+)?\s+[-*+]\s+|[([]\s*)*Reflections?:/i;
 const inProcessShortTermLocks = new Map<string, Promise<void>>();
 const ensuredShortTermDirs = new Map<string, Promise<void>>();
 
@@ -241,6 +237,40 @@ function normalizeSnippet(raw: string): string {
   return trimmed.replace(/\s+/g, " ");
 }
 
+function consumeDreamingLeadPrefix(snippet: string): string {
+  let index = 0;
+  while (index < snippet.length) {
+    const remaining = snippet.slice(index);
+    const diffMatch = /^@@\s*-\d+(?:,\d+)?\s+[-*+]\s+/i.exec(remaining);
+    if (diffMatch) {
+      index += diffMatch[0].length;
+      continue;
+    }
+    const char = snippet[index];
+    if (char === "[" || char === "(") {
+      index += 1;
+      while (snippet[index] === " ") {
+        index += 1;
+      }
+      continue;
+    }
+    if (
+      (char === "-" || char === "*" || char === "+" || char === ">") &&
+      snippet[index + 1] === " "
+    ) {
+      index += 2;
+      continue;
+    }
+    break;
+  }
+  return snippet.slice(index);
+}
+
+function hasDreamingNarrativeLead(snippet: string): boolean {
+  const withoutPrefix = consumeDreamingLeadPrefix(snippet);
+  return /^Candidate:/i.test(withoutPrefix) || /^Reflections?:/i.test(withoutPrefix);
+}
+
 function isContaminatedDreamingSnippet(raw: string): boolean {
   const snippet = normalizeSnippet(raw);
   if (!snippet) {
@@ -254,21 +284,20 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
     return true;
   }
 
-  const hasCandidateLead = DREAMING_CANDIDATE_LEAD_RE.test(snippet);
-  const hasReflectionLead = DREAMING_REFLECTION_LEAD_RE.test(snippet);
+  const hasNarrativeLead = hasDreamingNarrativeLead(snippet);
   const hasConfidence = /\bconfidence:\s*\d/i.test(snippet);
   const hasEvidence = /\bevidence:\s*(?:memory\/\.dreams\/session-corpus\/|memory\/)/i.test(
     snippet,
   );
   const hasStatus = /\bstatus:\s*staged\b/i.test(snippet);
   const hasRecalls = /\brecalls:\s*\d+\b/i.test(snippet);
-  if (hasEvidence && (hasCandidateLead || hasReflectionLead)) {
+  if (hasEvidence && hasNarrativeLead) {
     return true;
   }
   const structuredMarkers = [hasConfidence, hasEvidence, hasStatus, hasRecalls].filter(
     Boolean,
   ).length;
-  return (hasCandidateLead || hasReflectionLead) && structuredMarkers >= 2;
+  return hasNarrativeLead && structuredMarkers >= 2;
 }
 
 function normalizeMemoryPath(rawPath: string): string {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -38,7 +38,7 @@ const PHASE_SIGNAL_LIGHT_BOOST_MAX = 0.06;
 const PHASE_SIGNAL_REM_BOOST_MAX = 0.09;
 const PHASE_SIGNAL_HALF_LIFE_DAYS = 14;
 const DREAMING_TRANSCRIPT_PROMPT_LINE_RE =
-  /\[[^\]]*dreaming-narrative[^\]]*]\s*Write a dream diary entry from these memory fragments:?/i;
+  /\[[^\]]*dreaming-narrative[^\]]*]\s*(?:User|Assistant):\s*Write a dream diary entry from these memory fragments:?/i;
 const DREAMING_DIFF_PREFIX_RE = /@@\s*-\d+(?:,\d+)?\s+[-*+]\s+/iy;
 const inProcessShortTermLocks = new Map<string, Promise<void>>();
 const ensuredShortTermDirs = new Map<string, Promise<void>>();

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -39,6 +39,7 @@ const PHASE_SIGNAL_REM_BOOST_MAX = 0.09;
 const PHASE_SIGNAL_HALF_LIFE_DAYS = 14;
 const DREAMING_TRANSCRIPT_PROMPT_LINE_RE =
   /\[[^\]]*dreaming-narrative[^\]]*]\s*Write a dream diary entry from these memory fragments:?/i;
+const DREAMING_DIFF_PREFIX_RE = /@@\s*-\d+(?:,\d+)?\s+[-*+]\s+/iy;
 const inProcessShortTermLocks = new Map<string, Promise<void>>();
 const ensuredShortTermDirs = new Map<string, Promise<void>>();
 
@@ -240,10 +241,10 @@ function normalizeSnippet(raw: string): string {
 function consumeDreamingLeadPrefix(snippet: string): string {
   let index = 0;
   while (index < snippet.length) {
-    const remaining = snippet.slice(index);
-    const diffMatch = /^@@\s*-\d+(?:,\d+)?\s+[-*+]\s+/i.exec(remaining);
+    DREAMING_DIFF_PREFIX_RE.lastIndex = index;
+    const diffMatch = DREAMING_DIFF_PREFIX_RE.exec(snippet);
     if (diffMatch) {
-      index += diffMatch[0].length;
+      index = DREAMING_DIFF_PREFIX_RE.lastIndex;
       continue;
     }
     const char = snippet[index];

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -32,13 +32,13 @@ const SHORT_TERM_LOCK_RELATIVE_PATH = path.join("memory", ".dreams", "short-term
 const SHORT_TERM_LOCK_WAIT_TIMEOUT_MS = 10_000;
 const SHORT_TERM_LOCK_STALE_MS = 60_000;
 const SHORT_TERM_LOCK_RETRY_DELAY_MS = 40;
-const DREAMING_NARRATIVE_PROMPT_PREFIX = "Write a dream diary entry from these memory fragments";
 // Repeated dreaming revisits should be able to clear the default promotion gate
 // without requiring separate organic recall traffic for the same snippet.
 const PHASE_SIGNAL_LIGHT_BOOST_MAX = 0.06;
 const PHASE_SIGNAL_REM_BOOST_MAX = 0.09;
 const PHASE_SIGNAL_HALF_LIFE_DAYS = 14;
-const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
+const DREAMING_TRANSCRIPT_PROMPT_LINE_RE =
+  /\[[^\]]*dreaming-narrative[^\]]*]\s*Write a dream diary entry from these memory fragments:?/i;
 const inProcessShortTermLocks = new Map<string, Promise<void>>();
 const ensuredShortTermDirs = new Map<string, Promise<void>>();
 
@@ -277,9 +277,8 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
     return false;
   }
   if (
-    snippet.includes(DREAMING_NARRATIVE_PROMPT_PREFIX) ||
-    snippet.includes(PROMOTION_MARKER_PREFIX) ||
-    snippet.includes(DREAMING_NARRATIVE_RUN_PREFIX)
+    /<!--\s*openclaw-memory-promotion:/i.test(snippet) ||
+    DREAMING_TRANSCRIPT_PROMPT_LINE_RE.test(snippet)
   ) {
     return true;
   }
@@ -291,13 +290,7 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   );
   const hasStatus = /\bstatus:\s*staged\b/i.test(snippet);
   const hasRecalls = /\brecalls:\s*\d+\b/i.test(snippet);
-  if (hasEvidence && hasNarrativeLead) {
-    return true;
-  }
-  const structuredMarkers = [hasConfidence, hasEvidence, hasStatus, hasRecalls].filter(
-    Boolean,
-  ).length;
-  return hasNarrativeLead && structuredMarkers >= 2;
+  return hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls;
 }
 
 function normalizeMemoryPath(rawPath: string): string {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -33,12 +33,16 @@ const SHORT_TERM_LOCK_WAIT_TIMEOUT_MS = 10_000;
 const SHORT_TERM_LOCK_STALE_MS = 60_000;
 const SHORT_TERM_LOCK_RETRY_DELAY_MS = 40;
 const DREAMING_NARRATIVE_PROMPT_PREFIX = "Write a dream diary entry from these memory fragments";
-const DREAMING_PROMOTION_META_PREFIX = "openclaw-memory-promotion:";
 // Repeated dreaming revisits should be able to clear the default promotion gate
 // without requiring separate organic recall traffic for the same snippet.
 const PHASE_SIGNAL_LIGHT_BOOST_MAX = 0.06;
 const PHASE_SIGNAL_REM_BOOST_MAX = 0.09;
 const PHASE_SIGNAL_HALF_LIFE_DAYS = 14;
+const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
+const DREAMING_CANDIDATE_LEAD_RE =
+  /^(?:[-*+>]\s+|@@\s*-\d+(?:,\d+)?\s+[-*+]\s+|[([]\s*)*Candidate:/i;
+const DREAMING_REFLECTION_LEAD_RE =
+  /^(?:[-*+>]\s+|@@\s*-\d+(?:,\d+)?\s+[-*+]\s+|[([]\s*)*Reflections?:/i;
 const inProcessShortTermLocks = new Map<string, Promise<void>>();
 const ensuredShortTermDirs = new Map<string, Promise<void>>();
 
@@ -244,15 +248,14 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   }
   if (
     snippet.includes(DREAMING_NARRATIVE_PROMPT_PREFIX) ||
-    snippet.includes(DREAMING_PROMOTION_META_PREFIX) ||
-    snippet.includes("dreaming-narrative-")
+    snippet.includes(PROMOTION_MARKER_PREFIX) ||
+    snippet.includes(DREAMING_NARRATIVE_RUN_PREFIX)
   ) {
     return true;
   }
 
-  const hasCandidateLead = /^Candidate:/i.test(snippet) || /[([]\s*Candidate:/i.test(snippet);
-  const hasReflectionLead =
-    /^Reflections?:/i.test(snippet) || /[([]\s*Reflections?:/i.test(snippet);
+  const hasCandidateLead = DREAMING_CANDIDATE_LEAD_RE.test(snippet);
+  const hasReflectionLead = DREAMING_REFLECTION_LEAD_RE.test(snippet);
   const hasConfidence = /\bconfidence:\s*\d/i.test(snippet);
   const hasEvidence = /\bevidence:\s*(?:memory\/\.dreams\/session-corpus\/|memory\/)/i.test(
     snippet,

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -32,6 +32,8 @@ const SHORT_TERM_LOCK_RELATIVE_PATH = path.join("memory", ".dreams", "short-term
 const SHORT_TERM_LOCK_WAIT_TIMEOUT_MS = 10_000;
 const SHORT_TERM_LOCK_STALE_MS = 60_000;
 const SHORT_TERM_LOCK_RETRY_DELAY_MS = 40;
+const DREAMING_NARRATIVE_PROMPT_PREFIX = "Write a dream diary entry from these memory fragments";
+const DREAMING_PROMOTION_META_PREFIX = "openclaw-memory-promotion:";
 // Repeated dreaming revisits should be able to clear the default promotion gate
 // without requiring separate organic recall traffic for the same snippet.
 const PHASE_SIGNAL_LIGHT_BOOST_MAX = 0.06;
@@ -235,6 +237,37 @@ function normalizeSnippet(raw: string): string {
   return trimmed.replace(/\s+/g, " ");
 }
 
+function isContaminatedDreamingSnippet(raw: string): boolean {
+  const snippet = normalizeSnippet(raw);
+  if (!snippet) {
+    return false;
+  }
+  if (
+    snippet.includes(DREAMING_NARRATIVE_PROMPT_PREFIX) ||
+    snippet.includes(DREAMING_PROMOTION_META_PREFIX) ||
+    snippet.includes("dreaming-narrative-")
+  ) {
+    return true;
+  }
+
+  const hasCandidateLead = /^Candidate:/i.test(snippet) || /[([]\s*Candidate:/i.test(snippet);
+  const hasReflectionLead =
+    /^Reflections?:/i.test(snippet) || /[([]\s*Reflections?:/i.test(snippet);
+  const hasConfidence = /\bconfidence:\s*\d/i.test(snippet);
+  const hasEvidence = /\bevidence:\s*(?:memory\/\.dreams\/session-corpus\/|memory\/)/i.test(
+    snippet,
+  );
+  const hasStatus = /\bstatus:\s*staged\b/i.test(snippet);
+  const hasRecalls = /\brecalls:\s*\d+\b/i.test(snippet);
+  if (hasEvidence && (hasCandidateLead || hasReflectionLead)) {
+    return true;
+  }
+  const structuredMarkers = [hasConfidence, hasEvidence, hasStatus, hasRecalls].filter(
+    Boolean,
+  ).length;
+  return (hasCandidateLead || hasReflectionLead) && structuredMarkers >= 2;
+}
+
 function normalizeMemoryPath(rawPath: string): string {
   return rawPath.replaceAll("\\", "/").replace(/^\.\//, "");
 }
@@ -409,6 +442,9 @@ function normalizeStore(raw: unknown, nowIso: string): ShortTermRecallStore {
           ? entry.claimHash.trim()
           : undefined;
       const snippet = typeof entry.snippet === "string" ? normalizeSnippet(entry.snippet) : "";
+      if (snippet && isContaminatedDreamingSnippet(snippet)) {
+        continue;
+      }
       const queryHashes = Array.isArray(entry.queryHashes)
         ? normalizeDistinctStrings(entry.queryHashes, MAX_QUERY_HASHES)
         : [];
@@ -849,6 +885,9 @@ export async function recordShortTermRecalls(params: {
     for (const result of relevant) {
       const normalizedPath = normalizeMemoryPath(result.path);
       const snippet = normalizeSnippet(result.snippet);
+      if (!snippet || isContaminatedDreamingSnippet(snippet)) {
+        continue;
+      }
       const claimHash = snippet ? buildClaimHash(snippet) : undefined;
       const groundedKey = claimHash
         ? buildEntryKey({
@@ -954,6 +993,7 @@ export async function recordGroundedShortTermCandidates(params: {
       const normalizedPath = normalizeMemoryPath(item.path);
       if (
         !snippet ||
+        isContaminatedDreamingSnippet(snippet) ||
         !normalizedPath ||
         !isShortTermMemoryPath(normalizedPath) ||
         !Number.isFinite(item.startLine) ||
@@ -1134,6 +1174,9 @@ export async function rankShortTermPromotionCandidates(
 
   for (const entry of Object.values(store.entries)) {
     if (!entry || entry.source !== "memory" || !isShortTermMemoryPath(entry.path)) {
+      continue;
+    }
+    if (isContaminatedDreamingSnippet(entry.snippet)) {
       continue;
     }
     if (!includePromoted && entry.promotedAt) {
@@ -1471,6 +1514,9 @@ export async function applyShortTermPromotions(
     const store = await readStore(workspaceDir, nowIso);
     const selected = options.candidates
       .filter((candidate) => {
+        if (isContaminatedDreamingSnippet(candidate.snippet)) {
+          return false;
+        }
         if (candidate.promotedAt) {
           return false;
         }
@@ -1506,7 +1552,7 @@ export async function applyShortTermPromotions(
     const rehydratedSelected: PromotionCandidate[] = [];
     for (const candidate of selected) {
       const rehydrated = await rehydratePromotionCandidate(workspaceDir, candidate);
-      if (rehydrated) {
+      if (rehydrated && !isContaminatedDreamingSnippet(rehydrated.snippet)) {
         rehydratedSelected.push(rehydrated);
       }
     }
@@ -1881,4 +1927,5 @@ export const __testing = {
   calculatePhaseSignalBoost,
   buildClaimHash,
   totalSignalCountForEntry,
+  isContaminatedDreamingSnippet,
 };

--- a/src/memory-host-sdk/host/session-files.test.ts
+++ b/src/memory-host-sdk/host/session-files.test.ts
@@ -174,4 +174,30 @@ describe("buildSessionEntry", () => {
     expect(entry).not.toBeNull();
     expect(entry?.generatedByDreamingNarrative).toBe(true);
   });
+
+  it("flags dreaming narrative transcripts from the dream-diary prompt body", async () => {
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content:
+            "Write a dream diary entry from these memory fragments:\n- Candidate: durable note",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "A drifting archive breathed in moonlight." },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "dreaming-prompt-session.jsonl");
+    await fs.writeFile(filePath, jsonlLines.join("\n"));
+
+    const entry = await buildSessionEntry(filePath);
+
+    expect(entry).not.toBeNull();
+    expect(entry?.generatedByDreamingNarrative).toBe(true);
+    expect(entry?.content).toBe("");
+    expect(entry?.lineMap).toEqual([]);
+  });
 });

--- a/src/memory-host-sdk/host/session-files.test.ts
+++ b/src/memory-host-sdk/host/session-files.test.ts
@@ -203,4 +203,29 @@ describe("buildSessionEntry", () => {
     expect(entry?.content).toContain("Assistant: A drifting archive breathed in moonlight.");
     expect(entry?.lineMap).toEqual([1, 2]);
   });
+
+  it("does not flag transcripts when dreaming markers only appear mid-string", async () => {
+    const jsonlLines = [
+      JSON.stringify({
+        type: "custom",
+        customType: "note",
+        data: {
+          runId: "user-context-dreaming-narrative-light-1775894400455",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "Keep the archive index updated." },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "substring-marker-session.jsonl");
+    await fs.writeFile(filePath, jsonlLines.join("\n"));
+
+    const entry = await buildSessionEntry(filePath);
+
+    expect(entry).not.toBeNull();
+    expect(entry?.generatedByDreamingNarrative).toBeUndefined();
+    expect(entry?.content).toContain("User: Keep the archive index updated.");
+    expect(entry?.lineMap).toEqual([2]);
+  });
 });

--- a/src/memory-host-sdk/host/session-files.test.ts
+++ b/src/memory-host-sdk/host/session-files.test.ts
@@ -175,7 +175,7 @@ describe("buildSessionEntry", () => {
     expect(entry?.generatedByDreamingNarrative).toBe(true);
   });
 
-  it("flags dreaming narrative transcripts from the dream-diary prompt body", async () => {
+  it("does not flag ordinary transcripts that quote the dream-diary prompt", async () => {
     const jsonlLines = [
       JSON.stringify({
         type: "message",
@@ -196,8 +196,11 @@ describe("buildSessionEntry", () => {
     const entry = await buildSessionEntry(filePath);
 
     expect(entry).not.toBeNull();
-    expect(entry?.generatedByDreamingNarrative).toBe(true);
-    expect(entry?.content).toBe("");
-    expect(entry?.lineMap).toEqual([]);
+    expect(entry?.generatedByDreamingNarrative).toBeUndefined();
+    expect(entry?.content).toContain(
+      "User: Write a dream diary entry from these memory fragments:",
+    );
+    expect(entry?.content).toContain("Assistant: A drifting archive breathed in moonlight.");
+    expect(entry?.lineMap).toEqual([1, 2]);
   });
 });

--- a/src/memory-host-sdk/host/session-files.ts
+++ b/src/memory-host-sdk/host/session-files.ts
@@ -47,7 +47,7 @@ function isDreamingNarrativeBootstrapRecord(record: unknown): boolean {
 }
 
 function hasDreamingNarrativeRunId(value: unknown): boolean {
-  return typeof value === "string" && value.includes(DREAMING_NARRATIVE_RUN_PREFIX);
+  return typeof value === "string" && value.startsWith(DREAMING_NARRATIVE_RUN_PREFIX);
 }
 
 function isDreamingNarrativeGeneratedRecord(record: unknown): boolean {

--- a/src/memory-host-sdk/host/session-files.ts
+++ b/src/memory-host-sdk/host/session-files.ts
@@ -7,6 +7,8 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { hashText } from "./internal.js";
 
 const log = createSubsystemLogger("memory");
+const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
+const DREAMING_NARRATIVE_PROMPT_PREFIX = "Write a dream diary entry from these memory fragments";
 
 export type SessionFileEntry = {
   path: string;
@@ -42,7 +44,42 @@ function isDreamingNarrativeBootstrapRecord(record: unknown): boolean {
     return false;
   }
   const runId = (candidate.data as { runId?: unknown }).runId;
-  return typeof runId === "string" && runId.startsWith("dreaming-narrative-");
+  return typeof runId === "string" && runId.startsWith(DREAMING_NARRATIVE_RUN_PREFIX);
+}
+
+function hasDreamingNarrativeRunId(value: unknown): boolean {
+  return typeof value === "string" && value.includes(DREAMING_NARRATIVE_RUN_PREFIX);
+}
+
+function isDreamingNarrativeGeneratedRecord(record: unknown, messageText?: string | null): boolean {
+  if (isDreamingNarrativeBootstrapRecord(record)) {
+    return true;
+  }
+  if (messageText?.includes(DREAMING_NARRATIVE_PROMPT_PREFIX)) {
+    return true;
+  }
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    return false;
+  }
+  const candidate = record as {
+    runId?: unknown;
+    sessionKey?: unknown;
+    data?: unknown;
+  };
+  if (
+    hasDreamingNarrativeRunId(candidate.runId) ||
+    hasDreamingNarrativeRunId(candidate.sessionKey)
+  ) {
+    return true;
+  }
+  if (!candidate.data || typeof candidate.data !== "object" || Array.isArray(candidate.data)) {
+    return false;
+  }
+  const nested = candidate.data as {
+    runId?: unknown;
+    sessionKey?: unknown;
+  };
+  return hasDreamingNarrativeRunId(nested.runId) || hasDreamingNarrativeRunId(nested.sessionKey);
 }
 
 export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
@@ -140,7 +177,7 @@ export async function buildSessionEntry(absPath: string): Promise<SessionFileEnt
       } catch {
         continue;
       }
-      if (!generatedByDreamingNarrative && isDreamingNarrativeBootstrapRecord(record)) {
+      if (!generatedByDreamingNarrative && isDreamingNarrativeGeneratedRecord(record)) {
         generatedByDreamingNarrative = true;
       }
       if (
@@ -161,6 +198,12 @@ export async function buildSessionEntry(absPath: string): Promise<SessionFileEnt
       }
       const text = extractSessionText(message.content);
       if (!text) {
+        continue;
+      }
+      if (!generatedByDreamingNarrative && isDreamingNarrativeGeneratedRecord(record, text)) {
+        generatedByDreamingNarrative = true;
+      }
+      if (generatedByDreamingNarrative) {
         continue;
       }
       const safe = redactSensitiveText(text, { mode: "tools" });

--- a/src/memory-host-sdk/host/session-files.ts
+++ b/src/memory-host-sdk/host/session-files.ts
@@ -8,7 +8,6 @@ import { hashText } from "./internal.js";
 
 const log = createSubsystemLogger("memory");
 const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
-const DREAMING_NARRATIVE_PROMPT_PREFIX = "Write a dream diary entry from these memory fragments";
 
 export type SessionFileEntry = {
   path: string;
@@ -51,11 +50,8 @@ function hasDreamingNarrativeRunId(value: unknown): boolean {
   return typeof value === "string" && value.includes(DREAMING_NARRATIVE_RUN_PREFIX);
 }
 
-function isDreamingNarrativeGeneratedRecord(record: unknown, messageText?: string | null): boolean {
+function isDreamingNarrativeGeneratedRecord(record: unknown): boolean {
   if (isDreamingNarrativeBootstrapRecord(record)) {
-    return true;
-  }
-  if (messageText?.includes(DREAMING_NARRATIVE_PROMPT_PREFIX)) {
     return true;
   }
   if (!record || typeof record !== "object" || Array.isArray(record)) {
@@ -199,9 +195,6 @@ export async function buildSessionEntry(absPath: string): Promise<SessionFileEnt
       const text = extractSessionText(message.content);
       if (!text) {
         continue;
-      }
-      if (!generatedByDreamingNarrative && isDreamingNarrativeGeneratedRecord(record, text)) {
-        generatedByDreamingNarrative = true;
       }
       if (generatedByDreamingNarrative) {
         continue;


### PR DESCRIPTION
## Summary
- Problem: dreaming-generated narrative/report artifacts could loop back into short-term promotion, while prompt-text-only transcript detection could also suppress ordinary chats that merely quoted the dream prompt.
- Why it matters: synthetic dreaming output should not become durable memory, and real user transcripts should not be dropped from session recall ingestion.
- What changed: session transcript skipping now relies on internal dreaming run markers with prefix-only matching instead of prompt text; short-term promotion rejects dreaming/promotion-shaped snippets during normalization, recording, ranking, and apply; the dreaming lead detector was hardened with a linear parser that handles markdown/diff wrappers without the backtracking-prone regex shape.
- What did NOT change (scope boundary): this PR does not add end-to-end provenance plumbing or a new persisted schema for first-class origin tracking.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: dreaming-generated text and grounded recall snippets converged into downstream plain-text surfaces, so promotion-path filtering had to infer provenance from content patterns.
- Missing detection / guardrail: transcript ingestion also treated quoted prompt text as an authoritative dreaming marker, which could falsely classify ordinary chats as internal dreaming runs.
- Contributing context (if known): dreaming reports are emitted as markdown bullets/diff-like snippets, so narrow start-of-string heuristics were insufficient to catch all contamination shapes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/memory-host-sdk/host/session-files.test.ts`
  - `extensions/memory-core/src/short-term-promotion.test.ts`
  - `extensions/memory-core/src/dreaming-phases.test.ts`
- Scenario the test should lock in: real chats that quote the dream prompt still ingest normally, actual dreaming transcripts checkpoint as skipped, and dreaming markdown/diff candidate snippets never enter short-term promotion.
- Why this is the smallest reliable guardrail: the bug spans one transcript-ingestion seam plus the short-term promotion insertion/ranking/apply surfaces.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Dreaming diary/report artifacts no longer feed durable memory promotion.
- Ordinary transcripts that quote the dream-diary prompt continue to participate in session recall ingestion.

## Diagram (if applicable)

```text
Before:
[dreaming transcript or dreaming-shaped snippet] -> [session recall / short-term store] -> [promotion candidate] -> [durable memory pollution]
[ordinary chat quoting prompt] -> [misclassified as dreaming] -> [session ingestion skipped]

After:
[dreaming transcript] -> [checkpoint as skipped] -> [no session recall ingestion]
[dreaming-shaped snippet] -> [filtered from short-term promotion paths] -> [no durable promotion]
[ordinary chat quoting prompt] -> [normal session ingestion] -> [eligible grounded recall]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default memory-core dreaming/session ingestion paths

### Steps

1. Create a dreaming transcript with internal dreaming bootstrap/run markers, or create a short-term snippet shaped like a dreaming candidate/report.
2. Run the memory-core transcript ingestion / short-term promotion path.
3. Create a normal transcript that merely quotes the dream-diary prompt and run the same ingestion path.

### Expected

- Dreaming-generated transcripts and dreaming-shaped snippets are excluded from promotion inputs.
- Ordinary prompt-quoting transcripts are still ingested.

### Actual

- Matches expected on the current PR head.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - targeted session-files regression for prompt-quoting chats vs dreaming-marker transcripts
  - targeted short-term promotion filtering for direct, stored, markdown-bullet, and diff-prefixed dreaming snippets
  - targeted dreaming-phases checkpoint expectation for skipped dreaming transcripts
- Edge cases checked:
  - prefix-only runId/sessionKey matching
  - markdown bullet wrappers
  - diff-prefix wrappers
  - bracket wrappers
- What you did **not** verify:
  - full end-to-end provenance redesign beyond the current heuristic/path-level fix
  - full repo test suite

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: content-based contamination heuristics remain a compatibility backstop rather than first-class provenance.
  - Mitigation: transcript-side false positives were narrowed to internal markers, promotion-path filters now cover the known dreaming formats, and a provenance-first follow-up can replace the remaining heuristics later.
