### PR TITLE
fix: add redaction patterns for JWT, Basic auth, and custom header tokens

### DIFF
--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -38,6 +38,13 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   // Telegram Bot API URLs embed the token as `/bot<token>/...` (no word-boundary before digits).
   String.raw`\bbot(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
   String.raw`\b(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
+  // JWT tokens (eyJ... format — three base64url segments separated by dots).
+  String.raw`\b(eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,})\b`,
+  // Authorization: Basic <base64>
+  String.raw`Authorization\s*[:=]\s*Basic\s+([A-Za-z0-9+/=]{10,})`,
+  String.raw`\bBasic\s+([A-Za-z0-9+/=]{18,})\b`,
+  // Custom header-style token assignments (X-OpenClaw-Token, x-pomerium-jwt-assertion, etc.).
+  String.raw`(?:X-OpenClaw-Token|x-pomerium-jwt-assertion|[Xx]-[A-Za-z0-9-]*[Tt]oken|[Xx]-[A-Za-z0-9-]*[Aa]ssertion|[Xx]-[A-Za-z0-9-]*[Ss]ecret)\s*[:=]\s*([^\s\"']{10,})`,
 ];
 
 type RedactOptions = {


### PR DESCRIPTION
## Summary
`logs.tail` gateway method was missing redaction patterns for several credential formats, potentially exposing live secrets to `operator.read` clients.

## Root Cause
The `DEFAULT_REDACT_PATTERNS` array in `src/logging/redact.ts` covered Bearer tokens, ENV assignments, JSON fields, and common token prefixes, but did not cover:
- JWT tokens (`eyJ...`)
- Basic auth headers (`Authorization: Basic <base64>`)
- Custom header-style tokens (`X-OpenClaw-Token`, `x-pomerium-jwt-assertion`, etc.)

## Fix
Added 4 new regex patterns to `DEFAULT_REDACT_PATTERNS`:
1. JWT token detection (`eyJ...` three-segment format)
2. `Authorization: Basic` header redaction
3. Bare `Basic <base64>` pattern
4. Custom X-header token/assertion/secret patterns

## Test Plan
- [ ] Unit tests for new redaction patterns
- [ ] Manual: write log lines with JWT/Basic/custom tokens and verify `logs.tail` redacts them

Closes openclaw#66832