### PR TITLE
fix(discord): preserve embed URLs when message content is empty

### DIFF
--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -933,6 +933,17 @@ describe("resolveDiscordMessageText", () => {
     expect(text).toBe("Breaking\nDetails");
   });
 
+  it("uses embed url when content is empty and embed has no text fields", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        embeds: [{ url: "https://example.com/test" }],
+      }),
+    );
+
+    expect(text).toBe("https://example.com/test");
+  });
+
   it("prefers message content over embed fallback text", () => {
     const text = resolveDiscordMessageText(
       asMessage({

--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -604,12 +604,22 @@ function buildDiscordMediaPlaceholder(params: {
 }
 
 export function resolveDiscordEmbedText(
-  embed?: { title?: string | null; description?: string | null } | null,
+  embed?: { title?: string | null; description?: string | null; url?: string | null } | null,
 ): string {
   const title = normalizeOptionalString(embed?.title) ?? "";
   const description = normalizeOptionalString(embed?.description) ?? "";
+  const url = normalizeOptionalString((embed as { url?: string | null } | null | undefined)?.url) ?? "";
   if (title && description) {
     return `${title}\n${description}`;
+  }
+  if (title && url) {
+    return `${title}\n${url}`;
+  }
+  if (description && url) {
+    return `${description}\n${url}`;
+  }
+  if (url) {
+    return url;
   }
   return title || description || "";
 }


### PR DESCRIPTION
## Summary
- Include \embed.url\ in inbound message text when Discord delivers an URL-only embed with empty \message.content\.
- Prevent https links from being silently dropped before reaching the agent.

Fixes #67151.

## Test plan
- \pnpm vitest run extensions/discord/src/monitor/message-utils.test.ts\

Made with [Cursor](https://cursor.com)