### PR TITLE
fix: keep redactedRaw string in config snapshot fallback for raw mode display

### DIFF
--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -452,7 +452,9 @@ export function redactConfigSnapshot(
         ),
     })
   ) {
-    redactedRaw = null;
+    // Keep redactedRaw string so UI can display raw view without edit.
+    // isReadonly state is controlled upstream — fallback only blocks editing,
+    // not rendering.
   }
   // Also redact the resolved config (contains values after ${ENV} substitution)
   const redactedResolved = redactConfigObject(snapshot.resolved, uiHints);


### PR DESCRIPTION
## Summary
Fixes Config UI raw mode being silently disabled when the redaction fallback triggers.

## Root Cause
When `shouldFallbackToStructuredRawRedaction` returns true, the code set `redactedRaw = null`. The UI interprets `raw: null` as "raw mode not supported" and force-switches to form view, even though the raw text is still displayable (just not safely round-trippable for editing).

## Fix
Keep the `redactedRaw` string instead of nullifying it. The UI can still display raw view — the `isReadonly` state (controlled upstream) prevents editing when round-trip safety can't be guaranteed.

Closes openclaw#66988