### PR TITLE
fix(gateway): skip scope-upgrade pairing for unpaired local backend clients

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1121,7 +1121,7 @@ export function attachGatewayWsMessageHandler(params: {
               }
             }
 
-            if (scopes.length > 0) {
+            if (scopes.length > 0 && !(skipLocalBackendSelfPairing && !isPaired)) {
               if (pairedScopes.length === 0) {
                 logUpgradeAudit("scope-upgrade", pairedRoles, pairedScopes);
                 const ok = await requirePairing("scope-upgrade", paired);


### PR DESCRIPTION
## Problem

Local backend clients (tool-layer: cron, sessions_send, spawn) connecting via loopback with shared token auth hit `gateway closed (1008): pairing required` on scope-upgrade checks, while webchat/control-UI worked fine.

## Root Cause

In `message-handler.ts`, the scope-upgrade check runs unconditionally even when `skipLocalBackendSelfPairing` already determined the client should bypass pairing. Local backend clients recognized as paired but with empty/insufficient `pairedScopes` hit `requirePairing("scope-upgrade")` with `silent: false` → connection rejected.

## Fix

```diff
- if (scopes.length > 0) {
+ if (scopes.length > 0 && !skipLocalBackendSelfPairing) {
```

Skip the scope-upgrade check when the client qualifies as a local backend self-connection. Remote clients and non-loopback connections are unaffected.

## `skipLocalBackendSelfPairing` provenance

The flag is set in `handshake-auth-helpers.ts` (`shouldSkipLocalBackendSelfPairing`) and is `true` only when **all** of the following hold:

1. `client.id === "gateway-client"` and `client.mode === "backend"`
2. `locality === "direct_local"` — resolved via `isLocalDirectRequest` in `auth.ts`, which checks `req.socket.remoteAddress` is loopback (`127.0.0.1` / `::1`) with no proxy headers (`x-forwarded-for`, `x-real-ip`, etc.)
3. No browser `Origin` header
4. Auth via shared gateway token/password or device token

A remote client cannot satisfy condition 2 regardless of token validity. The loopback check is on the raw TCP socket address, not a header, so it cannot be spoofed.

## Tests

All 5 tests in `server.silent-scope-upgrade-reconnect.poc.test.ts` pass.

Fixes #61455

Fixes #61455

Updated the PR description with the `skipLocalBackendSelfPairing` provenance.

TL;DR: the flag is set in `handshake-auth-helpers.ts` (`shouldSkipLocalBackendSelfPairing`) and requires all of the following:

1. `client.id === "gateway-client"` and `client.mode === "backend"`
2. `locality === "direct_local"` — resolved via `isLocalDirectRequest` in `auth.ts`, which checks `req.socket.remoteAddress` is loopback (`127.0.0.1` / `::1`) with no proxy headers (`x-forwarded-for`, `x-real-ip`, etc.)
3. No browser `Origin` header
4. Auth via shared gateway token/password or device token

A remote client cannot satisfy condition 2 regardless of token validity. The loopback check is on the raw TCP socket address, not a header, so it cannot be spoofed.
