### PR TITLE
fix(dreaming): use ingestion date for dayBucket instead of file date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/security: block DM pairing-store entries from authorizing room control commands. (#67294) Thanks @pgondhi987.
 - Gateway/security: enforce `localRoots` containment on the webchat audio embedding path. (#67298) Thanks @pgondhi987.
 - Webchat/security: reject remote-host `file://` URLs in the media embedding path. (#67293) Thanks @pgondhi987.
+- Dreaming/memory-core: use the ingestion day, not the source file day, for daily recall dedupe so repeat sweeps of the same daily note can increment `dailyCount` across days instead of stalling at `1`. (#67091) Thanks @Bartok9.
 
 ## 2026.4.14
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1648,4 +1648,94 @@ describe("memory-core dreaming phases", () => {
       "The traces braided themselves into a map.",
     );
   });
+
+  it("increments dailyCount when the same daily file is re-ingested on a later day", async () => {
+    // Regression test for #67061: dayBucket used the file date instead of the
+    // ingestion date, so re-ingesting the same file on a different day was
+    // treated as a duplicate and dailyCount stayed at 1.
+    const workspaceDir = await createDreamingWorkspace();
+    // Write a daily note dated 2026-04-03 (two days before the base test time).
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-03.md"),
+      ["# 2026-04-03", "", "- Move backups to S3 Glacier.", "- Keep retention at 365 days."].join(
+        "\n",
+      ),
+      "utf-8",
+    );
+
+    const configForTest: OpenClawConfig = {
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                phases: {
+                  light: {
+                    enabled: true,
+                    limit: 20,
+                    lookbackDays: 7,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // First ingestion on 2026-04-05.
+    const day1Ms = Date.parse("2026-04-05T10:00:00.000Z");
+    const { beforeAgentReply: reply1 } = createHarness(configForTest, workspaceDir);
+    await withDreamingTestClock(async () => {
+      vi.setSystemTime(new Date(day1Ms));
+      await reply1(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    });
+
+    const after1 = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: day1Ms,
+    });
+    expect(after1).toHaveLength(1);
+    expect(after1[0]?.dailyCount).toBe(1);
+
+    // Clear the daily ingestion checkpoint so the file is re-read on the second
+    // sweep (simulating a new day where the same lookback window still covers
+    // this file).
+    const dailyStatePath = path.join(workspaceDir, "memory", ".dreams", "daily-ingestion.json");
+    try {
+      await fs.unlink(dailyStatePath);
+    } catch {
+      // ignore if not created
+    }
+
+    // Second ingestion on 2026-04-06 (next day).
+    const day2Ms = Date.parse("2026-04-06T10:00:00.000Z");
+    const { beforeAgentReply: reply2 } = createHarness(configForTest, workspaceDir);
+    await withDreamingTestClock(async () => {
+      vi.setSystemTime(new Date(day2Ms));
+      await reply2(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    });
+
+    const after2 = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: day2Ms,
+    });
+    expect(after2).toHaveLength(1);
+    // With the fix, dailyCount should be 2 because the ingestion date changed.
+    // Before the fix, it stayed at 1 because dayBucket was the file date.
+    expect(after2[0]?.dailyCount).toBe(2);
+  });
 });

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -954,6 +954,7 @@ async function ingestSessionTranscriptSignals(params: {
     timezone: params.timezone,
     state,
   });
+  const ingestionDayBucket = formatMemoryDreamingDay(params.nowMs, params.timezone);
   for (const batch of collected.batches) {
     await recordShortTermRecalls({
       workspaceDir: params.workspaceDir,
@@ -961,7 +962,7 @@ async function ingestSessionTranscriptSignals(params: {
       results: batch.results,
       signalType: "daily",
       dedupeByQueryPerDay: true,
-      dayBucket: batch.day,
+      dayBucket: ingestionDayBucket,
       nowMs: params.nowMs,
       timezone: params.timezone,
     });
@@ -1113,6 +1114,7 @@ async function ingestDailyMemorySignals(params: {
     nowMs: params.nowMs,
     state,
   });
+  const ingestionDayBucket = formatMemoryDreamingDay(params.nowMs, params.timezone);
   for (const batch of collected.batches) {
     await recordShortTermRecalls({
       workspaceDir: params.workspaceDir,
@@ -1120,7 +1122,7 @@ async function ingestDailyMemorySignals(params: {
       results: batch.results,
       signalType: "daily",
       dedupeByQueryPerDay: true,
-      dayBucket: batch.day,
+      dayBucket: ingestionDayBucket,
       nowMs: params.nowMs,
       timezone: params.timezone,
     });
@@ -1222,7 +1224,7 @@ export async function seedHistoricalDailyMemorySignals(params: {
       results,
       signalType: "daily",
       dedupeByQueryPerDay: true,
-      dayBucket: entry.day,
+      dayBucket: formatMemoryDreamingDay(params.nowMs, params.timezone),
       nowMs: params.nowMs,
       timezone: params.timezone,
     });


### PR DESCRIPTION
## Summary

Fixes #67061.

When dreaming re-ingests the same daily memory file across multiple days, `dailyCount` stays stuck at `1` because `dayBucket` was set to `batch.day` (the file date) instead of the current ingestion date. Since `dedupeByQueryPerDay` checks whether `todayBucket` already appears in `recallDays`, using the file date causes every subsequent sweep to hit the dedupe guard — the file date was already recorded on the first ingestion.

This keeps `signalCount` (recallCount + dailyCount + groundedCount) below the default `minRecallCount=3` promotion gate, so **zero entries ever reach the scoring stage**, and the phase reinforcement from #64068 can never take effect.

## Root cause

In `dreaming-phases.ts`, all three ingestion functions pass the *file* date as `dayBucket`:

```ts
dayBucket: batch.day,  // e.g. "2026-04-11"
```

The dedupe logic in `recordShortTermRecalls` then checks:

```ts
const dedupeSignal =
  Boolean(params.dedupeByQueryPerDay) &&
  queryHashesBase.includes(queryHash) &&
  recallDaysBase.includes(todayBucket);
```

Since both `queryHash` and `todayBucket` (derived from `dayBucket`) are identical across sweeps, `dedupeSignal` is always `true` after the first ingestion, preventing `dailyCount` from incrementing.

## Fix

Change `dayBucket` from the file date to the ingestion date (via `formatMemoryDreamingDay(params.nowMs, params.timezone)`) in all three call sites:

1. `ingestSessionTranscriptSignals` 
2. `ingestDailyMemorySignals`
3. `seedHistoricalDailyMemorySignals`

The `query` string still uses the file date for identification; only the dedupe bucket changes to reflect when the sweep actually ran. `formatMemoryDreamingDay` was already imported and `params.nowMs`/`params.timezone` were already available at all three sites.

## Test

Added a regression test that:
1. Ingests a daily memory file on day 1 (2026-04-05)
2. Clears the checkpoint, then re-ingests the same file on day 2 (2026-04-06)  
3. Verifies `dailyCount` increments to `2` (was stuck at `1` before this fix)

All 22 tests in `dreaming-phases.test.ts` pass.