### PR TITLE
feat: add SenseAudio audio transcription provider

### DIFF
--- a/extensions/senseaudio/index.ts
+++ b/extensions/senseaudio/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { senseaudioMediaUnderstandingProvider } from "./media-understanding-provider.js";
+
+export default definePluginEntry({
+  id: "senseaudio",
+  name: "SenseAudio",
+  description: "Bundled SenseAudio audio transcription provider",
+  register(api) {
+    api.registerMediaUnderstandingProvider(senseaudioMediaUnderstandingProvider);
+  },
+});

--- a/extensions/senseaudio/media-understanding-provider.test.ts
+++ b/extensions/senseaudio/media-understanding-provider.test.ts
@@ -9,6 +9,20 @@ import { transcribeSenseAudioAudio } from "./media-understanding-provider.js";
 installPinnedHostnameTestHooks();
 
 describe("transcribeSenseAudioAudio", () => {
+  it("uses SenseAudio base URL by default", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "ok" });
+
+    await transcribeSenseAudioAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "note.mp3",
+      apiKey: "test-key",
+      timeoutMs: 1000,
+      fetchFn,
+    });
+
+    expect(getRequest().url).toBe("https://api.senseaudio.cn/v1/audio/transcriptions");
+  });
+
   it("respects lowercase authorization header overrides", async () => {
     const { fetchFn, getAuthHeader } = createAuthCaptureJsonFetch({ text: "ok" });
 

--- a/extensions/senseaudio/media-understanding-provider.test.ts
+++ b/extensions/senseaudio/media-understanding-provider.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAuthCaptureJsonFetch,
+  createRequestCaptureJsonFetch,
+  installPinnedHostnameTestHooks,
+} from "../../src/media-understanding/audio.test-helpers.ts";
+import { transcribeSenseAudioAudio } from "./media-understanding-provider.js";
+
+installPinnedHostnameTestHooks();
+
+describe("transcribeSenseAudioAudio", () => {
+  it("respects lowercase authorization header overrides", async () => {
+    const { fetchFn, getAuthHeader } = createAuthCaptureJsonFetch({ text: "ok" });
+
+    const result = await transcribeSenseAudioAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "note.mp3",
+      apiKey: "test-key",
+      timeoutMs: 1000,
+      headers: { authorization: "Bearer override" },
+      fetchFn,
+    });
+
+    expect(getAuthHeader()).toBe("Bearer override");
+    expect(result.text).toBe("ok");
+  });
+
+  it("builds the expected request payload", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+
+    const result = await transcribeSenseAudioAudio({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "voice.wav",
+      apiKey: "test-key",
+      timeoutMs: 1234,
+      baseUrl: "https://api.example.com/v1/",
+      model: " ",
+      language: " en ",
+      prompt: " hello ",
+      mime: "audio/wav",
+      headers: { "X-Custom": "1" },
+      fetchFn,
+    });
+    const { url: seenUrl, init: seenInit } = getRequest();
+
+    expect(result.model).toBe("senseaudio-asr-pro-1.5-260319");
+    expect(result.text).toBe("hello");
+    expect(seenUrl).toBe("https://api.example.com/v1/audio/transcriptions");
+    expect(seenInit?.method).toBe("POST");
+    expect(seenInit?.signal).toBeInstanceOf(AbortSignal);
+
+    const headers = new Headers(seenInit?.headers);
+    expect(headers.get("authorization")).toBe("Bearer test-key");
+    expect(headers.get("x-custom")).toBe("1");
+
+    const form = seenInit?.body as FormData;
+    expect(form).toBeInstanceOf(FormData);
+    expect(form.get("model")).toBe("senseaudio-asr-pro-1.5-260319");
+    expect(form.get("language")).toBe("en");
+    expect(form.get("prompt")).toBe("hello");
+    const file = form.get("file") as Blob | { type?: string; name?: string } | null;
+    expect(file).not.toBeNull();
+    if (file) {
+      expect(file.type).toBe("audio/wav");
+      if ("name" in file && typeof file.name === "string") {
+        expect(file.name).toBe("voice.wav");
+      }
+    }
+  });
+
+  it("throws when the provider response omits text", async () => {
+    const { fetchFn } = createRequestCaptureJsonFetch({});
+
+    await expect(
+      transcribeSenseAudioAudio({
+        buffer: Buffer.from("audio-bytes"),
+        fileName: "voice.wav",
+        apiKey: "test-key",
+        timeoutMs: 1234,
+        fetchFn,
+      }),
+    ).rejects.toThrow("Audio transcription response missing text");
+  });
+});

