### PR TITLE
fix(mcp): add required Accept header for streamable-http transport

### DIFF
--- a/src/agents/mcp-transport.test.ts
+++ b/src/agents/mcp-transport.test.ts
@@ -17,6 +17,8 @@ vi.mock("../logger.js", () => ({ logDebug: vi.fn() }));
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
 
+const MockTransport = StreamableHTTPClientTransport as ReturnType<typeof vi.fn>;
+
 describe("resolveMcpTransport — streamable-http Accept header", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -28,8 +30,8 @@ describe("resolveMcpTransport — streamable-http Accept header", () => {
       transport: "streamable-http",
     });
 
-    expect(StreamableHTTPClientTransport).toHaveBeenCalledOnce();
-    const [, options] = (StreamableHTTPClientTransport as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(MockTransport).toHaveBeenCalledOnce();
+    const [, options] = MockTransport.mock.calls[0];
     expect(options.requestInit.headers).toMatchObject({
       Accept: "application/json, text/event-stream",
     });
@@ -42,7 +44,7 @@ describe("resolveMcpTransport — streamable-http Accept header", () => {
       headers: { Authorization: "Bearer token" },
     });
 
-    const [, options] = (StreamableHTTPClientTransport as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, options] = MockTransport.mock.calls[0];
     expect(options.requestInit.headers).toMatchObject({
       Authorization: "Bearer token",
       Accept: "application/json, text/event-stream",
@@ -56,7 +58,7 @@ describe("resolveMcpTransport — streamable-http Accept header", () => {
       headers: { Accept: "application/json" },
     });
 
-    const [, options] = (StreamableHTTPClientTransport as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, options] = MockTransport.mock.calls[0];
     expect(options.requestInit.headers["Accept"]).toBe("application/json");
   });
 
@@ -67,8 +69,18 @@ describe("resolveMcpTransport — streamable-http Accept header", () => {
       headers: { accept: "application/json" },
     });
 
-    const [, options] = (StreamableHTTPClientTransport as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, options] = MockTransport.mock.calls[0];
     expect(options.requestInit.headers["accept"]).toBe("application/json");
     expect(options.requestInit.headers["Accept"]).toBeUndefined();
+  });
+
+  it("does not inject Accept header into SSE transport", () => {
+    resolveMcpTransport("probe", {
+      url: "https://mcp.example.com/sse",
+      // no transport field → resolves as SSE, not streamable-http
+    });
+
+    // StreamableHTTPClientTransport must NOT have been called
+    expect(MockTransport).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/mcp-transport.test.ts
+++ b/src/agents/mcp-transport.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: vi.fn(),
+}));
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn(),
+}));
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: vi.fn(),
+}));
+vi.mock("../infra/net/undici-runtime.js", () => ({
+  loadUndiciRuntimeDeps: vi.fn(() => ({ fetch: vi.fn() })),
+}));
+vi.mock("../logger.js", () => ({ logDebug: vi.fn() }));
+
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { resolveMcpTransport } from "./mcp-transport.js";
+
+describe("resolveMcpTransport — streamable-http Accept header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds Accept header when no user headers provided", () => {
+    resolveMcpTransport("probe", {
+      url: "https://mcp.example.com/http",
+      transport: "streamable-http",
+    });
+
+    expect(StreamableHTTPClientTransport).toHaveBeenCalledOnce();
+    const [, options] = (StreamableHTTPClientTransport as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.requestInit.headers).toMatchObject({
+      Accept: "application/json, text/event-stream",
+    });
+  });
+
+  it("adds Accept header when user headers present but no Accept set", () => {
+    resolveMcpTransport("probe", {
+      url: "https://mcp.example.com/http",
+      transport: "streamable-http",
+      headers: { Authorization: "Bearer token" },
+    });
+
+    const [, options] = (StreamableHTTPClientTransport as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.requestInit.headers).toMatchObject({
+      Authorization: "Bearer token",
+      Accept: "application/json, text/event-stream",
+    });
+  });
+
+  it("does not override Accept header when user already set it", () => {
+    resolveMcpTransport("probe", {
+      url: "https://mcp.example.com/http",
+      transport: "streamable-http",
+      headers: { Accept: "application/json" },
+    });
+
+    const [, options] = (StreamableHTTPClientTransport as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.requestInit.headers["Accept"]).toBe("application/json");
+  });
+
+  it("does not override Accept header when user set lowercase accept", () => {
+    resolveMcpTransport("probe", {
+      url: "https://mcp.example.com/http",
+      transport: "streamable-http",
+      headers: { accept: "application/json" },
+    });
+
+    const [, options] = (StreamableHTTPClientTransport as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.requestInit.headers["accept"]).toBe("application/json");
+    expect(options.requestInit.headers["Accept"]).toBeUndefined();
+  });
+});

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -100,9 +100,16 @@ export function resolveMcpTransport(
     };
   }
   if (resolved.transportType === "streamable-http") {
+    const streamableHeaders: Record<string, string> = { ...resolved.headers };
+    const hasAccept = Object.keys(streamableHeaders).some(
+      (k) => k.toLowerCase() === "accept",
+    );
+    if (!hasAccept) {
+      streamableHeaders["Accept"] = "application/json, text/event-stream";
+    }
     return {
       transport: new StreamableHTTPClientTransport(new URL(resolved.url), {
-        requestInit: resolved.headers ? { headers: resolved.headers } : undefined,
+        requestInit: { headers: streamableHeaders },
       }),
       description: resolved.description,
       transportType: "streamable-http",


### PR DESCRIPTION
## Summary

- **Problem:** MCP servers configured with `type: "streamable-http"` fail to connect because OpenClaw never sends the required `Accept` header — servers that enforce the MCP spec reject the request before any tools load
- **Why it matters:** Any streamable-http MCP server that validates headers (e.g. Zhipu BigModel's `web_search_prime`) is completely unusable; tools never appear
- **What changed:** `mcp-transport.ts` now injects `Accept: application/json, text/event-stream` into every streamable-http request unless the user has already set an `Accept` header (any casing)
- **What did NOT change:** SSE transport, stdio transport, user-supplied headers (all preserved)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66940
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `StreamableHTTPClientTransport` was constructed in `resolveMcpTransport()` with `requestInit: resolved.headers ? { headers: resolved.headers } : undefined` — only user-supplied headers forwarded, spec-required `Accept` header never set
- Missing detection / guardrail: No test existed for the headers passed to `StreamableHTTPClientTransport`
- Contributing context (if known): The SSE transport path already handles its own headers via `eventSourceInit`; the streamable-http path was added later without carrying the same care for required headers

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/mcp-transport.test.ts` (new file)
- Scenario the test should lock in: `StreamableHTTPClientTransport` always receives `Accept: application/json, text/event-stream` unless the user explicitly set their own `Accept` header
- Why this is the smallest reliable guardrail: Mocks the SDK constructor and inspects `requestInit.headers` directly — no network needed, fast, deterministic
- Existing test that already covers this (if any): None
- If no new test is added, why not: N/A — test added

## User-visible / Behavior Changes

Streamable-http MCP servers that require the `Accept` header per the MCP spec will now connect and expose their tools. Previously they were silently unreachable.

## Diagram (if applicable)

```text
Before:
POST <streamable-http-url>
Content-Type: application/json
Authorization: Bearer <key>
→ "Accept header must include both application/json and text/event-stream"

After:
POST <streamable-http-url>
Content-Type: application/json
Authorization: Bearer <key>
Accept: application/json, text/event-stream
→ SSE stream / valid MCP initialize result ✅
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same request, one additional header)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 22.04
- Node: v24.14.0
- Integration: MCP streamable-http (Zhipu BigModel `web_search_prime`)

### Steps

1. Configure a streamable-http MCP server in `mcp.json`
2. Start OpenClaw and observe MCP server never loads tools
3. Apply this fix
4. Restart OpenClaw — server connects and tools are available

### Expected

- MCP streamable-http server loads tools on startup

### Actual (before fix)

- Server never loads; `Accept` header rejection from server

## Evidence

- [x] Failing test/log before + passing after: 5 unit tests — 2 failed before fix, 5/5 pass after

## Human Verification (required)

- Verified scenarios: Header injection when no user headers, header injection alongside user headers, user `Accept` header preserved (uppercase), user `accept` header preserved (lowercase), SSE path not affected
- Edge cases checked: lowercase `accept` key from user config
- What you did **not** verify: Live connection test against a real streamable-http server (issue reporter's curl repro was used as reference)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: User with a custom `Accept` header that intentionally omits `text/event-stream` may see different server behavior
  - Mitigation: User-supplied `Accept` header (any casing) always wins — no injection occurs if user set one

## AI Disclosure

- [x] AI-assisted (Claude Code)
- [x] Lightly tested (5 unit tests pass; curl repro from issue used as manual reference)
- [x] I understand what the code does