### PR TITLE
fix(auth-profiles): make post-success bookkeeping saves non-fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ Docs: https://docs.openclaw.ai
 - Agents/error rendering: ignore stale assistant `errorMessage` fields on successful turns so background/tool-side failures no longer prepend synthetic billing errors over valid replies. (#40616) Thanks @ingyukoh.
 - Agents/fallback: recognize Venice `402 Insufficient USD or Diem balance` billing errors so configured model fallbacks trigger instead of surfacing the raw provider error. (#43205) Thanks @Squabble9.
 - Dependencies: refresh workspace dependencies except the pinned Carbon package, and harden ACP session-config writes against non-string SDK values so newer ACP clients fail fast instead of tripping type/runtime mismatches.
+- Agents/auth-profiles: treat post-completion bookkeeping save failures (for example Windows EPERM when `auth-profiles.json` gets a ReadOnly attribute during concurrent hot-reload) as non-fatal in `markAuthProfileGood`, `markAuthProfileUsed`, and `markAuthProfileFailure`, so a succeeded LLM request is not turned into a cascading gateway failure. Fixes #62099. Thanks @ademczuk.
 
 ## 2026.3.8
 

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -1,6 +1,7 @@
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { normalizeProviderId, normalizeProviderIdForAuth } from "../model-selection.js";
+import { log } from "./constants.js";
 import {
   ensureAuthProfileStore,
   saveAuthProfileStore,
@@ -91,25 +92,36 @@ export async function markAuthProfileGood(params: {
   agentDir?: string;
 }): Promise<void> {
   const { store, provider, profileId, agentDir } = params;
-  const updated = await updateAuthProfileStoreWithLock({
-    agentDir,
-    updater: (freshStore) => {
-      const profile = freshStore.profiles[profileId];
-      if (!profile || profile.provider !== provider) {
-        return false;
-      }
-      freshStore.lastGood = { ...freshStore.lastGood, [provider]: profileId };
-      return true;
-    },
-  });
-  if (updated) {
-    store.lastGood = updated.lastGood;
-    return;
+  // Post-success bookkeeping. Save failures (e.g. Windows EPERM on a ReadOnly
+  // auth-profiles.json during concurrent hot-reload) must not propagate and
+  // fail an LLM request that has already completed.
+  try {
+    const updated = await updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (freshStore) => {
+        const profile = freshStore.profiles[profileId];
+        if (!profile || profile.provider !== provider) {
+          return false;
+        }
+        freshStore.lastGood = { ...freshStore.lastGood, [provider]: profileId };
+        return true;
+      },
+    });
+    if (updated) {
+      store.lastGood = updated.lastGood;
+      return;
+    }
+    const profile = store.profiles[profileId];
+    if (!profile || profile.provider !== provider) {
+      return;
+    }
+    store.lastGood = { ...store.lastGood, [provider]: profileId };
+    saveAuthProfileStore(store, agentDir);
+  } catch (err) {
+    log.warn("markAuthProfileGood: failed to persist last-good profile; continuing", {
+      provider,
+      profileId,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
-  const profile = store.profiles[profileId];
-  if (!profile || profile.provider !== provider) {
-    return;
-  }
-  store.lastGood = { ...store.lastGood, [provider]: profileId };
-  saveAuthProfileStore(store, agentDir);
 }

--- a/src/agents/auth-profiles/usage.persist-nonfatal.test.ts
+++ b/src/agents/auth-profiles/usage.persist-nonfatal.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { markAuthProfileGood } from "./profiles.js";
+import type { AuthProfileStore } from "./types.js";
+import { markAuthProfileFailure, markAuthProfileUsed } from "./usage.js";
+
+// Regression: #62099. On Windows, concurrent config hot-reload can leave
+// auth-profiles.json with a ReadOnly attribute, and saveAuthProfileStore
+// throws EPERM. The mark* functions run as post-completion bookkeeping
+// (after the LLM request has already returned), so the throw used to
+// cascade into the request flow and make the gateway unresponsive. They
+// must now swallow persistence failures instead.
+
+vi.mock("./store.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./store.js")>();
+  const buildEperm = (): Error => {
+    const err = new Error(
+      "EPERM: operation not permitted, copyfile auth-profiles.json.tmp -> auth-profiles.json",
+    );
+    (err as NodeJS.ErrnoException).code = "EPERM";
+    return err;
+  };
+  return {
+    ...original,
+    // Mirror the observed Windows hot-reload race: both the lock-guarded
+    // update path and the direct save path hit the read-only file.
+    updateAuthProfileStoreWithLock: vi.fn().mockRejectedValue(buildEperm()),
+    saveAuthProfileStore: vi.fn(() => {
+      throw buildEperm();
+    }),
+  };
+});
+
+function makeStore(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "anthropic:default": {
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-test",
+      },
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-test-2",
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("auth-profile bookkeeping persists best-effort on EPERM", () => {
+  it("markAuthProfileGood does not throw when the store cannot be persisted", async () => {
+    const store = makeStore();
+    await expect(
+      markAuthProfileGood({
+        store,
+        provider: "anthropic",
+        profileId: "anthropic:default",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("markAuthProfileUsed does not throw when the store cannot be persisted", async () => {
+    const store = makeStore();
+    await expect(
+      markAuthProfileUsed({
+        store,
+        profileId: "anthropic:default",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("markAuthProfileFailure does not throw when the store cannot be persisted", async () => {
+    const store = makeStore();
+    await expect(
+      markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeProviderId } from "../model-selection.js";
+import { log } from "./constants.js";
 import { logAuthProfileFailureStateChange } from "./state-observation.js";
 import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
 import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } from "./types.js";
@@ -247,30 +248,40 @@ export async function markAuthProfileUsed(params: {
   agentDir?: string;
 }): Promise<void> {
   const { store, profileId, agentDir } = params;
-  const updated = await updateAuthProfileStoreWithLock({
-    agentDir,
-    updater: (freshStore) => {
-      if (!freshStore.profiles[profileId]) {
-        return false;
-      }
-      updateUsageStatsEntry(freshStore, profileId, (existing) =>
-        resetUsageStats(existing, { lastUsed: Date.now() }),
-      );
-      return true;
-    },
-  });
-  if (updated) {
-    store.usageStats = updated.usageStats;
-    return;
-  }
-  if (!store.profiles[profileId]) {
-    return;
-  }
+  // Post-success bookkeeping. Save failures (e.g. Windows EPERM on a ReadOnly
+  // auth-profiles.json during concurrent hot-reload) must not propagate and
+  // fail an LLM request that has already completed.
+  try {
+    const updated = await updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (freshStore) => {
+        if (!freshStore.profiles[profileId]) {
+          return false;
+        }
+        updateUsageStatsEntry(freshStore, profileId, (existing) =>
+          resetUsageStats(existing, { lastUsed: Date.now() }),
+        );
+        return true;
+      },
+    });
+    if (updated) {
+      store.usageStats = updated.usageStats;
+      return;
+    }
+    if (!store.profiles[profileId]) {
+      return;
+    }
 
-  updateUsageStatsEntry(store, profileId, (existing) =>
-    resetUsageStats(existing, { lastUsed: Date.now() }),
-  );
-  saveAuthProfileStore(store, agentDir);
+    updateUsageStatsEntry(store, profileId, (existing) =>
+      resetUsageStats(existing, { lastUsed: Date.now() }),
+    );
+    saveAuthProfileStore(store, agentDir);
+  } catch (err) {
+    log.warn("markAuthProfileUsed: failed to persist usage stats; continuing", {
+      profileId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 export function calculateAuthProfileCooldownMs(errorCount: number): number {
@@ -477,78 +488,89 @@ export async function markAuthProfileFailure(params: {
   let nextStats: ProfileUsageStats | undefined;
   let previousStats: ProfileUsageStats | undefined;
   let updateTime = 0;
-  const updated = await updateAuthProfileStoreWithLock({
-    agentDir,
-    updater: (freshStore) => {
-      const profile = freshStore.profiles[profileId];
-      if (!profile || isAuthCooldownBypassedForProvider(profile.provider)) {
-        return false;
+  // Post-event bookkeeping. Save failures (e.g. Windows EPERM on a ReadOnly
+  // auth-profiles.json during concurrent hot-reload) must not propagate and
+  // turn a transient provider failure into an unrecoverable gateway cascade.
+  try {
+    const updated = await updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (freshStore) => {
+        const profile = freshStore.profiles[profileId];
+        if (!profile || isAuthCooldownBypassedForProvider(profile.provider)) {
+          return false;
+        }
+        const now = Date.now();
+        const providerKey = normalizeProviderId(profile.provider);
+        const cfgResolved = resolveAuthCooldownConfig({
+          cfg,
+          providerId: providerKey,
+        });
+
+        previousStats = freshStore.usageStats?.[profileId];
+        updateTime = now;
+        const computed = computeNextProfileUsageStats({
+          existing: previousStats ?? {},
+          now,
+          reason,
+          cfgResolved,
+        });
+        nextStats = computed;
+        updateUsageStatsEntry(freshStore, profileId, () => computed);
+        return true;
+      },
+    });
+    if (updated) {
+      store.usageStats = updated.usageStats;
+      if (nextStats) {
+        logAuthProfileFailureStateChange({
+          runId,
+          profileId,
+          provider: profile.provider,
+          reason,
+          previous: previousStats,
+          next: nextStats,
+          now: updateTime,
+        });
       }
-      const now = Date.now();
-      const providerKey = normalizeProviderId(profile.provider);
-      const cfgResolved = resolveAuthCooldownConfig({
-        cfg,
-        providerId: providerKey,
-      });
-
-      previousStats = freshStore.usageStats?.[profileId];
-      updateTime = now;
-      const computed = computeNextProfileUsageStats({
-        existing: previousStats ?? {},
-        now,
-        reason,
-        cfgResolved,
-      });
-      nextStats = computed;
-      updateUsageStatsEntry(freshStore, profileId, () => computed);
-      return true;
-    },
-  });
-  if (updated) {
-    store.usageStats = updated.usageStats;
-    if (nextStats) {
-      logAuthProfileFailureStateChange({
-        runId,
-        profileId,
-        provider: profile.provider,
-        reason,
-        previous: previousStats,
-        next: nextStats,
-        now: updateTime,
-      });
+      return;
     }
-    return;
-  }
-  if (!store.profiles[profileId]) {
-    return;
-  }
+    if (!store.profiles[profileId]) {
+      return;
+    }
 
-  const now = Date.now();
-  const providerKey = normalizeProviderId(store.profiles[profileId]?.provider ?? "");
-  const cfgResolved = resolveAuthCooldownConfig({
-    cfg,
-    providerId: providerKey,
-  });
+    const now = Date.now();
+    const providerKey = normalizeProviderId(store.profiles[profileId]?.provider ?? "");
+    const cfgResolved = resolveAuthCooldownConfig({
+      cfg,
+      providerId: providerKey,
+    });
 
-  previousStats = store.usageStats?.[profileId];
-  const computed = computeNextProfileUsageStats({
-    existing: previousStats ?? {},
-    now,
-    reason,
-    cfgResolved,
-  });
-  nextStats = computed;
-  updateUsageStatsEntry(store, profileId, () => computed);
-  saveAuthProfileStore(store, agentDir);
-  logAuthProfileFailureStateChange({
-    runId,
-    profileId,
-    provider: store.profiles[profileId]?.provider ?? profile.provider,
-    reason,
-    previous: previousStats,
-    next: nextStats,
-    now,
-  });
+    previousStats = store.usageStats?.[profileId];
+    const computed = computeNextProfileUsageStats({
+      existing: previousStats ?? {},
+      now,
+      reason,
+      cfgResolved,
+    });
+    nextStats = computed;
+    updateUsageStatsEntry(store, profileId, () => computed);
+    saveAuthProfileStore(store, agentDir);
+    logAuthProfileFailureStateChange({
+      runId,
+      profileId,
+      provider: store.profiles[profileId]?.provider ?? profile.provider,
+      reason,
+      previous: previousStats,
+      next: nextStats,
+      now,
+    });
+  } catch (err) {
+    log.warn("markAuthProfileFailure: failed to persist failure state; continuing", {
+      profileId,
+      reason,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #62099. On Windows, concurrent config hot-reload can leave `auth-profiles.json` with a ReadOnly attribute. The atomic write in `saveAuthProfileStore` then throws `EPERM`, and because `markAuthProfileGood` / `markAuthProfileUsed` / `markAuthProfileFailure` run as post-completion bookkeeping, that throw used to cascade into the LLM request that had already succeeded. Fallback triggers, hits the same read-only file, fails the same way. The gateway becomes unresponsive; restarts don't help because the file attribute persists.

The fix wraps the body of each `mark*` function in try/catch, logging the persistence failure and continuing. Caller-visible behavior is unchanged on the happy path.

## What this does NOT change

`saveAuthProfileStore` itself still throws on failure. OAuth token refresh (in `oauth.ts`) depends on that behavior, since a silent token-save failure would be a security concern. Only the three `mark*` functions that run after a successful provider call now tolerate save errors.

## Scope

- `src/agents/auth-profiles/profiles.ts` - wrap `markAuthProfileGood` body in try/catch, log warn
- `src/agents/auth-profiles/usage.ts` - wrap `markAuthProfileUsed` and `markAuthProfileFailure` bodies in try/catch, log warn
- `src/agents/auth-profiles/usage.persist-nonfatal.test.ts` - new regression tests, one per mark function, simulating EPERM from both the lock-guarded and direct save paths

`markAuthProfileCooldown` delegates to `markAuthProfileFailure` so it's covered transitively.

## Before

```
Error: EPERM: operation not permitted, copyfile
  'auth-profiles.json.<uuid>.tmp' -> 'auth-profiles.json'
    at Object.copyFileSync (node:fs:3104:11)
    at renameJsonFileWithFallback
    at saveJsonFile
    at saveAuthProfileStore
    at markAuthProfileGood
    at pi-embedded:36473
```

The LLM response arrived, then the save threw, then every fallback hit the same file, then the gateway ran out of models. User hits `attrib -R` on the file and restarts to recover.

## After

The save throws, the catch runs, the warning lands in the subsystem log, the mark function returns void, the LLM request completes normally. `lastGood` / usage stats stay slightly stale until the next successful save, which is the right tradeoff for a bookkeeping write.

## Testing

- New tests in `usage.persist-nonfatal.test.ts` pass (3/3). Mocks both `updateAuthProfileStoreWithLock` and `saveAuthProfileStore` to throw EPERM, asserts the `mark*` functions resolve without throwing.
- Existing `usage.test.ts` (39 tests) and `auth-profiles.markauthprofilefailure.test.ts` (9 tests) still pass. Also verified `auth-profiles.runtime-snapshot-save.test.ts` (1 test).
- Two pre-existing test failures in `state-observation.test.ts` and `oauth.fallback-to-main-agent.test.ts` already fail on main, unrelated to this change.
- `oxlint --type-aware` clean on modified files.
- `tsgo --noEmit` clean (exit 0).
- `oxfmt --check` clean.

## Risk

Low. Behavioral change is scoped to the error path of a bookkeeping function. Callers that previously got an unhandled rejection on EPERM now get a resolved promise, which is the intended outcome. Profile state in memory stays authoritative; disk just gets slightly stale until the next successful write.

## AI disclosure

This change was drafted with Claude Code acting as coding assistant. The issue was picked from the triaged backlog, the root-cause analysis and implementation plan were produced interactively, and tests were written against the exact stack trace in the issue report. Human review of the patch and regression tests before submission.

## Understanding confirmation

Yes, I've read CONTRIBUTING.md and VISION.md. This is a single-concern bug fix with no dependency updates, no schema changes, and no new public APIs. The affected module is `src/agents/auth-profiles/`. No Carbon changes, no `@ts-nocheck`, no lint suppression.