--- a/extensions/senseaudio/media-understanding-provider.ts
+++ b/extensions/senseaudio/media-understanding-provider.ts
@@ -1,0 +1,24 @@
+import {
+  transcribeOpenAiCompatibleAudio,
+  type AudioTranscriptionRequest,
+  type MediaUnderstandingProvider,
+} from "openclaw/plugin-sdk/media-understanding";
+
+const DEFAULT_SENSEAUDIO_AUDIO_BASE_URL = "https://api.senseaudio.cn/v1";
+const DEFAULT_SENSEAUDIO_AUDIO_MODEL = "senseaudio-asr-pro-1.5-260319";
+
+export async function transcribeSenseAudioAudio(params: AudioTranscriptionRequest) {
+  return await transcribeOpenAiCompatibleAudio({
+    ...params,
+    provider: "senseaudio",
+    defaultBaseUrl: DEFAULT_SENSEAUDIO_AUDIO_BASE_URL,
+    defaultModel: DEFAULT_SENSEAUDIO_AUDIO_MODEL,
+  });
+}
+
+export const senseaudioMediaUnderstandingProvider: MediaUnderstandingProvider = {
+  id: "senseaudio",
+  capabilities: ["audio"],
+  defaultModels: { audio: DEFAULT_SENSEAUDIO_AUDIO_MODEL },
+  transcribeAudio: transcribeSenseAudioAudio,
+};

--- a/extensions/senseaudio/media-understanding-provider.ts
+++ b/extensions/senseaudio/media-understanding-provider.ts
@@ -20,5 +20,6 @@ export const senseaudioMediaUnderstandingProvider: MediaUnderstandingProvider = 
   id: "senseaudio",
   capabilities: ["audio"],
   defaultModels: { audio: DEFAULT_SENSEAUDIO_AUDIO_MODEL },
+  autoPriority: { audio: 40 },
   transcribeAudio: transcribeSenseAudioAudio,
 };

