### PR TITLE
fix(context-engine): gracefully degrade to legacy engine on third-party plugin resolution failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - QQBot/cron: guard against undefined `event.content` in `parseFaceTags` and `filterInternalMarkers` so cron-triggered agent turns with no content payload no longer crash with `TypeError: Cannot read properties of undefined (reading 'startsWith')`. (#66302) Thanks @xinmotlanthua.
 - CLI/plugins: stop `--dangerously-force-unsafe-install` plugin installs from falling back to hook-pack installs after security scan failures, while still preserving non-security fallback behavior for real hook packs. (#58909) Thanks @hxy91819.
 - Claude CLI/sessions: classify `No conversation found with session ID` as `session_expired` so expired CLI-backed conversations clear the stale binding and recover on the next turn. (#65028) thanks @Ivan-Fn.
+- Context Engine: gracefully fall back to the legacy engine when a third-party context engine plugin fails at resolution time (unregistered id, factory throw, or contract violation), preventing a full gateway outage on every channel. (#66887) Thanks @openperf.
 
 ## 2026.4.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Docs: https://docs.openclaw.ai
 - QQBot/cron: guard against undefined `event.content` in `parseFaceTags` and `filterInternalMarkers` so cron-triggered agent turns with no content payload no longer crash with `TypeError: Cannot read properties of undefined (reading 'startsWith')`. (#66302) Thanks @xinmotlanthua.
 - CLI/plugins: stop `--dangerously-force-unsafe-install` plugin installs from falling back to hook-pack installs after security scan failures, while still preserving non-security fallback behavior for real hook packs. (#58909) Thanks @hxy91819.
 - Claude CLI/sessions: classify `No conversation found with session ID` as `session_expired` so expired CLI-backed conversations clear the stale binding and recover on the next turn. (#65028) thanks @Ivan-Fn.
-- Context Engine: gracefully fall back to the legacy engine when a third-party context engine plugin fails at resolution time (unregistered id, factory throw, or contract violation), preventing a full gateway outage on every channel. (#66887) Thanks @openperf.
+- Context Engine: gracefully fall back to the legacy engine when a third-party context engine plugin fails at resolution time (unregistered id, factory throw, or contract violation), preventing a full gateway outage on every channel. (#66930) Thanks @openperf.
 
 ## 2026.4.14
 

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { clearMemoryPluginState, registerMemoryPromptSection } from "../plugins/memory-state.js";
@@ -705,26 +705,58 @@ describe("Default engine selection", () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("Invalid engine fallback", () => {
-  it("includes the requested id and available ids in unknown-engine errors", async () => {
-    // Ensure at least legacy is registered so we see it in the available list
+  beforeEach(() => {
     registerLegacyContextEngine();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to default engine when requested engine is not registered", async () => {
+    const engine = await resolveContextEngine(configWithSlot("does-not-exist"));
+    expect(engine.info.id).toBe("legacy");
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("does-not-exist"));
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("falling back to default engine"),
+    );
+  });
+
+  it("throws when the default engine itself is not registered", async () => {
+    // Access the process-global registry via the well-known symbol and clear it
+    // so even the default engine is missing.
+    const registryState = (globalThis as Record<symbol, unknown>)[
+      Symbol.for("openclaw.contextEngineRegistryState")
+    ] as { engines: Map<string, unknown> };
+    const snapshot = new Map(registryState.engines);
+    registryState.engines.clear();
 
     try {
-      await resolveContextEngine(configWithSlot("does-not-exist"));
-      // Should not reach here
-      expect.unreachable("Expected resolveContextEngine to throw");
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      expect(message).toContain("does-not-exist");
-      expect(message).toContain("not registered");
-      // Should mention available engines
-      expect(message).toMatch(/Available engines:/);
-      // At least "legacy" should be listed as available
-      expect(message).toContain("legacy");
+      await expect(resolveContextEngine()).rejects.toThrow("not registered");
+    } finally {
+      // Restore so other tests are not affected.
+      for (const [key, value] of snapshot) {
+        registryState.engines.set(key, value);
+      }
     }
   });
 
-  it("rejects resolved engines that omit info metadata", async () => {
+  it("falls back to default engine when factory throws", async () => {
+    const engineId = `factory-throw-${Date.now().toString(36)}`;
+    registerContextEngine(engineId, () => {
+      throw new Error("plugin version mismatch");
+    });
+
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+    expect(engine.info.id).toBe("legacy");
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("plugin version mismatch"));
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("falling back to default engine"),
+    );
+  });
+
+  it("falls back to default engine when resolved engine omits info metadata", async () => {
     const engineId = `invalid-info-${Date.now().toString(36)}`;
     registerContextEngine(
       engineId,
@@ -742,36 +774,12 @@ describe("Invalid engine fallback", () => {
         }) as unknown as ContextEngine,
     );
 
-    await expect(resolveContextEngine(configWithSlot(engineId))).rejects.toThrow(
-      `Context engine "${engineId}" factory returned an invalid ContextEngine: missing info.`,
-    );
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+    expect(engine.info.id).toBe("legacy");
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("missing info"));
   });
 
-  it("rejects resolved engines that omit required info fields", async () => {
-    const engineId = `invalid-info-fields-${Date.now().toString(36)}`;
-    registerContextEngine(
-      engineId,
-      () =>
-        ({
-          info: { id: engineId },
-          async ingest() {
-            return { ingested: false };
-          },
-          async assemble({ messages }: { messages: AgentMessage[] }) {
-            return { messages, estimatedTokens: 0 };
-          },
-          async compact() {
-            return { ok: true, compacted: false };
-          },
-        }) as unknown as ContextEngine,
-    );
-
-    await expect(resolveContextEngine(configWithSlot(engineId))).rejects.toThrow(
-      `Context engine "${engineId}" factory returned an invalid ContextEngine: missing info.name.`,
-    );
-  });
-
-  it("rejects resolved engines whose info.id mismatches the registered id", async () => {
+  it("falls back to default engine when info.id mismatches the registered id", async () => {
     const engineId = `mismatched-info-id-${Date.now().toString(36)}`;
     registerContextEngine(
       engineId,
@@ -790,12 +798,14 @@ describe("Invalid engine fallback", () => {
         }) as unknown as ContextEngine,
     );
 
-    await expect(resolveContextEngine(configWithSlot(engineId))).rejects.toThrow(
-      `Context engine "${engineId}" factory returned an invalid ContextEngine: info.id must match registered id "${engineId}".`,
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+    expect(engine.info.id).toBe("legacy");
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(`info.id must match registered id "${engineId}"`),
     );
   });
 
-  it("rejects resolved engines that omit required lifecycle methods", async () => {
+  it("falls back to default engine when resolved engine omits lifecycle methods", async () => {
     const engineId = `invalid-methods-${Date.now().toString(36)}`;
     registerContextEngine(
       engineId,
@@ -808,8 +818,10 @@ describe("Invalid engine fallback", () => {
         }) as unknown as ContextEngine,
     );
 
-    await expect(resolveContextEngine(configWithSlot(engineId))).rejects.toThrow(
-      `Context engine "${engineId}" factory returned an invalid ContextEngine: missing assemble(), missing compact().`,
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+    expect(engine.info.id).toBe("legacy");
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("missing assemble(), missing compact()"),
     );
   });
 });

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -725,21 +725,51 @@ describe("Invalid engine fallback", () => {
 
   it("throws when the default engine itself is not registered", async () => {
     // Access the process-global registry via the well-known symbol and clear it
-    // so even the default engine is missing.
+    // so even the default engine is missing. The symbol key must match the
+    // private CONTEXT_ENGINE_REGISTRY_STATE constant in registry.ts — guard
+    // against a silent key mismatch so a rename surfaces loudly.
     const registryState = (globalThis as Record<symbol, unknown>)[
       Symbol.for("openclaw.contextEngineRegistryState")
-    ] as { engines: Map<string, unknown> };
-    const snapshot = new Map(registryState.engines);
-    registryState.engines.clear();
+    ] as { engines: Map<string, unknown> } | undefined;
+    expect(registryState).toBeDefined();
+    const snapshot = new Map(registryState!.engines);
+    registryState!.engines.clear();
 
     try {
       await expect(resolveContextEngine()).rejects.toThrow("not registered");
     } finally {
-      // Restore so other tests are not affected.
       for (const [key, value] of snapshot) {
-        registryState.engines.set(key, value);
+        registryState!.engines.set(key, value);
       }
     }
+  });
+
+  it("propagates error when default engine factory throws", async () => {
+    // Override the default "legacy" engine with a throwing factory via the
+    // core-owner path so the registration is accepted.
+    registerContextEngineForOwner(
+      "legacy",
+      () => {
+        throw new Error("default engine init failed");
+      },
+      "core",
+      { allowSameOwnerRefresh: true },
+    );
+
+    await expect(resolveContextEngine()).rejects.toThrow("default engine init failed");
+  });
+
+  it("propagates error when default engine fails contract validation", async () => {
+    registerContextEngineForOwner(
+      "legacy",
+      () => ({ broken: true }) as unknown as ContextEngine,
+      "core",
+      { allowSameOwnerRefresh: true },
+    );
+
+    await expect(resolveContextEngine()).rejects.toThrow(
+      'Context engine "legacy" factory returned an invalid ContextEngine',
+    );
   });
 
   it("falls back to default engine when factory throws", async () => {
@@ -822,6 +852,20 @@ describe("Invalid engine fallback", () => {
     expect(engine.info.id).toBe("legacy");
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("missing assemble(), missing compact()"),
+    );
+  });
+
+  it("falls back to default engine when contract validation itself throws", async () => {
+    const engineId = `validation-throw-${Date.now().toString(36)}`;
+    // BigInt cannot be JSON.stringify'd — triggers a throw inside
+    // describeResolvedContextEngineContractError when the factory returns
+    // a non-object value that passes the typeof !== "object" branch.
+    registerContextEngine(engineId, () => 42n as unknown as ContextEngine);
+
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+    expect(engine.info.id).toBe("legacy");
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("contract validation threw"),
     );
   });
 });

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -494,13 +494,27 @@ export async function resolveContextEngine(config?: OpenClawConfig): Promise<Con
     return resolveDefaultContextEngine(defaultEngineId);
   }
 
-  const contractError = describeResolvedContextEngineContractError(engineId, engine);
+  let contractError: string | null;
+  try {
+    contractError = describeResolvedContextEngineContractError(engineId, engine);
+  } catch (validationError) {
+    if (isDefaultEngine) {
+      throw validationError;
+    }
+    console.error(
+      `[context-engine] Context engine "${sanitizeForLog(engineId)}" contract validation threw: ` +
+        `${sanitizeForLog(validationError instanceof Error ? validationError.message : String(validationError))}; ` +
+        `falling back to default engine "${defaultEngineId}".`,
+    );
+    return resolveDefaultContextEngine(defaultEngineId);
+  }
   if (contractError) {
     if (isDefaultEngine) {
       throw new Error(contractError);
     }
+    // contractError includes engineId from plugin config; sanitizeForLog covers it
     console.error(
-      `[context-engine] ${sanitizeForLog(contractError)} Falling back to default engine "${defaultEngineId}".`,
+      `[context-engine] ${sanitizeForLog(contractError)}; falling back to default engine "${defaultEngineId}".`,
     );
     return resolveDefaultContextEngine(defaultEngineId);
   }
@@ -518,14 +532,14 @@ async function resolveDefaultContextEngine(defaultEngineId: string): Promise<Con
   const defaultEntry = getContextEngineRegistryState().engines.get(defaultEngineId);
   if (!defaultEntry) {
     throw new Error(
-      `Context engine fallback failed: default engine "${defaultEngineId}" is not registered. ` +
+      `[context-engine] fallback failed: default engine "${defaultEngineId}" is not registered. ` +
         `Available engines: ${listContextEngineIds().join(", ") || "(none)"}`,
     );
   }
   const engine = await defaultEntry.factory();
   const contractError = describeResolvedContextEngineContractError(defaultEngineId, engine);
   if (contractError) {
-    throw new Error(contractError);
+    throw new Error(`[context-engine] ${contractError}`);
   }
   return wrapContextEngineWithSessionKeyCompat(engine);
 }

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.js";
 import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { sanitizeForLog } from "../terminal/ansi.js";
 import type { ContextEngine } from "./types.js";
 
 /**
@@ -449,7 +450,9 @@ function describeResolvedContextEngineContractError(
  *   1. `config.plugins.slots.contextEngine` (explicit slot override)
  *   2. Default slot value ("legacy")
  *
- * Throws if the resolved engine id has no registered factory.
+ * Non-default engines that fail (unregistered, factory throw, or contract
+ * violation) are logged and silently replaced by the default engine.
+ * Throws only when the default engine itself cannot be resolved.
  */
 export async function resolveContextEngine(config?: OpenClawConfig): Promise<ContextEngine> {
   const slotValue = config?.plugins?.slots?.contextEngine;
@@ -458,19 +461,71 @@ export async function resolveContextEngine(config?: OpenClawConfig): Promise<Con
       ? slotValue.trim()
       : defaultSlotIdForKey("contextEngine");
 
+  const defaultEngineId = defaultSlotIdForKey("contextEngine");
+  const isDefaultEngine = engineId === defaultEngineId;
+
   const entry = getContextEngineRegistryState().engines.get(engineId);
   if (!entry) {
+    if (isDefaultEngine) {
+      throw new Error(
+        `Context engine "${engineId}" is not registered. ` +
+          `Available engines: ${listContextEngineIds().join(", ") || "(none)"}`,
+      );
+    }
+    console.error(
+      `[context-engine] Context engine "${sanitizeForLog(engineId)}" is not registered; ` +
+        `falling back to default engine "${defaultEngineId}".`,
+    );
+    return resolveDefaultContextEngine(defaultEngineId);
+  }
+
+  let engine: ContextEngine;
+  try {
+    engine = await entry.factory();
+  } catch (factoryError) {
+    if (isDefaultEngine) {
+      throw factoryError;
+    }
+    console.error(
+      `[context-engine] Context engine "${sanitizeForLog(engineId)}" factory threw during resolution: ` +
+        `${sanitizeForLog(factoryError instanceof Error ? factoryError.message : String(factoryError))}; ` +
+        `falling back to default engine "${defaultEngineId}".`,
+    );
+    return resolveDefaultContextEngine(defaultEngineId);
+  }
+
+  const contractError = describeResolvedContextEngineContractError(engineId, engine);
+  if (contractError) {
+    if (isDefaultEngine) {
+      throw new Error(contractError);
+    }
+    console.error(
+      `[context-engine] ${sanitizeForLog(contractError)} Falling back to default engine "${defaultEngineId}".`,
+    );
+    return resolveDefaultContextEngine(defaultEngineId);
+  }
+
+  return wrapContextEngineWithSessionKeyCompat(engine);
+}
+
+/**
+ * Resolve the default context engine as a last-resort fallback.
+ *
+ * This helper is intentionally strict: if the default engine itself fails,
+ * there is no further fallback and the error must propagate.
+ */
+async function resolveDefaultContextEngine(defaultEngineId: string): Promise<ContextEngine> {
+  const defaultEntry = getContextEngineRegistryState().engines.get(defaultEngineId);
+  if (!defaultEntry) {
     throw new Error(
-      `Context engine "${engineId}" is not registered. ` +
+      `Context engine fallback failed: default engine "${defaultEngineId}" is not registered. ` +
         `Available engines: ${listContextEngineIds().join(", ") || "(none)"}`,
     );
   }
-
-  const engine = await entry.factory();
-  const contractError = describeResolvedContextEngineContractError(engineId, engine);
+  const engine = await defaultEntry.factory();
+  const contractError = describeResolvedContextEngineContractError(defaultEngineId, engine);
   if (contractError) {
     throw new Error(contractError);
   }
-
   return wrapContextEngineWithSessionKeyCompat(engine);
 }


### PR DESCRIPTION
## Summary

- **Problem**: When a third-party context engine plugin (e.g. `lossless-claw`) registers a factory that fails at resolution time — by throwing an error or returning an object violating the `ContextEngine` contract — `resolveContextEngine()` (`src/context-engine/registry.ts:454-476`) throws unconditionally. Because the broken factory persists in the process-global `Symbol.for()` registry, every subsequent agent run re-triggers the same failure, rendering all channels (Telegram, Discord, Webchat) completely unresponsive.

- **Root Cause**: `resolveContextEngine()` had no fallback path for non-default engine failures. The plugin loader's `register()` phase try/catch (`src/plugins/loader.ts:1814-1862`) protects only the registration call itself, but ContextEngine factories are merely stored during registration and only invoked later during the first agent run — outside the loader's error boundary. Three failure modes were unhandled: (1) engine id not registered, (2) factory throws during execution, (3) factory returns a contract-violating object.

- **Fix**: `resolveContextEngine()` now catches all three failure modes for non-default engines and falls back to the default `legacy` engine, logging a `console.error` with sanitized error details. A new `resolveDefaultContextEngine()` helper provides a strict fallback path — if the default engine itself fails, the error still propagates (no infinite fallback chain). Default engine failures remain fatal as before. Untrusted strings from plugin config and error messages are sanitized via `sanitizeForLog()` before logging to prevent log injection (CWE-117).

- **What changed**:
  - `src/context-engine/registry.ts`: Import `sanitizeForLog`; update JSDoc to document fallback behavior; `resolveContextEngine()` wraps factory invocation in try/catch for non-default engines with sanitized log output; new `resolveDefaultContextEngine()` private helper.
  - `src/context-engine/context-engine.test.ts`: Import `afterEach`; updated "Invalid engine fallback" test group — `beforeEach` spies on `console.error`, `afterEach` calls `vi.restoreAllMocks()` for reliable cleanup; tests verify fallback-to-legacy behavior; added test for factory-throws scenario and default-engine-missing scenario.

- **What did NOT change (scope boundary)**: Plugin loader (`src/plugins/loader.ts`), gateway startup sequence (`src/gateway/`), context engine contract validation logic (`describeResolvedContextEngineContractError`), the `ContextEngine` type interface, the public `registerContextEngine` API, and the `wrapContextEngineWithSessionKeyCompat` proxy. No new external dependencies introduced. No changes to any module outside `src/context-engine/`.

## Reproduction

1. Install a third-party context engine plugin (e.g. `lossless-claw`)
2. Configure `plugins.slots.contextEngine` to point to the plugin's engine id
3. Update the gateway to a version that causes a plugin incompatibility
4. Plugin factory throws `"info.id must match registered id"` during the first agent run
5. **Result**: Every message on every channel returns "Agent failed before reply" — the gateway is effectively down

## Risk / Mitigation

- **Risk**: Users may not immediately notice their configured context engine has been replaced by the legacy fallback, potentially missing LCM (Lossless Context Management) functionality.
- **Mitigation**: Every fallback emits a `console.error` with the `[context-engine]` prefix, the sanitized original error message, and the fallback engine id — visible in gateway logs and `openclaw logs --follow`. The default engine fallback is strictly validated (same contract checks) and cannot silently degrade. Untrusted values are sanitized before logging to prevent log injection. Test mock cleanup uses `afterEach(vi.restoreAllMocks)` to prevent inter-test pollution.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Context Engine
- [x] Plugin System (fault isolation)
- [x] Gateway (availability)

## Linked Issue/PR

Fixes #66887