### PR TITLE
fix: add required Accept header for MCP streamable-http transport

### DIFF
--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -102,7 +102,12 @@ export function resolveMcpTransport(
   if (resolved.transportType === "streamable-http") {
     return {
       transport: new StreamableHTTPClientTransport(new URL(resolved.url), {
-        requestInit: resolved.headers ? { headers: resolved.headers } : undefined,
+        requestInit: {
+          headers: {
+            Accept: "application/json, text/event-stream",
+            ...resolved.headers,
+          },
+        },
       }),
       description: resolved.description,
       transportType: "streamable-http",


### PR DESCRIPTION
## Summary
Fixes MCP streamable-http connection failures caused by missing `Accept` header.

## Root Cause
`StreamableHTTPClientTransport` was created without the required `Accept` header. Per the MCP Streamable HTTP spec, servers require `Accept: application/json, text/event-stream` on all requests.

## Fix
Added `Accept: "application/json, text/event-stream"` as a default header in `src/agents/mcp-transport.ts`, with user-provided headers spread after to allow overrides.

## Test Plan
- [ ] Configure a streamable-http MCP server (e.g., Zhipu BigModel) and verify tools load correctly
- [ ] Existing MCP tests should pass

Closes openclaw#66940