### PR TITLE
fix(logging): honor logging.file config early

### DIFF
--- a/src/logging/config.test.ts
+++ b/src/logging/config.test.ts
@@ -1,31 +1,45 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { readLoggingConfig } from "./config.js";
 
-const loadConfigMock = vi.hoisted(() => vi.fn());
-
-vi.mock("../config/config.js", async () => {
-  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
-  return {
-    ...actual,
-    loadConfig: () => loadConfigMock(),
-  };
-});
-
 const originalArgv = process.argv;
+const originalEnv = process.env.OPENCLAW_CONFIG_PATH;
 
 describe("readLoggingConfig", () => {
   afterEach(() => {
     process.argv = originalArgv;
-    loadConfigMock.mockReset();
+    if (originalEnv === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = originalEnv;
+    }
   });
 
   it("skips mutating config loads for config schema", async () => {
     process.argv = ["node", "openclaw", "config", "schema"];
-    loadConfigMock.mockImplementation(() => {
-      throw new Error("loadConfig should not be called");
-    });
-
     expect(readLoggingConfig()).toBeUndefined();
-    expect(loadConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("reads logging.file from the config path without loading the full config stack", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-logcfg-"));
+    const configPath = path.join(dir, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        logging: {
+          file: "/tmp/openclaw-test/custom.log",
+          level: "info",
+        },
+      }),
+      "utf-8",
+    );
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    process.argv = ["node", "openclaw", "gateway"];
+
+    const cfg = readLoggingConfig();
+    expect(cfg?.file).toBe("/tmp/openclaw-test/custom.log");
+    expect(cfg?.level).toBe("info");
   });
 });

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -1,6 +1,10 @@
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
+import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
+import JSON5 from "json5";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
+import fs from "node:fs";
+import os from "node:os";
 
 type LoggingConfig = OpenClawConfig["logging"];
 
@@ -16,13 +20,13 @@ export function readLoggingConfig(): LoggingConfig | undefined {
     return undefined;
   }
   try {
-    const loaded = requireConfig?.("../config/config.js") as
-      | {
-          loadConfig?: () => OpenClawConfig;
-        }
-      | undefined;
-    const parsed = loaded?.loadConfig?.();
-    const logging = parsed?.logging;
+    const configPath = resolveConfigPath(process.env, resolveStateDir(process.env, os.homedir));
+    if (!configPath || !fs.existsSync(configPath)) {
+      return undefined;
+    }
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const parsed = JSON5.parse(raw) as OpenClawConfig;
+    const logging = parsed?.logging as unknown;
     if (!logging || typeof logging !== "object" || Array.isArray(logging)) {
       return undefined;
     }


### PR DESCRIPTION
## Summary
- Ensure file logging honors \logging.file\ from config instead of staying on the default rolling tmp path.
- Avoid circular startup ordering by reading logging config directly from the resolved config path.

Fixes #67168.

## Test plan
- \pnpm vitest run src/logging/config.test.ts\

Made with [Cursor](https://cursor.com)