### PR TITLE
fix(plugins): stabilize bundled setup runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: keep optimistic user message cards visible during active sends by deferring same-session history reloads until the active run ends, including aborted and errored runs. (#66997) Thanks @scotthuang and @vincentkoc.
 - Media/Slack: allow host-local CSV and Markdown uploads only when the fallback buffer actually decodes as text, so real plain-text files work without letting opaque non-text blobs renamed to `.csv` or `.md` slip past the host-read guard. (#67047) Thanks @Unayung.
 - Ollama/onboarding: split setup into `Cloud + Local`, `Cloud only`, and `Local only`, support direct `OLLAMA_API_KEY` cloud setup without a local daemon, and keep Ollama web search on the local-host path. (#67005) Thanks @obviyus.
+- Plugins/bundled channels: partition bundled channel lazy caches by active bundled root so `OPENCLAW_BUNDLED_PLUGINS_DIR` flips stop reusing stale plugin, setup, secrets, and runtime state. (#67200) Thanks @gumadeiras.
 
 ## 2026.4.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
 - Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 - Cron/announce delivery: suppress mixed-content isolated cron announce replies that end with `NO_REPLY` so trailing silent sentinels no longer leak summary text to the target channel. (#65004) thanks @neo1027144-creator.
+- Plugins/bundled channels: partition bundled channel lazy caches by active bundled root so `OPENCLAW_BUNDLED_PLUGINS_DIR` flips stop reusing stale plugin, setup, secrets, and runtime state. (#67200) Thanks @gumadeiras.
 
 ## 2026.4.15-beta.1
 
@@ -69,7 +70,6 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: keep optimistic user message cards visible during active sends by deferring same-session history reloads until the active run ends, including aborted and errored runs. (#66997) Thanks @scotthuang and @vincentkoc.
 - Media/Slack: allow host-local CSV and Markdown uploads only when the fallback buffer actually decodes as text, so real plain-text files work without letting opaque non-text blobs renamed to `.csv` or `.md` slip past the host-read guard. (#67047) Thanks @Unayung.
 - Ollama/onboarding: split setup into `Cloud + Local`, `Cloud only`, and `Local only`, support direct `OLLAMA_API_KEY` cloud setup without a local daemon, and keep Ollama web search on the local-host path. (#67005) Thanks @obviyus.
-- Plugins/bundled channels: partition bundled channel lazy caches by active bundled root so `OPENCLAW_BUNDLED_PLUGINS_DIR` flips stop reusing stale plugin, setup, secrets, and runtime state. (#67200) Thanks @gumadeiras.
 
 ## 2026.4.14
 

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -493,6 +493,11 @@ should use `resolveInboundMentionDecision({ facts, policy })`.
     or unconfigured. It avoids pulling in heavy runtime code during setup flows.
     See [Setup and Config](/plugins/sdk-setup#setup-entry) for details.
 
+    Bundled workspace channels that split setup-safe exports into sidecar
+    modules can use `defineBundledChannelSetupEntry(...)` from
+    `openclaw/plugin-sdk/channel-entry-contract` when they also need an
+    explicit setup-time runtime setter.
+
   </Step>
 
   <Step title="Handle inbound messages">

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -145,6 +145,31 @@ families:
 Keep heavy SDKs, CLI registration, and long-lived runtime services in the full
 entry.
 
+Bundled workspace channels that split setup and runtime surfaces can use
+`defineBundledChannelSetupEntry(...)` from
+`openclaw/plugin-sdk/channel-entry-contract` instead. That contract lets the
+setup entry keep setup-safe plugin/secrets exports while still exposing a
+runtime setter:
+
+```typescript
+import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+
+export default defineBundledChannelSetupEntry({
+  importMetaUrl: import.meta.url,
+  plugin: {
+    specifier: "./channel-plugin-api.js",
+    exportName: "myChannelPlugin",
+  },
+  runtime: {
+    specifier: "./runtime-api.js",
+    exportName: "setMyChannelRuntime",
+  },
+});
+```
+
+Use that bundled contract only when setup flows truly need a lightweight runtime
+setter before the full channel entry loads.
+
 ## Registration mode
 
 `api.registrationMode` tells your plugin how it was loaded:

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -385,7 +385,10 @@ the `register` callback:
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
-const store = createPluginRuntimeStore<PluginRuntime>("my-plugin runtime not initialized");
+const store = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "my-plugin",
+  errorMessage: "my-plugin runtime not initialized",
+});
 
 // In your entry point
 export default defineChannelPluginEntry({
@@ -405,6 +408,10 @@ export function tryGetRuntime() {
   return store.tryGetRuntime(); // returns null if not initialized
 }
 ```
+
+Prefer `pluginId` for the runtime-store identity. The lower-level `key` form is
+for uncommon cases where one plugin intentionally needs more than one runtime
+slot.
 
 ## Other top-level `api` fields
 

--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -279,6 +279,12 @@ export default defineSetupPluginEntry(myChannelPlugin);
 This avoids loading heavy runtime code (crypto libraries, CLI registrations,
 background services) during setup flows.
 
+Bundled workspace channels that keep setup-safe exports in sidecar modules can
+use `defineBundledChannelSetupEntry(...)` from
+`openclaw/plugin-sdk/channel-entry-contract` instead of
+`defineSetupPluginEntry(...)`. That bundled contract also supports an optional
+`runtime` export so setup-time runtime wiring can stay lightweight and explicit.
+
 **When OpenClaw uses `setupEntry` instead of the full entry:**
 
 - The channel is disabled but needs setup/onboarding surfaces

--- a/docs/plugins/sdk-testing.md
+++ b/docs/plugins/sdk-testing.md
@@ -155,7 +155,10 @@ For code that uses `createPluginRuntimeStore`, mock the runtime in tests:
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
-const store = createPluginRuntimeStore<PluginRuntime>("test runtime not set");
+const store = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "test-plugin",
+  errorMessage: "test runtime not set",
+});
 
 // In test setup
 const mockRuntime = {

--- a/extensions/bluebubbles/src/runtime.ts
+++ b/extensions/bluebubbles/src/runtime.ts
@@ -1,7 +1,10 @@
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "./runtime-api.js";
 
-const runtimeStore = createPluginRuntimeStore<PluginRuntime>("BlueBubbles runtime not initialized");
+const runtimeStore = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "bluebubbles",
+  errorMessage: "BlueBubbles runtime not initialized",
+});
 type LegacyRuntimeLogShape = { log?: (message: string) => void };
 export const setBlueBubblesRuntime = runtimeStore.setRuntime;
 

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -16,5 +16,8 @@ const {
   setRuntime: setDiscordRuntime,
   tryGetRuntime: getOptionalDiscordRuntime,
   getRuntime: getDiscordRuntime,
-} = createPluginRuntimeStore<DiscordRuntime>("Discord runtime not initialized");
+} = createPluginRuntimeStore<DiscordRuntime>({
+  pluginId: "discord",
+  errorMessage: "Discord runtime not initialized",
+});
 export { getDiscordRuntime, getOptionalDiscordRuntime, setDiscordRuntime };

--- a/extensions/feishu/src/runtime.ts
+++ b/extensions/feishu/src/runtime.ts
@@ -2,5 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setFeishuRuntime, getRuntime: getFeishuRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Feishu runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "feishu",
+    errorMessage: "Feishu runtime not initialized",
+  });
 export { getFeishuRuntime, setFeishuRuntime };

--- a/extensions/googlechat/src/runtime.ts
+++ b/extensions/googlechat/src/runtime.ts
@@ -2,5 +2,8 @@ import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setGoogleChatRuntime, getRuntime: getGoogleChatRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Google Chat runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "googlechat",
+    errorMessage: "Google Chat runtime not initialized",
+  });
 export { getGoogleChatRuntime, setGoogleChatRuntime };

--- a/extensions/imessage/src/runtime.ts
+++ b/extensions/imessage/src/runtime.ts
@@ -2,5 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setIMessageRuntime, getRuntime: getIMessageRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("iMessage runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "imessage",
+    errorMessage: "iMessage runtime not initialized",
+  });
 export { getIMessageRuntime, setIMessageRuntime };

--- a/extensions/irc/src/runtime.ts
+++ b/extensions/irc/src/runtime.ts
@@ -1,9 +1,15 @@
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "./runtime-api.js";
 
-const { setRuntime: setIrcRuntime, getRuntime: getIrcRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("IRC runtime not initialized");
+const {
+  setRuntime: setIrcRuntime,
+  clearRuntime: clearStoredIrcRuntime,
+  getRuntime: getIrcRuntime,
+} = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "irc",
+  errorMessage: "IRC runtime not initialized",
+});
 export { getIrcRuntime, setIrcRuntime };
 export function clearIrcRuntime() {
-  setIrcRuntime(undefined as unknown as PluginRuntime);
+  clearStoredIrcRuntime();
 }

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -25,5 +25,8 @@ const {
   setRuntime: setLineRuntime,
   clearRuntime: clearLineRuntime,
   getRuntime: getLineRuntime,
-} = createPluginRuntimeStore<LineRuntime>("LINE runtime not initialized - plugin not registered");
+} = createPluginRuntimeStore<LineRuntime>({
+  pluginId: "line",
+  errorMessage: "LINE runtime not initialized - plugin not registered",
+});
 export { clearLineRuntime, getLineRuntime, setLineRuntime };

--- a/extensions/matrix/setup-entry.ts
+++ b/extensions/matrix/setup-entry.ts
@@ -10,4 +10,8 @@ export default defineBundledChannelSetupEntry({
     specifier: "./secret-contract-api.js",
     exportName: "channelSecrets",
   },
+  runtime: {
+    specifier: "./runtime-api.js",
+    exportName: "setMatrixRuntime",
+  },
 });

--- a/extensions/matrix/src/runtime.ts
+++ b/extensions/matrix/src/runtime.ts
@@ -2,6 +2,9 @@ import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "./runtime-api.js";
 
 const { setRuntime: setMatrixRuntime, getRuntime: getMatrixRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Matrix runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "matrix",
+    errorMessage: "Matrix runtime not initialized",
+  });
 
 export { getMatrixRuntime, setMatrixRuntime };

--- a/extensions/mattermost/src/runtime.ts
+++ b/extensions/mattermost/src/runtime.ts
@@ -2,5 +2,8 @@ import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setMattermostRuntime, getRuntime: getMattermostRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Mattermost runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "mattermost",
+    errorMessage: "Mattermost runtime not initialized",
+  });
 export { getMattermostRuntime, setMattermostRuntime };

--- a/extensions/msteams/src/runtime.ts
+++ b/extensions/msteams/src/runtime.ts
@@ -2,5 +2,8 @@ import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setMSTeamsRuntime, getRuntime: getMSTeamsRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("MSTeams runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "msteams",
+    errorMessage: "MSTeams runtime not initialized",
+  });
 export { getMSTeamsRuntime, setMSTeamsRuntime };

--- a/extensions/nextcloud-talk/src/runtime.ts
+++ b/extensions/nextcloud-talk/src/runtime.ts
@@ -2,5 +2,8 @@ import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setNextcloudTalkRuntime, getRuntime: getNextcloudTalkRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Nextcloud Talk runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "nextcloud-talk",
+    errorMessage: "Nextcloud Talk runtime not initialized",
+  });
 export { getNextcloudTalkRuntime, setNextcloudTalkRuntime };

--- a/extensions/nostr/src/runtime.ts
+++ b/extensions/nostr/src/runtime.ts
@@ -2,5 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setNostrRuntime, getRuntime: getNostrRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Nostr runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "nostr",
+    errorMessage: "Nostr runtime not initialized",
+  });
 export { getNostrRuntime, setNostrRuntime };

--- a/extensions/qqbot/src/runtime.ts
+++ b/extensions/qqbot/src/runtime.ts
@@ -2,5 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setQQBotRuntime, getRuntime: getQQBotRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("QQBot runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "qqbot",
+    errorMessage: "QQBot runtime not initialized",
+  });
 export { getQQBotRuntime, setQQBotRuntime };

--- a/extensions/signal/src/runtime.ts
+++ b/extensions/signal/src/runtime.ts
@@ -5,5 +5,8 @@ const {
   setRuntime: setSignalRuntime,
   clearRuntime: clearSignalRuntime,
   getRuntime: getSignalRuntime,
-} = createPluginRuntimeStore<PluginRuntime>("Signal runtime not initialized");
+} = createPluginRuntimeStore<PluginRuntime>({
+  pluginId: "signal",
+  errorMessage: "Signal runtime not initialized",
+});
 export { clearSignalRuntime, getSignalRuntime, setSignalRuntime };

--- a/extensions/slack/src/runtime.ts
+++ b/extensions/slack/src/runtime.ts
@@ -16,5 +16,8 @@ const {
   clearRuntime: clearSlackRuntime,
   tryGetRuntime: getOptionalSlackRuntime,
   getRuntime: getSlackRuntime,
-} = createPluginRuntimeStore<SlackRuntime>("Slack runtime not initialized");
+} = createPluginRuntimeStore<SlackRuntime>({
+  pluginId: "slack",
+  errorMessage: "Slack runtime not initialized",
+});
 export { clearSlackRuntime, getOptionalSlackRuntime, getSlackRuntime, setSlackRuntime };

--- a/extensions/synology-chat/src/runtime.ts
+++ b/extensions/synology-chat/src/runtime.ts
@@ -2,7 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setSynologyRuntime, getRuntime: getSynologyRuntime } =
-  createPluginRuntimeStore<PluginRuntime>(
-    "Synology Chat runtime not initialized - plugin not registered",
-  );
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "synology-chat",
+    errorMessage: "Synology Chat runtime not initialized - plugin not registered",
+  });
 export { getSynologyRuntime, setSynologyRuntime };

--- a/extensions/telegram/src/runtime.ts
+++ b/extensions/telegram/src/runtime.ts
@@ -6,5 +6,8 @@ const {
   setRuntime: setTelegramRuntime,
   clearRuntime: clearTelegramRuntime,
   getRuntime: getTelegramRuntime,
-} = createPluginRuntimeStore<TelegramRuntime>("Telegram runtime not initialized");
+} = createPluginRuntimeStore<TelegramRuntime>({
+  pluginId: "telegram",
+  errorMessage: "Telegram runtime not initialized",
+});
 export { clearTelegramRuntime, getTelegramRuntime, setTelegramRuntime };

--- a/extensions/tlon/src/runtime.ts
+++ b/extensions/tlon/src/runtime.ts
@@ -2,5 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setTlonRuntime, getRuntime: getTlonRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Tlon runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "tlon",
+    errorMessage: "Tlon runtime not initialized",
+  });
 export { getTlonRuntime, setTlonRuntime };

--- a/extensions/twitch/src/runtime.ts
+++ b/extensions/twitch/src/runtime.ts
@@ -2,5 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setTwitchRuntime, getRuntime: getTwitchRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Twitch runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "twitch",
+    errorMessage: "Twitch runtime not initialized",
+  });
 export { getTwitchRuntime, setTwitchRuntime };

--- a/extensions/whatsapp/src/runtime.ts
+++ b/extensions/whatsapp/src/runtime.ts
@@ -2,5 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setWhatsAppRuntime, getRuntime: getWhatsAppRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("WhatsApp runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "whatsapp",
+    errorMessage: "WhatsApp runtime not initialized",
+  });
 export { getWhatsAppRuntime, setWhatsAppRuntime };

--- a/extensions/zalo/src/runtime.ts
+++ b/extensions/zalo/src/runtime.ts
@@ -2,5 +2,8 @@ import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import type { PluginRuntime } from "./runtime-support.js";
 
 const { setRuntime: setZaloRuntime, getRuntime: getZaloRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Zalo runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "zalo",
+    errorMessage: "Zalo runtime not initialized",
+  });
 export { getZaloRuntime, setZaloRuntime };

--- a/extensions/zalouser/src/runtime.ts
+++ b/extensions/zalouser/src/runtime.ts
@@ -2,5 +2,8 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setZalouserRuntime, getRuntime: getZalouserRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("Zalouser runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "zalouser",
+    errorMessage: "Zalouser runtime not initialized",
+  });
 export { getZalouserRuntime, setZalouserRuntime };

--- a/src/channels/plugins/bootstrap-registry.ts
+++ b/src/channels/plugins/bootstrap-registry.ts
@@ -19,6 +19,10 @@ type CachedBootstrapPlugins = {
 
 const cachedBootstrapPluginsByRoot = new Map<string, CachedBootstrapPlugins>();
 
+function resolveBootstrapChannelId(id: ChannelId): string {
+  return normalizeOptionalString(id) ?? "";
+}
+
 function mergePluginSection<T>(
   runtimeValue: T | undefined,
   setupValue: T | undefined,
@@ -89,8 +93,12 @@ function getBootstrapPlugins(
   return created;
 }
 
+function resolveActiveBootstrapPlugins(): CachedBootstrapPlugins {
+  return getBootstrapPlugins(resolveBundledChannelPackageRoot());
+}
+
 export function listBootstrapChannelPluginIds(): readonly string[] {
-  return getBootstrapPlugins().sortedIds;
+  return resolveActiveBootstrapPlugins().sortedIds;
 }
 
 export function* iterateBootstrapChannelPlugins(): IterableIterator<ChannelPlugin> {
@@ -107,11 +115,11 @@ export function listBootstrapChannelPlugins(): readonly ChannelPlugin[] {
 }
 
 export function getBootstrapChannelPlugin(id: ChannelId): ChannelPlugin | undefined {
-  const resolvedId = normalizeOptionalString(id) ?? "";
+  const resolvedId = resolveBootstrapChannelId(id);
   if (!resolvedId) {
     return undefined;
   }
-  const registry = getBootstrapPlugins(resolveBundledChannelPackageRoot());
+  const registry = resolveActiveBootstrapPlugins();
   const cached = registry.byId.get(resolvedId);
   if (cached) {
     return cached;
@@ -134,11 +142,11 @@ export function getBootstrapChannelPlugin(id: ChannelId): ChannelPlugin | undefi
 }
 
 export function getBootstrapChannelSecrets(id: ChannelId): ChannelPlugin["secrets"] | undefined {
-  const resolvedId = normalizeOptionalString(id) ?? "";
+  const resolvedId = resolveBootstrapChannelId(id);
   if (!resolvedId) {
     return undefined;
   }
-  const registry = getBootstrapPlugins(resolveBundledChannelPackageRoot());
+  const registry = resolveActiveBootstrapPlugins();
   const cached = registry.secretsById.get(resolvedId);
   if (cached) {
     return cached;

--- a/src/channels/plugins/bootstrap-registry.ts
+++ b/src/channels/plugins/bootstrap-registry.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
-import { listBundledChannelPluginIds } from "./bundled-ids.js";
+import { listBundledChannelPluginIdsForRoot } from "./bundled-ids.js";
+import { resolveBundledChannelPackageRoot } from "./bundled-root.js";
 import {
   getBundledChannelPlugin,
   getBundledChannelSecrets,
@@ -16,7 +17,7 @@ type CachedBootstrapPlugins = {
   missingIds: Set<string>;
 };
 
-let cachedBootstrapPlugins: CachedBootstrapPlugins | null = null;
+const cachedBootstrapPluginsByRoot = new Map<string, CachedBootstrapPlugins>();
 
 function mergePluginSection<T>(
   runtimeValue: T | undefined,
@@ -63,18 +64,29 @@ function mergeBootstrapPlugin(
   } as ChannelPlugin;
 }
 
-function buildBootstrapPlugins(): CachedBootstrapPlugins {
+function buildBootstrapPlugins(
+  packageRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): CachedBootstrapPlugins {
   return {
-    sortedIds: listBundledChannelPluginIds(),
+    sortedIds: listBundledChannelPluginIdsForRoot(packageRoot, env),
     byId: new Map(),
     secretsById: new Map(),
     missingIds: new Set(),
   };
 }
 
-function getBootstrapPlugins(): CachedBootstrapPlugins {
-  cachedBootstrapPlugins ??= buildBootstrapPlugins();
-  return cachedBootstrapPlugins;
+function getBootstrapPlugins(
+  packageRoot = resolveBundledChannelPackageRoot(),
+  env: NodeJS.ProcessEnv = process.env,
+): CachedBootstrapPlugins {
+  const cached = cachedBootstrapPluginsByRoot.get(packageRoot);
+  if (cached) {
+    return cached;
+  }
+  const created = buildBootstrapPlugins(packageRoot, env);
+  cachedBootstrapPluginsByRoot.set(packageRoot, created);
+  return created;
 }
 
 export function listBootstrapChannelPluginIds(): readonly string[] {
@@ -99,7 +111,7 @@ export function getBootstrapChannelPlugin(id: ChannelId): ChannelPlugin | undefi
   if (!resolvedId) {
     return undefined;
   }
-  const registry = getBootstrapPlugins();
+  const registry = getBootstrapPlugins(resolveBundledChannelPackageRoot());
   const cached = registry.byId.get(resolvedId);
   if (cached) {
     return cached;
@@ -126,7 +138,7 @@ export function getBootstrapChannelSecrets(id: ChannelId): ChannelPlugin["secret
   if (!resolvedId) {
     return undefined;
   }
-  const registry = getBootstrapPlugins();
+  const registry = getBootstrapPlugins(resolveBundledChannelPackageRoot());
   const cached = registry.secretsById.get(resolvedId);
   if (cached) {
     return cached;
@@ -142,5 +154,5 @@ export function getBootstrapChannelSecrets(id: ChannelId): ChannelPlugin["secret
 }
 
 export function clearBootstrapChannelPluginCache(): void {
-  cachedBootstrapPlugins = null;
+  cachedBootstrapPluginsByRoot.clear();
 }

--- a/src/channels/plugins/bootstrap-registry.ts
+++ b/src/channels/plugins/bootstrap-registry.ts
@@ -1,6 +1,6 @@
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { listBundledChannelPluginIdsForRoot } from "./bundled-ids.js";
-import { resolveBundledChannelPackageRoot } from "./bundled-root.js";
+import { resolveBundledChannelRootScope } from "./bundled-root.js";
 import {
   getBundledChannelPlugin,
   getBundledChannelSecrets,
@@ -69,11 +69,11 @@ function mergeBootstrapPlugin(
 }
 
 function buildBootstrapPlugins(
-  packageRoot: string,
+  cacheKey: string,
   env: NodeJS.ProcessEnv = process.env,
 ): CachedBootstrapPlugins {
   return {
-    sortedIds: listBundledChannelPluginIdsForRoot(packageRoot, env),
+    sortedIds: listBundledChannelPluginIdsForRoot(cacheKey, env),
     byId: new Map(),
     secretsById: new Map(),
     missingIds: new Set(),
@@ -81,20 +81,20 @@ function buildBootstrapPlugins(
 }
 
 function getBootstrapPlugins(
-  packageRoot = resolveBundledChannelPackageRoot(),
+  cacheKey = resolveBundledChannelRootScope().cacheKey,
   env: NodeJS.ProcessEnv = process.env,
 ): CachedBootstrapPlugins {
-  const cached = cachedBootstrapPluginsByRoot.get(packageRoot);
+  const cached = cachedBootstrapPluginsByRoot.get(cacheKey);
   if (cached) {
     return cached;
   }
-  const created = buildBootstrapPlugins(packageRoot, env);
-  cachedBootstrapPluginsByRoot.set(packageRoot, created);
+  const created = buildBootstrapPlugins(cacheKey, env);
+  cachedBootstrapPluginsByRoot.set(cacheKey, created);
   return created;
 }
 
 function resolveActiveBootstrapPlugins(): CachedBootstrapPlugins {
-  return getBootstrapPlugins(resolveBundledChannelPackageRoot());
+  return getBootstrapPlugins(resolveBundledChannelRootScope().cacheKey);
 }
 
 export function listBootstrapChannelPluginIds(): readonly string[] {

--- a/src/channels/plugins/bundled-ids.ts
+++ b/src/channels/plugins/bundled-ids.ts
@@ -1,10 +1,23 @@
 import { listChannelCatalogEntries } from "../../plugins/channel-catalog-registry.js";
+import { resolveBundledChannelPackageRoot } from "./bundled-root.js";
 
-let bundledChannelPluginIds: string[] | null = null;
+const bundledChannelPluginIdsByRoot = new Map<string, string[]>();
 
-export function listBundledChannelPluginIds(): string[] {
-  bundledChannelPluginIds ??= listChannelCatalogEntries({ origin: "bundled" })
+export function listBundledChannelPluginIdsForRoot(
+  packageRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const cached = bundledChannelPluginIdsByRoot.get(packageRoot);
+  if (cached) {
+    return [...cached];
+  }
+  const loaded = listChannelCatalogEntries({ origin: "bundled", env })
     .map((entry) => entry.pluginId)
     .toSorted((left, right) => left.localeCompare(right));
-  return [...bundledChannelPluginIds];
+  bundledChannelPluginIdsByRoot.set(packageRoot, loaded);
+  return [...loaded];
+}
+
+export function listBundledChannelPluginIds(): string[] {
+  return listBundledChannelPluginIdsForRoot(resolveBundledChannelPackageRoot());
 }

--- a/src/channels/plugins/bundled-ids.ts
+++ b/src/channels/plugins/bundled-ids.ts
@@ -1,5 +1,5 @@
 import { listChannelCatalogEntries } from "../../plugins/channel-catalog-registry.js";
-import { resolveBundledChannelPackageRoot } from "./bundled-root.js";
+import { resolveBundledChannelRootScope } from "./bundled-root.js";
 
 const bundledChannelPluginIdsByRoot = new Map<string, string[]>();
 
@@ -19,5 +19,5 @@ export function listBundledChannelPluginIdsForRoot(
 }
 
 export function listBundledChannelPluginIds(): string[] {
-  return listBundledChannelPluginIdsForRoot(resolveBundledChannelPackageRoot());
+  return listBundledChannelPluginIdsForRoot(resolveBundledChannelRootScope().cacheKey);
 }

--- a/src/channels/plugins/bundled-root-caches.test.ts
+++ b/src/channels/plugins/bundled-root-caches.test.ts
@@ -15,6 +15,20 @@ function makeBundledRoot(prefix: string): { root: string; pluginsDir: string } {
   return { root, pluginsDir };
 }
 
+function resolveMockRootSuffix(params: {
+  activeRoot: string | undefined;
+  rootAPluginsDir: string;
+  rootBPluginsDir: string;
+}): "A" | "B" | "unknown" {
+  if (params.activeRoot === params.rootAPluginsDir) {
+    return "A";
+  }
+  if (params.activeRoot === params.rootBPluginsDir) {
+    return "B";
+  }
+  return "unknown";
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -84,9 +98,11 @@ describe("bundled root-aware caches", () => {
         config: {},
       }),
       getBundledChannelSetupPlugin: (id: string) => {
-        const activeRoot = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
-        const suffix =
-          activeRoot === rootA.pluginsDir ? "A" : activeRoot === rootB.pluginsDir ? "B" : "unknown";
+        const suffix = resolveMockRootSuffix({
+          activeRoot: process.env.OPENCLAW_BUNDLED_PLUGINS_DIR,
+          rootAPluginsDir: rootA.pluginsDir,
+          rootBPluginsDir: rootB.pluginsDir,
+        });
         return {
           id,
           meta: { id, label: `setup-${suffix}` },
@@ -98,9 +114,11 @@ describe("bundled root-aware caches", () => {
         secretTargetRegistryEntries: [{ id: `runtime-${id}`, targetType: "channel" }],
       }),
       getBundledChannelSetupSecrets: (id: string) => {
-        const activeRoot = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
-        const suffix =
-          activeRoot === rootA.pluginsDir ? "A" : activeRoot === rootB.pluginsDir ? "B" : "unknown";
+        const suffix = resolveMockRootSuffix({
+          activeRoot: process.env.OPENCLAW_BUNDLED_PLUGINS_DIR,
+          rootAPluginsDir: rootA.pluginsDir,
+          rootBPluginsDir: rootB.pluginsDir,
+        });
         return {
           secretTargetRegistryEntries: [{ id: `setup-${id}-${suffix}`, targetType: "channel" }],
         };

--- a/src/channels/plugins/bundled-root-caches.test.ts
+++ b/src/channels/plugins/bundled-root-caches.test.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { importFreshModule } from "../../../test/helpers/import-fresh.ts";
+
+const tempDirs: string[] = [];
+const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+
+function makeBundledRoot(prefix: string): { root: string; pluginsDir: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(root);
+  const pluginsDir = path.join(root, "dist", "extensions");
+  fs.mkdirSync(pluginsDir, { recursive: true });
+  return { root, pluginsDir };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  if (originalBundledPluginsDir === undefined) {
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  } else {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledPluginsDir;
+  }
+  vi.resetModules();
+  vi.doUnmock("../../plugins/channel-catalog-registry.js");
+  vi.doUnmock("./bundled.js");
+  vi.doUnmock("./bundled-ids.js");
+});
+
+describe("bundled root-aware caches", () => {
+  it("partitions bundled channel ids by active bundled root without re-importing", async () => {
+    const rootA = makeBundledRoot("openclaw-bundled-ids-a-");
+    const rootB = makeBundledRoot("openclaw-bundled-ids-b-");
+
+    vi.doMock("../../plugins/channel-catalog-registry.js", () => ({
+      listChannelCatalogEntries: (params?: { env?: NodeJS.ProcessEnv }) => {
+        const activeRoot = params?.env?.OPENCLAW_BUNDLED_PLUGINS_DIR;
+        if (activeRoot === rootA.pluginsDir) {
+          return [{ pluginId: "alpha" }];
+        }
+        if (activeRoot === rootB.pluginsDir) {
+          return [{ pluginId: "beta" }];
+        }
+        return [];
+      },
+    }));
+
+    const bundledIds = await importFreshModule<typeof import("./bundled-ids.js")>(
+      import.meta.url,
+      "./bundled-ids.js?scope=root-aware-id-cache",
+    );
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootA.pluginsDir;
+    expect(bundledIds.listBundledChannelPluginIds()).toEqual(["alpha"]);
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootB.pluginsDir;
+    expect(bundledIds.listBundledChannelPluginIds()).toEqual(["beta"]);
+  });
+
+  it("partitions bootstrap plugin caches by active bundled root without re-importing", async () => {
+    const rootA = makeBundledRoot("openclaw-bootstrap-a-");
+    const rootB = makeBundledRoot("openclaw-bootstrap-b-");
+
+    vi.doMock("./bundled-ids.js", () => ({
+      listBundledChannelPluginIdsForRoot: (packageRoot: string) => {
+        if (packageRoot === rootA.root) {
+          return ["alpha"];
+        }
+        if (packageRoot === rootB.root) {
+          return ["beta"];
+        }
+        return [];
+      },
+    }));
+
+    vi.doMock("./bundled.js", () => ({
+      getBundledChannelPlugin: (id: string) => ({
+        id,
+        meta: { id, label: `runtime-${id}` },
+        capabilities: {},
+        config: {},
+      }),
+      getBundledChannelSetupPlugin: (id: string) => {
+        const activeRoot = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+        const suffix =
+          activeRoot === rootA.pluginsDir ? "A" : activeRoot === rootB.pluginsDir ? "B" : "unknown";
+        return {
+          id,
+          meta: { id, label: `setup-${suffix}` },
+          capabilities: {},
+          config: {},
+        };
+      },
+      getBundledChannelSecrets: (id: string) => ({
+        secretTargetRegistryEntries: [{ id: `runtime-${id}`, targetType: "channel" }],
+      }),
+      getBundledChannelSetupSecrets: (id: string) => {
+        const activeRoot = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+        const suffix =
+          activeRoot === rootA.pluginsDir ? "A" : activeRoot === rootB.pluginsDir ? "B" : "unknown";
+        return {
+          secretTargetRegistryEntries: [{ id: `setup-${id}-${suffix}`, targetType: "channel" }],
+        };
+      },
+    }));
+
+    const bootstrapRegistry = await importFreshModule<typeof import("./bootstrap-registry.js")>(
+      import.meta.url,
+      "./bootstrap-registry.js?scope=root-aware-bootstrap-cache",
+    );
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootA.pluginsDir;
+    expect(bootstrapRegistry.listBootstrapChannelPluginIds()).toEqual(["alpha"]);
+    expect(bootstrapRegistry.getBootstrapChannelPlugin("alpha")?.meta.label).toBe("setup-A");
+    expect(
+      bootstrapRegistry.getBootstrapChannelSecrets("alpha")?.secretTargetRegistryEntries?.[0]?.id,
+    ).toBe("setup-alpha-A");
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootB.pluginsDir;
+    expect(bootstrapRegistry.listBootstrapChannelPluginIds()).toEqual(["beta"]);
+    expect(bootstrapRegistry.getBootstrapChannelPlugin("beta")?.meta.label).toBe("setup-B");
+    expect(
+      bootstrapRegistry.getBootstrapChannelSecrets("beta")?.secretTargetRegistryEntries?.[0]?.id,
+    ).toBe("setup-beta-B");
+  });
+});

--- a/src/channels/plugins/bundled-root-caches.test.ts
+++ b/src/channels/plugins/bundled-root-caches.test.ts
@@ -79,11 +79,11 @@ describe("bundled root-aware caches", () => {
     const rootB = makeBundledRoot("openclaw-bootstrap-b-");
 
     vi.doMock("./bundled-ids.js", () => ({
-      listBundledChannelPluginIdsForRoot: (packageRoot: string) => {
-        if (packageRoot === rootA.root) {
+      listBundledChannelPluginIdsForRoot: (cacheKey: string) => {
+        if (cacheKey === rootA.pluginsDir) {
           return ["alpha"];
         }
-        if (packageRoot === rootB.root) {
+        if (cacheKey === rootB.pluginsDir) {
           return ["beta"];
         }
         return [];

--- a/src/channels/plugins/bundled-root.ts
+++ b/src/channels/plugins/bundled-root.ts
@@ -13,12 +13,14 @@ const OPENCLAW_PACKAGE_ROOT =
     ? path.resolve(fileURLToPath(new URL("../../..", import.meta.url)))
     : process.cwd());
 
-export function derivePackageRootFromBundledPluginsDir(pluginsDir: string): string {
-  const resolvedDir = path.resolve(pluginsDir);
-  if (path.basename(resolvedDir) !== "extensions") {
-    return resolvedDir;
-  }
-  const parentDir = path.dirname(resolvedDir);
+export type BundledChannelRootScope = {
+  packageRoot: string;
+  cacheKey: string;
+  pluginsDir?: string;
+};
+
+function derivePackageRootFromExtensionsDir(extensionsDir: string): string {
+  const parentDir = path.dirname(extensionsDir);
   const parentBase = path.basename(parentDir);
   if (parentBase === "dist" || parentBase === "dist-runtime") {
     return path.dirname(parentDir);
@@ -26,10 +28,23 @@ export function derivePackageRootFromBundledPluginsDir(pluginsDir: string): stri
   return parentDir;
 }
 
-export function resolveBundledChannelPackageRoot(env: NodeJS.ProcessEnv = process.env): string {
+export function resolveBundledChannelRootScope(
+  env: NodeJS.ProcessEnv = process.env,
+): BundledChannelRootScope {
   const bundledPluginsDir = resolveBundledPluginsDir(env);
-  if (bundledPluginsDir) {
-    return derivePackageRootFromBundledPluginsDir(bundledPluginsDir);
+  if (!bundledPluginsDir) {
+    return {
+      packageRoot: OPENCLAW_PACKAGE_ROOT,
+      cacheKey: OPENCLAW_PACKAGE_ROOT,
+    };
   }
-  return OPENCLAW_PACKAGE_ROOT;
+  const resolvedPluginsDir = path.resolve(bundledPluginsDir);
+  return {
+    packageRoot:
+      path.basename(resolvedPluginsDir) === "extensions"
+        ? derivePackageRootFromExtensionsDir(resolvedPluginsDir)
+        : resolvedPluginsDir,
+    cacheKey: resolvedPluginsDir,
+    pluginsDir: resolvedPluginsDir,
+  };
 }

--- a/src/channels/plugins/bundled-root.ts
+++ b/src/channels/plugins/bundled-root.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
+import { resolveBundledPluginsDir } from "../../plugins/bundled-dir.js";
+
+const OPENCLAW_PACKAGE_ROOT =
+  resolveOpenClawPackageRootSync({
+    argv1: process.argv[1],
+    cwd: process.cwd(),
+    moduleUrl: import.meta.url.startsWith("file:") ? import.meta.url : undefined,
+  }) ??
+  (import.meta.url.startsWith("file:")
+    ? path.resolve(fileURLToPath(new URL("../../..", import.meta.url)))
+    : process.cwd());
+
+export function derivePackageRootFromBundledPluginsDir(pluginsDir: string): string {
+  const resolvedDir = path.resolve(pluginsDir);
+  if (path.basename(resolvedDir) !== "extensions") {
+    return resolvedDir;
+  }
+  const parentDir = path.dirname(resolvedDir);
+  const parentBase = path.basename(parentDir);
+  if (parentBase === "dist" || parentBase === "dist-runtime") {
+    return path.dirname(parentDir);
+  }
+  return parentDir;
+}
+
+export function resolveBundledChannelPackageRoot(env: NodeJS.ProcessEnv = process.env): string {
+  const bundledPluginsDir = resolveBundledPluginsDir(env);
+  if (bundledPluginsDir) {
+    return derivePackageRootFromBundledPluginsDir(bundledPluginsDir);
+  }
+  return OPENCLAW_PACKAGE_ROOT;
+}

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -77,6 +77,94 @@ describe("bundled channel entry shape guards", () => {
     ).not.toThrow();
   });
 
+  it("uses the active bundled plugin root override for channel entry loading", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-override-"));
+    const previousBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+    const pluginDir = path.join(tempRoot, "dist", "extensions", "alpha");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "index.js"),
+      [
+        "globalThis.__bundledOverrideRuntime = undefined;",
+        "const plugin = { id: 'alpha', meta: {}, capabilities: {}, config: {} };",
+        "export default {",
+        "  kind: 'bundled-channel-entry',",
+        "  id: 'alpha',",
+        "  name: 'Alpha',",
+        "  description: 'Alpha',",
+        "  register() {},",
+        "  loadChannelPlugin() { return plugin; },",
+        "  setChannelRuntime(runtime) { globalThis.__bundledOverrideRuntime = runtime.marker; },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    let metadataRootDir: string | undefined;
+    let generatedRootDir: string | undefined;
+
+    vi.doMock("../../plugins/bundled-channel-runtime.js", () => ({
+      listBundledChannelPluginMetadata: (params?: { rootDir?: string }) => {
+        metadataRootDir = params?.rootDir;
+        return [
+          {
+            dirName: "alpha",
+            manifest: {
+              id: "alpha",
+              channels: ["alpha"],
+            },
+            source: {
+              source: "./index.js",
+              built: "./index.js",
+            },
+          },
+        ];
+      },
+      resolveBundledChannelGeneratedPath: (
+        rootDir: string,
+        entry: { built?: string; source?: string },
+        pluginDirName?: string,
+      ) => {
+        generatedRootDir = rootDir;
+        return path.join(
+          rootDir,
+          "dist",
+          "extensions",
+          pluginDirName ?? "alpha",
+          (entry.built ?? entry.source ?? "./index.js").replace(/^\.\//u, ""),
+        );
+      },
+    }));
+
+    try {
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = path.join(tempRoot, "dist", "extensions");
+
+      const bundled = await importFreshModule<typeof import("./bundled.js")>(
+        import.meta.url,
+        "./bundled.js?scope=bundled-override-root",
+      );
+
+      bundled.setBundledChannelRuntime("alpha", { marker: "ok" } as never);
+      const testGlobal = globalThis as typeof globalThis & {
+        __bundledOverrideRuntime?: unknown;
+      };
+
+      expect(metadataRootDir).toBe(tempRoot);
+      expect(generatedRootDir).toBe(tempRoot);
+      expect(testGlobal.__bundledOverrideRuntime).toBe("ok");
+      expect(bundled.requireBundledChannelPlugin("alpha").id).toBe("alpha");
+    } finally {
+      if (previousBundledPluginsDir === undefined) {
+        delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+      } else {
+        process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = previousBundledPluginsDir;
+      }
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+      delete (globalThis as { __bundledOverrideRuntime?: unknown }).__bundledOverrideRuntime;
+    }
+  });
+
   it("keeps channel entrypoints on the dedicated entry-contract SDK surface", () => {
     const offenders: string[] = [];
 

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -165,6 +165,97 @@ describe("bundled channel entry shape guards", () => {
     }
   });
 
+  it("treats direct bundled plugin-tree overrides as scan roots", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-direct-override-"));
+    const previousBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+    const pluginsRoot = path.join(tempRoot, "bundled-plugins");
+    const pluginDir = path.join(pluginsRoot, "alpha");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "index.js"),
+      [
+        "globalThis.__bundledOverrideRuntime = undefined;",
+        "const plugin = { id: 'alpha', meta: {}, capabilities: {}, config: {} };",
+        "export default {",
+        "  kind: 'bundled-channel-entry',",
+        "  id: 'alpha',",
+        "  name: 'Alpha',",
+        "  description: 'Alpha',",
+        "  register() {},",
+        "  loadChannelPlugin() { return plugin; },",
+        "  setChannelRuntime(runtime) { globalThis.__bundledOverrideRuntime = runtime.marker; },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    let metadataScanDir: string | undefined;
+    let generatedRootDir: string | undefined;
+    let generatedScanDir: string | undefined;
+
+    vi.doMock("../../plugins/bundled-channel-runtime.js", () => ({
+      listBundledChannelPluginMetadata: (params?: { rootDir?: string; scanDir?: string }) => {
+        metadataScanDir = params?.scanDir;
+        return [
+          {
+            dirName: "alpha",
+            manifest: {
+              id: "alpha",
+              channels: ["alpha"],
+            },
+            source: {
+              source: "./index.js",
+              built: "./index.js",
+            },
+          },
+        ];
+      },
+      resolveBundledChannelGeneratedPath: (
+        rootDir: string,
+        entry: { built?: string; source?: string },
+        pluginDirName?: string,
+        scanDir?: string,
+      ) => {
+        generatedRootDir = rootDir;
+        generatedScanDir = scanDir;
+        return path.join(
+          scanDir ?? path.join(rootDir, "dist", "extensions"),
+          pluginDirName ?? "alpha",
+          (entry.built ?? entry.source ?? "./index.js").replace(/^\.\//u, ""),
+        );
+      },
+    }));
+
+    try {
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = pluginsRoot;
+
+      const bundled = await importFreshModule<typeof import("./bundled.js")>(
+        import.meta.url,
+        "./bundled.js?scope=bundled-direct-override-root",
+      );
+
+      bundled.setBundledChannelRuntime("alpha", { marker: "ok" } as never);
+      const testGlobal = globalThis as typeof globalThis & {
+        __bundledOverrideRuntime?: unknown;
+      };
+
+      expect(metadataScanDir).toBe(pluginsRoot);
+      expect(generatedRootDir).toBe(pluginsRoot);
+      expect(generatedScanDir).toBe(pluginsRoot);
+      expect(testGlobal.__bundledOverrideRuntime).toBe("ok");
+      expect(bundled.requireBundledChannelPlugin("alpha").id).toBe("alpha");
+    } finally {
+      if (previousBundledPluginsDir === undefined) {
+        delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+      } else {
+        process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = previousBundledPluginsDir;
+      }
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+      delete (globalThis as { __bundledOverrideRuntime?: unknown }).__bundledOverrideRuntime;
+    }
+  });
+
   it("partitions bundled channel lazy caches by active bundled root without re-importing", async () => {
     const rootA = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-root-a-"));
     const rootB = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-root-b-"));

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -165,6 +165,147 @@ describe("bundled channel entry shape guards", () => {
     }
   });
 
+  it("partitions bundled channel lazy caches by active bundled root without re-importing", async () => {
+    const rootA = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-root-a-"));
+    const rootB = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-root-b-"));
+    const previousBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+    const testGlobal = globalThis as typeof globalThis & {
+      __bundledRootRuntime?: unknown;
+    };
+
+    const writeBundledRoot = (rootDir: string, label: string) => {
+      const pluginDir = path.join(rootDir, "dist", "extensions", "alpha");
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginDir, "index.js"),
+        [
+          `globalThis.__bundledRootRuntime = globalThis.__bundledRootRuntime ?? [];`,
+          "export default {",
+          "  kind: 'bundled-channel-entry',",
+          "  id: 'alpha',",
+          `  name: ${JSON.stringify(`Alpha ${label}`)},`,
+          `  description: ${JSON.stringify(`Alpha ${label}`)},`,
+          "  register() {},",
+          "  loadChannelPlugin() {",
+          "    return {",
+          "      id: 'alpha',",
+          `      meta: { id: 'alpha', label: ${JSON.stringify(`Alpha ${label}`)} },`,
+          "      capabilities: {},",
+          "      config: {},",
+          `      secrets: { secretTargetRegistryEntries: [{ id: ${JSON.stringify(`channels.alpha.${label}.token`)}, targetType: 'channel' }] },`,
+          "    };",
+          "  },",
+          "  loadChannelSecrets() {",
+          `    return { secretTargetRegistryEntries: [{ id: ${JSON.stringify(`channels.alpha.${label}.entry-token`)}, targetType: 'channel' }] };`,
+          "  },",
+          "  setChannelRuntime(runtime) {",
+          `    globalThis.__bundledRootRuntime.push(${JSON.stringify(`entry:${label}`)} + ':' + String(runtime.marker));`,
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(pluginDir, "setup-entry.js"),
+        [
+          "export default {",
+          "  kind: 'bundled-channel-setup-entry',",
+          "  loadSetupPlugin() {",
+          "    return {",
+          "      id: 'alpha',",
+          `      meta: { id: 'alpha', label: ${JSON.stringify(`Setup ${label}`)} },`,
+          "      capabilities: {},",
+          "      config: {},",
+          `      secrets: { secretTargetRegistryEntries: [{ id: ${JSON.stringify(`channels.alpha.${label}.setup-plugin-token`)}, targetType: 'channel' }] },`,
+          "    };",
+          "  },",
+          "  loadSetupSecrets() {",
+          `    return { secretTargetRegistryEntries: [{ id: ${JSON.stringify(`channels.alpha.${label}.setup-entry-token`)}, targetType: 'channel' }] };`,
+          "  },",
+          "};",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+    };
+
+    writeBundledRoot(rootA, "A");
+    writeBundledRoot(rootB, "B");
+
+    vi.doMock("../../plugins/bundled-channel-runtime.js", () => ({
+      listBundledChannelPluginMetadata: () => [
+        {
+          dirName: "alpha",
+          manifest: {
+            id: "alpha",
+            channels: ["alpha"],
+          },
+          source: {
+            source: "./index.js",
+            built: "./index.js",
+          },
+          setupSource: {
+            source: "./setup-entry.js",
+            built: "./setup-entry.js",
+          },
+        },
+      ],
+      resolveBundledChannelGeneratedPath: (
+        rootDir: string,
+        entry: { built?: string; source?: string },
+        pluginDirName?: string,
+      ) =>
+        path.join(
+          rootDir,
+          "dist",
+          "extensions",
+          pluginDirName ?? "alpha",
+          (entry.built ?? entry.source ?? "./index.js").replace(/^\.\//u, ""),
+        ),
+    }));
+
+    try {
+      const bundled = await importFreshModule<typeof import("./bundled.js")>(
+        import.meta.url,
+        "./bundled.js?scope=bundled-root-partition",
+      );
+
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = path.join(rootA, "dist", "extensions");
+      expect(bundled.requireBundledChannelPlugin("alpha").meta.label).toBe("Alpha A");
+      expect(bundled.getBundledChannelSetupPlugin("alpha")?.meta.label).toBe("Setup A");
+      expect(bundled.getBundledChannelSecrets("alpha")?.secretTargetRegistryEntries?.[0]?.id).toBe(
+        "channels.alpha.A.entry-token",
+      );
+      expect(
+        bundled.getBundledChannelSetupSecrets("alpha")?.secretTargetRegistryEntries?.[0]?.id,
+      ).toBe("channels.alpha.A.setup-entry-token");
+      bundled.setBundledChannelRuntime("alpha", { marker: "first" } as never);
+
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = path.join(rootB, "dist", "extensions");
+      expect(bundled.requireBundledChannelPlugin("alpha").meta.label).toBe("Alpha B");
+      expect(bundled.getBundledChannelSetupPlugin("alpha")?.meta.label).toBe("Setup B");
+      expect(bundled.getBundledChannelSecrets("alpha")?.secretTargetRegistryEntries?.[0]?.id).toBe(
+        "channels.alpha.B.entry-token",
+      );
+      expect(
+        bundled.getBundledChannelSetupSecrets("alpha")?.secretTargetRegistryEntries?.[0]?.id,
+      ).toBe("channels.alpha.B.setup-entry-token");
+      bundled.setBundledChannelRuntime("alpha", { marker: "second" } as never);
+
+      expect(testGlobal.__bundledRootRuntime).toEqual(["entry:A:first", "entry:B:second"]);
+    } finally {
+      if (previousBundledPluginsDir === undefined) {
+        delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+      } else {
+        process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = previousBundledPluginsDir;
+      }
+      fs.rmSync(rootA, { recursive: true, force: true });
+      fs.rmSync(rootB, { recursive: true, force: true });
+      delete testGlobal.__bundledRootRuntime;
+    }
+  });
+
   it("keeps channel entrypoints on the dedicated entry-contract SDK surface", () => {
     const offenders: string[] = [];
 

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -8,7 +8,7 @@ import {
 } from "../../plugins/bundled-channel-runtime.js";
 import { unwrapDefaultModuleExport } from "../../plugins/module-export.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
-import { resolveBundledChannelPackageRoot } from "./bundled-root.js";
+import { resolveBundledChannelRootScope, type BundledChannelRootScope } from "./bundled-root.js";
 import { isJavaScriptModulePath, loadChannelPluginModule } from "./module-loader.js";
 import type { ChannelPlugin } from "./types.plugin.js";
 import type { ChannelId } from "./types.public.js";
@@ -102,9 +102,20 @@ function hasSetupEntryFeature(
 
 function resolveBundledChannelBoundaryRoot(params: {
   packageRoot: string;
+  pluginsDir?: string;
   metadata: BundledChannelPluginMetadata;
   modulePath: string;
 }): string {
+  const overrideRoot = params.pluginsDir
+    ? path.resolve(params.pluginsDir, params.metadata.dirName)
+    : null;
+  if (
+    overrideRoot &&
+    (params.modulePath === overrideRoot ||
+      params.modulePath.startsWith(`${overrideRoot}${path.sep}`))
+  ) {
+    return overrideRoot;
+  }
   const distRoot = path.resolve(params.packageRoot, "dist", "extensions", params.metadata.dirName);
   if (params.modulePath === distRoot || params.modulePath.startsWith(`${distRoot}${path.sep}`)) {
     return distRoot;
@@ -112,27 +123,28 @@ function resolveBundledChannelBoundaryRoot(params: {
   return path.resolve(params.packageRoot, "extensions", params.metadata.dirName);
 }
 
+function resolveBundledChannelScanDir(rootScope: BundledChannelRootScope): string | undefined {
+  return rootScope.pluginsDir;
+}
+
 function resolveGeneratedBundledChannelModulePath(params: {
-  packageRoot: string;
+  rootScope: BundledChannelRootScope;
   metadata: BundledChannelPluginMetadata;
   entry: BundledChannelPluginMetadata["source"] | BundledChannelPluginMetadata["setupSource"];
 }): string | null {
   if (!params.entry) {
     return null;
   }
-  const resolved = resolveBundledChannelGeneratedPath(
-    params.packageRoot,
+  return resolveBundledChannelGeneratedPath(
+    params.rootScope.packageRoot,
     params.entry,
     params.metadata.dirName,
+    resolveBundledChannelScanDir(params.rootScope),
   );
-  if (resolved) {
-    return resolved;
-  }
-  return null;
 }
 
 function loadGeneratedBundledChannelModule(params: {
-  packageRoot: string;
+  rootScope: BundledChannelRootScope;
   metadata: BundledChannelPluginMetadata;
   entry: BundledChannelPluginMetadata["source"] | BundledChannelPluginMetadata["setupSource"];
 }): unknown {
@@ -140,8 +152,10 @@ function loadGeneratedBundledChannelModule(params: {
   if (!modulePath) {
     throw new Error(`missing generated module for bundled channel ${params.metadata.manifest.id}`);
   }
+  const scanDir = resolveBundledChannelScanDir(params.rootScope);
   const boundaryRoot = resolveBundledChannelBoundaryRoot({
-    packageRoot: params.packageRoot,
+    packageRoot: params.rootScope.packageRoot,
+    ...(scanDir ? { pluginsDir: scanDir } : {}),
     metadata: params.metadata,
     modulePath,
   });
@@ -155,14 +169,14 @@ function loadGeneratedBundledChannelModule(params: {
 }
 
 function loadGeneratedBundledChannelEntry(params: {
-  packageRoot: string;
+  rootScope: BundledChannelRootScope;
   metadata: BundledChannelPluginMetadata;
   includeSetup: boolean;
 }): GeneratedBundledChannelEntry | null {
   try {
     const entry = resolveChannelPluginModuleEntry(
       loadGeneratedBundledChannelModule({
-        packageRoot: params.packageRoot,
+        rootScope: params.rootScope,
         metadata: params.metadata,
         entry: params.metadata.source,
       }),
@@ -177,7 +191,7 @@ function loadGeneratedBundledChannelEntry(params: {
       params.includeSetup && params.metadata.setupSource
         ? resolveChannelSetupModuleEntry(
             loadGeneratedBundledChannelModule({
-              packageRoot: params.packageRoot,
+              rootScope: params.rootScope,
               metadata: params.metadata,
               entry: params.metadata.setupSource,
             }),
@@ -211,65 +225,69 @@ function createBundledChannelCacheContext(): BundledChannelCacheContext {
   };
 }
 
-function getBundledChannelCacheContext(packageRoot: string): BundledChannelCacheContext {
-  const cached = bundledChannelCacheContexts.get(packageRoot);
+function getBundledChannelCacheContext(cacheKey: string): BundledChannelCacheContext {
+  const cached = bundledChannelCacheContexts.get(cacheKey);
   if (cached) {
     return cached;
   }
   const created = createBundledChannelCacheContext();
-  bundledChannelCacheContexts.set(packageRoot, created);
+  bundledChannelCacheContexts.set(cacheKey, created);
   return created;
 }
 
 function resolveActiveBundledChannelCacheScope(): {
-  packageRoot: string;
+  rootScope: BundledChannelRootScope;
   cacheContext: BundledChannelCacheContext;
 } {
-  const packageRoot = resolveBundledChannelPackageRoot();
+  const rootScope = resolveBundledChannelRootScope();
   return {
-    packageRoot,
-    cacheContext: getBundledChannelCacheContext(packageRoot),
+    rootScope,
+    cacheContext: getBundledChannelCacheContext(rootScope.cacheKey),
   };
 }
 
 function listBundledChannelMetadata(
-  packageRoot = resolveBundledChannelPackageRoot(),
+  rootScope = resolveBundledChannelRootScope(),
 ): readonly BundledChannelPluginMetadata[] {
-  const cached = cachedBundledChannelMetadata.get(packageRoot);
+  const cached = cachedBundledChannelMetadata.get(rootScope.cacheKey);
   if (cached) {
     return cached;
   }
+  const scanDir = resolveBundledChannelScanDir(rootScope);
   const loaded = listBundledChannelPluginMetadata({
-    rootDir: packageRoot,
+    rootDir: rootScope.packageRoot,
+    ...(scanDir ? { scanDir } : {}),
     includeChannelConfigs: false,
     includeSyntheticChannelConfigs: false,
   }).filter((metadata) => (metadata.manifest.channels?.length ?? 0) > 0);
-  cachedBundledChannelMetadata.set(packageRoot, loaded);
+  cachedBundledChannelMetadata.set(rootScope.cacheKey, loaded);
   return loaded;
 }
 
-function listBundledChannelPluginIdsForRoot(packageRoot: string): readonly ChannelId[] {
-  return listBundledChannelMetadata(packageRoot)
+function listBundledChannelPluginIdsForRoot(
+  rootScope: BundledChannelRootScope,
+): readonly ChannelId[] {
+  return listBundledChannelMetadata(rootScope)
     .map((metadata) => metadata.manifest.id)
     .toSorted((left, right) => left.localeCompare(right));
 }
 
 export function listBundledChannelPluginIds(): readonly ChannelId[] {
-  return listBundledChannelPluginIdsForRoot(resolveBundledChannelPackageRoot());
+  return listBundledChannelPluginIdsForRoot(resolveBundledChannelRootScope());
 }
 
 function resolveBundledChannelMetadata(
   id: ChannelId,
-  packageRoot: string,
+  rootScope: BundledChannelRootScope,
 ): BundledChannelPluginMetadata | undefined {
-  return listBundledChannelMetadata(packageRoot).find(
+  return listBundledChannelMetadata(rootScope).find(
     (metadata) => metadata.manifest.id === id || metadata.manifest.channels?.includes(id),
   );
 }
 
 function getLazyGeneratedBundledChannelEntryForRoot(
   id: ChannelId,
-  packageRoot: string,
+  rootScope: BundledChannelRootScope,
   cacheContext: BundledChannelCacheContext,
   params?: { includeSetup?: boolean },
 ): GeneratedBundledChannelEntry | null {
@@ -280,7 +298,7 @@ function getLazyGeneratedBundledChannelEntryForRoot(
   if (cached === null && !params?.includeSetup) {
     return null;
   }
-  const metadata = resolveBundledChannelMetadata(id, packageRoot);
+  const metadata = resolveBundledChannelMetadata(id, rootScope);
   if (!metadata) {
     cacheContext.lazyEntriesById.set(id, null);
     return null;
@@ -291,7 +309,7 @@ function getLazyGeneratedBundledChannelEntryForRoot(
   cacheContext.entryLoadInProgressIds.add(id);
   try {
     const entry = loadGeneratedBundledChannelEntry({
-      packageRoot,
+      rootScope,
       metadata,
       includeSetup: params?.includeSetup === true,
     });
@@ -307,7 +325,7 @@ function getLazyGeneratedBundledChannelEntryForRoot(
 
 function getBundledChannelPluginForRoot(
   id: ChannelId,
-  packageRoot: string,
+  rootScope: BundledChannelRootScope,
   cacheContext: BundledChannelCacheContext,
 ): ChannelPlugin | undefined {
   const cached = cacheContext.lazyPluginsById.get(id);
@@ -317,7 +335,7 @@ function getBundledChannelPluginForRoot(
   if (cacheContext.pluginLoadInProgressIds.has(id)) {
     return undefined;
   }
-  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext)?.entry;
+  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, rootScope, cacheContext)?.entry;
   if (!entry) {
     return undefined;
   }
@@ -333,26 +351,26 @@ function getBundledChannelPluginForRoot(
 
 function getBundledChannelSecretsForRoot(
   id: ChannelId,
-  packageRoot: string,
+  rootScope: BundledChannelRootScope,
   cacheContext: BundledChannelCacheContext,
 ): ChannelPlugin["secrets"] | undefined {
   if (cacheContext.lazySecretsById.has(id)) {
     return cacheContext.lazySecretsById.get(id) ?? undefined;
   }
-  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext)?.entry;
+  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, rootScope, cacheContext)?.entry;
   if (!entry) {
     return undefined;
   }
   const secrets =
     entry.loadChannelSecrets?.() ??
-    getBundledChannelPluginForRoot(id, packageRoot, cacheContext)?.secrets;
+    getBundledChannelPluginForRoot(id, rootScope, cacheContext)?.secrets;
   cacheContext.lazySecretsById.set(id, secrets ?? null);
   return secrets;
 }
 
 function getBundledChannelSetupPluginForRoot(
   id: ChannelId,
-  packageRoot: string,
+  rootScope: BundledChannelRootScope,
   cacheContext: BundledChannelCacheContext,
 ): ChannelPlugin | undefined {
   const cached = cacheContext.lazySetupPluginsById.get(id);
@@ -362,7 +380,7 @@ function getBundledChannelSetupPluginForRoot(
   if (cacheContext.setupPluginLoadInProgressIds.has(id)) {
     return undefined;
   }
-  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext, {
+  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, rootScope, cacheContext, {
     includeSetup: true,
   })?.setupEntry;
   if (!entry) {
@@ -380,13 +398,13 @@ function getBundledChannelSetupPluginForRoot(
 
 function getBundledChannelSetupSecretsForRoot(
   id: ChannelId,
-  packageRoot: string,
+  rootScope: BundledChannelRootScope,
   cacheContext: BundledChannelCacheContext,
 ): ChannelPlugin["secrets"] | undefined {
   if (cacheContext.lazySetupSecretsById.has(id)) {
     return cacheContext.lazySetupSecretsById.get(id) ?? undefined;
   }
-  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext, {
+  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, rootScope, cacheContext, {
     includeSetup: true,
   })?.setupEntry;
   if (!entry) {
@@ -394,23 +412,23 @@ function getBundledChannelSetupSecretsForRoot(
   }
   const secrets =
     entry.loadSetupSecrets?.() ??
-    getBundledChannelSetupPluginForRoot(id, packageRoot, cacheContext)?.secrets;
+    getBundledChannelSetupPluginForRoot(id, rootScope, cacheContext)?.secrets;
   cacheContext.lazySetupSecretsById.set(id, secrets ?? null);
   return secrets;
 }
 
 export function listBundledChannelPlugins(): readonly ChannelPlugin[] {
-  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
-  return listBundledChannelPluginIdsForRoot(packageRoot).flatMap((id) => {
-    const plugin = getBundledChannelPluginForRoot(id, packageRoot, cacheContext);
+  const { rootScope, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return listBundledChannelPluginIdsForRoot(rootScope).flatMap((id) => {
+    const plugin = getBundledChannelPluginForRoot(id, rootScope, cacheContext);
     return plugin ? [plugin] : [];
   });
 }
 
 export function listBundledChannelSetupPlugins(): readonly ChannelPlugin[] {
-  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
-  return listBundledChannelPluginIdsForRoot(packageRoot).flatMap((id) => {
-    const plugin = getBundledChannelSetupPluginForRoot(id, packageRoot, cacheContext);
+  const { rootScope, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return listBundledChannelPluginIdsForRoot(rootScope).flatMap((id) => {
+    const plugin = getBundledChannelSetupPluginForRoot(id, rootScope, cacheContext);
     return plugin ? [plugin] : [];
   });
 }
@@ -418,37 +436,37 @@ export function listBundledChannelSetupPlugins(): readonly ChannelPlugin[] {
 export function listBundledChannelSetupPluginsByFeature(
   feature: keyof NonNullable<BundledChannelSetupEntryRuntimeContract["features"]>,
 ): readonly ChannelPlugin[] {
-  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
-  return listBundledChannelPluginIdsForRoot(packageRoot).flatMap((id) => {
-    const setupEntry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext, {
+  const { rootScope, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return listBundledChannelPluginIdsForRoot(rootScope).flatMap((id) => {
+    const setupEntry = getLazyGeneratedBundledChannelEntryForRoot(id, rootScope, cacheContext, {
       includeSetup: true,
     })?.setupEntry;
     if (!hasSetupEntryFeature(setupEntry, feature)) {
       return [];
     }
-    const plugin = getBundledChannelSetupPluginForRoot(id, packageRoot, cacheContext);
+    const plugin = getBundledChannelSetupPluginForRoot(id, rootScope, cacheContext);
     return plugin ? [plugin] : [];
   });
 }
 
 export function getBundledChannelPlugin(id: ChannelId): ChannelPlugin | undefined {
-  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
-  return getBundledChannelPluginForRoot(id, packageRoot, cacheContext);
+  const { rootScope, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return getBundledChannelPluginForRoot(id, rootScope, cacheContext);
 }
 
 export function getBundledChannelSecrets(id: ChannelId): ChannelPlugin["secrets"] | undefined {
-  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
-  return getBundledChannelSecretsForRoot(id, packageRoot, cacheContext);
+  const { rootScope, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return getBundledChannelSecretsForRoot(id, rootScope, cacheContext);
 }
 
 export function getBundledChannelSetupPlugin(id: ChannelId): ChannelPlugin | undefined {
-  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
-  return getBundledChannelSetupPluginForRoot(id, packageRoot, cacheContext);
+  const { rootScope, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return getBundledChannelSetupPluginForRoot(id, rootScope, cacheContext);
 }
 
 export function getBundledChannelSetupSecrets(id: ChannelId): ChannelPlugin["secrets"] | undefined {
-  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
-  return getBundledChannelSetupSecretsForRoot(id, packageRoot, cacheContext);
+  const { rootScope, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return getBundledChannelSetupSecretsForRoot(id, rootScope, cacheContext);
 }
 
 export function requireBundledChannelPlugin(id: ChannelId): ChannelPlugin {
@@ -460,8 +478,8 @@ export function requireBundledChannelPlugin(id: ChannelId): ChannelPlugin {
 }
 
 export function setBundledChannelRuntime(id: ChannelId, runtime: PluginRuntime): void {
-  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
-  const setter = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext)?.entry
+  const { rootScope, cacheContext } = resolveActiveBundledChannelCacheScope();
+  const setter = getLazyGeneratedBundledChannelEntryForRoot(id, rootScope, cacheContext)?.entry
     .setChannelRuntime;
   if (!setter) {
     throw new Error(`missing bundled channel runtime setter: ${id}`);

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -1,16 +1,14 @@
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   listBundledChannelPluginMetadata,
   resolveBundledChannelGeneratedPath,
   type BundledChannelPluginMetadata,
 } from "../../plugins/bundled-channel-runtime.js";
-import { resolveBundledPluginsDir } from "../../plugins/bundled-dir.js";
 import { unwrapDefaultModuleExport } from "../../plugins/module-export.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
+import { resolveBundledChannelPackageRoot } from "./bundled-root.js";
 import { isJavaScriptModulePath, loadChannelPluginModule } from "./module-loader.js";
 import type { ChannelPlugin } from "./types.plugin.js";
 import type { ChannelId } from "./types.public.js";
@@ -54,36 +52,6 @@ type BundledChannelCacheContext = {
 };
 
 const log = createSubsystemLogger("channels");
-const OPENCLAW_PACKAGE_ROOT =
-  resolveOpenClawPackageRootSync({
-    argv1: process.argv[1],
-    cwd: process.cwd(),
-    moduleUrl: import.meta.url.startsWith("file:") ? import.meta.url : undefined,
-  }) ??
-  (import.meta.url.startsWith("file:")
-    ? path.resolve(fileURLToPath(new URL("../../..", import.meta.url)))
-    : process.cwd());
-
-function derivePackageRootFromBundledPluginsDir(pluginsDir: string): string {
-  const resolvedDir = path.resolve(pluginsDir);
-  if (path.basename(resolvedDir) !== "extensions") {
-    return resolvedDir;
-  }
-  const parentDir = path.dirname(resolvedDir);
-  const parentBase = path.basename(parentDir);
-  if (parentBase === "dist" || parentBase === "dist-runtime") {
-    return path.dirname(parentDir);
-  }
-  return parentDir;
-}
-
-function resolveBundledChannelPackageRoot(): string {
-  const bundledPluginsDir = resolveBundledPluginsDir(process.env);
-  if (bundledPluginsDir) {
-    return derivePackageRootFromBundledPluginsDir(bundledPluginsDir);
-  }
-  return OPENCLAW_PACKAGE_ROOT;
-}
 
 function resolveChannelPluginModuleEntry(
   moduleExport: unknown,

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -42,6 +42,17 @@ type GeneratedBundledChannelEntry = {
   setupEntry?: BundledChannelSetupEntryRuntimeContract;
 };
 
+type BundledChannelCacheContext = {
+  pluginLoadInProgressIds: Set<ChannelId>;
+  setupPluginLoadInProgressIds: Set<ChannelId>;
+  entryLoadInProgressIds: Set<ChannelId>;
+  lazyEntriesById: Map<ChannelId, GeneratedBundledChannelEntry | null>;
+  lazyPluginsById: Map<ChannelId, ChannelPlugin>;
+  lazySetupPluginsById: Map<ChannelId, ChannelPlugin>;
+  lazySecretsById: Map<ChannelId, ChannelPlugin["secrets"] | null>;
+  lazySetupSecretsById: Map<ChannelId, ChannelPlugin["secrets"] | null>;
+};
+
 const log = createSubsystemLogger("channels");
 const OPENCLAW_PACKAGE_ROOT =
   resolveOpenClawPackageRootSync({
@@ -122,27 +133,27 @@ function hasSetupEntryFeature(
 }
 
 function resolveBundledChannelBoundaryRoot(params: {
+  packageRoot: string;
   metadata: BundledChannelPluginMetadata;
   modulePath: string;
 }): string {
-  const packageRoot = resolveBundledChannelPackageRoot();
-  const distRoot = path.resolve(packageRoot, "dist", "extensions", params.metadata.dirName);
+  const distRoot = path.resolve(params.packageRoot, "dist", "extensions", params.metadata.dirName);
   if (params.modulePath === distRoot || params.modulePath.startsWith(`${distRoot}${path.sep}`)) {
     return distRoot;
   }
-  return path.resolve(packageRoot, "extensions", params.metadata.dirName);
+  return path.resolve(params.packageRoot, "extensions", params.metadata.dirName);
 }
 
 function resolveGeneratedBundledChannelModulePath(params: {
+  packageRoot: string;
   metadata: BundledChannelPluginMetadata;
   entry: BundledChannelPluginMetadata["source"] | BundledChannelPluginMetadata["setupSource"];
 }): string | null {
   if (!params.entry) {
     return null;
   }
-  const packageRoot = resolveBundledChannelPackageRoot();
   const resolved = resolveBundledChannelGeneratedPath(
-    packageRoot,
+    params.packageRoot,
     params.entry,
     params.metadata.dirName,
   );
@@ -153,6 +164,7 @@ function resolveGeneratedBundledChannelModulePath(params: {
 }
 
 function loadGeneratedBundledChannelModule(params: {
+  packageRoot: string;
   metadata: BundledChannelPluginMetadata;
   entry: BundledChannelPluginMetadata["source"] | BundledChannelPluginMetadata["setupSource"];
 }): unknown {
@@ -163,10 +175,12 @@ function loadGeneratedBundledChannelModule(params: {
   return loadChannelPluginModule({
     modulePath,
     rootDir: resolveBundledChannelBoundaryRoot({
+      packageRoot: params.packageRoot,
       metadata: params.metadata,
       modulePath,
     }),
     boundaryRootDir: resolveBundledChannelBoundaryRoot({
+      packageRoot: params.packageRoot,
       metadata: params.metadata,
       modulePath,
     }),
@@ -176,12 +190,14 @@ function loadGeneratedBundledChannelModule(params: {
 }
 
 function loadGeneratedBundledChannelEntry(params: {
+  packageRoot: string;
   metadata: BundledChannelPluginMetadata;
   includeSetup: boolean;
 }): GeneratedBundledChannelEntry | null {
   try {
     const entry = resolveChannelPluginModuleEntry(
       loadGeneratedBundledChannelModule({
+        packageRoot: params.packageRoot,
         metadata: params.metadata,
         entry: params.metadata.source,
       }),
@@ -196,6 +212,7 @@ function loadGeneratedBundledChannelEntry(params: {
       params.includeSetup && params.metadata.setupSource
         ? resolveChannelSetupModuleEntry(
             loadGeneratedBundledChannelModule({
+              packageRoot: params.packageRoot,
               metadata: params.metadata,
               entry: params.metadata.setupSource,
             }),
@@ -214,9 +231,30 @@ function loadGeneratedBundledChannelEntry(params: {
 }
 
 const cachedBundledChannelMetadata = new Map<string, readonly BundledChannelPluginMetadata[]>();
+const bundledChannelCacheContexts = new Map<string, BundledChannelCacheContext>();
 
-function listBundledChannelMetadata(): readonly BundledChannelPluginMetadata[] {
-  const packageRoot = resolveBundledChannelPackageRoot();
+function getBundledChannelCacheContext(packageRoot: string): BundledChannelCacheContext {
+  const cached = bundledChannelCacheContexts.get(packageRoot);
+  if (cached) {
+    return cached;
+  }
+  const created: BundledChannelCacheContext = {
+    pluginLoadInProgressIds: new Set(),
+    setupPluginLoadInProgressIds: new Set(),
+    entryLoadInProgressIds: new Set(),
+    lazyEntriesById: new Map(),
+    lazyPluginsById: new Map(),
+    lazySetupPluginsById: new Map(),
+    lazySecretsById: new Map(),
+    lazySetupSecretsById: new Map(),
+  };
+  bundledChannelCacheContexts.set(packageRoot, created);
+  return created;
+}
+
+function listBundledChannelMetadata(
+  packageRoot = resolveBundledChannelPackageRoot(),
+): readonly BundledChannelPluginMetadata[] {
   const cached = cachedBundledChannelMetadata.get(packageRoot);
   if (cached) {
     return cached;
@@ -230,72 +268,171 @@ function listBundledChannelMetadata(): readonly BundledChannelPluginMetadata[] {
   return loaded;
 }
 
-export function listBundledChannelPluginIds(): readonly ChannelId[] {
-  return listBundledChannelMetadata()
+function listBundledChannelPluginIdsForRoot(packageRoot: string): readonly ChannelId[] {
+  return listBundledChannelMetadata(packageRoot)
     .map((metadata) => metadata.manifest.id)
     .toSorted((left, right) => left.localeCompare(right));
 }
 
-const pluginLoadInProgressIds = new Set<ChannelId>();
-const setupPluginLoadInProgressIds = new Set<ChannelId>();
-const entryLoadInProgressIds = new Set<ChannelId>();
-const lazyEntriesById = new Map<ChannelId, GeneratedBundledChannelEntry | null>();
-const lazyPluginsById = new Map<ChannelId, ChannelPlugin>();
-const lazySetupPluginsById = new Map<ChannelId, ChannelPlugin>();
-const lazySecretsById = new Map<ChannelId, ChannelPlugin["secrets"] | null>();
-const lazySetupSecretsById = new Map<ChannelId, ChannelPlugin["secrets"] | null>();
+export function listBundledChannelPluginIds(): readonly ChannelId[] {
+  return listBundledChannelPluginIdsForRoot(resolveBundledChannelPackageRoot());
+}
 
-function resolveBundledChannelMetadata(id: ChannelId): BundledChannelPluginMetadata | undefined {
-  return listBundledChannelMetadata().find(
+function resolveBundledChannelMetadata(
+  id: ChannelId,
+  packageRoot: string,
+): BundledChannelPluginMetadata | undefined {
+  return listBundledChannelMetadata(packageRoot).find(
     (metadata) => metadata.manifest.id === id || metadata.manifest.channels?.includes(id),
   );
 }
 
-function getLazyGeneratedBundledChannelEntry(
+function getLazyGeneratedBundledChannelEntryForRoot(
   id: ChannelId,
+  packageRoot: string,
+  cacheContext: BundledChannelCacheContext,
   params?: { includeSetup?: boolean },
 ): GeneratedBundledChannelEntry | null {
-  const cached = lazyEntriesById.get(id);
+  const cached = cacheContext.lazyEntriesById.get(id);
   if (cached && (!params?.includeSetup || cached.setupEntry)) {
     return cached;
   }
   if (cached === null && !params?.includeSetup) {
     return null;
   }
-  const metadata = resolveBundledChannelMetadata(id);
+  const metadata = resolveBundledChannelMetadata(id, packageRoot);
   if (!metadata) {
-    lazyEntriesById.set(id, null);
+    cacheContext.lazyEntriesById.set(id, null);
     return null;
   }
-  if (entryLoadInProgressIds.has(id)) {
+  if (cacheContext.entryLoadInProgressIds.has(id)) {
     return null;
   }
-  entryLoadInProgressIds.add(id);
+  cacheContext.entryLoadInProgressIds.add(id);
   try {
     const entry = loadGeneratedBundledChannelEntry({
+      packageRoot,
       metadata,
       includeSetup: params?.includeSetup === true,
     });
-    lazyEntriesById.set(id, entry);
+    cacheContext.lazyEntriesById.set(id, entry);
     if (entry?.entry.id && entry.entry.id !== id) {
-      lazyEntriesById.set(entry.entry.id, entry);
+      cacheContext.lazyEntriesById.set(entry.entry.id, entry);
     }
     return entry;
   } finally {
-    entryLoadInProgressIds.delete(id);
+    cacheContext.entryLoadInProgressIds.delete(id);
   }
 }
 
+function getBundledChannelPluginForRoot(
+  id: ChannelId,
+  packageRoot: string,
+  cacheContext: BundledChannelCacheContext,
+): ChannelPlugin | undefined {
+  const cached = cacheContext.lazyPluginsById.get(id);
+  if (cached) {
+    return cached;
+  }
+  if (cacheContext.pluginLoadInProgressIds.has(id)) {
+    return undefined;
+  }
+  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext)?.entry;
+  if (!entry) {
+    return undefined;
+  }
+  cacheContext.pluginLoadInProgressIds.add(id);
+  try {
+    const plugin = entry.loadChannelPlugin();
+    cacheContext.lazyPluginsById.set(id, plugin);
+    return plugin;
+  } finally {
+    cacheContext.pluginLoadInProgressIds.delete(id);
+  }
+}
+
+function getBundledChannelSecretsForRoot(
+  id: ChannelId,
+  packageRoot: string,
+  cacheContext: BundledChannelCacheContext,
+): ChannelPlugin["secrets"] | undefined {
+  if (cacheContext.lazySecretsById.has(id)) {
+    return cacheContext.lazySecretsById.get(id) ?? undefined;
+  }
+  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext)?.entry;
+  if (!entry) {
+    return undefined;
+  }
+  const secrets =
+    entry.loadChannelSecrets?.() ??
+    getBundledChannelPluginForRoot(id, packageRoot, cacheContext)?.secrets;
+  cacheContext.lazySecretsById.set(id, secrets ?? null);
+  return secrets;
+}
+
+function getBundledChannelSetupPluginForRoot(
+  id: ChannelId,
+  packageRoot: string,
+  cacheContext: BundledChannelCacheContext,
+): ChannelPlugin | undefined {
+  const cached = cacheContext.lazySetupPluginsById.get(id);
+  if (cached) {
+    return cached;
+  }
+  if (cacheContext.setupPluginLoadInProgressIds.has(id)) {
+    return undefined;
+  }
+  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext, {
+    includeSetup: true,
+  })?.setupEntry;
+  if (!entry) {
+    return undefined;
+  }
+  cacheContext.setupPluginLoadInProgressIds.add(id);
+  try {
+    const plugin = entry.loadSetupPlugin();
+    cacheContext.lazySetupPluginsById.set(id, plugin);
+    return plugin;
+  } finally {
+    cacheContext.setupPluginLoadInProgressIds.delete(id);
+  }
+}
+
+function getBundledChannelSetupSecretsForRoot(
+  id: ChannelId,
+  packageRoot: string,
+  cacheContext: BundledChannelCacheContext,
+): ChannelPlugin["secrets"] | undefined {
+  if (cacheContext.lazySetupSecretsById.has(id)) {
+    return cacheContext.lazySetupSecretsById.get(id) ?? undefined;
+  }
+  const entry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext, {
+    includeSetup: true,
+  })?.setupEntry;
+  if (!entry) {
+    return undefined;
+  }
+  const secrets =
+    entry.loadSetupSecrets?.() ??
+    getBundledChannelSetupPluginForRoot(id, packageRoot, cacheContext)?.secrets;
+  cacheContext.lazySetupSecretsById.set(id, secrets ?? null);
+  return secrets;
+}
+
 export function listBundledChannelPlugins(): readonly ChannelPlugin[] {
-  return listBundledChannelPluginIds().flatMap((id) => {
-    const plugin = getBundledChannelPlugin(id);
+  const packageRoot = resolveBundledChannelPackageRoot();
+  const cacheContext = getBundledChannelCacheContext(packageRoot);
+  return listBundledChannelPluginIdsForRoot(packageRoot).flatMap((id) => {
+    const plugin = getBundledChannelPluginForRoot(id, packageRoot, cacheContext);
     return plugin ? [plugin] : [];
   });
 }
 
 export function listBundledChannelSetupPlugins(): readonly ChannelPlugin[] {
-  return listBundledChannelPluginIds().flatMap((id) => {
-    const plugin = getBundledChannelSetupPlugin(id);
+  const packageRoot = resolveBundledChannelPackageRoot();
+  const cacheContext = getBundledChannelCacheContext(packageRoot);
+  return listBundledChannelPluginIdsForRoot(packageRoot).flatMap((id) => {
+    const plugin = getBundledChannelSetupPluginForRoot(id, packageRoot, cacheContext);
     return plugin ? [plugin] : [];
   });
 }
@@ -303,84 +440,54 @@ export function listBundledChannelSetupPlugins(): readonly ChannelPlugin[] {
 export function listBundledChannelSetupPluginsByFeature(
   feature: keyof NonNullable<BundledChannelSetupEntryRuntimeContract["features"]>,
 ): readonly ChannelPlugin[] {
-  return listBundledChannelPluginIds().flatMap((id) => {
-    const setupEntry = getLazyGeneratedBundledChannelEntry(id, { includeSetup: true })?.setupEntry;
+  const packageRoot = resolveBundledChannelPackageRoot();
+  const cacheContext = getBundledChannelCacheContext(packageRoot);
+  return listBundledChannelPluginIdsForRoot(packageRoot).flatMap((id) => {
+    const setupEntry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext, {
+      includeSetup: true,
+    })?.setupEntry;
     if (!hasSetupEntryFeature(setupEntry, feature)) {
       return [];
     }
-    const plugin = getBundledChannelSetupPlugin(id);
+    const plugin = getBundledChannelSetupPluginForRoot(id, packageRoot, cacheContext);
     return plugin ? [plugin] : [];
   });
 }
 
 export function getBundledChannelPlugin(id: ChannelId): ChannelPlugin | undefined {
-  const cached = lazyPluginsById.get(id);
-  if (cached) {
-    return cached;
-  }
-  if (pluginLoadInProgressIds.has(id)) {
-    return undefined;
-  }
-  const entry = getLazyGeneratedBundledChannelEntry(id)?.entry;
-  if (!entry) {
-    return undefined;
-  }
-  pluginLoadInProgressIds.add(id);
-  try {
-    const plugin = entry.loadChannelPlugin();
-    lazyPluginsById.set(id, plugin);
-    return plugin;
-  } finally {
-    pluginLoadInProgressIds.delete(id);
-  }
+  const packageRoot = resolveBundledChannelPackageRoot();
+  return getBundledChannelPluginForRoot(
+    id,
+    packageRoot,
+    getBundledChannelCacheContext(packageRoot),
+  );
 }
 
 export function getBundledChannelSecrets(id: ChannelId): ChannelPlugin["secrets"] | undefined {
-  if (lazySecretsById.has(id)) {
-    return lazySecretsById.get(id) ?? undefined;
-  }
-  const entry = getLazyGeneratedBundledChannelEntry(id)?.entry;
-  if (!entry) {
-    return undefined;
-  }
-  const secrets = entry.loadChannelSecrets?.() ?? getBundledChannelPlugin(id)?.secrets;
-  lazySecretsById.set(id, secrets ?? null);
-  return secrets;
+  const packageRoot = resolveBundledChannelPackageRoot();
+  return getBundledChannelSecretsForRoot(
+    id,
+    packageRoot,
+    getBundledChannelCacheContext(packageRoot),
+  );
 }
 
 export function getBundledChannelSetupPlugin(id: ChannelId): ChannelPlugin | undefined {
-  const cached = lazySetupPluginsById.get(id);
-  if (cached) {
-    return cached;
-  }
-  if (setupPluginLoadInProgressIds.has(id)) {
-    return undefined;
-  }
-  const entry = getLazyGeneratedBundledChannelEntry(id, { includeSetup: true })?.setupEntry;
-  if (!entry) {
-    return undefined;
-  }
-  setupPluginLoadInProgressIds.add(id);
-  try {
-    const plugin = entry.loadSetupPlugin();
-    lazySetupPluginsById.set(id, plugin);
-    return plugin;
-  } finally {
-    setupPluginLoadInProgressIds.delete(id);
-  }
+  const packageRoot = resolveBundledChannelPackageRoot();
+  return getBundledChannelSetupPluginForRoot(
+    id,
+    packageRoot,
+    getBundledChannelCacheContext(packageRoot),
+  );
 }
 
 export function getBundledChannelSetupSecrets(id: ChannelId): ChannelPlugin["secrets"] | undefined {
-  if (lazySetupSecretsById.has(id)) {
-    return lazySetupSecretsById.get(id) ?? undefined;
-  }
-  const entry = getLazyGeneratedBundledChannelEntry(id, { includeSetup: true })?.setupEntry;
-  if (!entry) {
-    return undefined;
-  }
-  const secrets = entry.loadSetupSecrets?.() ?? getBundledChannelSetupPlugin(id)?.secrets;
-  lazySetupSecretsById.set(id, secrets ?? null);
-  return secrets;
+  const packageRoot = resolveBundledChannelPackageRoot();
+  return getBundledChannelSetupSecretsForRoot(
+    id,
+    packageRoot,
+    getBundledChannelCacheContext(packageRoot),
+  );
 }
 
 export function requireBundledChannelPlugin(id: ChannelId): ChannelPlugin {
@@ -392,7 +499,12 @@ export function requireBundledChannelPlugin(id: ChannelId): ChannelPlugin {
 }
 
 export function setBundledChannelRuntime(id: ChannelId, runtime: PluginRuntime): void {
-  const setter = getLazyGeneratedBundledChannelEntry(id)?.entry.setChannelRuntime;
+  const packageRoot = resolveBundledChannelPackageRoot();
+  const setter = getLazyGeneratedBundledChannelEntryForRoot(
+    id,
+    packageRoot,
+    getBundledChannelCacheContext(packageRoot),
+  )?.entry.setChannelRuntime;
   if (!setter) {
     throw new Error(`missing bundled channel runtime setter: ${id}`);
   }

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -140,18 +140,15 @@ function loadGeneratedBundledChannelModule(params: {
   if (!modulePath) {
     throw new Error(`missing generated module for bundled channel ${params.metadata.manifest.id}`);
   }
+  const boundaryRoot = resolveBundledChannelBoundaryRoot({
+    packageRoot: params.packageRoot,
+    metadata: params.metadata,
+    modulePath,
+  });
   return loadChannelPluginModule({
     modulePath,
-    rootDir: resolveBundledChannelBoundaryRoot({
-      packageRoot: params.packageRoot,
-      metadata: params.metadata,
-      modulePath,
-    }),
-    boundaryRootDir: resolveBundledChannelBoundaryRoot({
-      packageRoot: params.packageRoot,
-      metadata: params.metadata,
-      modulePath,
-    }),
+    rootDir: boundaryRoot,
+    boundaryRootDir: boundaryRoot,
     shouldTryNativeRequire: (safePath) =>
       safePath.includes(`${path.sep}dist${path.sep}`) && isJavaScriptModulePath(safePath),
   });
@@ -201,12 +198,8 @@ function loadGeneratedBundledChannelEntry(params: {
 const cachedBundledChannelMetadata = new Map<string, readonly BundledChannelPluginMetadata[]>();
 const bundledChannelCacheContexts = new Map<string, BundledChannelCacheContext>();
 
-function getBundledChannelCacheContext(packageRoot: string): BundledChannelCacheContext {
-  const cached = bundledChannelCacheContexts.get(packageRoot);
-  if (cached) {
-    return cached;
-  }
-  const created: BundledChannelCacheContext = {
+function createBundledChannelCacheContext(): BundledChannelCacheContext {
+  return {
     pluginLoadInProgressIds: new Set(),
     setupPluginLoadInProgressIds: new Set(),
     entryLoadInProgressIds: new Set(),
@@ -216,8 +209,27 @@ function getBundledChannelCacheContext(packageRoot: string): BundledChannelCache
     lazySecretsById: new Map(),
     lazySetupSecretsById: new Map(),
   };
+}
+
+function getBundledChannelCacheContext(packageRoot: string): BundledChannelCacheContext {
+  const cached = bundledChannelCacheContexts.get(packageRoot);
+  if (cached) {
+    return cached;
+  }
+  const created = createBundledChannelCacheContext();
   bundledChannelCacheContexts.set(packageRoot, created);
   return created;
+}
+
+function resolveActiveBundledChannelCacheScope(): {
+  packageRoot: string;
+  cacheContext: BundledChannelCacheContext;
+} {
+  const packageRoot = resolveBundledChannelPackageRoot();
+  return {
+    packageRoot,
+    cacheContext: getBundledChannelCacheContext(packageRoot),
+  };
 }
 
 function listBundledChannelMetadata(
@@ -388,8 +400,7 @@ function getBundledChannelSetupSecretsForRoot(
 }
 
 export function listBundledChannelPlugins(): readonly ChannelPlugin[] {
-  const packageRoot = resolveBundledChannelPackageRoot();
-  const cacheContext = getBundledChannelCacheContext(packageRoot);
+  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
   return listBundledChannelPluginIdsForRoot(packageRoot).flatMap((id) => {
     const plugin = getBundledChannelPluginForRoot(id, packageRoot, cacheContext);
     return plugin ? [plugin] : [];
@@ -397,8 +408,7 @@ export function listBundledChannelPlugins(): readonly ChannelPlugin[] {
 }
 
 export function listBundledChannelSetupPlugins(): readonly ChannelPlugin[] {
-  const packageRoot = resolveBundledChannelPackageRoot();
-  const cacheContext = getBundledChannelCacheContext(packageRoot);
+  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
   return listBundledChannelPluginIdsForRoot(packageRoot).flatMap((id) => {
     const plugin = getBundledChannelSetupPluginForRoot(id, packageRoot, cacheContext);
     return plugin ? [plugin] : [];
@@ -408,8 +418,7 @@ export function listBundledChannelSetupPlugins(): readonly ChannelPlugin[] {
 export function listBundledChannelSetupPluginsByFeature(
   feature: keyof NonNullable<BundledChannelSetupEntryRuntimeContract["features"]>,
 ): readonly ChannelPlugin[] {
-  const packageRoot = resolveBundledChannelPackageRoot();
-  const cacheContext = getBundledChannelCacheContext(packageRoot);
+  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
   return listBundledChannelPluginIdsForRoot(packageRoot).flatMap((id) => {
     const setupEntry = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext, {
       includeSetup: true,
@@ -423,39 +432,23 @@ export function listBundledChannelSetupPluginsByFeature(
 }
 
 export function getBundledChannelPlugin(id: ChannelId): ChannelPlugin | undefined {
-  const packageRoot = resolveBundledChannelPackageRoot();
-  return getBundledChannelPluginForRoot(
-    id,
-    packageRoot,
-    getBundledChannelCacheContext(packageRoot),
-  );
+  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return getBundledChannelPluginForRoot(id, packageRoot, cacheContext);
 }
 
 export function getBundledChannelSecrets(id: ChannelId): ChannelPlugin["secrets"] | undefined {
-  const packageRoot = resolveBundledChannelPackageRoot();
-  return getBundledChannelSecretsForRoot(
-    id,
-    packageRoot,
-    getBundledChannelCacheContext(packageRoot),
-  );
+  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return getBundledChannelSecretsForRoot(id, packageRoot, cacheContext);
 }
 
 export function getBundledChannelSetupPlugin(id: ChannelId): ChannelPlugin | undefined {
-  const packageRoot = resolveBundledChannelPackageRoot();
-  return getBundledChannelSetupPluginForRoot(
-    id,
-    packageRoot,
-    getBundledChannelCacheContext(packageRoot),
-  );
+  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return getBundledChannelSetupPluginForRoot(id, packageRoot, cacheContext);
 }
 
 export function getBundledChannelSetupSecrets(id: ChannelId): ChannelPlugin["secrets"] | undefined {
-  const packageRoot = resolveBundledChannelPackageRoot();
-  return getBundledChannelSetupSecretsForRoot(
-    id,
-    packageRoot,
-    getBundledChannelCacheContext(packageRoot),
-  );
+  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
+  return getBundledChannelSetupSecretsForRoot(id, packageRoot, cacheContext);
 }
 
 export function requireBundledChannelPlugin(id: ChannelId): ChannelPlugin {
@@ -467,12 +460,9 @@ export function requireBundledChannelPlugin(id: ChannelId): ChannelPlugin {
 }
 
 export function setBundledChannelRuntime(id: ChannelId, runtime: PluginRuntime): void {
-  const packageRoot = resolveBundledChannelPackageRoot();
-  const setter = getLazyGeneratedBundledChannelEntryForRoot(
-    id,
-    packageRoot,
-    getBundledChannelCacheContext(packageRoot),
-  )?.entry.setChannelRuntime;
+  const { packageRoot, cacheContext } = resolveActiveBundledChannelCacheScope();
+  const setter = getLazyGeneratedBundledChannelEntryForRoot(id, packageRoot, cacheContext)?.entry
+    .setChannelRuntime;
   if (!setter) {
     throw new Error(`missing bundled channel runtime setter: ${id}`);
   }

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -8,6 +8,7 @@ import {
   resolveBundledChannelGeneratedPath,
   type BundledChannelPluginMetadata,
 } from "../../plugins/bundled-channel-runtime.js";
+import { resolveBundledPluginsDir } from "../../plugins/bundled-dir.js";
 import { unwrapDefaultModuleExport } from "../../plugins/module-export.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import { isJavaScriptModulePath, loadChannelPluginModule } from "./module-loader.js";
@@ -51,6 +52,27 @@ const OPENCLAW_PACKAGE_ROOT =
   (import.meta.url.startsWith("file:")
     ? path.resolve(fileURLToPath(new URL("../../..", import.meta.url)))
     : process.cwd());
+
+function derivePackageRootFromBundledPluginsDir(pluginsDir: string): string {
+  const resolvedDir = path.resolve(pluginsDir);
+  if (path.basename(resolvedDir) !== "extensions") {
+    return resolvedDir;
+  }
+  const parentDir = path.dirname(resolvedDir);
+  const parentBase = path.basename(parentDir);
+  if (parentBase === "dist" || parentBase === "dist-runtime") {
+    return path.dirname(parentDir);
+  }
+  return parentDir;
+}
+
+function resolveBundledChannelPackageRoot(): string {
+  const bundledPluginsDir = resolveBundledPluginsDir(process.env);
+  if (bundledPluginsDir) {
+    return derivePackageRootFromBundledPluginsDir(bundledPluginsDir);
+  }
+  return OPENCLAW_PACKAGE_ROOT;
+}
 
 function resolveChannelPluginModuleEntry(
   moduleExport: unknown,
@@ -103,16 +125,12 @@ function resolveBundledChannelBoundaryRoot(params: {
   metadata: BundledChannelPluginMetadata;
   modulePath: string;
 }): string {
-  const distRoot = path.resolve(
-    OPENCLAW_PACKAGE_ROOT,
-    "dist",
-    "extensions",
-    params.metadata.dirName,
-  );
+  const packageRoot = resolveBundledChannelPackageRoot();
+  const distRoot = path.resolve(packageRoot, "dist", "extensions", params.metadata.dirName);
   if (params.modulePath === distRoot || params.modulePath.startsWith(`${distRoot}${path.sep}`)) {
     return distRoot;
   }
-  return path.resolve(OPENCLAW_PACKAGE_ROOT, "extensions", params.metadata.dirName);
+  return path.resolve(packageRoot, "extensions", params.metadata.dirName);
 }
 
 function resolveGeneratedBundledChannelModulePath(params: {
@@ -122,8 +140,9 @@ function resolveGeneratedBundledChannelModulePath(params: {
   if (!params.entry) {
     return null;
   }
+  const packageRoot = resolveBundledChannelPackageRoot();
   const resolved = resolveBundledChannelGeneratedPath(
-    OPENCLAW_PACKAGE_ROOT,
+    packageRoot,
     params.entry,
     params.metadata.dirName,
   );
@@ -194,14 +213,21 @@ function loadGeneratedBundledChannelEntry(params: {
   }
 }
 
-let cachedBundledChannelMetadata: readonly BundledChannelPluginMetadata[] | null = null;
+const cachedBundledChannelMetadata = new Map<string, readonly BundledChannelPluginMetadata[]>();
 
 function listBundledChannelMetadata(): readonly BundledChannelPluginMetadata[] {
-  cachedBundledChannelMetadata ??= listBundledChannelPluginMetadata({
+  const packageRoot = resolveBundledChannelPackageRoot();
+  const cached = cachedBundledChannelMetadata.get(packageRoot);
+  if (cached) {
+    return cached;
+  }
+  const loaded = listBundledChannelPluginMetadata({
+    rootDir: packageRoot,
     includeChannelConfigs: false,
     includeSyntheticChannelConfigs: false,
   }).filter((metadata) => (metadata.manifest.channels?.length ?? 0) > 0);
-  return cachedBundledChannelMetadata;
+  cachedBundledChannelMetadata.set(packageRoot, loaded);
+  return loaded;
 }
 
 export function listBundledChannelPluginIds(): readonly ChannelId[] {

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -44,6 +44,7 @@ type DefineBundledChannelSetupEntryOptions = {
   importMetaUrl: string;
   plugin: BundledEntryModuleRef;
   secrets?: BundledEntryModuleRef;
+  runtime?: BundledEntryModuleRef;
   features?: BundledChannelSetupEntryFeatures;
 };
 
@@ -68,6 +69,7 @@ export type BundledChannelSetupEntryContract<TPlugin = ChannelPlugin> = {
   kind: "bundled-channel-setup-entry";
   loadSetupPlugin: () => TPlugin;
   loadSetupSecrets?: () => ChannelPlugin["secrets"] | undefined;
+  setChannelRuntime?: (runtime: PluginRuntime) => void;
   features?: BundledChannelSetupEntryFeatures;
 };
 
@@ -380,8 +382,21 @@ export function defineBundledChannelSetupEntry<TPlugin = ChannelPlugin>({
   importMetaUrl,
   plugin,
   secrets,
+  runtime,
   features,
 }: DefineBundledChannelSetupEntryOptions): BundledChannelSetupEntryContract<TPlugin> {
+  // Bundled setup entries stay on a light path during setup-only/setup-runtime loads.
+  // When runtime wiring is needed, expose only the setter so the loader can hand
+  // the setup surface the active runtime without importing the full channel entry.
+  const setChannelRuntime = runtime
+    ? (pluginRuntime: PluginRuntime) => {
+        const setter = loadBundledEntryExportSync<(runtime: PluginRuntime) => void>(
+          importMetaUrl,
+          runtime,
+        );
+        setter(pluginRuntime);
+      }
+    : undefined;
   return {
     kind: "bundled-channel-setup-entry",
     loadSetupPlugin: () => loadBundledEntryExportSync<TPlugin>(importMetaUrl, plugin),
@@ -394,6 +409,7 @@ export function defineBundledChannelSetupEntry<TPlugin = ChannelPlugin>({
             ),
         }
       : {}),
+    ...(setChannelRuntime ? { setChannelRuntime } : {}),
     ...(features ? { features } : {}),
   };
 }

--- a/src/plugin-sdk/runtime-store.test.ts
+++ b/src/plugin-sdk/runtime-store.test.ts
@@ -70,6 +70,27 @@ describe("createPluginRuntimeStore", () => {
     expect(secondStore.getRuntime()).toEqual({ value: "custom" });
   });
 
+  test("rejects empty plugin ids", () => {
+    expect(() =>
+      createPluginRuntimeStore({
+        pluginId: "   ",
+        errorMessage: "runtime not initialized",
+      }),
+    ).toThrow("pluginId must not be empty");
+  });
+
+  test("treats falsy runtime values as initialized", () => {
+    const store = createPluginRuntimeStore<number>({
+      key: "custom-falsy-runtime-key",
+      errorMessage: "runtime not initialized",
+    });
+
+    store.clearRuntime();
+    store.setRuntime(0);
+
+    expect(store.getRuntime()).toBe(0);
+  });
+
   test("shares runtime slots across duplicate module instances when plugin id matches", async () => {
     const firstModule = await importFreshModule<typeof import("./runtime-store.js")>(
       import.meta.url,

--- a/src/plugin-sdk/runtime-store.test.ts
+++ b/src/plugin-sdk/runtime-store.test.ts
@@ -40,7 +40,7 @@ describe("createPluginRuntimeStore", () => {
     expect(rightStore.tryGetRuntime()).toBeNull();
   });
 
-  test("keeps legacy string callers working", () => {
+  test("keeps legacy string callers isolated per store", () => {
     const firstStore = createPluginRuntimeStore<{ value: string }>(
       "legacy runtime not initialized",
     );
@@ -51,7 +51,8 @@ describe("createPluginRuntimeStore", () => {
     firstStore.clearRuntime();
     firstStore.setRuntime({ value: "legacy" });
 
-    expect(secondStore.getRuntime()).toEqual({ value: "legacy" });
+    expect(firstStore.getRuntime()).toEqual({ value: "legacy" });
+    expect(secondStore.tryGetRuntime()).toBeNull();
   });
 
   test("still supports explicit custom store keys", () => {

--- a/src/plugin-sdk/runtime-store.test.ts
+++ b/src/plugin-sdk/runtime-store.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { importFreshModule } from "../../test/helpers/import-fresh.ts";
+import { createPluginRuntimeStore } from "./runtime-store.js";
+
+describe("createPluginRuntimeStore", () => {
+  test("shares runtime slots for the same plugin id", () => {
+    const firstStore = createPluginRuntimeStore<{ value: string }>({
+      pluginId: "shared-plugin",
+      errorMessage: "shared plugin runtime not initialized",
+    });
+    const secondStore = createPluginRuntimeStore<{ value: string }>({
+      pluginId: "shared-plugin",
+      errorMessage: "shared plugin runtime not initialized",
+    });
+
+    firstStore.clearRuntime();
+    firstStore.setRuntime({ value: "ok" });
+
+    expect(secondStore.getRuntime()).toEqual({ value: "ok" });
+
+    secondStore.clearRuntime();
+    expect(firstStore.tryGetRuntime()).toBeNull();
+  });
+
+  test("keeps different plugin ids isolated", () => {
+    const leftStore = createPluginRuntimeStore<{ value: string }>({
+      pluginId: "left-plugin",
+      errorMessage: "left runtime not initialized",
+    });
+    const rightStore = createPluginRuntimeStore<{ value: string }>({
+      pluginId: "right-plugin",
+      errorMessage: "right runtime not initialized",
+    });
+
+    leftStore.clearRuntime();
+    rightStore.clearRuntime();
+    leftStore.setRuntime({ value: "left" });
+
+    expect(leftStore.getRuntime()).toEqual({ value: "left" });
+    expect(rightStore.tryGetRuntime()).toBeNull();
+  });
+
+  test("keeps legacy string callers working", () => {
+    const firstStore = createPluginRuntimeStore<{ value: string }>(
+      "legacy runtime not initialized",
+    );
+    const secondStore = createPluginRuntimeStore<{ value: string }>(
+      "legacy runtime not initialized",
+    );
+
+    firstStore.clearRuntime();
+    firstStore.setRuntime({ value: "legacy" });
+
+    expect(secondStore.getRuntime()).toEqual({ value: "legacy" });
+  });
+
+  test("still supports explicit custom store keys", () => {
+    const firstStore = createPluginRuntimeStore<{ value: string }>({
+      key: "custom-runtime-key",
+      errorMessage: "custom runtime not initialized",
+    });
+    const secondStore = createPluginRuntimeStore<{ value: string }>({
+      key: "custom-runtime-key",
+      errorMessage: "custom runtime not initialized",
+    });
+
+    firstStore.clearRuntime();
+    firstStore.setRuntime({ value: "custom" });
+
+    expect(secondStore.getRuntime()).toEqual({ value: "custom" });
+  });
+
+  test("shares runtime slots across duplicate module instances when plugin id matches", async () => {
+    const firstModule = await importFreshModule<typeof import("./runtime-store.js")>(
+      import.meta.url,
+      "./runtime-store.js?scope=runtime-store-a",
+    );
+    const secondModule = await importFreshModule<typeof import("./runtime-store.js")>(
+      import.meta.url,
+      "./runtime-store.js?scope=runtime-store-b",
+    );
+    const firstStore = firstModule.createPluginRuntimeStore<{ value: string }>({
+      pluginId: "duplicate-module-plugin",
+      errorMessage: "duplicate module runtime not initialized",
+    });
+    const secondStore = secondModule.createPluginRuntimeStore<{ value: string }>({
+      pluginId: "duplicate-module-plugin",
+      errorMessage: "duplicate module runtime not initialized",
+    });
+
+    firstStore.clearRuntime();
+    firstStore.setRuntime({ value: "shared" });
+
+    expect(secondStore.getRuntime()).toEqual({ value: "shared" });
+  });
+});

--- a/src/plugin-sdk/runtime-store.ts
+++ b/src/plugin-sdk/runtime-store.ts
@@ -22,7 +22,11 @@ function getPluginRuntimeStoreRegistry(): PluginRuntimeStoreRegistry {
 }
 
 function pluginRuntimeStoreKeyForPluginId(pluginId: string): string {
-  return `plugin-runtime:${pluginId.trim()}`;
+  const normalizedPluginId = pluginId.trim();
+  if (!normalizedPluginId) {
+    throw new Error("createPluginRuntimeStore: pluginId must not be empty");
+  }
+  return `plugin-runtime:${normalizedPluginId}`;
 }
 
 function resolvePluginRuntimeStoreOptions(
@@ -78,7 +82,7 @@ export function createPluginRuntimeStore<T>(options: string | PluginRuntimeStore
       return (slot.runtime as T | null) ?? null;
     },
     getRuntime() {
-      if (!slot.runtime) {
+      if (slot.runtime === null) {
         throw new Error(resolved.errorMessage);
       }
       return slot.runtime as T;

--- a/src/plugin-sdk/runtime-store.ts
+++ b/src/plugin-sdk/runtime-store.ts
@@ -1,29 +1,87 @@
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 
+const pluginRuntimeStoreRegistryKey = Symbol.for("openclaw.plugin-sdk.runtime-store-registry");
+
+type PluginRuntimeStoreRegistry = Map<string, { runtime: unknown }>;
+type PluginRuntimeStoreKeyOptions = {
+  key: string;
+  errorMessage: string;
+};
+type PluginRuntimeStorePluginOptions = {
+  pluginId: string;
+  errorMessage: string;
+};
+type PluginRuntimeStoreOptions = PluginRuntimeStoreKeyOptions | PluginRuntimeStorePluginOptions;
+
+function getPluginRuntimeStoreRegistry(): PluginRuntimeStoreRegistry {
+  const globalRecord = globalThis as typeof globalThis & {
+    [pluginRuntimeStoreRegistryKey]?: PluginRuntimeStoreRegistry;
+  };
+  globalRecord[pluginRuntimeStoreRegistryKey] ??= new Map();
+  return globalRecord[pluginRuntimeStoreRegistryKey];
+}
+
+function pluginRuntimeStoreKeyForPluginId(pluginId: string): string {
+  return `plugin-runtime:${pluginId.trim()}`;
+}
+
+function resolvePluginRuntimeStoreOptions(
+  options: string | PluginRuntimeStoreOptions,
+): PluginRuntimeStoreKeyOptions {
+  if (typeof options === "string") {
+    return { key: options, errorMessage: options };
+  }
+  if ("pluginId" in options) {
+    return {
+      key: pluginRuntimeStoreKeyForPluginId(options.pluginId),
+      errorMessage: options.errorMessage,
+    };
+  }
+  return options;
+}
+
 /** Create a tiny mutable runtime slot with strict access when the runtime has not been initialized. */
 export function createPluginRuntimeStore<T>(errorMessage: string): {
   setRuntime: (next: T) => void;
   clearRuntime: () => void;
   tryGetRuntime: () => T | null;
   getRuntime: () => T;
+};
+export function createPluginRuntimeStore<T>(options: PluginRuntimeStoreOptions): {
+  setRuntime: (next: T) => void;
+  clearRuntime: () => void;
+  tryGetRuntime: () => T | null;
+  getRuntime: () => T;
+};
+export function createPluginRuntimeStore<T>(options: string | PluginRuntimeStoreOptions): {
+  setRuntime: (next: T) => void;
+  clearRuntime: () => void;
+  tryGetRuntime: () => T | null;
+  getRuntime: () => T;
 } {
-  let runtime: T | null = null;
+  const resolved = resolvePluginRuntimeStoreOptions(options);
+  const registry = getPluginRuntimeStoreRegistry();
+  let slot = registry.get(resolved.key);
+  if (!slot) {
+    slot = { runtime: null };
+    registry.set(resolved.key, slot);
+  }
 
   return {
     setRuntime(next: T) {
-      runtime = next;
+      slot.runtime = next;
     },
     clearRuntime() {
-      runtime = null;
+      slot.runtime = null;
     },
     tryGetRuntime() {
-      return runtime;
+      return (slot.runtime as T | null) ?? null;
     },
     getRuntime() {
-      if (!runtime) {
-        throw new Error(errorMessage);
+      if (!slot.runtime) {
+        throw new Error(resolved.errorMessage);
       }
-      return runtime;
+      return slot.runtime as T;
     },
   };
 }

--- a/src/plugin-sdk/runtime-store.ts
+++ b/src/plugin-sdk/runtime-store.ts
@@ -64,12 +64,18 @@ export function createPluginRuntimeStore<T>(options: string | PluginRuntimeStore
   getRuntime: () => T;
 } {
   const resolved = resolvePluginRuntimeStoreOptions(options);
-  const registry = getPluginRuntimeStoreRegistry();
-  let slot = registry.get(resolved.key);
-  if (!slot) {
-    slot = { runtime: null };
-    registry.set(resolved.key, slot);
-  }
+  const slot =
+    typeof options === "string"
+      ? { runtime: null }
+      : (() => {
+          const registry = getPluginRuntimeStoreRegistry();
+          let existingSlot = registry.get(resolved.key);
+          if (!existingSlot) {
+            existingSlot = { runtime: null };
+            registry.set(resolved.key, existingSlot);
+          }
+          return existingSlot;
+        })();
 
   return {
     setRuntime(next: T) {

--- a/src/plugins/bundled-channel-runtime.ts
+++ b/src/plugins/bundled-channel-runtime.ts
@@ -9,6 +9,7 @@ export type BundledChannelPluginMetadata = BundledPluginMetadata;
 
 export function listBundledChannelPluginMetadata(params?: {
   rootDir?: string;
+  scanDir?: string;
   includeChannelConfigs?: boolean;
   includeSyntheticChannelConfigs?: boolean;
 }): readonly BundledChannelPluginMetadata[] {
@@ -19,12 +20,14 @@ export function resolveBundledChannelGeneratedPath(
   rootDir: string,
   entry: BundledPluginMetadata["source"] | BundledPluginMetadata["setupSource"],
   pluginDirName?: string,
+  scanDir?: string,
 ): string | null {
-  return resolveBundledPluginGeneratedPath(rootDir, entry, pluginDirName);
+  return resolveBundledPluginGeneratedPath(rootDir, entry, pluginDirName, scanDir);
 }
 
 export function resolveBundledChannelWorkspacePath(params: {
   rootDir: string;
+  scanDir?: string;
   pluginId: string;
 }): string | null {
   return resolveBundledPluginWorkspaceSourcePath(params);

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -274,6 +274,45 @@ describe("bundled plugin metadata", () => {
     );
   });
 
+  it("scans direct plugin-tree overrides and resolves generated paths from that scan dir", () => {
+    const tempRoot = createGeneratedPluginTempRoot("openclaw-bundled-plugin-direct-tree-");
+    const pluginsDir = path.join(tempRoot, "bundled-plugins");
+    const pluginRoot = path.join(pluginsDir, "alpha");
+
+    writeJson(path.join(pluginRoot, "package.json"), {
+      name: "@openclaw/alpha",
+      version: "0.0.1",
+      openclaw: {
+        extensions: ["./index.ts"],
+      },
+    });
+    writeJson(path.join(pluginRoot, "openclaw.plugin.json"), {
+      id: "alpha",
+      channels: ["alpha"],
+      configSchema: { type: "object" },
+    });
+    fs.writeFileSync(path.join(pluginRoot, "index.ts"), "export const source = true;\n", "utf8");
+
+    clearBundledPluginMetadataCache();
+    expect(
+      listBundledPluginMetadata({
+        rootDir: tempRoot,
+        scanDir: pluginsDir,
+      }).map((entry) => entry.manifest.id),
+    ).toEqual(["alpha"]);
+    expect(
+      resolveBundledPluginGeneratedPath(
+        tempRoot,
+        {
+          source: "./index.ts",
+          built: "index.js",
+        },
+        "alpha",
+        pluginsDir,
+      ),
+    ).toBe(path.join(pluginRoot, "index.ts"));
+  });
+
   it("resolves bundled repo entry paths from dist before workspace source", () => {
     const tempRoot = createGeneratedPluginTempRoot("openclaw-bundled-plugin-repo-entry-");
     const pluginRoot = path.join(tempRoot, "extensions", "alpha");

--- a/src/plugins/bundled-plugin-metadata.ts
+++ b/src/plugins/bundled-plugin-metadata.ts
@@ -67,26 +67,44 @@ function readPackageManifest(pluginDir: string): PackageManifest | undefined {
   }
 }
 
-function collectBundledPluginMetadataForPackageRoot(
+function resolveBundledPluginMetadataScanDir(
   packageRoot: string,
-  includeChannelConfigs: boolean,
-  includeSyntheticChannelConfigs: boolean,
-): readonly BundledPluginMetadata[] {
-  const scanDir = resolveBundledPluginScanDir({
+  scanDir?: string,
+): string | undefined {
+  if (scanDir) {
+    return path.resolve(scanDir);
+  }
+  return resolveBundledPluginScanDir({
     packageRoot,
     runningFromBuiltArtifact: RUNNING_FROM_BUILT_ARTIFACT,
   });
-  if (!scanDir || !fs.existsSync(scanDir)) {
+}
+
+function resolveBundledPluginLookupParams(params: { rootDir: string; scanDir?: string }): {
+  rootDir: string;
+  scanDir?: string;
+} {
+  return params.scanDir ? params : { rootDir: params.rootDir };
+}
+
+function collectBundledPluginMetadata(
+  packageRoot: string,
+  includeChannelConfigs: boolean,
+  includeSyntheticChannelConfigs: boolean,
+  scanDir?: string,
+): readonly BundledPluginMetadata[] {
+  const resolvedScanDir = resolveBundledPluginMetadataScanDir(packageRoot, scanDir);
+  if (!resolvedScanDir || !fs.existsSync(resolvedScanDir)) {
     return [];
   }
 
   const entries: BundledPluginMetadata[] = [];
   for (const dirName of fs
-    .readdirSync(scanDir, { withFileTypes: true })
+    .readdirSync(resolvedScanDir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
     .toSorted((left, right) => left.localeCompare(right))) {
-    const pluginDir = path.join(scanDir, dirName);
+    const pluginDir = path.join(resolvedScanDir, dirName);
     const manifestResult = loadPluginManifest(pluginDir, false);
     if (!manifestResult.ok) {
       continue;
@@ -165,15 +183,18 @@ function collectBundledPluginMetadataForPackageRoot(
 
 export function listBundledPluginMetadata(params?: {
   rootDir?: string;
+  scanDir?: string;
   includeChannelConfigs?: boolean;
   includeSyntheticChannelConfigs?: boolean;
 }): readonly BundledPluginMetadata[] {
   const rootDir = path.resolve(params?.rootDir ?? OPENCLAW_PACKAGE_ROOT);
+  const scanDir = params?.scanDir ? path.resolve(params.scanDir) : undefined;
   const includeChannelConfigs = params?.includeChannelConfigs ?? !RUNNING_FROM_BUILT_ARTIFACT;
   const includeSyntheticChannelConfigs =
     params?.includeSyntheticChannelConfigs ?? includeChannelConfigs;
   const cacheKey = JSON.stringify({
     rootDir,
+    scanDir,
     includeChannelConfigs,
     includeSyntheticChannelConfigs,
   });
@@ -182,10 +203,11 @@ export function listBundledPluginMetadata(params?: {
     return cached;
   }
   const entries = Object.freeze(
-    collectBundledPluginMetadataForPackageRoot(
+    collectBundledPluginMetadata(
       rootDir,
       includeChannelConfigs,
       includeSyntheticChannelConfigs,
+      scanDir,
     ),
   );
   bundledPluginMetadataCache.set(cacheKey, entries);
@@ -194,26 +216,50 @@ export function listBundledPluginMetadata(params?: {
 
 export function findBundledPluginMetadataById(
   pluginId: string,
-  params?: { rootDir?: string },
+  params?: { rootDir?: string; scanDir?: string },
 ): BundledPluginMetadata | undefined {
   return listBundledPluginMetadata(params).find((entry) => entry.manifest.id === pluginId);
 }
 
 export function resolveBundledPluginWorkspaceSourcePath(params: {
   rootDir: string;
+  scanDir?: string;
   pluginId: string;
 }): string | null {
-  const metadata = findBundledPluginMetadataById(params.pluginId, { rootDir: params.rootDir });
+  const metadata = findBundledPluginMetadataById(
+    params.pluginId,
+    resolveBundledPluginLookupParams({
+      rootDir: params.rootDir,
+      scanDir: params.scanDir,
+    }),
+  );
   if (!metadata) {
     return null;
   }
+  if (params.scanDir) {
+    return path.resolve(params.scanDir, metadata.dirName);
+  }
   return path.resolve(params.rootDir, "extensions", metadata.dirName);
+}
+
+function listBundledPluginEntryBaseDirs(params: {
+  rootDir: string;
+  pluginDirName?: string;
+  scanDir?: string;
+}): string[] {
+  const baseDirs = [
+    path.resolve(params.rootDir, "dist", "extensions", params.pluginDirName ?? ""),
+    path.resolve(params.rootDir, "extensions", params.pluginDirName ?? ""),
+    ...(params.scanDir ? [path.resolve(params.scanDir, params.pluginDirName ?? "")] : []),
+  ];
+  return baseDirs.filter((entry, index, all) => all.indexOf(entry) === index);
 }
 
 export function resolveBundledPluginGeneratedPath(
   rootDir: string,
   entry: BundledPluginPathPair | undefined,
   pluginDirName?: string,
+  scanDir?: string,
 ): string | null {
   if (!entry) {
     return null;
@@ -221,10 +267,11 @@ export function resolveBundledPluginGeneratedPath(
   const entryOrder = [entry.built, entry.source].filter(
     (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
   );
-  const baseDirs = [
-    path.resolve(rootDir, "dist", "extensions", pluginDirName ?? ""),
-    path.resolve(rootDir, "extensions", pluginDirName ?? ""),
-  ];
+  const baseDirs = listBundledPluginEntryBaseDirs({
+    rootDir,
+    pluginDirName,
+    ...(scanDir ? { scanDir } : {}),
+  });
   for (const baseDir of baseDirs) {
     for (const entryPath of entryOrder) {
       const candidate = path.resolve(baseDir, normalizeRelativePluginEntryPath(entryPath));
@@ -244,8 +291,15 @@ export function resolveBundledPluginRepoEntryPath(params: {
   rootDir: string;
   pluginId: string;
   preferBuilt?: boolean;
+  scanDir?: string;
 }): string | null {
-  const metadata = findBundledPluginMetadataById(params.pluginId, { rootDir: params.rootDir });
+  const metadata = findBundledPluginMetadataById(
+    params.pluginId,
+    resolveBundledPluginLookupParams({
+      rootDir: params.rootDir,
+      scanDir: params.scanDir,
+    }),
+  );
   if (!metadata) {
     return null;
   }
@@ -253,10 +307,11 @@ export function resolveBundledPluginRepoEntryPath(params: {
   const entryOrder = params.preferBuilt
     ? [metadata.source.built, metadata.source.source]
     : [metadata.source.source, metadata.source.built];
-  const baseDirs = [
-    path.resolve(params.rootDir, "dist", "extensions", metadata.dirName),
-    path.resolve(params.rootDir, "extensions", metadata.dirName),
-  ];
+  const baseDirs = listBundledPluginEntryBaseDirs({
+    rootDir: params.rootDir,
+    pluginDirName: metadata.dirName,
+    ...(params.scanDir ? { scanDir: params.scanDir } : {}),
+  });
 
   for (const baseDir of baseDirs) {
     for (const entryPath of entryOrder) {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -522,8 +522,11 @@ function createSetupEntryChannelPluginFixture(params: {
   setupBlurb: string;
   configured: boolean;
   startupDeferConfiguredChannelFullLoadUntilAfterListen?: boolean;
+  useBundledFullEntryContract?: boolean;
   useBundledSetupEntryContract?: boolean;
   splitBundledSetupSecrets?: boolean;
+  bundledSetupRuntimeMarker?: string;
+  bundledFullRuntimeMarker?: string;
 }) {
   useNoBundledPlugins();
   const pluginDir = makeTempDir();
@@ -571,7 +574,39 @@ function createSetupEntryChannelPluginFixture(params: {
   );
   fs.writeFileSync(
     path.join(pluginDir, "index.cjs"),
-    `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
+    params.useBundledFullEntryContract
+      ? `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
+module.exports = {
+  kind: "bundled-channel-entry",
+  id: ${JSON.stringify(params.id)},
+  name: ${JSON.stringify(params.label)},
+  description: ${JSON.stringify(params.fullBlurb)},
+  loadChannelPlugin: () => ({
+    id: ${JSON.stringify(params.id)},
+    meta: {
+      id: ${JSON.stringify(params.id)},
+      label: ${JSON.stringify(params.label)},
+      selectionLabel: ${JSON.stringify(params.label)},
+      docsPath: ${JSON.stringify(`/channels/${params.id}`)},
+      blurb: ${JSON.stringify(params.fullBlurb)},
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => ${listAccountIds},
+      resolveAccount: () => ${resolveAccount},
+    },
+    outbound: { deliveryMode: "direct" },
+  }),
+  ${
+    params.bundledFullRuntimeMarker
+      ? `setChannelRuntime: () => {
+    require("node:fs").writeFileSync(${JSON.stringify(params.bundledFullRuntimeMarker)}, "loaded", "utf-8");
+  },`
+      : ""
+  }
+  register() {},
+};`
+      : `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
 module.exports = {
   id: ${JSON.stringify(params.id)},
   register(api) {
@@ -629,6 +664,13 @@ module.exports = {
       },
     ],
   }),`
+      : ""
+  }
+  ${
+    params.bundledSetupRuntimeMarker
+      ? `setChannelRuntime: () => {
+    require("node:fs").writeFileSync(${JSON.stringify(params.bundledSetupRuntimeMarker)}, "loaded", "utf-8");
+  },`
       : ""
   }
 };`
@@ -3268,7 +3310,7 @@ module.exports = {
             },
           },
         }),
-      expectFullLoaded: false,
+      expectFullLoaded: true,
       expectSetupLoaded: true,
       expectedChannels: 1,
     },
@@ -3294,10 +3336,65 @@ module.exports = {
             },
           },
         }),
-      expectFullLoaded: false,
+      expectFullLoaded: true,
       expectSetupLoaded: true,
       expectedChannels: 1,
       expectedSetupSecretId: "channels.setup-runtime-bundled-contract-secrets-test.setup-token",
+    },
+    {
+      name: "applies bundled setupEntry runtime setter for setup-runtime channel loads",
+      fixture: {
+        id: "setup-runtime-bundled-contract-runtime-test",
+        label: "Setup Runtime Bundled Contract Runtime Test",
+        packageName: "@openclaw/setup-runtime-bundled-contract-runtime-test",
+        fullBlurb: "full entry should not run while unconfigured",
+        setupBlurb: "setup runtime bundled contract runtime",
+        configured: false,
+        useBundledSetupEntryContract: true,
+        bundledSetupRuntimeMarker: path.join(makeTempDir(), "setup-runtime-applied.txt"),
+      },
+      load: ({ pluginDir }: { pluginDir: string }) =>
+        loadOpenClawPlugins({
+          cache: false,
+          config: {
+            plugins: {
+              load: { paths: [pluginDir] },
+              allow: ["setup-runtime-bundled-contract-runtime-test"],
+            },
+          },
+        }),
+      expectFullLoaded: true,
+      expectSetupLoaded: true,
+      expectedChannels: 1,
+      expectSetupRuntimeLoaded: true,
+    },
+    {
+      name: "merges bundled runtime plugin into setup-runtime channel loads",
+      fixture: {
+        id: "setup-runtime-bundled-runtime-merge-test",
+        label: "Setup Runtime Bundled Runtime Merge Test",
+        packageName: "@openclaw/setup-runtime-bundled-runtime-merge-test",
+        fullBlurb: "full runtime plugin",
+        setupBlurb: "setup runtime override",
+        configured: false,
+        useBundledFullEntryContract: true,
+        useBundledSetupEntryContract: true,
+        bundledFullRuntimeMarker: path.join(makeTempDir(), "bundled-runtime-applied.txt"),
+      },
+      load: ({ pluginDir }: { pluginDir: string }) =>
+        loadOpenClawPlugins({
+          cache: false,
+          config: {
+            plugins: {
+              load: { paths: [pluginDir] },
+              allow: ["setup-runtime-bundled-runtime-merge-test"],
+            },
+          },
+        }),
+      expectFullLoaded: true,
+      expectSetupLoaded: true,
+      expectedChannels: 1,
+      expectBundledFullRuntimeLoaded: true,
     },
     {
       name: "does not prefer setupEntry for configured channel loads without startup opt-in",
@@ -3339,6 +3436,8 @@ module.exports = {
       expectSetupLoaded,
       expectedChannels,
       expectedSetupSecretId,
+      expectSetupRuntimeLoaded,
+      expectBundledFullRuntimeLoaded,
     }) => {
       const built = createSetupEntryChannelPluginFixture(fixture);
       const registry = load({ pluginDir: built.pluginDir });
@@ -3347,6 +3446,16 @@ module.exports = {
       expect(fs.existsSync(built.setupMarker)).toBe(expectSetupLoaded);
       expect(registry.channelSetups).toHaveLength(1);
       expect(registry.channels).toHaveLength(expectedChannels);
+      if (fixture.bundledSetupRuntimeMarker) {
+        expect(fs.existsSync(fixture.bundledSetupRuntimeMarker)).toBe(
+          expectSetupRuntimeLoaded ?? false,
+        );
+      }
+      if (fixture.bundledFullRuntimeMarker) {
+        expect(fs.existsSync(fixture.bundledFullRuntimeMarker)).toBe(
+          expectBundledFullRuntimeLoaded ?? false,
+        );
+      }
       if (expectedSetupSecretId) {
         expect(registry.channelSetups[0]?.plugin.secrets?.secretTargetRegistryEntries).toEqual(
           expect.arrayContaining([

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -523,6 +523,7 @@ function createSetupEntryChannelPluginFixture(params: {
   configured: boolean;
   startupDeferConfiguredChannelFullLoadUntilAfterListen?: boolean;
   useBundledFullEntryContract?: boolean;
+  bundledFullEntryId?: string;
   useBundledSetupEntryContract?: boolean;
   splitBundledSetupSecrets?: boolean;
   bundledSetupRuntimeMarker?: string;
@@ -580,7 +581,7 @@ function createSetupEntryChannelPluginFixture(params: {
       ? `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
 module.exports = {
   kind: "bundled-channel-entry",
-  id: ${JSON.stringify(params.id)},
+  id: ${JSON.stringify(params.bundledFullEntryId ?? params.id)},
   name: ${JSON.stringify(params.label)},
   description: ${JSON.stringify(params.fullBlurb)},
   loadChannelPlugin: () => {
@@ -592,12 +593,12 @@ module.exports = {
         : ""
     }
     return {
-      id: ${JSON.stringify(params.id)},
+      id: ${JSON.stringify(params.bundledFullEntryId ?? params.id)},
       meta: {
-        id: ${JSON.stringify(params.id)},
+        id: ${JSON.stringify(params.bundledFullEntryId ?? params.id)},
         label: ${JSON.stringify(params.label)},
         selectionLabel: ${JSON.stringify(params.label)},
-        docsPath: ${JSON.stringify(`/channels/${params.id}`)},
+        docsPath: ${JSON.stringify(`/channels/${params.bundledFullEntryId ?? params.id}`)},
         blurb: ${JSON.stringify(params.fullBlurb)},
       },
       capabilities: { chatTypes: ["direct"] },
@@ -3587,6 +3588,39 @@ module.exports = {
     expect(registry.plugins.find((entry) => entry.id === "setup-runtime-helper-test")?.status).toBe(
       "loaded",
     );
+  });
+
+  it("rejects mismatched bundled runtime plugin ids during setup-runtime merge", () => {
+    const built = createSetupEntryChannelPluginFixture({
+      id: "setup-runtime-mismatch-test",
+      bundledFullEntryId: "wrong-runtime-id",
+      label: "Setup Runtime Mismatch Test",
+      packageName: "@openclaw/setup-runtime-mismatch-test",
+      fullBlurb: "full runtime plugin",
+      setupBlurb: "setup runtime override",
+      configured: false,
+      useBundledFullEntryContract: true,
+      useBundledSetupEntryContract: true,
+      bundledFullRuntimeMarker: path.join(makeTempDir(), "setup-runtime-mismatch.txt"),
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [built.pluginDir] },
+          allow: ["setup-runtime-mismatch-test"],
+        },
+      },
+    });
+
+    expect(
+      registry.plugins.find((entry) => entry.id === "setup-runtime-mismatch-test")?.status,
+    ).toBe("error");
+    expect(
+      registry.plugins.find((entry) => entry.id === "setup-runtime-mismatch-test")?.error,
+    ).toContain('runtime export uses "wrong-runtime-id"');
+    expect(registry.channels).toHaveLength(0);
   });
 
   it("isolates loadSetupPlugin errors as per-plugin diagnostics instead of crashing registry load", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -526,7 +526,9 @@ function createSetupEntryChannelPluginFixture(params: {
   useBundledSetupEntryContract?: boolean;
   splitBundledSetupSecrets?: boolean;
   bundledSetupRuntimeMarker?: string;
+  bundledSetupRuntimeError?: string;
   bundledFullRuntimeMarker?: string;
+  requireBundledFullRuntimeBeforeLoad?: boolean;
 }) {
   useNoBundledPlugins();
   const pluginDir = makeTempDir();
@@ -581,22 +583,31 @@ module.exports = {
   id: ${JSON.stringify(params.id)},
   name: ${JSON.stringify(params.label)},
   description: ${JSON.stringify(params.fullBlurb)},
-  loadChannelPlugin: () => ({
-    id: ${JSON.stringify(params.id)},
-    meta: {
+  loadChannelPlugin: () => {
+    ${
+      params.requireBundledFullRuntimeBeforeLoad && params.bundledFullRuntimeMarker
+        ? `if (!require("node:fs").existsSync(${JSON.stringify(params.bundledFullRuntimeMarker)})) {
+      throw new Error("bundled runtime not initialized");
+    }`
+        : ""
+    }
+    return {
       id: ${JSON.stringify(params.id)},
-      label: ${JSON.stringify(params.label)},
-      selectionLabel: ${JSON.stringify(params.label)},
-      docsPath: ${JSON.stringify(`/channels/${params.id}`)},
-      blurb: ${JSON.stringify(params.fullBlurb)},
-    },
-    capabilities: { chatTypes: ["direct"] },
-    config: {
-      listAccountIds: () => ${listAccountIds},
-      resolveAccount: () => ${resolveAccount},
-    },
-    outbound: { deliveryMode: "direct" },
-  }),
+      meta: {
+        id: ${JSON.stringify(params.id)},
+        label: ${JSON.stringify(params.label)},
+        selectionLabel: ${JSON.stringify(params.label)},
+        docsPath: ${JSON.stringify(`/channels/${params.id}`)},
+        blurb: ${JSON.stringify(params.fullBlurb)},
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ${listAccountIds},
+        resolveAccount: () => ${resolveAccount},
+      },
+      outbound: { deliveryMode: "direct" },
+    };
+  },
   ${
     params.bundledFullRuntimeMarker
       ? `setChannelRuntime: () => {
@@ -667,11 +678,15 @@ module.exports = {
       : ""
   }
   ${
-    params.bundledSetupRuntimeMarker
+    params.bundledSetupRuntimeError
       ? `setChannelRuntime: () => {
+    throw new Error(${JSON.stringify(params.bundledSetupRuntimeError)});
+  },`
+      : params.bundledSetupRuntimeMarker
+        ? `setChannelRuntime: () => {
     require("node:fs").writeFileSync(${JSON.stringify(params.bundledSetupRuntimeMarker)}, "loaded", "utf-8");
   },`
-      : ""
+        : ""
   }
 };`
       : `require("node:fs").writeFileSync(${JSON.stringify(setupMarker)}, "loaded", "utf-8");
@@ -3266,6 +3281,36 @@ module.exports = {
       expectedChannels: 0,
     },
     {
+      name: "keeps bundled setupEntry setup-only loads on the setup-safe path",
+      fixture: {
+        id: "setup-only-bundled-contract-test",
+        label: "Setup Only Bundled Contract Test",
+        packageName: "@openclaw/setup-only-bundled-contract-test",
+        fullBlurb: "full entry should not run in setup-only mode",
+        setupBlurb: "setup-only bundled contract",
+        configured: false,
+        useBundledSetupEntryContract: true,
+      },
+      load: ({ pluginDir }: { pluginDir: string }) =>
+        loadOpenClawPlugins({
+          cache: false,
+          config: {
+            plugins: {
+              load: { paths: [pluginDir] },
+              allow: ["setup-only-bundled-contract-test"],
+              entries: {
+                "setup-only-bundled-contract-test": { enabled: false },
+              },
+            },
+          },
+          includeSetupOnlyChannelPlugins: true,
+          onlyPluginIds: ["setup-only-bundled-contract-test"],
+        }),
+      expectFullLoaded: false,
+      expectSetupLoaded: true,
+      expectedChannels: 0,
+    },
+    {
       name: "uses package setupEntry for enabled but unconfigured channel loads",
       fixture: {
         id: "setup-runtime-test",
@@ -3474,6 +3519,75 @@ module.exports = {
       }
     },
   );
+
+  it("applies the bundled runtime setter before loading the merged setup-runtime plugin", () => {
+    const runtimeMarker = path.join(makeTempDir(), "setup-runtime-before-load.txt");
+    const built = createSetupEntryChannelPluginFixture({
+      id: "setup-runtime-order-test",
+      label: "Setup Runtime Order Test",
+      packageName: "@openclaw/setup-runtime-order-test",
+      fullBlurb: "full runtime plugin",
+      setupBlurb: "setup runtime override",
+      configured: false,
+      useBundledFullEntryContract: true,
+      useBundledSetupEntryContract: true,
+      bundledFullRuntimeMarker: runtimeMarker,
+      requireBundledFullRuntimeBeforeLoad: true,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [built.pluginDir] },
+          allow: ["setup-runtime-order-test"],
+        },
+      },
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "setup-runtime-order-test")?.status).toBe(
+      "loaded",
+    );
+    expect(fs.existsSync(runtimeMarker)).toBe(true);
+  });
+
+  it("records setup runtime setter failures without aborting the full load pass", () => {
+    const built = createSetupEntryChannelPluginFixture({
+      id: "setup-runtime-error-test",
+      label: "Setup Runtime Error Test",
+      packageName: "@openclaw/setup-runtime-error-test",
+      fullBlurb: "full runtime plugin",
+      setupBlurb: "setup runtime override",
+      configured: false,
+      useBundledSetupEntryContract: true,
+      bundledSetupRuntimeError: "broken setup runtime setter",
+    });
+    const helperPlugin = writePlugin({
+      id: "setup-runtime-helper-test",
+      filename: "setup-runtime-helper-test.cjs",
+      body: `module.exports = { id: "setup-runtime-helper-test", register() {} };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [built.pluginDir, helperPlugin.file] },
+          allow: ["setup-runtime-error-test", "setup-runtime-helper-test"],
+        },
+      },
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "setup-runtime-error-test")?.status).toBe(
+      "error",
+    );
+    expect(
+      registry.plugins.find((entry) => entry.id === "setup-runtime-error-test")?.error,
+    ).toContain("broken setup runtime setter");
+    expect(registry.plugins.find((entry) => entry.id === "setup-runtime-helper-test")?.status).toBe(
+      "loaded",
+    );
+  });
 
   it("isolates loadSetupPlugin errors as per-plugin diagnostics instead of crashing registry load", () => {
     useNoBundledPlugins();

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -525,6 +525,7 @@ function createSetupEntryChannelPluginFixture(params: {
   useBundledFullEntryContract?: boolean;
   bundledFullEntryId?: string;
   useBundledSetupEntryContract?: boolean;
+  bundledSetupEntryId?: string;
   splitBundledSetupSecrets?: boolean;
   bundledSetupRuntimeMarker?: string;
   bundledSetupRuntimeError?: string;
@@ -651,12 +652,12 @@ module.exports = {
 module.exports = {
   kind: "bundled-channel-setup-entry",
   loadSetupPlugin: () => ({
-    id: ${JSON.stringify(params.id)},
+    id: ${JSON.stringify(params.bundledSetupEntryId ?? params.id)},
     meta: {
-      id: ${JSON.stringify(params.id)},
+      id: ${JSON.stringify(params.bundledSetupEntryId ?? params.id)},
       label: ${JSON.stringify(params.label)},
       selectionLabel: ${JSON.stringify(params.label)},
-      docsPath: ${JSON.stringify(`/channels/${params.id}`)},
+      docsPath: ${JSON.stringify(`/channels/${params.bundledSetupEntryId ?? params.id}`)},
       blurb: ${JSON.stringify(params.setupBlurb)},
     },
     capabilities: { chatTypes: ["direct"] },
@@ -3622,6 +3623,42 @@ module.exports = {
       registry.plugins.find((entry) => entry.id === "setup-runtime-mismatch-test")?.error,
     ).toContain('runtime entry uses "wrong-runtime-id"');
     expect(registry.channels).toHaveLength(0);
+    expect(fs.existsSync(runtimeMarker)).toBe(false);
+  });
+
+  it("rejects mismatched bundled setup export ids before loading setup-runtime entry code", () => {
+    const runtimeMarker = path.join(makeTempDir(), "setup-runtime-mismatch.txt");
+    const built = createSetupEntryChannelPluginFixture({
+      id: "setup-export-mismatch-test",
+      bundledSetupEntryId: "wrong-setup-id",
+      label: "Setup Export Mismatch Test",
+      packageName: "@openclaw/setup-export-mismatch-test",
+      fullBlurb: "full runtime plugin",
+      setupBlurb: "setup runtime override",
+      configured: false,
+      useBundledFullEntryContract: true,
+      useBundledSetupEntryContract: true,
+      bundledFullRuntimeMarker: runtimeMarker,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [built.pluginDir] },
+          allow: ["setup-export-mismatch-test"],
+        },
+      },
+    });
+
+    expect(
+      registry.plugins.find((entry) => entry.id === "setup-export-mismatch-test")?.status,
+    ).toBe("error");
+    expect(
+      registry.plugins.find((entry) => entry.id === "setup-export-mismatch-test")?.error,
+    ).toContain('setup export uses "wrong-setup-id"');
+    expect(registry.channels).toHaveLength(0);
+    expect(fs.existsSync(built.fullMarker)).toBe(false);
     expect(fs.existsSync(runtimeMarker)).toBe(false);
   });
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3590,7 +3590,8 @@ module.exports = {
     );
   });
 
-  it("rejects mismatched bundled runtime plugin ids during setup-runtime merge", () => {
+  it("rejects mismatched bundled runtime entry ids before applying setup-runtime setters", () => {
+    const runtimeMarker = path.join(makeTempDir(), "setup-runtime-mismatch.txt");
     const built = createSetupEntryChannelPluginFixture({
       id: "setup-runtime-mismatch-test",
       bundledFullEntryId: "wrong-runtime-id",
@@ -3601,7 +3602,7 @@ module.exports = {
       configured: false,
       useBundledFullEntryContract: true,
       useBundledSetupEntryContract: true,
-      bundledFullRuntimeMarker: path.join(makeTempDir(), "setup-runtime-mismatch.txt"),
+      bundledFullRuntimeMarker: runtimeMarker,
     });
 
     const registry = loadOpenClawPlugins({
@@ -3619,8 +3620,9 @@ module.exports = {
     ).toBe("error");
     expect(
       registry.plugins.find((entry) => entry.id === "setup-runtime-mismatch-test")?.error,
-    ).toContain('runtime export uses "wrong-runtime-id"');
+    ).toContain('runtime entry uses "wrong-runtime-id"');
     expect(registry.channels).toHaveLength(0);
+    expect(fs.existsSync(runtimeMarker)).toBe(false);
   });
 
   it("isolates loadSetupPlugin errors as per-plugin diagnostics instead of crashing registry load", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -684,6 +684,7 @@ function mergeSetupRuntimeChannelPlugin(
 }
 
 function resolveBundledRuntimeChannelRegistration(moduleExport: unknown): {
+  id?: string;
   loadChannelPlugin?: () => ChannelPlugin;
   loadChannelSecrets?: () => ChannelPlugin["secrets"] | undefined;
   setChannelRuntime?: (runtime: PluginRuntime) => void;
@@ -694,17 +695,20 @@ function resolveBundledRuntimeChannelRegistration(moduleExport: unknown): {
   }
   const entryRecord = resolved as {
     kind?: unknown;
+    id?: unknown;
     loadChannelPlugin?: unknown;
     loadChannelSecrets?: unknown;
     setChannelRuntime?: unknown;
   };
   if (
     entryRecord.kind !== "bundled-channel-entry" ||
+    typeof entryRecord.id !== "string" ||
     typeof entryRecord.loadChannelPlugin !== "function"
   ) {
     return {};
   }
   return {
+    id: entryRecord.id,
     loadChannelPlugin: entryRecord.loadChannelPlugin as () => ChannelPlugin,
     ...(typeof entryRecord.loadChannelSecrets === "function"
       ? {
@@ -1850,6 +1854,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
               continue;
             }
             const runtimeRegistration = resolveBundledRuntimeChannelRegistration(runtimeMod);
+            if (runtimeRegistration.id && runtimeRegistration.id !== record.id) {
+              pushPluginLoadError(
+                `plugin id mismatch (config uses "${record.id}", runtime entry uses "${runtimeRegistration.id}")`,
+              );
+              continue;
+            }
             if (runtimeRegistration.setChannelRuntime) {
               try {
                 runtimeRegistration.setChannelRuntime(api.runtime);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -684,9 +684,9 @@ function mergeSetupRuntimeChannelPlugin(
 }
 
 function resolveBundledRuntimeChannelRegistration(moduleExport: unknown): {
-  plugin?: ChannelPlugin;
+  loadChannelPlugin?: () => ChannelPlugin;
+  loadChannelSecrets?: () => ChannelPlugin["secrets"] | undefined;
   setChannelRuntime?: (runtime: PluginRuntime) => void;
-  loadError?: unknown;
 } {
   const resolved = unwrapDefaultModuleExport(moduleExport);
   if (!resolved || typeof resolved !== "object") {
@@ -704,33 +704,48 @@ function resolveBundledRuntimeChannelRegistration(moduleExport: unknown): {
   ) {
     return {};
   }
+  return {
+    loadChannelPlugin: entryRecord.loadChannelPlugin as () => ChannelPlugin,
+    ...(typeof entryRecord.loadChannelSecrets === "function"
+      ? {
+          loadChannelSecrets: entryRecord.loadChannelSecrets as () =>
+            | ChannelPlugin["secrets"]
+            | undefined,
+        }
+      : {}),
+    ...(typeof entryRecord.setChannelRuntime === "function"
+      ? {
+          setChannelRuntime: entryRecord.setChannelRuntime as (runtime: PluginRuntime) => void,
+        }
+      : {}),
+  };
+}
+
+function loadBundledRuntimeChannelPlugin(params: {
+  registration: ReturnType<typeof resolveBundledRuntimeChannelRegistration>;
+}): {
+  plugin?: ChannelPlugin;
+  loadError?: unknown;
+} {
+  if (typeof params.registration.loadChannelPlugin !== "function") {
+    return {};
+  }
   try {
-    const loadedPlugin = entryRecord.loadChannelPlugin();
-    const loadedSecrets =
-      typeof entryRecord.loadChannelSecrets === "function"
-        ? (entryRecord.loadChannelSecrets() as ChannelPlugin["secrets"] | undefined)
-        : undefined;
-    if (loadedPlugin && typeof loadedPlugin === "object") {
-      const mergedSecrets = mergeChannelPluginSection(
-        (loadedPlugin as ChannelPlugin).secrets,
-        loadedSecrets,
-      );
-      return {
-        plugin: {
-          ...(loadedPlugin as ChannelPlugin),
-          ...(mergedSecrets !== undefined ? { secrets: mergedSecrets } : {}),
-        },
-        ...(typeof entryRecord.setChannelRuntime === "function"
-          ? {
-              setChannelRuntime: entryRecord.setChannelRuntime as (runtime: PluginRuntime) => void,
-            }
-          : {}),
-      };
+    const loadedPlugin = params.registration.loadChannelPlugin();
+    const loadedSecrets = params.registration.loadChannelSecrets?.();
+    if (!loadedPlugin || typeof loadedPlugin !== "object") {
+      return {};
     }
+    const mergedSecrets = mergeChannelPluginSection(loadedPlugin.secrets, loadedSecrets);
+    return {
+      plugin: {
+        ...loadedPlugin,
+        ...(mergedSecrets !== undefined ? { secrets: mergedSecrets } : {}),
+      },
+    };
   } catch (err) {
     return { loadError: err };
   }
-  return {};
 }
 
 function resolveSetupChannelRegistration(moduleExport: unknown): {
@@ -1783,8 +1798,19 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           continue;
         }
         if (setupRegistration.plugin) {
+          const api = createApi(record, {
+            config: cfg,
+            pluginConfig: {},
+            hookPolicy: entry?.hooks,
+            registrationMode,
+          });
           let mergedSetupRegistration = setupRegistration;
-          if (setupRegistration.usesBundledSetupContract && candidate.source !== safeSource) {
+          let runtimeSetterApplied = false;
+          if (
+            registrationMode === "setup-runtime" &&
+            setupRegistration.usesBundledSetupContract &&
+            candidate.source !== safeSource
+          ) {
             const runtimeOpened = openBoundaryFileSync({
               absolutePath: candidate.source,
               rootPath: pluginRoot,
@@ -1824,7 +1850,30 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
               continue;
             }
             const runtimeRegistration = resolveBundledRuntimeChannelRegistration(runtimeMod);
-            if (runtimeRegistration.loadError) {
+            if (runtimeRegistration.setChannelRuntime) {
+              try {
+                runtimeRegistration.setChannelRuntime(api.runtime);
+                runtimeSetterApplied = true;
+              } catch (err) {
+                recordPluginError({
+                  logger,
+                  registry,
+                  record,
+                  seenIds,
+                  pluginId,
+                  origin: candidate.origin,
+                  phase: "load",
+                  error: err,
+                  logPrefix: `[plugins] ${record.id} failed to apply setup-runtime channel runtime from ${record.source}: `,
+                  diagnosticMessagePrefix: "failed to apply setup-runtime channel runtime: ",
+                });
+                continue;
+              }
+            }
+            const runtimePluginRegistration = loadBundledRuntimeChannelPlugin({
+              registration: runtimeRegistration,
+            });
+            if (runtimePluginRegistration.loadError) {
               recordPluginError({
                 logger,
                 registry,
@@ -1833,17 +1882,17 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
                 pluginId,
                 origin: candidate.origin,
                 phase: "load",
-                error: runtimeRegistration.loadError,
+                error: runtimePluginRegistration.loadError,
                 logPrefix: `[plugins] ${record.id} failed to load setup-runtime channel entry from ${record.source}: `,
                 diagnosticMessagePrefix: "failed to load setup-runtime channel entry: ",
               });
               continue;
             }
-            if (runtimeRegistration.plugin) {
+            if (runtimePluginRegistration.plugin) {
               mergedSetupRegistration = {
                 ...setupRegistration,
                 plugin: mergeSetupRuntimeChannelPlugin(
-                  runtimeRegistration.plugin,
+                  runtimePluginRegistration.plugin,
                   setupRegistration.plugin,
                 ),
                 setChannelRuntime:
@@ -1861,13 +1910,25 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             );
             continue;
           }
-          const api = createApi(record, {
-            config: cfg,
-            pluginConfig: {},
-            hookPolicy: entry?.hooks,
-            registrationMode,
-          });
-          mergedSetupRegistration.setChannelRuntime?.(api.runtime);
+          if (!runtimeSetterApplied) {
+            try {
+              mergedSetupRegistration.setChannelRuntime?.(api.runtime);
+            } catch (err) {
+              recordPluginError({
+                logger,
+                registry,
+                record,
+                seenIds,
+                pluginId,
+                origin: candidate.origin,
+                phase: "load",
+                error: err,
+                logPrefix: `[plugins] ${record.id} failed to apply setup channel runtime from ${record.source}: `,
+                diagnosticMessagePrefix: "failed to apply setup channel runtime: ",
+              });
+              continue;
+            }
+          }
           api.registerChannel(mergedSetupPlugin);
           registry.plugins.push(record);
           seenIds.set(pluginId, candidate.origin);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1802,6 +1802,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           continue;
         }
         if (setupRegistration.plugin) {
+          if (setupRegistration.plugin.id && setupRegistration.plugin.id !== record.id) {
+            pushPluginLoadError(
+              `plugin id mismatch (config uses "${record.id}", setup export uses "${setupRegistration.plugin.id}")`,
+            );
+            continue;
+          }
           const api = createApi(record, {
             config: cfg,
             pluginConfig: {},

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -638,15 +638,20 @@ function resolvePluginModuleExport(moduleExport: unknown): {
   return {};
 }
 
-function mergeSetupPluginSection<T>(
+function mergeChannelPluginSection<T>(
   baseValue: T | undefined,
-  setupValue: T | undefined,
+  overrideValue: T | undefined,
 ): T | undefined {
-  if (baseValue && setupValue && typeof baseValue === "object" && typeof setupValue === "object") {
+  if (
+    baseValue &&
+    overrideValue &&
+    typeof baseValue === "object" &&
+    typeof overrideValue === "object"
+  ) {
     const merged = {
       ...(baseValue as Record<string, unknown>),
     };
-    for (const [key, value] of Object.entries(setupValue as Record<string, unknown>)) {
+    for (const [key, value] of Object.entries(overrideValue as Record<string, unknown>)) {
       if (value !== undefined) {
         merged[key] = value;
       }
@@ -655,11 +660,83 @@ function mergeSetupPluginSection<T>(
       ...merged,
     } as T;
   }
-  return setupValue ?? baseValue;
+  return overrideValue ?? baseValue;
+}
+
+function mergeSetupRuntimeChannelPlugin(
+  runtimePlugin: ChannelPlugin,
+  setupPlugin: ChannelPlugin,
+): ChannelPlugin {
+  return {
+    ...runtimePlugin,
+    ...setupPlugin,
+    meta: mergeChannelPluginSection(runtimePlugin.meta, setupPlugin.meta),
+    capabilities: mergeChannelPluginSection(runtimePlugin.capabilities, setupPlugin.capabilities),
+    commands: mergeChannelPluginSection(runtimePlugin.commands, setupPlugin.commands),
+    doctor: mergeChannelPluginSection(runtimePlugin.doctor, setupPlugin.doctor),
+    reload: mergeChannelPluginSection(runtimePlugin.reload, setupPlugin.reload),
+    config: mergeChannelPluginSection(runtimePlugin.config, setupPlugin.config),
+    setup: mergeChannelPluginSection(runtimePlugin.setup, setupPlugin.setup),
+    messaging: mergeChannelPluginSection(runtimePlugin.messaging, setupPlugin.messaging),
+    actions: mergeChannelPluginSection(runtimePlugin.actions, setupPlugin.actions),
+    secrets: mergeChannelPluginSection(runtimePlugin.secrets, setupPlugin.secrets),
+  } as ChannelPlugin;
+}
+
+function resolveBundledRuntimeChannelRegistration(moduleExport: unknown): {
+  plugin?: ChannelPlugin;
+  setChannelRuntime?: (runtime: PluginRuntime) => void;
+  loadError?: unknown;
+} {
+  const resolved = unwrapDefaultModuleExport(moduleExport);
+  if (!resolved || typeof resolved !== "object") {
+    return {};
+  }
+  const entryRecord = resolved as {
+    kind?: unknown;
+    loadChannelPlugin?: unknown;
+    loadChannelSecrets?: unknown;
+    setChannelRuntime?: unknown;
+  };
+  if (
+    entryRecord.kind !== "bundled-channel-entry" ||
+    typeof entryRecord.loadChannelPlugin !== "function"
+  ) {
+    return {};
+  }
+  try {
+    const loadedPlugin = entryRecord.loadChannelPlugin();
+    const loadedSecrets =
+      typeof entryRecord.loadChannelSecrets === "function"
+        ? (entryRecord.loadChannelSecrets() as ChannelPlugin["secrets"] | undefined)
+        : undefined;
+    if (loadedPlugin && typeof loadedPlugin === "object") {
+      const mergedSecrets = mergeChannelPluginSection(
+        (loadedPlugin as ChannelPlugin).secrets,
+        loadedSecrets,
+      );
+      return {
+        plugin: {
+          ...(loadedPlugin as ChannelPlugin),
+          ...(mergedSecrets !== undefined ? { secrets: mergedSecrets } : {}),
+        },
+        ...(typeof entryRecord.setChannelRuntime === "function"
+          ? {
+              setChannelRuntime: entryRecord.setChannelRuntime as (runtime: PluginRuntime) => void,
+            }
+          : {}),
+      };
+    }
+  } catch (err) {
+    return { loadError: err };
+  }
+  return {};
 }
 
 function resolveSetupChannelRegistration(moduleExport: unknown): {
   plugin?: ChannelPlugin;
+  setChannelRuntime?: (runtime: PluginRuntime) => void;
+  usesBundledSetupContract?: boolean;
   loadError?: unknown;
 } {
   const resolved = unwrapDefaultModuleExport(moduleExport);
@@ -670,6 +747,7 @@ function resolveSetupChannelRegistration(moduleExport: unknown): {
     kind?: unknown;
     loadSetupPlugin?: unknown;
     loadSetupSecrets?: unknown;
+    setChannelRuntime?: unknown;
   };
   if (
     setupEntryRecord.kind === "bundled-channel-setup-entry" &&
@@ -682,7 +760,7 @@ function resolveSetupChannelRegistration(moduleExport: unknown): {
           ? (setupEntryRecord.loadSetupSecrets() as ChannelPlugin["secrets"] | undefined)
           : undefined;
       if (loadedPlugin && typeof loadedPlugin === "object") {
-        const mergedSecrets = mergeSetupPluginSection(
+        const mergedSecrets = mergeChannelPluginSection(
           (loadedPlugin as ChannelPlugin).secrets,
           loadedSecrets,
         );
@@ -691,6 +769,14 @@ function resolveSetupChannelRegistration(moduleExport: unknown): {
             ...(loadedPlugin as ChannelPlugin),
             ...(mergedSecrets !== undefined ? { secrets: mergedSecrets } : {}),
           },
+          usesBundledSetupContract: true,
+          ...(typeof setupEntryRecord.setChannelRuntime === "function"
+            ? {
+                setChannelRuntime: setupEntryRecord.setChannelRuntime as (
+                  runtime: PluginRuntime,
+                ) => void,
+              }
+            : {}),
         };
       }
     } catch (err) {
@@ -1697,9 +1783,81 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           continue;
         }
         if (setupRegistration.plugin) {
-          if (setupRegistration.plugin.id && setupRegistration.plugin.id !== record.id) {
+          let mergedSetupRegistration = setupRegistration;
+          if (setupRegistration.usesBundledSetupContract && candidate.source !== safeSource) {
+            const runtimeOpened = openBoundaryFileSync({
+              absolutePath: candidate.source,
+              rootPath: pluginRoot,
+              boundaryLabel: "plugin root",
+              rejectHardlinks: candidate.origin !== "bundled",
+              skipLexicalRootCheck: true,
+            });
+            if (!runtimeOpened.ok) {
+              pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+              continue;
+            }
+            const safeRuntimeSource = runtimeOpened.path;
+            fs.closeSync(runtimeOpened.fd);
+            const safeRuntimeImportSource = toSafeImportPath(safeRuntimeSource);
+            let runtimeMod: OpenClawPluginModule | null = null;
+            try {
+              runtimeMod = profilePluginLoaderSync({
+                phase: "load-setup-runtime-entry",
+                pluginId: record.id,
+                source: safeRuntimeSource,
+                run: () =>
+                  getJiti(safeRuntimeSource)(safeRuntimeImportSource) as OpenClawPluginModule,
+              });
+            } catch (err) {
+              recordPluginError({
+                logger,
+                registry,
+                record,
+                seenIds,
+                pluginId,
+                origin: candidate.origin,
+                phase: "load",
+                error: err,
+                logPrefix: `[plugins] ${record.id} failed to load setup-runtime entry from ${record.source}: `,
+                diagnosticMessagePrefix: "failed to load setup-runtime entry: ",
+              });
+              continue;
+            }
+            const runtimeRegistration = resolveBundledRuntimeChannelRegistration(runtimeMod);
+            if (runtimeRegistration.loadError) {
+              recordPluginError({
+                logger,
+                registry,
+                record,
+                seenIds,
+                pluginId,
+                origin: candidate.origin,
+                phase: "load",
+                error: runtimeRegistration.loadError,
+                logPrefix: `[plugins] ${record.id} failed to load setup-runtime channel entry from ${record.source}: `,
+                diagnosticMessagePrefix: "failed to load setup-runtime channel entry: ",
+              });
+              continue;
+            }
+            if (runtimeRegistration.plugin) {
+              mergedSetupRegistration = {
+                ...setupRegistration,
+                plugin: mergeSetupRuntimeChannelPlugin(
+                  runtimeRegistration.plugin,
+                  setupRegistration.plugin,
+                ),
+                setChannelRuntime:
+                  runtimeRegistration.setChannelRuntime ?? setupRegistration.setChannelRuntime,
+              };
+            }
+          }
+          const mergedSetupPlugin = mergedSetupRegistration.plugin;
+          if (!mergedSetupPlugin) {
+            continue;
+          }
+          if (mergedSetupPlugin.id && mergedSetupPlugin.id !== record.id) {
             pushPluginLoadError(
-              `plugin id mismatch (config uses "${record.id}", setup export uses "${setupRegistration.plugin.id}")`,
+              `plugin id mismatch (config uses "${record.id}", setup export uses "${mergedSetupPlugin.id}")`,
             );
             continue;
           }
@@ -1709,7 +1867,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             hookPolicy: entry?.hooks,
             registrationMode,
           });
-          api.registerChannel(setupRegistration.plugin);
+          mergedSetupRegistration.setChannelRuntime?.(api.runtime);
+          api.registerChannel(mergedSetupPlugin);
           registry.plugins.push(record);
           seenIds.set(pluginId, candidate.origin);
           continue;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1889,6 +1889,15 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
               continue;
             }
             if (runtimePluginRegistration.plugin) {
+              if (
+                runtimePluginRegistration.plugin.id &&
+                runtimePluginRegistration.plugin.id !== record.id
+              ) {
+                pushPluginLoadError(
+                  `plugin id mismatch (config uses "${record.id}", runtime export uses "${runtimePluginRegistration.plugin.id}")`,
+                );
+                continue;
+              }
               mergedSetupRegistration = {
                 ...setupRegistration,
                 plugin: mergeSetupRuntimeChannelPlugin(


### PR DESCRIPTION
## Summary
- stabilize bundled channel runtime-store identity by sharing runtime stores by `pluginId` for bundled channel runtimes, while keeping legacy string-overload stores isolated per call
- make bundled setup-entry/runtime-entry loading explicit and safe: setup entries can declare a runtime entry, runtime setters run only after early setup/runtime id validation, and setup-runtime failures stay isolated as per-plugin load errors
- make bundled channel discovery and caches root-aware end to end so `OPENCLAW_BUNDLED_PLUGINS_DIR` flips do not reuse stale metadata, entries, plugins, secrets, bootstrap plugins, or bundled id lists
- support direct plugin-tree bundled overrides in addition to package-root overrides, with regression coverage for duplicate module instances, same-module root flips, setup-runtime loader behavior, and runtime-store edge cases

## Scope
- `plugin-sdk` runtime-store and bundled channel setup-entry contract changes only where needed for the fix
- plugin-owned bundled channel runtime updates and Matrix setup-entry runtime wiring
- bundled channel root/metadata/bootstrap/id helpers
- docs, changelog, and regression tests for the touched plugin surfaces only

## Testing
- `pnpm build`
- `pnpm check`
- `pnpm test src/plugins/loader.test.ts src/plugin-sdk/runtime-store.test.ts src/plugin-sdk/channel-entry-contract.test.ts src/channels/plugins/bundled.shape-guard.test.ts src/channels/plugins/bundled-root-caches.test.ts src/plugins/bundled-plugin-metadata.test.ts`
