### PR TITLE
fix(dreaming): use isolated sessionTarget instead of main (#67021)

### DIFF
--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -155,7 +155,7 @@ function buildManagedDreamingCronJob(
       expr: config.cron,
       ...(config.timezone ? { tz: config.timezone } : {}),
     },
-    sessionTarget: "main",
+    sessionTarget: "isolated",
     wakeMode: "now",
     payload: {
       kind: "systemEvent",

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -255,8 +255,8 @@ function buildManagedDreamingPatch(
   }
 
   const sessionTarget = normalizeLowercaseStringOrEmpty(normalizeTrimmedString(job.sessionTarget));
-  if (sessionTarget !== "main") {
-    patch.sessionTarget = "main";
+  if (sessionTarget !== "isolated") {
+    patch.sessionTarget = "isolated";
   }
   const wakeMode = normalizeLowercaseStringOrEmpty(normalizeTrimmedString(job.wakeMode));
   if (wakeMode !== "now") {


### PR DESCRIPTION
## Summary

The managed dreaming cron was hardcoded to `sessionTarget: 'main'` in `extensions/memory-core/src/dreaming.ts` line 158. This causes:

1. **Main workspace skipped**: When Thomas is asleep (03:00 UTC), the main Telegram session is dormant. The cron fires but the event cannot be delivered to a non-polling session → main workspace never dreams.

2. **Session contamination**: Dreaming runs inside the main session, consuming its context buffer. This can push the session toward compaction threshold, degrading Thomas's next morning conversation.

3. **Worst memory for primary agent**: Every other agent (Hector, etc.) uses `sessionTarget: 'isolated'` for their cron jobs — they work reliably. The main agent — the most important one — has broken dreaming.

## The fix

Change line 158 from `sessionTarget: 'main'` to `sessionTarget: 'isolated'`.

This matches the pattern already used by the Hector heartbeat cron job (created 5 days earlier, already uses `isolated`). The developers knew about `isolated` but accidentally used `main` for dreaming.

## Testing

Before: `openclaw cron list` shows `Memory Dreaming Promotion` with `Target: main`
After: Same job will show `Target: isolated` after reconciliation

## Related Issues

Fixes #67021 (main workspace excluded from dreaming schedule)
See also: #65374 (dreaming identity contamination in multi-agent setups)