### PR TITLE
fix #67088: detect GUI on macOS correctly when SSH env vars are present

### DIFF
--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   })),
   pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
   probeGateway: vi.fn(),
+  detectBinary: vi.fn<(name: string) => Promise<boolean>>(async () => true),
 }));
 
 vi.mock("../process/exec.js", () => ({
@@ -40,6 +41,10 @@ vi.mock("../infra/tailnet.js", () => ({
 
 vi.mock("../gateway/probe.js", () => ({
   probeGateway: mocks.probeGateway,
+}));
+
+vi.mock("../infra/detect-binary.js", () => ({
+  detectBinary: mocks.detectBinary,
 }));
 
 afterEach(() => {
@@ -133,6 +138,73 @@ describe("resolveBrowserOpenCommand", () => {
     const resolved = await resolveBrowserOpenCommand();
     expect(resolved.argv).toEqual([rundll32, "url.dll,FileProtocolHandler"]);
     expect(resolved.command).toBe(rundll32);
+    platformSpy.mockRestore();
+  });
+
+  it("skips ssh-no-display guard on darwin even with stale SSH env vars", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.stubEnv("SSH_CLIENT", "10.0.0.1 12345 22");
+    vi.stubEnv("SSH_TTY", "/dev/ttys000");
+    // No DISPLAY or WAYLAND_DISPLAY
+
+    const resolved = await resolveBrowserOpenCommand();
+    // darwin should skip the ssh-no-display guard and fall through to `open`
+    expect(resolved.argv).toEqual(["open"]);
+    expect(resolved.command).toBe("open");
+    expect(resolved.reason).toBeUndefined();
+
+    platformSpy.mockRestore();
+  });
+
+  it("skips ssh-no-display guard on darwin with SSH_CONNECTION", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.stubEnv("SSH_CONNECTION", "10.0.0.1 12345 10.0.0.2 22");
+    // No DISPLAY or WAYLAND_DISPLAY
+
+    const resolved = await resolveBrowserOpenCommand();
+    expect(resolved.argv).toEqual(["open"]);
+    expect(resolved.command).toBe("open");
+    expect(resolved.reason).toBeUndefined();
+
+    platformSpy.mockRestore();
+  });
+
+  it("returns ssh-no-display on linux with SSH vars and no display", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.stubEnv("SSH_CLIENT", "10.0.0.1 12345 22");
+    vi.stubEnv("DISPLAY", "");
+    vi.stubEnv("WAYLAND_DISPLAY", "");
+
+    const resolved = await resolveBrowserOpenCommand();
+    expect(resolved.argv).toBeNull();
+    expect(resolved.reason).toBe("ssh-no-display");
+
+    platformSpy.mockRestore();
+  });
+
+  it("returns ssh-no-display on linux with SSH_TTY and no display", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.stubEnv("SSH_TTY", "/dev/ttys000");
+    vi.stubEnv("DISPLAY", "");
+    vi.stubEnv("WAYLAND_DISPLAY", "");
+
+    const resolved = await resolveBrowserOpenCommand();
+    expect(resolved.argv).toBeNull();
+    expect(resolved.reason).toBe("ssh-no-display");
+
+    platformSpy.mockRestore();
+  });
+
+  it("skips ssh-no-display guard on win32 even with SSH vars and no display", async () => {
+    vi.stubEnv("SystemRoot", "C:\\Windows");
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("SSH_CLIENT", "10.0.0.1 12345 22");
+    const rundll32 = path.win32.join("C:\\Windows", "System32", "rundll32.exe");
+
+    const resolved = await resolveBrowserOpenCommand();
+    expect(resolved.argv).toEqual([rundll32, "url.dll,FileProtocolHandler"]);
+    expect(resolved.command).toBe(rundll32);
+
     platformSpy.mockRestore();
   });
 });

--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -47,7 +47,11 @@ export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
     Boolean(process.env.SSH_TTY) ||
     Boolean(process.env.SSH_CONNECTION);
 
-  if (isSsh && !hasDisplay && platform !== "win32") {
+  // SSH_CLIENT and SSH_TTY can linger after Tailscale SSH sessions end, so
+  // they alone don't prove an active remote session. On macOS, `open` works
+  // even over an SSH connection, so only apply the no-display guard on
+  // non-darwin platforms.
+  if (isSsh && !hasDisplay && platform !== "darwin" && platform !== "win32") {
     return { argv: null, reason: "ssh-no-display" };
   }
 


### PR DESCRIPTION
## Summary
Fixes #67088

### Issue
openclaw dashboard falsely reports "No GUI detected" on macOS when SSH_* env vars are present (e.g. Tailscale SSH, reused shell sessions).

### Solution
On macOS, `open` command works even over SSH connections. The previous fix was too broad — it disabled GUI detection when SSH_* env vars were present on all platforms. The fix now only applies the no-display guard on non-darwin platforms, allowing macOS to correctly detect GUI availability regardless of SSH session state.

### Changes
- `src/infra/browser-open.ts`: Changed condition from `platform != "win32"` to `platform != "darwin" && platform != "win32"` to allow GUI detection on macOS over SSH.
- Added clarifying comment explaining why SSH_CLIENT/SSH_TTY alone don't prove an active remote session.

### Testing
- Code change verified: condition now correctly allows macOS to use `open` command even when SSH vars are present.
- The change is minimal and targeted — no other platforms affected.