### PR TITLE
fix onboard crash from missing bundled channel fallback metadata

### DIFF
--- a/scripts/write-official-channel-catalog.d.mts
+++ b/scripts/write-official-channel-catalog.d.mts
@@ -7,7 +7,7 @@ export function buildOfficialChannelCatalog(params?: { repoRoot?: string; cwd?: 
     description?: string;
     openclaw: {
       channel: Record<string, unknown>;
-      install: {
+      install?: {
         npmSpec: string;
         localPath?: string;
         defaultChoice?: "npm" | "local";

--- a/scripts/write-official-channel-catalog.mjs
+++ b/scripts/write-official-channel-catalog.mjs
@@ -28,12 +28,21 @@ function buildCatalogEntry(packageJson) {
   const release = manifest && isRecord(manifest.release) ? manifest.release : null;
   const channel = manifest && isRecord(manifest.channel) ? manifest.channel : null;
   if (!packageName || !channel || release?.publishToNpm !== true) {
-    return null;
+    if (!packageName || !channel) {
+      return null;
+    }
+    const version = trimString(packageJson.version);
+    const description = trimString(packageJson.description);
+    return {
+      name: packageName,
+      ...(version ? { version } : {}),
+      ...(description ? { description } : {}),
+      openclaw: {
+        channel,
+      },
+    };
   }
   const install = toCatalogInstall(manifest.install, packageName);
-  if (!install) {
-    return null;
-  }
   const version = trimString(packageJson.version);
   const description = trimString(packageJson.description);
   return {

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 describe("buildOfficialChannelCatalog", () => {
-  it("includes publishable official channel plugins and skips non-publishable entries", () => {
+  it("includes all bundled channel metadata and only keeps install metadata for publishable entries", () => {
     const repoRoot = makeRepoRoot("openclaw-official-channel-catalog-");
     writeJson(path.join(repoRoot, "extensions", "whatsapp", "package.json"), {
       name: "@openclaw/whatsapp",
@@ -70,6 +70,18 @@ describe("buildOfficialChannelCatalog", () => {
 
     expect(buildOfficialChannelCatalog({ repoRoot })).toEqual({
       entries: [
+        {
+          name: "@openclaw/local-only",
+          openclaw: {
+            channel: {
+              id: "local-only",
+              label: "Local Only",
+              selectionLabel: "Local Only",
+              docsPath: "/channels/local-only",
+              blurb: "dev only",
+            },
+          },
+        },
         {
           name: "@openclaw/whatsapp",
           version: "2026.3.23",
@@ -132,6 +144,46 @@ describe("buildOfficialChannelCatalog", () => {
             },
             install: {
               npmSpec: "@openclaw/whatsapp",
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("preserves non-publishable bundled channel metadata without advertising an install target", () => {
+    const repoRoot = makeRepoRoot("openclaw-official-channel-catalog-private-");
+    writeJson(path.join(repoRoot, "extensions", "telegram", "package.json"), {
+      name: "@openclaw/telegram",
+      version: "2026.4.12",
+      description: "OpenClaw Telegram channel plugin",
+      openclaw: {
+        channel: {
+          id: "telegram",
+          label: "Telegram",
+          selectionLabel: "Telegram (Bot API)",
+          docsPath: "/channels/telegram",
+          blurb: "simplest way to get started",
+        },
+        install: {
+          npmSpec: "@openclaw/telegram",
+        },
+      },
+    });
+
+    expect(buildOfficialChannelCatalog({ repoRoot })).toEqual({
+      entries: [
+        {
+          name: "@openclaw/telegram",
+          version: "2026.4.12",
+          description: "OpenClaw Telegram channel plugin",
+          openclaw: {
+            channel: {
+              id: "telegram",
+              label: "Telegram",
+              selectionLabel: "Telegram (Bot API)",
+              docsPath: "/channels/telegram",
+              blurb: "simplest way to get started",
             },
           },
         },


### PR DESCRIPTION
## Summary

- keep bundled channel metadata in the generated official fallback catalog even when a bundled channel is not published to npm
- continue emitting `openclaw.install` metadata only for publishable channels
- add regression coverage for metadata-only bundled channels in the catalog generator

## Root Cause

Installed builds can fall back to `dist/channel-catalog.json` when bundled plugin package metadata is unavailable. The generator currently filters the shipped catalog to `release.publishToNpm === true`, which drops private bundled channels such as `telegram`, `signal`, `imessage`, and `slack` from the fallback metadata.

That leaves onboarding and channel setup paths without `label` / `blurb` / `docsPath` for those bundled channels. When the summary path later formats docs links, it can end up calling `.trim()` on an undefined `docsPath` and crash.

This change keeps bundled `openclaw.channel` metadata in the shipped fallback catalog for all bundled channels, while still omitting install targets for non-publishable entries.

## Testing

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts test/official-channel-catalog.test.ts src/channels/bundled-channel-catalog-read.test.ts test/release-check.test.ts`
- repository pre-commit checks via `git commit` (`pnpm check`, lint, and auth/webhook policy checks)

Closes #67130