--- a/extensions/senseaudio/openclaw.plugin.json
+++ b/extensions/senseaudio/openclaw.plugin.json
@@ -1,0 +1,15 @@
+{
+  "id": "senseaudio",
+  "enabledByDefault": true,
+  "providerAuthEnvVars": {
+    "senseaudio": ["SENSEAUDIO_API_KEY"]
+  },
+  "contracts": {
+    "mediaUnderstandingProviders": ["senseaudio"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/senseaudio/package.json
+++ b/extensions/senseaudio/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/senseaudio-provider",
+  "version": "2026.4.14-beta.1",
+  "private": true,
+  "description": "OpenClaw SenseAudio media-understanding provider",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/senseaudio/test-api.ts
+++ b/extensions/senseaudio/test-api.ts
@@ -1,0 +1,1 @@
+export { senseaudioMediaUnderstandingProvider } from "./media-understanding-provider.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1049,6 +1049,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/senseaudio:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/sglang:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/plugins/contracts/plugin-registration.senseaudio.contract.test.ts
+++ b/src/plugins/contracts/plugin-registration.senseaudio.contract.test.ts
@@ -1,0 +1,4 @@
+import { pluginRegistrationContractCases } from "../../../test/helpers/plugins/plugin-registration-contract-cases.js";
+import { describePluginRegistrationContract } from "../../../test/helpers/plugins/plugin-registration-contract.js";
+
+describePluginRegistrationContract(pluginRegistrationContractCases.senseaudio);

--- a/test/helpers/plugins/plugin-registration-contract-cases.ts
+++ b/test/helpers/plugins/plugin-registration-contract-cases.ts
@@ -118,6 +118,10 @@ export const pluginRegistrationContractCases = {
     pluginId: "perplexity",
     webSearchProviderIds: ["perplexity"],
   },
+  senseaudio: {
+    pluginId: "senseaudio",
+    mediaUnderstandingProviderIds: ["senseaudio"],
+  },
   tavily: {
     pluginId: "tavily",
     webSearchProviderIds: ["tavily"],


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw has no built-in audio transcription provider; users who want STT must wire up an external solution.
- **Why it matters:** SenseAudio provides an OpenAI-compatible ASR API (`/v1/audio/transcriptions`) with a purpose-built model (`senseaudio-asr-pro-1.5-260319`), making it straightforward to integrate as a `mediaUnderstandingProvider`.
- **What changed:** Added a new bundled `senseaudio` plugin that registers a `mediaUnderstandingProvider` backed by SenseAudio's ASR endpoint. The implementation reuses the shared `transcribeOpenAiCompatibleAudio` helper — no new core logic.
- **What did NOT change:** No core code modified. No other providers or channels affected.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A — new feature, no regression surface.

- [x] Existing coverage already sufficient
- Target test or file: `extensions/senseaudio/media-understanding-provider.test.ts`, `src/plugins/contracts/plugin-registration.senseaudio.contract.test.ts`
- Scenario: plugin registration contract asserts `mediaUnderstandingProvider` id is declared; unit test covers the transcription path.
- If no new test is added, why not: tests are included in this PR.

## User-visible / Behavior Changes

- New `senseaudio` plugin is enabled by default. If `SENSEAUDIO_API_KEY` is set, SenseAudio is available as an audio transcription provider with no additional configuration.
- No changes to existing providers or defaults.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — outbound HTTPS to `https://api.senseaudio.cn/v1/audio/transcriptions`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: API key is read from `SENSEAUDIO_API_KEY` env var via the standard `providerAuthEnvVars` manifest field. Key is never logged or persisted. Network call is scoped to transcription requests only and goes through the existing OpenAI-compatible audio helper.

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime/container: Node 22 / Bun
- Model/provider: senseaudio (`senseaudio-asr-pro-1.5-260319`)
- Integration/channel: CLI (`openclaw capability audio transcribe`)

### Steps

1. Set `SENSEAUDIO_API_KEY=<key>` in environment.
2. Run `openclaw capability audio transcribe --file /path/to/audio.mp3 --model senseaudio/senseaudio-asr-pro-1.5-260319`.
3. Observe transcription result printed to stdout.

### Expected

- Audio is transcribed and returned as text.

### Actual

- Audio is transcribed and returned as text.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets — transcription returned successfully via `capability audio transcribe` CLI
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: live transcription via `openclaw capability audio transcribe` with a real `SENSEAUDIO_API_KEY`; plugin contract test and unit test pass locally.
- Edge cases checked: plugin is a no-op when `SENSEAUDIO_API_KEY` is absent (standard manifest behavior).
- What I did **not** verify: behavior under network timeout or invalid API key (deferred to existing error-handling paths in the shared helper).

<img width="1003" height="428" alt="image" src="https://github.com/user-attachments/assets/a2c6e674-2186-4cfb-976e-aa6955a90fe9" />


## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` — `SENSEAUDIO_API_KEY` is optional; plugin is a no-op when absent.
- Migration needed? `No`

## Risks and Mitigations

- Risk: SenseAudio endpoint availability or API contract changes break transcription.
  - Mitigation: failure is isolated to this provider; other providers are unaffected. Users can disable the plugin via config.
