### PR TITLE
fix(plugins): include memory slot plugin in primary wiki CLI scope

### DIFF
--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -1,7 +1,7 @@
 import { collectUniqueCommandDescriptors } from "../cli/program/command-descriptor-utils.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { resolveManifestActivationPluginIds } from "./activation-planner.js";
+import { normalizePluginsConfig } from "./config-state.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadOpenClawPluginCliRegistry, loadOpenClawPlugins } from "./loader.js";
 import type { PluginRegistry } from "./registry.js";
@@ -119,8 +119,8 @@ function withPrimaryMemorySlotPluginId(
 }
 
 function resolveConfiguredMemorySlotPluginId(config: OpenClawConfig): string | null {
-  const memorySlotPluginId = normalizeOptionalLowercaseString(config.plugins?.slots?.memory);
-  if (!memorySlotPluginId || memorySlotPluginId === "none") {
+  const memorySlotPluginId = normalizePluginsConfig(config.plugins).slots.memory;
+  if (!memorySlotPluginId) {
     return null;
   }
   return memorySlotPluginId;

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -1,5 +1,6 @@
 import { collectUniqueCommandDescriptors } from "../cli/program/command-descriptor-utils.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { resolveManifestActivationPluginIds } from "./activation-planner.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadOpenClawPluginCliRegistry, loadOpenClawPlugins } from "./loader.js";
@@ -89,7 +90,7 @@ function resolvePrimaryCommandPluginIds(
   if (!normalizedPrimary) {
     return [];
   }
-  return resolveManifestActivationPluginIds({
+  const plannedPluginIds = resolveManifestActivationPluginIds({
     trigger: {
       kind: "command",
       command: normalizedPrimary,
@@ -98,6 +99,31 @@ function resolvePrimaryCommandPluginIds(
     workspaceDir: context.workspaceDir,
     env: context.env,
   });
+  return withPrimaryMemorySlotPluginId(plannedPluginIds, context.activationSourceConfig);
+}
+
+function withPrimaryMemorySlotPluginId(
+  pluginIds: readonly string[],
+  config: OpenClawConfig,
+): string[] {
+  if (pluginIds.length === 0) {
+    return [];
+  }
+  const memorySlotPluginId = resolveConfiguredMemorySlotPluginId(config);
+  if (!memorySlotPluginId) {
+    return [...pluginIds];
+  }
+  return [...new Set([...pluginIds, memorySlotPluginId])].toSorted((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+function resolveConfiguredMemorySlotPluginId(config: OpenClawConfig): string | null {
+  const memorySlotPluginId = normalizeOptionalLowercaseString(config.plugins?.slots?.memory);
+  if (!memorySlotPluginId || memorySlotPluginId === "none") {
+    return null;
+  }
+  return memorySlotPluginId;
 }
 
 export function resolvePluginCliLoadContext(params: {

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -421,6 +421,93 @@ describe("registerPluginCliCommands", () => {
     expect(mocks.memoryListAction).toHaveBeenCalledTimes(1);
   });
 
+  it("includes memory slot plugin when primary command is wiki", async () => {
+    const program = createProgram();
+    program.exitOverride();
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-wiki"]);
+
+    await registerPluginCliCommands(
+      program,
+      {
+        plugins: {
+          slots: {
+            memory: "memory-core",
+          },
+        },
+      } as OpenClawConfig,
+      undefined,
+      undefined,
+      {
+        mode: "lazy",
+        primary: "wiki",
+      },
+    );
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["memory-core", "memory-wiki"],
+      }),
+    );
+  });
+
+  it("does not append memory slot when slot is none", async () => {
+    const program = createProgram();
+    program.exitOverride();
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-wiki"]);
+
+    await registerPluginCliCommands(
+      program,
+      {
+        plugins: {
+          slots: {
+            memory: "none",
+          },
+        },
+      } as OpenClawConfig,
+      undefined,
+      undefined,
+      {
+        mode: "lazy",
+        primary: "wiki",
+      },
+    );
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["memory-wiki"],
+      }),
+    );
+  });
+
+  it("dedupes memory slot plugin in primary scope", async () => {
+    const program = createProgram();
+    program.exitOverride();
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-core", "memory-wiki"]);
+
+    await registerPluginCliCommands(
+      program,
+      {
+        plugins: {
+          slots: {
+            memory: "memory-core",
+          },
+        },
+      } as OpenClawConfig,
+      undefined,
+      undefined,
+      {
+        mode: "lazy",
+        primary: "wiki",
+      },
+    );
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["memory-core", "memory-wiki"],
+      }),
+    );
+  });
+
   it("keeps full CLI loading when primary command planning finds no plugin match", async () => {
     const program = createProgram();
     program.exitOverride();

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -450,6 +450,31 @@ describe("registerPluginCliCommands", () => {
     );
   });
 
+  it("includes default memory slot plugin when slot is omitted", async () => {
+    const program = createProgram();
+    program.exitOverride();
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["memory-wiki"]);
+
+    await registerPluginCliCommands(
+      program,
+      {
+        plugins: {},
+      } as OpenClawConfig,
+      undefined,
+      undefined,
+      {
+        mode: "lazy",
+        primary: "wiki",
+      },
+    );
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["memory-core", "memory-wiki"],
+      }),
+    );
+  });
+
   it("does not append memory slot when slot is none", async () => {
     const program = createProgram();
     program.exitOverride();


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

  - Problem: openclaw wiki status/doctor could report bridgePublicArtifactCount: 0 and bridge-artifacts-missing even when memory artifacts existed.
  - Why it matters: users saw a false unhealthy bridge state and misleading remediation guidance.
  - What changed: primary-command scoped CLI plugin loading now appends the configured memory slot plugin id (unless slot is none) with deduped deterministic ordering.
  - What did NOT change (scope boundary): no hardcoded memory-core special case, no full-loader behavior change when primary planning returns no plugin match, no protocol/config contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66082
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

  - Root cause: command-scoped plugin loading for primary: "wiki" loaded memory-wiki but did not also load the active memory slot plugin that owns public artifact export capability.
  - Missing detection / guardrail: no regression test for “primary command scope + memory slot dependency” in CLI loader behavior.
  - Contributing context (if known): scoped loading is intentionally narrow for startup, but memory-wiki bridge status depends on runtime memory capability registration from the active memory slot plugin.


## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
  - Target test or file: src/plugins/cli.test.ts
  - Scenario the test should lock in: for primary: "wiki", loader scope includes both planned command owner plugin ids and configured
    plugins.slots.memory plugin id.
  - Why this is the smallest reliable guardrail: bug is in scope-construction logic before runtime execution; unit coverage on the loader contract is direct and stable.
  - Existing test that already covers this (if any): existing “no primary match keeps full loading” test (kept and validated).
  - If no new test is added, why not: N/A (new tests added).

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

  - openclaw wiki status --json in bridge mode now reports non-zero bridgePublicArtifactCount when artifacts exist.
  - openclaw wiki doctor --json no longer emits false bridge-artifacts-missing in that scenario.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

  Before:
  [wiki primary scoped load] -> [loads memory-wiki only] -> [no active memory runtime capability] -> [artifact count 0 + false warning]

  After:
  [wiki primary scoped load] -> [loads memory-wiki + configured memory slot plugin] -> [memory public artifacts registered] -> [correct count + no false warning]


## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) Yes
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation: scoped CLI loading may include one additional plugin (configured memory slot) during primary command
    execution; mitigation is strict config-driven inclusion only when primary scope is already active, none is respected, ids are deduped/sorted, and regression tests cover scope boundaries.

## Repro + Verification

### Environment

  - OS: macOS (local dev machine)
  - Runtime/container: Node + pnpm workspace (pnpm openclaw ...)
  - Model/provider: N/A
  - Integration/channel (if any): memory-wiki bridge + memory-core slot
  - Relevant config (redacted): temp config with plugins.slots.memory="memory-core", memory-wiki bridge enabled, workspace containing MEMORY.md,
    memory/day-1.md, memory/.dreams/events.jsonl

### Steps

  1. Run OPENCLAW_CONFIG_PATH=/tmp/openclaw-issue-66082/openclaw.json pnpm openclaw wiki status --json.
  2. Run OPENCLAW_CONFIG_PATH=/tmp/openclaw-issue-66082/openclaw.json pnpm openclaw wiki doctor --json.
  3. Run targeted tests: pnpm test src/plugins/cli.test.ts src/plugins/activation-planner.test.ts extensions/memory-wiki/src/status.test.ts.

### Expected

  - Bridge artifact count reflects existing artifacts (> 0) and no false bridge-artifacts-missing warning.

### Actual

  - Before fix: count 0 and warning present.
  - After fix: count 3 and warning absent; doctor healthy.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

  - Verified scenarios: manual CLI repro before/after with same fixture config; root-cause script (loadOpenClawPlugins scoped/full) showing 0 vs >0; targeted and full src/plugins/cli.test.ts runs.
  - Edge cases checked: slot=none does not append; dedupe when planned ids already include slot plugin; no-primary-match keeps full loading behavior.
  - What you did not verify: live remote environments/channels beyond local CLI + tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk: additional plugin load in primary-scoped CLI path could widen initialization work for some commands.
      - Mitigation: only applies when primary planning returns non-empty scope; adds only configured memory slot plugin; none disabled path
        preserved; dedupe and deterministic ordering; regression tests added in src/plugins/cli.test.ts.

### Built with Codex
