### PR TITLE
fix(chat): support non-image attachments in webchat file upload

### DIFF
--- a/ui/src/ui/chat/attachment-support.ts
+++ b/ui/src/ui/chat/attachment-support.ts
@@ -1,5 +1,15 @@
-export const CHAT_ATTACHMENT_ACCEPT = "image/*";
+export const CHAT_ATTACHMENT_ACCEPT = "image/*, video/*, audio/*, application/pdf, text/*, application/json";
+
+const SUPPORTED_MIME_PREFIXES = [
+  "image/",
+  "video/",
+  "audio/",
+  "application/pdf",
+  "text/",
+  "application/json",
+];
 
 export function isSupportedChatAttachmentMimeType(mimeType: string | null | undefined): boolean {
-  return typeof mimeType === "string" && mimeType.startsWith("image/");
+  if (typeof mimeType !== "string" || !mimeType) return false;
+  return SUPPORTED_MIME_PREFIXES.some(prefix => mimeType.startsWith(prefix));
 }


### PR DESCRIPTION
## Summary

Fix Issue #60644: WebChat/Control-UI file upload only supports images.

### Problem
- `CHAT_ATTACHMENT_ACCEPT` only accepts `image/*`
- `isSupportedChatAttachmentMimeType()` only validates `image/*` types
- Users cannot upload PDF, video, audio or text files

### Solution
- Expand `CHAT_ATTACHMENT_ACCEPT` to include `video/*, audio/*, application/pdf, text/*, application/json`
- Update `isSupportedChatAttachmentMimeType()` to validate all supported types

### Testing
- [ ] Upload PDF document via webchat
- [ ] Upload video file via webchat
- [ ] Upload audio file via webchat
- [ ] Existing image upload still works

Fixes #60644