### PR TITLE
fix(ui): skip session.message reloads during active chat

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -758,6 +758,40 @@ describe("connectGateway", () => {
     expect(host.chatStream).toBeNull();
   });
 
+  it("does not reload chat history when session.message follows a tracked final", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "engine-run-2";
+    host.chatStream = "Done";
+    host.chatStreamStartedAt = 125;
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "engine-run-2",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+          timestamp: 126,
+        },
+      },
+    });
+    client.emitEvent({
+      event: "session.message",
+      payload: { sessionKey: "main" },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(host.chatMessages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+        timestamp: 126,
+      },
+    ]);
+  });
+
   it("reloads chat history once after the final chat event when tool output was used", () => {
     const { client } = connectHostGateway();
     emitToolResultEvent(client);

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -97,7 +97,9 @@ vi.mock("./controllers/chat.ts", async (importOriginal) => {
 type TestGatewayHost = Parameters<typeof connectGateway>[0] & {
   chatSideResult: unknown;
   chatSideResultTerminalRuns: Set<string>;
+  chatMessages: Record<string, unknown>[];
   chatStream: string | null;
+  chatStreamStartedAt: number | null;
   chatToolMessages: Record<string, unknown>[];
   toolStreamById: Map<string, unknown>;
   toolStreamOrder: string[];

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -794,6 +794,37 @@ describe("connectGateway", () => {
     ]);
   });
 
+  it("reloads chat history after the tracked final when a same-session update was deferred", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "engine-run-3";
+    host.chatStream = "";
+    host.chatStreamStartedAt = 127;
+
+    client.emitEvent({
+      event: "session.message",
+      payload: { sessionKey: "main" },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "engine-run-3",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+          timestamp: 128,
+        },
+      },
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect((host as Record<string, unknown>).pendingSessionMessageReloadForSessionKey).toBeNull();
+  });
+
   it("reloads chat history once after the final chat event when tool output was used", () => {
     const { client } = connectHostGateway();
     emitToolResultEvent(client);

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -760,7 +760,7 @@ describe("connectGateway", () => {
     expect(host.chatStream).toBeNull();
   });
 
-  it("does not reload chat history when session.message follows a tracked final", () => {
+  it("does not reload chat history when a matching session.message follows a tracked final", () => {
     const { host, client } = connectHostGateway();
     host.chatRunId = "engine-run-2";
     host.chatStream = "Done";
@@ -781,7 +781,13 @@ describe("connectGateway", () => {
     });
     client.emitEvent({
       event: "session.message",
-      payload: { sessionKey: "main" },
+      payload: {
+        sessionKey: "main",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+        },
+      },
     });
 
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
@@ -794,6 +800,39 @@ describe("connectGateway", () => {
     ]);
   });
 
+  it("reloads chat history when the next session.message does not match the tracked final", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "engine-run-2b";
+    host.chatStream = "Done";
+    host.chatStreamStartedAt = 125;
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "engine-run-2b",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+          timestamp: 126,
+        },
+      },
+    });
+    client.emitEvent({
+      event: "session.message",
+      payload: {
+        sessionKey: "main",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Other update" }],
+        },
+      },
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+  });
+
   it("reloads chat history after the tracked final when a same-session update was deferred", () => {
     const { host, client } = connectHostGateway();
     host.chatRunId = "engine-run-3";
@@ -802,7 +841,13 @@ describe("connectGateway", () => {
 
     client.emitEvent({
       event: "session.message",
-      payload: { sessionKey: "main" },
+      payload: {
+        sessionKey: "main",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Deferred update" }],
+        },
+      },
     });
 
     expect(loadChatHistoryMock).not.toHaveBeenCalled();

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -726,6 +726,38 @@ describe("connectGateway", () => {
     expect(host.execApprovalQueue).toHaveLength(0);
   });
 
+  it("does not reload chat history after the tracked run finishes without tool output", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "engine-run-1";
+    host.chatStream = "Done";
+    host.chatStreamStartedAt = 123;
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "engine-run-1",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+          timestamp: 124,
+        },
+      },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(host.chatMessages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+        timestamp: 124,
+      },
+    ]);
+    expect(host.chatRunId).toBeNull();
+    expect(host.chatStream).toBeNull();
+  });
+
   it("reloads chat history once after the final chat event when tool output was used", () => {
     const { client } = connectHostGateway();
     emitToolResultEvent(client);

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -158,6 +158,46 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
   });
 
