### PR TITLE
feat(ui): persistent red fallback model indicator on model picker

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -335,6 +335,25 @@ That cooldown summary is model-aware:
 - if the remaining block is a matching model-scoped rate limit, OpenClaw
   reports the last matching expiry that still blocks that model
 
+## UI fallback indicator
+
+When a model fallback occurs during a run, the OpenClaw Control UI shows two
+indications:
+
+1. **Temporary toast notification** — A banner appears in the chat area for 8
+   seconds showing the active fallback model and the reason (e.g., `Fallback
+   active: openai/gpt-4o — model picker highlighted`).
+
+2. **Persistent model picker highlight** — The model picker in the chat header
+   is highlighted red and continues to pulse until the user manually selects a
+   different model from the picker. This ensures the fallback is still visible
+   after the toast disappears.
+
+The persistent highlight is cleared only when the user explicitly chooses a
+model from the picker. Switching between chat sessions does not clear it —
+if a session's model fell back, its picker remains highlighted until a
+deliberate model change is made for that session.
+
 ## Related config
 
 See [Gateway configuration](/gateway/configuration) for:

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -900,6 +900,19 @@
   max-width: 320px;
 }
 
+/* Fallback model indicator — persists until user manually changes the model */
+.chat-controls__model--fallback select {
+  border-color: var(--danger) !important;
+  color: var(--danger);
+  box-shadow: 0 0 0 2px var(--danger-subtle);
+  animation: fallback-model-pulse 2s ease-in-out infinite;
+}
+
+@keyframes fallback-model-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px var(--danger-subtle); }
+  50% { box-shadow: 0 0 0 3px var(--danger-muted); }
+}
+
 .chat-controls__thinking {
   display: flex;
   align-items: center;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -589,8 +589,9 @@ function renderChatModelSelect(state: AppViewState) {
     currentOverride === ""
       ? defaultLabel
       : (options.find((entry) => entry.value === currentOverride)?.label ?? currentOverride);
+  const inFallback = Boolean(state.modelFallbackSessions?.[state.sessionKey]);
   return html`
-    <label class="field chat-controls__session chat-controls__model">
+    <label class=${`field chat-controls__session chat-controls__model${inFallback ? " chat-controls__model--fallback" : ""}`}>
       <select
         data-chat-model-select="true"
         aria-label="Chat model"
@@ -755,6 +756,9 @@ async function switchChatModel(state: AppViewState, nextModel: string) {
       key: targetSessionKey,
       model: nextModel || null,
     });
+    // Clear the fallback indicator — user has intentionally chosen a model
+    const { [targetSessionKey]: _removed, ...rest } = state.modelFallbackSessions ?? {};
+    state.modelFallbackSessions = rest as Record<string, true>;
     void refreshVisibleToolsEffectiveForCurrentSession(state);
     await refreshSessionOptions(state);
   } catch (err) {

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -270,6 +270,7 @@ type CompactionHost = ToolStreamHost & {
   compactionClearTimer?: number | null;
   fallbackStatus?: FallbackStatus | null;
   fallbackClearTimer?: number | null;
+  modelFallbackSessions?: Record<string, true>;
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
@@ -428,6 +429,13 @@ function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventP
   if (host.fallbackClearTimer != null) {
     window.clearTimeout(host.fallbackClearTimer);
     host.fallbackClearTimer = null;
+  }
+  if (phase !== "fallback_cleared") {
+    // Persist fallback indicator on picker until user manually changes model
+    const sessionKey = accepted.sessionKey ?? host.sessionKey;
+    if (sessionKey) {
+      host.modelFallbackSessions = { ...(host.modelFallbackSessions ?? {}), [sessionKey]: true };
+    }
   }
   host.fallbackStatus = {
     phase: phase === "fallback_cleared" ? "cleared" : "active",

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -83,6 +83,7 @@ export type AppViewState = {
   chatSideResultTerminalRuns: Set<string>;
   compactionStatus: CompactionStatus | null;
   fallbackStatus: FallbackStatus | null;
+  modelFallbackSessions: Record<string, true>;
   chatAvatarUrl: string | null;
   chatThinkingLevel: string | null;
   chatModelOverrides: Record<string, ChatModelOverride | null>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -179,6 +179,7 @@ export class OpenClawApp extends LitElement {
   @state() chatSideResult: ChatSideResult | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() fallbackStatus: FallbackStatus | null = null;
+  @state() modelFallbackSessions: Record<string, true> = {};
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
   @state() chatModelOverrides: Record<string, ChatModelOverride | null> = {};

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -440,7 +440,7 @@ function renderFallbackIndicator(status: FallbackStatus | null | undefined) {
   const message =
     phase === "cleared"
       ? `Fallback cleared: ${status.selected}`
-      : `Fallback active: ${status.active}`;
+      : `Fallback active: ${status.active} — model picker highlighted`;
   const className =
     phase === "cleared"
       ? "compaction-indicator compaction-indicator--fallback-cleared"


### PR DESCRIPTION
## Summary

When a model fallback occurs, the model picker in the chat header is now highlighted red and remains highlighted until the user manually selects a different model.

Previously, fallback changes were only shown as a temporary 8-second toast notification that disappeared silently.

## Changes

- Add `modelFallbackSessions: Record<string, true>` to `AppViewState`
- Add `modelFallbackSessions` to `CompactionHost` type in `app-tool-stream.ts`
- Set flag in `handleLifecycleFallbackEvent` when phase=fallback
- Clear flag in `switchChatModel` on user-initiated model change
- Add `@state() modelFallbackSessions` to Lit component in `app.ts`
- Apply `chat-controls__model--fallback` CSS class when flag is set for the current session
- Add pulsing red border/glow CSS for the fallback indicator
- Update `renderFallbackIndicator` toast message to note picker is highlighted
- Update `docs/concepts/model-failover.md` with persistent indicator section

## Behavior

1. Model fallback occurs → picker shows red pulsing highlight + 8s toast with '— model picker highlighted' note
2. User manually changes model from picker → red highlight clears immediately
3. Switching between chat sessions does not clear the highlight — it persists per session until explicitly changed