### PR TITLE
fix(memory-core): default dreaming storage to "separate" to stop polluting daily memory files

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -27,6 +27,10 @@ const LIGHT_DREAMING_TEST_CONFIG: OpenClawConfig = {
           dreaming: {
             enabled: true,
             timezone: "UTC",
+            storage: {
+              mode: "inline",
+              separateReports: false,
+            },
             phases: {
               light: {
                 enabled: true,
@@ -305,6 +309,10 @@ describe("memory-core dreaming phases", () => {
               config: {
                 dreaming: {
                   enabled: true,
+                  storage: {
+                    mode: "inline",
+                    separateReports: false,
+                  },
                   phases: {
                     light: {
                       enabled: true,
@@ -371,6 +379,10 @@ describe("memory-core dreaming phases", () => {
               config: {
                 dreaming: {
                   enabled: true,
+                  storage: {
+                    mode: "inline",
+                    separateReports: false,
+                  },
                   phases: {
                     light: {
                       enabled: true,
@@ -979,6 +991,10 @@ describe("memory-core dreaming phases", () => {
               config: {
                 dreaming: {
                   enabled: true,
+                  storage: {
+                    mode: "inline",
+                    separateReports: false,
+                  },
                   phases: {
                     light: {
                       enabled: true,
@@ -1292,6 +1308,10 @@ describe("memory-core dreaming phases", () => {
               config: {
                 dreaming: {
                   enabled: true,
+                  storage: {
+                    mode: "inline",
+                    separateReports: false,
+                  },
                   phases: {
                     light: {
                       enabled: true,
@@ -1352,6 +1372,10 @@ describe("memory-core dreaming phases", () => {
               config: {
                 dreaming: {
                   enabled: true,
+                  storage: {
+                    mode: "inline",
+                    separateReports: false,
+                  },
                   phases: {
                     light: {
                       enabled: true,
@@ -1423,6 +1447,10 @@ describe("memory-core dreaming phases", () => {
               config: {
                 dreaming: {
                   enabled: true,
+                  storage: {
+                    mode: "inline",
+                    separateReports: false,
+                  },
                   phases: {
                     light: {
                       enabled: true,

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -184,7 +184,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 30,
       verboseLogging: false,
       storage: {
-        mode: "inline",
+        mode: "separate",
         separateReports: false,
       },
     });
@@ -223,7 +223,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 30,
       verboseLogging: true,
       storage: {
-        mode: "inline",
+        mode: "separate",
         separateReports: false,
       },
     });
@@ -259,7 +259,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 45,
       verboseLogging: false,
       storage: {
-        mode: "inline",
+        mode: "separate",
         separateReports: false,
       },
     });
@@ -294,7 +294,7 @@ describe("short-term dreaming config", () => {
       maxAgeDays: 30,
       verboseLogging: false,
       storage: {
-        mode: "inline",
+        mode: "separate",
         separateReports: false,
       },
     });

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -615,7 +615,7 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
         bodyLines: reportLines,
         nowMs: sweepNowMs,
         timezone: params.config.timezone,
-        storage: params.config.storage ?? { mode: "inline", separateReports: false },
+        storage: params.config.storage ?? { mode: "separate", separateReports: false },
       });
       // Generate dream diary narrative from promoted memories.
       if (params.subagent && (candidates.length > 0 || applied.applied > 0)) {

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -12,7 +12,7 @@ import {
 export const DEFAULT_MEMORY_DREAMING_ENABLED = false;
 export const DEFAULT_MEMORY_DREAMING_TIMEZONE = undefined;
 export const DEFAULT_MEMORY_DREAMING_VERBOSE_LOGGING = false;
-export const DEFAULT_MEMORY_DREAMING_STORAGE_MODE = "inline";
+export const DEFAULT_MEMORY_DREAMING_STORAGE_MODE = "separate";
 export const DEFAULT_MEMORY_DREAMING_SEPARATE_REPORTS = false;
 export const DEFAULT_MEMORY_DREAMING_FREQUENCY = "0 3 * * *";
 export const DEFAULT_MEMORY_DREAMING_PLUGIN_ID = "memory-core";


### PR DESCRIPTION
## Summary

- Change `DEFAULT_MEMORY_DREAMING_STORAGE_MODE` from `"inline"` to `"separate"` in `src/memory-host-sdk/dreaming.ts` so Light/REM phase blocks are written to `memory/dreaming/<phase>/YYYY-MM-DD.md` instead of `memory/YYYY-MM-DD.md`.
- Update the matching fallback in `extensions/memory-core/src/dreaming.ts` when `params.config.storage` is entirely missing.

Fixes #66947.

## Why

The current default writes Light/REM dreaming output directly into the agent's daily memory file (`memory/YYYY-MM-DD.md`). The dreaming sweep runs at 3 AM, so by the time the first real heartbeat fires later that day, the daily file already exists with dreaming content. The LLM-driven heartbeat then judges "file exists, nothing new" and replies `HEARTBEAT_OK` without logging any actual session activity, producing days with zero agent-curated content despite active conversations.

The `"separate"` storage mode is already implemented — `resolveSeparateReportPath` writes Light/REM to `memory/dreaming/<phase>/YYYY-MM-DD.md`, and the Deep phase already writes only to that separate location. The codebase also already ships `stripManagedDailyDreamingLines` on the ingest side, which confirms the system already treats dreaming blocks as "not real content". This change simply stops producing that pollution in the first place for new default installs.

Existing workspaces that explicitly set `storage.mode` in their config are unaffected.

## Test plan

- [ ] `pnpm test extensions/memory-core`
- [ ] Fresh workspace without explicit `dreaming.storage.mode` — verify Light/REM output lands in `memory/dreaming/light/YYYY-MM-DD.md` and `memory/dreaming/rem/YYYY-MM-DD.md`, and that `memory/YYYY-MM-DD.md` is no longer created by the dreaming sweep alone.
- [ ] Workspace with explicit `storage.mode: "inline"` — verify inline behavior is preserved for backwards compatibility.
- [ ] Confirm heartbeat agents now see an empty/absent daily file and resume logging real session activity.

## Notes

- Historical polluted files (e.g. `memory/2026-04-14.md`) still contain inline dreaming blocks after this change and would need a separate migration or manual cleanup.
- No changelog entry added; this is a default change that could be called out in release notes at maintainer discretion.