### PR TITLE
fix(docs): correct imageGenerationModel → imageModel in config examples

### DIFF
--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -12,7 +12,7 @@ title: "Image Generation"
 The `image_generate` tool lets the agent create and edit images using your configured providers. Generated images are delivered automatically as media attachments in the agent's reply.
 
 <Note>
-The tool only appears when at least one image generation provider is available. If you don't see `image_generate` in your agent's tools, configure `agents.defaults.imageGenerationModel` or set up a provider API key.
+The tool only appears when at least one image generation provider is available. If you don't see `image_generate` in your agent's tools, configure `agents.defaults.imageModel` or set up a provider API key.
 </Note>
 
 ## Quick start
@@ -24,7 +24,7 @@ The tool only appears when at least one image generation provider is available. 
 {
   agents: {
     defaults: {
-      imageGenerationModel: {
+      imageModel: {
         primary: "openai/gpt-image-1",
       },
     },
@@ -80,7 +80,7 @@ Tool results report the applied settings. When OpenClaw remaps geometry during p
 {
   agents: {
     defaults: {
-      imageGenerationModel: {
+      imageModel: {
         primary: "openai/gpt-image-1",
         fallbacks: ["google/gemini-3.1-flash-image-preview", "fal/fal-ai/flux/dev"],
       },
@@ -94,8 +94,8 @@ Tool results report the applied settings. When OpenClaw remaps geometry during p
 When generating an image, OpenClaw tries providers in this order:
 
 1. **`model` parameter** from the tool call (if the agent specifies one)
-2. **`imageGenerationModel.primary`** from config
-3. **`imageGenerationModel.fallbacks`** in order
+2. **`imageModel.primary`** from config
+3. **`imageModel.fallbacks`** in order
 4. **Auto-detection** — uses auth-backed provider defaults only:
    - current default provider first
    - remaining registered image-generation providers in provider-id order
@@ -147,5 +147,5 @@ MiniMax image generation is available through both bundled MiniMax auth paths:
 - [MiniMax](/providers/minimax) — MiniMax image provider setup
 - [OpenAI](/providers/openai) — OpenAI Images provider setup
 - [Vydra](/providers/vydra) — Vydra image, video, and speech setup
-- [Configuration Reference](/gateway/configuration-reference#agent-defaults) — `imageGenerationModel` config
+- [Configuration Reference](/gateway/configuration-reference#agent-defaults) — `imageModel` config
 - [Models](/concepts/models) — model configuration and failover


### PR DESCRIPTION
The configuration reference and quick-start examples used `imageGenerationModel` as the config key for image generation models. The actual Zod schema in the codebase defines this field as `imageModel` under `agents.defaults`. Since the schema uses `.strict()` validation, any config using the incorrect key name will be rejected at startup.

Updated all occurrences of `imageGenerationModel` to `imageModel` to match the implemented schema in `zod-schema.agent-defaults.ts`.

Ref: AgentDefaultsSchema → imageModel (z.object({ primary, fallbacks }).strict())

Here's the filled-out PR template:

## Summary
- Problem: The docs use `imageGenerationModel` as the config key for image generation models, but the actual Zod schema defines the field as `imageModel` under `agents.defaults`.
- Why it matters: `AgentDefaultsSchema` uses `.strict()` validation, so any config containing `imageGenerationModel` is rejected at startup with a Zod validation error. Users following the docs cannot configure image generation.
- What changed: Replaced all occurrences of `imageGenerationModel` with `imageModel` in config examples and reference text.
- What did NOT change (scope boundary): No code changes. Only documentation text and examples were updated.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50659
- Related #53450
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The docs were written using a key name (`imageGenerationModel`) that was either a pre-release draft name or a naming error. The implemented schema at `src/config/zod-schema.agent-defaults.ts` has always used `imageModel`.
- Missing detection / guardrail: No automated check validates that config keys in docs match the Zod schema.
- Contributing context (if known): The `imageModel` field mirrors the structure of `model` (both use `{ primary, fallbacks }`), so the shorter name is consistent with the codebase conventions.

## Regression Test Plan (if applicable)

N/A — docs-only change. The schema itself is already covered by existing validation tests.

## User-visible / Behavior Changes

Users following the configuration reference will now use the correct key (`imageModel`) that passes `.strict()` schema validation, instead of the incorrect `imageGenerationModel` that causes startup failure.

## Diagram (if applicable)

```text
Before:
[user copies docs example with imageGenerationModel] -> [Zod .strict() rejects unknown key] -> [startup failure]

After:
[user copies docs example with imageModel] -> [schema validates] -> [image generation works]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Any OpenClaw >= 2026.4.12
- Model/provider: Any image-capable provider
- Integration/channel (if any): N/A
- Relevant config (redacted):
```json5
{
  agents: {
    defaults: {
      imageModel: {           // was incorrectly documented as imageGenerationModel
        primary: "openai/gpt-image-1",
      },
    },
  },
}
```

### Steps

1. Copy the config example from the docs (before this fix) using `imageGenerationModel`
2. Start OpenClaw
3. Observe Zod validation error on startup

### Expected

- Config accepted, image generation tool available

### Actual

- Startup fails with strict schema validation error for unknown key `imageGenerationModel`

## Evidence

- [x] Trace/log snippets

Verified against `src/config/zod-schema.agent-defaults.ts`:
```typescript
export const AgentDefaultsSchema = z
  .object({
    model: z.object({ primary: z.string().optional(), fallbacks: z.array(z.string()).optional() }).strict().optional(),
    imageModel: z.object({ primary: z.string().optional(), fallbacks: z.array(z.string()).optional() }).strict().optional(),
    // ...
  })
  .strict()  // <-- rejects any key not listed above
```

No `imageGenerationModel` key exists anywhere in the codebase (zero matches across all source files).

## Human Verification (required)

- Verified scenarios: Searched full codebase for both `imageModel` and `imageGenerationModel` — confirmed `imageModel` is the only accepted key. Verified schema uses `.strict()`.
- Edge cases checked: Checked legacy migration rules — no migration path exists from `imageGenerationModel` to `imageModel`, confirming the docs key was never valid.
- What you did **not** verify: Did not verify every docs page for other potential references; only updated the pages found.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — docs-only change, no code impact
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

None.