### PR TITLE
QA lab: respect homedir fallback for CODEX_HOME

### DIFF
--- a/extensions/qa-lab/src/multipass.runtime.test.ts
+++ b/extensions/qa-lab/src/multipass.runtime.test.ts
@@ -181,6 +181,7 @@ describe("qa multipass runtime", () => {
     const fakeCodexHome = path.join(fakeHome, ".codex");
     fs.mkdirSync(fakeCodexHome, { recursive: true });
     vi.stubEnv("HOME", "");
+    vi.stubEnv("CODEX_HOME", "");
     vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
 
     try {

--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -280,8 +280,9 @@ function resolveQaLiveCliAuthEnv(baseEnv: NodeJS.ProcessEnv) {
     const codexHome = resolveUserPath(configuredCodexHome, baseEnv);
     return fs.existsSync(codexHome) ? { CODEX_HOME: codexHome } : {};
   }
-  const hostHome = baseEnv.HOME?.trim() || os.homedir();
-  const codexHome = path.join(hostHome, ".codex");
+  const hostHome = baseEnv.HOME?.trim();
+  const effectiveHome = hostHome || os.homedir();
+  const codexHome = path.join(effectiveHome, ".codex");
   return fs.existsSync(codexHome) ? { CODEX_HOME: codexHome } : {};
 }
 


### PR DESCRIPTION
## Summary
- resolve QA multipass live CLI auth against `os.homedir()` when `HOME` is unset
- ignore empty inherited `CODEX_HOME` values in the homedir fallback test

## Testing
- OPENCLAW_LOCAL_CHECK=0 pnpm test extensions/qa-lab/src/multipass.runtime.test.ts
- OPENCLAW_LOCAL_CHECK=0 pnpm run test