### PR TITLE
fix(telegram): avoid duplicate preview after compaction retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Models/config: preserve an existing `models.json` provider `baseUrl` during merge-mode regeneration so custom endpoints do not get reset on restart. (#67893) Thanks @lawrence3699.
 - Plugins/discovery: reuse bundled and global plugin discovery results across workspace cache misses so Windows multi-workspace startup stops redoing the shared synchronous scan. (#67940) Thanks @obviyus.
 - Plugins/webhooks: enforce synchronous plugin registration with full rollback of failed plugin side effects, and cache SecretRef-backed webhook auth per route so plugin startup and inbound webhook auth stay deterministic. (#67941) Thanks @obviyus.
+- Telegram/streaming: keep a transient preview on the same Telegram message when auto-compaction retries an in-flight answer, so streamed replies no longer appear duplicated after compaction. (#66939) Thanks @rubencu.
 
 ## 2026.4.15
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -838,6 +838,44 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("does not double-rotate when assistant_message_start arrives after final delivery drains", async () => {
+    const answerDraftStream = createSequencedDraftStream(1001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        await replyOptions?.onPartialReply?.({ text: "Message B early" });
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        await replyOptions?.onAssistantMessageStart?.();
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      1,
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      2,
+      123,
+      1002,
+      "Message B final",
+      expect.any(Object),
+    );
+  });
+
   it("clears active preview even when an unrelated boundary archive exists", async () => {
     const answerDraftStream = createDraftStream(999);
     answerDraftStream.materialize.mockResolvedValue(4321);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1231,6 +1231,65 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("keeps the transient preview when a local exec approval prompt is suppressed after compaction", async () => {
+    const answerDraftStream = createSequencedDraftStream(1001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onCompactionStart?.();
+        await replyOptions?.onCompactionEnd?.();
+        await dispatcherOptions.deliver(
+          {
+            text: "Approval required.\n\n```txt\n/approve 7f423fdc allow-once\n```",
+            channelData: {
+              execApproval: {
+                approvalId: "7f423fdc-1111-2222-3333-444444444444",
+                approvalSlug: "7f423fdc",
+                allowedDecisions: ["allow-once", "allow-always", "deny"],
+              },
+            },
+          },
+          { kind: "tool" },
+        );
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message B partial" });
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "partial",
+      cfg: {
+        channels: {
+          telegram: {
+            execApprovals: {
+              enabled: true,
+              approvers: ["12345"],
+              target: "dm",
+            },
+          },
+        },
+      },
+    });
+
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      1001,
+      "Message B final",
+      expect.any(Object),
+    );
+  });
+
   it("finalizes multi-message assistant stream to matching preview messages in order", async () => {
     const answerDraftStream = createSequencedDraftStream(1001);
     const reasoningDraftStream = createDraftStream();

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -800,6 +800,44 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("preserves pre-rotation skip until queued message-start callbacks flush", async () => {
+    const answerDraftStream = createSequencedDraftStream(1001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        await replyOptions?.onPartialReply?.({ text: "Message B early" });
+        void replyOptions?.onAssistantMessageStart?.();
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      1,
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      2,
+      123,
+      1002,
+      "Message B final",
+      expect.any(Object),
+    );
+  });
+
   it("clears active preview even when an unrelated boundary archive exists", async () => {
     const answerDraftStream = createDraftStream(999);
     answerDraftStream.materialize.mockResolvedValue(4321);
@@ -1052,6 +1090,145 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Message B first chunk");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Message B second chunk");
+  });
+
+  it("does not rotate the streamed preview when compaction retries replay the same assistant message", async () => {
+    const answerDraftStream = createSequencedDraftStream(1001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onCompactionStart?.();
+        await replyOptions?.onCompactionEnd?.();
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onPartialReply?.({ text: "Message A partial extended" });
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(answerDraftStream.materialize).not.toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+  });
+
+  it("clears the compaction replay skip after the retried message finalizes", async () => {
+    const answerDraftStream = createSequencedDraftStream(1001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onCompactionStart?.();
+        await replyOptions?.onCompactionEnd?.();
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message A partial extended" });
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Message B partial" });
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      1,
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+    expect(editMessageTelegram).toHaveBeenNthCalledWith(
+      2,
+      123,
+      1002,
+      "Message B final",
+      expect.any(Object),
+    );
+  });
+
+  it("preserves the compaction replay flag until queued retry callbacks flush", async () => {
+    const answerDraftStream = createSequencedDraftStream(1001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onCompactionStart?.();
+        await replyOptions?.onCompactionEnd?.();
+        void replyOptions?.onAssistantMessageStart?.();
+        await dispatcherOptions.deliver({ text: "Message A final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      1001,
+      "Message A final",
+      expect.any(Object),
+    );
+  });
+
+  it("keeps the existing preview when the retried answer only arrives as final text", async () => {
+    const answerDraftStream = createSequencedDraftStream(1001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Message A partial" });
+        await replyOptions?.onCompactionStart?.();
+        await replyOptions?.onCompactionEnd?.();
+        await replyOptions?.onAssistantMessageStart?.();
+        await dispatcherOptions.deliver({ text: "Message B final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(answerDraftStream.materialize).not.toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      1001,
+      "Message B final",
+      expect.any(Object),
+    );
   });
 
   it("finalizes multi-message assistant stream to matching preview messages in order", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -616,7 +616,6 @@ export const dispatchTelegramMessage = async ({
             // Assistant callbacks are fire-and-forget; ensure queued boundary
             // rotations/partials are applied before final delivery mapping.
             await enqueueDraftLaneEvent(async () => {});
-            skipNextAnswerMessageStartRotation = false;
           }
           if (
             shouldSuppressLocalTelegramExecApprovalPrompt({

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -280,6 +280,10 @@ export const dispatchTelegramMessage = async ({
   const reasoningLane = lanes.reasoning;
   let splitReasoningOnNextStream = false;
   let skipNextAnswerMessageStartRotation = false;
+  // If compaction interrupts a still-transient answer preview, keep the next
+  // assistant-message boundary on that same preview instead of materializing a
+  // duplicate retry message.
+  let pendingCompactionReplayBoundary = false;
   let draftLaneEventQueue = Promise.resolve();
   const reasoningStepState = createTelegramReasoningStepState();
   const enqueueDraftLaneEvent = (task: () => Promise<void>): Promise<void> => {
@@ -612,6 +616,7 @@ export const dispatchTelegramMessage = async ({
             // Assistant callbacks are fire-and-forget; ensure queued boundary
             // rotations/partials are applied before final delivery mapping.
             await enqueueDraftLaneEvent(async () => {});
+            skipNextAnswerMessageStartRotation = false;
           }
           if (
             shouldSuppressLocalTelegramExecApprovalPrompt({
@@ -693,6 +698,9 @@ export const dispatchTelegramMessage = async ({
             }
           }
           if (segments.length > 0) {
+            if (info.kind === "final") {
+              pendingCompactionReplayBoundary = false;
+            }
             return;
           }
           if (split.suppressedReasoningOnly) {
@@ -703,6 +711,7 @@ export const dispatchTelegramMessage = async ({
             }
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();
+              pendingCompactionReplayBoundary = false;
             }
             return;
           }
@@ -716,12 +725,14 @@ export const dispatchTelegramMessage = async ({
           if (!canSendAsIs) {
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();
+              pendingCompactionReplayBoundary = false;
             }
             return;
           }
           await sendPayload(payload);
           if (info.kind === "final") {
             await flushBufferedFinalAnswer();
+            pendingCompactionReplayBoundary = false;
           }
         },
         onSkip: (payload, info) => {
@@ -793,6 +804,12 @@ export const dispatchTelegramMessage = async ({
                   retainPreviewOnCleanupByLane.answer = false;
                   return;
                 }
+                if (pendingCompactionReplayBoundary) {
+                  pendingCompactionReplayBoundary = false;
+                  activePreviewLifecycleByLane.answer = "transient";
+                  retainPreviewOnCleanupByLane.answer = false;
+                  return;
+                }
                 await rotateAnswerLaneForNewAssistantMessage();
                 // Message-start is an explicit assistant-message boundary.
                 // Even when no forceNewMessage happened (e.g. prior answer had no
@@ -817,9 +834,20 @@ export const dispatchTelegramMessage = async ({
               }
             }
           : undefined,
-        onCompactionStart: statusReactionController
-          ? () => statusReactionController.setCompacting()
-          : undefined,
+        onCompactionStart:
+          statusReactionController || answerLane.stream
+            ? async () => {
+                if (
+                  answerLane.hasStreamedMessage &&
+                  activePreviewLifecycleByLane.answer === "transient"
+                ) {
+                  pendingCompactionReplayBoundary = true;
+                }
+                if (statusReactionController) {
+                  await statusReactionController.setCompacting();
+                }
+              }
+            : undefined,
         onCompactionEnd: statusReactionController
           ? async () => {
               statusReactionController.cancelPending();


### PR DESCRIPTION
## Summary

- Problem: when Telegram was already showing a streamed transient assistant preview and auto-compaction retried that same in-flight answer, Telegram could show the already-visible answer text again as a duplicate.
- Why it matters: a healthy retry looked like the assistant sent the same answer twice, which is confusing and makes the stream feel unreliable.
- What changed: if compaction interrupts a still-transient streamed answer preview, Telegram now keeps that same preview across the retry boundary instead of rotating/materializing a new preview on the next `assistant_message_start`.
- Scope boundary: this change is limited to Telegram preview handling for compaction retries. It does not change config defaults or shared reply/plugin contracts.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Telegram treated the next `assistant_message_start` after compaction as a fresh message boundary even when compaction had only restarted the same in-flight answer whose preview was already visible.
- Missing detection / guardrail: the preview lane did not preserve transient-preview ownership across a compaction retry boundary.
- Contributing context (if known): auto-compaction can retry an in-flight answer after some assistant text has already been streamed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/bot-message-dispatch.test.ts`
- Scenarios the tests lock in:
  - a streamed Telegram answer is already visible, compaction happens, and the retried run resumes that same answer without materializing a duplicate preview
  - queued retry callbacks still preserve the same preview until they drain
  - delayed `assistant_message_start` callbacks that arrive after final-delivery drain still consume the existing pre-rotation skip instead of forcing a second boundary rotation
  - later real assistant-message boundaries rotate normally again after the retried message finalizes
  - a locally suppressed Telegram exec-approval prompt after compaction does not count as a visible boundary, so Telegram keeps editing the same transient preview
- Why this is the smallest reliable guardrail: the bug lives in Telegram preview-lane orchestration rather than in an isolated helper.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Telegram no longer duplicates already-visible streamed assistant text when auto-compaction retries the same in-flight answer.
- When Telegram suppresses a local native exec-approval prompt during that retry flow, it keeps the same transient preview instead of materializing a new visible message boundary.
- No config or default behavior changes.

## Diagram (if applicable)

```text
Before:
[transient preview visible] -> [compaction retry] -> [next assistant message start rotates preview] -> [duplicate visible answer]

After:
[transient preview visible] -> [compaction retry] -> [keep same preview across retry boundary] -> [continued edits on existing preview]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev run
- Model/provider: embedded PI / OpenAI lane
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram preview streaming enabled (`partial`)

### Steps

1. Send a Telegram message that starts streaming an assistant answer.
2. Let some assistant text become visible while the answer preview is still transient.
3. Trigger auto-compaction so the in-flight answer retries.

### Expected

- The existing transient preview should continue through the retry without a duplicate visible answer.

### Actual

- Telegram could materialize a duplicate visible answer after compaction retry.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: manually reproduced the Telegram compaction duplicate before the fix, then manually confirmed no duplicate appears after compaction retry with this branch.
- Edge cases checked: queued retry callbacks preserve the same preview until they drain, delayed `assistant_message_start` callbacks after final-delivery drain now preserve the correct preview boundary via regression coverage, later real message boundaries rotate normally after the retried message finalizes, and suppressed local Telegram exec-approval prompts after compaction keep the existing transient preview instead of creating a new visible boundary.
- What you did **not** verify: other replay/duplicate issues outside this compaction-retry scenario.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the retry-boundary guard could suppress a genuine new boundary if compaction happened while a transient preview was active.
  - Mitigation: the guard is limited to transient Telegram answer previews at compaction boundaries, and the regression tests cover queued callbacks, delayed `assistant_message_start` ordering, plus restoration of normal rotation after the retried message finalizes.
- Risk: a locally suppressed Telegram exec-approval prompt after compaction could be interpreted as a boundary by some readers.
  - Mitigation: this PR treats only user-visible Telegram messages as preview boundaries, and the regression test now documents that suppressed local approval prompts intentionally keep the same transient preview.

AI-assisted with Codex. Tested locally and manually validated for the Telegram compaction replay repro.
