### PR TITLE
feat: add SenseAudio music generation provider

### DIFF
--- a/extensions/music-generation-providers.live.test.ts
+++ b/extensions/music-generation-providers.live.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../test/helpers/plugins/provider-registration.js";
 import googlePlugin from "./google/index.js";
 import minimaxPlugin from "./minimax/index.js";
+import senseaudioPlugin from "./senseaudio/index.js";
 
 const LIVE = isLiveTestEnabled();
 const REQUIRE_PROFILE_KEYS =
@@ -49,6 +50,12 @@ const CASES: LiveProviderCase[] = [
     pluginId: "minimax",
     pluginName: "MiniMax Provider",
     providerId: "minimax",
+  },
+  {
+    plugin: senseaudioPlugin,
+    pluginId: "senseaudio",
+    pluginName: "SenseAudio Provider",
+    providerId: "senseaudio",
   },
 ]
   .filter((entry) => (providerFilter ? providerFilter.has(entry.providerId) : true))

--- a/extensions/senseaudio/index.ts
+++ b/extensions/senseaudio/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { buildSenseaudioMusicGenerationProvider } from "./music-generation-provider.js";
+
+export default definePluginEntry({
+  id: "senseaudio",
+  name: "SenseAudio",
+  description: "Bundled SenseAudio music generation provider",
+  register(api) {
+    api.registerMusicGenerationProvider(buildSenseaudioMusicGenerationProvider());
+  },
+});

