### PR TITLE
fix: skip test files and directories in install security scanner

### DIFF
--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -10,6 +10,7 @@ import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../auto-reply/reply/queue.js";
+import { drainSystemEventEntries } from "../infra/system-events.js";
 import {
   buildSessionEndHookPayload,
   buildSessionStartHookPayload,
@@ -256,6 +257,12 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
+  // Drain stale system events so they don't leak into the fresh session.
+  // The sessionKey is preserved across /new, so any events enqueued before
+  // the reset would otherwise be injected into the first post-reset message.
+  for (const key of queueKeys) {
+    drainSystemEventEntries(key);
+  }
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     clearBootstrapSnapshot(params.target.canonicalKey);

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -10,7 +10,6 @@ import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../auto-reply/reply/queue.js";
-import { drainSystemEventEntries } from "../infra/system-events.js";
 import {
   buildSessionEndHookPayload,
   buildSessionStartHookPayload,
@@ -257,12 +256,6 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
-  // Drain stale system events so they don't leak into the fresh session.
-  // The sessionKey is preserved across /new, so any events enqueued before
-  // the reset would otherwise be injected into the first post-reset message.
-  for (const key of queueKeys) {
-    drainSystemEventEntries(key);
-  }
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     clearBootstrapSnapshot(params.target.canonicalKey);

--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -339,11 +339,31 @@ async function walkDirWithLimit(dirPath: string, maxFiles: number): Promise<stri
       if (entry.name.startsWith(".") || entry.name === "node_modules") {
         continue;
       }
+      // Skip test directories — test files commonly mock env vars + fetch,
+      // which triggers false-positive "credential harvesting" findings.
+      if (
+        entry.kind === "dir" &&
+        (entry.name === "tests" ||
+          entry.name === "__tests__" ||
+          entry.name === "__mocks__" ||
+          entry.name === "test" ||
+          entry.name === "__fixtures__")
+      ) {
+        continue;
+      }
 
       const fullPath = path.join(currentDir, entry.name);
       if (entry.kind === "dir") {
         stack.push(fullPath);
       } else if (entry.kind === "file" && isScannable(entry.name)) {
+        // Skip test files by name pattern
+        if (
+          entry.name.includes(".test.") ||
+          entry.name.includes(".spec.") ||
+          entry.name.includes(".mock.")
+        ) {
+          continue;
+        }
         files.push(fullPath);
       }
     }


### PR DESCRIPTION
## Summary

The install-time security scanner blocks plugins that ship unit tests containing `process.env` access + `fetch()` calls in the same file. This is a standard unit-testing pattern (mocking env vars and network for telemetry opt-out tests, feature flag tests, etc.) and triggers false-positive "credential harvesting" findings.

## Changes

In `walkDirWithLimit` (`src/security/skill-scanner.ts`):
- Skip common test directories: `tests/`, `__tests__/`, `test/`, `__mocks__/`, `__fixtures__/`
- Skip test file patterns: `*.test.*`, `*.spec.*`, `*.mock.*`

These files are never loaded at plugin runtime and should not be scanned for security threats.

## Impact

Plugins like `@axonflow/openclaw` that include test files in their ClawHub archive will no longer be blocked during installation due to false-positive security findings from test mocks.

Fixes #66840
