### PR TITLE
fix(models): honor Codex synthetic auth in status

### DIFF
--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
-import { withEnv } from "../../test-utils/env.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+
+const resolveProviderSyntheticAuthWithPluginMock = vi.hoisted(() =>
+  vi
+    .fn<
+      typeof import("../../plugins/provider-runtime.runtime.js").resolveProviderSyntheticAuthWithPlugin
+    >()
+    .mockResolvedValue(undefined),
+);
+
+vi.mock("../../plugins/provider-runtime.runtime.js", () => ({
+  resolveProviderSyntheticAuthWithPlugin: resolveProviderSyntheticAuthWithPluginMock,
+}));
+
 import { resolveProviderAuthOverview } from "./list.auth-overview.js";
 
 function resolveOpenAiOverview(apiKey: string) {
@@ -24,8 +37,8 @@ function resolveOpenAiOverview(apiKey: string) {
 }
 
 describe("resolveProviderAuthOverview", () => {
-  it("does not throw when token profile only has tokenRef", () => {
-    const overview = resolveProviderAuthOverview({
+  it("does not throw when token profile only has tokenRef", async () => {
+    const overview = await resolveProviderAuthOverview({
       provider: "github-copilot",
       cfg: {},
       store: {
@@ -44,8 +57,8 @@ describe("resolveProviderAuthOverview", () => {
     expect(overview.profiles.labels[0]).toContain("token:ref(env:GITHUB_TOKEN)");
   });
 
-  it("renders marker-backed models.json auth as marker detail", () => {
-    const overview = withEnv({ OPENAI_API_KEY: undefined }, () =>
+  it("renders marker-backed models.json auth as marker detail", async () => {
+    const overview = await withEnvAsync({ OPENAI_API_KEY: undefined }, () =>
       resolveOpenAiOverview(NON_ENV_SECRETREF_MARKER),
     );
 
@@ -54,8 +67,8 @@ describe("resolveProviderAuthOverview", () => {
     expect(overview.modelsJson?.value).toContain(`marker(${NON_ENV_SECRETREF_MARKER})`);
   });
 
-  it("keeps env-var-shaped models.json values masked to avoid accidental plaintext exposure", () => {
-    const overview = withEnv({ OPENAI_API_KEY: undefined }, () =>
+  it("keeps env-var-shaped models.json values masked to avoid accidental plaintext exposure", async () => {
+    const overview = await withEnvAsync({ OPENAI_API_KEY: undefined }, () =>
       resolveOpenAiOverview("OPENAI_API_KEY"),
     );
 
@@ -65,19 +78,38 @@ describe("resolveProviderAuthOverview", () => {
     expect(overview.modelsJson?.value).not.toContain("OPENAI_API_KEY");
   });
 
-  it("treats env-var marker as usable only when the env key is currently resolvable", () => {
-    const prior = process.env.OPENAI_API_KEY;
-    process.env.OPENAI_API_KEY = "sk-openai-from-env"; // pragma: allowlist secret
-    try {
-      const overview = resolveOpenAiOverview("OPENAI_API_KEY");
-      expect(overview.effective.kind).toBe("env");
-      expect(overview.effective.detail).not.toContain("OPENAI_API_KEY");
-    } finally {
-      if (prior === undefined) {
-        delete process.env.OPENAI_API_KEY;
-      } else {
-        process.env.OPENAI_API_KEY = prior;
-      }
-    }
+  it("treats env-var marker as usable only when the env key is currently resolvable", async () => {
+    await withEnvAsync(
+      { OPENAI_API_KEY: "sk-openai-from-env" }, // pragma: allowlist secret
+      async () => {
+        const overview = await resolveOpenAiOverview("OPENAI_API_KEY");
+        expect(overview.effective.kind).toBe("env");
+        expect(overview.effective.detail).not.toContain("OPENAI_API_KEY");
+      },
+    );
+  });
+
+  it("reports plugin-owned synthetic auth when no store or env auth exists", async () => {
+    resolveProviderSyntheticAuthWithPluginMock.mockResolvedValueOnce({
+      apiKey: "codex-app-server",
+      source: "codex-app-server",
+      mode: "token",
+    });
+
+    const overview = await resolveProviderAuthOverview({
+      provider: "codex",
+      cfg: {},
+      store: { version: 1, profiles: {} } as never,
+      modelsPath: "/tmp/models.json",
+    });
+
+    expect(overview.effective).toEqual({
+      kind: "synthetic",
+      detail: "token:codex-app-server",
+    });
+    expect(overview.synthetic).toEqual({
+      mode: "token",
+      source: "codex-app-server",
+    });
   });
 });

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -12,7 +12,10 @@ import {
   resolveEnvApiKey,
   resolveUsableCustomProviderApiKey,
 } from "../../agents/model-auth.js";
+import { normalizeProviderId } from "../../agents/provider-id.js";
+import type { ModelProviderConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveProviderSyntheticAuthWithPlugin } from "../../plugins/provider-runtime.runtime.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -44,12 +47,12 @@ function formatProfileSecretLabel(params: {
   return params.kind === "token" ? "token:missing" : "missing";
 }
 
-export function resolveProviderAuthOverview(params: {
+export async function resolveProviderAuthOverview(params: {
   provider: string;
   cfg: OpenClawConfig;
   store: AuthProfileStore;
   modelsPath: string;
-}): ProviderAuthOverview {
+}): Promise<ProviderAuthOverview> {
   const { provider, cfg, store } = params;
   const now = Date.now();
   const profiles = listProfilesForProvider(store, provider);
@@ -108,6 +111,30 @@ export function resolveProviderAuthOverview(params: {
   const envKey = resolveEnvApiKey(provider);
   const customKey = getCustomProviderApiKey(cfg, provider);
   const usableCustomKey = resolveUsableCustomProviderApiKey({ cfg, provider });
+  const providerConfig = (() => {
+    const providers = cfg.models?.providers ?? {};
+    const direct = providers[provider];
+    if (direct) {
+      return direct;
+    }
+    const normalized = normalizeProviderId(provider);
+    if (!normalized) {
+      return undefined;
+    }
+    const matched = Object.entries(providers).find(
+      ([key]) => normalizeProviderId(key) === normalized,
+    );
+    return matched?.[1];
+  })();
+  const synthetic = await resolveProviderSyntheticAuthWithPlugin({
+    provider,
+    config: cfg,
+    context: {
+      config: cfg,
+      provider,
+      providerConfig,
+    },
+  });
 
   const effective: ProviderAuthOverview["effective"] = (() => {
     if (profiles.length > 0) {
@@ -127,6 +154,12 @@ export function resolveProviderAuthOverview(params: {
     }
     if (usableCustomKey) {
       return { kind: "models.json", detail: formatMarkerOrSecret(usableCustomKey.apiKey) };
+    }
+    if (synthetic) {
+      return {
+        kind: "synthetic",
+        detail: `${synthetic.mode}:${synthetic.source}`,
+      };
     }
     return { kind: "missing", detail: "missing" };
   })();
@@ -159,6 +192,14 @@ export function resolveProviderAuthOverview(params: {
           modelsJson: {
             value: formatMarkerOrSecret(customKey),
             source: `models.json: ${shortenHomePath(params.modelsPath)}`,
+          },
+        }
+      : {}),
+    ...(synthetic
+      ? {
+          synthetic: {
+            mode: synthetic.mode,
+            source: synthetic.source,
           },
         }
       : {}),

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -170,12 +170,20 @@ export async function modelsStatusCommand(
   const shellFallbackEnabled =
     shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true;
 
-  const providerAuth = providers
-    .map((provider) => resolveProviderAuthOverview({ provider, cfg, store, modelsPath }))
-    .filter((entry) => {
-      const hasAny = entry.profiles.count > 0 || Boolean(entry.env) || Boolean(entry.modelsJson);
-      return hasAny;
-    });
+  const providerAuth = (
+    await Promise.all(
+      providers.map((provider) =>
+        resolveProviderAuthOverview({ provider, cfg, store, modelsPath }),
+      ),
+    )
+  ).filter((entry) => {
+    const hasAny =
+      entry.profiles.count > 0 ||
+      Boolean(entry.env) ||
+      Boolean(entry.modelsJson) ||
+      Boolean(entry.synthetic);
+    return hasAny;
+  });
   const providerAuthMap = new Map(providerAuth.map((entry) => [entry.provider, entry]));
   const missingProvidersInUse = Array.from(providersInUse)
     .filter((provider) => !providerAuthMap.has(provider))
@@ -250,11 +258,18 @@ export async function modelsStatusCommand(
   const providersWithOauth = providerAuth
     .filter(
       (entry) =>
-        entry.profiles.oauth > 0 || entry.profiles.token > 0 || entry.env?.value === "OAuth (env)",
+        entry.profiles.oauth > 0 ||
+        entry.profiles.token > 0 ||
+        entry.env?.value === "OAuth (env)" ||
+        entry.synthetic?.mode === "oauth" ||
+        entry.synthetic?.mode === "token",
     )
     .map((entry) => {
       const count =
-        entry.profiles.oauth + entry.profiles.token + (entry.env?.value === "OAuth (env)" ? 1 : 0);
+        entry.profiles.oauth +
+        entry.profiles.token +
+        (entry.env?.value === "OAuth (env)" ? 1 : 0) +
+        (entry.synthetic?.mode === "oauth" || entry.synthetic?.mode === "token" ? 1 : 0);
       return `${entry.provider} (${count})`;
     });
 
@@ -510,6 +525,14 @@ export async function modelsStatusCommand(
         formatKeyValue(
           "models.json",
           `${entry.modelsJson.value}${separator}${formatKeyValue("source", entry.modelsJson.source)}`,
+        ),
+      );
+    }
+    if (entry.synthetic) {
+      bits.push(
+        formatKeyValue(
+          "synthetic",
+          `${entry.synthetic.mode}${separator}${formatKeyValue("source", entry.synthetic.source)}`,
         ),
       );
     }

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -89,6 +89,7 @@ const mocks = vi.hoisted(() => {
     getCustomProviderApiKey: vi.fn().mockReturnValue(undefined),
     getShellEnvAppliedKeys: vi.fn().mockReturnValue(["OPENAI_API_KEY", "ANTHROPIC_OAUTH_TOKEN"]),
     shouldEnableShellEnvFallback: vi.fn().mockReturnValue(true),
+    resolveProviderSyntheticAuthWithPlugin: vi.fn().mockResolvedValue(undefined),
     createConfigIO: vi.fn().mockReturnValue({
       configPath: "/tmp/openclaw-dev/openclaw.json",
     }),
@@ -158,6 +159,9 @@ async function loadFreshModelsStatusCommandModuleForTest() {
     formatUsageWindowSummary: vi.fn().mockReturnValue("-"),
     loadProviderUsageSummary: mocks.loadProviderUsageSummary,
     resolveUsageProviderId: vi.fn((providerId: string) => providerId),
+  }));
+  vi.doMock("../../plugins/provider-runtime.runtime.js", () => ({
+    resolveProviderSyntheticAuthWithPlugin: mocks.resolveProviderSyntheticAuthWithPlugin,
   }));
   ({ modelsStatusCommand } = await import("./list.status-command.js"));
 }
@@ -433,6 +437,76 @@ describe("modelsStatusCommand auth overview", () => {
       } else {
         mocks.resolveEnvApiKey.mockImplementation(() => null);
       }
+    }
+  });
+
+  it("does not report Codex synthetic auth as missing for codex models", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: {
+            primary: "codex/gpt-5.4",
+            fallbacks: ["codex/gpt-5.4-mini"],
+          },
+          models: {
+            "codex/gpt-5.4": { alias: "codex" },
+            "codex/gpt-5.4-mini": { alias: "codex-mini" },
+          },
+        },
+      },
+      models: { providers: {} },
+      plugins: { entries: { codex: { enabled: true } } },
+      env: { shellEnv: { enabled: true } },
+    });
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+    mocks.resolveProviderSyntheticAuthWithPlugin.mockImplementation(async ({ provider }) => {
+      if (provider === "codex") {
+        return {
+          apiKey: "codex-app-server",
+          source: "codex-app-server",
+          mode: "token",
+        };
+      }
+      return undefined;
+    });
+
+    try {
+      await modelsStatusCommand({ json: true }, localRuntime as never);
+      const payload = JSON.parse(String((localRuntime.log as Mock).mock.calls[0]?.[0]));
+      expect(payload.defaultModel).toBe("codex/gpt-5.4");
+      expect(payload.auth.missingProvidersInUse).toEqual([]);
+      expect(payload.auth.providersWithOAuth).toContain("codex (1)");
+      expect(payload.auth.providers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            provider: "codex",
+            effective: expect.objectContaining({
+              kind: "synthetic",
+              detail: "token:codex-app-server",
+            }),
+            synthetic: {
+              mode: "token",
+              source: "codex-app-server",
+            },
+          }),
+        ]),
+      );
+    } finally {
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      mocks.resolveProviderSyntheticAuthWithPlugin.mockResolvedValue(undefined);
     }
   });
 

--- a/src/commands/models/list.types.ts
+++ b/src/commands/models/list.types.ts
@@ -19,7 +19,7 @@ export type ModelRow = {
 export type ProviderAuthOverview = {
   provider: string;
   effective: {
-    kind: "profiles" | "env" | "models.json" | "missing";
+    kind: "profiles" | "env" | "models.json" | "synthetic" | "missing";
     detail: string;
   };
   profiles: {
@@ -31,4 +31,5 @@ export type ProviderAuthOverview = {
   };
   env?: { value: string; source: string };
   modelsJson?: { value: string; source: string };
+  synthetic?: { mode: "api-key" | "oauth" | "token"; source: string };
 };

--- a/src/plugins/provider-runtime.runtime.ts
+++ b/src/plugins/provider-runtime.runtime.ts
@@ -11,6 +11,8 @@ type FormatProviderAuthProfileApiKeyWithPlugin =
 type PrepareProviderRuntimeAuth = ProviderRuntimeModule["prepareProviderRuntimeAuth"];
 type RefreshProviderOAuthCredentialWithPlugin =
   ProviderRuntimeModule["refreshProviderOAuthCredentialWithPlugin"];
+type ResolveProviderSyntheticAuthWithPlugin =
+  ProviderRuntimeModule["resolveProviderSyntheticAuthWithPlugin"];
 
 let providerRuntimePromise: Promise<ProviderRuntimeModule> | undefined;
 
@@ -61,4 +63,11 @@ export async function refreshProviderOAuthCredentialWithPlugin(
 ): Promise<Awaited<ReturnType<RefreshProviderOAuthCredentialWithPlugin>>> {
   const runtime = await loadProviderRuntime();
   return runtime.refreshProviderOAuthCredentialWithPlugin(...args);
+}
+
+export async function resolveProviderSyntheticAuthWithPlugin(
+  ...args: Parameters<ResolveProviderSyntheticAuthWithPlugin>
+): Promise<Awaited<ReturnType<ResolveProviderSyntheticAuthWithPlugin>>> {
+  const runtime = await loadProviderRuntime();
+  return runtime.resolveProviderSyntheticAuthWithPlugin(...args);
 }


### PR DESCRIPTION
## Summary

- Problem: `openclaw models status --json` could report `auth.missingProvidersInUse: ["codex"]` for `codex/*` models even when the Codex provider had plugin-owned synthetic auth available.
- Why it matters: the status output incorrectly implied missing Codex auth and sent people debugging a provider that was already usable.
- What changed: `models status` now resolves provider-plugin synthetic auth when building auth overviews, surfaces that auth in the provider summary, and treats token/oauth synthetic auth as satisfying the in-use provider check.
- What did NOT change (scope boundary): no model routing, provider execution, or Codex auth storage behavior changed; this only fixes status reporting and its regression coverage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66872
- Related #66872
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/commands/models/list.status-command.ts` only considered auth entries returned from `resolveProviderAuthOverview`, and that overview only checked auth-store profiles, env keys, and `models.json` values. It never consulted provider-plugin `resolveSyntheticAuth`, so `codex` stayed absent from `providerAuthMap` and was flagged as missing.
- Missing detection / guardrail: the closest `models status` tests covered stored auth, env auth, and CLI backends, but not a provider whose usable auth only exists through plugin-owned synthetic auth.
- Contributing context (if known): the Codex provider already declared synthetic auth through the provider plugin, but the status path was not using the same seam that runtime auth resolution uses.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/models/list.status.test.ts` and `src/commands/models/list.auth-overview.test.ts`
- Scenario the test should lock in: `codex/gpt-5.4` should not appear in `missingProvidersInUse` when the Codex provider resolves plugin-owned synthetic token auth.
- Why this is the smallest reliable guardrail: the regression is entirely inside the status/auth overview path, so command-level and overview-level tests cover it without needing a broader provider execution harness.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw models status --json` no longer reports `codex` as missing when the Codex provider resolves plugin-owned synthetic auth.
- Provider auth summaries now show synthetic auth details for providers that expose them through the plugin runtime.

## Diagram (if applicable)

```text
Before:
[codex/* in use] -> [status checks store/env/models.json only] -> [codex missing]

After:
[codex/* in use] -> [status also checks provider synthetic auth] -> [codex synthetic auth found] -> [missingProvidersInUse stays empty]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime/container: local CLI on repo `main`
- Model/provider: `codex/gpt-5.4`, `codex/gpt-5.4-mini`
- Integration/channel (if any): N/A
- Relevant config (redacted): temp `OPENCLAW_HOME` with `codex/*` defaults and the Codex plugin enabled

### Steps

1. Create a temp `OPENCLAW_HOME` with `codex/gpt-5.4` as the default model and an `openai-codex` OAuth profile in `auth-profiles.json`.
2. Run `pnpm openclaw models status --json` against that temp home.
3. Inspect `auth.missingProvidersInUse` and the provider auth summary.

### Expected

- `missingProvidersInUse` is empty for the active `codex/*` models.
- The provider summary reflects that Codex auth is available through the provider plugin.

### Actual

- Before this change, the same repro reported `missingProvidersInUse: ["codex"]`.
- After this change, the repro reports `missingProvidersInUse: []` and shows `codex` with synthetic token auth.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Ran `pnpm test src/commands/models/list.status.test.ts src/commands/models/list.auth-overview.test.ts`
  - Ran `pnpm build`
  - Reproduced the issue with a temp `OPENCLAW_HOME` before the fix and verified the same repro returns `missingProvidersInUse: []` after the fix
- Edge cases checked:
  - Existing stored/env auth summaries still pass in the targeted tests
  - Codex synthetic auth is surfaced both in the auth overview unit test and the command-level JSON output test
- What you did **not** verify:
  - Full `pnpm test`
  - Other providers with synthetic auth beyond the targeted command tests

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: providers with synthetic auth now appear in the status provider summary where they were previously invisible.
  - Mitigation: coverage was added at both the auth-overview and command JSON layers, and the change is limited to the status-reporting path.