--- a/extensions/senseaudio/music-generation-provider.ts
+++ b/extensions/senseaudio/music-generation-provider.ts
@@ -1,0 +1,302 @@
+import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
+import type {
+  GeneratedMusicAsset,
+  MusicGenerationProvider,
+  MusicGenerationRequest,
+} from "openclaw/plugin-sdk/music-generation";
+import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  assertOkOrThrowHttpError,
+  fetchWithTimeout,
+  postJsonRequest,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+
+const DEFAULT_SENSEAUDIO_BASE_URL = "https://api.senseaudio.cn";
+const DEFAULT_SENSEAUDIO_MUSIC_MODEL = "senseaudio-music-1.0-260319";
+// SenseAudio generation typically takes 1–5 min; cap at 30 min like the hermes agent.
+const DEFAULT_TIMEOUT_MS = 1_800_000;
+const POLL_INTERVAL_MS = 5_000;
+const API_CALL_TIMEOUT_MS = 30_000;
+const DOWNLOAD_TIMEOUT_MS = 60_000;
+
+type SenseaudioLyricsCreateResponse = {
+  data?: Array<{
+    text?: string;
+    title?: string;
+  }>;
+};
+
+type SenseaudioSongCreateResponse = {
+  task_id?: string;
+};
+
+type SenseaudioSongPendingItem = {
+  audio_url?: string;
+  cover_url?: string;
+  duration?: number;
+  title?: string;
+  lyrics?: string;
+};
+
+type SenseaudioSongPendingResponse = {
+  status?: string;
+  response?: {
+    data?: SenseaudioSongPendingItem[];
+  };
+};
+
+function resolveSenseaudioBaseUrl(
+  cfg: Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
+): string {
+  const direct = normalizeOptionalString(cfg?.models?.providers?.senseaudio?.baseUrl);
+  if (!direct) {
+    return DEFAULT_SENSEAUDIO_BASE_URL;
+  }
+  try {
+    return new URL(direct).origin;
+  } catch {
+    return DEFAULT_SENSEAUDIO_BASE_URL;
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function downloadTrack(params: {
+  url: string;
+  index: number;
+  title?: string;
+  timeoutMs: number;
+  fetchFn: typeof fetch;
+}): Promise<GeneratedMusicAsset> {
+  const response = await fetchWithTimeout(
+    params.url,
+    { method: "GET" },
+    Math.min(DOWNLOAD_TIMEOUT_MS, params.timeoutMs),
+    params.fetchFn,
+  );
+  await assertOkOrThrowHttpError(response, "SenseAudio audio download failed");
+  const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "audio/mpeg";
+  const ext = extensionForMime(mimeType)?.replace(/^\./u, "") || "mp3";
+  const baseName = params.title
+    ? params.title.replace(/[^\w.-]/gu, "-").slice(0, 60)
+    : `track-${params.index + 1}`;
+  return {
+    buffer: Buffer.from(await response.arrayBuffer()),
+    mimeType,
+    fileName: `${baseName}.${ext}`,
+  };
+}
+
+export function buildSenseaudioMusicGenerationProvider(): MusicGenerationProvider {
+  return {
+    id: "senseaudio",
+    label: "SenseAudio",
+    defaultModel: DEFAULT_SENSEAUDIO_MUSIC_MODEL,
+    models: [DEFAULT_SENSEAUDIO_MUSIC_MODEL],
+    isConfigured: ({ agentDir }) =>
+      isProviderApiKeyConfigured({
+        provider: "senseaudio",
+        agentDir,
+      }),
+    capabilities: {
+      generate: {
+        maxTracks: 1,
+        supportsLyrics: true,
+        supportsInstrumental: true,
+        // SenseAudio does not expose duration or format controls.
+        supportsDuration: false,
+        supportsFormat: false,
+        supportedFormats: ["mp3"],
+      },
+      edit: {
+        enabled: false,
+      },
+    },
+    async generateMusic(req: MusicGenerationRequest) {
+      if ((req.inputImages?.length ?? 0) > 0) {
+        throw new Error("SenseAudio music generation does not support image reference inputs.");
+      }
+
+      const auth = await resolveApiKeyForProvider({
+        provider: "senseaudio",
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        store: req.authStore,
+      });
+      if (!auth.apiKey) {
+        throw new Error("SenseAudio API key missing");
+      }
+
+      const fetchFn = fetch;
+      const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
+        resolveProviderHttpRequestConfig({
+          baseUrl: resolveSenseaudioBaseUrl(req.cfg),
+          defaultBaseUrl: DEFAULT_SENSEAUDIO_BASE_URL,
+          allowPrivateNetwork: false,
+          defaultHeaders: {
+            Authorization: `Bearer ${auth.apiKey}`,
+          },
+        });
+      const jsonHeaders = new Headers(headers);
+      jsonHeaders.set("Content-Type", "application/json");
+
+      const model = normalizeOptionalString(req.model) || DEFAULT_SENSEAUDIO_MUSIC_MODEL;
+      const timeoutMs = req.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+      // Step 1: Generate structured lyrics from prompt when no lyrics are provided.
+      // This applies to both vocal and instrumental tracks: for instrumental,
+      // the lyrics structure guides musical composition (timing, energy) while
+      // instrumental=true suppresses vocals. Passing a raw prompt with
+      // custom_mode=true causes a 400 "无效的歌词格式" from the SenseAudio API.
+      let resolvedLyrics = normalizeOptionalString(req.lyrics);
+      let resolvedTitle: string | undefined;
+
+      if (!resolvedLyrics) {
+        const { response: lyricsRes, release: lyricsRelease } = await postJsonRequest({
+          url: `${baseUrl}/v1/music/lyrics/create`,
+          headers: jsonHeaders,
+          body: { prompt: req.prompt, provider: model },
+          timeoutMs: API_CALL_TIMEOUT_MS,
+          fetchFn,
+          pinDns: false,
+          allowPrivateNetwork,
+          dispatcherPolicy,
+        });
+        try {
+          await assertOkOrThrowHttpError(lyricsRes, "SenseAudio lyrics generation failed");
+          const lyricsPayload = (await lyricsRes.json()) as SenseaudioLyricsCreateResponse;
+          const first = lyricsPayload.data?.[0];
+          const text = normalizeOptionalString(first?.text);
+          if (!text) {
+            throw new Error(
+              `SenseAudio lyrics generation returned no text: ${JSON.stringify(lyricsPayload)}`,
+            );
+          }
+          resolvedLyrics = text;
+          resolvedTitle = normalizeOptionalString(first?.title) || undefined;
+        } finally {
+          await lyricsRelease();
+        }
+      }
+
+      // Step 2: Submit the song creation task.
+      // custom_mode=true: the API treats the lyrics field as a free-form prompt.
+      // custom_mode=false: the API treats it as structured lyrics with section tags.
+      const customMode = !resolvedLyrics;
+      const songBody: Record<string, unknown> = {
+        model,
+        lyrics: resolvedLyrics ?? req.prompt,
+        custom_mode: customMode,
+        instrumental: req.instrumental === true,
+      };
+      if (resolvedTitle) {
+        songBody["title"] = resolvedTitle;
+      }
+
+      const { response: songRes, release: songRelease } = await postJsonRequest({
+        url: `${baseUrl}/v1/music/song/create`,
+        headers: jsonHeaders,
+        body: songBody,
+        timeoutMs: API_CALL_TIMEOUT_MS,
+        fetchFn,
+        pinDns: false,
+        allowPrivateNetwork,
+        dispatcherPolicy,
+      });
+      let taskId: string;
+      try {
+        await assertOkOrThrowHttpError(songRes, "SenseAudio song creation failed");
+        const songPayload = (await songRes.json()) as SenseaudioSongCreateResponse;
+        const id = normalizeOptionalString(songPayload.task_id);
+        if (!id) {
+          throw new Error(
+            `SenseAudio song creation returned no task_id: ${JSON.stringify(songPayload)}`,
+          );
+        }
+        taskId = id;
+      } finally {
+        await songRelease();
+      }
+
+      // Step 3: Poll until the task reaches SUCCESS or FAILED.
+      const deadline = Date.now() + timeoutMs;
+      let pendingData: SenseaudioSongPendingResponse | null = null;
+      while (Date.now() < deadline) {
+        const remaining = deadline - Date.now();
+        const pollRes = await fetchWithTimeout(
+          `${baseUrl}/v1/music/song/pending/${taskId}`,
+          { method: "GET", headers },
+          Math.min(API_CALL_TIMEOUT_MS, remaining),
+          fetchFn,
+        );
+        await assertOkOrThrowHttpError(pollRes, "SenseAudio task status check failed");
+        const data = (await pollRes.json()) as SenseaudioSongPendingResponse;
+        const status = normalizeOptionalString(data.status);
+        if (status === "SUCCESS") {
+          pendingData = data;
+          break;
+        }
+        if (status === "FAILED") {
+          throw new Error(`SenseAudio task ${taskId} failed`);
+        }
+        if (Date.now() + POLL_INTERVAL_MS >= deadline) {
+          break;
+        }
+        await sleep(POLL_INTERVAL_MS);
+      }
+
+      if (!pendingData) {
+        throw new Error(`SenseAudio task ${taskId} did not complete within ${timeoutMs}ms`);
+      }
+
+      // Step 4: Download the generated audio tracks.
+      const items = pendingData.response?.data ?? [];
+      if (items.length === 0) {
+        throw new Error("SenseAudio music generation response missing audio data");
+      }
+
+      const tracks: GeneratedMusicAsset[] = [];
+      const lyricsOut: string[] = [];
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        const audioUrl = normalizeOptionalString(item?.audio_url);
+        if (!audioUrl) {
+          continue;
+        }
+        tracks.push(
+          await downloadTrack({
+            url: audioUrl,
+            index: i,
+            title: normalizeOptionalString(item?.title) || undefined,
+            timeoutMs: Math.max(0, deadline - Date.now()),
+            fetchFn,
+          }),
+        );
+        const lyrics = normalizeOptionalString(item?.lyrics);
+        if (lyrics) {
+          lyricsOut.push(lyrics);
+        }
+      }
+
+      if (tracks.length === 0) {
+        throw new Error("SenseAudio music generation produced no downloadable tracks");
+      }
+
+      return {
+        tracks,
+        ...(lyricsOut.length > 0 ? { lyrics: lyricsOut } : {}),
+        model,
+        metadata: {
+          taskId,
+          instrumental: req.instrumental === true,
+          ...(resolvedLyrics ? { requestedLyrics: true } : {}),
+        },
+      };
+    },
+  };
+}

--- a/extensions/senseaudio/music-generation-provider.ts
+++ b/extensions/senseaudio/music-generation-provider.ts
@@ -185,13 +185,13 @@ export function buildSenseaudioMusicGenerationProvider(): MusicGenerationProvide
       }
 
       // Step 2: Submit the song creation task.
