### PR TITLE
slack: stream thinking text and tool progress in real time

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -34,7 +34,12 @@ import {
   resolveSlackStreamingConfig,
 } from "../../stream-mode.js";
 import type { SlackStreamSession } from "../../streaming.js";
-import { appendSlackStream, startSlackStream, stopSlackStream } from "../../streaming.js";
+import {
+  appendSlackStream,
+  appendSlackStreamTask,
+  startSlackStream,
+  stopSlackStream,
+} from "../../streaming.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
 import { normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import { resolveStorePath, updateLastRoute } from "../config.runtime.js";
@@ -686,6 +691,61 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         }
       };
 
+  // ---------------------------------------------------------------------------
+  // Progress streaming — start the native stream early so thinking text and
+  // tool events appear in real time before the final reply lands.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Start the native Slack stream for progress output (thinking/tools) if it
+   * hasn't been started yet. Returns the session, or null on failure.
+   *
+   * The stream is started against `streamThreadHint` (the thread that the
+   * incoming message lives in / that replies should target). Once started,
+   * `streamSession` is set so that `deliverWithStreaming` will append to it
+   * rather than opening a second stream.
+   */
+  const startProgressStream = async (): Promise<SlackStreamSession | null> => {
+    if (streamSession || streamFailed || !streamThreadHint) {
+      return streamSession;
+    }
+    try {
+      const session = await startSlackStream({
+        client: ctx.app.client,
+        channel: message.channel,
+        threadTs: streamThreadHint,
+        teamId: ctx.teamId,
+        userId: message.user,
+      });
+      streamSession = session;
+      // Mark that we have opened a Slack message so the status-reaction
+      // finalization and thread-participation recording work correctly.
+      observedReplyDelivery = true;
+      usedReplyThreadTs ??= streamThreadHint;
+      replyPlan.markSent();
+      return session;
+    } catch (err) {
+      logVerbose(`slack-stream: failed to start progress stream: ${String(err)}`);
+      return null;
+    }
+  };
+
+  /**
+   * Safely append markdown text to the active stream (or the progress stream
+   * if it needs to be started now). Swallows errors so a streaming hiccup
+   * never blocks the final reply.
+   */
+  const appendToProgressStream = async (text: string): Promise<void> => {
+    try {
+      const session = streamSession ?? (await startProgressStream());
+      if (session && !session.stopped) {
+        await appendSlackStream({ session, text });
+      }
+    } catch (err) {
+      logVerbose(`slack-stream: progress append failed: ${String(err)}`);
+    }
+  };
+
   let dispatchError: unknown;
   let queuedFinal = false;
   let counts: { final?: number; block?: number } = {};
@@ -712,17 +772,70 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
                 updateDraftFromPartial(payload.text);
               },
         onAssistantMessageStart: onDraftBoundary,
-        onReasoningEnd: onDraftBoundary,
-        onReasoningStream: statusReactionsEnabled
+        onReasoningEnd: useStreaming
           ? async () => {
-              await statusReactions.setThinking();
+              // Separate thinking from the reply text with a blank line.
+              await appendToProgressStream("\n");
             }
-          : undefined,
-        onToolStart: statusReactionsEnabled
-          ? async (payload) => {
-              await statusReactions.setTool(payload.name);
+          : onDraftBoundary,
+        onReasoningStream: async (payload) => {
+          // Always update the emoji reaction so the user knows thinking is live.
+          if (statusReactionsEnabled) {
+            await statusReactions.setThinking();
+          }
+          // Stream the actual thinking text when native streaming is active.
+          if (useStreaming && payload.text) {
+            await appendToProgressStream(payload.text);
+          } else if (!useStreaming && previewStreamingEnabled) {
+            // Fallback: show a generic thinking indicator in the draft stream.
+            updateDraftFromPartial("_Thinking..._");
+          }
+        },
+        onToolStart: async (payload) => {
+          // Emoji reaction for non-streaming setups.
+          if (statusReactionsEnabled) {
+            await statusReactions.setTool(payload.name);
+          }
+          if (useStreaming && payload.name) {
+            const name = payload.name;
+            // Try a task_update card first; fall back to inline markdown on error.
+            try {
+              const session = streamSession ?? (await startProgressStream());
+              if (session && !session.stopped) {
+                await appendSlackStreamTask({
+                  session,
+                  taskId: `tool-${name}`,
+                  title: name,
+                  status: "in_progress",
+                });
+              }
+            } catch {
+              // task_update not supported or stream not ready — use inline text.
+              await appendToProgressStream(`\n_⎿ ${name}_`);
             }
-          : undefined,
+          } else if (!useStreaming && previewStreamingEnabled && payload.name) {
+            updateDraftFromPartial(`_⎿ ${payload.name}_`);
+          }
+        },
+        onItemEvent: async (payload) => {
+          if (!useStreaming) return;
+          // Show completion of tool tasks when status transitions to "complete".
+          if (payload.status === "complete" && payload.name) {
+            try {
+              const session = streamSession;
+              if (session && !session.stopped) {
+                await appendSlackStreamTask({
+                  session,
+                  taskId: `tool-${payload.name}`,
+                  title: payload.summary ?? payload.name,
+                  status: "complete",
+                });
+              }
+            } catch {
+              // Ignore — task card completion is best-effort.
+            }
+          }
+        },
       },
     });
     queuedFinal = result.queuedFinal;

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -55,6 +55,16 @@ export type AppendSlackStreamParams = {
   text: string;
 };
 
