### PR TITLE
docs(msteams): fix federated auth added-in date to 2026.4.11

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -194,7 +194,7 @@ Before configuring OpenClaw, you need to create an Azure Bot resource.
 
 ## Federated Authentication (Certificate + Managed Identity)
 
-> Added in 2026.3.24
+> Added in 2026.4.11
 
 For production deployments, OpenClaw supports **federated authentication** as a more secure alternative to client secrets. Two methods are available:
 


### PR DESCRIPTION
Fix the "Added in" date for the Federated Authentication (Certificate + Managed Identity) section in `docs/channels/msteams.md` from `2026.3.24` to `2026.4.11`.

#53615 is merged to commit !26f633b604fd59b8a76a15808c68cec2d58f849a , which start to present in tag `2026.4.11`