### PR TITLE
fix(wizard): guard text-input prompts against undefined clack results

### DIFF
--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -985,13 +985,13 @@ export async function promptSingleChannelToken(params: {
   keepPrompt: string;
   inputPrompt: string;
 }): Promise<{ useEnv: boolean; token: string | null }> {
-  const promptToken = async (): Promise<string> =>
-    (
-      await params.prompter.text({
-        message: params.inputPrompt,
-        validate: (value) => (value?.trim() ? undefined : "Required"),
-      })
-    ).trim();
+  const promptToken = async (): Promise<string> => {
+    const rawValue = await params.prompter.text({
+      message: params.inputPrompt,
+      validate: (value) => (value?.trim() ? undefined : "Required"),
+    });
+    return (rawValue ?? "").trim();
+  };
 
   if (params.canUseEnv) {
     const keepEnv = await params.prompter.confirm({

--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -455,7 +455,7 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
               });
             },
           });
-          const trimmedValue = rawValue.trim();
+          const trimmedValue = (rawValue ?? "").trim();
           if (!trimmedValue && textInput.required === false) {
             if (textInput.applyEmptyValue) {
               next = await applyWizardTextInputValue({

--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it } from "vitest";
-import { tokenizedOptionFilter } from "./clack-prompter.js";
+import { describe, expect, it, vi } from "vitest";
+import { createClackPrompter, tokenizedOptionFilter } from "./clack-prompter.js";
+
+vi.mock("@clack/prompts", async () => {
+  const actual = await vi.importActual<typeof import("@clack/prompts")>("@clack/prompts");
+  return {
+    ...actual,
+    intro: vi.fn(),
+    outro: vi.fn(),
+    cancel: vi.fn(),
+    spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() })),
+    text: vi.fn(),
+    select: vi.fn(),
+    multiselect: vi.fn(),
+    autocompleteMultiselect: vi.fn(),
+    confirm: vi.fn(),
+  };
+});
 
 describe("tokenizedOptionFilter", () => {
   it("matches tokens regardless of order", () => {
@@ -31,5 +47,27 @@ describe("tokenizedOptionFilter", () => {
 
     expect(tokenizedOptionFilter("provider openai", option)).toBe(true);
     expect(tokenizedOptionFilter("openai gpt-5.4", option)).toBe(true);
+  });
+});
+
+describe("createClackPrompter().text", () => {
+  it("coerces undefined clack results to an empty string", async () => {
+    const clack = await import("@clack/prompts");
+    (clack.text as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(undefined);
+
+    const prompter = createClackPrompter();
+    const result = await prompter.text({ message: "Enter value" });
+
+    expect(result).toBe("");
+  });
+
+  it("passes string results through unchanged", async () => {
+    const clack = await import("@clack/prompts");
+    (clack.text as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce("hello  ");
+
+    const prompter = createClackPrompter();
+    const result = await prompter.text({ message: "Enter value" });
+
+    expect(result).toBe("hello  ");
   });
 });

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -100,7 +100,7 @@ export function createClackPrompter(): WizardPrompter {
     },
     text: async (params) => {
       const validate = params.validate;
-      return guardCancel(
+      const result = guardCancel(
         await text({
           message: stylePromptMessage(params.message),
           initialValue: params.initialValue,
@@ -108,6 +108,12 @@ export function createClackPrompter(): WizardPrompter {
           validate: validate ? (value) => validate(value ?? "") : undefined,
         }),
       );
+      // `@clack/prompts` `text()` can resolve to `undefined` in edge cases
+      // (e.g. submitting an empty value with no `initialValue`/`placeholder`).
+      // The `WizardPrompter.text` contract is `Promise<string>`, so coerce
+      // nullish results to "" here rather than letting them escape and
+      // crash downstream `.trim()` / `.length` callers.
+      return typeof result === "string" ? result : "";
     },
     confirm: async (params) =>
       guardCancel(


### PR DESCRIPTION
## Summary

Fixes the widespread onboarding crash:

```
TypeError: Cannot read properties of undefined (reading 'trim')
```

that kills `openclaw onboard` / `openclaw configure` during channel selection and channel-specific text-input steps (Telegram, Slack, Discord, etc.).

## Root cause

`@clack/prompts` `text()` can resolve to `undefined` in some edge cases (e.g. submitting an empty value when neither `initialValue` nor `placeholder` is set), even though `WizardPrompter.text` is declared as `Promise<string>`. The wrapper in `src/wizard/clack-prompter.ts` passes the value through `guardCancel` but does not coerce the non-cancel path, so `undefined` leaks out to callers. `buildChannelSetupWizardAdapterFromSetupWizard` in `src/channels/plugins/setup-wizard.ts` then calls `rawValue.trim()` directly and crashes.

## Fix

- **`src/wizard/clack-prompter.ts`** — enforce the declared `Promise<string>` contract by coercing nullish results to `""` after `guardCancel`. This covers every `prompter.text` caller in one place.
- **`src/channels/plugins/setup-wizard.ts`** — belt-and-suspenders `rawValue ?? ""` at the existing call site so the same symptom can't be reintroduced by a future prompter swap.
- **`src/wizard/clack-prompter.test.ts`** — unit tests for the wrapper covering both the `undefined → ""` coercion and the string passthrough.

## Related issues

- #66693 [Bug]: While onboarding: TypeError: Cannot read properties of undefined (reading 'trim')
- #66718 [Bug] openclaw configure TypeError: Cannot read properties of undefined (reading 'trim')
- #66848 [Bug]: TypeError: Cannot read properties of undefined (reading 'trim')
- #66677 [Bug]: Select channel (QuickStart)
- #66624 (closed) same symptom, v2026.4.14
- #66728 (closed) Skip for now variant
- #66641 (closed) installer crashes after Select channel (QuickStart)
- #66619 (closed) Telegram setup variant

## Test plan

- [x] New unit tests in `src/wizard/clack-prompter.test.ts` pass locally against the patched wrapper.
- [ ] CI: `pnpm test:unit` / channel plugin tests.
- [ ] Manual: `openclaw onboard`, pick Telegram, step through the text-input steps without hitting the TypeError.