### PR TITLE
fix: don't classify 400/422 with no body as format error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Docs: https://docs.openclaw.ai
 
 - Matrix: require full cross-signing identity trust for self-device verification and add `openclaw matrix verify self` so operators can establish that trust from the CLI. (#70401) Thanks @gumadeiras.
 
+### Fixes
+
+- Agents/failover: stop body-less HTTP 400/422 proxy failures from defaulting to `"format"` classification, so embedded retries surface the opaque provider failure instead of falling into a compaction loop. Fixes #66462. (#67024) Thanks @altaywtf and @HongzhuLiu.
+
 ## 2026.4.24
 
 ### Breaking
@@ -191,7 +195,6 @@ Docs: https://docs.openclaw.ai
 - Memory/dreaming: decouple the managed dreaming cron from heartbeat by running it as an isolated lightweight agent turn, so dreaming runs even when heartbeat is disabled for the default agent and is no longer skipped by `heartbeat.activeHours`. `openclaw doctor --fix` migrates stale main-session dreaming jobs in persisted cron configs to the new shape. Fixes #69811, #67397, #68972. (#70737) Thanks @jalehman.
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
 - Plugins/Comfy: read workflow and cloud auth configuration from `plugins.entries.comfy.config` while preserving legacy Comfy config fallback, so image, video, and music workflows pass config validation. Fixes #61915. (#63058) Thanks @547895019.
-- Agents/failover: stop body-less HTTP 400/422 proxy failures from defaulting to `"format"` classification, so embedded retries surface the opaque provider failure instead of falling into a compaction loop. Fixes #66462. (#67024) Thanks @altaywtf and @HongzhuLiu.
 
 ## 2026.4.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ Docs: https://docs.openclaw.ai
 - Memory/dreaming: decouple the managed dreaming cron from heartbeat by running it as an isolated lightweight agent turn, so dreaming runs even when heartbeat is disabled for the default agent and is no longer skipped by `heartbeat.activeHours`. `openclaw doctor --fix` migrates stale main-session dreaming jobs in persisted cron configs to the new shape. Fixes #69811, #67397, #68972. (#70737) Thanks @jalehman.
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
 - Plugins/Comfy: read workflow and cloud auth configuration from `plugins.entries.comfy.config` while preserving legacy Comfy config fallback, so image, video, and music workflows pass config validation. Fixes #61915. (#63058) Thanks @547895019.
+- Agents/failover: stop body-less HTTP 400/422 proxy failures from defaulting to `"format"` classification, so embedded retries surface the opaque provider failure instead of falling into a compaction loop. Fixes #66462. (#67024) Thanks @altaywtf and @HongzhuLiu.
 
 ## 2026.4.22
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -73,8 +73,105 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 410 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 499 })).toBe("timeout");
-    expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
-    expect(resolveFailoverReasonFromError({ status: 422 })).toBe("format");
+    // 400/422 with no body returns null — avoids triggering a compaction loop
+    // when the provider returns an empty or wrapper-only 400/422 (e.g.
+    // transient proxy issue).
+    expect(resolveFailoverReasonFromError({ status: 400 })).toBeNull();
+    expect(resolveFailoverReasonFromError({ status: 422 })).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        status: 400,
+        message: "400 status code (no body)",
+      }),
+    ).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "HTTP 422: No body",
+      }),
+    ).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "HTTP 422: No response body",
+      }),
+    ).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "Error: HTTP 422: No response body",
+      }),
+    ).toBeNull();
+    expect(resolveFailoverReasonFromError({ message: "400 status code (no body)" })).toBeNull();
+    expect(resolveFailoverReasonFromError({ message: "HTTP 422: No body" })).toBeNull();
+    expect(resolveFailoverReasonFromError({ message: "HTTP 422: No response body" })).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        message: "outer wrapper",
+        cause: {
+          status: 422,
+          message: "HTTP 422: No response body",
+        },
+      }),
+    ).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "check open ai req parameter error",
+        cause: {
+          status: 422,
+          message: "HTTP 422: No response body",
+        },
+      }),
+    ).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "check open ai req parameter error",
+        cause: new Error("No response body"),
+      }),
+    ).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "Unprocessable Entity",
+        error: {
+          message: "HTTP 422: No response body",
+        },
+      }),
+    ).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        message: "Unprocessable Entity",
+        cause: {
+          message: "Unprocessable Entity",
+          error: {
+            message: "HTTP 422: No response body",
+          },
+        },
+      }),
+    ).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        error: {
+          message: "missing required property",
+        },
+        cause: {},
+      }),
+    ).toBe("format");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 422,
+        error: {
+          message: "missing required property",
+        },
+        cause: {
+          message: "HTTP 422: No response body",
+        },
+      }),
+    ).toBe("format");
     // Transient server errors (500/502/503/504) should trigger failover as timeout.
     expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
