### PR TITLE
fix: drain system events on /new session reset

### DIFF
--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -10,6 +10,7 @@ import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../auto-reply/reply/queue.js";
+import { drainSystemEventEntries } from "../infra/system-events.js";
 import {
   buildSessionEndHookPayload,
   buildSessionStartHookPayload,
@@ -256,6 +257,12 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
+  // Drain stale system events so they don't leak into the fresh session.
+  // The sessionKey is preserved across /new, so any events enqueued before
+  // the reset would otherwise be injected into the first post-reset message.
+  for (const key of queueKeys) {
+    drainSystemEventEntries(key);
+  }
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     clearBootstrapSnapshot(params.target.canonicalKey);


### PR DESCRIPTION
## Summary

When a session is reset via \/new\, \clearSessionQueues\ purges followup/command lane queues but does not drain the process-global system events map. Because \sessionKey\ is preserved across \/new\, stale system events (e.g. exec failure notifications from \maybeNotifyOnExit\) survive and get injected as \System (untrusted): ...\ prefixed text into the first message of the fresh session.

## Changes

Added \drainSystemEventEntries(key)\ for each queue key immediately after \clearSessionQueues()\ in \nsureSessionRuntimeCleanup\. This is symmetric with the existing followup/command queue purge.

## Impact

- Prevents stale exec failure events from leaking across session boundaries
- Prevents unintended context (file paths, command output) from appearing in fresh sessions
- ~5 lines, no function rewrite

Fixes #66864