### PR TITLE
fix(cli): explicitly skip plugin loading for cron subcommand

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -126,4 +126,8 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     exact: true,
     policy: { loadPlugins: "never" },
   },
+  {
+    commandPath: ["cron"],
+    policy: { loadPlugins: "never" },
+  },
 ];


### PR DESCRIPTION
## Summary

- Add explicit `loadPlugins: "never"` catalog entry for the `cron` subcommand in `src/cli/command-catalog.ts`
- Prevents plugin initialization failures from crashing management commands like `openclaw cron add`

Fixes #67026

## Context

The `cron` subcommand is a pure management command that does not need business plugins. Without an explicit catalog entry, it relies on implicit defaults and subcli registration timing to skip plugin loading. When a plugin (e.g., `openclaw-cns-plugin`) fails to initialize due to missing config, `throwOnLoadError: true` causes the entire CLI to exit with status 1.

This change is consistent with how `onboard` and `channels add` are already handled with explicit `loadPlugins: "never"` policies.

## Test plan

- [ ] Verify `resolveCliCommandPathPolicy(["cron"]).loadPlugins` resolves to `"never"`
- [ ] Verify `openclaw cron add` does not trigger plugin loading
- [ ] `pnpm build` passes
- [ ] `pnpm test -- src/cli/command-startup-policy` passes