### PR TITLE
fix(memory): respect user batch.concurrency even when batch mode is disabled

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -463,6 +463,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   protected getIndexConcurrency(): number {
+    // Always respect the user's configured concurrency (batch.concurrency),
+    // even when batch mode is disabled (e.g. Ollama without batch API).
+    // Only fall back to the hardcoded default when no user config is present.
+    const userConcurrency = this.settings.remote?.batch?.concurrency;
+    if (typeof userConcurrency === "number" && userConcurrency >= 1) {
+      return userConcurrency;
+    }
     return this.batch.enabled ? this.batch.concurrency : EMBEDDING_INDEX_CONCURRENCY;
   }
 

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -463,14 +463,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   protected getIndexConcurrency(): number {
-    // Always respect the user's configured concurrency (batch.concurrency),
-    // even when batch mode is disabled (e.g. Ollama without batch API).
-    // Only fall back to the hardcoded default when no user config is present.
-    const userConcurrency = this.settings.remote?.batch?.concurrency;
-    if (typeof userConcurrency === "number" && userConcurrency >= 1) {
-      return userConcurrency;
-    }
-    return this.batch.enabled ? this.batch.concurrency : EMBEDDING_INDEX_CONCURRENCY;
+    // Respect the user's configured concurrency even when batch mode is
+    // disabled (e.g. Ollama without batch API). Only fall back to the
+    // hardcoded default when no user config is present.
+    const hasUserConcurrency = this.settings.remote?.batch?.concurrency != null;
+    return hasUserConcurrency || this.batch.enabled
+      ? this.batch.concurrency
+      : EMBEDDING_INDEX_CONCURRENCY;
   }
 
   private clearIndexedFileData(pathname: string, source: MemorySource): void {


### PR DESCRIPTION
## Summary
- `getIndexConcurrency()` ignored the user's configured `agents.defaults.memorySearch.remote.batch.concurrency` when batch mode was disabled (e.g. with Ollama which lacks the batch API)
- Fell back to a hardcoded concurrency of **4**, causing 30+ concurrent embedding requests to flood Ollama, exhausting resources and resulting in SIGKILLs
- Now checks the raw user config first and respects it regardless of whether batch mode is enabled

Fixes #66822

## Test plan
- [ ] Set `agents.defaults.memorySearch.remote.batch.concurrency = 1` with Ollama provider
- [ ] Run `openclaw memory index --verbose --force` on a workspace with 50+ memory files
- [ ] Verify only 1 embedding request is sent at a time (no concurrent flooding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)