### PR TITLE
Telegram: disable HTTP/2 polling transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles/inbound: add a persistent file-backed GUID dedupe so MessagePoller webhook replays after BB Server restart or reconnect no longer cause the agent to re-reply to already-handled messages. (#19176, #12053, #66816) Thanks @omarshahine.
 - Secrets/plugins/status: align SecretRef inspect-vs-strict handling across plugin preload, read-only status/agents surfaces, and runtime auth paths so unresolved refs no longer crash read-only CLI flows while runtime-required non-env refs stay strict. (#66818) Thanks @joshavant.
 - Memory/dreaming: stop ordinary transcripts that merely quote the dream-diary prompt from being classified as internal dreaming runs and silently dropped from session recall ingestion. (#66852) Thanks @gumadeiras.
+- Telegram/polling: force the polling transport onto HTTP/1.1 dispatchers so Windows installs with broken IPv6 or undici HTTP/2 fallback no longer stall `getUpdates`, freeze Telegram delivery for minutes at a time, or time out subagent announces. (#66885)
 
 ## 2026.4.14
 

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
+
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());
 const loggerInfo = vi.hoisted(() => vi.fn());
@@ -118,10 +120,17 @@ beforeEach(() => {
   }
   loggerInfo.mockReset();
   loggerDebug.mockReset();
+  (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+    Agent: AgentCtor,
+    EnvHttpProxyAgent: EnvHttpProxyAgentCtor,
+    ProxyAgent: ProxyAgentCtor,
+    fetch: undiciFetch,
+  };
 });
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  Reflect.deleteProperty(globalThis as object, TEST_UNDICI_RUNTIME_DEPS_KEY);
 });
 
 function resolveTelegramFetchOrThrow(
@@ -146,6 +155,14 @@ function getDispatcherFromUndiciCall(nth: number) {
         };
       }
     | undefined;