+  it("consumes the one-shot suppression on the next session.message", () => {
+    loadChatHistoryMock.mockReset();
+    const host = createHost() as Record<string, unknown>;
+    host.sessionKey = "agent:qa:main";
+    host.suppressNextSessionMessageReloadForSessionKey = "agent:qa:main";
+
+    handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:qa:main" },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(host.suppressNextSessionMessageReloadForSessionKey).toBeNull();
+  });
+
+  it("reloads on a later session.message after the one-shot suppression is consumed", () => {
+    loadChatHistoryMock.mockReset();
+    const host = createHost() as Record<string, unknown>;
+    host.sessionKey = "agent:qa:main";
+    host.suppressNextSessionMessageReloadForSessionKey = "agent:qa:main";
+
+    handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:qa:main" },
+      seq: 1,
+    });
+    handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:qa:main" },
+      seq: 2,
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host as Parameters<typeof handleGatewayEvent>[0]);
+  });
+
   it("ignores transcript updates for other sessions", () => {
     loadChatHistoryMock.mockReset();
     const host = createHost();

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -194,45 +194,57 @@ describe("handleGatewayEvent session.message", () => {
     expect(host.pendingSessionMessageReloadForSessionKey).toBe("agent:qa:main");
   });
 
-  it("consumes the one-shot suppression on the next session.message", () => {
+  it("consumes the one-shot suppression on the matching next session.message", () => {
     loadChatHistoryMock.mockReset();
     const host = createHost() as Record<string, unknown>;
     host.sessionKey = "agent:qa:main";
     host.suppressNextSessionMessageReloadForSessionKey = "agent:qa:main";
+    host.suppressNextSessionMessageReloadMessageSignature = "assistant:done";
     host.suppressNextSessionMessageReloadExpiresAtMs = Date.now() + 5_000;
 
     handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
       type: "event",
       event: "session.message",
-      payload: { sessionKey: "agent:qa:main" },
+      payload: {
+        sessionKey: "agent:qa:main",
+        message: { role: "assistant", content: [{ type: "text", text: "Done" }] },
+      },
       seq: 1,
     });
 
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
     expect(host.suppressNextSessionMessageReloadForSessionKey).toBeNull();
+    expect(host.suppressNextSessionMessageReloadMessageSignature).toBeNull();
   });
 
-  it("reloads on a later session.message after the one-shot suppression is consumed", () => {
+  it("reloads when the next session.message does not match the suppressed final", () => {
     loadChatHistoryMock.mockReset();
     const host = createHost() as Record<string, unknown>;
     host.sessionKey = "agent:qa:main";
     host.suppressNextSessionMessageReloadForSessionKey = "agent:qa:main";
+    host.suppressNextSessionMessageReloadMessageSignature = "assistant:done";
     host.suppressNextSessionMessageReloadExpiresAtMs = Date.now() + 5_000;
 
     handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
       type: "event",
       event: "session.message",
-      payload: { sessionKey: "agent:qa:main" },
+      payload: {
+        sessionKey: "agent:qa:main",
+        message: { role: "assistant", content: [{ type: "text", text: "Other update" }] },
+      },
       seq: 1,
     });
     handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
       type: "event",
       event: "session.message",
-      payload: { sessionKey: "agent:qa:main" },
+      payload: {
+        sessionKey: "agent:qa:main",
+        message: { role: "assistant", content: [{ type: "text", text: "Another update" }] },
+      },
       seq: 2,
     });
 
-    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(2);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(
       host as Parameters<typeof handleGatewayEvent>[0],
     );
@@ -243,17 +255,22 @@ describe("handleGatewayEvent session.message", () => {
     const host = createHost() as Record<string, unknown>;
     host.sessionKey = "agent:qa:main";
     host.suppressNextSessionMessageReloadForSessionKey = "agent:qa:main";
+    host.suppressNextSessionMessageReloadMessageSignature = "assistant:done";
     host.suppressNextSessionMessageReloadExpiresAtMs = Date.now() - 1;
 
     handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
       type: "event",
       event: "session.message",
-      payload: { sessionKey: "agent:qa:main" },
+      payload: {
+        sessionKey: "agent:qa:main",
+        message: { role: "assistant", content: [{ type: "text", text: "Done" }] },
+      },
       seq: 1,
     });
 
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
     expect(host.suppressNextSessionMessageReloadForSessionKey).toBeNull();
+    expect(host.suppressNextSessionMessageReloadMessageSignature).toBeNull();
     expect(host.suppressNextSessionMessageReloadExpiresAtMs).toBeNull();
   });
 

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -142,6 +142,22 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
   });
 
