### PR TITLE
Add Mason Huang as maintainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,9 @@ Welcome to the lobster tank! 🦞
 - **Sliverp** - Chinese Channel: QQ, WeChat, Wecom, Dingtalk, Feishu
   - GitHub: [@sliverp](https://github.com/sliverp) · X: [@sliver01234](https://x.com/sliver01234)
 
+- **Mason Huang** - Stability, Security, Speed
+  - GitHub: [@hxy91819](https://github.com/hxy91819) · X: [@chenjingtalk](https://x.com/chenjingtalk)
+
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!


### PR DESCRIPTION
## Summary

Add **Mason Huang** to the Maintainers list in `CONTRIBUTING.md`.

- **Focus areas:** Stability, Security, Speed
- **GitHub:** @hxy91819
- **X:** @chenjingtalk

## Checklist
- [x] Docs-only change (no code impact)
- [x] Follows existing maintainer entry format
