### PR TITLE
fix(security): add model_spawn to gateway HTTP tool denylist

### DIFF
--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -23,6 +23,8 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
   "apply_patch",
   // Session orchestration — spawning agents remotely is RCE
   "sessions_spawn",
+  // model_spawn in spawn mode calls spawnSubagentDirect — same RCE surface as sessions_spawn
+  "model_spawn",
   // Cross-session injection — message injection across sessions
   "sessions_send",
   // Persistent automation control plane — can create/update/remove scheduled runs


### PR DESCRIPTION
## Summary

`model_spawn` in spawn mode calls `spawnSubagentDirect` — the same session orchestration primitive that `sessions_spawn` uses. `sessions_spawn` is already in `DEFAULT_GATEWAY_HTTP_TOOL_DENY` because "spawning agents remotely is RCE", but `model_spawn` was omitted when it was registered in `openclaw-tools.ts` (commit 62acb4790a, PR #66652).

An HTTP client with any valid bearer token (or no token if pairing is disabled) can call:
```
POST /tools/invoke {"tool": "model_spawn", "args": {"mode": "spawn", "task": "arbitrary prompt"}}
```
This spawns an agent session with an arbitrary task, bypassing the HTTP denylist.

## Fix

One-line addition to `src/security/dangerous-tools.ts` — add `model_spawn` alongside `sessions_spawn` in the HTTP deny list.

## Found by

Codex automated review on PR #66652.

## Test plan

- [ ] Verify `POST /tools/invoke {"tool": "model_spawn", ...}` returns 403/denied on HTTP gateway
- [ ] Verify `model_spawn` still works via CLI/TUI (non-HTTP surface)
- [ ] Verify `sessions_spawn` remains denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)