### PR TITLE
fix(terminal): tolerate undefined path in formatDocsLink

### DIFF
--- a/src/terminal/links.test.ts
+++ b/src/terminal/links.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { formatDocsLink } from "./links.js";
+
+describe("formatDocsLink", () => {
+  it("prepends the docs root when given a relative path", () => {
+    const out = formatDocsLink("/channels/telegram", "telegram");
+    expect(out).toContain("https://docs.openclaw.ai/channels/telegram");
+  });
+
+  it("preserves an absolute http url", () => {
+    const out = formatDocsLink("https://example.com/page", "page");
+    expect(out).toContain("https://example.com/page");
+  });
+
+  it("treats whitespace-only path like an empty path and falls back to docs root", () => {
+    const out = formatDocsLink("   ", "root");
+    expect(out).toContain("https://docs.openclaw.ai");
+  });
+
+  it("does not crash when path is undefined (regression: #67076, #67074)", () => {
+    expect(() =>
+      formatDocsLink(undefined as unknown as string, "label"),
+    ).not.toThrow();
+    const out = formatDocsLink(undefined as unknown as string, "label");
+    expect(out).toContain("https://docs.openclaw.ai");
+  });
+
+  it("does not crash when path is null", () => {
+    expect(() => formatDocsLink(null as unknown as string)).not.toThrow();
+  });
+});

--- a/src/terminal/links.ts
+++ b/src/terminal/links.ts
@@ -5,15 +5,21 @@ function resolveDocsRoot(): string {
 }
 
 export function formatDocsLink(
-  path: string,
+  path: string | undefined | null,
   label?: string,
   opts?: { fallback?: string; force?: boolean },
 ): string {
-  const trimmed = path.trim();
   const docsRoot = resolveDocsRoot();
-  const url = trimmed.startsWith("http")
-    ? trimmed
-    : `${docsRoot}${trimmed.startsWith("/") ? trimmed : `/${trimmed}`}`;
+  const trimmed = typeof path === "string" ? path.trim() : "";
+  // When a caller has no docsPath, link to the docs root rather than crashing
+  // the onboarding/channel-selection flows that pass meta.docsPath through
+  // here unguarded. The typed contract says docsPath is required, but a
+  // handful of channel plugins and catalog rows leave it unset at runtime.
+  const url = trimmed
+    ? trimmed.startsWith("http")
+      ? trimmed
+      : `${docsRoot}${trimmed.startsWith("/") ? trimmed : `/${trimmed}`}`
+    : docsRoot;
   return formatTerminalLink(label ?? url, url, {
     fallback: opts?.fallback ?? url,
     force: opts?.force,


### PR DESCRIPTION
## What

Widen `formatDocsLink(path, ...)` in `src/terminal/links.ts` to accept `string | undefined | null` and fall back to the docs root (`https://docs.openclaw.ai`) when `path` is missing or whitespace-only.

## Why

Fixes #67076 and #67074.

`formatDocsLink` called `path.trim()` unconditionally. The typed contract says `ChannelMeta.docsPath: string` (required), but a handful of channel plugins / catalog rows leave it unset at runtime. When the onboarding flow calls `formatChannelSelectionLine(entry.meta, formatDocsLink)` in `src/flows/channel-setup.status.ts:233` for every channel, the first entry whose `meta.docsPath` is undefined throws:

```text
TypeError: Cannot read properties of undefined (reading 'trim')
  at formatDocsLink (.../links-BlUEqVE8.js:7)
  at formatChannelSelectionLine
  at resolveChannelSelectionNoteLines
```

Reproduction paths from the two reports:
- Select Discord → bot token → any channel option (macOS/Ubuntu, 4.14)
- `Select channel (QuickStart)` → `Skip for now` (Windows, 4.12/4.14)

Root cause confirmed by @Kovisun in #67074: the crash is inside `formatDocsLink` because at least one meta in the selection pass lacks `docsPath`.

## Why defensive at this site (vs hunting every plugin that drops docsPath)

- `formatDocsLink` is the single chokepoint shared by every plugin-sdk `formatDocsLink` re-export (`nextcloud-talk`, `tlon`, `twitch`, `bluebubbles`, `msteams`, `feishu`, `matrix`, `irc`, `googlechat`, etc.) and by the onboarding + setup flows.
- A defensive change here fixes two separate user-visible crash reports with one code site and no behavioral change for callers that already pass a string.
- The typed contract stays honest for the guarded callers (`optional-channel-setup.ts` already wraps in `if (params.docsPath)`) and no-longer-crashes for unguarded ones (`registry.ts:formatChannelSelectionLine`).

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `"/channels/telegram"` | `https://docs.openclaw.ai/channels/telegram` | unchanged |
| `"https://example.com/p"` | `https://example.com/p` | unchanged |
| `"  "` (whitespace) | malformed URL `https://docs.openclaw.ai/` (empty trimmed) | `https://docs.openclaw.ai` |
| `undefined` | **crash** — `TypeError` | `https://docs.openclaw.ai` |
| `null` | **crash** | `https://docs.openclaw.ai` |

## Test

Added `src/terminal/links.test.ts` with 5 cases covering the existing happy paths plus the two regression cases (`undefined`, `null`).

```
pnpm test -- src/terminal/links.test.ts
# Test Files  1 passed
# Tests       5 passed
```

## Risk

Minimal. Single file, 16 lines changed, widens a permissive signature. Callers that still pass required strings see identical output. Callers that previously crashed now silently fall back to the docs root URL — the onboarding flow continues rather than wedging.