### PR TITLE
fix: add Accept header to streamable-http MCP transport

### DIFF
--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -100,9 +100,13 @@ export function resolveMcpTransport(
     };
   }
   if (resolved.transportType === "streamable-http") {
+    const headers: Record<string, string> = {
+      ...resolved.headers,
+      Accept: "application/json, text/event-stream",
+    };
     return {
       transport: new StreamableHTTPClientTransport(new URL(resolved.url), {
-        requestInit: resolved.headers ? { headers: resolved.headers } : undefined,
+        requestInit: { headers },
       }),
       description: resolved.description,
       transportType: "streamable-http",


### PR DESCRIPTION
## Problem

When configuring MCP servers with `type: "streamable-http"` (e.g. Zhipu BigModel), OpenClaw fails to connect because the required `Accept: application/json, text/event-stream` header is not sent.

Server response without the header:
```
"Accept header must include both application/json and text/event-stream"
```

## Root Cause

In `src/agents/mcp-transport.ts`, the `StreamableHTTPClientTransport` was initialized with only user-provided headers (e.g. `Authorization`) but the critical `Accept` header required by the MCP Streamable HTTP spec was not included.

## Fix

Explicitly set `Accept: application/json, text/event-stream` in the `requestInit` headers when creating the `StreamableHTTPClientTransport`, merging with any user-provided headers.

## Testing

`pnpm test src/agents/mcp-transport-config.test.ts` passes.

## Issue

Fixes #66940
