### PR TITLE
fix(ui): filter leaked control ui transcript rows

### DIFF
--- a/ui/src/ui/chat/export.test.ts
+++ b/ui/src/ui/chat/export.test.ts
@@ -1,0 +1,33 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import { buildChatMarkdown } from "./export.ts";
+
+describe("buildChatMarkdown", () => {
+  it("omits leaked internal history rows from exports", () => {
+    const markdown = buildChatMarkdown(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "System (untrusted): [2026-04-14 22:56:23 PDT] Exec completed (tidy-zep, code 0)",
+            },
+          ],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "real reply" }],
+          timestamp: 2,
+        },
+      ],
+      "OpenClaw",
+    );
+
+    expect(markdown).toContain("real reply");
+    expect(markdown).not.toContain("System (untrusted)");
+    expect(markdown).not.toContain("Exec completed");
+  });
+});

--- a/ui/src/ui/chat/export.test.ts
+++ b/ui/src/ui/chat/export.test.ts
@@ -30,4 +30,19 @@ describe("buildChatMarkdown", () => {
     expect(markdown).not.toContain("System (untrusted)");
     expect(markdown).not.toContain("Exec completed");
   });
+
+  it("keeps legitimate System-prefixed chat text with generic exec wording in exports", () => {
+    const markdown = buildChatMarkdown(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "System: exec failed after deploy, retrying" }],
+          timestamp: 1,
+        },
+      ],
+      "OpenClaw",
+    );
+
+    expect(markdown).toContain("System: exec failed after deploy, retrying");
+  });
 });

--- a/ui/src/ui/chat/export.test.ts
+++ b/ui/src/ui/chat/export.test.ts
@@ -45,4 +45,25 @@ describe("buildChatMarkdown", () => {
 
     expect(markdown).toContain("System: exec failed after deploy, retrying");
   });
+
+  it("keeps quoted reset-instruction text that only matches the shared prefix in exports", () => {
+    const markdown = buildChatMarkdown(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user. Can you explain what this instruction means?",
+            },
+          ],
+          timestamp: 1,
+        },
+      ],
+      "OpenClaw",
+    );
+
+    expect(markdown).toContain("A new session was started via /new or /reset.");
+    expect(markdown).toContain("Can you explain what this instruction means?");
+  });
 });

