### PR TITLE
fix: drain system events on session reset to prevent cross-session leak

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -13,6 +13,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { drainSystemEventEntries } from "../../infra/system-events.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import {
   ErrorCodes,
@@ -124,6 +125,9 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
+  for (const key of queueKeys) {
+    drainSystemEventEntries(key);
+  }
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     return undefined;

--- a/src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.e2e.test.ts
@@ -17,6 +17,7 @@ import {
 const sessionCleanupMocks = vi.hoisted(() => ({
   clearSessionQueues: vi.fn(() => ({ followupCleared: 0, laneCleared: 0, keys: [] })),
   stopSubagentsForRequester: vi.fn(() => ({ stopped: 0 })),
+  drainSystemEventEntries: vi.fn(() => []),
 }));
 
 const sessionHookMocks = vi.hoisted(() => ({
@@ -40,6 +41,16 @@ vi.mock("../auto-reply/reply/abort.js", async () => {
   return {
     ...actual,
     stopSubagentsForRequester: sessionCleanupMocks.stopSubagentsForRequester,
+  };
+});
+
+vi.mock("../infra/system-events.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/system-events.js")>(
+    "../infra/system-events.js",
+  );
+  return {
+    ...actual,
+    drainSystemEventEntries: sessionCleanupMocks.drainSystemEventEntries,
   };
 });
 
@@ -105,6 +116,13 @@ function expectActiveRunCleanup(
   expect(sessionCleanupMocks.clearSessionQueues).toHaveBeenCalledTimes(1);
   const clearedKeys = sessionCleanupMocks.clearSessionQueues.mock.calls[0]?.[0] as string[];
   expect(clearedKeys).toEqual(expect.arrayContaining(expectedQueueKeys));
+  // Verify system events are drained for each queue key
+  expect(sessionCleanupMocks.drainSystemEventEntries).toHaveBeenCalledTimes(
+    expectedQueueKeys.length,
+  );
+  for (const key of expectedQueueKeys) {
+    expect(sessionCleanupMocks.drainSystemEventEntries).toHaveBeenCalledWith(key);
+  }
   expect(embeddedRunMock.abortCalls).toEqual([sessionId]);
   expect(embeddedRunMock.waitCalls).toEqual([sessionId]);
 }
@@ -128,6 +146,7 @@ describe("gateway server sessions", () => {
   beforeEach(() => {
     sessionCleanupMocks.clearSessionQueues.mockClear();
     sessionCleanupMocks.stopSubagentsForRequester.mockClear();
+    sessionCleanupMocks.drainSystemEventEntries.mockClear();
     sessionHookMocks.triggerInternalHook.mockClear();
   });
 


### PR DESCRIPTION
## Summary
- Fixes #66864: System events queue not purged on `/new` session reset
- Drains system-events Map entries in `ensureSessionRuntimeCleanup` for each queue key
- Prevents stale exec failure notifications from leaking into fresh sessions

## Problem
When a session is reset via `/new`, `ensureSessionRuntimeCleanup` called `clearSessionQueues()` to purge followup/command lane queues, but did not drain the process-global system-events `Map`. Because `sessionKey` is preserved across `/new`, any system events enqueued before the reset survived and got drained into the first user message of the fresh session.

## Solution
Added a loop to call `drainSystemEventEntries(key)` for each queue key after clearing session queues. This is symmetric with the existing followup/command queue purge.

## Test Plan
- Updated `server.sessions.gateway-server-sessions-a.e2e.test.ts` to mock and verify `drainSystemEventEntries` is called for each queue key
- All 9 session tests pass
- E2E test suite runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)