### PR TITLE
docs: clarify provider request proxy configuration

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -480,44 +480,6 @@ Many of the bundled provider plugins below already publish a default catalog.
 Use explicit `models.providers.<id>` entries only when you want to override the
 default base URL, headers, or model list.
 
-## Provider request proxy
-
-OpenClaw does not automatically apply `HTTP_PROXY` / `HTTPS_PROXY` environment variables to provider requests.
-
-If you run OpenClaw in a proxy-required environment (for example WSL, local proxy tools, or corporate networks), configure proxy behavior explicitly for the provider you use.
-
-If you define an explicit `models.providers.<provider>` entry, it must satisfy the provider schema for your current version. In practice, this usually means including the provider's `baseUrl` and `models` along with the proxy configuration.
-
-Example:
-
-```json
-{
-  "models": {
-    "providers": {
-      "openai": {
-        "baseUrl": "https://api.openai.com/v1",
-        "models": [
-          {
-            "id": "gpt-5.4",
-            "name": "gpt-5.4"
-          },
-          {
-            "id": "gpt-5.4-mini",
-            "name": "gpt-5.4-mini"
-          }
-        ],
-        "request": {
-          "proxy": {
-            "mode": "env-proxy"
-          }
-        }
-      }
-    }
-  }
-}
-```
-This is a provider-level setting and is not specific to OpenAI. Use the corresponding provider id under `models.providers.<provider>`.
-
 ### Moonshot AI (Kimi)
 
 Moonshot ships as a bundled provider plugin. Use the built-in provider by
@@ -866,6 +828,45 @@ Notes:
   headers.
 - If `baseUrl` is empty/omitted, OpenClaw keeps the default OpenAI behavior (which resolves to `api.openai.com`).
 - For safety, an explicit `compat.supportsDeveloperRole: true` is still overridden on non-native `openai-completions` endpoints.
+
+## Provider request proxy
+
+OpenClaw does not automatically apply `HTTP_PROXY` / `HTTPS_PROXY` environment variables to provider requests.
+
+If you run OpenClaw in a proxy-required environment (for example WSL, local proxy tools, or corporate networks), configure proxy behavior explicitly for the provider you use.
+
+If you define an explicit `models.providers.<provider>` entry, it must satisfy the provider schema for your current version. In practice, this usually means including the provider's `baseUrl` and `models` along with the proxy configuration.
+
+Example:
+
+```json
+{
+  "models": {
+    "providers": {
+      "openai": {
+        "baseUrl": "https://api.openai.com/v1",
+        "models": [
+          {
+            "id": "gpt-5.4",
+            "name": "gpt-5.4"
+          },
+          {
+            "id": "gpt-5.4-mini",
+            "name": "gpt-5.4-mini"
+          }
+        ],
+        "request": {
+          "proxy": {
+            "mode": "env-proxy"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This is a provider-level setting and is not specific to OpenAI. Use the corresponding provider id under `models.providers.<provider>`.
 
 ## CLI examples
 

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -480,6 +480,44 @@ Many of the bundled provider plugins below already publish a default catalog.
 Use explicit `models.providers.<id>` entries only when you want to override the
 default base URL, headers, or model list.
 
+## Provider request proxy
+
+OpenClaw does not automatically apply `HTTP_PROXY` / `HTTPS_PROXY` environment variables to provider requests.
+
+If you run OpenClaw in a proxy-required environment (for example WSL, local proxy tools, or corporate networks), configure proxy behavior explicitly for the provider you use.
+
+If you define an explicit `models.providers.<provider>` entry, it must satisfy the provider schema for your current version. In practice, this usually means including the provider's `baseUrl` and `models` along with the proxy configuration.
+
+Example:
+
+```json
+{
+  "models": {
+    "providers": {
+      "openai": {
+        "baseUrl": "https://api.openai.com/v1",
+        "models": [
+          {
+            "id": "gpt-5.4",
+            "name": "gpt-5.4"
+          },
+          {
+            "id": "gpt-5.4-mini",
+            "name": "gpt-5.4-mini"
+          }
+        ],
+        "request": {
+          "proxy": {
+            "mode": "env-proxy"
+          }
+        }
+      }
+    }
+  }
+}
+```
+This is a provider-level setting and is not specific to OpenAI. Use the corresponding provider id under `models.providers.<provider>`.
+
 ### Moonshot AI (Kimi)
 
 Moonshot ships as a bundled provider plugin. Use the built-in provider by

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -866,7 +866,7 @@ Example:
 }
 ```
 
-This is a provider-level setting and is not specific to OpenAI. Use the corresponding provider id under `models.providers.<provider>`.
+This example uses OpenAI for illustration only. Support for `request.proxy` depends on the provider transport API used by the provider you configure.
 
 ## CLI examples
 


### PR DESCRIPTION
This clarifies that provider requests do not automatically use `HTTP_PROXY` / `HTTPS_PROXY` environment variables.

In proxy-required environments (for example WSL, local proxy tools, or corporate networks), users need to explicitly configure provider request proxy behavior.

This also clarifies that when defining an explicit `models.providers.<provider>` entry, the entry must satisfy the provider schema for the current version. In practice, this means proxy configuration is typically added together with `baseUrl` and `models`.

The example uses OpenAI only as an example; this is a provider-level setting and is not specific to OpenAI.