### PR TITLE
feat(ui/sessions): add Hide system toggle to Sessions tab

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -32,6 +32,7 @@ vi.mock("./controllers/sessions.ts", () => ({
 
 import {
   isCronSessionKey,
+  isSystemSessionKey,
   parseSessionKey,
   resolveAssistantAttachmentAuthToken,
   resolveSessionOptionGroups,
@@ -368,6 +369,25 @@ describe("isCronSessionKey", () => {
     expect(isCronSessionKey("main")).toBe(false);
     expect(isCronSessionKey("discord:group:eng")).toBe(false);
     expect(isCronSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
+  });
+});
+
+describe("isSystemSessionKey", () => {
+  it("returns true for dreaming-narrative agent keys", () => {
+    expect(
+      isSystemSessionKey("agent:aqiqi:dreaming-narrative-rem-e99f5dec5305-1776193792495"),
+    ).toBe(true);
+    expect(
+      isSystemSessionKey("agent:aqiqi:dreaming-narrative-light-58a895993323-1776193732815"),
+    ).toBe(true);
+  });
+
+  it("returns false for non-system keys", () => {
+    expect(isSystemSessionKey("")).toBe(false);
+    expect(isSystemSessionKey("agent:main:main")).toBe(false);
+    expect(isSystemSessionKey("agent:main:cron:abc")).toBe(false);
+    expect(isSystemSessionKey("discord:group:eng")).toBe(false);
+    expect(isSystemSessionKey("dreaming-narrative-rem-abc")).toBe(false);
   });
 });
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -5,6 +5,7 @@ import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import {
   isCronSessionKey,
+  isSystemSessionKey,
   parseSessionKey,
   renderChatSessionSelect as renderChatSessionSelectBase,
   renderChatThinkingSelect,
@@ -21,7 +22,13 @@ import { normalizeOptionalString } from "./string-coerce.ts";
 import type { ThemeMode } from "./theme.ts";
 import type { SessionsListResult } from "./types.ts";
 
-export { isCronSessionKey, parseSessionKey, resolveSessionDisplayName, resolveSessionOptionGroups };
+export {
+  isCronSessionKey,
+  isSystemSessionKey,
+  parseSessionKey,
+  resolveSessionDisplayName,
+  resolveSessionOptionGroups,
+};
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1551,6 +1551,7 @@ export function renderApp(state: AppViewState) {
                 limit: state.sessionsFilterLimit,
                 includeGlobal: state.sessionsIncludeGlobal,
                 includeUnknown: state.sessionsIncludeUnknown,
+                hideSystemSessions: state.sessionsHideSystem ?? true,
                 basePath: state.basePath,
                 searchQuery: state.sessionsSearchQuery,
                 sortColumn: state.sessionsSortColumn,
@@ -1568,6 +1569,8 @@ export function renderApp(state: AppViewState) {
                   state.sessionsFilterLimit = next.limit;
                   state.sessionsIncludeGlobal = next.includeGlobal;
                   state.sessionsIncludeUnknown = next.includeUnknown;
+                  state.sessionsHideSystem = next.hideSystemSessions;
+                  state.sessionsPage = 0;
                 },
                 onSearchChange: (q) => {
                   state.sessionsSearchQuery = q;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -226,6 +226,7 @@ export type AppViewState = {
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
   sessionsHideCron: boolean;
+  sessionsHideSystem: boolean;
   sessionsSearchQuery: string;
   sessionsSortColumn: "key" | "kind" | "updated" | "tokens";
   sessionsSortDir: "asc" | "desc";

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -329,6 +329,7 @@ export class OpenClawApp extends LitElement {
   @state() sessionsIncludeGlobal = true;
   @state() sessionsIncludeUnknown = false;
   @state() sessionsHideCron = true;
+  @state() sessionsHideSystem = true;
   @state() sessionsSearchQuery = "";
   @state() sessionsSortColumn: "key" | "kind" | "updated" | "tokens" = "updated";
   @state() sessionsSortDir: "asc" | "desc" = "desc";

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -434,6 +434,24 @@ export function isCronSessionKey(key: string): boolean {
   return rest.startsWith("cron:");
 }
 
+// Matches background/system sessions that pollute the list for most users
+// (e.g. nightly dreaming runs written as `agent:<id>:dreaming-narrative-...`).
+export function isSystemSessionKey(key: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(key);
+  if (!normalized) {
+    return false;
+  }
+  if (!normalized.startsWith("agent:")) {
+    return false;
+  }
+  const parts = normalized.split(":").filter(Boolean);
+  if (parts.length < 3) {
+    return false;
+  }
+  const rest = parts.slice(2).join(":");
+  return rest.startsWith("dreaming-narrative-");
+}
+
 type SessionOptionEntry = {
   key: string;
   label: string;

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -34,6 +34,7 @@ function buildProps(result: SessionsListResult): SessionsProps {
     limit: "120",
     includeGlobal: false,
     includeUnknown: false,
+    hideSystemSessions: false,
     basePath: "",
     searchQuery: "",
     sortColumn: "updated",

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { t } from "../../i18n/index.ts";
+import { isSystemSessionKey } from "../app-render.helpers.ts";
 import { formatRelativeTimestamp } from "../format.ts";
 import { icons } from "../icons.ts";
 import { pathForTab } from "../navigation.ts";
@@ -19,6 +20,7 @@ export type SessionsProps = {
   limit: string;
   includeGlobal: boolean;
   includeUnknown: boolean;
+  hideSystemSessions: boolean;
   basePath: string;
   searchQuery: string;
   sortColumn: "key" | "kind" | "updated" | "tokens";
@@ -36,6 +38,7 @@ export type SessionsProps = {
     limit: string;
     includeGlobal: boolean;
     includeUnknown: boolean;
+    hideSystemSessions: boolean;
   }) => void;
   onSearchChange: (query: string) => void;
   onSortChange: (column: "key" | "kind" | "updated" | "tokens", dir: "asc" | "desc") => void;
@@ -144,12 +147,17 @@ function resolveThinkLevelPatchValue(value: string, isBinary: boolean): string |
   return value;
 }
 
-function filterRows(rows: GatewaySessionRow[], query: string): GatewaySessionRow[] {
+function filterRows(
+  rows: GatewaySessionRow[],
+  query: string,
+  hideSystem: boolean,
+): GatewaySessionRow[] {
+  const base = hideSystem ? rows.filter((row) => !isSystemSessionKey(row.key)) : rows;
   const q = normalizeLowercaseStringOrEmpty(query);
   if (!q) {
-    return rows;
+    return base;
   }
-  return rows.filter((row) => {
+  return base.filter((row) => {
     const key = normalizeLowercaseStringOrEmpty(row.key);
     const label = normalizeLowercaseStringOrEmpty(row.label);
     const kind = normalizeLowercaseStringOrEmpty(row.kind);
@@ -227,7 +235,10 @@ function formatCheckpointDelta(checkpoint: SessionCompactionCheckpoint): string 
 
 export function renderSessions(props: SessionsProps) {
   const rawRows = props.result?.sessions ?? [];
-  const filtered = filterRows(rawRows, props.searchQuery);
+  const hiddenSystemCount = props.hideSystemSessions
+    ? rawRows.reduce((acc, row) => acc + (isSystemSessionKey(row.key) ? 1 : 0), 0)
+    : 0;
+  const filtered = filterRows(rawRows, props.searchQuery, props.hideSystemSessions);
   const sorted = sortRows(filtered, props.sortColumn, props.sortDir);
   const totalRows = sorted.length;
   const totalPages = Math.max(1, Math.ceil(totalRows / props.pageSize));
@@ -283,6 +294,7 @@ export function renderSessions(props: SessionsProps) {
                 limit: props.limit,
                 includeGlobal: props.includeGlobal,
                 includeUnknown: props.includeUnknown,
+                hideSystemSessions: props.hideSystemSessions,
               })}
           />
         </label>
@@ -297,6 +309,7 @@ export function renderSessions(props: SessionsProps) {
                 limit: (e.target as HTMLInputElement).value,
                 includeGlobal: props.includeGlobal,
                 includeUnknown: props.includeUnknown,
+                hideSystemSessions: props.hideSystemSessions,
               })}
           />
         </label>
@@ -310,6 +323,7 @@ export function renderSessions(props: SessionsProps) {
                 limit: props.limit,
                 includeGlobal: (e.target as HTMLInputElement).checked,
                 includeUnknown: props.includeUnknown,
+                hideSystemSessions: props.hideSystemSessions,
               })}
           />
           <span>Global</span>
@@ -324,9 +338,28 @@ export function renderSessions(props: SessionsProps) {
                 limit: props.limit,
                 includeGlobal: props.includeGlobal,
                 includeUnknown: (e.target as HTMLInputElement).checked,
+                hideSystemSessions: props.hideSystemSessions,
               })}
           />
           <span>Unknown</span>
+        </label>
+        <label
+          class="field-inline checkbox"
+          title="Hide background/system sessions (e.g. dreaming-narrative runs)"
+        >
+          <input
+            type="checkbox"
+            .checked=${props.hideSystemSessions}
+            @change=${(e: Event) =>
+              props.onFiltersChange({
+                activeMinutes: props.activeMinutes,
+                limit: props.limit,
+                includeGlobal: props.includeGlobal,
+                includeUnknown: props.includeUnknown,
+                hideSystemSessions: (e.target as HTMLInputElement).checked,
+              })}
+          />
+          <span>Hide system${hiddenSystemCount > 0 ? html` (${hiddenSystemCount})` : nothing}</span>
         </label>
       </div>
 


### PR DESCRIPTION
## Summary

- Problem: the Control UI Sessions list shows every session, including background `agent:<id>:dreaming-narrative-*` runs from the memory-core nightly dreaming job. After a few weeks the table is mostly system rows and normal agent sessions are hard to find.
- Why it matters: dreaming sessions have `kind: "other"` / `channel: "unknown"` and there is currently no way to hide them. Issue #67058 calls this out as a UX regression that worsens over time.
- What changed: added a client-side "Hide system" filter to the Sessions tab (default on) that hides session keys matching the dreaming-narrative pattern, plus a hidden-count badge `Hide system (N)` so users can see how many rows are filtered.
- What did NOT change (scope boundary): no gateway/protocol changes, no `sessions.list` RPC params, no server-side filtering. The chat sidebar's existing `sessionsHideCron` behavior is untouched. Only the dreaming-narrative pattern is matched today; cron sessions remain handled by the existing toggle.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67058
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/app-render.helpers.node.test.ts` (`isSystemSessionKey` describe block) and `ui/src/ui/views/sessions.test.ts` (props fixture extended).
- Scenario the test should lock in: `agent:<id>:dreaming-narrative-*` keys are recognized as system sessions; non-matching keys (`agent:main:main`, `cron:*`, `discord:*`, bare `dreaming-narrative-*`) are not.
- Why this is the smallest reliable guardrail: the filter is a pure key-pattern predicate — a unit test on the helper is sufficient to lock the contract; the view test exercises the prop wiring.
- Existing test that already covers this (if any): `isCronSessionKey` tests in the same file (used as the prior-art template).
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Sessions tab now has a "Hide system" checkbox next to Global / Unknown.
- Default is **on**, so dreaming-narrative rows are hidden out of the box.
- When any rows are hidden, the label shows `Hide system (N)` so the count is discoverable.
- Toggling the checkbox resets pagination to page 0.
- No config, no API, no persisted state changes.

## Diagram (if applicable)

```text
Before:
[open Sessions tab] -> [list shows agent:main:main + N dreaming-narrative-*]

After:
[open Sessions tab] -> [Hide system: ✓ default] -> [list shows agent:main:main only]
                                                -> [label: "Hide system (N)" shows hidden count]
[uncheck Hide system]                            -> [list shows all rows including dreaming]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A — pure client-side render filter over rows already returned by `sessions.list`.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `pnpm openclaw gateway --force` against `dist/control-ui`
- Model/provider: N/A (UI-only)
- Integration/channel (if any): N/A
- Relevant config (redacted): default

### Steps

1. `pnpm ui:build && pnpm openclaw gateway --force`
2. `pnpm openclaw dashboard --no-open` and open the printed tokenized URL
3. Click **Sessions** in the sidebar
4. Inspect filter row and toggle "Hide system"

### Expected

- "Hide system" checkbox is present, checked by default
- `agent:<id>:dreaming-narrative-*` rows are filtered out when checked
- Label shows `Hide system (N)` when N > 0; plain "Hide system" when N = 0
- Unchecking reveals dreaming rows; rechecking hides them

### Actual

- Matches expected. Verified locally on a store with `agent:main:main` (no dreaming sessions present in the test store, so label shows plain "Hide system" with N=0); pattern coverage is locked in by `isSystemSessionKey` unit tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```
$ pnpm test ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/views/sessions.test.ts ui/src/ui/controllers/sessions.test.ts
 Test Files  3 passed (3)
      Tests  53 passed (53)

$ pnpm check
... (all gates green; tsgo, oxlint, import-cycles, madge-import-cycles, host-env-policy)
```

## Human Verification (required)

- Verified scenarios:
  - Sessions tab loads with the new checkbox, checked by default
  - Toggling the checkbox does not throw and does not break existing Global/Unknown filters or pagination
  - Filter logic round-trips through `isSystemSessionKey` unit tests
- Edge cases checked:
  - Empty store (N=0) — label renders without the parenthetical
  - Plain `dreaming-narrative-*` keys (no `agent:` prefix) are NOT matched, by design (avoid false positives on user-named sessions)
  - Non-`agent:` keys (`cron:*`, `discord:*`) are NOT matched
- What you did **not** verify:
  - Live dreaming-narrative session in the local store — none present at test time; covered by unit tests instead of a live row

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A user with a real session whose key happens to start with `dreaming-narrative-` (after the agent prefix) would be hidden by default.
  - Mitigation: The pattern is intentionally narrow (`agent:<id>:dreaming-narrative-`) and matches the `DREAMING_SESSION_KEY_PREFIX` constant in `extensions/memory-core/src/dreaming-narrative.ts`. The toggle is a single click to reveal everything.
- Risk: Future system session families (other background jobs) won't be covered.
  - Mitigation: `isSystemSessionKey` is a single helper — adding new patterns is a one-line change with a unit test, mirroring how `isCronSessionKey` evolves.

## Screenshots

https://github.com/user-attachments/assets/91173151-e247-4050-ac92-2261b87e32ae