### PR TITLE
fix(openai-codex): default undefined model.api to openai-codex-responses

### DIFF
--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -104,8 +104,15 @@ function normalizeCodexTransport(model: ProviderRuntimeModel): ProviderRuntimeMo
       : model.name;
   const useCodexTransport =
     !model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl) || isOpenAICodexBaseUrl(model.baseUrl);
+  // When the request targets the OpenAI Codex transport, default to the
+  // `openai-codex-responses` api (→ /responses endpoint). The previous
+  // condition only converted `openai-responses`, leaving `undefined` and
+  // other variants to fall back to `/chat/completions`, which Cloudflare
+  // began blocking on 2026-04-14 with a managed challenge (403).
   const api =
-    useCodexTransport && model.api === "openai-responses" ? "openai-codex-responses" : model.api;
+    useCodexTransport && (!model.api || model.api === "openai-responses")
+      ? "openai-codex-responses"
+      : model.api;
   const baseUrl =
     api === "openai-codex-responses" && (!model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl))
       ? OPENAI_CODEX_BASE_URL


### PR DESCRIPTION
## Summary

- `normalizeCodexTransport()` only converts `model.api` to `openai-codex-responses` when the source value is literally `"openai-responses"`; an undefined / unset `model.api` falls through to the default `/chat/completions` endpoint.
- Cloudflare began issuing managed challenges (403) on `/backend-api/codex/chat/completions` on 2026-04-14, breaking every `openai-codex` request that did not explicitly set `api: "openai-responses"` in user config.
- The regression appears to have been introduced in commit `b90d4ea3d7` ("fix(codex): canonicalize the gpt-5.4-codex alias"), between 2026.4.11 and 2026.4.14 releases.
- **Fix**: widen the conversion to also handle `!model.api`, so the default path ships requests to `/responses` (which CF is not blocking yet) without requiring user-side workarounds.

Closes the need for the `openai-codex-responses` override stanza documented in #66633.

## Test plan

- [ ] Unit: existing codex provider tests cover api normalization (add case for undefined `model.api`)
- [ ] Integration: run gpt-5.4 turn with default user config (no `openai-codex` override) — request should hit `/responses`, not `/chat/completions`
- [ ] Regression: verify that an explicit `model.api` (e.g., `"openai"`) is still preserved as-is

Related: #66633, #62142, #62087

🤖 Generated with [Claude Code](https://claude.com/claude-code)