+export type AppendSlackStreamTaskParams = {
+  session: SlackStreamSession;
+  /** Stable identifier for this task (used to update the same card). */
+  taskId: string;
+  /** Display title shown on the task card. */
+  title: string;
+  /** "in_progress" while the task is running, "complete" when done. */
+  status: "in_progress" | "complete";
+};
+
 export type StopSlackStreamParams = {
   session: SlackStreamSession;
   /** Optional final markdown text to append before stopping. */
@@ -123,6 +133,34 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
 
   await session.streamer.append({ markdown_text: text });
   logVerbose(`slack-stream: appended ${text.length} chars`);
+}
+
+/**
+ * Append a task-update card to an active Slack stream.
+ *
+ * Task cards render as a collapsible "plan" item in the Slack UI, matching
+ * the native Slack AI Apps streaming UX for showing tool progress.
+ *
+ * @see https://docs.slack.dev/ai/developing-ai-apps#streaming-tasks
+ */
+export async function appendSlackStreamTask(params: AppendSlackStreamTaskParams): Promise<void> {
+  const { session, taskId, title, status } = params;
+
+  if (session.stopped) {
+    logVerbose("slack-stream: attempted to append task to a stopped stream, ignoring");
+    return;
+  }
+
+  // The Slack SDK ChatStreamer.append() accepts task_update alongside markdown_text.
+  // We cast to any since the SDK types don't expose the full union yet.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (session.streamer as any).append({
+    type: "task_update",
+    task_id: taskId,
+    title,
+    status,
+  });
+  logVerbose(`slack-stream: task_update taskId=${taskId} status=${status} title="${title}"`);
 }
 
 /**


### PR DESCRIPTION
## Problem

`onReasoningStream` and `onToolStart` callbacks in the Slack message handler currently only set emoji reactions. The user has no visibility into what the agent is thinking or which tools it's running until the final reply lands.

## Solution

Wire both callbacks into the Slack native streaming API so thinking text streams live into the same message the final reply will appear in, and each tool call shows up as a task card (or inline indicator) as it happens.

### How it works

**`startProgressStream()`** — a new helper that opens the native Slack stream early, before the first reply text arrives. The same `SlackStreamSession` is then reused by the existing `deliverWithStreaming` path for the final reply, so everything stays in one message.

**`onReasoningStream`** — streams thinking text token-by-token via `appendToProgressStream`. Falls back to `_Thinking..._` in the draft-stream path (non-native).

**`onToolStart`** — posts a `task_update` card (collapsible "plan" item matching Slack's AI Apps UX) when a tool starts. Falls back to `_⎿ ToolName_` inline markdown if `task_update` isn't supported.

**`onItemEvent`** — flips the task card to `complete` when the tool finishes.

**`onReasoningEnd`** — appends a blank line to visually separate thinking from the response.

**`appendSlackStreamTask()`** — new export in `streaming.ts` that sends a `task_update` chunk via the `ChatStreamer`.

### Fallback safety

All progress-stream calls swallow errors (logging to verbose) so a streaming failure never blocks the final reply from being delivered normally.

## Test plan

- [ ] Enable `streaming.nativeStreaming: true` in Slack config
- [ ] Send a message that triggers extended thinking — verify thinking text appears live in the stream before the reply
- [ ] Send a message that triggers tool calls (read file, search, etc.) — verify task cards appear per tool
- [ ] Verify the final reply appends to the same message as the thinking/tool output
- [ ] Disable native streaming — verify draft stream falls back to `_Thinking..._` / `_⎿ ToolName_` indicators
- [ ] Verify streaming failures (network blip) don't prevent the final reply from sending

🤖 Generated with [Claude Code](https://claude.com/claude-code)