### PR TITLE
fix(agents): handle Qwen3 reasoning_details in OpenRouter stream

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1106,7 +1106,12 @@ async function processOpenAICompletionsStream(
       });
       continue;
     }
-    const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"] as const;
+    const reasoningFields = [
+      "reasoning_content",
+      "reasoning",
+      "reasoning_text",
+      "reasoning_details",
+    ] as const;
     const reasoningField = reasoningFields.find((field) => {
       const value = (choice.delta as Record<string, unknown>)[field];
       return typeof value === "string" && value.length > 0;


### PR DESCRIPTION
## Summary

Qwen3 models via OpenRouter return reasoning content in the `reasoning_details` field on streamed `choice.delta`. The existing OpenAI transport stream parser only recognized `reasoning_content`, `reasoning`, and `reasoning_text`, causing turns to end with `payloads=0` and surface an incomplete-turn error to users.

## Change Type

- [x] Bug fix

## Related Issue

Fixes #66833

## Testing

- `pnpm vitest run src/agents/openai-transport-stream.test.ts` — 52/52 passed
- `pnpm tsgo` — passed
- `pnpm lint` — 0 warnings, 0 errors

## Checklist

- [x] Minimal, focused change
- [x] Existing tests pass
- [x] Type-check passes
- [x] Lint passes