### PR TITLE
fix: honor agent-specific thinking defaults on ingress runs

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -38,6 +38,7 @@ import { sanitizeForLog } from "../terminal/ansi.js";
 import { resolveMessageChannel } from "../utils/message-channel.js";
 import {
   listAgentIds,
+  resolveAgentConfig,
   resolveAgentDir,
   resolveEffectiveModelFallbacks,
   resolveSessionAgentId,
@@ -781,17 +782,20 @@ async function agentCommandInternal(
     }
 
     if (!resolvedThinkLevel) {
+      const agentThinkingDefault = resolveAgentConfig(cfg, sessionAgentId)?.thinkingDefault;
       let catalogForThinking = modelCatalog ?? allowedModelCatalog;
       if (!catalogForThinking || catalogForThinking.length === 0) {
         modelCatalog = await loadModelCatalog({ config: cfg });
         catalogForThinking = modelCatalog;
       }
-      resolvedThinkLevel = resolveThinkingDefault({
-        cfg,
-        provider,
-        model,
-        catalog: catalogForThinking,
-      });
+      resolvedThinkLevel =
+        agentThinkingDefault ??
+        resolveThinkingDefault({
+          cfg,
+          provider,
+          model,
+          catalog: catalogForThinking,
+        });
     }
     if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
       const explicitThink = Boolean(thinkOnce || thinkOverride);

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -782,20 +782,24 @@ async function agentCommandInternal(
     }
 
     if (!resolvedThinkLevel) {
-      const agentThinkingDefault = resolveAgentConfig(cfg, sessionAgentId)?.thinkingDefault;
-      let catalogForThinking = modelCatalog ?? allowedModelCatalog;
-      if (!catalogForThinking || catalogForThinking.length === 0) {
-        modelCatalog = await loadModelCatalog({ config: cfg });
-        catalogForThinking = modelCatalog;
-      }
-      resolvedThinkLevel =
-        agentThinkingDefault ??
-        resolveThinkingDefault({
+      const agentThinkingDefault = normalizeThinkLevel(
+        resolveAgentConfig(cfg, sessionAgentId)?.thinkingDefault,
+      );
+      if (agentThinkingDefault) {
+        resolvedThinkLevel = agentThinkingDefault;
+      } else {
+        let catalogForThinking = modelCatalog ?? allowedModelCatalog;
+        if (!catalogForThinking || catalogForThinking.length === 0) {
+          modelCatalog = await loadModelCatalog({ config: cfg });
+          catalogForThinking = modelCatalog;
+        }
+        resolvedThinkLevel = resolveThinkingDefault({
           cfg,
           provider,
           model,
           catalog: catalogForThinking,
         });
+      }
     }
     if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
       const explicitThink = Boolean(thinkOnce || thinkOverride);

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -362,6 +362,35 @@ describe("agentCommand", () => {
     });
   });
 
+  it("prefers per-agent thinkingDefault for ingress runs", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      configSpy.mockReturnValue({
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-6" },
+            models: { "anthropic/claude-opus-4-6": {} },
+            workspace: path.join(home, "openclaw"),
+          },
+          list: [{ id: "beta", thinkingDefault: "minimal" }],
+        },
+        session: { store, mainKey: "main" },
+      } as OpenClawConfig);
+
+      await agentCommandFromIngress(
+        {
+          message: "hi",
+          sessionKey: "agent:beta:openai:test",
+          senderIsOwner: false,
+          allowModelOverride: false,
+        },
+        runtime,
+      );
+
+      expect(getLastEmbeddedCall()?.thinkLevel).toBe("minimal");
+    });
+  });
+
   it("resumes when session-id is provided", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -391,6 +391,35 @@ describe("agentCommand", () => {
     });
   });
 
+  it("normalizes per-agent thinkingDefault for ingress runs", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      configSpy.mockReturnValue({
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-6" },
+            models: { "anthropic/claude-opus-4-6": {} },
+            workspace: path.join(home, "openclaw"),
+          },
+          list: [{ id: "beta", thinkingDefault: " Minimal " as never }],
+        },
+        session: { store, mainKey: "main" },
+      } as OpenClawConfig);
+
+      await agentCommandFromIngress(
+        {
+          message: "hi",
+          sessionKey: "agent:beta:openai:test",
+          senderIsOwner: false,
+          allowModelOverride: false,
+        },
+        runtime,
+      );
+
+      expect(getLastEmbeddedCall()?.thinkLevel).toBe("minimal");
+    });
+  });
+
   it("resumes when session-id is provided", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");


### PR DESCRIPTION
## Summary
- honor agent-specific `thinkingDefault` when ingress runs compute their fallback think level
- keep the existing model/global fallback path unchanged when no agent override exists
- add a regression test that exercises `agentCommandFromIngress()` with an agent-scoped session key

## Testing
- node scripts/test-projects.mjs src/commands/agent.test.ts

Closes #67199
