### PR TITLE
fix(sessions): dedupe redundant delivery mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI Codex/CLI: keep resumed `codex exec resume` runs on the safe non-interactive path without reintroducing the removed dangerous bypass flag by passing the supported `--skip-git-repo-check` resume arg that real Codex CLI requires outside trusted git directories. (#67666) Thanks @plgonzalezrx8.
 - Codex/app-server: parse Desktop-originated app-server user agents such as `Codex Desktop/0.118.0`, keeping the version gate working when the Codex CLI inherits a multi-word originator. (#64666) Thanks @cyrusaf.
 - Cron/announce delivery: keep isolated announce `NO_REPLY` stripping case-insensitive across direct and text delivery, preserve structured media-only sends when a caption strips silent, and derive main-session awareness from the cleaned payloads so silent captions no longer leak stale `NO_REPLY` text. (#65016) Thanks @BKF-Gitty.
+- Sessions/Codex: skip redundant `delivery-mirror` transcript appends only when the latest assistant message has the same visible text, preventing duplicate visible replies on Codex-backed turns without suppressing repeated answers across turns. (#67185) Thanks @andyylin.
 
 ## 2026.4.15-beta.1
 

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -164,6 +164,76 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
+  it("does not reuse an older matching assistant message across turns", async () => {
+    writeTranscriptStore();
+
+    const olderResult = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Repeated answer" }],
+        api: "openai-responses",
+        provider: "codex",
+        model: "gpt-5.4",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      },
+    });
+
+    const latestResult = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Different latest answer" }],
+        api: "openai-responses",
+        provider: "codex",
+        model: "gpt-5.4",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      },
+    });
+
+    const mirrorResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Repeated answer",
+      storePath: fixture.storePath(),
+    });
+
+    expect(olderResult.ok).toBe(true);
+    expect(latestResult.ok).toBe(true);
+    expect(mirrorResult.ok).toBe(true);
+    if (olderResult.ok && latestResult.ok && mirrorResult.ok) {
+      expect(mirrorResult.messageId).not.toBe(olderResult.messageId);
+      expect(mirrorResult.messageId).not.toBe(latestResult.messageId);
+
+      const lines = fs.readFileSync(mirrorResult.sessionFile, "utf-8").trim().split("\n");
+      expect(lines.length).toBe(4);
+
+      const messageLine = JSON.parse(lines[3]);
+      expect(messageLine.message.provider).toBe("openclaw");
+      expect(messageLine.message.model).toBe("delivery-mirror");
+      expect(messageLine.message.content[0].text).toBe("Repeated answer");
+    }
+  });
+
   it("finds session entry using normalized (lowercased) key", async () => {
     const storeKey = "agent:main:bluebubbles:direct:+15551234567";
     const store = {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -118,6 +118,52 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(messageLine.message.content[0].text).toBe("Hello from delivery mirror!");
   });
 
+  it("does not append a duplicate delivery mirror when the latest assistant message already matches", async () => {
+    writeTranscriptStore();
+
+    const exactResult = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello from Codex!" }],
+        api: "openai-responses",
+        provider: "codex",
+        model: "gpt-5.4",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      },
+    });
+
+    expect(exactResult.ok).toBe(true);
+
+    const mirrorResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Hello from Codex!",
+      storePath: fixture.storePath(),
+    });
+
+    expect(mirrorResult.ok).toBe(true);
+    if (exactResult.ok && mirrorResult.ok) {
+      expect(mirrorResult.messageId).toBe(exactResult.messageId);
+      const lines = fs.readFileSync(mirrorResult.sessionFile, "utf-8").trim().split("\n");
+      expect(lines.length).toBe(2);
+
+      const messageLine = JSON.parse(lines[1]);
+      expect(messageLine.message.provider).toBe("codex");
+      expect(messageLine.message.model).toBe("gpt-5.4");
+      expect(messageLine.message.content[0].text).toBe("Hello from Codex!");
+    }
+  });
+
   it("finds session entry using normalized (lowercased) key", async () => {
     const storeKey = "agent:main:bluebubbles:direct:+15551234567";
     const store = {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -265,9 +265,6 @@ function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): 
 }
 
 function extractAssistantMessageText(message: SessionTranscriptAssistantMessage): string | null {
-  if (typeof message.text === "string" && message.text.trim()) {
-    return message.text.trim();
-  }
   if (!Array.isArray(message.content)) {
     return null;
   }
@@ -314,11 +311,12 @@ async function findLatestEquivalentAssistantMessageId(
         }
         const candidateText = extractAssistantMessageText(candidate);
         if (candidateText !== expectedText) {
-          continue;
+          return undefined;
         }
         if (typeof parsed.id === "string" && parsed.id) {
           return parsed.id;
         }
+        return undefined;
       } catch {
         continue;
       }

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -201,6 +201,13 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
     return { ok: true, sessionFile, messageId: existingMessageId };
   }
 