+}
+
+function expectHttp1OnlyDispatcherOptions(options: unknown) {
+  expect(options).toEqual(
+    expect.objectContaining({
+      allowH2: false,
+    }),
+  );
 }
 
 function buildFetchFallbackError(code: string) {
@@ -316,6 +333,7 @@ describe("resolveTelegramFetch", () => {
 
     expect(AgentCtor).toHaveBeenCalledTimes(1);
     expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
+    expectHttp1OnlyDispatcherOptions(AgentCtor.mock.calls[0]?.[0]);
 
     const dispatcher = getDispatcherFromUndiciCall(1);
     expect(dispatcher).toBeDefined();
@@ -352,6 +370,7 @@ describe("resolveTelegramFetch", () => {
 
     expect(EnvHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
     expect(AgentCtor).not.toHaveBeenCalled();
+    expectHttp1OnlyDispatcherOptions(EnvHttpProxyAgentCtor.mock.calls[0]?.[0]);
 
     const dispatcher = getDispatcherFromUndiciCall(1);
     expect(dispatcher?.options?.connect).toEqual(
@@ -379,6 +398,7 @@ describe("resolveTelegramFetch", () => {
     expect(ProxyAgentCtor).toHaveBeenCalledTimes(1);
     expect(ProxyAgentCtor).toHaveBeenCalledWith(
       expect.objectContaining({
+        allowH2: false,
         uri: "http://127.0.0.1:7777",
       }),
     );

--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-
-const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
+import { TEST_UNDICI_RUNTIME_DEPS_KEY } from "../../../src/infra/net/undici-runtime.js";
 
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
 const setDefaultAutoSelectFamily = vi.hoisted(() => vi.fn());

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -3,6 +3,9 @@ import * as dns from "node:dns";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
+  createHttp1Agent,
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
   createPinnedLookup,
   hasEnvHttpProxyConfigured,
   resolveFetch,
@@ -275,7 +278,7 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
       : policy.proxyUrl;
     try {
       return {
-        dispatcher: new ProxyAgent(proxyOptions),
+        dispatcher: createHttp1ProxyAgent(proxyOptions),
         mode: "explicit-proxy",
         effectivePolicy: policy,
       };
@@ -297,7 +300,7 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
         : undefined;
     try {
       return {
-        dispatcher: new EnvHttpProxyAgent(proxyOptions),
+        dispatcher: createHttp1EnvHttpProxyAgent(proxyOptions),
         mode: "env-proxy",
         effectivePolicy: policy,
       };
@@ -310,7 +313,7 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
         ...(connectOptions ? { connect: connectOptions } : {}),
       };
       return {
-        dispatcher: new Agent(
+        dispatcher: createHttp1Agent(
           directPolicy.connect
             ? ({ connect: directPolicy.connect } satisfies ConstructorParameters<typeof Agent>[0])
             : undefined,
@@ -323,7 +326,7 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
 
   const connectOptions = withPinnedLookup(policy.connect, policy.pinnedHostname);
   return {
-    dispatcher: new Agent(
+    dispatcher: createHttp1Agent(
       connectOptions
         ? ({
             connect: connectOptions,

--- a/src/plugin-sdk/fetch-runtime.ts
+++ b/src/plugin-sdk/fetch-runtime.ts
@@ -1,6 +1,11 @@
 // Public fetch/proxy helpers for plugins that need wrapped fetch behavior.
 
 export { resolveFetch, wrapFetchWithAbortSignal } from "../infra/fetch.js";
+export {
+  createHttp1Agent,
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
+} from "../infra/net/undici-runtime.ts";
 export { withTrustedEnvProxyGuardedFetchMode } from "../infra/net/fetch-guard.ts";
 export { hasEnvHttpProxyConfigured } from "../infra/net/proxy-env.js";
 export { getProxyUrlFromFetch, makeProxyFetch } from "../infra/net/proxy-fetch.js";


### PR DESCRIPTION
## Summary

- Problem: Telegram polling still built raw undici dispatchers on the transport path, so the repo's HTTP/1.1 guard never reached `getUpdates`.
- Why it matters: On affected Windows installs, long polling could stall for minutes, freeze Telegram delivery, and time out subagent announce.
- What changed: route Telegram transport dispatcher creation through the shared HTTP/1.1 helpers and extend the Telegram transport tests to lock in `allowH2: false` for direct, env-proxy, and explicit-proxy paths.
- What did NOT change (scope boundary): this does not change polling retry policy, stall watchdog behavior, or Telegram session restart heuristics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66885
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/telegram/src/fetch.ts` instantiated raw undici `Agent` / `EnvHttpProxyAgent` / `ProxyAgent` dispatchers instead of the shared HTTP/1.1-only helper path, so Telegram polling still allowed undici 8 HTTP/2 ALPN on the affected transport path.
- Missing detection / guardrail: the Telegram fetch transport tests covered fallback and retry behavior, but they did not assert the `allowH2: false` invariant on the constructed dispatchers.
- Contributing context (if known): the shared HTTP/1.1 guard already existed in `src/infra/net/undici-runtime.ts` and was already used by other guarded transport paths.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/fetch.test.ts`
- Scenario the test should lock in: direct, env-proxy, and explicit-proxy Telegram dispatchers all set `allowH2: false` while keeping the existing sticky IPv4 fallback behavior.
- Why this is the smallest reliable guardrail: the regression lives in Telegram dispatcher construction, so this is the narrowest place that can prove the fix without needing a Windows-only repro lane.
- Existing test that already covers this (if any): the existing Telegram fetch transport suite already covered fallback and retry behavior; this PR extends that suite to cover the missing HTTP/1.1 invariant.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Telegram polling now uses HTTP/1.1-only undici dispatchers on the transport path, matching the repo's guarded transport behavior.
- Windows installs affected by the HTTP/2/IPv6 stall should stop freezing long-polling delivery and the related subagent announce timeouts.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.3 dev host; issue repro/evidence from the linked Windows report
- Runtime/container: local repo build
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram polling with the default Bot API host

### Steps

1. Construct Telegram transport for direct, env-proxy, or explicit-proxy polling paths.
2. Inspect the dispatcher options used for Telegram API requests.
3. Confirm those dispatchers keep `allowH2: false` while preserving the existing sticky IPv4 fallback behavior.

### Expected

- Telegram polling transport disables HTTP/2 on its dispatchers and preserves current fallback logic.

### Actual

- Before this PR, Telegram built raw undici dispatchers on this path, so the HTTP/1.1 guard was missing.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: traced the polling path from `polling-session` -> `bot` -> `fetch`, confirmed Telegram now builds dispatchers through the shared HTTP/1.1 helpers, and ran `pnpm test extensions/telegram/src/fetch.test.ts`, `pnpm plugin-sdk:api:check`, and `pnpm build`.
- Edge cases checked: direct transport, env-proxy transport, explicit proxy transport, sticky IPv4 fallback, pinned IP fallback, and plugin-sdk export validation.
- What you did **not** verify: a live Windows VM repro against Telegram.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: widening the plugin-sdk runtime surface by three helpers.
  - Mitigation: kept the change additive on the existing `fetch-runtime` subpath and verified it with `pnpm plugin-sdk:api:check` plus `pnpm build`.
- Risk: there may be Windows-specific behavior outside dispatcher construction that this PR does not cover.
  - Mitigation: kept the fix scoped to the verified root cause and preserved the existing Telegram fallback/restart behavior.

## Additional Notes

- AI-assisted: Yes
- Testing degree: targeted regression tests + build
- Prompt/session logs: not included
- Confirmed understanding of the changed code path: Yes

Made with [Cursor](https://cursor.com)