### PR TITLE
fix: prevent plugin loading for cron management commands

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -126,4 +126,8 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     exact: true,
     policy: { loadPlugins: "never" },
   },
+  {
+    commandPath: ["cron"],
+    policy: { loadPlugins: "never" },
+  },
 ];


### PR DESCRIPTION
## Summary
Cron subcommands like 'openclaw cron add' are pure management operations that should not load business plugins. Without an explicit catalog entry, plugin loading depends on implicit defaults which can fail when a plugin requires unconfigured settings.

## Root Cause
The 'cron' command was not listed in 'cliCommandCatalog' with an explicit 'loadPlugins: "never"' policy. While the default policy happens to be 'never', the lack of an explicit entry means the command relies entirely on implicit defaults and subcli registration timing.

## Fix
Added 'cron' to 'cliCommandCatalog' in 'src/cli/command-catalog.ts' with 'loadPlugins: "never"', consistent with how 'onboard' and 'channels add' are already handled.

Closes openclaw#67026