### PR TITLE
agents/google: round-trip Gemini 3 thoughtSignature on tool calls to unblock Gemini 3.x tool-calling

### DIFF
--- a/src/agents/google-transport-stream.test.ts
+++ b/src/agents/google-transport-stream.test.ts
@@ -295,6 +295,187 @@ describe("google transport stream", () => {
     });
   });
 
+  it("captures thoughtSignature on tool-call parts from Gemini SSE responses", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          responseId: "resp_sig",
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { name: "exec", args: { cmd: "ls" } },
+                    thoughtSignature: "sig_tool_1",
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 1,
+            candidatesTokenCount: 1,
+            totalTokenCount: 2,
+          },
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({ id: "gemini-3-flash-preview" }),
+        {
+          messages: [{ role: "user", content: "hi", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        { apiKey: "k" } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        type: "toolCall",
+        name: "exec",
+        thoughtSignature: "sig_tool_1",
+      }),
+    ]);
+  });
+
+  it("re-emits thoughtSignature byte-exact on same-provider tool-call replays", () => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel({ id: "gemini-3-flash-preview" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "google",
+            api: "google-generative-ai",
+            model: "gemini-3-flash-preview",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "exec",
+                arguments: { cmd: "ls" },
+                thoughtSignature: "sig_tool_1",
+              },
+            ],
+          },
+        ],
+      } as never,
+    );
+
+    expect(params.contents[0]).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          functionCall: { name: "exec", args: { cmd: "ls" } },
+          thoughtSignature: "sig_tool_1",
+        },
+      ],
+    });
+  });
+
+  it("omits thoughtSignature on tool-call replays when absent", () => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel({ id: "gemini-3-flash-preview" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "google",
+            api: "google-generative-ai",
+            model: "gemini-3-flash-preview",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "exec",
+                arguments: { cmd: "ls" },
+              },
+            ],
+          },
+        ],
+      } as never,
+    );
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).not.toHaveProperty("thoughtSignature");
+  });
+
+  it("drops thoughtSignature on tool-call replays when switching providers", () => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel({ id: "gemini-3-flash-preview" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "openai",
+            api: "openai-responses",
+            model: "gpt-5.4",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "exec",
+                arguments: { cmd: "ls" },
+                thoughtSignature: "sig_from_other_provider",
+              },
+            ],
+          },
+        ],
+      } as never,
+    );
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).not.toHaveProperty("thoughtSignature");
+  });
+
+  it("preserves thoughtSignature only on the parts that carried one in a parallel tool-call turn", () => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel({ id: "gemini-3-flash-preview" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "google",
+            api: "google-generative-ai",
+            model: "gemini-3-flash-preview",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "exec",
+                arguments: { cmd: "ls" },
+                thoughtSignature: "sig_first_only",
+              },
+              {
+                type: "toolCall",
+                id: "call_2",
+                name: "exec",
+                arguments: { cmd: "pwd" },
+              },
+            ],
+          },
+        ],
+      } as never,
+    );
+
+    const parts = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts;
+    expect(parts[0]).toMatchObject({ thoughtSignature: "sig_first_only" });
+    expect(parts[1]).not.toHaveProperty("thoughtSignature");
+  });
+
   it("includes cachedContent in direct Gemini payloads when requested", () => {
     const params = buildGoogleGenerativeAiParams(
       buildGeminiModel(),

--- a/src/agents/google-transport-stream.ts
+++ b/src/agents/google-transport-stream.ts
@@ -63,7 +63,13 @@ type GoogleGenerateContentRequest = {
 type GoogleTransportContentBlock =
   | { type: "text"; text: string; textSignature?: string }
   | { type: "thinking"; thinking: string; thinkingSignature?: string }
-  | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> };
+  | {
+      type: "toolCall";
+      id: string;
+      name: string;
+      arguments: Record<string, unknown>;
+      thoughtSignature?: string;
+    };
 
 type MutableAssistantOutput = {
   role: "assistant";
@@ -705,6 +711,9 @@ export function createGoogleGenerativeAiTransportStreamFn(): StreamFn {
                   id: toolCallId,
                   name: part.functionCall.name || "",
                   arguments: part.functionCall.args ?? {},
+                  ...(typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0
+                    ? { thoughtSignature: part.thoughtSignature }
+                    : {}),
                 };
                 output.content.push(toolCall);
                 const blockIndex = output.content.length - 1;

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1783,8 +1783,13 @@ describe("openai transport stream", () => {
     });
 
     it("does not replay thought_signature across a different provider/model", () => {
+      const altProviderModel = {
+        ...geminiModel,
+        provider: "openai",
+        id: "gpt-5.4",
+      } satisfies Model<"openai-completions">;
       const params = buildOpenAICompletionsParams(
-        { ...geminiModel, provider: "openai", id: "gpt-5.4" } as Model<"openai-completions">,
+        altProviderModel,
         {
           systemPrompt: "system",
           messages: [
@@ -1876,6 +1881,57 @@ describe("openai transport stream", () => {
         }>;
       };
       expect(assistant?.tool_calls?.[0]?.function).toBeDefined();
+      expect(assistant?.tool_calls?.[0]?.extra_content).toBeUndefined();
+    });
+
+    it("does not replay thought_signature captured on a different API surface for the same provider/model", () => {
+      const params = buildOpenAICompletionsParams(
+        geminiModel,
+        {
+          systemPrompt: "system",
+          messages: [
+            {
+              role: "assistant",
+              // Same provider + model, different API surface. The signature is
+              // only valid for replay on the API that produced it.
+              api: "google-generative-ai",
+              provider: geminiModel.provider,
+              model: geminiModel.id,
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "toolUse",
+              timestamp: 1,
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call_abc",
+                  name: "exec",
+                  arguments: { cmd: "ls" },
+                  thoughtSignature: "SIG-OPAQUE-ABC==",
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_abc",
+              toolName: "exec",
+              content: [{ type: "text", text: "ok" }],
+              isError: false,
+            },
+          ],
+          tools: [],
+        } as never,
+        undefined,
+      ) as { messages: Array<Record<string, unknown>> };
+      const assistant = params.messages.find((m) => m.role === "assistant") as {
+        tool_calls?: Array<{ extra_content?: Record<string, unknown> }>;
+      };
       expect(assistant?.tool_calls?.[0]?.extra_content).toBeUndefined();
     });
   });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1633,6 +1633,253 @@ describe("openai transport stream", () => {
     expect(params).toHaveProperty("tool_choice", "required");
   });
 
+  describe("Gemini 3 thought_signature round-trip (openai-completions)", () => {
+    const geminiModel = {
+      id: "gemini-3-flash-preview",
+      name: "Gemini 3 Flash Preview",
+      api: "openai-completions",
+      provider: "google",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1000000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    function makeAssistantOutput() {
+      return {
+        role: "assistant" as const,
+        content: [],
+        api: geminiModel.api,
+        provider: geminiModel.provider,
+        model: geminiModel.id,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      };
+    }
+
+    it("captures thought_signature from streaming tool_calls into the parsed block", async () => {
+      const output = makeAssistantOutput();
+      const chunks = [
+        {
+          id: "chatcmpl-x",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: geminiModel.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_abc",
+                    type: "function",
+                    function: { name: "exec", arguments: "" },
+                    extra_content: { google: { thought_signature: "SIG-OPAQUE-ABC==" } },
+                  },
+                ],
+              },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "chatcmpl-x",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: geminiModel.id,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [{ index: 0, function: { arguments: '{"cmd":"ls"}' } }],
+              },
+              logprobs: null,
+              finish_reason: "tool_calls" as const,
+            },
+          ],
+        },
+      ] as const;
+      async function* gen() {
+        for (const c of chunks) {
+          yield c as never;
+        }
+      }
+      await __testing.processOpenAICompletionsStream(gen(), output, geminiModel, {
+        push: () => {},
+      });
+      const block = output.content[0] as Record<string, unknown>;
+      expect(block.type).toBe("toolCall");
+      expect(block.id).toBe("call_abc");
+      expect(block.thoughtSignature).toBe("SIG-OPAQUE-ABC==");
+    });
+
+    it("re-emits thought_signature on outgoing tool_calls when replaying same provider+model", () => {
+      const params = buildOpenAICompletionsParams(
+        geminiModel,
+        {
+          systemPrompt: "system",
+          messages: [
+            { role: "user", content: "hi" },
+            {
+              role: "assistant",
+              api: geminiModel.api,
+              provider: geminiModel.provider,
+              model: geminiModel.id,
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "toolUse",
+              timestamp: 1,
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call_abc",
+                  name: "exec",
+                  arguments: { cmd: "ls" },
+                  thoughtSignature: "SIG-OPAQUE-ABC==",
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_abc",
+              toolName: "exec",
+              content: [{ type: "text", text: "ok" }],
+              isError: false,
+            },
+          ],
+          tools: [],
+        } as never,
+        undefined,
+      ) as { messages: Array<Record<string, unknown>> };
+
+      const assistant = params.messages.find((m) => m.role === "assistant") as {
+        tool_calls?: Array<{
+          id?: string;
+          extra_content?: { google?: { thought_signature?: string } };
+        }>;
+      };
+      expect(assistant?.tool_calls?.[0]?.id).toBe("call_abc");
+      expect(assistant?.tool_calls?.[0]?.extra_content?.google?.thought_signature).toBe(
+        "SIG-OPAQUE-ABC==",
+      );
+    });
+
+    it("does not replay thought_signature across a different provider/model", () => {
+      const params = buildOpenAICompletionsParams(
+        { ...geminiModel, provider: "openai", id: "gpt-5.4" } as Model<"openai-completions">,
+        {
+          systemPrompt: "system",
+          messages: [
+            {
+              role: "assistant",
+              api: geminiModel.api,
+              provider: geminiModel.provider,
+              model: geminiModel.id,
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "toolUse",
+              timestamp: 1,
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call_abc",
+                  name: "exec",
+                  arguments: { cmd: "ls" },
+                  thoughtSignature: "SIG-OPAQUE-ABC==",
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_abc",
+              toolName: "exec",
+              content: [{ type: "text", text: "ok" }],
+              isError: false,
+            },
+          ],
+          tools: [],
+        } as never,
+        undefined,
+      ) as { messages: Array<Record<string, unknown>> };
+
+      const assistant = params.messages.find((m) => m.role === "assistant") as {
+        tool_calls?: Array<{ extra_content?: { google?: { thought_signature?: string } } }>;
+      };
+      expect(assistant?.tool_calls?.[0]?.extra_content?.google?.thought_signature).toBeUndefined();
+    });
+
+    it("emits no thought_signature when none was captured", () => {
+      const params = buildOpenAICompletionsParams(
+        geminiModel,
+        {
+          systemPrompt: "system",
+          messages: [
+            {
+              role: "assistant",
+              api: geminiModel.api,
+              provider: geminiModel.provider,
+              model: geminiModel.id,
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "toolUse",
+              timestamp: 1,
+              content: [
+                { type: "toolCall", id: "call_xyz", name: "exec", arguments: { cmd: "ls" } },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_xyz",
+              toolName: "exec",
+              content: [{ type: "text", text: "ok" }],
+              isError: false,
+            },
+          ],
+          tools: [],
+        } as never,
+        undefined,
+      ) as { messages: Array<Record<string, unknown>> };
+      const assistant = params.messages.find((m) => m.role === "assistant") as {
+        tool_calls?: Array<{
+          function?: Record<string, unknown>;
+          extra_content?: Record<string, unknown>;
+        }>;
+      };
+      expect(assistant?.tool_calls?.[0]?.function).toBeDefined();
+      expect(assistant?.tool_calls?.[0]?.extra_content).toBeUndefined();
+    });
+  });
+
   it("resets stopReason to stop when finish_reason is tool_calls but tool_calls array is empty", async () => {
     const model = {
       id: "nemotron-3-super",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1359,8 +1359,13 @@ function injectToolCallThoughtSignatures(
     if ((msg as { role?: string }).role !== "assistant") {
       continue;
     }
-    const m = msg as { provider?: string; model?: string; content?: unknown };
-    if (m.provider !== model.provider || m.model !== model.id) {
+    const m = msg as { api?: string; provider?: string; model?: string; content?: unknown };
+    // Scope replay to the same API surface as well as provider+model: the signature
+    // is opaque to openclaw and only valid for replay on the route that produced it.
+    // Mixing `google-generative-ai` and `openai-completions` turns for the same
+    // Gemini model would otherwise cross API boundaries and reintroduce the same
+    // class of 400 this path is trying to prevent.
+    if (m.api !== model.api || m.provider !== model.provider || m.model !== model.id) {
       continue;
     }
     if (!Array.isArray(m.content)) {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1051,6 +1051,7 @@ async function processOpenAICompletionsStream(
         name: string;
         arguments: Record<string, unknown>;
         partialArgs: string;
+        thoughtSignature?: string;
       }
     | null = null;
   const blockIndex = () => output.content.length - 1;
@@ -1135,12 +1136,16 @@ async function processOpenAICompletionsStream(
           (toolCall.id && currentBlock.id !== toolCall.id)
         ) {
           finishCurrentBlock();
+          const initialSig = extractGoogleThoughtSignature(toolCall);
           currentBlock = {
             type: "toolCall",
             id: toolCall.id || "",
             name: toolCall.function?.name || "",
             arguments: {},
             partialArgs: "",
+            ...(typeof initialSig === "string" && initialSig.length > 0
+              ? { thoughtSignature: initialSig }
+              : {}),
           };
           output.content.push(currentBlock);
           stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
@@ -1153,6 +1158,10 @@ async function processOpenAICompletionsStream(
         }
         if (toolCall.function?.name) {
           currentBlock.name = toolCall.function.name;
+        }
+        const deltaSig = extractGoogleThoughtSignature(toolCall);
+        if (typeof deltaSig === "string" && deltaSig.length > 0) {
+          currentBlock.thoughtSignature = deltaSig;
         }
         if (toolCall.function?.arguments) {
           currentBlock.partialArgs += toolCall.function.arguments;
@@ -1317,6 +1326,91 @@ function convertTools(
   }));
 }
 
+function extractGoogleThoughtSignature(toolCall: unknown): string | undefined {
+  const tc = toolCall as Record<string, unknown> | undefined;
+  if (!tc) {
+    return undefined;
+  }
+  // Google's OpenAI-compat endpoint emits the signature on each tool_call as
+  // tool_calls[].extra_content.google.thought_signature. Some other providers
+  // place it directly on the function object; accept both for robustness.
+  const extra = (tc.extra_content as Record<string, unknown> | undefined)?.google as
+    | Record<string, unknown>
+    | undefined;
+  const fromExtra = extra?.thought_signature;
+  if (typeof fromExtra === "string" && fromExtra.length > 0) {
+    return fromExtra;
+  }
+  const fromFunction = (tc.function as { thought_signature?: unknown } | undefined)
+    ?.thought_signature;
+  if (typeof fromFunction === "string" && fromFunction.length > 0) {
+    return fromFunction;
+  }
+  return undefined;
+}
+
+function injectToolCallThoughtSignatures(
+  outgoing: unknown[],
+  context: Context,
+  model: OpenAIModeModel,
+): void {
+  const sigById = new Map<string, string>();
+  for (const msg of context.messages ?? []) {
+    if ((msg as { role?: string }).role !== "assistant") {
+      continue;
+    }
+    const m = msg as { provider?: string; model?: string; content?: unknown };
+    if (m.provider !== model.provider || m.model !== model.id) {
+      continue;
+    }
+    if (!Array.isArray(m.content)) {
+      continue;
+    }
+    for (const block of m.content as Array<Record<string, unknown>>) {
+      if (block?.type !== "toolCall") {
+        continue;
+      }
+      const id = block.id;
+      const sig = block.thoughtSignature;
+      if (typeof id === "string" && typeof sig === "string" && sig.length > 0) {
+        sigById.set(id, sig);
+      }
+    }
+  }
+  if (sigById.size === 0) {
+    return;
+  }
+  for (const out of outgoing) {
+    const o = out as { tool_calls?: Array<Record<string, unknown>> };
+    if (!Array.isArray(o.tool_calls)) {
+      continue;
+    }
+    for (const tc of o.tool_calls) {
+      const id = (tc as { id?: unknown }).id;
+      if (typeof id !== "string") {
+        continue;
+      }
+      const sig = sigById.get(id);
+      if (!sig) {
+        continue;
+      }
+      // Google OAI-compat expects the signature at
+      // tool_calls[].extra_content.google.thought_signature on the next request.
+      let extra = tc.extra_content as Record<string, unknown> | undefined;
+      if (!extra || typeof extra !== "object") {
+        extra = {};
+        tc.extra_content = extra;
+      }
+      let google = extra.google as Record<string, unknown> | undefined;
+      if (!google || typeof google !== "object") {
+        google = {};
+        extra.google = google;
+      }
+      google.thought_signature = sig;
+    }
+  }
+}
+
 export function buildOpenAICompletionsParams(
   model: OpenAIModeModel,
   context: Context,
@@ -1330,6 +1424,7 @@ export function buildOpenAICompletionsParams(
       }
     : context;
   const messages = convertMessages(model as never, completionsContext, compat as never);
+  injectToolCallThoughtSignatures(messages as unknown[], context, model);
   const params: Record<string, unknown> = {
     model: model.id,
     messages: compat.requiresStringContent


### PR DESCRIPTION
## Summary

**Impact: enables Gemini 3.x for openclaw tool-calling.** Without this, any tool-calling turn on `gemini-3-flash-preview` (or Gemini 3.1 Pro Preview) softlocks on turn two — the model emits a tool call, openclaw executes it, and the follow-up request 400s because the signature was dropped in transit. The fix covers both transports openclaw can reach Gemini through: the native `google-generative-ai` API and the `openai-completions` compat path.

- **Problem (native Google transport):** `src/agents/google-transport-stream.ts` parses `thoughtSignature` off thinking/text parts but not off tool-call parts. Google rejects any subsequent request whose `functionCall` parts are missing the signature that was attached on the way in: `Function call is missing a thought_signature in functionCall parts. ... function call <namespace>:<tool>, position N`.
- **Problem (OpenAI-compat path):** Google's OpenAI-compat endpoint emits the signature on each tool_call as `tool_calls[].extra_content.google.thought_signature`. openclaw's `src/agents/openai-transport-stream.ts` neither captured the field on the way in nor re-emitted it on the next request, so compat-path tool-calling turns against Gemini 3 fail with the same 400.
- **Why it matters:** Gemini 3 is unusable for tool calling through openclaw today on either transport. Agents show typing indicators and never reply. This blocks any MCP integration or tool-catalog plugin that guarantees a tool-call turn.
- **What changed — native transport:** Capture `part.thoughtSignature` at the tool-call construction site in the SSE parser and plumb it through `GoogleTransportContentBlock.toolCall` so the existing serializer (which already re-emits signatures byte-exact on same-provider-and-model replay) has data to emit.
- **What changed — OpenAI-compat transport:** Add `extractGoogleThoughtSignature` to read `tool_calls[].extra_content.google.thought_signature` (with a `function.thought_signature` fallback) in the streaming parser, stash it on the assistant tool-call block, and add `injectToolCallThoughtSignatures` to re-emit it on outgoing `tool_calls[]` during same-provider replay.
- **Cross-provider safety:** Cross-model replay still strips `thoughtSignature` via the existing `transport-message-transform.ts` logic (unchanged and verified). Tests lock that in on both transports.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations
- [x] API / contracts

## Linked Issue/PR

- Closes #63397 (Vertex AI Gemini — native path, exact match)
- Closes #53658 (Google OpenAI-compat fallback — parallel bug on the compat path, now fixed here)
- Closes #58235 (Gemini 3.1 Pro Preview via OpenAI-compat API — same, compat path)
- Related #34008 (Gemini 3 via Ollama Cloud — same missing-signature symptom, different transport)
- Context #5001, #841 (prior thought-signature-related reports)
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause (native):** Parser/serializer asymmetry. The serializer at `src/agents/google-transport-stream.ts:355` already emits `thoughtSignature` when present on a tool-call block under same-provider-and-model replay. The parser at `src/agents/google-transport-stream.ts:709` constructed the tool-call block *without* reading `part.thoughtSignature`, so the field was never set and the serializer had nothing to emit. The SSE chunk type already declared the field as a sibling to `functionCall`, so the wire model was correct — only the in-memory content block lost it.
- **Root cause (compat):** The OpenAI-completions transport had no awareness of `thought_signature` at all. Google's compat endpoint nests it under `extra_content.google` on each `tool_call`, which never appeared on the parsed block and was never put back on the outgoing request.
- **Missing detection / guardrail:** No regression test exercised round-tripping a `thoughtSignature` on a tool-call part on either transport. Thinking-block signatures were covered on the native side; tool-call signatures were not.
- **Contributing context (if known):** Gemini 3 was the first generation where the signature became mandatory on tool-call replay. Gemini 2.5 and earlier tolerated missing signatures, so the gap hid until Gemini 3 preview models started rejecting those requests.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target tests: `src/agents/google-transport-stream.test.ts`, `src/agents/openai-transport-stream.test.ts`
- Scenario locked in: byte-exact `thoughtSignature` round-trip on tool-call parts across same-provider replay; stripped on cross-provider replay; parallel-call first-only preservation; absence stays absent — on both transports.
- Why this is the smallest reliable guardrail: the bug is a one-field data-flow failure between parser and serializer. Provider-level unit tests are the tightest surface that reproduces it without needing a live model.

Tests added in this PR:
1. [native] Parser captures `thoughtSignature` on tool-call SSE parts
2. [native] Serializer emits it byte-exact on same-provider replay
3. [native] Serializer omits the field when the tool call carried no signature
4. [native] Serializer strips the field when replaying across providers
5. [native] Parallel tool calls: signature preserved only on the parts that had one
6. [compat] Parser captures `tool_calls[].extra_content.google.thought_signature` into the assistant block
7. [compat] Outgoing request re-emits the signature on same provider+model replay
8. [compat] Outgoing request does not replay the signature across a different provider/model

## User-visible / Behavior Changes

None on the happy path for non-Gemini-3 users — the field is absent end-to-end for models that don't emit it, and same-provider replay for Gemini 2.5 and below is byte-identical on both transports. Gemini 3.x users gain working tool-calling on both native Google and OpenAI-compat routes.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same endpoints; adds one optional field to the request body that Google itself produced on the prior response)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux x86_64, Node 22.22.1
- Models: `gemini-3-flash-preview` via `google-generative-ai` native transport and via Google's `openai-completions` compat endpoint
- Integration/channel: any MCP server whose tool catalog guarantees a tool-call turn

### Steps

1. Configure an openclaw-driven agent on `gemini-3-flash-preview` with at least one tool plugin or MCP server.
2. Send a query that routes through a tool.
3. Observe the gateway emit two inference POSTs and zero outbound reply to the calling channel.

### Expected

- Agent replies. The second POST returns 200 on every turn of a multi-turn tool-calling conversation, on both transports.

### Actual (before fix)

- Turn one succeeds (initial tool call). Turn two 400s with `Function call is missing a thought_signature in functionCall parts. Please remove the thought signature from the previous Part.part at content[...] ... function call <namespace>:<tool>, position N`. The agent never posts a reply.

### Actual (after fix)

- Both turns 200 on both transports. Agent replies. Fetch-level 4xx/5xx capture stays empty across a multi-turn tool exchange.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Captured 400 response body before the fix (via a fetch-level preload):

```
Function call is missing a thought_signature in functionCall parts.
Please remove the thought signature from the previous Part.part at content[...].parts
function call <namespace>:<tool>, position 44
```

End-to-end verified against a multi-tool-call conversation on `gemini-3-flash-preview`: every turn returned 200 on both transports, the fetch-level error log stayed empty, and the agent completed the exchange normally.
