### PR TITLE
fix(test): stop overriding host-aware vitest scheduling in prepare gates

### DIFF
--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -103,11 +103,16 @@ prepare_gates() {
       echo "Docs-only change detected with high confidence; skipping pnpm test."
     else
       gates_mode="full"
-      echo "Running pnpm test with OPENCLAW_VITEST_MAX_WORKERS=${OPENCLAW_VITEST_MAX_WORKERS:-4}."
-      run_quiet_logged \
-        "pnpm test" \
-        ".local/gates-test.log" \
-        env OPENCLAW_VITEST_MAX_WORKERS="${OPENCLAW_VITEST_MAX_WORKERS:-4}" pnpm test
+      if [ -n "${OPENCLAW_VITEST_MAX_WORKERS:-}" ]; then
+        echo "Running pnpm test with OPENCLAW_VITEST_MAX_WORKERS=$OPENCLAW_VITEST_MAX_WORKERS."
+        run_quiet_logged \
+          "pnpm test" \
+          ".local/gates-test.log" \
+          env OPENCLAW_VITEST_MAX_WORKERS="$OPENCLAW_VITEST_MAX_WORKERS" pnpm test
+      else
+        echo "Running pnpm test with host-aware scheduling defaults."
+        run_quiet_logged "pnpm test" ".local/gates-test.log" pnpm test
+      fi
       previous_full_gates_head="$current_head"
     fi
   fi


### PR DESCRIPTION
## Summary

- The hardcoded `OPENCLAW_VITEST_MAX_WORKERS=${OPENCLAW_VITEST_MAX_WORKERS:-4}` default in `gates.sh` short-circuits the host-aware scheduling system introduced in c247e366
- `resolveLocalVitestScheduling` sees the explicit `4` and returns `maxWorkers=4`, which falls below the `>= 5` threshold in `shouldUseLargeLocalFullSuiteProfile`, so every machine gets the DEFAULT profile (4 shard parallelism) instead of LARGE (10)
- Now only forwards `OPENCLAW_VITEST_MAX_WORKERS` when explicitly set by the user; otherwise lets `test-projects.mjs` detect host resources and pick the appropriate profile automatically

## Test plan

- [ ] Verify on a machine with >= 12 cores / >= 48GB RAM that `scripts/pr-prepare gates <PR>` now prints `parallelism 10` instead of `parallelism 4`
- [ ] Verify that setting `OPENCLAW_VITEST_MAX_WORKERS=2` still correctly forwards the override
- [ ] Verify that CI behavior is unchanged (CI uses `OPENCLAW_LOCAL_CHECK=0` and does not set `OPENCLAW_VITEST_MAX_WORKERS`)