### PR TITLE
fix(media-understanding): add allowPrivateNetwork to transport overrides type

### DIFF
--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -83,6 +83,7 @@ export type MediaUnderstandingProviderRequestTransportOverrides = {
   auth?: MediaUnderstandingProviderRequestAuthOverride;
   proxy?: MediaUnderstandingProviderRequestProxyOverride;
   tls?: MediaUnderstandingProviderRequestTlsOverride;
+  allowPrivateNetwork?: boolean;
 };
 
 export type AudioTranscriptionRequest = {


### PR DESCRIPTION
`MediaUnderstandingProviderRequestTransportOverrides` was missing the `allowPrivateNetwork` field. The field is already used in `shared.ts` and tested in `runner.proxy.test.ts`, but its absence from the type definition produces a tsgo type error:

```
src/media-understanding/runner.proxy.test.ts(231,25): error TS2339:
Property 'allowPrivateNetwork' does not exist on type
'MediaUnderstandingProviderRequestTransportOverrides'.
```

One-line fix: add `allowPrivateNetwork?: boolean` to the type.
