### PR TITLE
fix: resolve TUI status bar stuck on streaming after response completes

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -138,7 +138,10 @@ export function createEventHandlers(context: EventHandlerContext) {
     noteFinalizedRun(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    // Set status to idle when this was the active run, OR when no session runs
+    // remain active (handles race where lifecycle cleared activeChatRunId before
+    // late chat deltas re-set status to "streaming").
+    if (params.wasActiveRun || sessionRuns.size === 0) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
@@ -153,7 +156,8 @@ export function createEventHandlers(context: EventHandlerContext) {
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    // Same race-condition guard as finalizeRun.
+    if (params.wasActiveRun || sessionRuns.size === 0) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();


### PR DESCRIPTION
## Summary
The TUI status bar could get permanently stuck showing "streaming" after a response finishes, never returning to "idle".

## Root Cause
Race condition between the `lifecycle` stream's `end` event and the `chat` stream's `final` event in `src/tui/tui-event-handlers.ts`:

1. Chat delta events set status to "streaming"
2. Lifecycle `end` event fires, setting status to "idle"
3. Late chat delta events arrive (SSE/WS reordering), setting status back to "streaming"
4. Chat `final` event checks `wasActiveRun = state.activeChatRunId === evt.runId` — but `activeChatRunId` was already cleared by the lifecycle handler, making `wasActiveRun = false`
5. `finalizeRun` only calls `setActivityStatus("idle")` when `wasActiveRun` is true, so status stays "streaming" forever

## Fix
In both `finalizeRun` and `terminateRun`, also set the activity status when the `sessionRuns` map is empty (no active runs remain). This ensures status is cleared even when the `wasActiveRun` check fails due to the race.

## Test Plan
- [ ] TUI tests pass
- [ ] Manual: open TUI, send messages, verify status returns to "idle" after responses complete
- [ ] Verify no regression with concurrent/multi-run scenarios

Closes openclaw#66876