### PR TITLE
fix(acp): reuse existing session key for persistent spawns with same label

### DIFF
--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1046,6 +1046,7 @@ export async function spawnAcpDirect(
   }
 
   let sessionKey: string | undefined;
+  let wasResolved = false;
   if (params.label && spawnMode === "session") {
     try {
       const resolved = await callGateway({
@@ -1054,11 +1055,12 @@ export async function spawnAcpDirect(
         timeoutMs: 5000,
       });
       if (resolved?.ok && resolved.key) {
-        const storePath = resolveStorePath(null, { agentId: targetAgentId });
+        const storePath = resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
         const store = loadSessionStore(storePath);
         const entry = store[resolved.key] as SessionEntry | undefined;
         if (!entry?.acp?.mode || entry.acp.mode === "persistent") {
           sessionKey = resolved.key;
+          wasResolved = true;
         }
       }
     } catch {
@@ -1145,8 +1147,8 @@ export async function spawnAcpDirect(
     await cleanupFailedAcpSpawn({
       cfg,
       sessionKey,
-      shouldDeleteSession: sessionCreated,
-      deleteTranscript: true,
+      shouldDeleteSession: sessionCreated && !wasResolved,
+      deleteTranscript: !wasResolved,
       runtimeCloseHandle: initializedRuntime,
     });
     return createAcpSpawnFailure({
@@ -1223,8 +1225,8 @@ export async function spawnAcpDirect(
     await cleanupFailedAcpSpawn({
       cfg,
       sessionKey,
-      shouldDeleteSession: true,
-      deleteTranscript: true,
+      shouldDeleteSession: !wasResolved,
+      deleteTranscript: !wasResolved,
     });
     return createAcpSpawnFailure({
       status: "error",

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1045,7 +1045,27 @@ export async function spawnAcpDirect(
     });
   }
 
-  const sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
+  let sessionKey: string | undefined;
+  if (params.label && spawnMode === "session") {
+    try {
+      const resolved = await callGateway({
+        method: "sessions.resolve",
+        params: { label: params.label, agentId: targetAgentId },
+        timeoutMs: 5000,
+      });
+      if (resolved?.ok && resolved.key) {
+        const storePath = resolveStorePath(null, { agentId: targetAgentId });
+        const store = loadSessionStore(storePath);
+        const entry = store[resolved.key] as SessionEntry | undefined;
+        if (!entry?.acp?.mode || entry.acp.mode === "persistent") {
+          sessionKey = resolved.key;
+        }
+      }
+    } catch {
+      // resolve failure → fall through to new UUID
+    }
+  }
+  if (!sessionKey) sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
   const runtimeMode = resolveAcpSessionMode(spawnMode);
   const resolvedCwd = resolveSpawnedWorkspaceInheritance({
     config: cfg,


### PR DESCRIPTION
## Summary

- When `sessions_spawn` is called with a label in persistent mode (`spawnMode === "session"`), resolve the existing session key via `sessions.resolve` instead of always generating a new random UUID
- Reusing the old key allows `ensureSession()` to find the existing ACPX record and resume the conversation via `loadSession()` (`--resume`) instead of creating a fresh session (`--session-id`)
- A mode guard checks `entry.acp.mode` from the session store to ensure oneshot sessions are never accidentally reused by persistent spawns
- Any resolve or store-read failure safely falls back to the original new-UUID behavior

## Problem

Persistent ACP sessions lose conversation history on re-spawn because each `sessions_spawn` call generates a new random UUID as the session key. This causes two issues:

1. **Lost context**: The ACPX runtime creates a fresh session (`--session-id`) instead of resuming the existing one (`--resume`), discarding all prior conversation history
2. **Label conflicts**: `sessions.patch` label uniqueness check rejects the new key because the old session still holds the same label, causing spawn failure

## Test plan

- [ ] Spawn a persistent ACP session with a label, verify `--resume` flag is used on subsequent spawns with the same label
- [ ] Verify oneshot sessions with the same label are not reused (mode guard)
- [ ] Verify `sessions.resolve` failure gracefully falls back to new UUID
- [ ] Verify no label conflicts on re-spawn with same label

🤖 Generated with [Claude Code](https://claude.com/claude-code)