### PR TITLE
fix(config-ui): keep Raw view readable when raw text withheld

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -617,6 +617,7 @@ export function renderApp(state: AppViewState) {
     gatewayUrl: state.settings.gatewayUrl,
     assistantName: state.assistantName,
     configPath: state.configSnapshot?.path ?? null,
+    // Raw view is always available; this flag indicates whether raw text is editable.
     rawAvailable: typeof state.configSnapshot?.raw === "string",
   } satisfies Omit<
     ConfigProps,

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -207,7 +207,7 @@ describe("config view", () => {
     expect(onFormModeChange).toHaveBeenCalledWith("raw");
   });
 
-  it("forces Form mode and disables Raw mode when raw text is unavailable", () => {
+  it("allows Raw view but keeps it read-only when raw text is unavailable", () => {
     const onFormModeChange = vi.fn();
     const { container } = renderConfigView({
       formMode: "raw",
@@ -234,15 +234,17 @@ describe("config view", () => {
     const rawButton = Array.from(container.querySelectorAll("button")).find(
       (btn) => btn.textContent?.trim() === "Raw",
     );
-    expect(formButton?.classList.contains("active")).toBe(true);
-    expect(rawButton?.disabled).toBe(true);
+    expect(formButton?.classList.contains("active")).toBe(false);
+    expect(rawButton?.disabled).toBe(false);
     expect(normalizedText(container)).toContain(
-      "Raw mode disabled (snapshot cannot safely round-trip raw text).",
+      "Raw view is read-only (snapshot cannot safely round-trip raw text).",
     );
-    expect(container.querySelector(".config-raw-field")).toBeNull();
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea).not.toBeNull();
+    expect(textarea?.readOnly).toBe(true);
 
     rawButton?.click();
-    expect(onFormModeChange).not.toHaveBeenCalled();
+    expect(onFormModeChange).toHaveBeenCalledWith("raw");
   });
 
   it("switches sections from the sidebar", () => {
@@ -450,7 +452,7 @@ describe("config view", () => {
   it("uses a file-edit placeholder for structured SecretRefs when raw mode is unavailable", () => {
     const { container } = renderConfigView({
       rawAvailable: false,
-      formMode: "raw",
+      formMode: "form",
       schema: {
         type: "object",
         properties: {
@@ -495,7 +497,7 @@ describe("config view", () => {
     const onFormPatch = vi.fn();
     const { container } = renderConfigView({
       rawAvailable: false,
-      formMode: "raw",
+      formMode: "form",
       schema: {
         type: "object",
         properties: {

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -711,8 +711,8 @@ export function renderConfig(props: ConfigProps) {
     unsupportedPaths: scopeUnsupportedPaths(rawAnalysis.unsupportedPaths, { include, exclude }),
   };
   const formUnsafe = analysis.schema ? analysis.unsupportedPaths.length > 0 : false;
-  const rawAvailable = props.rawAvailable ?? true;
-  const formMode = showModeToggle && rawAvailable ? props.formMode : "form";
+  const rawEditable = props.rawAvailable ?? true;
+  const formMode = showModeToggle ? props.formMode : "form";
   const envSensitiveVisible = cvs.envRevealed;
   const requestUpdate = props.onRequestUpdate ?? (() => props.onRawChange(props.raw));
 
@@ -762,20 +762,23 @@ export function renderConfig(props: ConfigProps) {
 
   // Compute diff for showing changes (works for both form and raw modes)
   const diff = formMode === "form" ? computeDiff(props.originalValue, props.formValue) : [];
-  const hasRawChanges = formMode === "raw" && props.raw !== props.originalRaw;
+  const hasRawChanges = rawEditable && formMode === "raw" && props.raw !== props.originalRaw;
   const hasChanges = formMode === "form" ? diff.length > 0 : hasRawChanges;
 
   // Save/apply buttons require actual changes to be enabled.
   // Note: formUnsafe warns about unsupported schema paths but shouldn't block saving.
   const canSaveForm = Boolean(props.formValue) && !props.loading && Boolean(analysis.schema);
   const canSave =
-    props.connected && !props.saving && hasChanges && (formMode === "raw" ? true : canSaveForm);
+    props.connected &&
+    !props.saving &&
+    hasChanges &&
+    (formMode === "raw" ? rawEditable : canSaveForm);
   const canApply =
     props.connected &&
     !props.applying &&
     !props.updating &&
     hasChanges &&
-    (formMode === "raw" ? true : canSaveForm);
+    (formMode === "raw" ? rawEditable : canSaveForm);
   const canUpdate = props.connected && !props.applying && !props.updating;
 
   const showAppearanceOnRoot =
@@ -802,10 +805,9 @@ export function renderConfig(props: ConfigProps) {
                     </button>
                     <button
                       class="config-mode-toggle__btn ${formMode === "raw" ? "active" : ""}"
-                      ?disabled=${!rawAvailable}
-                      title=${rawAvailable
+                      title=${rawEditable
                         ? "Edit raw JSON/JSON5 config"
-                        : "Raw mode unavailable for this snapshot"}
+                        : "Raw view is read-only for this snapshot"}
                       @click=${() => props.onFormModeChange("raw")}
                     >
                       Raw
@@ -824,10 +826,10 @@ export function renderConfig(props: ConfigProps) {
               : html` <span class="config-status muted">No changes</span> `}
           </div>
           <div class="config-actions__right">
-            ${!rawAvailable
+            ${!rawEditable && formMode === "raw"
               ? html`
                   <span class="config-status muted"
-                    >Raw mode disabled (snapshot cannot safely round-trip raw text).</span
+                    >Raw view is read-only (snapshot cannot safely round-trip raw text).</span
                   >
                 `
               : nothing}
@@ -1057,7 +1059,7 @@ export function renderConfig(props: ConfigProps) {
                         schema: analysis.schema,
                         uiHints: props.uiHints,
                         value: props.formValue,
-                        rawAvailable,
+                        rawAvailable: rawEditable,
                         disabled: props.loading || !props.formValue,
                         unsupportedPaths: analysis.unsupportedPaths,
                         onPatch: props.onFormPatch,
@@ -1115,7 +1117,7 @@ export function renderConfig(props: ConfigProps) {
                             `
                           : nothing}
                       </span>
-                      ${blurred
+                      ${blurred && rawEditable
                         ? html`
                             <div class="callout info" style="margin-top: 12px">
                               ${sensitiveCount} sensitive value${sensitiveCount === 1 ? "" : "s"}
@@ -1126,9 +1128,13 @@ export function renderConfig(props: ConfigProps) {
                             <textarea
                               placeholder="Raw config (JSON/JSON5)"
                               .value=${props.raw}
-                              @input=${(e: Event) => {
-                                props.onRawChange((e.target as HTMLTextAreaElement).value);
-                              }}
+                              ?readonly=${!rawEditable}
+                              title=${rawEditable ? "" : "Raw view is read-only for this snapshot"}
+                              @input=${rawEditable
+                                ? (e: Event) => {
+                                    props.onRawChange((e.target as HTMLTextAreaElement).value);
+                                  }
+                                : null}
                             ></textarea>
                           `}
                     </div>


### PR DESCRIPTION
## Summary
- Allow switching to Config Raw view even when the gateway withholds \snapshot.raw\ for safety.
- Render the Raw textarea read-only and prevent save/apply in Raw mode when raw editing is unavailable.

Fixes #66988.

## Test plan
- \pnpm vitest run ui/src/ui/views/config.browser.test.ts --pool=forks\

Made with [Cursor](https://cursor.com)