### PR TITLE
fix(image): preserve provider headers for custom OpenAI-compatible models

### DIFF
--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -229,6 +229,60 @@ describe("describeImageWithModel", () => {
     expect(context?.messages?.[0]?.content).toHaveLength(1);
   });
 
+  it("preserves configured provider headers for custom OpenAI-compatible image models", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "openai",
+        id: "gpt-4.1-mini",
+        input: ["text", "image"],
+        baseUrl: "https://example.test/v1",
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    await describeImageWithModel({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://example.test/v1",
+              headers: {
+                "X-Custom": "1",
+                "User-Agent": "custom-agent",
+              },
+            },
+          },
+        },
+      },
+      agentDir: "/tmp/openclaw-agent",
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    const [, , opts] = completeMock.mock.calls[0] ?? [];
+    expect(opts).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "X-Custom": "1",
+          "User-Agent": "custom-agent",
+        }),
+      }),
+    );
+  });
+
   it("normalizes deprecated google flash ids before lookup and keeps profile auth selection", async () => {
     const findMock = vi.fn((provider: string, modelId: string) => {
       expect(provider).toBe("google");

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -9,6 +9,7 @@ import {
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
 import { coerceImageAssistantText } from "../agents/tools/image-tool.helpers.js";
+import { resolveProviderRequestConfig } from "../agents/provider-request-config.js";
 import type {
   ImageDescriptionRequest,
   ImageDescriptionResult,
@@ -43,7 +44,7 @@ async function resolveImageRuntime(params: {
   model: string;
   profile?: string;
   preferredProfile?: string;
-}): Promise<{ apiKey: string; model: Model<Api> }> {
+}): Promise<{ apiKey: string; model: Model<Api>; headers?: Record<string, string> }> {
   await ensureOpenClawModelsJson(params.cfg, params.agentDir);
   const { discoverAuthStorage, discoverModels } = await loadPiModelDiscoveryRuntime();
   const authStorage = discoverAuthStorage(params.agentDir);
@@ -65,7 +66,23 @@ async function resolveImageRuntime(params: {
   });
   const apiKey = requireApiKey(apiKeyInfo, model.provider);
   authStorage.setRuntimeApiKey(model.provider, apiKey);
-  return { apiKey, model };
+  const providerConfig = params.cfg.models?.providers?.[resolvedRef.provider];
+  const providerHeaders =
+    providerConfig?.headers && typeof providerConfig.headers === "object"
+      ? Object.fromEntries(
+          Object.entries(providerConfig.headers as Record<string, unknown>)
+            .filter(([, value]) => typeof value === "string" && value.trim().length > 0)
+            .map(([key, value]) => [String(key), String(value).trim()]),
+        )
+      : undefined;
+  const requestConfig = resolveProviderRequestConfig({
+    provider: resolvedRef.provider,
+    baseUrl: model.baseUrl,
+    providerHeaders,
+    capability: "llm",
+    transport: "http",
+  });
+  return { apiKey, model, headers: requestConfig.headers };
 }
 
 function buildImageContext(
@@ -156,11 +173,13 @@ export async function describeImagesWithModel(
   const prompt = params.prompt ?? "Describe the image.";
   let apiKey: string;
   let model: Model<Api> | undefined;
+  let headers: Record<string, string> | undefined;
 
   try {
     const resolved = await resolveImageRuntime(params);
     apiKey = resolved.apiKey;
     model = resolved.model;
+    headers = resolved.headers;
   } catch (err) {
     if (!isMinimaxVlmModel(params.provider, params.model) || !isUnknownModelError(err)) {
       throw err;
@@ -197,6 +216,7 @@ export async function describeImagesWithModel(
     apiKey,
     maxTokens: resolveImageToolMaxTokens(model.maxTokens, params.maxTokens ?? 512),
     signal: controller.signal,
+    ...(headers ? { headers } : {}),
   }).finally(() => {
     clearTimeout(timeout);
   });


### PR DESCRIPTION
## Summary
- Preserve configured provider headers (e.g. custom User-Agent) when running the image runtime against OpenAI-compatible gateways.
- Add regression coverage for header propagation.

Fixes #67056.

## Test plan
- \pnpm vitest run src/media-understanding/image.test.ts\

Made with [Cursor](https://cursor.com)