@@ -85,6 +182,14 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 523 })).toBeNull();
     expect(resolveFailoverReasonFromError({ status: 524 })).toBeNull();
     expect(resolveFailoverReasonFromError({ status: 529 })).toBe("overloaded");
+  });
+
+  it("stops on cyclic cause chains", () => {
+    const first: { cause?: unknown } = {};
+    const second: { cause?: unknown } = { cause: first };
+    first.cause = second;
+
+    expect(resolveFailoverReasonFromError(first)).toBeNull();
   });
 
   it("treats session-specific HTTP 410s differently from generic 410s", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -1,6 +1,7 @@
 import { readErrorName } from "../infra/errors.js";
 import {
   classifyFailoverSignal,
+  isUnclassifiedNoBodyHttpSignal,
   type FailoverClassification,
   type FailoverSignal,
 } from "./pi-embedded-helpers/errors.js";
@@ -8,6 +9,7 @@ import { isTimeoutErrorMessage } from "./pi-embedded-helpers/errors.js";
 import type { FailoverReason } from "./pi-embedded-helpers/types.js";
 
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
+const MAX_FAILOVER_CAUSE_DEPTH = 25;
 
 export class FailoverError extends Error {
   readonly reason: FailoverReason;
@@ -186,11 +188,14 @@ function getErrorMessage(err: unknown): string {
   return findErrorProperty(err, readDirectErrorMessage) ?? "";
 }
 
-function getErrorCause(err: unknown): unknown {
-  if (!err || typeof err !== "object" || !("cause" in err)) {
-    return undefined;
-  }
-  return (err as { cause?: unknown }).cause;
+function normalizeDirectErrorSignal(err: unknown): FailoverSignal {
+  const message = readDirectErrorMessage(err);
+  return {
+    status: readDirectStatusCode(err),
+    code: readDirectErrorCode(err),
+    message: message || undefined,
+    provider: readDirectProvider(err),
+  };
 }
 
 function hasTimeoutHint(err: unknown): boolean {
@@ -239,7 +244,72 @@ function normalizeErrorSignal(err: unknown): FailoverSignal {
   };
 }
 
-function resolveFailoverClassificationFromError(err: unknown): FailoverClassification | null {
+function getNestedErrorCandidates(err: unknown): unknown[] {
+  if (!err || typeof err !== "object") {
+    return [];
+  }
+  const candidate = err as { error?: unknown; cause?: unknown };
+  return [candidate.error, candidate.cause].filter(
+    (value): value is unknown => value !== undefined && value !== err,
+  );
+}
+
+function isFormatClassification(classification: FailoverClassification | null): boolean {
+  return classification?.kind === "reason" && classification.reason === "format";
+}
+
+function decideNestedFormatOverride(
+  candidate: unknown,
+  inheritedStatus: number | undefined,
+  seen: Set<object>,
+  depth: number,
+): boolean | null {
+  if (depth > MAX_FAILOVER_CAUSE_DEPTH) {
+    return null;
+  }
+  if (candidate && typeof candidate === "object") {
+    if (seen.has(candidate)) {
+      return null;
+    }
+    seen.add(candidate);
+  }
+
+  const directSignal = normalizeDirectErrorSignal(candidate);
+  const nestedCandidates = getNestedErrorCandidates(candidate);
+  const nestedStatus = directSignal.status ?? inheritedStatus;
+  const hasDirectMessage = Boolean(directSignal.message?.trim());
+  if (
+    hasDirectMessage &&
+    isUnclassifiedNoBodyHttpSignal({ ...directSignal, status: nestedStatus })
+  ) {
+    return true;
+  }
+  if (hasDirectMessage && (nestedCandidates.length === 0 || classifyFailoverSignal(directSignal))) {
+    return false;
+  }
+  for (const nestedCandidate of nestedCandidates) {
+    const decision = decideNestedFormatOverride(nestedCandidate, nestedStatus, seen, depth + 1);
+    if (decision !== null) {
+      return decision;
+    }
+  }
+  return null;
+}
+
+function resolveFailoverClassificationFromErrorInternal(
+  err: unknown,
+  seen: Set<object>,
+  depth: number,
+): FailoverClassification | null {
+  if (depth > MAX_FAILOVER_CAUSE_DEPTH) {
+    return null;
+  }
+  if (err && typeof err === "object") {
+    if (seen.has(err)) {
+      return null;
+    }
+    seen.add(err);
+  }
   if (isFailoverError(err)) {
     return {
       kind: "reason",
@@ -247,14 +317,36 @@ function resolveFailoverClassificationFromError(err: unknown): FailoverClassific
     };
   }
 
-  const classification = classifyFailoverSignal(normalizeErrorSignal(err));
+  const signal = normalizeErrorSignal(err);
+  const classification = classifyFailoverSignal(signal);
+  const nestedCandidates = getNestedErrorCandidates(err);
+
   if (!classification || classification.kind === "context_overflow") {
-    // Let wrapped causes override parent timeout/overflow guesses.
-    const cause = getErrorCause(err);
-    if (cause && cause !== err) {
-      const causeClassification = resolveFailoverClassificationFromError(cause);
-      if (causeClassification) {
-        return causeClassification;
+    for (const candidate of nestedCandidates) {
+      const nestedClassification = resolveFailoverClassificationFromErrorInternal(
+        candidate,
+        seen,
+        depth + 1,
+      );
+      if (nestedClassification) {
+        return nestedClassification;
+      }
+    }
+  }
+
+  if (isFormatClassification(classification)) {
+    for (const candidate of nestedCandidates) {
+      const shouldClearFormat = decideNestedFormatOverride(
+        candidate,
+        signal.status,
+        seen,
+        depth + 1,
+      );
+      if (shouldClearFormat === true) {
+        return null;
+      }
+      if (shouldClearFormat === false) {
+        break;
       }
     }
   }
@@ -270,6 +362,10 @@ function resolveFailoverClassificationFromError(err: unknown): FailoverClassific
     };
   }
   return null;
+}
+
+function resolveFailoverClassificationFromError(err: unknown): FailoverClassification | null {
+  return resolveFailoverClassificationFromErrorInternal(err, new Set<object>(), 0);
 }
 
 export function resolveFailoverReasonFromError(err: unknown): FailoverReason | null {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -575,8 +575,21 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     expect(classifyFailoverReasonFromHttpStatus(401, "invalid_api_key")).toBe("auth");
   });
 
-  it("treats HTTP 422 as format error", () => {
-    expect(classifyFailoverReasonFromHttpStatus(422)).toBe("format");
+  it("treats body-less HTTP 422 as unknown instead of format", () => {
+    expect(classifyFailoverReasonFromHttpStatus(422)).toBeNull();
+  });
+
+  it("treats no-body HTTP 400/422 wrappers as unknown instead of format", () => {
+    expect(classifyFailoverReasonFromHttpStatus(400, "No body response")).toBeNull();
+    expect(classifyFailoverReasonFromHttpStatus(400, "400 status code (no body)")).toBeNull();
+    expect(classifyFailoverReasonFromHttpStatus(422, "HTTP 422: No body")).toBeNull();
+    expect(classifyFailoverReasonFromHttpStatus(422, "HTTP 422: No response body")).toBeNull();
+    expect(
+      classifyFailoverReasonFromHttpStatus(422, "Error: HTTP 422: No response body"),
+    ).toBeNull();
+  });
+
+  it("treats HTTP 422 with an unclassifiable body as format error", () => {
     expect(classifyFailoverReasonFromHttpStatus(422, "check open ai req parameter error")).toBe(
       "format",
     );
@@ -684,6 +697,15 @@ describe("classifyFailoverReason", () => {
   it("classifies HTTP 404 assistant errors as model_not_found so model fallback can continue", () => {
     expect(classifyFailoverReason("404 status code (no body)")).toBe("model_not_found");
     expect(classifyFailoverReason("HTTP 404: No body")).toBe("model_not_found");
+  });
+
+  it("keeps HTTP 400/422 no-body wrappers out of the format bucket", () => {
+    expect(classifyFailoverReason("400 status code (no body)")).toBeNull();
+    expect(classifyFailoverReason("HTTP 400: No body")).toBeNull();
+    expect(classifyFailoverReason("422 status code (no body)")).toBeNull();
+    expect(classifyFailoverReason("HTTP 422: No body")).toBeNull();
+    expect(classifyFailoverReason("HTTP 422: No response body")).toBeNull();
+    expect(classifyFailoverReason("Error: HTTP 422: No response body")).toBeNull();
   });
 
   it("preserves session and auth billing signals on HTTP 404 text", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -330,6 +330,8 @@ const REPLAY_INVALID_RE =
   /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b/i;
+const NO_BODY_HTTP_WRAPPER_RE =
+  /^(?:no body(?: response)?|no response body|status code \(no body\))$/i;
 
 function stripErrorPrefix(raw: string): string {
   return raw.replace(/^error:\s*/i, "").trim();
@@ -340,6 +342,31 @@ function inferSignalStatus(signal: FailoverSignal): number | undefined {
     return signal.status;
   }
   return extractLeadingHttpStatus(stripErrorPrefix(signal.message?.trim() ?? ""))?.code;
+}
+
+function isExplicitNoBodyHttpMessage(raw: string | undefined, status?: number): boolean {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const candidate = extractLeadingHttpStatus(trimmed) ? trimmed : stripErrorPrefix(trimmed);
+  const leadingStatus = extractLeadingHttpStatus(candidate);
+  if (leadingStatus) {
+    if (typeof status === "number" && leadingStatus.code !== status) {
+      return false;
+    }
+    return NO_BODY_HTTP_WRAPPER_RE.test(leadingStatus.rest);
+  }
+  return NO_BODY_HTTP_WRAPPER_RE.test(candidate);
+}
+
+export function isUnclassifiedNoBodyHttpSignal(signal: FailoverSignal): boolean {
+  const status = inferSignalStatus(signal);
+  if (status !== 400 && status !== 422) {
+    return false;
+  }
+  const message = signal.message?.trim();
+  return !message || isExplicitNoBodyHttpMessage(message, status);
 }
 
 function isHtmlErrorResponse(raw: string, status?: number): boolean {
@@ -683,6 +710,15 @@ function classifyFailoverClassificationFromHttpStatus(
     if (messageClassification) {
       return messageClassification;
     }
+    // When the response has no body at all, or only surfaces as an HTTP wrapper
+    // like "400 status code (no body)", return null instead of defaulting to
+    // "format". These shapes are likely transient proxy issues — classifying
+    // them as "format" triggers a compaction loop that cannot recover.
+    if (isUnclassifiedNoBodyHttpSignal({ status, message })) {
+      return null;
+    }
+    // Body exists but couldn't be classified — still treat as format error
+    // since the provider rejected the request schema.
     return toReasonClassification("format");
   }
   return null;


### PR DESCRIPTION
Summary:
- stop body-less HTTP 400/422 proxy failures from defaulting to `"format"`
- keep the fix scoped to failover classification and tests
- handle explicit wrapper-only shapes like `400 status code (no body)`

Credit:
- original fix and report path came from @HongzhuLiu in #66473; this PR is the cleaned, rebased maintainer replacement

Changes:
- return `null` for empty or explicit no-body 400/422 wrappers in failover classification
- update failover classifier regressions for raw and structured no-body shapes
- keep the changelog note in `Unreleased > Fixes`

Validation:
- `pnpm test src/agents/failover-error.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/pi-embedded-runner/run/failover-policy.test.ts`

Linked Issues:
- supersedes #66473
- fixes #66462