### PR TITLE
plugin-sdk: add stable embeddings subpath export

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -318,7 +318,8 @@ Current bundled provider examples:
   | `plugin-sdk/memory-core` | Bundled memory-core helpers | Memory manager/config/file/CLI helper surface |
   | `plugin-sdk/memory-core-engine-runtime` | Memory engine runtime facade | Memory index/search runtime facade |
   | `plugin-sdk/memory-core-host-engine-foundation` | Memory host foundation engine | Memory host foundation engine exports |
-  | `plugin-sdk/memory-core-host-engine-embeddings` | Memory host embedding engine | Memory host embedding engine exports |
+  | `plugin-sdk/embeddings` | Embedding provider API | Stable embedding provider factories, registry, and types (preferred path) |
+  | `plugin-sdk/memory-core-host-engine-embeddings` | Memory host embedding engine | Memory host embedding engine exports (prefer `plugin-sdk/embeddings`) |
   | `plugin-sdk/memory-core-host-engine-qmd` | Memory host QMD engine | Memory host QMD engine exports |
   | `plugin-sdk/memory-core-host-engine-storage` | Memory host storage engine | Memory host storage engine exports |
   | `plugin-sdk/memory-core-host-multimodal` | Memory host multimodal helpers | Memory host multimodal helpers |

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -261,10 +261,11 @@ explicitly promotes one as public.
   <Accordion title="Memory subpaths">
     | Subpath | Key exports |
     | --- | --- |
+    | `plugin-sdk/embeddings` | Stable embedding provider API — factory functions (`createOpenAiEmbeddingProvider`, `createGeminiEmbeddingProvider`, …), registry (`getMemoryEmbeddingProvider`, `listMemoryEmbeddingProviders`), and `MemoryEmbeddingProvider` type. Preferred over the internal `memory-core-host-engine-embeddings` path. |
     | `plugin-sdk/memory-core` | Bundled memory-core helper surface for manager/config/file/CLI helpers |
     | `plugin-sdk/memory-core-engine-runtime` | Memory index/search runtime facade |
     | `plugin-sdk/memory-core-host-engine-foundation` | Memory host foundation engine exports |
-    | `plugin-sdk/memory-core-host-engine-embeddings` | Memory host embedding engine exports |
+    | `plugin-sdk/memory-core-host-engine-embeddings` | Memory host embedding engine exports (prefer `plugin-sdk/embeddings`) |
     | `plugin-sdk/memory-core-host-engine-qmd` | Memory host QMD engine exports |
     | `plugin-sdk/memory-core-host-engine-storage` | Memory host storage engine exports |
     | `plugin-sdk/memory-core-host-multimodal` | Memory host multimodal helpers |

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -11,7 +11,7 @@ import {
   type MemoryEmbeddingProviderAdapter,
   type MemoryEmbeddingProviderCreateOptions,
   type MemoryEmbeddingProviderRuntime,
-} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+} from "openclaw/plugin-sdk/embeddings";
 import { formatErrorMessage } from "../dreaming-shared.js";
 import { canAutoSelectLocal } from "./provider-adapters.js";
 
@@ -23,7 +23,7 @@ export {
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
   DEFAULT_OPENAI_EMBEDDING_MODEL,
   DEFAULT_VOYAGE_EMBEDDING_MODEL,
-} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+} from "openclaw/plugin-sdk/embeddings";
 
 export type EmbeddingProvider = MemoryEmbeddingProvider;
 export type EmbeddingProviderId = string;

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -4,7 +4,7 @@ import {
   enforceEmbeddingMaxInputTokens,
   hasNonTextEmbeddingParts,
   type EmbeddingInput,
-} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+} from "openclaw/plugin-sdk/embeddings";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { type SessionFileEntry } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -9,7 +9,7 @@ import {
   buildCaseInsensitiveExtensionGlob,
   classifyMemoryMultimodalPath,
   getMemoryMultimodalExtensions,
-} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+} from "openclaw/plugin-sdk/embeddings";
 import {
   createSubsystemLogger,
   onSessionTranscriptUpdate,

--- a/extensions/memory-core/src/memory/provider-adapters.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.ts
@@ -22,7 +22,7 @@ import {
   runOpenAiEmbeddingBatches,
   runVoyageEmbeddingBatches,
   type MemoryEmbeddingProviderAdapter,
-} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+} from "openclaw/plugin-sdk/embeddings";
 import { resolveUserPath } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { getProviderEnvVars } from "openclaw/plugin-sdk/provider-env-vars";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";

--- a/extensions/ollama/src/memory-embedding-adapter.ts
+++ b/extensions/ollama/src/memory-embedding-adapter.ts
@@ -1,4 +1,4 @@
-import type { MemoryEmbeddingProviderAdapter } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import type { MemoryEmbeddingProviderAdapter } from "openclaw/plugin-sdk/embeddings";
 import {
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
   createOllamaEmbeddingProvider,

--- a/package.json
+++ b/package.json
@@ -523,6 +523,10 @@
       "types": "./dist/plugin-sdk/diffs.d.ts",
       "default": "./dist/plugin-sdk/diffs.js"
     },
