### PR TITLE
fix(logging): honor logging.file in bundled gateway runtime

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -14,6 +14,7 @@ import {
   shouldDeferShellEnvFallback,
   shouldEnableShellEnvFallback,
 } from "../infra/shell-env.js";
+import { registerLoggingConfigLoader } from "../logging/config.js";
 import {
   collectRelevantDoctorPluginIds,
   listPluginDoctorLegacyConfigRules,
@@ -1799,6 +1800,8 @@ export function loadConfig(): OpenClawConfig {
   // reparsing openclaw.json on hot code paths.
   return loadPinnedRuntimeConfig(() => createConfigIO().loadConfig());
 }
+
+registerLoggingConfigLoader(() => loadConfig().logging);
 
 export function getRuntimeConfig(): OpenClawConfig {
   return loadConfig();

--- a/src/logging/config.test.ts
+++ b/src/logging/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { readLoggingConfig } from "./config.js";
+import { readLoggingConfig, registerLoggingConfigLoader } from "./config.js";
 
 const loadConfigMock = vi.hoisted(() => vi.fn());
 
@@ -17,6 +17,7 @@ describe("readLoggingConfig", () => {
   afterEach(() => {
     process.argv = originalArgv;
     loadConfigMock.mockReset();
+    registerLoggingConfigLoader();
   });
 
   it("skips mutating config loads for config schema", async () => {
@@ -26,6 +27,17 @@ describe("readLoggingConfig", () => {
     });
 
     expect(readLoggingConfig()).toBeUndefined();
+    expect(loadConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("prefers a registered runtime loader over the fallback config require", () => {
+    const loggingConfig = { level: "info" as const, file: "/tmp/custom.log" };
+    loadConfigMock.mockImplementation(() => {
+      throw new Error("fallback loadConfig should not be called");
+    });
+    registerLoggingConfigLoader(() => loggingConfig);
+
+    expect(readLoggingConfig()).toEqual(loggingConfig);
     expect(loadConfigMock).not.toHaveBeenCalled();
   });
 });

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -41,7 +41,7 @@ export function readLoggingConfig(): LoggingConfig | undefined {
           loadConfig?: () => OpenClawConfig;
         }
       | undefined;
-    return coerceLoggingConfig(loaded?.loadConfig?.().logging);
+    return coerceLoggingConfig(loaded?.loadConfig?.()?.logging);
   } catch {
     return undefined;
   }

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -3,8 +3,21 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
 
 type LoggingConfig = OpenClawConfig["logging"];
+type LoggingConfigLoader = () => LoggingConfig | undefined;
 
 const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
+let registeredLoggingConfigLoader: LoggingConfigLoader | null = null;
+
+function coerceLoggingConfig(logging: unknown): LoggingConfig | undefined {
+  if (!logging || typeof logging !== "object" || Array.isArray(logging)) {
+    return undefined;
+  }
+  return logging as LoggingConfig;
+}
+
+export function registerLoggingConfigLoader(loader?: LoggingConfigLoader): void {
+  registeredLoggingConfigLoader = loader ?? null;
+}
 
 export function shouldSkipMutatingLoggingConfigRead(argv: string[] = process.argv): boolean {
   const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
@@ -15,18 +28,20 @@ export function readLoggingConfig(): LoggingConfig | undefined {
   if (shouldSkipMutatingLoggingConfigRead()) {
     return undefined;
   }
+  if (registeredLoggingConfigLoader) {
+    try {
+      return coerceLoggingConfig(registeredLoggingConfigLoader());
+    } catch {
+      return undefined;
+    }
+  }
   try {
     const loaded = requireConfig?.("../config/config.js") as
       | {
           loadConfig?: () => OpenClawConfig;
         }
       | undefined;
-    const parsed = loaded?.loadConfig?.();
-    const logging = parsed?.logging;
-    if (!logging || typeof logging !== "object" || Array.isArray(logging)) {
-      return undefined;
-    }
-    return logging as LoggingConfig;
+    return coerceLoggingConfig(loaded?.loadConfig?.().logging);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- register the runtime config loader with the logging config reader so bundled builds can resolve `logging.file` without relying on bundle-fragile relative `createRequire(import.meta.url)` paths
- prefer the registered loader in `readLoggingConfig()` before falling back to the legacy dynamic require path
- cover the new behavior with a focused logging config test

## Validation
- `pnpm lint src/logging/config.ts src/logging/config.test.ts src/config/io.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/logging/config.test.ts src/logging/logger-settings.test.ts src/logging/logger-env.test.ts src/logging/log-file-size-cap.test.ts src/logging/console-settings.test.ts`
- manual bundled repro:
  - before fix: `node scripts/run-node.mjs gateway run ...` reported `log file: /tmp/openclaw/openclaw-YYYY-MM-DD.log` and never created the configured custom file
  - after fix: the same bundled command reports the configured custom path and writes gateway startup logs there

## Notes
- `scripts/committer`'s full pre-commit path failed on unrelated pre-existing repo-wide `pnpm check` lint errors under `extensions/*`; this change passes file-scoped lint and targeted tests.
