### PR TITLE
[codex] suppress accidental silent-token message sends

### DIFF
--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -299,6 +299,86 @@ describe("runMessageAction context isolation", () => {
     ).rejects.toThrow(/message required/i);
   });
 
+  it("suppresses exact NO_REPLY sends as a handled no-op", async () => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "slack",
+        target: "#C12345678",
+        message: "NO_REPLY",
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.sendResult).toBeUndefined();
+    expect(result.payload).toEqual({
+      suppressed: true,
+      reason: "silent-token",
+      channel: "slack",
+      to: "C12345678",
+    });
+  });
+
+  it("does not suppress substantive text containing NO_REPLY", async () => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "slack",
+        target: "#C12345678",
+        message: "NO_REPLY -- nope",
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.sendResult?.dryRun).toBe(true);
+  });
+
+  it("does not suppress exact NO_REPLY when media is attached", async () => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "slack",
+        target: "#C12345678",
+        message: "NO_REPLY",
+        media: "https://example.com/note.ogg",
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.sendResult?.dryRun).toBe(true);
+  });
+
+  it("does not suppress exact NO_REPLY when components are attached", async () => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams: {
+        channel: "slack",
+        target: "#C12345678",
+        message: "NO_REPLY",
+        blocks: [{ type: "divider" }],
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
+    if (result.kind !== "send") {
+      throw new Error("expected send result");
+    }
+    expect(result.sendResult?.dryRun).toBe(true);
+  });
+
   it("allows send when only shared interactive payloads are provided", async () => {
     const result = await runDrySend({
       cfg: {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -6,6 +6,7 @@ import {
   readStringParam,
 } from "../../agents/tools/common.js";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
+import { isSilentReplyText } from "../../auto-reply/tokens.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import type {
@@ -472,6 +473,31 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   });
 
   const mediaUrl = readStringParam(params, "media", { trim: false });
+  const isAccidentalSilentSend =
+    isSilentReplyText(message) &&
+    !mediaUrl &&
+    mergedMediaUrls.length === 0 &&
+    !hasButtons &&
+    !hasCard &&
+    !hasComponents &&
+    !hasBlocks &&
+    !params.interactive;
+  if (isAccidentalSilentSend) {
+    return {
+      kind: "send",
+      channel,
+      action,
+      to,
+      handledBy: "core",
+      payload: {
+        suppressed: true,
+        reason: "silent-token",
+        channel,
+        to,
+      },
+      dryRun,
+    };
+  }
   if (
     !hasReplyPayloadContent(
       {


### PR DESCRIPTION
## What changed
- added a defensive message-tool no-op for exact silent-token sends (`NO_REPLY`) when there is no media, component, or interactive payload
- added regression coverage for exact silent-token suppression, substantive text containing `NO_REPLY`, and exact `NO_REPLY` sends that still carry media/components

## Why
Cortana heartbeat drift exposed a sharp edge in OpenClaw: if an agent accidentally tried to send the silent token as a real outbound message, the message action runner treated the normalized payload as empty and threw `send requires text or media`.

## Impact
- accidental pure `NO_REPLY` sends now degrade silently instead of paging
- substantive text and real content payloads still follow the normal send path
- direct heartbeat tokens like `HEARTBEAT_OK` are unchanged

## Validation
- `git diff --check -- src/infra/outbound/message-action-runner.ts src/infra/outbound/message-action-runner.context.test.ts`
- local Vitest execution is currently blocked in this checkout because the repo's installed dependencies are incomplete (`vitest` resolves, but `std-env` is missing from `node_modules`)
