### PR TITLE
fix: mask secrets in skills.update response

### DIFF
--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -341,6 +341,28 @@ export const skillsHandlers: GatewayRequestHandlers = {
       skills,
     };
     await writeConfigFile(nextConfig);
-    respond(true, { ok: true, skillKey: p.skillKey, config: current }, undefined);
+
+    // Mask secrets before returning to prevent leaking sensitive values
+    const redacted = { ...current };
+    if (redacted.apiKey) {
+      redacted.apiKey = redacted.apiKey.length > 8
+        ? redacted.apiKey.slice(0, 4) + "…" + redacted.apiKey.slice(-4)
+        : "••••••••";
+    }
+    if (redacted.env && typeof redacted.env === "object") {
+      const maskedEnv: Record<string, string> = {};
+      for (const [key, value] of Object.entries(redacted.env)) {
+        const lower = key.toLowerCase();
+        if (lower.includes("key") || lower.includes("secret") || lower.includes("token") || lower.includes("password")) {
+          maskedEnv[key] = value.length > 8
+            ? value.slice(0, 4) + "…" + value.slice(-4)
+            : "••••••••";
+        } else {
+          maskedEnv[key] = value;
+        }
+      }
+      redacted.env = maskedEnv;
+    }
+    respond(true, { ok: true, skillKey: p.skillKey, config: redacted }, undefined);
   },
 };

--- a/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
+++ b/src/gateway/server-methods/skills.update.normalizes-api-key.test.ts
@@ -50,4 +50,40 @@ describe("skills.update", () => {
       },
     });
   });
+
+  it("masks apiKey in the response to prevent leaking secrets", async () => {
+    writtenConfig = null;
+
+    let result: Record<string, unknown> | null = null;
+    await skillsHandlers["skills.update"]({
+      params: {
+        skillKey: "brave-search",
+        apiKey: "sk-1234567890abcdef",
+      },
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+      context: {} as never,
+      respond: (_success, res) => {
+        result = res as Record<string, unknown>;
+      },
+    });
+
+    const config = result?.config as Record<string, unknown>;
+    // The response should NOT contain the full API key
+    expect(config.apiKey).not.toBe("sk-1234567890abcdef");
+    // It should be masked (first 4 + … + last 4)
+    expect(config.apiKey).toBe("sk-1…cdef");
+
+    // But the written config should still have the full key
+    expect(writtenConfig).toMatchObject({
+      skills: {
+        entries: {
+          "brave-search": {
+            apiKey: "sk-1234567890abcdef",
+          },
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The \skills.update\ handler previously returned the full config object including plaintext \piKey\ and \nv\ values in the response. This poses a security risk as these secrets could be logged, displayed in UI, or transmitted to unintended recipients.

## Changes

- Mask \piKey\ in the response: shows first 4 + last 4 chars (e.g. \sk-1…cdef\), or \••••••••\ for short keys
- Mask \nv\ values where the key name contains \key\, \secret\, \	oken\, or \password\: same masking strategy
- Full values are still written to the config file correctly — only the response is redacted
- Added test to verify masking behavior and that the written config retains full values

## Test

Added test case \masks apiKey in the response to prevent leaking secrets\ that verifies:
1. Response contains masked apiKey
2. Written config retains the full apiKey

Fixes #66769