### PR TITLE
exec-safe-bin: replace prefix map with startsWith for long-option abbreviation resolution

### DIFF
--- a/src/infra/exec-safe-bin-policy-profiles.ts
+++ b/src/infra/exec-safe-bin-policy-profiles.ts
@@ -5,10 +5,6 @@ export type SafeBinProfile = {
   maxPositional?: number;
   allowedValueFlags?: ReadonlySet<string>;
   deniedFlags?: ReadonlySet<string>;
-  // Precomputed long-option metadata for GNU abbreviation resolution.
-  knownLongFlags?: readonly string[];
-  knownLongFlagsSet?: ReadonlySet<string>;
-  longFlagPrefixMap?: ReadonlyMap<string, string | null>;
 };
 
 export type SafeBinProfileFixture = {
@@ -31,59 +27,12 @@ const toFlagSet = (flags?: readonly string[]): ReadonlySet<string> => {
   return new Set(flags);
 };
 
-export function collectKnownLongFlags(
-  allowedValueFlags: ReadonlySet<string>,
-  deniedFlags: ReadonlySet<string>,
-): string[] {
-  const known = new Set<string>();
-  for (const flag of allowedValueFlags) {
-    if (flag.startsWith("--")) {
-      known.add(flag);
-    }
-  }
-  for (const flag of deniedFlags) {
-    if (flag.startsWith("--")) {
-      known.add(flag);
-    }
-  }
-  return Array.from(known);
-}
-
-export function buildLongFlagPrefixMap(
-  knownLongFlags: readonly string[],
-): ReadonlyMap<string, string | null> {
-  const prefixMap = new Map<string, string | null>();
-  for (const flag of knownLongFlags) {
-    if (!flag.startsWith("--") || flag.length <= 2) {
-      continue;
-    }
-    for (let length = 3; length <= flag.length; length += 1) {
-      const prefix = flag.slice(0, length);
-      const existing = prefixMap.get(prefix);
-      if (existing === undefined) {
-        prefixMap.set(prefix, flag);
-        continue;
-      }
-      if (existing !== flag) {
-        prefixMap.set(prefix, null);
-      }
-    }
-  }
-  return prefixMap;
-}
-
 function compileSafeBinProfile(fixture: SafeBinProfileFixture): SafeBinProfile {
-  const allowedValueFlags = toFlagSet(fixture.allowedValueFlags);
-  const deniedFlags = toFlagSet(fixture.deniedFlags);
-  const knownLongFlags = collectKnownLongFlags(allowedValueFlags, deniedFlags);
   return {
     minPositional: fixture.minPositional,
     maxPositional: fixture.maxPositional,
-    allowedValueFlags,
-    deniedFlags,
-    knownLongFlags,
-    knownLongFlagsSet: new Set(knownLongFlags),
-    longFlagPrefixMap: buildLongFlagPrefixMap(knownLongFlags),
+    allowedValueFlags: toFlagSet(fixture.allowedValueFlags),
+    deniedFlags: toFlagSet(fixture.deniedFlags),
   };
 }
 

--- a/src/infra/exec-safe-bin-policy-validator.ts
+++ b/src/infra/exec-safe-bin-policy-validator.ts
@@ -1,9 +1,5 @@
 import { parseExecArgvToken } from "./exec-command-resolution.js";
-import {
-  buildLongFlagPrefixMap,
-  collectKnownLongFlags,
-  type SafeBinProfile,
-} from "./exec-safe-bin-policy-profiles.js";
+import { type SafeBinProfile } from "./exec-safe-bin-policy-profiles.js";
 import { validateSafeBinSemantics } from "./exec-safe-bin-semantics.js";
 
 function isPathLikeToken(value: string): boolean {
@@ -42,18 +38,18 @@ function isInvalidValueToken(value: string | undefined): boolean {
   return !value || !isSafeLiteralToken(value);
 }
 
-function resolveCanonicalLongFlag(params: {
-  flag: string;
-  knownLongFlagsSet: ReadonlySet<string>;
-  longFlagPrefixMap: ReadonlyMap<string, string | null>;
-}): string | null {
-  if (!params.flag.startsWith("--") || params.flag.length <= 2) {
+function resolveCanonicalLongFlag(
+  flag: string,
+  knownLongFlags: readonly string[],
+): string | null {
+  if (!flag.startsWith("--") || flag.length <= 2) {
     return null;
   }
-  if (params.knownLongFlagsSet.has(params.flag)) {
-    return params.flag;
+  if (knownLongFlags.includes(flag)) {
+    return flag;
   }
-  return params.longFlagPrefixMap.get(params.flag) ?? null;
+  const matches = knownLongFlags.filter((f) => f.startsWith(flag));
+  return matches.length === 1 ? matches[0] : null;
 }
 
 function consumeLongOptionToken(params: {
@@ -63,14 +59,9 @@ function consumeLongOptionToken(params: {
   inlineValue: string | undefined;
   allowedValueFlags: ReadonlySet<string>;
   deniedFlags: ReadonlySet<string>;
-  knownLongFlagsSet: ReadonlySet<string>;
-  longFlagPrefixMap: ReadonlyMap<string, string | null>;
+  knownLongFlags: readonly string[];
 }): number {
-  const canonicalFlag = resolveCanonicalLongFlag({
-    flag: params.flag,
-    knownLongFlagsSet: params.knownLongFlagsSet,
-    longFlagPrefixMap: params.longFlagPrefixMap,
-  });
+  const canonicalFlag = resolveCanonicalLongFlag(params.flag, params.knownLongFlags);
   if (!canonicalFlag) {
     return -1;
   }
@@ -134,13 +125,28 @@ function validatePositionalCount(positional: string[], profile: SafeBinProfile):
   return true;
 }
 
+function collectKnownLongFlags(
+  allowedValueFlags: ReadonlySet<string>,
+  deniedFlags: ReadonlySet<string>,
+): string[] {
+  const known = new Set<string>();
+  for (const flag of allowedValueFlags) {
+    if (flag.startsWith("--")) {
+      known.add(flag);
+    }
+  }
+  for (const flag of deniedFlags) {
+    if (flag.startsWith("--")) {
+      known.add(flag);
+    }
+  }
+  return Array.from(known);
+}
+
 function collectPositionalTokens(args: string[], profile: SafeBinProfile): string[] | null {
   const allowedValueFlags = profile.allowedValueFlags ?? NO_FLAGS;
   const deniedFlags = profile.deniedFlags ?? NO_FLAGS;
-  const knownLongFlags =
-    profile.knownLongFlags ?? collectKnownLongFlags(allowedValueFlags, deniedFlags);
-  const knownLongFlagsSet = profile.knownLongFlagsSet ?? new Set(knownLongFlags);
-  const longFlagPrefixMap = profile.longFlagPrefixMap ?? buildLongFlagPrefixMap(knownLongFlags);
+  const knownLongFlags = collectKnownLongFlags(allowedValueFlags, deniedFlags);
 
   const positional: string[] = [];
   let i = 0;
@@ -182,8 +188,7 @@ function collectPositionalTokens(args: string[], profile: SafeBinProfile): strin
         inlineValue: token.inlineValue,
         allowedValueFlags,
         deniedFlags,
-        knownLongFlagsSet,
-        longFlagPrefixMap,
+        knownLongFlags,
       });
       if (nextIndex < 0) {
         return null;

--- a/src/infra/exec-safe-bin-policy.test.ts
+++ b/src/infra/exec-safe-bin-policy.test.ts
@@ -5,8 +5,6 @@ import {
   DEFAULT_SAFE_BINS,
   SAFE_BIN_PROFILE_FIXTURES,
   SAFE_BIN_PROFILES,
-  buildLongFlagPrefixMap,
-  collectKnownLongFlags,
   renderDefaultSafeBinsDocText,
   renderSafeBinDeniedFlagsDocBullets,
   validateSafeBinArgv,
@@ -120,35 +118,32 @@ describe("exec safe bin policy token hygiene", () => {
   });
 });
 
-describe("exec safe bin policy long-option metadata", () => {
-  it("precomputes long-option prefix mappings for compiled profiles", () => {
+describe("exec safe bin policy long-option abbreviation", () => {
+  it("resolves unambiguous denied-flag abbreviations", () => {
     const sortProfile = SAFE_BIN_PROFILES.sort;
-    expect(sortProfile.knownLongFlagsSet?.has("--compress-program")).toBe(true);
-    expect(sortProfile.longFlagPrefixMap?.get("--compress-prog")).toBe("--compress-program");
-    expect(sortProfile.longFlagPrefixMap?.get("--f")).toBe(null);
+    expect(validateSafeBinArgv(["--compress-prog=sh"], sortProfile)).toBe(false);
+    expect(validateSafeBinArgv(["--compress-pr=sh"], sortProfile)).toBe(false);
   });
 
-  it("preserves behavior when profile metadata is missing and rebuilt at runtime", () => {
+  it("rejects ambiguous long-option abbreviations", () => {
     const sortProfile = SAFE_BIN_PROFILES.sort;
-    const withoutMetadata = {
-      ...sortProfile,
-      knownLongFlags: undefined,
-      knownLongFlagsSet: undefined,
-      longFlagPrefixMap: undefined,
-    };
-    expect(validateSafeBinArgv(["--compress-prog=sh"], withoutMetadata)).toBe(false);
-    expect(validateSafeBinArgv(["--totally-unknown=1"], withoutMetadata)).toBe(false);
+    // --f is ambiguous: --field-separator vs --files0-from
+    expect(validateSafeBinArgv(["--f=1"], sortProfile)).toBe(false);
   });
 
-  it("builds prefix maps from collected long flags", () => {
+  it("rejects unknown long options", () => {
     const sortProfile = SAFE_BIN_PROFILES.sort;
-    const flags = collectKnownLongFlags(
-      sortProfile.allowedValueFlags ?? new Set(),
-      sortProfile.deniedFlags ?? new Set(),
-    );
-    const prefixMap = buildLongFlagPrefixMap(flags);
-    expect(prefixMap.get("--compress-pr")).toBe("--compress-program");
-    expect(prefixMap.get("--f")).toBe(null);
+    expect(validateSafeBinArgv(["--totally-unknown=1"], sortProfile)).toBe(false);
+  });
+
+  it("accepts exact flags that are prefixes of other flags", () => {
+    const jqProfile = SAFE_BIN_PROFILES.jq;
+    // --arg is a prefix of --argjson, --argstr, --argfile but must resolve exactly
+    expect(validateSafeBinArgv(["--arg", "key", ".foo"], jqProfile, { binName: "jq" })).toBe(true);
+
+    const grepProfile = SAFE_BIN_PROFILES.grep;
+    // --exclude is a prefix of --exclude-from but must resolve exactly
+    expect(validateSafeBinArgv(["-e", "needle", "--exclude", "build"], grepProfile)).toBe(true);
   });
 });
 

--- a/src/infra/exec-safe-bin-policy.ts
+++ b/src/infra/exec-safe-bin-policy.ts
@@ -2,8 +2,6 @@ export {
   DEFAULT_SAFE_BINS,
   SAFE_BIN_PROFILE_FIXTURES,
   SAFE_BIN_PROFILES,
-  buildLongFlagPrefixMap,
-  collectKnownLongFlags,
   normalizeSafeBinProfileFixtures,
   renderDefaultSafeBinsDocText,
   renderSafeBinDeniedFlagsDocBullets,


### PR DESCRIPTION
## Summary

- Replaces the precomputed trie-style prefix map (`buildLongFlagPrefixMap`, `knownLongFlagsSet`, `longFlagPrefixMap`) with a simple `startsWith` filter for GNU-style long-option abbreviation resolution in safe-bin profiles
- The flag sets per profile are small (~10-20 entries), so the O(n) filter is negligible vs the O(1) map lookup, and the code is significantly simpler (-107/+41 lines)
- Behavioral semantics are identical: exact match, unambiguous abbreviation resolution, and ambiguous/unknown rejection all work the same way

## Changes

- **`exec-safe-bin-policy-profiles.ts`**: Remove `knownLongFlags`, `knownLongFlagsSet`, `longFlagPrefixMap` from `SafeBinProfile` type. Delete `buildLongFlagPrefixMap` and `collectKnownLongFlags` exports. Simplify `compileSafeBinProfile`.
- **`exec-safe-bin-policy-validator.ts`**: Replace `resolveCanonicalLongFlag` with a one-line `startsWith` filter. Move `collectKnownLongFlags` here as a private helper.
- **`exec-safe-bin-policy.ts`** (barrel): Remove deleted exports.
- **`exec-safe-bin-policy.test.ts`**: Replace internal prefix-map structure assertions with behavioral abbreviation tests.

## Test plan

- [ ] Existing abbreviation tests pass (`--compress-prog`, `--files0-fro`, `--f` ambiguity, `--totally-unknown`)
- [ ] `pnpm test src/infra/exec-safe-bin-policy.test.ts src/infra/exec-approvals-safe-bins.test.ts`
- [ ] `pnpm check`

Made with [Cursor](https://cursor.com)