+  const latestEquivalentAssistantId = isRedundantDeliveryMirror(params.message)
+    ? await findLatestEquivalentAssistantMessageId(sessionFile, params.message)
+    : undefined;
+  if (latestEquivalentAssistantId) {
+    return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
+  }
+
   const message = {
     ...params.message,
     ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
@@ -250,5 +257,75 @@ async function transcriptHasIdempotencyKey(
   } catch {
     return undefined;
   }
+  return undefined;
+}
+
+function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
+  return message.provider === "openclaw" && message.model === "delivery-mirror";
+}
+
+function extractAssistantMessageText(message: SessionTranscriptAssistantMessage): string | null {
+  if (typeof message.text === "string" && message.text.trim()) {
+    return message.text.trim();
+  }
+  if (!Array.isArray(message.content)) {
+    return null;
+  }
+
+  const parts = message.content
+    .filter(
+      (
+        part,
+      ): part is {
+        type: "text";
+        text: string;
+      } => part.type === "text" && typeof part.text === "string" && part.text.trim().length > 0,
+    )
+    .map((part) => part.text.trim());
+
+  return parts.length > 0 ? parts.join("\n").trim() : null;
+}
+
+async function findLatestEquivalentAssistantMessageId(
+  transcriptPath: string,
+  message: SessionTranscriptAssistantMessage,
+): Promise<string | undefined> {
+  const expectedText = extractAssistantMessageText(message);
+  if (!expectedText) {
+    return undefined;
+  }
+
+  try {
+    const raw = await fs.promises.readFile(transcriptPath, "utf-8");
+    const lines = raw.split(/\r?\n/);
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      const line = lines[index];
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line) as {
+          id?: unknown;
+          message?: SessionTranscriptAssistantMessage;
+        };
+        const candidate = parsed.message;
+        if (!candidate || candidate.role !== "assistant") {
+          continue;
+        }
+        const candidateText = extractAssistantMessageText(candidate);
+        if (candidateText !== expectedText) {
+          continue;
+        }
+        if (typeof parsed.id === "string" && parsed.id) {
+          return parsed.id;
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
   return undefined;
 }


### PR DESCRIPTION
## Summary
- dedupe `delivery-mirror` transcript appends when the latest assistant message already has the same visible text
- keep the existing idempotency-key dedupe path unchanged
- add a regression test that reproduces the Codex case where the real assistant transcript entry already exists before the generic delivery mirror append runs

## Problem
When replies go through the Codex harness, OpenClaw already persists the real assistant message into the session transcript. The generic outbound delivery path still appends a synthetic `provider:"openclaw", model:"delivery-mirror"` assistant entry with the same text.

In Mattermost this can surface as duplicate visible replies for a single turn.

## Root Cause
Two transcript writers become active on the same turn:
- the Codex harness mirrors the real assistant transcript into the session file
- the generic delivery path appends `delivery-mirror`

The old idempotency-key guard does not help here because the real assistant message and the synthetic mirror do not share an idempotency key.

## Fix
Before appending a `delivery-mirror` message, scan backward through the transcript and reuse the latest assistant message id when its visible text already matches. This keeps the mirror path intact for channels that still need it, but avoids creating a second assistant artifact when the transcript already contains the real reply.

## Repro
1. Configure a channel session that routes through the Codex harness.
2. Send a prompt that produces a normal assistant reply.
3. Observe the session transcript contains:
   - a real assistant message from `provider:"codex"`
   - a second assistant message from `provider:"openclaw", model:"delivery-mirror"` with the same text
4. In Mattermost, both artifacts can surface as duplicate replies.

## Test Plan
- Added a unit test in `src/config/sessions/transcript.test.ts` that appends a real `codex` assistant message first, then attempts to append the matching `delivery-mirror`, and asserts that no second transcript line is written.
- I could not run Vitest in this environment because the checkout does not have `node_modules` installed, so the PR currently has code-level validation plus the focused regression test only.