-      // custom_mode=true: the API treats the lyrics field as a free-form prompt.
-      // custom_mode=false: the API treats it as structured lyrics with section tags.
-      const customMode = !resolvedLyrics;
+      // custom_mode=false: the API expects structured lyrics with section tags.
+      // Unstructured prompts with custom_mode=true cause a 400 "无效的歌词格式";
+      // resolvedLyrics is always set at this point (generated above if not user-supplied).
       const songBody: Record<string, unknown> = {
         model,
-        lyrics: resolvedLyrics ?? req.prompt,
-        custom_mode: customMode,
+        lyrics: resolvedLyrics,
+        custom_mode: false,
         instrumental: req.instrumental === true,
       };
       if (resolvedTitle) {

--- a/extensions/senseaudio/music-generation-provider.ts
+++ b/extensions/senseaudio/music-generation-provider.ts
@@ -147,6 +147,7 @@ export function buildSenseaudioMusicGenerationProvider(): MusicGenerationProvide
 
       const model = normalizeOptionalString(req.model) || DEFAULT_SENSEAUDIO_MUSIC_MODEL;
       const timeoutMs = req.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const deadline = Date.now() + timeoutMs;
 
       // Step 1: Generate structured lyrics from prompt when no lyrics are provided.
       // This applies to both vocal and instrumental tracks: for instrumental,
@@ -161,7 +162,7 @@ export function buildSenseaudioMusicGenerationProvider(): MusicGenerationProvide
           url: `${baseUrl}/v1/music/lyrics/create`,
           headers: jsonHeaders,
           body: { prompt: req.prompt, provider: model },
-          timeoutMs: API_CALL_TIMEOUT_MS,
+          timeoutMs: Math.min(API_CALL_TIMEOUT_MS, deadline - Date.now()),
           fetchFn,
           pinDns: false,
           allowPrivateNetwork,
@@ -202,7 +203,7 @@ export function buildSenseaudioMusicGenerationProvider(): MusicGenerationProvide
         url: `${baseUrl}/v1/music/song/create`,
         headers: jsonHeaders,
         body: songBody,
-        timeoutMs: API_CALL_TIMEOUT_MS,
+        timeoutMs: Math.min(API_CALL_TIMEOUT_MS, deadline - Date.now()),
         fetchFn,
         pinDns: false,
         allowPrivateNetwork,
@@ -224,7 +225,6 @@ export function buildSenseaudioMusicGenerationProvider(): MusicGenerationProvide
       }
 
       // Step 3: Poll until the task reaches SUCCESS or FAILED.
