### PR TITLE
googlechat: fix add-on token principal check for email-based appPrincipal

### DIFF
--- a/extensions/googlechat/src/auth.test.ts
+++ b/extensions/googlechat/src/auth.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { verifyGoogleChatRequest } from "./auth.js";
+
+const verifyIdToken = vi.hoisted(() => vi.fn());
+
+vi.mock("google-auth-library", () => ({
+  GoogleAuth: vi.fn(),
+  OAuth2Client: vi.fn(function () {
+    return { verifyIdToken };
+  }),
+}));
+
+describe("verifyGoogleChatRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mockTicket(payload: Record<string, unknown>) {
+    verifyIdToken.mockResolvedValue({
+      getPayload: () => payload,
+    });
+  }
+
+  it("rejects missing bearer", async () => {
+    const result = await verifyGoogleChatRequest({
+      bearer: null,
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    });
+    expect(result).toEqual({ ok: false, reason: "missing token" });
+  });
+
+  it("rejects missing audience", async () => {
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: null,
+    });
+    expect(result).toEqual({ ok: false, reason: "missing audience" });
+  });
+
+  it("accepts chat@system.gserviceaccount.com issuer", async () => {
+    mockTicket({
+      email_verified: true,
+      email: "chat@system.gserviceaccount.com",
+    });
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects unverified email", async () => {
+    mockTicket({
+      email_verified: false,
+      email: "chat@system.gserviceaccount.com",
+    });
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    });
+    expect(result).toEqual({ ok: false, reason: "email not verified" });
+  });
+
+  it("accepts add-on token when appPrincipal is email and matches token email", async () => {
+    mockTicket({
+      email_verified: true,
+      email: "service-45161530548@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+      sub: "103438788618831168836",
+    });
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+      expectedAddOnPrincipal: "service-45161530548@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects add-on token when appPrincipal is email and does not match token email", async () => {
+    mockTicket({
+      email_verified: true,
+      email: "service-45161530548@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+      sub: "103438788618831168836",
+    });
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+      expectedAddOnPrincipal: "other-service@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+    });
+    expect(result).toEqual({
+      ok: false,
+      reason:
+        "unexpected add-on principal: service-45161530548@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+    });
+  });
+
+  it("accepts add-on token when appPrincipal is numeric and matches token sub", async () => {
+    mockTicket({
+      email_verified: true,
+      email: "service-45161530548@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+      sub: "103438788618831168836",
+    });
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+      expectedAddOnPrincipal: "103438788618831168836",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects add-on token when appPrincipal is numeric and does not match token sub", async () => {
+    mockTicket({
+      email_verified: true,
+      email: "service-45161530548@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+      sub: "103438788618831168836",
+    });
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+      expectedAddOnPrincipal: "999999999999999999999",
+    });
+    expect(result).toEqual({
+      ok: false,
+      reason: "unexpected add-on principal: 103438788618831168836",
+    });
+  });
+
+  it("rejects invalid issuer", async () => {
+    mockTicket({
+      email_verified: true,
+      email: "unknown@example.com",
+    });
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    });
+    expect(result).toEqual({
+      ok: false,
+      reason: "invalid issuer: unknown@example.com",
+    });
+  });
+
+  it("rejects missing add-on principal binding", async () => {
+    mockTicket({
+      email_verified: true,
+      email: "service-45161530548@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+      sub: "103438788618831168836",
+    });
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+      expectedAddOnPrincipal: null,
+    });
+    expect(result).toEqual({
+      ok: false,
+      reason: "missing add-on principal binding",
+    });
+  });
+});

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -130,7 +130,9 @@ export async function verifyGoogleChatRequest(params: {
       if (!expectedAddOnPrincipal) {
         return { ok: false, reason: "missing add-on principal binding" };
       }
-      const tokenPrincipal = normalizeLowercaseStringOrEmpty(payload?.sub ?? "");
+      const tokenPrincipal = expectedAddOnPrincipal.includes("@")
+        ? email
+        : normalizeLowercaseStringOrEmpty(payload?.sub ?? "");
       if (!tokenPrincipal || tokenPrincipal !== expectedAddOnPrincipal) {
         return {
           ok: false,

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -124,6 +124,8 @@ export const googlechatPlugin = createChatChannelPlugin({
           configured: account.credentialSource !== "none",
           extra: {
             credentialSource: account.credentialSource,
+            audienceType: account.config.audienceType,
+            audience: account.config.audience,
           },
         }),
     },


### PR DESCRIPTION
## Summary

Fixes Google Chat inbound auth when the token is issued by a Google Workspace Add-ons service account (`service-*@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`).

## Problem

In `app-url` audience mode, OpenClaw only compared `expectedAddOnPrincipal` against `payload.sub`. However, real Google Workspace Add-on tokens have:

- `email=service-45161530548@gcp-sa-gsuiteaddons.iam.gserviceaccount.com`
- `sub=103438788618831168836`

When the configured `appPrincipal` is the service-account email, the old logic always returned `401 unauthorized` because it compared the email to the numeric `sub`.

## Fix

In `extensions/googlechat/src/auth.ts`, change the add-on principal check to:

- If `expectedAddOnPrincipal` looks like an email (contains `@`), compare against `payload.email`
- Otherwise, fall back to the existing `payload.sub` comparison

## Secondary fix

`openclaw status` was falsely reporting "Google Chat audience is missing" because `projectSafeChannelAccountSnapshotFields` did not forward `audience` and `audienceType` into the status snapshot. Added those fields in `src/channels/account-snapshot-fields.ts`.

## Tests

Added `extensions/googlechat/src/auth.test.ts` covering:

- appPrincipal as email matching token email → pass
- appPrincipal as email not matching token email → reject  
- appPrincipal as numeric ID matching token sub → pass
- appPrincipal as numeric ID not matching token sub → reject
- `chat@system.gserviceaccount.com` issuer branch unchanged
