### PR TITLE
fix: tolerate concurrent temp dir permission repair

### DIFF
--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -424,6 +424,7 @@ describe("resolvePreferredOpenClawTmpDir", () => {
     });
 
     expect(resolved).toBe(POSIX_OPENCLAW_TMP_DIR);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("throws when the fallback directory cannot be created", () => {

--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -394,6 +394,38 @@ describe("resolvePreferredOpenClawTmpDir", () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("tightened permissions on temp dir"));
   });
 
+  it("succeeds when another process already tightened permissions while we attempted repair", () => {
+    const chmodSync = vi.fn((target: string, mode: number) => {
+      if (target === POSIX_OPENCLAW_TMP_DIR && mode === 0o700) {
+        throw nodeErrorWithCode("EPERM");
+      }
+    });
+    let callCount = 0;
+    const warn = vi.fn();
+
+    const lstatSync = vi.fn<NonNullable<TmpDirOptions["lstatSync"]>>((target: string) => {
+      callCount++;
+      if (target === POSIX_OPENCLAW_TMP_DIR) {
+        if (callCount <= 2) {
+          return makeDirStat({ mode: 0o40777 });
+        }
+        return makeDirStat({ mode: 0o40700 });
+      }
+      return secureDirStat(501);
+    });
+
+    const resolved = resolvePreferredOpenClawTmpDir({
+      accessSync: vi.fn(),
+      lstatSync,
+      chmodSync,
+      getuid: vi.fn(() => 501),
+      tmpdir: vi.fn(() => "/var/fallback"),
+      warn,
+    });
+
+    expect(resolved).toBe(POSIX_OPENCLAW_TMP_DIR);
+  });
+
   it("throws when the fallback directory cannot be created", () => {
     expect(() =>
       resolvePreferredOpenClawTmpDir({

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -108,7 +108,18 @@ export function resolvePreferredOpenClawTmpDir(
       if (typeof st.mode !== "number" || (st.mode & 0o022) === 0) {
         return false;
       }
-      chmodSync(candidatePath, 0o700);
+      try {
+        chmodSync(candidatePath, 0o700);
+      } catch (chmodErr) {
+        if (
+          isNodeErrorWithCode(chmodErr, "EPERM") ||
+          isNodeErrorWithCode(chmodErr, "EACCES") ||
+          isNodeErrorWithCode(chmodErr, "ENOENT")
+        ) {
+          return resolveDirState(candidatePath) === "available";
+        }
+        throw chmodErr;
+      }
       warn(`[openclaw] tightened permissions on temp dir: ${candidatePath}`);
       return resolveDirState(candidatePath) === "available";
     } catch {


### PR DESCRIPTION
## Summary
- treat concurrent permission tightening as success when the temp dir is already secure by the time repair is re-checked
- keep the change narrowly scoped to the temp dir repair path
- add a regression test for the already-fixed-by-another-process race

## Why
If another process clears group/other write bits just before or during our repair attempt, the current flow can report failure even though the directory has already become valid. This patch re-checks the resulting directory state for expected permission-related race cases instead of treating them as hard failure.

## Testing
- added targeted regression coverage in `src/infra/tmp-openclaw-dir.test.ts`
- I could not run the local test command in this shell because `pnpm`/`corepack` are unavailable in PATH here, so this is source-reviewed but not locally executed in this environment