-      const deadline = Date.now() + timeoutMs;
       let pendingData: SenseaudioSongPendingResponse | null = null;
       while (Date.now() < deadline) {
         const remaining = deadline - Date.now();

--- a/extensions/senseaudio/openclaw.plugin.json
+++ b/extensions/senseaudio/openclaw.plugin.json
@@ -1,0 +1,15 @@
+{
+  "id": "senseaudio",
+  "enabledByDefault": true,
+  "providerAuthEnvVars": {
+    "senseaudio": ["SENSEAUDIO_API_KEY"]
+  },
+  "contracts": {
+    "musicGenerationProviders": ["senseaudio"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/senseaudio/package.json
+++ b/extensions/senseaudio/package.json
@@ -2,7 +2,7 @@
   "name": "@openclaw/senseaudio-provider",
   "version": "2026.4.14-beta.1",
   "private": true,
-  "description": "OpenClaw SenseAudio media-understanding provider",
+  "description": "OpenClaw SenseAudio music generation provider",
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/senseaudio/package.json
+++ b/extensions/senseaudio/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/senseaudio-provider",
+  "version": "2026.4.14-beta.1",
+  "private": true,
+  "description": "OpenClaw SenseAudio media-understanding provider",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1049,6 +1049,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/senseaudio:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/sglang:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/music-generation/live-test-helpers.ts
+++ b/src/music-generation/live-test-helpers.ts
@@ -12,6 +12,7 @@ export { parseProviderModelMap, redactLiveApiKey };
 export const DEFAULT_LIVE_MUSIC_MODELS: Record<string, string> = {
   google: "google/lyria-3-clip-preview",
   minimax: "minimax/music-2.5+",
+  senseaudio: "senseaudio/senseaudio-music-1.0-260319",
 };
 
 export function parseCsvFilter(raw?: string): Set<string> | null {

--- a/src/plugins/contracts/plugin-registration.senseaudio.contract.test.ts
+++ b/src/plugins/contracts/plugin-registration.senseaudio.contract.test.ts
@@ -1,0 +1,4 @@
+import { pluginRegistrationContractCases } from "../../../test/helpers/plugins/plugin-registration-contract-cases.js";
+import { describePluginRegistrationContract } from "../../../test/helpers/plugins/plugin-registration-contract.js";
+
+describePluginRegistrationContract(pluginRegistrationContractCases.senseaudio);

--- a/test/helpers/plugins/plugin-registration-contract-cases.ts
+++ b/test/helpers/plugins/plugin-registration-contract-cases.ts
@@ -118,6 +118,10 @@ export const pluginRegistrationContractCases = {
     pluginId: "perplexity",
     webSearchProviderIds: ["perplexity"],
   },
+  senseaudio: {
+    pluginId: "senseaudio",
+    musicGenerationProviderIds: ["senseaudio"],
+  },
   tavily: {
     pluginId: "tavily",
     webSearchProviderIds: ["tavily"],


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw has no built-in SenseAudio music generation provider; users with a SenseAudio API key cannot generate music through the agent.
- **Why it matters:** SenseAudio exposes an async music generation API with lyrics generation, vocal, and instrumental modes. It fits naturally into the `MusicGenerationProvider` contract.
- **What changed:** Added a new bundled `senseaudio` plugin that registers a `musicGenerationProvider`. The implementation follows SenseAudio's 3-step async workflow: (1) generate structured lyrics from a prompt via `lyrics/create`, (2) submit the song task via `song/create`, (3) poll `song/pending/:taskId` until `SUCCESS`, then download tracks.
- **What did NOT change:** No core code modified. No other providers or channels affected.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A — new feature, no regression surface.

- [x] Existing coverage already sufficient
- Target test or file: `src/plugins/contracts/plugin-registration.senseaudio.contract.test.ts`
- Scenario: plugin registration contract asserts `musicGenerationProvider` id is declared.
- If no new test is added, why not: the generation workflow is async/network-bound; covered by the live test suite (`extensions/music-generation-providers.live.test.ts`).

## User-visible / Behavior Changes

- New `senseaudio` plugin is enabled by default. If `SENSEAUDIO_API_KEY` is set, SenseAudio is available as a music generation provider.
- Supports vocal and instrumental generation. Does not support duration or format selection (mp3 only).
- No changes to existing providers or defaults.

## Diagram (if applicable)

```text
generateMusic(req)
  │
  ├─ [no user lyrics] → POST /v1/music/lyrics/create → resolvedLyrics
  │
  ├─ POST /v1/music/song/create  { lyrics, custom_mode, instrumental }
  │   └─ taskId
  │
  ├─ poll GET /v1/music/song/pending/:taskId  (every 5s, up to 30min)
  │   └─ status === "SUCCESS"
  │
  └─ download audio_url(s) → GeneratedMusicAsset[]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — outbound HTTPS to `https://api.senseaudio.cn/v1/music/*`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: API key is read from `SENSEAUDIO_API_KEY` via the standard `providerAuthEnvVars` manifest field. Key is passed only in `Authorization: Bearer` headers, never logged or persisted. Network calls go through the existing `resolveProviderHttpRequestConfig` / `fetchWithTimeout` helpers with per-call timeouts (`API_CALL_TIMEOUT_MS=30s`, `DOWNLOAD_TIMEOUT_MS=60s`).

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime/container: Node 22 / Bun
- Model/provider: senseaudio (`senseaudio-music-1.0-260319`)
- Integration/channel: OpenClaw TUI agent chat

### Steps

1. Set `SENSEAUDIO_API_KEY=<key>` in environment.
2. Run `openclaw gateway --force`.
3. Open agent chat, ask it to generate music with a prompt.
4. Observe the generated mp3 returned and saved locally.

### Expected

- A generated mp3 track is returned within ~1–3 minutes.

### Actual

- A generated mp3 track is returned and saved successfully.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets — generation completed and track downloaded via TUI
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: live generation via TUI agent chat (vocal and instrumental) with a real `SENSEAUDIO_API_KEY`; plugin contract test passes locally.
- Edge cases checked: instrumental mode always calls `lyrics/create` first — passing prompt directly with `custom_mode=true` causes a `400 无效的歌词格式` from the API; the implementation avoids this by always generating structured lyrics first.
- What I did **not** verify: behavior at exactly 30-minute timeout boundary; concurrent generation requests.

<img width="1057" height="495" alt="截屏2026-04-15 上午10 21 32" src="https://github.com/user-attachments/assets/afa83d8a-edc4-43f6-b937-b60e3ad403e2" />
<img width="1078" height="486" alt="截屏2026-04-15 上午10 21 42" src="https://github.com/user-attachments/assets/b71cd087-4503-4d71-8411-07f284baabc4" />


## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` — `SENSEAUDIO_API_KEY` is optional; plugin is a no-op when absent.
- Migration needed? `No`

## Risks and Mitigations

- Risk: SenseAudio's async generation can take several minutes; slow networks may hit download timeout.
  - Mitigation: `DOWNLOAD_TIMEOUT_MS` is set to 60s per track, separate from the overall `DEFAULT_TIMEOUT_MS` (30min). Failures are isolated to this provider.
- Risk: SenseAudio API contract changes (e.g. `lyrics/create` response shape) break generation silently.
  - Mitigation: explicit checks on `task_id`, `text`, and `audio_url` fields throw early with descriptive errors rather than returning empty results.
