### PR TITLE
Add stable tarball upgrade workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/openclaw/openclaw.git"
   },
   "bin": {
-    "openclaw": "openclaw.mjs"
+    "openclaw": "scripts/openclaw-runcli-launcher.mjs"
   },
   "directories": {
     "doc": "docs",
@@ -39,6 +39,7 @@
     "qa/scenarios/",
     "skills/",
     "scripts/npm-runner.mjs",
+    "scripts/openclaw-runcli-launcher.mjs",
     "scripts/postinstall-bundled-plugins.mjs",
     "scripts/windows-cmd-helpers.mjs"
   ],
@@ -1316,6 +1317,7 @@
     "test:live:media:image": "node --import tsx scripts/test-live-media.ts image",
     "test:live:media:music": "node --import tsx scripts/test-live-media.ts music",
     "test:live:media:video": "node --import tsx scripts/test-live-media.ts video",
+    "test:live:memory-pro:host": "node scripts/test-live-memory-pro-cli-host.mjs",
     "test:live:models-profiles": "node scripts/test-live.mjs -- src/agents/models.profiles.live.test.ts",
     "test:macos:ci": "node scripts/test-projects.mjs src/daemon/launchd.test.ts src/daemon/runtime-paths.test.ts src/daemon/runtime-binary.test.ts src/infra/brew.test.ts src/infra/stable-node-path.test.ts test/scripts/vitest-process-group.test.ts",
     "test:max": "OPENCLAW_VITEST_MAX_WORKERS=8 node scripts/test-projects.mjs",