+    "./plugin-sdk/embeddings": {
+      "types": "./dist/plugin-sdk/embeddings.d.ts",
+      "default": "./dist/plugin-sdk/embeddings.js"
+    },
     "./plugin-sdk/error-runtime": {
       "types": "./dist/plugin-sdk/error-runtime.d.ts",
       "default": "./dist/plugin-sdk/error-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -118,6 +118,7 @@
   "diagnostic-runtime",
   "diagnostics-otel",
   "diffs",
+  "embeddings",
   "error-runtime",
   "extension-shared",
   "channel-config-helpers",

--- a/src/plugin-sdk/embeddings.ts
+++ b/src/plugin-sdk/embeddings.ts
@@ -1,0 +1,5 @@
+// Public SDK surface for embedding providers.
+// Re-exports the embedding provider API from a stable path so that plugins
+// do not need to reach into memory-core internals.
+
+export * from "../memory-host-sdk/engine-embeddings.js";


### PR DESCRIPTION
## Summary

- **Problem:** when a third-party plugin occupies `plugins.slots.memory` (e.g. a custom associative-memory plugin), memory-core does not load. With memory-core disabled, the embedding provider API is effectively unavailable through the public SDK — the only path that exposes it today (`plugin-sdk/memory-core-host-engine-embeddings`) is memory-core-owned, and the embedding registry is empty. Third-party memory-slot plugins are forced to **duplicate** the embedding implementation (OpenAI/Gemini factories, batching, input limits, multimodal helpers) just to function.
- **Why it matters:** without this, any third-party plugin in the memory slot must either (a) reach into memory-core internals via a non-public path that offers no semver protection, or (b) reimplement the embedding stack. Both are fragile: a memory-core refactor breaks silently, and duplicated implementations drift over time.
- **What changed:** new stable subpath `openclaw/plugin-sdk/embeddings` that re-exports the embedding API (factory functions, registry, types, batch helpers) from `memory-host-sdk`, independent of whether the memory-core extension is active. Bundled extensions (`memory-core`, `ollama`) migrated to dogfood the new path and conform to the extension SDK self-import guardrail.
- **What did NOT change:** the old internal path keeps working for backward compatibility; memory-core runtime logic is untouched; API baseline hash unchanged (new path re-exports the same symbols).

## Change Type (select all)

- [x] Feature (additive public SDK surface)
- [ ] Bug fix
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None.

## Root Cause (if applicable)

N/A (additive public SDK surface, not a bug fix).

## Regression Test Plan (if applicable)

N/A. The repo's existing `pnpm plugin-sdk:check-exports` and `pnpm plugin-sdk:api:check` gates lock in the new subpath contract; no new unit test is meaningful for an additive re-export barrel whose API baseline is already verified by these checks.

## User-visible / Behavior Changes

None. Existing plugins continue to work unchanged. Plugin authors can switch to the new path when they want stable, documented imports.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: darwin 24.6.0 (arm64)
- Runtime/container: Node 22.22.0, pnpm 10.32.1
- Model/provider: OpenAI `text-embedding-3-small`
- Integration/channel: none (CLI-only test bot)
- Relevant config: `plugins.slots.memory = memory-core`, OpenAI key in `auth-profiles.json`

### Steps

1. `pnpm build` on this branch
2. `pnpm pack` → install the tarball into an isolated test directory with `OPENCLAW_STATE_DIR` pointing at a fresh state dir
3. `openclaw plugins list` — confirm memory-core loads
4. `openclaw memory status` — confirm embedding provider is ready
5. `openclaw memory index` — index a test `.md` file (triggers the factory call path)
6. `openclaw memory search "marine arthropod lifespan" --min-score 0` — semantic query over a test doc mentioning "crustaceans", "exoskeleton", "live over 50 years"

### Expected

- Memory-core loads through the new `openclaw/plugin-sdk/embeddings` path without module-resolution errors
- Indexing issues an embedding request successfully
- Semantic search returns the matching chunk even without keyword overlap

### Actual

- Memory-core loaded (55 plugins loaded, 0 errors)
- `memory status` reported `Vector: ready`, `FTS: ready`, provider `openai`, model `text-embedding-3-small`
- `memory index` produced `Memory index updated (main)`, `Indexed: 1/1 files · 1 chunks`
- `memory search "marine arthropod lifespan"` returned the expected chunk with score `0.17` (no keyword overlap — confirms real vector similarity)

## Evidence

- `pnpm tsgo` — passes
- `pnpm plugin-sdk:check-exports` — `plugin-sdk exports synced.`
- `pnpm plugin-sdk:api:gen` — baseline regenerated, hash unchanged (new path exposes the same symbols as the old one)
- `pnpm build` — succeeded, `dist/plugin-sdk/embeddings.{js,d.ts}` generated
- Semantic-search log snippet: `"score": 0.17198…, "snippet": "… Lobsters are crustaceans with a hard exoskeleton … live over 50 years …"`

## Human Verification (required)

The PR was deployed and tested with the `memory-core` plugin on top of 2026.4.14. The build succeeded and the basic memory-core functionality (search) with embeddings worked. `openclaw memory status` and `openclaw memory index` also worked.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — the old `memory-core-host-engine-embeddings` path keeps working
- Config/env changes? **No**
- Migration needed? **No** (third-party plugins can switch to the new path at their own pace)

## Risks and Mitigations

- **Risk:** SDK surface grows by one subpath.
  - **Mitigation:** the new subpath is narrow and purpose-built per the `src/plugin-sdk/CLAUDE.md` boundary rules; it is not a broad convenience barrel.
- **Risk:** two paths pointing at the same API may confuse consumers.
  - **Mitigation:** `sdk-overview.md` and `sdk-migration.md` mark the old path with "prefer `plugin-sdk/embeddings`".