+  it("does not reload chat history during active chat flow", () => {
+    loadChatHistoryMock.mockReset();
+    const host = createHost();
+    host.sessionKey = "agent:qa:main";
+    host.chatRunId = "run-123";
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:qa:main" },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
   it("ignores transcript updates for other sessions", () => {
     loadChatHistoryMock.mockReset();
     const host = createHost();

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -142,7 +142,26 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
   });
 
-  it("does not reload chat history during active chat flow", () => {
+  it("reloads chat history even while a prior history request is still loading", () => {
+    loadChatHistoryMock.mockReset();
+    const host = createHost() as Record<string, unknown>;
+    host.sessionKey = "agent:qa:main";
+    host.chatLoading = true;
+
+    handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:qa:main" },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(
+      host as Parameters<typeof handleGatewayEvent>[0],
+    );
+  });
+
+  it("does not reload chat history during an active tracked run", () => {
     loadChatHistoryMock.mockReset();
     const host = createHost();
     host.sessionKey = "agent:qa:main";
@@ -158,11 +177,29 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
   });
 
+  it("does not reload chat history while streaming is still active", () => {
+    loadChatHistoryMock.mockReset();
+    const host = createHost() as Record<string, unknown>;
+    host.sessionKey = "agent:qa:main";
+    host.chatStream = "";
+
+    handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:qa:main" },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(host.pendingSessionMessageReloadForSessionKey).toBe("agent:qa:main");
+  });
+
   it("consumes the one-shot suppression on the next session.message", () => {
     loadChatHistoryMock.mockReset();
     const host = createHost() as Record<string, unknown>;
     host.sessionKey = "agent:qa:main";
     host.suppressNextSessionMessageReloadForSessionKey = "agent:qa:main";
+    host.suppressNextSessionMessageReloadExpiresAtMs = Date.now() + 5_000;
 
     handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
       type: "event",
@@ -180,6 +217,7 @@ describe("handleGatewayEvent session.message", () => {
     const host = createHost() as Record<string, unknown>;
     host.sessionKey = "agent:qa:main";
     host.suppressNextSessionMessageReloadForSessionKey = "agent:qa:main";
+    host.suppressNextSessionMessageReloadExpiresAtMs = Date.now() + 5_000;
 
     handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
       type: "event",
@@ -195,7 +233,28 @@ describe("handleGatewayEvent session.message", () => {
     });
 
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
-    expect(loadChatHistoryMock).toHaveBeenCalledWith(host as Parameters<typeof handleGatewayEvent>[0]);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(
+      host as Parameters<typeof handleGatewayEvent>[0],
+    );
+  });
+
+  it("reloads on a later session.message after stale one-shot suppression expires", () => {
+    loadChatHistoryMock.mockReset();
+    const host = createHost() as Record<string, unknown>;
+    host.sessionKey = "agent:qa:main";
+    host.suppressNextSessionMessageReloadForSessionKey = "agent:qa:main";
+    host.suppressNextSessionMessageReloadExpiresAtMs = Date.now() - 1;
+
+    handleGatewayEvent(host as Parameters<typeof handleGatewayEvent>[0], {
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:qa:main" },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(host.suppressNextSessionMessageReloadForSessionKey).toBeNull();
+    expect(host.suppressNextSessionMessageReloadExpiresAtMs).toBeNull();
   });
 
   it("ignores transcript updates for other sessions", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -407,6 +407,7 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
       payload.sessionKey,
     );
   }
+  const trackedRunIdBeforeEvent = host.chatRunId;
   const sideResultHost = host as GatewayHostWithSideResults;
   const isTrackedSideResultTerminalEvent =
     isTerminalChatState(payload?.state) &&
@@ -418,7 +419,11 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
   }
   const state = handleChatEvent(host as unknown as ChatState, payload);
   const historyReloaded = handleTerminalChatEvent(host, payload, state);
-  if (state === "final" && !historyReloaded && shouldReloadHistoryForFinalEvent(payload)) {
+  if (
+    state === "final" &&
+    !historyReloaded &&
+    shouldReloadHistoryForFinalEvent(payload, { trackedRunId: trackedRunIdBeforeEvent })
+  ) {
     void loadChatHistory(host as unknown as ChatState);
   }
 }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -114,6 +114,15 @@ type GatewayHostWithSideResults = GatewayHost & {
   chatSideResultTerminalRuns?: Set<string>;
 };
 
+function isActiveChatFlow(host: GatewayHost & Partial<ChatState>): boolean {
+  return (
+    host.chatLoading === true ||
+    host.chatSending === true ||
+    Boolean(host.chatRunId) ||
+    (host.chatStream !== null && host.chatStream !== undefined)
+  );
+}
+
 function isTerminalChatState(
   state: ChatEventPayload["state"] | ReturnType<typeof handleChatEvent> | null | undefined,
 ): state is "final" | "aborted" | "error" {
@@ -420,6 +429,9 @@ function handleSessionMessageGatewayEvent(
 ) {
   const sessionKey = payload?.sessionKey?.trim();
   if (!sessionKey || sessionKey !== host.sessionKey) {
+    return;
+  }
+  if (isActiveChatFlow(host as GatewayHost & Partial<ChatState>)) {
     return;
   }
   void loadChatHistory(host as unknown as ChatState);

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -16,6 +16,7 @@ import {
 } from "./app-settings.ts";
 import { handleAgentEvent, resetToolStream, type AgentEventPayload } from "./app-tool-stream.ts";
 import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
+import { extractTextCached } from "./chat/message-extract.ts";
 import { parseChatSideResult, type ChatSideResult } from "./chat/side-result.ts";
 import { formatConnectError } from "./connect-error.ts";
 import { loadAgents, type AgentsState } from "./controllers/agents.ts";
@@ -50,6 +51,7 @@ import {
 import { GatewayBrowserClient } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import type { UiSettings } from "./storage.ts";
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 import type {
   AgentsListResult,
   PresenceEntry,
@@ -119,6 +121,7 @@ const SESSION_MESSAGE_RELOAD_SUPPRESSION_TTL_MS = 5_000;
 type GatewayHostWithSessionMessageReloadState = GatewayHost & {
   pendingSessionMessageReloadForSessionKey?: string | null;
   suppressNextSessionMessageReloadForSessionKey?: string | null;
+  suppressNextSessionMessageReloadMessageSignature?: string | null;
   suppressNextSessionMessageReloadExpiresAtMs?: number | null;
 };
 
@@ -156,32 +159,67 @@ function flushDeferredSessionMessageReload(host: GatewayHost): boolean {
   return true;
 }
 
+function extractComparableSessionMessageSignature(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const entry = message as Record<string, unknown>;
+  const role = normalizeLowercaseStringOrEmpty(entry.role);
+  if (role !== "assistant") {
+    return "";
+  }
+  const text = extractTextCached(message);
+  if (typeof text !== "string") {
+    return "";
+  }
+  const normalizedText = normalizeLowercaseStringOrEmpty(text.trim());
+  return normalizedText ? `${role}:${normalizedText}` : "";
+}
+
 function clearSessionMessageReloadSuppression(host: GatewayHost) {
   const reloadHost = host as GatewayHostWithSessionMessageReloadState;
   reloadHost.suppressNextSessionMessageReloadForSessionKey = null;
+  reloadHost.suppressNextSessionMessageReloadMessageSignature = null;
   reloadHost.suppressNextSessionMessageReloadExpiresAtMs = null;
 }
 
-function suppressNextSessionMessageReload(host: GatewayHost, sessionKey: string) {
+function suppressNextSessionMessageReload(host: GatewayHost, sessionKey: string, message: unknown) {
+  const signature = extractComparableSessionMessageSignature(message);
+  if (!signature) {
+    clearSessionMessageReloadSuppression(host);
+    return;
+  }
   const reloadHost = host as GatewayHostWithSessionMessageReloadState;
   reloadHost.suppressNextSessionMessageReloadForSessionKey = sessionKey;
+  reloadHost.suppressNextSessionMessageReloadMessageSignature = signature;
   reloadHost.suppressNextSessionMessageReloadExpiresAtMs =
     Date.now() + SESSION_MESSAGE_RELOAD_SUPPRESSION_TTL_MS;
 }
 
-function shouldSuppressNextSessionMessageReload(host: GatewayHost, sessionKey: string): boolean {
+function shouldSuppressNextSessionMessageReload(
+  host: GatewayHost,
+  payload: { sessionKey?: string; message?: unknown } | undefined,
+): boolean {
+  const sessionKey = payload?.sessionKey?.trim();
+  if (!sessionKey) {
+    return false;
+  }
   const reloadHost = host as GatewayHostWithSessionMessageReloadState;
   const suppressionSessionKey = reloadHost.suppressNextSessionMessageReloadForSessionKey;
+  const suppressionSignature = reloadHost.suppressNextSessionMessageReloadMessageSignature;
   const expiresAt = reloadHost.suppressNextSessionMessageReloadExpiresAtMs;
   const isExpired = typeof expiresAt === "number" && expiresAt <= Date.now();
   if (isExpired) {
     clearSessionMessageReloadSuppression(host);
-  }
-  if (suppressionSessionKey !== sessionKey) {
     return false;
   }
+  if (suppressionSessionKey !== sessionKey || !suppressionSignature) {
+    return false;
+  }
+  const incomingSignature = extractComparableSessionMessageSignature(payload?.message);
+  const shouldSuppress = incomingSignature === suppressionSignature;
   clearSessionMessageReloadSuppression(host);
-  return !isExpired;
+  return shouldSuppress;
 }
 
 function isTerminalChatState(
@@ -495,20 +533,24 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
       clearDeferredSessionMessageReload(host, payload?.sessionKey);
       void loadChatHistory(host as unknown as ChatState);
     } else {
-      suppressNextSessionMessageReload(host, payload?.sessionKey?.trim() || host.sessionKey);
+      suppressNextSessionMessageReload(
+        host,
+        payload?.sessionKey?.trim() || host.sessionKey,
+        payload?.message,
+      );
     }
   }
 }
 
 function handleSessionMessageGatewayEvent(
   host: GatewayHost,
-  payload: { sessionKey?: string } | undefined,
+  payload: { sessionKey?: string; message?: unknown } | undefined,
 ) {
   const sessionKey = payload?.sessionKey?.trim();
   if (!sessionKey || sessionKey !== host.sessionKey) {
     return;
   }
-  if (shouldSuppressNextSessionMessageReload(host, sessionKey)) {
+  if (shouldSuppressNextSessionMessageReload(host, payload)) {
     return;
   }
   if (isActiveChatFlow(host as GatewayHost & Partial<ChatState>)) {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -114,6 +114,10 @@ type GatewayHostWithSideResults = GatewayHost & {
   chatSideResultTerminalRuns?: Set<string>;
 };
 
+type GatewayHostWithSessionMessageSuppression = GatewayHost & {
+  suppressNextSessionMessageReloadForSessionKey?: string | null;
+};
+
 function isActiveChatFlow(host: GatewayHost & Partial<ChatState>): boolean {
   return (
     host.chatLoading === true ||
@@ -419,12 +423,17 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
   }
   const state = handleChatEvent(host as unknown as ChatState, payload);
   const historyReloaded = handleTerminalChatEvent(host, payload, state);
-  if (
-    state === "final" &&
-    !historyReloaded &&
-    shouldReloadHistoryForFinalEvent(payload, { trackedRunId: trackedRunIdBeforeEvent })
-  ) {
-    void loadChatHistory(host as unknown as ChatState);
+  if (state === "final" && !historyReloaded) {
+    const shouldReload = shouldReloadHistoryForFinalEvent(payload, {
+      trackedRunId: trackedRunIdBeforeEvent,
+    });
+    if (shouldReload) {
+      void loadChatHistory(host as unknown as ChatState);
+    } else {
+      const suppressionHost = host as GatewayHostWithSessionMessageSuppression;
+      suppressionHost.suppressNextSessionMessageReloadForSessionKey =
+        payload?.sessionKey?.trim() || host.sessionKey;
+    }
   }
 }
 
@@ -434,6 +443,11 @@ function handleSessionMessageGatewayEvent(
 ) {
   const sessionKey = payload?.sessionKey?.trim();
   if (!sessionKey || sessionKey !== host.sessionKey) {
+    return;
+  }
+  const suppressionHost = host as GatewayHostWithSessionMessageSuppression;
+  if (suppressionHost.suppressNextSessionMessageReloadForSessionKey === sessionKey) {
+    suppressionHost.suppressNextSessionMessageReloadForSessionKey = null;
     return;
   }
   if (isActiveChatFlow(host as GatewayHost & Partial<ChatState>)) {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -114,17 +114,74 @@ type GatewayHostWithSideResults = GatewayHost & {
   chatSideResultTerminalRuns?: Set<string>;
 };
 
-type GatewayHostWithSessionMessageSuppression = GatewayHost & {
+const SESSION_MESSAGE_RELOAD_SUPPRESSION_TTL_MS = 5_000;
+
+type GatewayHostWithSessionMessageReloadState = GatewayHost & {
+  pendingSessionMessageReloadForSessionKey?: string | null;
   suppressNextSessionMessageReloadForSessionKey?: string | null;
+  suppressNextSessionMessageReloadExpiresAtMs?: number | null;
 };
 
 function isActiveChatFlow(host: GatewayHost & Partial<ChatState>): boolean {
-  return (
-    host.chatLoading === true ||
-    host.chatSending === true ||
-    Boolean(host.chatRunId) ||
-    (host.chatStream !== null && host.chatStream !== undefined)
-  );
+  return Boolean(host.chatRunId) || (host.chatStream !== null && host.chatStream !== undefined);
+}
+
+function clearDeferredSessionMessageReload(host: GatewayHost, sessionKey?: string | null) {
+  const reloadHost = host as GatewayHostWithSessionMessageReloadState;
+  if (!sessionKey || reloadHost.pendingSessionMessageReloadForSessionKey === sessionKey) {
+    reloadHost.pendingSessionMessageReloadForSessionKey = null;
+  }
+}
+
+function queueDeferredSessionMessageReload(host: GatewayHost, sessionKey: string) {
+  const reloadHost = host as GatewayHostWithSessionMessageReloadState;
+  reloadHost.pendingSessionMessageReloadForSessionKey = sessionKey;
+}
+
+function flushDeferredSessionMessageReload(host: GatewayHost): boolean {
+  const reloadHost = host as GatewayHostWithSessionMessageReloadState;
+  const sessionKey = reloadHost.pendingSessionMessageReloadForSessionKey?.trim();
+  if (!sessionKey) {
+    return false;
+  }
+  if (sessionKey !== host.sessionKey) {
+    reloadHost.pendingSessionMessageReloadForSessionKey = null;
+    return false;
+  }
+  if (isActiveChatFlow(host as GatewayHost & Partial<ChatState>)) {
+    return false;
+  }
+  reloadHost.pendingSessionMessageReloadForSessionKey = null;
+  void loadChatHistory(host as unknown as ChatState);
+  return true;
+}
+
+function clearSessionMessageReloadSuppression(host: GatewayHost) {
+  const reloadHost = host as GatewayHostWithSessionMessageReloadState;
+  reloadHost.suppressNextSessionMessageReloadForSessionKey = null;
+  reloadHost.suppressNextSessionMessageReloadExpiresAtMs = null;
+}
+
+function suppressNextSessionMessageReload(host: GatewayHost, sessionKey: string) {
+  const reloadHost = host as GatewayHostWithSessionMessageReloadState;
+  reloadHost.suppressNextSessionMessageReloadForSessionKey = sessionKey;
+  reloadHost.suppressNextSessionMessageReloadExpiresAtMs =
+    Date.now() + SESSION_MESSAGE_RELOAD_SUPPRESSION_TTL_MS;
+}
+
+function shouldSuppressNextSessionMessageReload(host: GatewayHost, sessionKey: string): boolean {
+  const reloadHost = host as GatewayHostWithSessionMessageReloadState;
+  const suppressionSessionKey = reloadHost.suppressNextSessionMessageReloadForSessionKey;
+  const expiresAt = reloadHost.suppressNextSessionMessageReloadExpiresAtMs;
+  const isExpired = typeof expiresAt === "number" && expiresAt <= Date.now();
+  if (isExpired) {
+    clearSessionMessageReloadSuppression(host);
+  }
+  if (suppressionSessionKey !== sessionKey) {
+    return false;
+  }
+  clearSessionMessageReloadSuppression(host);
+  return !isExpired;
 }
 
 function isTerminalChatState(
@@ -423,16 +480,22 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
   }
   const state = handleChatEvent(host as unknown as ChatState, payload);
   const historyReloaded = handleTerminalChatEvent(host, payload, state);
+  if (historyReloaded) {
+    clearDeferredSessionMessageReload(host, payload?.sessionKey);
+    return;
+  }
+  if (isTerminalChatState(state) && flushDeferredSessionMessageReload(host)) {
+    return;
+  }
   if (state === "final" && !historyReloaded) {
     const shouldReload = shouldReloadHistoryForFinalEvent(payload, {
       trackedRunId: trackedRunIdBeforeEvent,
     });
     if (shouldReload) {
+      clearDeferredSessionMessageReload(host, payload?.sessionKey);
       void loadChatHistory(host as unknown as ChatState);
     } else {
-      const suppressionHost = host as GatewayHostWithSessionMessageSuppression;
-      suppressionHost.suppressNextSessionMessageReloadForSessionKey =
-        payload?.sessionKey?.trim() || host.sessionKey;
+      suppressNextSessionMessageReload(host, payload?.sessionKey?.trim() || host.sessionKey);
     }
   }
 }
@@ -445,14 +508,14 @@ function handleSessionMessageGatewayEvent(
   if (!sessionKey || sessionKey !== host.sessionKey) {
     return;
   }
-  const suppressionHost = host as GatewayHostWithSessionMessageSuppression;
-  if (suppressionHost.suppressNextSessionMessageReloadForSessionKey === sessionKey) {
-    suppressionHost.suppressNextSessionMessageReloadForSessionKey = null;
+  if (shouldSuppressNextSessionMessageReload(host, sessionKey)) {
     return;
   }
   if (isActiveChatFlow(host as GatewayHost & Partial<ChatState>)) {
+    queueDeferredSessionMessageReload(host, sessionKey);
     return;
   }
+  clearDeferredSessionMessageReload(host, sessionKey);
   void loadChatHistory(host as unknown as ChatState);
 }
 

--- a/ui/src/ui/chat-event-reload.test.ts
+++ b/ui/src/ui/chat-event-reload.test.ts
@@ -23,14 +23,31 @@ describe("shouldReloadHistoryForFinalEvent", () => {
     ).toBe(true);
   });
 
-  it("returns true when final event includes assistant payload", () => {
+  it("returns false when the final event completes the tracked run", () => {
     expect(
-      shouldReloadHistoryForFinalEvent({
-        runId: "run-1",
-        sessionKey: "main",
-        state: "final",
-        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
-      }),
+      shouldReloadHistoryForFinalEvent(
+        {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+        },
+        { trackedRunId: "run-1" },
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when final event includes assistant payload for a different run", () => {
+    expect(
+      shouldReloadHistoryForFinalEvent(
+        {
+          runId: "run-2",
+          sessionKey: "main",
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+        },
+        { trackedRunId: "run-1" },
+      ),
     ).toBe(true);
   });
 

--- a/ui/src/ui/chat-event-reload.ts
+++ b/ui/src/ui/chat-event-reload.ts
@@ -1,5 +1,19 @@
 import type { ChatEventPayload } from "./controllers/chat.ts";
 
-export function shouldReloadHistoryForFinalEvent(payload?: ChatEventPayload): boolean {
-  return Boolean(payload && payload.state === "final");
+type FinalEventReloadOptions = {
+  trackedRunId?: string | null;
+};
+
+export function shouldReloadHistoryForFinalEvent(
+  payload?: ChatEventPayload,
+  options?: FinalEventReloadOptions,
+): boolean {
+  if (!payload || payload.state !== "final") {
+    return false;
+  }
+  const trackedRunId = options?.trackedRunId?.trim();
+  if (trackedRunId && (!payload.runId || payload.runId === trackedRunId)) {
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
## Summary

- Problem: Control UI can eagerly reload `chat.history` on `session.message` while the current chat is still sending, loading, or streaming.
- Why it matters: this can race against optimistic/local state and produce flicker, collapse, duplicate bubbles, or temporarily incorrect ordering.
- What changed: added an active-chat-flow gate in `ui/src/ui/app-gateway.ts` so same-session `session.message` events do not reload history during an active chat, and added a regression test for that behavior.
- What did NOT change (scope boundary): this PR does not redesign full history reconciliation or change unrelated reload paths. It only suppresses one eager reload path during active chat flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66875
- Related #66207
- Related #66176
- Related #66274
- Related #37083
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `session.message` events could trigger `loadChatHistory(...)` for the active session even while the same chat was still in an active local send/load/stream state.
- Missing detection / guardrail: there was no active-chat-flow check before reloading history on `session.message`.
- Contributing context (if known): eager history replacement races with optimistic user messages and live assistant stream state.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `ui/src/ui/app-gateway.sessions.node.test.ts`
- Scenario the test should lock in:
  - when a `session.message` event arrives for the active session during an active chat flow, the UI does not reload chat history
- Why this is the smallest reliable guardrail:
  - the bug is specifically in the `session.message` event handler and can be locked down directly without a broader end-to-end harness
- Existing test that already covers this (if any):
  - existing coverage only checked that active-session `session.message` normally reloads history
- If no new test is added, why not:
  - N/A

## User-visible / Behavior Changes

- Control UI is less likely to flicker, collapse, duplicate, or reorder messages during an active send/stream cycle when `session.message` arrives for the current session.

## Diagram (if applicable)

```text
Before:
[user sends message] -> [chat active]
                     -> [session.message arrives]
                     -> [history reload]
                     -> [optimistic/live state replaced] -> [flicker/duplicate/reorder]

After:
[user sends message] -> [chat active]
                     -> [session.message arrives]
                     -> [reload skipped during active flow]
                     -> [local stream/final state stays stable]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw install, web Control UI
- Model/provider: N/A
- Integration/channel (if any): webchat / Control UI
- Relevant config (redacted): default local Control UI flow

### Steps

1. Open Control UI and send a message in webchat.
2. While the chat is still sending/loading/streaming, allow `session.message` to fire for the same session.
3. Observe whether chat history reloads and disturbs the visible optimistic/streaming state.

### Expected

- active local chat state remains stable during the send/stream cycle
- no eager history reload for same-session `session.message` during active flow

### Actual

- before this change, `session.message` could trigger history reload during active chat flow and contribute to flicker/collapse/duplicate behavior

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - local Control UI behavior improved after suppressing active-flow history reloads
  - same-session active-chat reload path was identified as a plausible causal trigger
- Edge cases checked:
  - active state via `chatRunId`
  - active state via sending/loading/stream presence
- What you did **not** verify:
  - full upstream CI/test suite in the source repo
  - all other history reload triggers such as unrelated `sessions.changed` paths

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - skipping reloads during active flow could delay some legitimate same-session hydration until the chat is no longer active
  - Mitigation:
    - the guard is narrow and only applies during active local chat flow
    - normal history loads still occur outside that active window
