### PR TITLE
Discord: ignore stale exec approval clicks

### DIFF
--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -209,4 +209,18 @@ describe("discord exec approval monitor helpers", () => {
       reason: "not-found",
     });
   });
+
+  it("does not suppress message-only errors as stale approvals", async () => {
+    resolveApprovalOverGatewayMock.mockRejectedValue(new Error("unknown or expired approval id"));
+    const ctx = createDiscordExecApprovalButtonContext({
+      cfg: buildConfig({ enabled: true, approvers: ["123"] }),
+      accountId: "default",
+      config: { enabled: true, approvers: ["123"] },
+    });
+
+    await expect(ctx.resolveApproval("abc", "allow-once")).resolves.toEqual({
+      ok: false,
+      reason: "error",
+    });
+  });
 });

--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -87,7 +87,7 @@ describe("discord exec approval monitor helpers", () => {
     const interaction = createInteraction();
     const button = new ExecApprovalButton({
       getApprovers: () => ["123"],
-      resolveApproval: async () => true,
+      resolveApproval: async () => ({ ok: true }),
     });
 
     await button.run(interaction, { id: "", action: "" });
@@ -102,7 +102,7 @@ describe("discord exec approval monitor helpers", () => {
     const interaction = createInteraction({ userId: "999" });
     const button = new ExecApprovalButton({
       getApprovers: () => ["123"],
-      resolveApproval: async () => true,
+      resolveApproval: async () => ({ ok: true }),
     });
 
     await button.run(interaction, { id: "abc", action: "allow-once" });
@@ -115,7 +115,7 @@ describe("discord exec approval monitor helpers", () => {
 
   it("acknowledges and resolves valid approval clicks", async () => {
     const interaction = createInteraction();
-    const resolveApproval = vi.fn(async () => true);
+    const resolveApproval = vi.fn(async () => ({ ok: true as const }));
     const button = new ExecApprovalButton({
       getApprovers: () => ["123"],
       resolveApproval,
@@ -132,7 +132,7 @@ describe("discord exec approval monitor helpers", () => {
     const interaction = createInteraction();
     const button = new ExecApprovalButton({
       getApprovers: () => ["123"],
-      resolveApproval: async () => false,
+      resolveApproval: async () => ({ ok: false, reason: "error" }),
     });
 
     await button.run(interaction, { id: "abc", action: "deny" });
@@ -142,6 +142,19 @@ describe("discord exec approval monitor helpers", () => {
         "Failed to submit approval decision for **Denied**. The request may have expired or already been resolved.",
       ephemeral: true,
     });
+  });
+
+  it("ignores stale approval clicks after the request was already resolved", async () => {
+    const interaction = createInteraction();
+    const button = new ExecApprovalButton({
+      getApprovers: () => ["123"],
+      resolveApproval: async () => ({ ok: false, reason: "not-found" }),
+    });
+
+    await button.run(interaction, { id: "abc", action: "allow-once" });
+
+    expect(interaction.acknowledge).toHaveBeenCalled();
+    expect(interaction.followUp).not.toHaveBeenCalled();
   });
 
   it("builds button context from config and routes resolution over gateway", async () => {
@@ -155,7 +168,7 @@ describe("discord exec approval monitor helpers", () => {
     });
 
     expect(ctx.getApprovers()).toEqual(["123"]);
-    await expect(ctx.resolveApproval("abc", "allow-once")).resolves.toBe(true);
+    await expect(ctx.resolveApproval("abc", "allow-once")).resolves.toEqual({ ok: true });
     expect(resolveApprovalOverGatewayMock).toHaveBeenCalledWith({
       cfg,
       approvalId: "abc",
@@ -165,7 +178,7 @@ describe("discord exec approval monitor helpers", () => {
     });
   });
 
-  it("returns false when gateway resolution throws", async () => {
+  it("returns a generic error result when gateway resolution throws", async () => {
     resolveApprovalOverGatewayMock.mockRejectedValue(new Error("boom"));
     const ctx = createDiscordExecApprovalButtonContext({
       cfg: buildConfig({ enabled: true, approvers: ["123"] }),
@@ -173,6 +186,27 @@ describe("discord exec approval monitor helpers", () => {
       config: { enabled: true, approvers: ["123"] },
     });
 
-    await expect(ctx.resolveApproval("abc", "allow-once")).resolves.toBe(false);
+    await expect(ctx.resolveApproval("abc", "allow-once")).resolves.toEqual({
+      ok: false,
+      reason: "error",
+    });
+  });
+
+  it("returns a not-found result when gateway resolution reports an expired approval", async () => {
+    resolveApprovalOverGatewayMock.mockRejectedValue(
+      Object.assign(new Error("unknown or expired approval id"), {
+        gatewayCode: "APPROVAL_NOT_FOUND",
+      }),
+    );
+    const ctx = createDiscordExecApprovalButtonContext({
+      cfg: buildConfig({ enabled: true, approvers: ["123"] }),
+      accountId: "default",
+      config: { enabled: true, approvers: ["123"] },
+    });
+
+    await expect(ctx.resolveApproval("abc", "allow-once")).resolves.toEqual({
+      ok: false,
+      reason: "not-found",
+    });
   });
 });

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -2,6 +2,7 @@ import { Button, type ButtonInteraction, type ComponentData } from "@buape/carbo
 import { ButtonStyle } from "discord-api-types/v10";
 import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import type { DiscordExecApprovalConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import type {
   ExecApprovalDecision,
   ExecApprovalRequest,
@@ -53,7 +54,10 @@ export function parseExecApprovalData(
 
 export type ExecApprovalButtonContext = {
   getApprovers: () => string[];
-  resolveApproval: (approvalId: string, decision: ExecApprovalDecision) => Promise<boolean>;
+  resolveApproval: (
+    approvalId: string,
+    decision: ExecApprovalDecision,
+  ) => Promise<{ ok: true } | { ok: false; reason: "error" | "not-found" }>;
 };
 
 export class ExecApprovalButton extends Button {
@@ -100,8 +104,12 @@ export class ExecApprovalButton extends Button {
       await interaction.acknowledge();
     } catch {}
 
-    const ok = await this.ctx.resolveApproval(parsed.approvalId, parsed.action);
-    if (!ok) {
+    const resolution = await this.ctx.resolveApproval(parsed.approvalId, parsed.action);
+    if (!resolution.ok) {
+      // Stale buttons can race with auto-resolution; keep those clicks silent.
+      if (resolution.reason === "not-found") {
+        return;
+      }
       try {
         await interaction.followUp({
           content: `Failed to submit approval decision for **${decisionLabel}**. The request may have expired or already been resolved.`,
@@ -138,9 +146,11 @@ export function createDiscordExecApprovalButtonContext(params: {
           gatewayUrl: params.gatewayUrl,
           clientDisplayName: `Discord approval (${params.accountId})`,
         });
-        return true;
-      } catch {
-        return false;
+        return { ok: true };
+      } catch (error) {
+        return isApprovalNotFoundError(error)
+          ? { ok: false, reason: "not-found" }
+          : { ok: false, reason: "error" };
       }
     },
   };

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -2,7 +2,6 @@ import { Button, type ButtonInteraction, type ComponentData } from "@buape/carbo
 import { ButtonStyle } from "discord-api-types/v10";
 import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import type { DiscordExecApprovalConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import type {
   ExecApprovalDecision,
   ExecApprovalRequest,
@@ -20,6 +19,33 @@ export type {
   PluginApprovalRequest,
   PluginApprovalResolved,
 } from "openclaw/plugin-sdk/infra-runtime";
+
+const INVALID_REQUEST = "INVALID_REQUEST";
+const APPROVAL_NOT_FOUND = "APPROVAL_NOT_FOUND";
+
+function isStructuredApprovalNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const gatewayCode =
+    typeof (error as { gatewayCode?: unknown }).gatewayCode === "string"
+      ? (error as { gatewayCode: string }).gatewayCode
+      : null;
+  if (gatewayCode === APPROVAL_NOT_FOUND) {
+    return true;
+  }
+  if (gatewayCode !== INVALID_REQUEST) {
+    return false;
+  }
+  const details = (error as { details?: unknown }).details;
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return false;
+  }
+  return (
+    typeof (details as { reason?: unknown }).reason === "string" &&
+    (details as { reason: string }).reason === APPROVAL_NOT_FOUND
+  );
+}
 
 function decodeCustomIdValue(value: string): string {
   try {
@@ -148,7 +174,7 @@ export function createDiscordExecApprovalButtonContext(params: {
         });
         return { ok: true };
       } catch (error) {
-        return isApprovalNotFoundError(error)
+        return isStructuredApprovalNotFoundError(error)
           ? { ok: false, reason: "not-found" }
           : { ok: false, reason: "error" };
       }


### PR DESCRIPTION
## Summary

- Problem: Discord exec approval buttons still surface a user-facing failure when the approval was already auto-resolved and the button is clicked late.
- Why it matters: stale approval cards can generate confusing ephemeral errors even though the approval already succeeded, which makes elevated-mode auto-resolution look broken.
- What changed: Discord now treats approval-not-found responses from the gateway as a benign stale-click outcome and suppresses the follow-up error; the nearby monitor tests now cover both generic failures and already-resolved approvals.
- What did NOT change (scope boundary): this PR does not change gateway approval resolution semantics, Discord approval delivery/update behavior, or approval-card cleanup policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66906
- Related #66906
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Discord button handler treated every failed `exec.approval.resolve` attempt the same, including the expected approval-not-found case that happens when a stale button races with auto-resolution.
- Missing detection / guardrail: the Discord monitor tests covered generic gateway failures but did not lock in the already-resolved approval case as a benign no-op.
- Contributing context (if known): `HEAD` already updates or removes approval cards after resolution, but a late click can still reach the handler before Discord reflects that state change.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/exec-approvals.test.ts`
- Scenario the test should lock in: a stale Discord exec approval click that reaches the gateway after the approval has already been resolved should acknowledge the interaction and not send an ephemeral failure follow-up.
- Why this is the smallest reliable guardrail: the bug lives in the Discord button handler's error classification path, so the focused monitor helper test exercises the exact branch without requiring a live Discord/gateway repro.
- Existing test that already covers this (if any): the file already covered the generic failed-resolution follow-up path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Late clicks on already-resolved Discord exec approval buttons no longer show the "Failed to submit approval decision" ephemeral error.
- Real Discord approval submission failures still surface the existing error follow-up.

## Diagram (if applicable)

```text
Before:
[stale Discord approval click] -> [gateway returns approval not found] -> [ephemeral failure shown]

After:
[stale Discord approval click] -> [gateway returns approval not found] -> [interaction acknowledged] -> [no user-facing error]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout on `main`
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord exec approvals enabled; issue repro uses session-level `elevated=on`

### Steps

1. Enable Discord exec approvals and run a session with auto-resolving elevated exec approvals.
2. Let an exec approval auto-resolve, then click a stale Discord approval button.
3. Observe the button handler outcome.

### Expected

- Already-resolved approval clicks are treated as stale/no-op interactions.
- Only genuine submission failures show the ephemeral error.

### Actual

- Before this change, already-resolved approval clicks showed the same ephemeral failure as real submission errors.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the live Discord button handler path, confirmed the gateway still returns approval-not-found for stale ids, added a focused regression test for the stale-click branch, reran the targeted test file, and ran the full Discord extension lane.
- Edge cases checked: generic gateway failures still show the existing ephemeral error; successful approval resolutions still return success; approval-not-found errors from the gateway resolver are now classified separately.
- What you did **not** verify: I did not run a live Discord manual repro against a real gateway session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a genuine gateway failure could be accidentally treated as stale if the not-found classification is too broad.
  - Mitigation: the handler only suppresses errors that match the shared approval-not-found helper; all other failures still follow the existing error path.

## Additional Notes

- Per repo policy for user-facing bug fixes, no changelog entry was added for this narrowly scoped test-backed regression fix.

## AI Assistance

- [x] AI-assisted
- [x] Testing level: scoped tests + full Discord extension lane
- [x] I reviewed the code changes and understand what they do

Made with [Cursor](https://cursor.com)