### PR TITLE
fix(acp): reuse existing session key for persistent spawns with same label

### DIFF
--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1045,7 +1045,29 @@ export async function spawnAcpDirect(
     });
   }
 
-  const sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
+  let sessionKey: string | undefined;
+  let wasResolved = false;
+  if (params.label && spawnMode === "session") {
+    try {
+      const resolved = await callGateway({
+        method: "sessions.resolve",
+        params: { label: params.label, agentId: targetAgentId },
+        timeoutMs: 5000,
+      });
+      if (resolved?.ok && resolved.key) {
+        const storePath = resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
+        const store = loadSessionStore(storePath);
+        const entry = store[resolved.key] as SessionEntry | undefined;
+        if (!entry?.acp?.mode || entry.acp.mode === "persistent") {
+          sessionKey = resolved.key;
+          wasResolved = true;
+        }
+      }
+    } catch {
+      // resolve failure → fall through to new UUID
+    }
+  }
+  if (!sessionKey) sessionKey = `agent:${targetAgentId}:acp:${crypto.randomUUID()}`;
   const runtimeMode = resolveAcpSessionMode(spawnMode);
   const resolvedCwd = resolveSpawnedWorkspaceInheritance({
     config: cfg,
@@ -1095,7 +1117,7 @@ export async function spawnAcpDirect(
       method: "sessions.patch",
       params: {
         key: sessionKey,
-        spawnedBy: requesterInternalKey,
+        ...(wasResolved ? {} : { spawnedBy: requesterInternalKey }),
         ...(params.label ? { label: params.label } : {}),
       },
       timeoutMs: 10_000,
@@ -1125,8 +1147,8 @@ export async function spawnAcpDirect(
     await cleanupFailedAcpSpawn({
       cfg,
       sessionKey,
-      shouldDeleteSession: sessionCreated,
-      deleteTranscript: true,
+      shouldDeleteSession: sessionCreated && !wasResolved,
+      deleteTranscript: !wasResolved,
       runtimeCloseHandle: initializedRuntime,
     });
     return createAcpSpawnFailure({
@@ -1203,8 +1225,8 @@ export async function spawnAcpDirect(
     await cleanupFailedAcpSpawn({
       cfg,
       sessionKey,
-      shouldDeleteSession: true,
-      deleteTranscript: true,
+      shouldDeleteSession: !wasResolved,
+      deleteTranscript: !wasResolved,
     });
     return createAcpSpawnFailure({
       status: "error",


### PR DESCRIPTION
## Summary

When a persistent ACP session is re-spawned with the same label, the current code always generates a new random UUID as the session key, causing two issues:

1. **Lost context**: ACPX runtime creates a fresh session (`--session-id`) instead of resuming (`--resume`), discarding conversation history
2. **Label conflicts**: `sessions.patch` uniqueness check rejects the new key because the old session still holds the same label

## Changes

- Resolve existing session key by label via `sessions.resolve` before generating a new UUID
- Mode guard reads `entry.acp.mode` from session store to prevent oneshot sessions from being reused by persistent spawns
- Use `cfg.session?.store` in `resolveStorePath` to respect custom session store configuration
- `wasResolved` flag prevents `cleanupFailedAcpSpawn` from deleting existing session records/transcripts on transient failures
- Skip `spawnedBy` update for resolved sessions to avoid immutable constraint rejection
- Any resolve failure safely falls back to the original new-UUID behavior

## Test plan

- [x] Spawn a persistent ACP session with a label, verify `--resume` flag is used on subsequent spawns with the same label
- [x] Verify oneshot sessions with the same label are not reused (mode guard)
- [x] Verify `sessions.resolve` failure gracefully falls back to new UUID
- [x] Verify no label conflicts on re-spawn with same label
- [x] Verify `spawnedBy` immutability does not block re-spawn from different requester context
- [x] Verify transient spawn failure does not delete existing session history

🤖 Generated with [Claude Code](https://claude.com/claude-code)