--- a/ui/src/ui/chat/export.ts
+++ b/ui/src/ui/chat/export.ts
@@ -1,3 +1,4 @@
+import { shouldHideHistoryMessage } from "./history-filter.ts";
 import { extractTextCached } from "./message-extract.ts";
 
 /**
@@ -24,6 +25,9 @@ export function buildChatMarkdown(messages: unknown[], assistantName: string): s
   }
   const lines: string[] = [`# Chat with ${assistantName}`, ""];
   for (const msg of history) {
+    if (shouldHideHistoryMessage(msg)) {
+      continue;
+    }
     const m = msg as Record<string, unknown>;
     const role = m.role === "user" ? "You" : m.role === "assistant" ? assistantName : "Tool";
     const content = extractTextCached(msg) ?? "";

--- a/ui/src/ui/chat/history-filter.test.ts
+++ b/ui/src/ui/chat/history-filter.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { isLeakedInternalHistoryMessage } from "./history-filter.ts";
+
+describe("isLeakedInternalHistoryMessage", () => {
+  it("keeps legitimate System-prefixed chat text with generic exec wording", () => {
+    expect(
+      isLeakedInternalHistoryMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "System: exec failed after deploy, retrying" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("hides timestamped leaked Control UI exec rows", () => {
+    expect(
+      isLeakedInternalHistoryMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "System (untrusted): [2026-04-14 22:56:23 PDT] Exec completed (tidy-zep, code 0)",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("hides leaked sender metadata rows for openclaw-control-ui", () => {
+    expect(
+      isLeakedInternalHistoryMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: 'Sender (untrusted metadata):\n```json\n{"label":"openclaw-control-ui"}\n```\n\n[2026-04-14 22:56:23 PDT] Exec completed',
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+});

--- a/ui/src/ui/chat/history-filter.test.ts
+++ b/ui/src/ui/chat/history-filter.test.ts
@@ -11,6 +11,20 @@ describe("isLeakedInternalHistoryMessage", () => {
     ).toBe(false);
   });
 
+  it("keeps quoted reset-instruction text that only matches the shared prefix", () => {
+    expect(
+      isLeakedInternalHistoryMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user. Can you explain what this instruction means?",
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
   it("hides timestamped leaked Control UI exec rows", () => {
     expect(
       isLeakedInternalHistoryMessage({
@@ -33,6 +47,20 @@ describe("isLeakedInternalHistoryMessage", () => {
           {
             type: "text",
             text: 'Sender (untrusted metadata):\n```json\n{"label":"openclaw-control-ui"}\n```\n\n[2026-04-14 22:56:23 PDT] Exec completed',
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the full leaked session reset prompt shape with appended current time", () => {
+    expect(
+      isLeakedInternalHistoryMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.\nCurrent time: Wednesday, April 15th, 2026 - 11:42 AM (America/Los_Angeles) / 2026-04-15 18:42 UTC",
           },
         ],
       }),

--- a/ui/src/ui/chat/history-filter.ts
+++ b/ui/src/ui/chat/history-filter.ts
@@ -5,6 +5,8 @@ export const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 export const LEAKED_SESSION_RESET_PROMPT_PREFIX =
   "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user.";
+const LEAKED_SESSION_RESET_PROMPT_BODY = `${LEAKED_SESSION_RESET_PROMPT_PREFIX} Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.`;
+const LEAKED_SESSION_RESET_PROMPT_CURRENT_TIME_PREFIX = "\ncurrent time:";
 const LEAKED_EXEC_STATUS_ACTION_PATTERN = "(?:started|completed|finished|failed|denied)";
 const LEAKED_SYSTEM_EXEC_STATUS_PATTERN = new RegExp(
   String.raw`^system(?: \(untrusted\))?:\s*\[[^\]\n]+\]\s*exec ${LEAKED_EXEC_STATUS_ACTION_PATTERN}\s*\([^\)\n]+\)`,
@@ -27,6 +29,13 @@ function hasLeakedSystemExecStatus(text: string): boolean {
 
 function hasLeakedSenderMetadataExecStatus(text: string): boolean {
   return LEAKED_SENDER_METADATA_EXEC_STATUS_PATTERN.test(text);
+}
+
+function hasLeakedSessionResetPrompt(text: string): boolean {
+  return (
+    text.startsWith(normalizeLowercaseStringOrEmpty(LEAKED_SESSION_RESET_PROMPT_BODY)) &&
+    text.includes(LEAKED_SESSION_RESET_PROMPT_CURRENT_TIME_PREFIX)
+  );
 }
 
 export function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
@@ -52,7 +61,7 @@ export function isLeakedInternalHistoryMessage(message: unknown): boolean {
   if (hasLeakedSenderMetadataExecStatus(lower)) {
     return true;
   }
-  return lower.startsWith(normalizeLowercaseStringOrEmpty(LEAKED_SESSION_RESET_PROMPT_PREFIX));
+  return hasLeakedSessionResetPrompt(lower);
 }
 
 export function shouldHideHistoryMessage(message: unknown): boolean {

--- a/ui/src/ui/chat/history-filter.ts
+++ b/ui/src/ui/chat/history-filter.ts
@@ -1,0 +1,56 @@
+import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
+import { extractTextCached } from "./message-extract.ts";
+
+export const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
+  "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
+export const LEAKED_SESSION_RESET_PROMPT_PREFIX =
+  "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user.";
+
+function extractLowercaseHistoryText(message: unknown): string {
+  const text = extractTextCached(message);
+  if (typeof text !== "string") {
+    return "";
+  }
+  return normalizeLowercaseStringOrEmpty(text.trim());
+}
+
+function hasLeakedExecStatus(text: string): boolean {
+  return (
+    text.includes("exec started") ||
+    text.includes("exec completed") ||
+    text.includes("exec finished") ||
+    text.includes("exec failed") ||
+    text.includes("exec denied")
+  );
+}
+
+export function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = normalizeLowercaseStringOrEmpty(entry.role);
+  if (role !== "toolresult") {
+    return false;
+  }
+  return extractLowercaseHistoryText(message) === SYNTHETIC_TRANSCRIPT_REPAIR_RESULT;
+}
+
+export function isLeakedInternalHistoryMessage(message: unknown): boolean {
+  const lower = extractLowercaseHistoryText(message);
+  if (!lower) {
+    return false;
+  }
+  const hasExecStatus = hasLeakedExecStatus(lower);
+  if (hasExecStatus && (lower.startsWith("system:") || lower.startsWith("system (untrusted):"))) {
+    return true;
+  }
+  if (lower.startsWith("sender (untrusted metadata):") && hasExecStatus) {
+    return true;
+  }
+  return lower.startsWith(normalizeLowercaseStringOrEmpty(LEAKED_SESSION_RESET_PROMPT_PREFIX));
+}
+
+export function shouldHideHistoryMessage(message: unknown): boolean {
+  return isSyntheticTranscriptRepairToolResult(message) || isLeakedInternalHistoryMessage(message);
+}

--- a/ui/src/ui/chat/history-filter.ts
+++ b/ui/src/ui/chat/history-filter.ts
@@ -5,6 +5,13 @@ export const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 export const LEAKED_SESSION_RESET_PROMPT_PREFIX =
   "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user.";
+const LEAKED_EXEC_STATUS_ACTION_PATTERN = "(?:started|completed|finished|failed|denied)";
+const LEAKED_SYSTEM_EXEC_STATUS_PATTERN = new RegExp(
+  String.raw`^system(?: \(untrusted\))?:\s*\[[^\]\n]+\]\s*exec ${LEAKED_EXEC_STATUS_ACTION_PATTERN}\s*\([^\)\n]+\)`,
+);
+const LEAKED_SENDER_METADATA_EXEC_STATUS_PATTERN = new RegExp(
+  String.raw`^sender \(untrusted metadata\):[\s\S]*"label"\s*:\s*"openclaw-control-ui"[\s\S]*\[[^\]\n]+\]\s*exec ${LEAKED_EXEC_STATUS_ACTION_PATTERN}\b`,
+);
 
 function extractLowercaseHistoryText(message: unknown): string {
   const text = extractTextCached(message);
@@ -14,14 +21,12 @@ function extractLowercaseHistoryText(message: unknown): string {
   return normalizeLowercaseStringOrEmpty(text.trim());
 }
 
-function hasLeakedExecStatus(text: string): boolean {
-  return (
-    text.includes("exec started") ||
-    text.includes("exec completed") ||
-    text.includes("exec finished") ||
-    text.includes("exec failed") ||
-    text.includes("exec denied")
-  );
+function hasLeakedSystemExecStatus(text: string): boolean {
+  return LEAKED_SYSTEM_EXEC_STATUS_PATTERN.test(text);
+}
+
+function hasLeakedSenderMetadataExecStatus(text: string): boolean {
+  return LEAKED_SENDER_METADATA_EXEC_STATUS_PATTERN.test(text);
 }
 
 export function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
@@ -41,11 +46,10 @@ export function isLeakedInternalHistoryMessage(message: unknown): boolean {
   if (!lower) {
     return false;
   }
-  const hasExecStatus = hasLeakedExecStatus(lower);
-  if (hasExecStatus && (lower.startsWith("system:") || lower.startsWith("system (untrusted):"))) {
+  if (hasLeakedSystemExecStatus(lower)) {
     return true;
   }
-  if (lower.startsWith("sender (untrusted metadata):") && hasExecStatus) {
+  if (hasLeakedSenderMetadataExecStatus(lower)) {
     return true;
   }
   return lower.startsWith(normalizeLowercaseStringOrEmpty(LEAKED_SESSION_RESET_PROMPT_PREFIX));

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -649,6 +649,32 @@ describe("loadChatHistory", () => {
     expect(state.chatMessages).toEqual([messages[0], messages[2]]);
   });
 
+  it("filters leaked exec rows from history even when the role is wrong", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "System (untrusted): [2026-04-14 22:56:23 PDT] Exec completed (tidy-zep, code 0)",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "real reply" }] },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([messages[1]]);
+  });
+
   it("filters leaked sender metadata exec rows from history", async () => {
     const messages = [
       {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -674,6 +674,32 @@ describe("loadChatHistory", () => {
 
     expect(state.chatMessages).toEqual([messages[1]]);
   });
+
+  it("filters leaked session reset startup prompts from history", async () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.\nCurrent time: Wednesday, April 15th, 2026 - 11:42 AM (America/Los_Angeles) / 2026-04-15 18:42 UTC",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "real reply" }] },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([messages[1]]);
+  });
 });
 
 describe("sendChatMessage", () => {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -722,6 +722,32 @@ describe("loadChatHistory", () => {
     expect(state.chatMessages).toEqual([messages[1]]);
   });
 
+  it("keeps quoted reset-instruction history text that only matches the shared prefix", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user. Can you explain what this instruction means?",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "real reply" }] },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual(messages);
+  });
+
   it("filters leaked session reset startup prompts from history", async () => {
     const messages = [
       {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -621,6 +621,59 @@ describe("loadChatHistory", () => {
 
     expect(state.chatMessages).toEqual(messages);
   });
+
+  it("filters leaked system exec rows from history", async () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      {
+        role: "system",
+        content: [
+          {
+            type: "text",
+            text: "System (untrusted): [2026-04-14 22:56:23 PDT] Exec completed (tidy-zep, code 0)",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "real reply" }] },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([messages[0], messages[2]]);
+  });
+
+  it("filters leaked sender metadata exec rows from history", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: 'Sender (untrusted metadata):\n```json\n{"label":"openclaw-control-ui"}\n```\n\n[2026-04-14 22:56:23 PDT] Exec completed',
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "real reply" }] },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([messages[1]]);
+  });
 });
 
 describe("sendChatMessage", () => {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -417,6 +417,29 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Working...");
   });
 
+  it("drops leaked internal final payload from another run", () => {
+    const state = createActiveStreamingState();
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "System (untrusted): [2026-04-18 12:09:02 PDT] Exec completed (brisk-tr, code 0)",
+          },
+        ],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([]);
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Working...");
+  });
+
   it("drops NO_REPLY final payload from own run", () => {
     const state = createState({
       sessionKey: "main",
@@ -445,6 +468,23 @@ describe("handleChatEvent", () => {
       sessionKey: "main",
       chatRunId: "run-1",
       chatStream: "NO_REPLY",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([]);
+  });
+
+  it("does not persist leaked internal stream text on final without message", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "System (untrusted): [2026-04-18 12:09:02 PDT] Exec completed (brisk-tr, code 0)",
       chatStreamStartedAt: 100,
     });
     const payload: ChatEventPayload = {
@@ -518,6 +558,32 @@ describe("handleChatEvent", () => {
     // entry.text takes precedence — "real reply" is NOT silent, so the message is kept.
     expect(handleChatEvent(state, payload)).toBe("final");
     expect(state.chatMessages).toHaveLength(1);
+  });
+
+  it("drops leaked internal final payload from own run", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "System (untrusted): [2026-04-18 12:09:02 PDT] Exec failed (amber-sl, signal SIGKILL)",
+          },
+        ],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([]);
   });
 });
 

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -675,6 +675,27 @@ describe("loadChatHistory", () => {
     expect(state.chatMessages).toEqual([messages[1]]);
   });
 
+  it("keeps legitimate System-prefixed chat text with generic exec wording", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "System: exec failed after deploy, retrying" }],
+      },
+      { role: "assistant", content: [{ type: "text", text: "real reply" }] },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual(messages);
+  });
+
   it("filters leaked sender metadata exec rows from history", async () => {
     const messages = [
       {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -71,8 +71,41 @@ function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
   return typeof text === "string" && text.trim() === SYNTHETIC_TRANSCRIPT_REPAIR_RESULT;
 }
 
+function isLeakedInternalHistoryMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const text = extractText(message);
+  if (typeof text !== "string") {
+    return false;
+  }
+  const lower = normalizeLowercaseStringOrEmpty(text.trim());
+  if (!lower) {
+    return false;
+  }
+  const role = normalizeLowercaseStringOrEmpty(entry.role);
+  const hasExecStatus =
+    lower.includes("exec started") ||
+    lower.includes("exec completed") ||
+    lower.includes("exec finished") ||
+    lower.includes("exec failed") ||
+    lower.includes("exec denied");
+  if (
+    role === "system" &&
+    (lower.startsWith("system:") || lower.startsWith("system (untrusted):") || hasExecStatus)
+  ) {
+    return true;
+  }
+  return lower.startsWith("sender (untrusted metadata):") && hasExecStatus;
+}
+
 function shouldHideHistoryMessage(message: unknown): boolean {
-  return isAssistantSilentReply(message) || isSyntheticTranscriptRepairToolResult(message);
+  return (
+    isAssistantSilentReply(message) ||
+    isSyntheticTranscriptRepairToolResult(message) ||
+    isLeakedInternalHistoryMessage(message)
+  );
 }
 
 function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -1,4 +1,5 @@
 import { resetToolStream } from "../app-tool-stream.ts";
+import { shouldHideHistoryMessage as shouldHideSharedHistoryMessage } from "../chat/history-filter.ts";
 import { extractText } from "../chat/message-extract.ts";
 import { formatConnectError } from "../connect-error.ts";
 import { GatewayRequestError, type GatewayBrowserClient } from "../gateway.ts";
@@ -11,10 +12,6 @@ import {
 } from "./scope-errors.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
-const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
-  "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
-const LEAKED_SESSION_RESET_PROMPT_PREFIX =
-  "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user.";
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
@@ -60,57 +57,8 @@ function isAssistantSilentReply(message: unknown): boolean {
   return typeof text === "string" && isSilentReplyStream(text);
 }
 
-function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const entry = message as Record<string, unknown>;
-  const role = normalizeLowercaseStringOrEmpty(entry.role);
-  if (role !== "toolresult") {
-    return false;
-  }
-  const text = extractText(message);
-  return typeof text === "string" && text.trim() === SYNTHETIC_TRANSCRIPT_REPAIR_RESULT;
-}
-
-function isLeakedInternalHistoryMessage(message: unknown): boolean {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  const entry = message as Record<string, unknown>;
-  const text = extractText(message);
-  if (typeof text !== "string") {
-    return false;
-  }
-  const lower = normalizeLowercaseStringOrEmpty(text.trim());
-  if (!lower) {
-    return false;
-  }
-  const role = normalizeLowercaseStringOrEmpty(entry.role);
-  const hasExecStatus =
-    lower.includes("exec started") ||
-    lower.includes("exec completed") ||
-    lower.includes("exec finished") ||
-    lower.includes("exec failed") ||
-    lower.includes("exec denied");
-  if (
-    role === "system" &&
-    (lower.startsWith("system:") || lower.startsWith("system (untrusted):") || hasExecStatus)
-  ) {
-    return true;
-  }
-  if (lower.startsWith("sender (untrusted metadata):") && hasExecStatus) {
-    return true;
-  }
-  return lower.startsWith(normalizeLowercaseStringOrEmpty(LEAKED_SESSION_RESET_PROMPT_PREFIX));
-}
-
 function shouldHideHistoryMessage(message: unknown): boolean {
-  return (
-    isAssistantSilentReply(message) ||
-    isSyntheticTranscriptRepairToolResult(message) ||
-    isLeakedInternalHistoryMessage(message)
-  );
+  return isAssistantSilentReply(message) || shouldHideSharedHistoryMessage(message);
 }
 
 function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -277,6 +277,19 @@ function normalizeFinalAssistantMessage(message: unknown): Record<string, unknow
   });
 }
 
+function shouldKeepLiveAssistantMessage(message: Record<string, unknown> | null): boolean {
+  return !!message && !shouldHideHistoryMessage(message);
+}
+
+function buildStreamedAssistantMessage(text: string): Record<string, unknown> | null {
+  const candidate = {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp: Date.now(),
+  };
+  return shouldHideHistoryMessage(candidate) ? null : candidate;
+}
+
 export async function sendChatMessage(
   state: ChatState,
   message: string,
@@ -401,7 +414,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
     if (payload.state === "final") {
       const finalMessage = normalizeFinalAssistantMessage(payload.message);
-      if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+      if (shouldKeepLiveAssistantMessage(finalMessage)) {
         state.chatMessages = [...state.chatMessages, finalMessage];
         return null;
       }
@@ -417,36 +430,28 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
-    if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+    if (shouldKeepLiveAssistantMessage(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
     } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
-      state.chatMessages = [
-        ...state.chatMessages,
-        {
-          role: "assistant",
-          content: [{ type: "text", text: state.chatStream }],
-          timestamp: Date.now(),
-        },
-      ];
+      const streamedMessage = buildStreamedAssistantMessage(state.chatStream);
+      if (streamedMessage) {
+        state.chatMessages = [...state.chatMessages, streamedMessage];
+      }
     }
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
-    if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
+    if (shouldKeepLiveAssistantMessage(normalizedMessage)) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
       const streamedText = state.chatStream ?? "";
       if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
-        state.chatMessages = [
-          ...state.chatMessages,
-          {
-            role: "assistant",
-            content: [{ type: "text", text: streamedText }],
-            timestamp: Date.now(),
-          },
-        ];
+        const streamedMessage = buildStreamedAssistantMessage(streamedText);
+        if (streamedMessage) {
+          state.chatMessages = [...state.chatMessages, streamedMessage];
+        }
       }
     }
     state.chatStream = null;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -13,6 +13,8 @@ import {
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
+const LEAKED_SESSION_RESET_PROMPT_PREFIX =
+  "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user.";
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
@@ -97,7 +99,10 @@ function isLeakedInternalHistoryMessage(message: unknown): boolean {
   ) {
     return true;
   }
-  return lower.startsWith("sender (untrusted metadata):") && hasExecStatus;
+  if (lower.startsWith("sender (untrusted metadata):") && hasExecStatus) {
+    return true;
+  }
+  return lower.startsWith(normalizeLowercaseStringOrEmpty(LEAKED_SESSION_RESET_PROMPT_PREFIX));
 }
 
 function shouldHideHistoryMessage(message: unknown): boolean {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1703,7 +1703,7 @@ describe("chat view", () => {
     expect(container.textContent).toContain("real reply");
   });
 
-  it("still renders legitimate messages that start with System without exec leak markers", () => {
+  it("still renders legitimate messages that start with System and mention exec status generically", () => {
     const container = document.createElement("div");
     render(
       renderChat(
@@ -1713,9 +1713,7 @@ describe("chat view", () => {
             {
               id: "user-visible-system-prefix",
               role: "user",
-              content: [
-                { type: "text", text: "System: please reset the session when you're ready." },
-              ],
+              content: [{ type: "text", text: "System: exec failed after deploy, retrying" }],
               timestamp: Date.now(),
             },
           ],
@@ -1724,7 +1722,7 @@ describe("chat view", () => {
       container,
     );
 
-    expect(container.textContent).toContain("System: please reset the session when you're ready.");
+    expect(container.textContent).toContain("System: exec failed after deploy, retrying");
   });
 
   it("renders canvas-only assistant bubbles", () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1703,6 +1703,30 @@ describe("chat view", () => {
     expect(container.textContent).toContain("real reply");
   });
 
+  it("still renders legitimate messages that start with System without exec leak markers", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showToolCalls: false,
+          messages: [
+            {
+              id: "user-visible-system-prefix",
+              role: "user",
+              content: [
+                { type: "text", text: "System: please reset the session when you're ready." },
+              ],
+              timestamp: Date.now(),
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("System: please reset the session when you're ready.");
+  });
+
   it("renders canvas-only assistant bubbles", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1725,6 +1725,34 @@ describe("chat view", () => {
     expect(container.textContent).toContain("System: exec failed after deploy, retrying");
   });
 
+  it("still renders quoted reset-instruction text that only matches the shared prefix", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showToolCalls: false,
+          messages: [
+            {
+              id: "assistant-visible-reset-quote",
+              role: "assistant",
+              content: [
+                {
+                  type: "text",
+                  text: "A new session was started via /new or /reset. If runtime-provided startup context is included for this first turn, use it before responding to the user. Can you explain what this instruction means?",
+                },
+              ],
+              timestamp: Date.now(),
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("A new session was started via /new or /reset.");
+    expect(container.textContent).toContain("Can you explain what this instruction means?");
+  });
+
   it("renders canvas-only assistant bubbles", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1668,6 +1668,41 @@ describe("chat view", () => {
     expect(container.textContent).toContain("Shortcode view");
   });
 
+  it("does not render leaked system exec rows from chat history", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showToolCalls: false,
+          messages: [
+            {
+              id: "leaked-system-row",
+              role: "assistant",
+              content: [
+                {
+                  type: "text",
+                  text: "System (untrusted): [2026-04-14 22:56:23 PDT] Exec completed (tidy-zep, code 0)",
+                },
+              ],
+              timestamp: Date.now(),
+            },
+            {
+              id: "assistant-visible-row",
+              role: "assistant",
+              content: [{ type: "text", text: "real reply" }],
+              timestamp: Date.now() + 1,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).not.toContain("System (untrusted)");
+    expect(container.textContent).not.toContain("Exec completed");
+    expect(container.textContent).toContain("real reply");
+  });
+
   it("renders canvas-only assistant bubbles", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1729,6 +1729,27 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   return result;
 }
 
+function shouldHideRenderedHistoryMessage(message: unknown): boolean {
+  const text = extractTextCached(message);
+  if (typeof text !== "string") {
+    return false;
+  }
+  const lower = text.trim().toLowerCase();
+  if (!lower) {
+    return false;
+  }
+  const hasExecStatus =
+    lower.includes("exec started") ||
+    lower.includes("exec completed") ||
+    lower.includes("exec finished") ||
+    lower.includes("exec failed") ||
+    lower.includes("exec denied");
+  if (lower.startsWith("system:") || lower.startsWith("system (untrusted):")) {
+    return true;
+  }
+  return lower.startsWith("sender (untrusted metadata):") && hasExecStatus;
+}
+
 function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
   const history = Array.isArray(props.messages) ? props.messages : [];
@@ -1747,6 +1768,9 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   }
   for (let i = historyStart; i < history.length; i++) {
     const msg = history[i];
+    if (shouldHideRenderedHistoryMessage(msg)) {
+      continue;
+    }
     const normalized = normalizeMessage(msg);
     const raw = msg as Record<string, unknown>;
     const marker = raw.__openclaw as Record<string, unknown> | undefined;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -14,6 +14,7 @@ import {
   renderReadingIndicatorGroup,
   renderStreamingGroup,
 } from "../chat/grouped-render.ts";
+import { shouldHideHistoryMessage } from "../chat/history-filter.ts";
 import { InputHistory } from "../chat/input-history.ts";
 import { extractTextCached } from "../chat/message-extract.ts";
 import {
@@ -1729,27 +1730,6 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   return result;
 }
 
-function shouldHideRenderedHistoryMessage(message: unknown): boolean {
-  const text = extractTextCached(message);
-  if (typeof text !== "string") {
-    return false;
-  }
-  const lower = text.trim().toLowerCase();
-  if (!lower) {
-    return false;
-  }
-  const hasExecStatus =
-    lower.includes("exec started") ||
-    lower.includes("exec completed") ||
-    lower.includes("exec finished") ||
-    lower.includes("exec failed") ||
-    lower.includes("exec denied");
-  if (lower.startsWith("system:") || lower.startsWith("system (untrusted):")) {
-    return true;
-  }
-  return lower.startsWith("sender (untrusted metadata):") && hasExecStatus;
-}
-
 function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
   const history = Array.isArray(props.messages) ? props.messages : [];
@@ -1768,7 +1748,7 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   }
   for (let i = historyStart; i < history.length; i++) {
     const msg = history[i];
-    if (shouldHideRenderedHistoryMessage(msg)) {
+    if (shouldHideHistoryMessage(msg)) {
       continue;
     }
     const normalized = normalizeMessage(msg);


### PR DESCRIPTION
## Summary

- Problem: Control UI can render leaked internal transcript rows such as `System:` / `System (untrusted):` exec-status lines and sender-envelope noise as normal chat messages.
- Why it matters: these rows expose internal plumbing in the user-visible transcript and make webchat feel broken and untrustworthy.
- What changed: added history-side filtering in `controllers/chat.ts`, added a render-time guard in `views/chat.ts`, and added regression tests for both layers.
- What did NOT change (scope boundary): this PR does not change backend event production or session history serialization. It only hardens the UI against known leaked row shapes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66814
- Related #65994
- Related #62418
- Related #66648
- Related #39473
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Control UI trusted some transcript/history rows that were clearly internal-status content and rendered them as ordinary chat messages.
- Missing detection / guardrail: there was no single defensive filter covering both history ingestion and final render-time grouping.
- Contributing context (if known): some leaked rows can arrive with inconsistent roles or replay from local chat state, so filtering in only one layer was not enough.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `ui/src/ui/controllers/chat.test.ts`
  - `ui/src/ui/views/chat.test.ts`
- Scenario the test should lock in:
  - leaked `System (untrusted): ... Exec completed ...` rows are dropped from loaded history
  - leaked sender-metadata + exec-status rows are dropped from loaded history
  - leaked rows are not rendered even if they reach the chat view
- Why this is the smallest reliable guardrail:
  - the regression is in UI-side message filtering and rendering, and these tests exercise exactly those paths without requiring a full gateway repro
- Existing test that already covers this (if any):
  - none specific to leaked internal transcript rows
- If no new test is added, why not:
  - N/A

## User-visible / Behavior Changes

- Control UI no longer shows known leaked internal exec-status transcript rows as visible conversation bubbles.
- Control UI no longer renders known sender-envelope leak shapes tied to exec status text.

## Diagram (if applicable)

```text
Before:
[leaked internal row reaches history/view] -> [rendered as normal chat bubble]

After:
[leaked internal row reaches history/view] -> [filtered at load and render guard] -> [not shown]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw install, web Control UI
- Model/provider: N/A
- Integration/channel (if any): webchat / Control UI
- Relevant config (redacted): default local Control UI flow

### Steps

1. Open Control UI on a session where leaked internal exec/system transcript rows are visible.
2. Load or refresh chat history.
3. Observe whether `System:` / `System (untrusted):` exec-status rows or sender-envelope noise appear as normal chat bubbles.

### Expected

- internal exec/system leak rows are not shown in the visible chat transcript

### Actual

- before this change, leaked internal rows could appear as normal visible chat content

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - locally patched Control UI no longer showed leaked `System (untrusted)` / exec rows after refresh
  - sender-envelope leak shapes were covered in filtering logic
- Edge cases checked:
  - leaked rows with inconsistent role assignment
  - leaked rows replayed from local recent chat state
- What you did **not** verify:
  - full upstream CI/test suite in the source repo
  - every possible backend leak shape outside the known signatures covered here

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - the filter could hide a legitimate user-visible message if it exactly matches a known leak signature
  - Mitigation:
    - signatures are intentionally narrow and tied to known internal leak patterns
    - render-time and load-time tests lock in the current intended behavior
