### PR TITLE
fix: discover allowlisted bundled TTS providers when active registry has self-registered providers

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -201,6 +201,72 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
   });
 
+  it("discovers allowlisted bundled providers even when another provider already self-registered", () => {
+    // Regression: openai TTS registers in the main runtime registry as a side-effect of being
+    // loaded for LLM. Without the fix, the early-return short-circuited before the compat path,
+    // so allowlisted bundled providers like microsoft Edge TTS were never discovered.
+    const openaiProvider = {
+      id: "openai",
+      label: "openai",
+      isConfigured: () => true,
+      synthesize: async () => ({
+        audioBuffer: Buffer.from("x"),
+        outputFormat: "mp3",
+        voiceCompatible: false,
+        fileExtension: ".mp3",
+      }),
+    };
+    const microsoftProvider = {
+      id: "microsoft",
+      label: "microsoft",
+      aliases: ["edge"],
+      isConfigured: () => true,
+      synthesize: async () => ({
+        audioBuffer: Buffer.from("x"),
+        outputFormat: "mp3",
+        voiceCompatible: true,
+        fileExtension: ".mp3",
+      }),
+    };
+
+    // Main registry: only openai (registered as LLM side-effect)
+    const active = createEmptyPluginRegistry();
+    active.speechProviders.push({
+      pluginId: "openai",
+      pluginName: "openai",
+      source: "test",
+      provider: openaiProvider,
+    } as never);
+
+    // Compat registry: both openai + microsoft (from allowlisted bundled providers)
+    const compat = createEmptyPluginRegistry();
+    compat.speechProviders.push(
+      { pluginId: "microsoft", pluginName: "microsoft", source: "test", provider: microsoftProvider } as never,
+      { pluginId: "openai", pluginName: "openai", source: "test", provider: openaiProvider } as never,
+    );
+
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : compat,
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        { id: "microsoft", origin: "bundled", contracts: { speechProviders: ["microsoft"] } },
+        { id: "openai", origin: "bundled", contracts: { speechProviders: ["openai"] } },
+      ] as never,
+      diagnostics: [],
+    });
+
+    const cfg = { plugins: { allow: ["openai", "microsoft"] } } as OpenClawConfig;
+    const providers = resolvePluginCapabilityProviders({ key: "speechProviders", cfg });
+
+    // Both providers should be returned (compat path ran, not short-circuited by openai alone)
+    expectResolvedCapabilityProviderIds(providers, ["microsoft", "openai"]);
+    // Compat path must have been invoked
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
+      config: expect.anything(),
+    });
+  });
+
   it("keeps active capability providers even when cfg is passed", () => {
     const active = createEmptyPluginRegistry();
     active.speechProviders.push({

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -259,12 +259,68 @@ describe("resolvePluginCapabilityProviders", () => {
     const cfg = { plugins: { allow: ["openai", "microsoft"] } } as OpenClawConfig;
     const providers = resolvePluginCapabilityProviders({ key: "speechProviders", cfg });
 
-    // Both providers should be returned (compat path ran, not short-circuited by openai alone)
+    // Both providers should be returned — compat discovered microsoft, openai already in compat too
     expectResolvedCapabilityProviderIds(providers, ["microsoft", "openai"]);
     // Compat path must have been invoked
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
       config: expect.anything(),
     });
+  });
+
+  it("merges active-only runtime providers with compat-discovered bundled providers", () => {
+    // Regression guard: a workspace plugin may register a TTS provider at runtime that is
+    // not in the bundled manifest. It should be preserved alongside compat-discovered providers.
+    const openaiProvider = {
+      id: "openai",
+      label: "openai",
+      isConfigured: () => true,
+      synthesize: async () => ({
+        audioBuffer: Buffer.from("x"),
+        outputFormat: "mp3",
+        voiceCompatible: false,
+        fileExtension: ".mp3",
+      }),
+    };
+    const customProvider = {
+      id: "custom-tts",
+      label: "custom-tts",
+      isConfigured: () => true,
+      synthesize: async () => ({
+        audioBuffer: Buffer.from("x"),
+        outputFormat: "mp3",
+        voiceCompatible: false,
+        fileExtension: ".mp3",
+      }),
+    };
+
+    // Active runtime registry: openai (LLM side-effect) + custom-tts (workspace plugin)
+    const active = createEmptyPluginRegistry();
+    active.speechProviders.push(
+      { pluginId: "openai", pluginName: "openai", source: "test", provider: openaiProvider } as never,
+      { pluginId: "custom-tts", pluginName: "custom-tts", source: "workspace", provider: customProvider } as never,
+    );
+
+    // Compat registry: only bundled providers (openai) — custom-tts is not in the manifest
+    const compat = createEmptyPluginRegistry();
+    compat.speechProviders.push(
+      { pluginId: "openai", pluginName: "openai", source: "test", provider: openaiProvider } as never,
+    );
+
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : compat,
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        { id: "openai", origin: "bundled", contracts: { speechProviders: ["openai"] } },
+      ] as never,
+      diagnostics: [],
+    });
+
+    const cfg = { plugins: { allow: ["openai"] } } as OpenClawConfig;
+    const providers = resolvePluginCapabilityProviders({ key: "speechProviders", cfg });
+
+    // custom-tts must be preserved even though it's not in the bundled manifest
+    expectResolvedCapabilityProviderIds(providers, ["openai", "custom-tts"]);
   });
 
   it("keeps active capability providers even when cfg is passed", () => {

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -84,13 +84,21 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
 }): CapabilityProviderForKey<K>[] {
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
-  if (activeProviders.length > 0) {
+  // When no cfg is available there is no allowlist to apply, so the active registry is
+  // the best we can do.
+  if (activeProviders.length > 0 && !params.cfg) {
     return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }
+  // When cfg is provided, always run the compat path so that allowlisted bundled providers
+  // (e.g. "microsoft" Edge TTS) are discovered even when another provider (e.g. "openai")
+  // has already self-registered in the main runtime registry as a side-effect of being
+  // loaded for a different capability (e.g. LLM completions).
   const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
   const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
   const registry = resolveRuntimePluginRegistry(loadOptions);
-  return (registry?.[params.key] ?? []).map(
+  const compatProviders = (registry?.[params.key] ?? []).map(
     (entry) => entry.provider,
   ) as CapabilityProviderForKey<K>[];
+  // Fall back to the active registry if the compat path found nothing.
+  return compatProviders.length > 0 ? compatProviders : (activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[]);
 }

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -84,20 +84,19 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
 }): CapabilityProviderForKey<K>[] {
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
-  // Without cfg there is no allowlist to apply — use the active registry directly,
-  // falling back to the compat path only if the active registry is empty.
-  if (!params.cfg) {
-    if (activeProviders.length > 0) {
-      return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
-    }
-    const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
-    const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
-    const registry = resolveRuntimePluginRegistry(loadOptions);
-    return (registry?.[params.key] ?? []).map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+  // The compat path is only meaningful when there is an explicit plugins.allow list to
+  // expand against.  Without it, withBundledPluginAllowlistCompat would add every bundled
+  // provider for the capability to the allow set, injecting providers (e.g. elevenlabs)
+  // that were never configured by the user.  When there is no allow list — or when the
+  // active registry is already empty and would naturally fall through to the compat path
+  // anyway — use the original behaviour.
+  if (activeProviders.length > 0 && !params.cfg?.plugins?.allow?.length) {
+    return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }
-  // When cfg is provided, run the compat path to discover all allowlisted bundled providers
-  // (e.g. "microsoft" Edge TTS), then merge with any active providers not already present
-  // so that runtime-registered providers from workspace plugins are preserved.
+  // Run the compat path to discover allowlisted bundled providers (e.g. "microsoft" Edge
+  // TTS) that were not self-registered at startup because another provider (e.g. "openai")
+  // registered first via a different capability code path and caused the early-return above
+  // to fire on previous runs.
   const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
   const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
   const compatRegistry = resolveRuntimePluginRegistry(loadOptions);
@@ -107,7 +106,9 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
   if (compatProviders.length === 0) {
     return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }
-  // Merge: compat providers first, then any active-only providers not covered by compat.
+  // Merge: compat-discovered providers first (respects the allowlist ordering), then any
+  // active-only providers not already present (e.g. workspace-plugin-registered providers
+  // that are not in the bundled manifest).
   const compatIds = new Set(compatProviders.map((p) => (p as { id: string }).id));
   const activeOnlyProviders = activeProviders
     .filter((entry) => !compatIds.has((entry.provider as { id: string }).id))

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -97,6 +97,16 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
   // TTS) that were not self-registered at startup because another provider (e.g. "openai")
   // registered first via a different capability code path and caused the early-return above
   // to fire on previous runs.
+  //
+  // Note: resolveRuntimePluginRegistry(loadOptions) may activate the compat registry as the
+  // new global active registry on cache miss (it calls loadOpenClawPlugins which sets active
+  // state).  This is intentional and safe: the compat config is derived from the real config
+  // by only extending plugins.allow with bundled provider IDs — plugins.load.paths and all
+  // other settings are unchanged.  The compat registry therefore loads the same workspace
+  // plugins and is a strict superset of the real registry.  Replacing the active registry
+  // with a superset cannot drop any previously-registered providers.  The activeOnlyProviders
+  // merge below additionally guards the current-call return value for the edge case of
+  // providers registered via out-of-band in-process mechanisms not backed by load paths.
   const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
   const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
   const compatRegistry = resolveRuntimePluginRegistry(loadOptions);

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -84,21 +84,33 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
 }): CapabilityProviderForKey<K>[] {
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
-  // When no cfg is available there is no allowlist to apply, so the active registry is
-  // the best we can do.
-  if (activeProviders.length > 0 && !params.cfg) {
-    return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+  // Without cfg there is no allowlist to apply — use the active registry directly,
+  // falling back to the compat path only if the active registry is empty.
+  if (!params.cfg) {
+    if (activeProviders.length > 0) {
+      return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+    }
+    const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
+    const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
+    const registry = resolveRuntimePluginRegistry(loadOptions);
+    return (registry?.[params.key] ?? []).map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }
-  // When cfg is provided, always run the compat path so that allowlisted bundled providers
-  // (e.g. "microsoft" Edge TTS) are discovered even when another provider (e.g. "openai")
-  // has already self-registered in the main runtime registry as a side-effect of being
-  // loaded for a different capability (e.g. LLM completions).
+  // When cfg is provided, run the compat path to discover all allowlisted bundled providers
+  // (e.g. "microsoft" Edge TTS), then merge with any active providers not already present
+  // so that runtime-registered providers from workspace plugins are preserved.
   const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
   const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
-  const registry = resolveRuntimePluginRegistry(loadOptions);
-  const compatProviders = (registry?.[params.key] ?? []).map(
+  const compatRegistry = resolveRuntimePluginRegistry(loadOptions);
+  const compatProviders = (compatRegistry?.[params.key] ?? []).map(
     (entry) => entry.provider,
   ) as CapabilityProviderForKey<K>[];
-  // Fall back to the active registry if the compat path found nothing.
-  return compatProviders.length > 0 ? compatProviders : (activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[]);
+  if (compatProviders.length === 0) {
+    return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+  }
+  // Merge: compat providers first, then any active-only providers not covered by compat.
+  const compatIds = new Set(compatProviders.map((p) => (p as { id: string }).id));
+  const activeOnlyProviders = activeProviders
+    .filter((entry) => !compatIds.has((entry.provider as { id: string }).id))
+    .map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+  return [...compatProviders, ...activeOnlyProviders];
 }


### PR DESCRIPTION
Fixes #66850

## Problem

When the `openai` plugin is enabled for LLM completions, it also registers its speech provider in the main runtime plugin registry as a side-effect of startup. `resolvePluginCapabilityProviders` short-circuits on the first call:

```ts
const activeProviders = activeRegistry?.[params.key] ?? [];
if (activeProviders.length > 0) {
  return activeProviders.map((entry) => entry.provider);  // ← compat path never reached
}
```

This prevents the compat path from running — the path that enumerates all bundled providers in `plugins.allow`. As a result, allowlisted bundled speech providers like **microsoft Edge TTS** are never discovered, causing:

```
TTS conversion failed: microsoft: no provider registered; openai: OpenAI TTS API error (401)
```

...even when `"microsoft"` is explicitly listed in `plugins.allow` and `messages.tts.provider` is set to `"edge"`.

## Fix

The compat path is now triggered when the active registry is non-empty **and** `cfg` carries an explicit `plugins.allow` list. That allow list is the signal that the caller wants a specific set of bundled providers to be available. Without an explicit allow list, `withBundledPluginAllowlistCompat` would add every bundled TTS provider to the set, injecting providers the user never configured (e.g. elevenlabs) into the fallback chain.

When the compat path does run, results are **merged** with the active registry rather than replacing it, so runtime-registered providers from workspace plugins that are not in the bundled manifest are preserved.

```
activeProviders non-empty + no plugins.allow  →  active registry as-is (original behaviour)
activeProviders non-empty + plugins.allow set →  compat path + merge with active-only providers
activeProviders empty                         →  compat path (original fallback, unchanged)
```

## Tests

- Regression test: openai self-registered in main registry + microsoft in `plugins.allow` → both returned via compat merge
- Workspace-plugin test: runtime-registered `custom-tts` not in bundled manifest → preserved in merge
- All existing tests pass unchanged, including the contract tests that use `cfg` without `plugins.allow`