### PR TITLE
fix: correct CONTROL_UI_BOOTSTRAP_CONFIG_PATH to avoid doubled __openclaw__ prefix

### DIFF
--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -1,4 +1,4 @@
-export const CONTROL_UI_BOOTSTRAP_CONFIG_PATH = "/__openclaw/control-ui-config.json";
+export const CONTROL_UI_BOOTSTRAP_CONFIG_PATH = "/control-ui-config.json";
 
 export type ControlUiEmbedSandboxMode = "strict" | "scripts" | "trusted";
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig(() => {
       {
         name: "control-ui-dev-stubs",
         configureServer(server) {
-          server.middlewares.use("/__openclaw/control-ui-config.json", (_req, res) => {
+          server.middlewares.use("/control-ui-config.json", (_req, res) => {
             res.setHeader("Content-Type", "application/json");
             res.end(
               JSON.stringify({


### PR DESCRIPTION
## Summary
Fixes Control UI 404 errors caused by doubled path prefix in bootstrap config URL.

## Root Cause
CONTROL_UI_BOOTSTRAP_CONFIG_PATH was set to '/__openclaw/control-ui-config.json' (single trailing underscore) while all other __openclaw__ paths use double underscores. When basePath '/__openclaw__/' is prepended, the result is '/__openclaw__/__openclaw/control-ui-config.json', causing a 404.

## Fix
Changed path to '/control-ui-config.json' — basePath prepending now produces the correct URL (e.g. '/__openclaw__/control-ui-config.json'). Also updated Vite dev server stub to match.

Closes openclaw#66946