### PR TITLE
Support paired-channel default message targets

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -608,6 +608,9 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("message: Send messages and channel actions");
     expect(prompt).toContain("### message tool");
     expect(prompt).toContain(`respond with ONLY: ${SILENT_REPLY_TOKEN}`);
+    expect(prompt).toContain(
+      "if the current channel or chosen `channel` has a paired/default recipient, you may omit `to`",
+    );
   });
 
   it("reapplies provider prompt contributions", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -319,7 +319,7 @@ function buildMessagingSection(params: {
           "",
           "### message tool",
           "- Use `message` for proactive sends + channel actions (polls, reactions, etc.).",
-          "- For `action=send`, include `to` and `message`.",
+          "- For `action=send`, always include `message`. Include `to` when targeting a specific chat; if the current channel or chosen `channel` has a paired/default recipient, you may omit `to` and let OpenClaw use the default target.",
           `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
           `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
           params.inlineButtonsEnabled

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -208,6 +208,7 @@ function createChannelPlugin(params: {
   capabilities?: readonly ChannelMessageCapability[];
   toolSchema?: MessageToolSchema | ((params: MessageToolDiscoveryContext) => MessageToolSchema);
   describeMessageTool?: DescribeMessageTool;
+  config?: ChannelPlugin["config"];
   messaging?: ChannelPlugin["messaging"];
 }): ChannelPlugin {
   return {
@@ -221,10 +222,12 @@ function createChannelPlugin(params: {
       aliases: params.aliases,
     },
     capabilities: { chatTypes: ["direct", "group"], media: true },
-    config: {
-      listAccountIds: () => ["default"],
-      resolveAccount: () => ({}),
-    },
+    config:
+      params.config ??
+      {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({}),
+      },
     ...(params.messaging ? { messaging: params.messaging } : {}),
     actions: {
       describeMessageTool:
@@ -987,6 +990,89 @@ describe("message tool description", () => {
 
     expect(tool.description).toContain("Current channel (bluebubbles) supports:");
     expect(tool.description).not.toContain("Other configured channels");
+  });
+
+  it("mentions default-target sends for the current channel when configured", () => {
+    const whatsappPlugin = createChannelPlugin({
+      id: "whatsapp",
+      label: "WhatsApp",
+      docsPath: "/channels/whatsapp",
+      blurb: "WhatsApp test plugin.",
+      actions: ["send", "react"],
+      config: {
+        resolveDefaultTo: ({ cfg }: { cfg: OpenClawConfig }) =>
+          typeof cfg.channels?.whatsapp?.defaultTo === "string"
+            ? cfg.channels.whatsapp.defaultTo
+            : undefined,
+      },
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", source: "test", plugin: whatsappPlugin }]),
+    );
+
+    const tool = createMessageTool({
+      config: {
+        channels: {
+          whatsapp: {
+            defaultTo: "+15551234567",
+          },
+        },
+      } as OpenClawConfig,
+      currentChannelProvider: "whatsapp",
+    });
+
+    expect(tool.description).toContain(
+      "Current channel has a default delivery target, so send/poll can omit target/to",
+    );
+  });
+
+  it("mentions configured channels with default targets outside the current chat channel", () => {
+    const whatsappPlugin = createChannelPlugin({
+      id: "whatsapp",
+      label: "WhatsApp",
+      docsPath: "/channels/whatsapp",
+      blurb: "WhatsApp test plugin.",
+      actions: ["send", "react"],
+      config: {
+        resolveDefaultTo: ({ cfg }: { cfg: OpenClawConfig }) =>
+          typeof cfg.channels?.whatsapp?.defaultTo === "string"
+            ? cfg.channels.whatsapp.defaultTo
+            : undefined,
+      },
+    });
+    const webchatPlugin = createChannelPlugin({
+      id: "webchat",
+      label: "WebChat",
+      docsPath: "/channels/webchat",
+      blurb: "WebChat test plugin.",
+      actions: ["send"],
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "webchat", source: "test", plugin: webchatPlugin },
+        { pluginId: "whatsapp", source: "test", plugin: whatsappPlugin },
+      ]),
+    );
+
+    const tool = createMessageTool({
+      config: {
+        channels: {
+          whatsapp: {
+            defaultTo: "+15551234567",
+          },
+        },
+      } as OpenClawConfig,
+      currentChannelProvider: "webchat",
+    });
+
+    expect(tool.description).toContain(
+      "Configured channels with a default delivery target: whatsapp.",
+    );
+    expect(tool.description).toContain(
+      "When you choose one of them with channel, send/poll can omit target/to",
+    );
   });
 
   it("includes the thread read hint when the current channel supports read", () => {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -581,6 +581,16 @@ function buildMessageToolDescription(options?: {
       if (otherChannels.length > 0) {
         desc += ` Other configured channels: ${otherChannels.join(", ")}.`;
       }
+      desc += buildDefaultTargetHint({
+        config: resolvedOptions.config,
+        currentChannel,
+        currentAccountId: resolvedOptions.currentAccountId,
+      });
+      desc += buildConfiguredChannelDefaultTargetHint({
+        config: resolvedOptions.config,
+        currentChannel,
+        currentAccountId: resolvedOptions.currentAccountId,
+      });
 
       return appendMessageToolReadHint(
         desc,
@@ -594,13 +604,70 @@ function buildMessageToolDescription(options?: {
     const actions = listAllMessageToolActions(messageToolDiscoveryParams);
     if (actions.length > 0) {
       return appendMessageToolReadHint(
-        `${baseDescription} Supports actions: ${actions.join(", ")}.`,
+        `${baseDescription} Supports actions: ${actions.join(", ")}.${buildDefaultTargetHint({
+          config: resolvedOptions.config,
+          currentChannel,
+          currentAccountId: resolvedOptions.currentAccountId,
+        })}${buildConfiguredChannelDefaultTargetHint({
+          config: resolvedOptions.config,
+          currentChannel,
+          currentAccountId: resolvedOptions.currentAccountId,
+        })}`,
         actions,
       );
     }
   }
 
   return `${baseDescription} Supports actions: send, delete, react, poll, pin, threads, and more.`;
+}
+
+function buildDefaultTargetHint(options?: {
+  config?: OpenClawConfig;
+  currentChannel?: string;
+  currentAccountId?: string;
+}): string {
+  const cfg = options?.config;
+  const currentChannel = normalizeMessageChannel(options?.currentChannel);
+  if (!cfg || !currentChannel) {
+    return "";
+  }
+  const plugin = listChannelPlugins().find((entry) => entry.id === currentChannel);
+  const defaultTo = plugin?.config.resolveDefaultTo?.({
+    cfg,
+    accountId: options?.currentAccountId,
+  });
+  if (!normalizeOptionalString(defaultTo == null ? undefined : String(defaultTo))) {
+    return "";
+  }
+  return " Current channel has a default delivery target, so send/poll can omit target/to when you mean the paired/default chat.";
+}
+
+function buildConfiguredChannelDefaultTargetHint(options?: {
+  config?: OpenClawConfig;
+  currentChannel?: string;
+  currentAccountId?: string;
+}): string {
+  const cfg = options?.config;
+  if (!cfg) {
+    return "";
+  }
+  const currentChannel = normalizeMessageChannel(options?.currentChannel);
+  const channelIds = listChannelPlugins().flatMap((plugin) => {
+    if (plugin.id === currentChannel) {
+      return [];
+    }
+    const defaultTo = plugin.config.resolveDefaultTo?.({
+      cfg,
+      accountId: undefined,
+    });
+    return normalizeOptionalString(defaultTo == null ? undefined : String(defaultTo))
+      ? [plugin.id]
+      : [];
+  });
+  if (channelIds.length === 0) {
+    return "";
+  }
+  return ` Configured channels with a default delivery target: ${channelIds.join(", ")}. When you choose one of them with channel, send/poll can omit target/to when you mean the paired/default chat.`;
 }
 
 function appendMessageToolReadHint(

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -8,22 +8,29 @@ import {
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { applyTargetToParams } from "./channel-target.js";
-import { actionHasTarget, actionRequiresTarget } from "./message-action-spec.js";
+import {
+  actionHasTarget,
+  actionRequiresTarget,
+} from "./message-action-spec.js";
 
 export function normalizeMessageActionInput(params: {
   action: ChannelMessageActionName;
   args: Record<string, unknown>;
   toolContext?: ChannelThreadingToolContext;
+  allowDeferredTargetResolution?: boolean;
 }): Record<string, unknown> {
   const normalizedArgs = { ...params.args };
-  const { action, toolContext } = params;
+  const { action, toolContext, allowDeferredTargetResolution } = params;
   const explicitChannel = normalizeOptionalString(normalizedArgs.channel) ?? "";
   const inferredChannel =
-    explicitChannel || normalizeMessageChannel(toolContext?.currentChannelProvider) || "";
+    explicitChannel ||
+    normalizeMessageChannel(toolContext?.currentChannelProvider) ||
+    "";
 
   const explicitTarget = normalizeOptionalString(normalizedArgs.target) ?? "";
   const hasLegacyTargetFields =
-    typeof normalizedArgs.to === "string" || typeof normalizedArgs.channelId === "string";
+    typeof normalizedArgs.to === "string" ||
+    typeof normalizedArgs.channelId === "string";
   const hasLegacyTarget =
     (normalizeOptionalString(normalizedArgs.to) ?? "").length > 0 ||
     (normalizeOptionalString(normalizedArgs.channelId) ?? "").length > 0;
@@ -39,7 +46,9 @@ export function normalizeMessageActionInput(params: {
     actionRequiresTarget(action) &&
     !actionHasTarget(action, normalizedArgs, { channel: inferredChannel })
   ) {
-    const inferredTarget = normalizeOptionalString(toolContext?.currentChannelId);
+    const inferredTarget = normalizeOptionalString(
+      toolContext?.currentChannelId,
+    );
     if (inferredTarget) {
       normalizedArgs.target = inferredTarget;
     }
@@ -47,7 +56,8 @@ export function normalizeMessageActionInput(params: {
 
   if (!explicitTarget && actionRequiresTarget(action) && hasLegacyTarget) {
     const legacyTo = normalizeOptionalString(normalizedArgs.to) ?? "";
-    const legacyChannelId = normalizeOptionalString(normalizedArgs.channelId) ?? "";
+    const legacyChannelId =
+      normalizeOptionalString(normalizedArgs.channelId) ?? "";
     const legacyTarget = legacyTo || legacyChannelId;
     if (legacyTarget) {
       normalizedArgs.target = legacyTarget;
@@ -65,7 +75,8 @@ export function normalizeMessageActionInput(params: {
   applyTargetToParams({ action, args: normalizedArgs });
   if (
     actionRequiresTarget(action) &&
-    !actionHasTarget(action, normalizedArgs, { channel: inferredChannel })
+    !actionHasTarget(action, normalizedArgs, { channel: inferredChannel }) &&
+    !(allowDeferredTargetResolution && (action === "send" || action === "poll"))
   ) {
     throw new Error(`Action ${action} requires a target.`);
   }

--- a/src/infra/outbound/message-action-runner.poll.test.ts
+++ b/src/infra/outbound/message-action-runner.poll.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  getActivePluginRegistry,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { runMessageAction } from "./message-action-runner.js";
 
@@ -54,6 +57,10 @@ const telegramPollTestPlugin: ChannelPlugin = {
     listAccountIds: () => ["default"],
     resolveAccount: () => ({ botToken: "telegram-test" }),
     isConfigured: () => true,
+    resolveDefaultTo: ({ cfg }) =>
+      typeof cfg.channels?.telegram?.defaultTo === "string"
+        ? cfg.channels.telegram.defaultTo
+        : undefined,
   },
   outbound: {
     deliveryMode: "gateway",
@@ -128,7 +135,9 @@ describe("runMessageAction poll handling", () => {
     mocks.resolveOutboundChannelPlugin.mockReset();
     mocks.resolveOutboundChannelPlugin.mockImplementation(
       ({ channel }: { channel: string }) =>
-        getActivePluginRegistry()?.channels.find((entry) => entry?.plugin?.id === channel)?.plugin,
+        getActivePluginRegistry()?.channels.find(
+          (entry) => entry?.plugin?.id === channel,
+        )?.plugin,
     );
     mocks.executePollAction.mockReset();
     mocks.executePollAction.mockImplementation(async (input) => ({
@@ -206,5 +215,25 @@ describe("runMessageAction poll handling", () => {
     });
 
     expect(call?.maxSelections).toBe(1);
+  });
+
+  it("allows target-less polls when telegram defaultTo is configured", async () => {
+    const call = await runPollAction({
+      cfg: {
+        channels: {
+          telegram: {
+            botToken: "telegram-test",
+            defaultTo: "123456789",
+          },
+        },
+      } as OpenClawConfig,
+      actionParams: {
+        channel: "telegram",
+        pollQuestion: "Lunch?",
+        pollOption: ["Pizza", "Sushi"],
+      },
+    });
+
+    expect(call?.to).toBe("123456789");
   });
 });

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -7,6 +7,7 @@ import {
   slackConfig,
   slackTestPlugin,
   telegramTestPlugin,
+  whatsappTestPlugin,
 } from "./message-action-runner.test-helpers.js";
 
 describe("runMessageAction send validation", () => {
@@ -22,6 +23,20 @@ describe("runMessageAction send validation", () => {
           pluginId: "telegram",
           source: "test",
           plugin: telegramTestPlugin,
+        },
+        {
+          pluginId: "whatsapp",
+          source: "test",
+          plugin: {
+            ...whatsappTestPlugin,
+            config: {
+              ...whatsappTestPlugin.config,
+              resolveDefaultTo: ({ cfg }) =>
+                typeof cfg.channels?.whatsapp?.defaultTo === "string"
+                  ? cfg.channels.whatsapp.defaultTo
+                  : undefined,
+            },
+          },
         },
       ]),
     );
@@ -82,6 +97,29 @@ describe("runMessageAction send validation", () => {
     });
 
     expect(result.kind).toBe("send");
+  });
+
+  it("allows target-less WhatsApp sends when defaultTo is configured", async () => {
+    const result = await runDrySend({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15551234567"],
+            defaultTo: "+15551234567",
+          },
+        },
+      } as OpenClawConfig,
+      actionParams: {
+        channel: "whatsapp",
+        message: "hello",
+      },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.to).toBe("+15551234567");
   });
 
   it.each([

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -14,7 +14,10 @@ import type {
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { hasInteractiveReplyBlocks, hasReplyPayloadContent } from "../../interactive/payload.js";
+import {
+  hasInteractiveReplyBlocks,
+  hasReplyPayloadContent,
+} from "../../interactive/payload.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
@@ -66,9 +69,19 @@ import {
   enforceCrossContextPolicy,
   shouldApplyCrossContextMarker,
 } from "./outbound-policy.js";
-import { executePollAction, executeSendAction } from "./outbound-send-service.js";
-import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
-import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
+import {
+  executePollAction,
+  executeSendAction,
+} from "./outbound-send-service.js";
+import {
+  ensureOutboundSessionEntry,
+  resolveOutboundSessionRoute,
+} from "./outbound-session.js";
+import {
+  resolveChannelTarget,
+  type ResolvedMessagingTarget,
+} from "./target-resolver.js";
+import { resolveOutboundTarget } from "./targets.js";
 import { extractToolPayload } from "./tool-payload.js";
 
 export type MessageActionRunnerGateway = {
@@ -171,7 +184,8 @@ function resolveGatewayActionOptions(gateway?: MessageActionRunnerGateway) {
     url: gateway?.url,
     token: gateway?.token,
     timeoutMs:
-      typeof gateway?.timeoutMs === "number" && Number.isFinite(gateway.timeoutMs)
+      typeof gateway?.timeoutMs === "number" &&
+      Number.isFinite(gateway.timeoutMs)
         ? Math.max(1, Math.floor(gateway.timeoutMs))
         : 10_000,
     clientName: gateway?.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
@@ -198,7 +212,9 @@ async function callGatewayMessageAction<T>(params: {
   });
 }
 
-async function resolveGatewayActionIdempotencyKey(idempotencyKey?: string): Promise<string> {
+async function resolveGatewayActionIdempotencyKey(
+  idempotencyKey?: string,
+): Promise<string> {
   if (idempotencyKey) {
     return idempotencyKey;
   }
@@ -313,6 +329,29 @@ async function resolveActionTarget(params: {
   return resolvedTarget;
 }
 
+function resolveRequiredDeliveryTarget(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  args: Record<string, unknown>;
+  accountId?: string | null;
+}): string {
+  const resolved = resolveOutboundTarget({
+    channel: params.channel,
+    to: normalizeOptionalString(params.args.to) ?? undefined,
+    cfg: params.cfg,
+    accountId: params.accountId ?? undefined,
+    mode: "explicit",
+  });
+  if (!resolved.ok) {
+    throw resolved.error;
+  }
+  params.args.to = resolved.to;
+  if (!normalizeOptionalString(params.args.target)) {
+    params.args.target = resolved.to;
+  }
+  return resolved.to;
+}
+
 function sanitizeGroupTargetId(target: string): string {
   return target.replace(/^(channel|group):/i, "");
 }
@@ -323,7 +362,9 @@ async function resolveResolvedTargetOrThrow(params: {
   input: string;
   accountId?: string;
   preferredKind?: "group" | "user" | "channel";
-  validateResolvedTarget?: (target: ResolvedMessagingTarget) => string | undefined;
+  validateResolvedTarget?: (
+    target: ResolvedMessagingTarget,
+  ) => string | undefined;
 }): Promise<ResolvedMessagingTarget> {
   const resolved = await resolveChannelTarget({
     cfg: params.cfg,
@@ -355,7 +396,9 @@ type ResolvedActionContext = {
   resolvedTarget?: ResolvedMessagingTarget;
   abortSignal?: AbortSignal;
 };
-function resolveGateway(input: RunMessageActionParams): MessageActionRunnerGateway | undefined {
+function resolveGateway(
+  input: RunMessageActionParams,
+): MessageActionRunnerGateway | undefined {
   if (!input.gateway) {
     return undefined;
   }
@@ -374,22 +417,35 @@ async function handleBroadcastAction(
   params: Record<string, unknown>,
 ): Promise<MessageActionRunResult> {
   throwIfAborted(input.abortSignal);
-  const broadcastEnabled = input.cfg.tools?.message?.broadcast?.enabled !== false;
+  const broadcastEnabled =
+    input.cfg.tools?.message?.broadcast?.enabled !== false;
   if (!broadcastEnabled) {
-    throw new Error("Broadcast is disabled. Set tools.message.broadcast.enabled to true.");
+    throw new Error(
+      "Broadcast is disabled. Set tools.message.broadcast.enabled to true.",
+    );
   }
-  const rawTargets = readStringArrayParam(params, "targets", { required: true });
+  const rawTargets = readStringArrayParam(params, "targets", {
+    required: true,
+  });
   if (rawTargets.length === 0) {
     throw new Error("Broadcast requires at least one target in --targets.");
   }
   const channelHint = readStringParam(params, "channel");
   const targetChannels =
     channelHint && normalizeOptionalLowercaseString(channelHint) !== "all"
-      ? [await resolveChannel(input.cfg, { channel: channelHint }, input.toolContext)]
+      ? [
+          await resolveChannel(
+            input.cfg,
+            { channel: channelHint },
+            input.toolContext,
+          ),
+        ]
       : await (async () => {
           const configured = await listConfiguredMessageChannels(input.cfg);
           if (configured.length === 0) {
-            throw new Error("Broadcast requires at least one configured channel.");
+            throw new Error(
+              "Broadcast requires at least one configured channel.",
+            );
           }
           return configured;
         })();
@@ -400,7 +456,8 @@ async function handleBroadcastAction(
     error?: string;
     result?: MessageSendResult;
   }> = [];
-  const isAbortError = (err: unknown): boolean => err instanceof Error && err.name === "AbortError";
+  const isAbortError = (err: unknown): boolean =>
+    err instanceof Error && err.name === "AbortError";
   for (const targetChannel of targetChannels) {
     throwIfAborted(input.abortSignal);
     for (const target of rawTargets) {
@@ -424,7 +481,8 @@ async function handleBroadcastAction(
           channel: targetChannel,
           to: resolved.to,
           ok: true,
-          result: sendResult.kind === "send" ? sendResult.sendResult : undefined,
+          result:
+            sendResult.kind === "send" ? sendResult.sendResult : undefined,
         });
       } catch (err) {
         if (isAbortError(err)) {
@@ -441,7 +499,10 @@ async function handleBroadcastAction(
   }
   return {
     kind: "broadcast",
-    channel: targetChannels[0] ?? normalizeOptionalLowercaseString(channelHint) ?? "unknown",
+    channel:
+      targetChannels[0] ??
+      normalizeOptionalLowercaseString(channelHint) ??
+      "unknown",
     action: "broadcast",
     handledBy: input.dryRun ? "dry-run" : "core",
     payload: { results },
@@ -449,7 +510,9 @@ async function handleBroadcastAction(
   };
 }
 
-async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
+async function handleSendAction(
+  ctx: ResolvedActionContext,
+): Promise<MessageActionRunResult> {
   const {
     cfg,
     params,
@@ -464,7 +527,12 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   } = ctx;
   throwIfAborted(abortSignal);
   const action: ChannelMessageActionName = "send";
-  const to = readStringParam(params, "to", { required: true });
+  const to = resolveRequiredDeliveryTarget({
+    cfg,
+    channel,
+    args: params,
+    accountId,
+  });
   // Support media, path, and filePath parameters for attachments
   const mediaHint =
     readStringParam(params, "media", { trim: false }) ??
@@ -474,16 +542,23 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     readStringParam(params, "fileUrl", { trim: false });
   const hasButtons = Array.isArray(params.buttons) && params.buttons.length > 0;
   const hasCard = params.card != null && typeof params.card === "object";
-  const hasComponents = params.components != null && typeof params.components === "object";
+  const hasComponents =
+    params.components != null && typeof params.components === "object";
   const hasInteractive = hasInteractiveReplyBlocks(params.interactive);
   const hasBlocks =
     (Array.isArray(params.blocks) && params.blocks.length > 0) ||
     (typeof params.blocks === "string" && params.blocks.trim().length > 0);
-  const caption = readStringParam(params, "caption", { allowEmpty: true }) ?? "";
+  const caption =
+    readStringParam(params, "caption", { allowEmpty: true }) ?? "";
   let message =
     readStringParam(params, "message", {
       required:
-        !mediaHint && !hasButtons && !hasCard && !hasComponents && !hasInteractive && !hasBlocks,
+        !mediaHint &&
+        !hasButtons &&
+        !hasCard &&
+        !hasComponents &&
+        !hasInteractive &&
+        !hasBlocks,
       allowEmpty: true,
     }) ?? "";
   if (message.includes("\\n")) {
@@ -561,7 +636,9 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   params.message = message;
   const gifPlayback = readBooleanParam(params, "gifPlayback") ?? false;
   const forceDocument =
-    readBooleanParam(params, "forceDocument") ?? readBooleanParam(params, "asDocument") ?? false;
+    readBooleanParam(params, "forceDocument") ??
+    readBooleanParam(params, "asDocument") ??
+    false;
   const bestEffort = readBooleanParam(params, "bestEffort");
   const silent = readBooleanParam(params, "silent");
 
@@ -577,12 +654,17 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     currentSessionKey: input.sessionKey,
     dryRun,
     resolvedTarget,
-    resolveAutoThreadId: getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
+    resolveAutoThreadId:
+      getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
     resolveOutboundSessionRoute,
     ensureOutboundSessionEntry,
   });
   const mirrorMediaUrls =
-    mergedMediaUrls.length > 0 ? mergedMediaUrls : mediaUrl ? [mediaUrl] : undefined;
+    mergedMediaUrls.length > 0
+      ? mergedMediaUrls
+      : mediaUrl
+        ? [mediaUrl]
+        : undefined;
   throwIfAborted(abortSignal);
   const send = await executeSendAction({
     ctx: {
@@ -638,11 +720,27 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   };
 }
 
-async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
-  const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal } = ctx;
+async function handlePollAction(
+  ctx: ResolvedActionContext,
+): Promise<MessageActionRunResult> {
+  const {
+    cfg,
+    params,
+    channel,
+    accountId,
+    dryRun,
+    gateway,
+    input,
+    abortSignal,
+  } = ctx;
   throwIfAborted(abortSignal);
   const action: ChannelMessageActionName = "poll";
-  const to = readStringParam(params, "to", { required: true });
+  const to = resolveRequiredDeliveryTarget({
+    cfg,
+    channel,
+    args: params,
+    accountId,
+  });
   const silent = readBooleanParam(params, "silent");
 
   const resolvedThreadId = resolveAndApplyOutboundThreadId(params, {
@@ -650,7 +748,8 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
     to,
     accountId,
     toolContext: input.toolContext,
-    resolveAutoThreadId: getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
+    resolveAutoThreadId:
+      getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
   });
 
   const base = typeof params.message === "string" ? params.message : "";
@@ -681,7 +780,9 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
       const question = readStringParam(params, "pollQuestion", {
         required: true,
       });
-      const options = readStringArrayParam(params, "pollOption", { required: true });
+      const options = readStringArrayParam(params, "pollOption", {
+        required: true,
+      });
       if (options.length < 2) {
         throw new Error("pollOption requires at least two values");
       }
@@ -695,7 +796,10 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
         to,
         question,
         options,
-        maxSelections: resolvePollMaxSelections(options.length, allowMultiselect),
+        maxSelections: resolvePollMaxSelections(
+          options.length,
+          allowMultiselect,
+        ),
         durationHours: durationHours ?? undefined,
         threadId: resolvedThreadId ?? undefined,
       };
@@ -715,7 +819,9 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
   };
 }
 
-async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
+async function handlePluginAction(
+  ctx: ResolvedActionContext,
+): Promise<MessageActionRunResult> {
   const {
     cfg,
     params,
@@ -729,7 +835,10 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     agentId,
   } = ctx;
   throwIfAborted(abortSignal);
-  const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
+  const action = input.action as Exclude<
+    ChannelMessageActionName,
+    "send" | "poll" | "broadcast"
+  >;
   if (dryRun) {
     return {
       kind: "action",
@@ -743,9 +852,12 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
 
   const plugin = resolveOutboundChannelPlugin({ channel, cfg });
   if (!plugin?.actions?.handleAction) {
-    throw new Error(`Channel ${channel} is unavailable for message actions (plugin not loaded).`);
+    throw new Error(
+      `Channel ${channel} is unavailable for message actions (plugin not loaded).`,
+    );
   }
-  const executionMode = plugin.actions.resolveExecutionMode?.({ action }) ?? "local";
+  const executionMode =
+    plugin.actions.resolveExecutionMode?.({ action }) ?? "local";
   if (executionMode === "gateway" && gateway) {
     // Gateway-owned actions must execute where the live channel runtime exists.
     const payload = await callGatewayMessageAction<unknown>({
@@ -795,7 +907,9 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     dryRun,
   });
   if (!handled) {
-    throw new Error(`Message action ${action} not supported for channel ${channel}.`);
+    throw new Error(
+      `Message action ${action} not supported for channel ${channel}.`,
+    );
   }
   return {
     kind: "action",
@@ -831,10 +945,12 @@ export async function runMessageAction(
     action,
     args: params,
     toolContext: input.toolContext,
+    allowDeferredTargetResolution: true,
   });
 
   const channel = await resolveChannel(cfg, params, input.toolContext);
-  let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
+  let accountId =
+    readStringParam(params, "accountId") ?? input.defaultAccountId;
   if (!accountId && resolvedAgentId) {
     const byAgent = buildChannelAccountBindings(cfg).get(channel);
     const boundAccountIds = byAgent?.get(normalizeAgentId(resolvedAgentId));
@@ -850,17 +966,18 @@ export async function runMessageAction(
     sandboxRoot: input.sandboxRoot,
     mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, resolvedAgentId),
   });
-  const extraActionMediaSourceParamKeys = resolveExtraActionMediaSourceParamKeys({
-    cfg,
-    action,
-    channel,
-    accountId,
-    sessionKey: input.sessionKey,
-    sessionId: input.sessionId,
-    agentId: resolvedAgentId,
-    requesterSenderId: input.requesterSenderId,
-    senderIsOwner: input.senderIsOwner,
-  });
+  const extraActionMediaSourceParamKeys =
+    resolveExtraActionMediaSourceParamKeys({
+      cfg,
+      action,
+      channel,
+      accountId,
+      sessionKey: input.sessionKey,
+      sessionId: input.sessionId,
+      agentId: resolvedAgentId,
+      requesterSenderId: input.requesterSenderId,
+      senderIsOwner: input.senderIsOwner,
+    });
 
   await normalizeSandboxMediaParams({
     args: params,
@@ -871,10 +988,15 @@ export async function runMessageAction(
   const mediaAccess = resolveAgentScopedOutboundMediaAccess({
     cfg,
     agentId: resolvedAgentId,
-    mediaSources: collectActionMediaSourceHints(params, extraActionMediaSourceParamKeys),
+    mediaSources: collectActionMediaSourceHints(
+      params,
+      extraActionMediaSourceParamKeys,
+    ),
     sessionKey: input.sessionKey,
     messageProvider: input.sessionKey ? undefined : channel,
-    accountId: input.sessionKey ? (input.requesterAccountId ?? accountId) : accountId,
+    accountId: input.sessionKey
+      ? (input.requesterAccountId ?? accountId)
+      : accountId,
     requesterSenderId: input.requesterSenderId,
     requesterSenderName: input.requesterSenderName,
     requesterSenderUsername: input.requesterSenderUsername,
@@ -912,7 +1034,9 @@ export async function runMessageAction(
   });
 
   if (action === "send" && hasPollCreationParams(params)) {
-    throw new Error('Poll fields require action "poll"; use action "poll" instead of "send".');
+    throw new Error(
+      'Poll fields require action "poll"; use action "poll" instead of "send".',
+    );
   }
 
   const gateway = resolveGateway(input);


### PR DESCRIPTION
## Summary
- let message actions resolve paired/default delivery targets when send or poll is invoked without an explicit target
- teach the agent prompt and message tool description that a chosen channel can rely on its configured paired/default recipient
- cover both current-channel and dashboard-to-WhatsApp default-target flows in tests

## Testing
- pnpm vitest run src/agents/system-prompt.test.ts src/agents/tools/message-tool.test.ts src/infra/outbound/message-action-runner.send-validation.test.ts src/infra/outbound/message-action-runner.poll.test.ts
