### PR TITLE
fix: guard against undefined docsPath in formatDocsLink and formatChannelSelectionLine

### DIFF
--- a/src/channels/registry.helpers.test.ts
+++ b/src/channels/registry.helpers.test.ts
@@ -40,6 +40,17 @@ describe("channel registry helpers", () => {
     expect(line).toContain("https://openclaw.ai");
   });
 
+  it("falls back to /channels/{id} when meta.docsPath is missing", () => {
+    const partialMeta = {
+      id: "test-channel" as never,
+      label: "Test Channel",
+      blurb: "A test channel",
+      // docsPath intentionally omitted
+    };
+    const line = formatChannelSelectionLine(partialMeta, (path) => path);
+    expect(line).toContain("/channels/test-channel");
+  });
+
   it("prefers the pinned channel registry when resolving registered plugin channels", () => {
     const startupRegistry = createEmptyPluginRegistry();
     startupRegistry.channels = [

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -103,10 +103,11 @@ export function formatChannelSelectionLine(
   docsLink: (path: string, label?: string) => string,
 ): string {
   const docsPrefix = meta.selectionDocsPrefix ?? "Docs:";
+  const docsPath = meta.docsPath ?? `/channels/${meta.id}`;
   const docsLabel = meta.docsLabel ?? meta.id;
   const docs = meta.selectionDocsOmitLabel
-    ? docsLink(meta.docsPath)
-    : docsLink(meta.docsPath, docsLabel);
+    ? docsLink(docsPath)
+    : docsLink(docsPath, docsLabel);
   const extras = (meta.selectionExtras ?? []).filter(Boolean).join(" ");
   return `${meta.label} — ${meta.blurb} ${docsPrefix ? `${docsPrefix} ` : ""}${docs}${extras ? ` ${extras}` : ""}`;
 }

--- a/src/terminal/links.ts
+++ b/src/terminal/links.ts
@@ -5,11 +5,19 @@ function resolveDocsRoot(): string {
 }
 
 export function formatDocsLink(
-  path: string,
+  path: string | undefined,
   label?: string,
   opts?: { fallback?: string; force?: boolean },
 ): string {
+  if (!path) {
+    const root = resolveDocsRoot();
+    return opts?.fallback ?? root;
+  }
   const trimmed = path.trim();
+  if (!trimmed) {
+    const root = resolveDocsRoot();
+    return opts?.fallback ?? root;
+  }
   const docsRoot = resolveDocsRoot();
   const url = trimmed.startsWith("http")
     ? trimmed


### PR DESCRIPTION
## Summary
Fixes TypeError: Cannot read properties of undefined (reading 'trim') crash during `openclaw onboard` channel setup.

## Root Cause
Two issues combine to cause the crash:
1. `formatDocsLink(path)` in `src/terminal/links.ts` calls `path.trim()` without checking if `path` is undefined.
2. `formatChannelSelectionLine()` in `src/channels/registry.ts` passes `meta.docsPath` to the docsLink callback without a fallback, and some channel metadata entries may have missing `docsPath`.

## Fix
1. Added null/undefined guard in `formatDocsLink` — returns docs root URL (or opts.fallback) when path is empty/undefined.
2. Added default docsPath fallback (`/channels/${id}`) in `formatChannelSelectionLine` when `meta.docsPath` is missing.
3. Added regression test for missing docsPath case.

## Test Plan
- [ ] Added regression test `falls back to /channels/{id} when meta.docsPath is missing`
- [ ] Manual verification: `openclaw onboard` should no longer crash during channel selection

Closes openclaw#66945
Closes openclaw#66942