### PR TITLE
feat: add configurable concurrency for CommandLane.Nested

### DIFF
--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -27,5 +27,7 @@ export function resolveNestedMaxConcurrent(cfg?: OpenClawConfig): number {
   if (typeof raw === "number" && Number.isFinite(raw)) {
     return Math.max(1, Math.floor(raw));
   }
-  return DEFAULT_NESTED_MAX_CONCURRENT;
+  // Fall back to agent-level maxConcurrent so nested lane scales with the
+  // overall concurrency setting without requiring a separate config entry.
+  return resolveAgentMaxConcurrent(cfg);
 }

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
+export const DEFAULT_NESTED_MAX_CONCURRENT = 8;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;
 
@@ -19,4 +20,12 @@ export function resolveSubagentMaxConcurrent(cfg?: OpenClawConfig): number {
     return Math.max(1, Math.floor(raw));
   }
   return DEFAULT_SUBAGENT_MAX_CONCURRENT;
+}
+
+export function resolveNestedMaxConcurrent(cfg?: OpenClawConfig): number {
+  const raw = cfg?.agents?.defaults?.nested?.maxConcurrent;
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(1, Math.floor(raw));
+  }
+  return DEFAULT_NESTED_MAX_CONCURRENT;
 }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -349,6 +349,11 @@ export type AgentDefaultsConfig = {
   };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;
+  /** Nested (inter-agent sessions_send) lane concurrency. Default: 8. */
+  nested?: {
+    /** Max concurrent nested agent runs (global lane: "nested"). Default: 8. */
+    maxConcurrent?: number;
+  };
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
     /** Default allowlist of target agent ids for sessions_spawn. Use "*" to allow any. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -208,6 +208,12 @@ export const AgentDefaultsSchema = z
     typingMode: TypingModeSchema.optional(),
     heartbeat: HeartbeatSchema,
     maxConcurrent: z.number().int().positive().optional(),
+    nested: z
+      .object({
+        maxConcurrent: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -1,4 +1,8 @@
-import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
+import {
+  resolveAgentMaxConcurrent,
+  resolveNestedMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
@@ -7,4 +11,5 @@ export function applyGatewayLaneConcurrency(cfg: OpenClawConfig) {
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(CommandLane.Nested, resolveNestedMaxConcurrent(cfg));
 }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,7 +1,11 @@
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.types.js";
-import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
+import {
+  resolveAgentMaxConcurrent,
+  resolveNestedMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "../config/agent-limits.js";
 import { isRestartEnabled } from "../config/commands.flags.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
@@ -140,6 +144,7 @@ export function createGatewayReloadHandlers(params: {
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
+    setCommandLaneConcurrency(CommandLane.Nested, resolveNestedMaxConcurrent(nextConfig));
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);


### PR DESCRIPTION
## Problem

`applyGatewayLaneConcurrency()` in `server-lanes.ts` sets concurrency for Cron, Main, and Subagent lanes, but omits `CommandLane.Nested`, leaving it at the default value of 1.

This means all `sessions_send` calls between agents are serialized. When dispatching tasks to multiple agents simultaneously, delays accumulate significantly.

## Changes

- `src/config/agent-limits.ts`: Add `resolveNestedMaxConcurrent()` that reads `agents.defaults.nested.maxConcurrent`, falling back to `resolveAgentMaxConcurrent()` so the nested lane inherits the overall concurrency setting automatically
- `src/config/types.agent-defaults.ts`: Add `nested?: { maxConcurrent?: number }` to `AgentDefaultsConfig`
- `src/config/zod-schema.agent-defaults.ts`: Add `nested` entry to `AgentDefaultsSchema` so the config key passes strict Zod validation
- `src/gateway/server-lanes.ts`: Call `setCommandLaneConcurrency(CommandLane.Nested, resolveNestedMaxConcurrent(cfg))`
- `src/gateway/server-reload-handlers.ts`: Apply nested lane concurrency on hot reload so live config changes take effect without a Gateway restart
- `docs/.generated/config-baseline.sha256`: Regenerated

## Configuration

No explicit config needed — the nested lane now inherits `agents.defaults.maxConcurrent` automatically.

For finer-grained control, override via `openclaw.json`:

```json
{
  "agents": {
    "defaults": {
      "nested": { "maxConcurrent": 16 }
    }
  }
}
```

## Benchmark Results

Tested with 7 agents dispatched simultaneously via `sessions_send`. T1 = message received by agent.

### Before (concurrency = 1)

| Agent | T1 received | Gap |
|-------|-------------|-----|
| navi  | 17:40:39    | 0s  |
| ar    | 17:42:51    | +132s |
| pm    | 17:43:27    | +168s |
| qa    | 17:44:14    | +215s |
| cm    | 17:44:56    | +257s |
| dm    | 17:45:30    | +291s |

T1 spread: **291 seconds**

### After (concurrency inherits maxConcurrent)

| Agent | T1 received | Gap |
|-------|-------------|-----|
| navi  | 17:54:45    | 0s  |
| rs    | 17:54:53    | +8s |
| ar    | 17:55:07    | +22s |
| pm    | 17:55:26    | +41s |
| qa    | 17:55:38    | +53s |

T1 spread: **53 seconds — 75% reduction**

### Concurrency verification

Agents waited until a fixed timestamp then issued simultaneous API calls:

| Agent | T2 (start)   | T3 (response) | T2→T3 |
|-------|-------------|---------------|-------|
| navi  | 17:56:00.006 | 17:56:01.550 | 1.5s  |
| rs    | 17:56:00.013 | 17:56:04.158 | 4.1s  |
| ar    | 17:56:00.005 | 17:56:00.071 | 0.07s |
| pm    | 17:56:00.789 | 17:56:04.631 | 3.8s  |
| qa    | 17:56:00.005 | 17:56:07.590 | 7.6s  |

T2 spread: **< 1 second** across all agents. Agents now receive messages and act concurrently. Remaining response variance is provider API latency, not OC internal queuing.