### PR TITLE
fix(hooks): expose inbound media on early receive hooks

### DIFF
--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -66,6 +66,14 @@ export type MessageReceivedHookContext = {
   conversationId?: string;
   /** Message ID from the provider */
   messageId?: string;
+  /** Path to the first inbound media file, if present */
+  mediaPath?: string;
+  /** MIME type of the first inbound media file, if present */
+  mediaType?: string;
+  /** Paths to all inbound media files, if present */
+  mediaPaths?: string[];
+  /** MIME types aligned with `mediaPaths`, if present */
+  mediaTypes?: string[];
   /** Additional provider-specific metadata */
   metadata?: Record<string, unknown>;
 };
@@ -136,6 +144,10 @@ type MessageEnrichedBodyHookContext = {
   mediaPath?: string;
   /** MIME type of the media */
   mediaType?: string;
+  /** Paths to all inbound media files, if present */
+  mediaPaths?: string[];
+  /** MIME types aligned with `mediaPaths`, if present */
+  mediaTypes?: string[];
 };
 
 export type MessageTranscribedHookContext = MessageEnrichedBodyHookContext & {

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -131,6 +131,62 @@ describe("message hook mappers", () => {
     );
   });
 
+  it("bounds inbound media arrays before exposing hook payloads", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        MediaPath: undefined,
+        MediaType: undefined,
+        MediaPaths: [
+          "/tmp/1.jpg",
+          "/tmp/2.jpg",
+          "/tmp/3.jpg",
+          "/tmp/4.jpg",
+          "/tmp/5.jpg",
+          "/tmp/6.jpg",
+          "/tmp/7.jpg",
+          "/tmp/8.jpg",
+          "/tmp/9.jpg",
+          "/tmp/10.jpg",
+          "/tmp/11.jpg",
+          "/tmp/12.jpg",
+          "/tmp/13.jpg",
+          "/tmp/14.jpg",
+          "/tmp/15.jpg",
+          "/tmp/16.jpg",
+          "/tmp/17.jpg",
+          "",
+          "x".repeat(2049),
+        ],
+        MediaTypes: [
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "image/jpeg",
+          "x".repeat(2049),
+        ],
+      }),
+    );
+
+    expect(canonical.mediaPaths).toHaveLength(16);
+    expect(canonical.mediaPaths?.[0]).toBe("/tmp/1.jpg");
+    expect(canonical.mediaPaths?.at(-1)).toBe("/tmp/16.jpg");
+    expect(canonical.mediaTypes).toHaveLength(16);
+    expect(canonical.mediaType).toBe("image/jpeg");
+  });
+
   it("maps canonical inbound context to plugin/internal received payloads", () => {
     const canonical = deriveInboundMessageHookContext(
       makeInboundCtx({
@@ -155,10 +211,6 @@ describe("message hook mappers", () => {
         messageId: "msg-1",
         senderName: "User One",
         threadId: 42,
-        mediaPath: "/tmp/tree.jpg",
-        mediaType: "image/jpeg",
-        mediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
-        mediaTypes: ["image/jpeg", "image/jpeg"],
         topicName: "Deployments",
       }),
     });
@@ -177,10 +229,6 @@ describe("message hook mappers", () => {
       metadata: expect.objectContaining({
         senderUsername: "userone",
         senderE164: "+15551234567",
-        mediaPath: "/tmp/tree.jpg",
-        mediaType: "image/jpeg",
-        mediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
-        mediaTypes: ["image/jpeg", "image/jpeg"],
         topicName: "Deployments",
       }),
     });

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -187,6 +187,22 @@ describe("message hook mappers", () => {
     expect(canonical.mediaType).toBe("image/jpeg");
   });
 
+  it("keeps media path/type pairing aligned when filtering invalid entries", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        MediaPath: undefined,
+        MediaType: undefined,
+        MediaPaths: ["x".repeat(2049), "/tmp/ramp.jpg"],
+        MediaTypes: ["image/png", "image/jpeg"],
+      }),
+    );
+
+    expect(canonical.mediaPath).toBe("/tmp/ramp.jpg");
+    expect(canonical.mediaType).toBe("image/jpeg");
+    expect(canonical.mediaPaths).toEqual(["/tmp/ramp.jpg"]);
+    expect(canonical.mediaTypes).toEqual(["image/jpeg"]);
+  });
+
   it("maps canonical inbound context to plugin/internal received payloads", () => {
     const canonical = deriveInboundMessageHookContext(
       makeInboundCtx({

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -207,6 +207,10 @@ describe("message hook mappers", () => {
       from: "demo-chat:user:123",
       content: "commands-body",
       timestamp: 1710000000,
+      mediaPath: "/tmp/tree.jpg",
+      mediaType: "image/jpeg",
+      mediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
+      mediaTypes: ["image/jpeg", "image/jpeg"],
       metadata: expect.objectContaining({
         messageId: "msg-1",
         senderName: "User One",

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -132,7 +132,15 @@ describe("message hook mappers", () => {
   });
 
   it("maps canonical inbound context to plugin/internal received payloads", () => {
-    const canonical = deriveInboundMessageHookContext(makeInboundCtx({ TopicName: "Deployments" }));
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        TopicName: "Deployments",
+        MediaPath: undefined,
+        MediaType: undefined,
+        MediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
+        MediaTypes: ["image/jpeg", "image/jpeg"],
+      }),
+    );
 
     expect(toPluginMessageContext(canonical)).toEqual({
       channelId: "demo-chat",
@@ -147,6 +155,10 @@ describe("message hook mappers", () => {
         messageId: "msg-1",
         senderName: "User One",
         threadId: 42,
+        mediaPath: "/tmp/tree.jpg",
+        mediaType: "image/jpeg",
+        mediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
+        mediaTypes: ["image/jpeg", "image/jpeg"],
         topicName: "Deployments",
       }),
     });
@@ -158,9 +170,17 @@ describe("message hook mappers", () => {
       accountId: "acc-1",
       conversationId: "demo-chat:chat:456",
       messageId: "msg-1",
+      mediaPath: "/tmp/tree.jpg",
+      mediaType: "image/jpeg",
+      mediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
+      mediaTypes: ["image/jpeg", "image/jpeg"],
       metadata: expect.objectContaining({
         senderUsername: "userone",
         senderE164: "+15551234567",
+        mediaPath: "/tmp/tree.jpg",
+        mediaType: "image/jpeg",
+        mediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
+        mediaTypes: ["image/jpeg", "image/jpeg"],
         topicName: "Deployments",
       }),
     });
@@ -215,7 +235,15 @@ describe("message hook mappers", () => {
 
   it("maps transcribed and preprocessed internal payloads", () => {
     const cfg = {} as OpenClawConfig;
-    const canonical = deriveInboundMessageHookContext(makeInboundCtx({ Transcript: undefined }));
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        Transcript: undefined,
+        MediaPath: undefined,
+        MediaType: undefined,
+        MediaPaths: ["/tmp/tree.jpg", "/tmp/ramp.jpg"],
+        MediaTypes: ["image/jpeg", "image/jpeg"],
+      }),
+    );
 
     const transcribed = toInternalMessageTranscribedContext(canonical, cfg);
     expect(transcribed.transcript).toBe("");
@@ -225,6 +253,10 @@ describe("message hook mappers", () => {
     expect(preprocessed.transcript).toBeUndefined();
     expect(preprocessed.isGroup).toBe(true);
     expect(preprocessed.groupId).toBe("demo-chat:chat:456");
+    expect(preprocessed.mediaPath).toBe("/tmp/tree.jpg");
+    expect(preprocessed.mediaType).toBe("image/jpeg");
+    expect(preprocessed.mediaPaths).toEqual(["/tmp/tree.jpg", "/tmp/ramp.jpg"]);
+    expect(preprocessed.mediaTypes).toEqual(["image/jpeg", "image/jpeg"]);
     expect(preprocessed.cfg).toBe(cfg);
   });
 

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -22,24 +22,45 @@ import type {
 const MAX_HOOK_MEDIA_ITEMS = 16;
 const MAX_HOOK_MEDIA_VALUE_LENGTH = 2048;
 
-function normalizeHookMediaValues(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
+function normalizeHookMediaValue(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0) {
     return undefined;
   }
-  const normalized: string[] = [];
-  for (const entry of value) {
-    if (typeof entry !== "string" || entry.length === 0) {
+  if (value.length > MAX_HOOK_MEDIA_VALUE_LENGTH) {
+    return undefined;
+  }
+  return value;
+}
+
+function normalizeHookMediaPairs(
+  paths: unknown,
+  types: unknown,
+): {
+  mediaPaths?: string[];
+  mediaTypes?: string[];
+} {
+  if (!Array.isArray(paths) || !Array.isArray(types)) {
+    return {};
+  }
+  const mediaPaths: string[] = [];
+  const mediaTypes: string[] = [];
+  const pairCount = Math.min(paths.length, types.length);
+  for (let index = 0; index < pairCount; index += 1) {
+    const path = normalizeHookMediaValue(paths[index]);
+    const type = normalizeHookMediaValue(types[index]);
+    if (!path || !type) {
       continue;
     }
-    if (entry.length > MAX_HOOK_MEDIA_VALUE_LENGTH) {
-      continue;
-    }
-    normalized.push(entry);
-    if (normalized.length >= MAX_HOOK_MEDIA_ITEMS) {
+    mediaPaths.push(path);
+    mediaTypes.push(type);
+    if (mediaPaths.length >= MAX_HOOK_MEDIA_ITEMS) {
       break;
     }
   }
-  return normalized.length > 0 ? normalized : undefined;
+  if (mediaPaths.length === 0 || mediaTypes.length === 0) {
+    return {};
+  }
+  return { mediaPaths, mediaTypes };
 }
 
 export type CanonicalInboundMessageHookContext = {
@@ -108,9 +129,9 @@ export function deriveInboundMessageHookContext(
   );
   const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
   const isGroup = Boolean(ctx.GroupSubject || ctx.GroupChannel);
-  const mediaPaths = normalizeHookMediaValues(ctx.MediaPaths);
-  // Keep media type cardinality aligned with the exported media paths.
-  const mediaTypes = normalizeHookMediaValues(ctx.MediaTypes)?.slice(0, mediaPaths?.length);
+  const { mediaPaths, mediaTypes } = normalizeHookMediaPairs(ctx.MediaPaths, ctx.MediaTypes);
+  const normalizedMediaPath = normalizeHookMediaValue(ctx.MediaPath);
+  const normalizedMediaType = normalizeHookMediaValue(ctx.MediaType);
   return {
     from: ctx.From ?? "",
     to: ctx.To,
@@ -138,8 +159,8 @@ export function deriveInboundMessageHookContext(
     provider: ctx.Provider,
     surface: ctx.Surface,
     threadId: ctx.MessageThreadId,
-    mediaPath: ctx.MediaPath ?? mediaPaths?.[0],
-    mediaType: ctx.MediaType ?? mediaTypes?.[0],
+    mediaPath: normalizedMediaPath ?? mediaPaths?.[0],
+    mediaType: normalizedMediaType ?? mediaTypes?.[0],
     mediaPaths,
     mediaTypes,
     originatingChannel: ctx.OriginatingChannel,

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -292,6 +292,10 @@ export function toPluginMessageReceivedEvent(
       senderName: canonical.senderName,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
+      mediaPath: canonical.mediaPath,
+      mediaType: canonical.mediaType,
+      mediaPaths: canonical.mediaPaths,
+      mediaTypes: canonical.mediaTypes,
       guildId: canonical.guildId,
       channelName: canonical.channelName,
       topicName: canonical.topicName,
@@ -321,6 +325,10 @@ export function toInternalMessageReceivedContext(
     accountId: canonical.accountId,
     conversationId: canonical.conversationId,
     messageId: canonical.messageId,
+    mediaPath: canonical.mediaPath,
+    mediaType: canonical.mediaType,
+    mediaPaths: canonical.mediaPaths,
+    mediaTypes: canonical.mediaTypes,
     metadata: {
       to: canonical.to,
       provider: canonical.provider,
@@ -330,6 +338,10 @@ export function toInternalMessageReceivedContext(
       senderName: canonical.senderName,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
+      mediaPath: canonical.mediaPath,
+      mediaType: canonical.mediaType,
+      mediaPaths: canonical.mediaPaths,
+      mediaTypes: canonical.mediaTypes,
       guildId: canonical.guildId,
       channelName: canonical.channelName,
       topicName: canonical.topicName,
@@ -380,6 +392,8 @@ function toInternalInboundMessageHookContextBase(canonical: CanonicalInboundMess
     surface: canonical.surface,
     mediaPath: canonical.mediaPath,
     mediaType: canonical.mediaType,
+    mediaPaths: canonical.mediaPaths,
+    mediaTypes: canonical.mediaTypes,
   };
 }
 

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -296,6 +296,10 @@ export function toPluginMessageReceivedEvent(
     from: canonical.from,
     content: canonical.content,
     timestamp: canonical.timestamp,
+    mediaPath: canonical.mediaPath,
+    mediaType: canonical.mediaType,
+    mediaPaths: canonical.mediaPaths,
+    mediaTypes: canonical.mediaTypes,
     metadata: {
       to: canonical.to,
       provider: canonical.provider,

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -19,6 +19,29 @@ import type {
   MessageTranscribedHookContext,
 } from "./internal-hooks.js";
 
+const MAX_HOOK_MEDIA_ITEMS = 16;
+const MAX_HOOK_MEDIA_VALUE_LENGTH = 2048;
+
+function normalizeHookMediaValues(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string" || entry.length === 0) {
+      continue;
+    }
+    if (entry.length > MAX_HOOK_MEDIA_VALUE_LENGTH) {
+      continue;
+    }
+    normalized.push(entry);
+    if (normalized.length >= MAX_HOOK_MEDIA_ITEMS) {
+      break;
+    }
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 export type CanonicalInboundMessageHookContext = {
   from: string;
   to?: string;
@@ -85,16 +108,9 @@ export function deriveInboundMessageHookContext(
   );
   const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
   const isGroup = Boolean(ctx.GroupSubject || ctx.GroupChannel);
-  const mediaPaths = Array.isArray(ctx.MediaPaths)
-    ? ctx.MediaPaths.filter(
-        (value): value is string => typeof value === "string" && value.length > 0,
-      )
-    : undefined;
-  const mediaTypes = Array.isArray(ctx.MediaTypes)
-    ? ctx.MediaTypes.filter(
-        (value): value is string => typeof value === "string" && value.length > 0,
-      )
-    : undefined;
+  const mediaPaths = normalizeHookMediaValues(ctx.MediaPaths);
+  // Keep media type cardinality aligned with the exported media paths.
+  const mediaTypes = normalizeHookMediaValues(ctx.MediaTypes)?.slice(0, mediaPaths?.length);
   return {
     from: ctx.From ?? "",
     to: ctx.To,
@@ -292,10 +308,6 @@ export function toPluginMessageReceivedEvent(
       senderName: canonical.senderName,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
-      mediaPath: canonical.mediaPath,
-      mediaType: canonical.mediaType,
-      mediaPaths: canonical.mediaPaths,
-      mediaTypes: canonical.mediaTypes,
       guildId: canonical.guildId,
       channelName: canonical.channelName,
       topicName: canonical.topicName,
@@ -338,10 +350,6 @@ export function toInternalMessageReceivedContext(
       senderName: canonical.senderName,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
-      mediaPath: canonical.mediaPath,
-      mediaType: canonical.mediaType,
-      mediaPaths: canonical.mediaPaths,
-      mediaTypes: canonical.mediaTypes,
       guildId: canonical.guildId,
       channelName: canonical.channelName,
       topicName: canonical.topicName,

--- a/src/plugins/hook-message.types.ts
+++ b/src/plugins/hook-message.types.ts
@@ -35,6 +35,10 @@ export type PluginHookMessageReceivedEvent = {
   from: string;
   content: string;
   timestamp?: number;
+  mediaPath?: string;
+  mediaType?: string;
+  mediaPaths?: string[];
+  mediaTypes?: string[];
   metadata?: Record<string, unknown>;
 };
 


### PR DESCRIPTION
## Summary

- Problem: Telegram inbound media reached the finalized inbound context, but `message:received` hooks dropped the media fields before managed hooks could inspect them.
- Why it matters: repo-level hook code could not claim or preprocess inbound Telegram media early, even though the downloaded media paths already existed.
- What changed: `message:received` now carries inbound media fields, and enriched internal message hook contexts now preserve media arrays alongside the first media item.
- What did NOT change (scope boundary): this does not add raw Telegram-native ids like `file_id` or `media_group_id`; it only exposes the finalized inbound media data already available in the runtime.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #66827
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the hook mapper dropped `mediaPath`/`mediaType` entirely for `message:received`, and it dropped `mediaPaths`/`mediaTypes` for enriched internal hook contexts.
- Missing detection / guardrail: the nearest mapper regression test covered inbound-claim media metadata, but not the early receive/preprocessed hook surfaces.
- Contributing context (if known): Telegram resolves inbound media into finalized context before the hook bridge runs, so the missing data was a mapper-contract bug rather than a Telegram download-timing bug.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/hooks/message-hook-mappers.test.ts`
- Scenario the test should lock in: canonical inbound media arrays survive into plugin/internal `message:received` payloads and internal `message:preprocessed` payloads.
- Why this is the smallest reliable guardrail: the regression happens in the shared hook mapper contract after inbound context is finalized, so a focused mapper test directly exercises the bug surface without depending on Telegram runtime setup.
- Existing test that already covers this (if any): `extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts` proves Telegram inbound media paths are created before the mapper stage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram/media-aware managed hooks can now read finalized inbound media paths earlier:
- internal `message:received` hooks now include `mediaPath`, `mediaType`, `mediaPaths`, and `mediaTypes`
- internal enriched hooks like `message:preprocessed` now preserve `mediaPaths` and `mediaTypes`
- plugin `message_received` hooks now include the same media fields in `event.metadata`

## Diagram (if applicable)

```text
Before:
[telegram inbound media] -> [finalized context has MediaPath/MediaPaths] -> [message:received mapper drops media] -> [hook cannot claim media early]

After:
[telegram inbound media] -> [finalized context has MediaPath/MediaPaths] -> [message:received/preprocessed mapper preserves media] -> [hook can inspect media early]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.3.0
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram managed hook surface
- Relevant config (redacted): N/A

### Steps

1. Build a canonical inbound context with multiple media paths/types.
2. Map it into plugin/internal `message:received` payloads and internal `message:preprocessed` payloads.
3. Verify the resulting hook payloads still expose the finalized media fields.

### Expected

- Early message hook payloads preserve the inbound media metadata already present on the finalized context.

### Actual

- Before this change, `message:received` dropped media entirely and enriched internal hooks dropped media arrays.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/hooks/message-hook-mappers.test.ts src/hooks/message-hooks.test.ts`
  - `pnpm test extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts -t "keeps Telegram inbound media paths with triple-dash ids"`
  - `pnpm check`
  - `pnpm build`
- Edge cases checked:
  - multi-attachment inbound media arrays remain aligned with the first media item
  - existing hook fixtures still pass without requiring new fields
- What you did **not** verify:
  - live Telegram manual end-to-end verification against a real bot account

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: hook consumers may start depending on the newly surfaced media fields before raw Telegram-native ids are available.
  - Mitigation: the PR keeps scope explicit and only surfaces finalized runtime media data that already exists today.

## AI Assistance

Prepared with coding assistance and manually verified with the checks listed above.

Made with [Cursor](https://cursor.com)