--- a/scripts/local-upgrade-from-tarball.sh
+++ b/scripts/local-upgrade-from-tarball.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/local-upgrade-from-tarball.sh [--pack-dir DIR] [--tarball FILE] [--skip-regression]
+
+Build a local OpenClaw tarball from the current repo, install it globally, verify
+that the global install no longer points at /tmp, then run the live memory-pro
+host regression.
+
+Environment overrides:
+  OPENCLAW_LOCAL_PACK_DIR   Stable directory for generated tarballs
+  OPENCLAW_TARBALL          Prebuilt tarball to install instead of running npm pack
+  OPENCLAW_BIN              OpenClaw binary name/path used by the regression script
+EOF
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "Missing required command: $name" >&2
+    exit 1
+  fi
+}
+
+resolve_realpath() {
+  node -e 'const fs=require("fs"); process.stdout.write(fs.realpathSync(process.argv[1]));' "$1"
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+PACK_DIR="${OPENCLAW_LOCAL_PACK_DIR:-$REPO_ROOT/tmp/openclaw-packages}"
+TARBALL_PATH="${OPENCLAW_TARBALL:-}"
+RUN_REGRESSION=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pack-dir)
+      PACK_DIR="$2"
+      shift 2
+      ;;
+    --tarball)
+      TARBALL_PATH="$2"
+      shift 2
+      ;;
+    --skip-regression)
+      RUN_REGRESSION=0
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd npm
+require_cmd node
+require_cmd openclaw
+
+mkdir -p "$PACK_DIR"
+
+if [[ -z "$TARBALL_PATH" ]]; then
+  echo "[1/5] Packing OpenClaw tarball into $PACK_DIR"
+  if git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ -n "$(git -C "$REPO_ROOT" status --short)" ]]; then
+      echo "Notice: packing a dirty working tree from $REPO_ROOT" >&2
+    fi
+  fi
+  npm pack "$REPO_ROOT" --pack-destination "$PACK_DIR" >/dev/null
+  TARBALL_PATH="$(ls -t "$PACK_DIR"/openclaw-*.tgz | head -n 1)"
+fi
+
+if [[ ! -f "$TARBALL_PATH" ]]; then
+  echo "Tarball not found: $TARBALL_PATH" >&2
+  exit 1
+fi
+
+echo "[2/5] Installing $TARBALL_PATH globally"
+npm install -g "$TARBALL_PATH"
+
+GLOBAL_PREFIX="$(npm prefix -g)"
+INSTALL_DIR="$GLOBAL_PREFIX/lib/node_modules/openclaw"
+BIN_PATH="$GLOBAL_PREFIX/bin/openclaw"
+
+if [[ ! -e "$INSTALL_DIR/package.json" ]]; then
+  echo "Global install missing package.json at $INSTALL_DIR" >&2
+  exit 1
+fi
+
+echo "[3/5] Verifying global install path"
+if [[ -L "$INSTALL_DIR" ]]; then
+  echo "Global install is still a symlink: $INSTALL_DIR -> $(readlink "$INSTALL_DIR")" >&2
+  exit 1
+fi
+
+INSTALL_REALPATH="$(resolve_realpath "$INSTALL_DIR")"
+if [[ "$INSTALL_REALPATH" == /tmp/* || "$INSTALL_REALPATH" == /private/tmp/* ]]; then
+  echo "Global install still resolves into tmp: $INSTALL_REALPATH" >&2
+  exit 1
+fi
+
+PACKAGE_BIN="$(node -p "require('$INSTALL_DIR/package.json').bin.openclaw")"
+if [[ "$PACKAGE_BIN" != "scripts/openclaw-runcli-launcher.mjs" ]]; then
+  echo "Unexpected package bin entry: $PACKAGE_BIN" >&2
+  exit 1
+fi
+
+if [[ ! -e "$BIN_PATH" ]]; then
+  echo "Global openclaw bin missing: $BIN_PATH" >&2
+  exit 1
+fi
+
+BIN_REALPATH="$(resolve_realpath "$BIN_PATH")"
+EXPECTED_BIN_REALPATH="$(resolve_realpath "$INSTALL_DIR/scripts/openclaw-runcli-launcher.mjs")"
+if [[ "$BIN_REALPATH" != "$EXPECTED_BIN_REALPATH" ]]; then
+  echo "Global openclaw bin does not resolve to launcher" >&2
+  echo "  actual:   $BIN_REALPATH" >&2
+  echo "  expected: $EXPECTED_BIN_REALPATH" >&2
+  exit 1
+fi
+
+echo "[4/5] Verifying installed CLI version"
+openclaw --version
+
+if [[ "$RUN_REGRESSION" -eq 1 ]]; then
+  echo "[5/5] Running live memory-pro host regression"
+  node "$REPO_ROOT/scripts/test-live-memory-pro-cli-host.mjs"
+else
+  echo "[5/5] Skipped live memory-pro host regression"
+fi

--- a/scripts/openclaw-runcli-launcher.mjs
+++ b/scripts/openclaw-runcli-launcher.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import { readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distDir = join(__dirname, "..", "dist");
+const runMainEntry = readdirSync(distDir).find((name) => /^run-main-.*\.js$/u.test(name));
+
+if (!runMainEntry) {
+  throw new Error(`openclaw: missing run-main entry in ${distDir}`);
+}
+
+const { runCli } = await import(pathToFileURL(join(distDir, runMainEntry)).href);
+if (typeof runCli !== "function") {
+  throw new Error(`openclaw: ${runMainEntry} does not export runCli()`);
+}
+
+process.env.OPENCLAW_CLI = "1";
+await runCli(process.argv);
+process.exit(process.exitCode ?? 0);

--- a/scripts/test-live-memory-pro-cli-host.mjs
+++ b/scripts/test-live-memory-pro-cli-host.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+const DEFAULT_TIMEOUT_MS = Number(process.env.OPENCLAW_HOST_CLI_TIMEOUT_MS || "15000");
+const OPENCLAW_BIN = process.env.OPENCLAW_BIN?.trim() || "openclaw";
+
+function fail(message, details = {}) {
+  const error = new Error(message);
+  error.details = details;
+  throw error;
+}
+
+function ensureTimeoutMs(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 15000;
+  }
+  return Math.floor(value);
+}
+
+function killProcessTree(pid, detached, signal) {
+  if (!pid) {
+    return;
+  }
+
+  try {
+    process.kill(detached ? -pid : pid, signal);
+  } catch {
+    // Process already exited.
+  }
+}
+
+function runOpenClaw(args, options = {}) {
+  const timeoutMs = ensureTimeoutMs(options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    const detached = process.platform !== "win32";
+    let stdout = "";
+    let stderr = "";
+    let spawnError = null;
+    let timedOut = false;
+    let settled = false;
+    let killTimer = null;
+
+    const child = spawn(OPENCLAW_BIN, args, {
+      detached,
+      env: {
+        ...process.env,
+        ...(options.env ?? {}),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    const finish = (status, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutTimer);
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+      const elapsedMs = Date.now() - startedAt;
+      resolve({
+        args,
+        status,
+        signal,
+        error: spawnError,
+        timedOut,
+        timeoutMs,
+        elapsedMs,
+        stdout,
+        stderr,
+        combined: `${stderr}${stderr && stdout ? "\n" : ""}${stdout}`,
+      });
+    };
+
+    child.on("error", (error) => {
+      spawnError = error;
+    });
+
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      spawnError = Object.assign(new Error(`Command timed out after ${timeoutMs}ms`), {
+        code: "ETIMEDOUT",
+      });
+      killProcessTree(child.pid, detached, "SIGTERM");
+      killTimer = setTimeout(() => {
+        killProcessTree(child.pid, detached, "SIGKILL");
+      }, 500);
+      killTimer.unref?.();
+    }, timeoutMs);
+    timeoutTimer.unref?.();
+
+    child.on("close", (status, signal) => {
+      finish(status, signal);
+    });
+  });
+}
+
+function assertCommandSucceeded(result, label) {
+  if (result.timedOut) {
+    fail(`${label} timed out after ${result.timeoutMs}ms`, { result });
+  }
+  if (result.error) {
+    fail(`${label} failed to start`, { result });
+  }
+  if (result.signal) {
+    fail(`${label} exited by signal ${result.signal}`, { result });
+  }
+  if (result.status !== 0) {
+    fail(`${label} exited with status ${result.status}`, { result });
+  }
+}
+
+function extractVersion(text) {
+  const match = text.match(/\b\d+\.\d+\.\d+(?:[-+][A-Za-z0-9._-]+)?\b/);
+  return match?.[0] ?? null;
+}
+
+function extractProfiledCliMetadataPlugins(text) {
+  const plugins = [];
+  const regex = /^\[plugin-load-profile\] phase=cli-metadata plugin=([^\s]+)\s/mg;
+  let match = regex.exec(text);
+  while (match) {
+    plugins.push(match[1]);
+    match = regex.exec(text);
+  }
+  return plugins;
+}
+
+function extractFirstJsonObject(text) {
+  const start = text.indexOf("{");
+  if (start < 0) {
+    return null;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === "\"") {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      depth += 1;
+      continue;
+    }
+    if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        const candidate = text.slice(start, i + 1);
+        return JSON.parse(candidate);
+      }
+    }
+  }
+
+  return null;
+}
+
+function assertOnlyOwnerPlugin(result, label) {
+  const plugins = extractProfiledCliMetadataPlugins(result.combined);
+  const unique = [...new Set(plugins)];
+  if (unique.length !== 1 || unique[0] !== "memory-lancedb-pro") {
+    fail(`${label} loaded unexpected cli-metadata plugins`, {
+      plugins,
+      result,
+    });
+  }
+  return unique;
+}
+
+function buildSummary(results) {
+  return {
+    openclawBin: OPENCLAW_BIN,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    checks: results,
+  };
+}
+
+async function main() {
+  const checks = [];
+
+  const versionResult = await runOpenClaw(["memory-pro", "version"]);
+  assertCommandSucceeded(versionResult, "memory-pro version");
+  const version = extractVersion(`${versionResult.stdout}\n${versionResult.stderr}`);
+  if (!version) {
+    fail("memory-pro version did not print a version string", { result: versionResult });
+  }
+  checks.push({
+    name: "memory-pro version",
+    elapsedMs: versionResult.elapsedMs,
+    version,
+  });
+
+  const statsResult = await runOpenClaw(["memory-pro", "stats", "--json"]);
+  assertCommandSucceeded(statsResult, "memory-pro stats --json");
+  const statsJson = extractFirstJsonObject(statsResult.combined);
+  if (!statsJson || typeof statsJson !== "object") {
+    fail("memory-pro stats --json did not return parseable JSON", { result: statsResult });
+  }
+  const fts = statsJson?.retrieval?.fts;
+  if (!fts || typeof fts.available !== "boolean") {
+    fail("memory-pro stats --json missing retrieval.fts status", { statsJson, result: statsResult });
+  }
+  checks.push({
+    name: "memory-pro stats --json",
+    elapsedMs: statsResult.elapsedMs,
+    retrievalMode: statsJson?.retrieval?.mode ?? null,
+    fts,
+  });
+
+  const profiledVersion = await runOpenClaw(["memory-pro", "version"], {
+    env: { OPENCLAW_PLUGIN_LOAD_PROFILE: "1" },
+  });
+  assertCommandSucceeded(profiledVersion, "profiled memory-pro version");
+  const versionPlugins = assertOnlyOwnerPlugin(profiledVersion, "profiled memory-pro version");
+  checks.push({
+    name: "profiled memory-pro version",
+    elapsedMs: profiledVersion.elapsedMs,
+    cliMetadataPlugins: versionPlugins,
+  });
+
+  const profiledStats = await runOpenClaw(["memory-pro", "stats", "--json"], {
+    env: { OPENCLAW_PLUGIN_LOAD_PROFILE: "1" },
+  });
+  assertCommandSucceeded(profiledStats, "profiled memory-pro stats --json");
+  const statsPlugins = assertOnlyOwnerPlugin(profiledStats, "profiled memory-pro stats --json");
+  checks.push({
+    name: "profiled memory-pro stats --json",
+    elapsedMs: profiledStats.elapsedMs,
+    cliMetadataPlugins: statsPlugins,
+  });
+
+  console.log(JSON.stringify(buildSummary(checks), null, 2));
+}
+
+try {
+  main();
+} catch (error) {
+  const payload = {
+    ok: false,
+    error: error instanceof Error ? error.message : String(error),
+    details: error && typeof error === "object" && "details" in error ? error.details : undefined,
+  };
+  console.error(JSON.stringify(payload, null, 2));
+  process.exit(1);
+}

--- a/scripts/test-live-memory-pro-cli-host.mjs
+++ b/scripts/test-live-memory-pro-cli-host.mjs
@@ -128,12 +128,12 @@ function extractVersion(text) {
   return match?.[0] ?? null;
 }
 
-function extractProfiledCliMetadataPlugins(text) {
+function extractProfiledPlugins(text) {
   const plugins = [];
-  const regex = /^\[plugin-load-profile\] phase=cli-metadata plugin=([^\s]+)\s/mg;
+  const regex = /^\[plugin-load-profile\] phase=([^\s]+) plugin=([^\s]+)\s/mg;
   let match = regex.exec(text);
   while (match) {
-    plugins.push(match[1]);
+    plugins.push({ phase: match[1], plugin: match[2] });
     match = regex.exec(text);
   }
   return plugins;
@@ -183,15 +183,21 @@ function extractFirstJsonObject(text) {
 }
 
 function assertOnlyOwnerPlugin(result, label) {
-  const plugins = extractProfiledCliMetadataPlugins(result.combined);
-  const unique = [...new Set(plugins)];
+  const profiled = extractProfiledPlugins(result.combined);
+  const unique = [...new Set(profiled.map((entry) => entry.plugin))];
+  if (unique.length === 0) {
+    fail(`${label} did not emit any plugin-load-profile lines`, { result });
+  }
   if (unique.length !== 1 || unique[0] !== "memory-lancedb-pro") {
     fail(`${label} loaded unexpected cli-metadata plugins`, {
-      plugins,
+      plugins: profiled,
       result,
     });
   }
-  return unique;
+  return {
+    plugins: unique,
+    phases: [...new Set(profiled.map((entry) => entry.phase))],
+  };
 }
 
 function buildSummary(results) {
@@ -238,22 +244,24 @@ async function main() {
     env: { OPENCLAW_PLUGIN_LOAD_PROFILE: "1" },
   });
   assertCommandSucceeded(profiledVersion, "profiled memory-pro version");
-  const versionPlugins = assertOnlyOwnerPlugin(profiledVersion, "profiled memory-pro version");
+  const versionProfile = assertOnlyOwnerPlugin(profiledVersion, "profiled memory-pro version");
   checks.push({
     name: "profiled memory-pro version",
     elapsedMs: profiledVersion.elapsedMs,
-    cliMetadataPlugins: versionPlugins,
+    profiledPlugins: versionProfile.plugins,
+    profilePhases: versionProfile.phases,
   });
 
   const profiledStats = await runOpenClaw(["memory-pro", "stats", "--json"], {
     env: { OPENCLAW_PLUGIN_LOAD_PROFILE: "1" },
   });
   assertCommandSucceeded(profiledStats, "profiled memory-pro stats --json");
-  const statsPlugins = assertOnlyOwnerPlugin(profiledStats, "profiled memory-pro stats --json");
+  const statsProfile = assertOnlyOwnerPlugin(profiledStats, "profiled memory-pro stats --json");
   checks.push({
     name: "profiled memory-pro stats --json",
     elapsedMs: profiledStats.elapsedMs,
-    cliMetadataPlugins: statsPlugins,
+    profiledPlugins: statsProfile.plugins,
+    profilePhases: statsProfile.phases,
   });
 
   console.log(JSON.stringify(buildSummary(checks), null, 2));

--- a/test/openclaw-runcli-launcher.e2e.test.ts
+++ b/test/openclaw-runcli-launcher.e2e.test.ts
@@ -15,6 +15,102 @@ async function makeRunCliLauncherFixture(fixtureRoots: string[]): Promise<string
   return fixtureRoot;
 }
 
+async function writeMemoryProCliFixture(fixtureRoot: string): Promise<void> {
+  const stateDir = path.join(fixtureRoot, ".openclaw");
+  const pluginDir = path.join(fixtureRoot, "plugins", "memory-lancedb-pro");
+  const pluginFile = path.join(pluginDir, "index.cjs");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.mkdir(pluginDir, { recursive: true });
+  await fs.writeFile(
+    path.join(stateDir, "openclaw.json"),
+    JSON.stringify(
+      {
+        plugins: {
+          enabled: true,
+          load: { paths: [pluginFile] },
+          allow: ["memory-lancedb-pro"],
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: "memory-lancedb-pro",
+        configSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {},
+        },
+        commandAliases: [{ name: "memory-pro" }],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  await fs.writeFile(
+    pluginFile,
+    `function leakHandle() {
+  setInterval(() => {}, 1_000);
+}
+
+module.exports = {
+  id: "memory-lancedb-pro",
+  register(api) {
+    api.registerCli(
+      ({ program }) => {
+        const memoryPro = program.command("memory-pro").description("Memory Pro");
+        memoryPro
+          .command("version")
+          .description("Print plugin version")
+          .action(() => {
+            leakHandle();
+            process.stdout.write("1.1.0-test\\n");
+          });
+        memoryPro
+          .command("stats")
+          .description("Print stats")
+          .option("--json")
+          .action((options) => {
+            leakHandle();
+            const payload = {
+              retrieval: {
+                mode: "hybrid",
+                fts: { available: true, lastError: null },
+              },
+            };
+            process.stdout.write(options.json ? JSON.stringify(payload) + "\\n" : "stats\\n");
+          });
+      },
+      {
+        commands: ["memory-pro"],
+        descriptors: [
+          {
+            name: "memory-pro",
+            description: "Memory Pro",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    );
+  },
+};
+`,
+    "utf8",
+  );
+}
+
+function extractProfiledPlugins(text: string): string[] {
+  return [...text.matchAll(/^\[plugin-load-profile\] phase=[^\s]+ plugin=([^\s]+)\s/mg)].map(
+    (match) => match[1],
+  );
+}
+
 describe("openclaw runCli launcher", () => {
   const fixtureRoots: string[] = [];
 
@@ -49,5 +145,86 @@ describe("openclaw runCli launcher", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("stub runCli memory-pro version");
     expect(elapsedMs).toBeLessThan(1_500);
+  });
+
+  it("executes the real memory-pro version command path and exits despite active plugin handles", async () => {
+    const fixtureRoot = await makeRunCliLauncherFixture(fixtureRoots);
+    await writeMemoryProCliFixture(fixtureRoot);
+
+    const launcherPath = path.resolve(process.cwd(), "scripts", "openclaw-runcli-launcher.mjs");
+    const env = {
+      ...process.env,
+      HOME: fixtureRoot,
+      USERPROFILE: fixtureRoot,
+      OPENCLAW_STATE_DIR: path.join(fixtureRoot, ".openclaw"),
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(fixtureRoot, "no-bundled-plugins"),
+      OPENCLAW_PLUGIN_LOAD_PROFILE: "1",
+      OPENCLAW_TEST_FAST: "1",
+    };
+    delete env.VITEST;
+
+    const startedAt = Date.now();
+    const result = spawnSync(process.execPath, [launcherPath, "memory-pro", "version"], {
+      cwd: process.cwd(),
+      env,
+      encoding: "utf8",
+      timeout: 1_500,
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("1.1.0-test");
+    expect(elapsedMs).toBeLessThan(1_500);
+    expect([...new Set(extractProfiledPlugins(`${result.stderr}\n${result.stdout}`))]).toEqual([
+      "memory-lancedb-pro",
+    ]);
+  });
+
+  it("keeps memory-pro stats --json parseable and short-lived on the real command path", async () => {
+    const fixtureRoot = await makeRunCliLauncherFixture(fixtureRoots);
+    await writeMemoryProCliFixture(fixtureRoot);
+
+    const launcherPath = path.resolve(process.cwd(), "scripts", "openclaw-runcli-launcher.mjs");
+    const env = {
+      ...process.env,
+      HOME: fixtureRoot,
+      USERPROFILE: fixtureRoot,
+      OPENCLAW_STATE_DIR: path.join(fixtureRoot, ".openclaw"),
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(fixtureRoot, "no-bundled-plugins"),
+      OPENCLAW_PLUGIN_LOAD_PROFILE: "1",
+      OPENCLAW_TEST_FAST: "1",
+    };
+    delete env.VITEST;
+
+    const startedAt = Date.now();
+    const result = spawnSync(
+      process.execPath,
+      [launcherPath, "memory-pro", "stats", "--json"],
+      {
+        cwd: process.cwd(),
+        env,
+        encoding: "utf8",
+        timeout: 1_500,
+      },
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+    const stdout = result.stdout.trim();
+    expect(() => JSON.parse(stdout)).not.toThrow();
+    expect(JSON.parse(stdout)).toMatchObject({
+      retrieval: {
+        mode: "hybrid",
+        fts: { available: true, lastError: null },
+      },
+    });
+    expect(elapsedMs).toBeLessThan(1_500);
+    expect([...new Set(extractProfiledPlugins(`${result.stderr}\n${result.stdout}`))]).toEqual([
+      "memory-lancedb-pro",
+    ]);
   });
 });

--- a/test/openclaw-runcli-launcher.e2e.test.ts
+++ b/test/openclaw-runcli-launcher.e2e.test.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
+
+async function makeRunCliLauncherFixture(fixtureRoots: string[]): Promise<string> {
+  const fixtureRoot = makeTempDir(fixtureRoots, "openclaw-runcli-launcher-");
+  await fs.mkdir(path.join(fixtureRoot, "scripts"), { recursive: true });
+  await fs.copyFile(
+    path.resolve(process.cwd(), "scripts", "openclaw-runcli-launcher.mjs"),
+    path.join(fixtureRoot, "scripts", "openclaw-runcli-launcher.mjs"),
+  );
+  await fs.mkdir(path.join(fixtureRoot, "dist"), { recursive: true });
+  return fixtureRoot;
+}
+
+describe("openclaw runCli launcher", () => {
+  const fixtureRoots: string[] = [];
+
+  afterEach(async () => {
+    cleanupTempDirs(fixtureRoots);
+  });
+
+  it("forces process exit after runCli resolves even when active handles remain", async () => {
+    const fixtureRoot = await makeRunCliLauncherFixture(fixtureRoots);
+    await fs.writeFile(
+      path.join(fixtureRoot, "dist", "run-main-fixture.js"),
+      `export async function runCli(argv) {
+  setInterval(() => {}, 1_000);
+  process.exitCode = 0;
+  process.stdout.write(\`stub runCli \${argv.slice(2).join(" ")}\\n\`);
+}
+`,
+      "utf8",
+    );
+
+    const launcherPath = path.join(fixtureRoot, "scripts", "openclaw-runcli-launcher.mjs");
+    const startedAt = Date.now();
+    const result = spawnSync(process.execPath, [launcherPath, "memory-pro", "version"], {
+      cwd: fixtureRoot,
+      encoding: "utf8",
+      timeout: 1_500,
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("stub runCli memory-pro version");
+    expect(elapsedMs).toBeLessThan(1_500);
+  });
+});


### PR DESCRIPTION
## Why
- npm global installs built from unpacked source trees can leave the live `openclaw` bin resolving back into an ephemeral `/tmp/...` install root, which makes later upgrades and reinstalls fragile
- the shortest host-side symptom was `openclaw memory-pro version` / `openclaw memory-pro stats --json`: these commands should behave like short-lived CLI surfaces, but they were also the easiest place to detect launcher/lifecycle regressions

## What changed
- switch the published npm bin entry to `scripts/openclaw-runcli-launcher.mjs` and include that launcher in packaged files
- add `scripts/local-upgrade-from-tarball.sh` so local upgrades can pack from a stable repo path, install globally, and verify the installed bin no longer resolves into `/tmp`
- add `scripts/test-live-memory-pro-cli-host.mjs` so upgrades can live-smoke the host path with `memory-pro version` and `memory-pro stats --json`
- relax the profile parsing in that live smoke so it validates the loaded plugin set instead of hard-coding a single `plugin-load-profile` phase name
- add launcher e2e coverage in two layers:
  - a generic lifecycle check that forces process exit after `runCli()` resolves even if an active handle remains
  - a `memory-pro` subcommand-path check that runs the real launcher against a fixture owner plugin and verifies `memory-pro version` and `memory-pro stats --json` both stay short-lived and only load the owning plugin

## Risk
- packaging/install surface only: the main behavior change is which file the npm-installed `openclaw` bin points at
- the new live regression does not loosen plugin ownership checks; it still requires the profiled plugin set to be exactly `memory-lancedb-pro`
- the new e2e lifecycle regressions are self-contained and fixture-based; they do not rely on the local extension state or live gateway state

## Verification
- `npm --prefix /Users/coxi/Desktop/旅游/travel-system/openclaw-upstream-v2026.4.14 run test:live:memory-pro:host`
- `npx vitest run --config test/vitest/vitest.e2e.config.ts test/openclaw-launcher.e2e.test.ts test/openclaw-runcli-launcher.e2e.test.ts`
- `/Users/coxi/Desktop/旅游/travel-system/openclaw-upstream-v2026.4.14/scripts/local-upgrade-from-tarball.sh`

## Live outcome
- rebuilt and reinstalled the local OpenClaw CLI from this branch
- verified the live install now reports `OpenClaw 2026.4.14 (f76f2bc)` via the launcher-backed global bin
- verified the memory-pro host smoke returns promptly and only profiles `memory-lancedb-pro`
