### PR TITLE
fix(commands): resolve auto setting during startup with empty registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.worktrees/
 node_modules
 **/node_modules/
 .env

--- a/src/config/commands.test.ts
+++ b/src/config/commands.test.ts
@@ -214,3 +214,25 @@ describe("isCommandFlagEnabled", () => {
     ).toBe(false);
   });
 });
+
+describe("resolveNativeCommandsEnabled / resolveNativeSkillsEnabled — empty registry (startup timing)", () => {
+  it("returns true for telegram native commands when channel registry is empty", () => {
+    // Simulate startup race: channel registry not yet populated
+    setActivePluginRegistry(createTestRegistry([]));
+
+    expect(
+      resolveNativeCommandsEnabled({ providerId: "telegram", globalSetting: "auto" }),
+    ).toBe(true);
+    expect(
+      resolveNativeSkillsEnabled({ providerId: "telegram", globalSetting: "auto" }),
+    ).toBe(true);
+  });
+
+  it("returns false for unknown provider when registry is empty", () => {
+    setActivePluginRegistry(createTestRegistry([]));
+
+    expect(
+      resolveNativeCommandsEnabled({ providerId: "unknown-channel" as never, globalSetting: "auto" }),
+    ).toBe(false);
+  });
+});

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -3,13 +3,23 @@ import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { NativeCommandsSetting } from "./types.js";
 export { isCommandFlagEnabled, isRestartEnabled, type CommandFlagKey } from "./commands.flags.js";
 
+// Bundled channels with auto-enabled native commands/skills.
+// Used as fallback during startup when plugin registry not yet populated.
+const BUNDLED_AUTO_ENABLED = {
+  telegram: { native: true, nativeSkills: true },
+  discord: { native: true, nativeSkills: true },
+} as const;
+
 function resolveAutoDefault(
   providerId: ChannelId | undefined,
   kind: "native" | "nativeSkills",
 ): boolean {
   const id = normalizeChannelId(providerId);
   if (!id) {
-    return false;
+    // Fallback for startup race: registry not yet populated when config loads.
+    // Check against known bundled channels until registry initializes.
+    const bundled = providerId ? BUNDLED_AUTO_ENABLED[providerId as keyof typeof BUNDLED_AUTO_ENABLED] : undefined;
+    return bundled?.[kind] ?? false;
   }
   const plugin = getChannelPlugin(id);
   if (!plugin) {

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -3,25 +3,15 @@ import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { NativeCommandsSetting } from "./types.js";
 export { isCommandFlagEnabled, isRestartEnabled, type CommandFlagKey } from "./commands.flags.js";
 
-// Bundled channels with auto-enabled native commands/skills.
-// Used as fallback during startup when plugin registry not yet populated.
-const BUNDLED_AUTO_ENABLED = {
-  telegram: { native: true, nativeSkills: true },
-  discord: { native: true, nativeSkills: true },
-} as const;
-
 function resolveAutoDefault(
   providerId: ChannelId | undefined,
   kind: "native" | "nativeSkills",
 ): boolean {
   const id = normalizeChannelId(providerId);
-  if (!id) {
-    // Fallback for startup race: registry not yet populated when config loads.
-    // Check against known bundled channels until registry initializes.
-    const bundled = providerId ? BUNDLED_AUTO_ENABLED[providerId as keyof typeof BUNDLED_AUTO_ENABLED] : undefined;
-    return bundled?.[kind] ?? false;
-  }
-  const plugin = getChannelPlugin(id);
+  // Pass id ?? providerId to getChannelPlugin: when normalizeChannelId returns null
+  // (registry empty during startup), getChannelPlugin's getBundledChannelPlugin fallback
+  // can still resolve bundled channels by reading manifest metadata from disk.
+  const plugin = getChannelPlugin(id ?? providerId);
   if (!plugin) {
     return false;
   }

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -11,7 +11,11 @@ function resolveAutoDefault(
   // Pass id ?? providerId to getChannelPlugin: when normalizeChannelId returns null
   // (registry empty during startup), getChannelPlugin's getBundledChannelPlugin fallback
   // can still resolve bundled channels by reading manifest metadata from disk.
-  const plugin = getChannelPlugin(id ?? providerId);
+  const resolvedId = id ?? providerId;
+  if (!resolvedId) {
+    return false;
+  }
+  const plugin = getChannelPlugin(resolvedId);
   if (!plugin) {
     return false;
   }


### PR DESCRIPTION
## What does this PR do?

Fixes the Telegram command menu staying empty when \`commands.native=auto\` resolves to \`false\` during provider startup due to an empty plugin registry.

## Problem Statement

**Issue:** #67104

During gateway startup, \`createTelegramBot()\` calls \`resolveNativeCommandsEnabled()\` with \`commands.native=auto\`. The \`resolveAutoDefault()\` function attempts to normalize the channel ID using \`normalizeChannelId(providerId)\`, which delegates to \`normalizeAnyChannelId()\` — a runtime registry lookup. 

**Root cause:** When the channel registry is not yet populated during startup, \`normalizeChannelId()\` returns \`null\`, causing \`resolveAutoDefault()\` to return \`false\` immediately without ever calling \`getChannelPlugin()\`. This results in:
- \`nativeEnabled = false\`
- \`nativeSkillsEnabled = false\`
- Empty Telegram command menu (no \`/start\`, \`/help\`, etc.)

**Workaround:** Users must explicitly set \`commands.native: true\` instead of relying on \`auto\`.

## Solution Applied

Changed \`resolveAutoDefault()\` to pass \`id ?? providerId\` to \`getChannelPlugin()\`:

\`\`\`typescript
const plugin = getChannelPlugin(id ?? providerId);
\`\`\`

**Why this works:**
- When \`normalizeChannelId()\` returns \`null\` (registry empty), \`getChannelPlugin()\` receives the raw \`providerId\`
- \`getChannelPlugin()\` has a \`getBundledChannelPlugin()\` fallback that reads manifest metadata from disk independently of the runtime registry
- This fallback works during startup without requiring the registry to be populated
- Manifest-driven approach (no hardcoded channel capability lists)

## Outcomes / Expected Behavior

**Before fix:**
- \`commands.native=auto\` → \`false\` for telegram during startup
- Empty command menu in Telegram bot

**After fix:**
- \`commands.native=auto\` → \`true\` for telegram during startup (reads from manifest)
- Command menu populates correctly with native commands
- Once registry initializes, uses runtime lookup as before (no behavior change for populated registry)

## Test Results

**Regression tests added:**
- ✅ \`returns true for telegram native commands when channel registry is empty\`
- ✅ \`returns false for unknown provider when registry is empty\`

**Test suite:**
\`\`\`
✓ Test Files  1 passed (1)
✓ Tests  12 passed (12)
  Duration  17.39s
\`\`\`

All existing tests pass. New tests verify the empty-registry startup scenario.

## Current Workflow

1. Gateway starts → \`loadGatewayStartupPlugins()\`
2. Channel registry not yet populated
3. \`createTelegramBot()\` called → \`resolveNativeCommandsEnabled({ providerId: "telegram", globalSetting: "auto" })\`
4. \`resolveAutoDefault()\` called with \`providerId="telegram"\`, \`kind="native"\`
5. \`normalizeChannelId("telegram")\` returns \`null\` (registry empty)
6. **NEW:** \`getChannelPlugin(null ?? "telegram")\` → \`getBundledChannelPlugin("telegram")\` → reads manifest from disk
7. Returns \`plugin.commands.nativeCommandsAutoEnabled === true\`
8. Telegram command menu populates correctly