### PR TITLE
Fix heartbeat async exec delivery leaks

### DIFF
--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -46,16 +46,34 @@ describe("heartbeat event prompts", () => {
 
   it.each([
     {
-      name: "builds user-relay exec prompt by default",
+      name: "builds internal-only exec prompt by default",
       opts: undefined,
-      expected: ["Please relay the command output to the user", "If it failed"],
-      unexpected: ["Handle the result internally"],
+      expected: [
+        "Handle the result internally only",
+        "Do not relay it to the user",
+        "Reply HEARTBEAT_OK when there is no separate user-facing follow-up",
+      ],
+      unexpected: ["Please relay the command output to the user", "If it failed"],
     },
     {
-      name: "builds internal-only exec prompt when delivery is disabled",
+      name: "builds the same internal-only exec prompt even when delivery is enabled",
+      opts: { deliverToUser: true },
+      expected: [
+        "Handle the result internally only",
+        "Do not relay it to the user",
+        "Reply HEARTBEAT_OK when there is no separate user-facing follow-up",
+      ],
+      unexpected: ["Please relay the command output to the user", "If it failed"],
+    },
+    {
+      name: "builds the same internal-only exec prompt when delivery is disabled",
       opts: { deliverToUser: false },
-      expected: ["Handle the result internally"],
-      unexpected: ["Please relay the command output to the user"],
+      expected: [
+        "Handle the result internally only",
+        "Do not relay it to the user",
+        "Reply HEARTBEAT_OK when there is no separate user-facing follow-up",
+      ],
+      unexpected: ["Please relay the command output to the user", "If it failed"],
     },
   ])("$name", ({ opts, expected, unexpected }) => {
     const prompt = buildExecEventPrompt(opts);

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -38,18 +38,12 @@ export function buildCronEventPrompt(
   );
 }
 
-export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string {
-  const deliverToUser = opts?.deliverToUser ?? true;
-  if (!deliverToUser) {
-    return (
-      "An async command you ran earlier has completed. The result is shown in the system messages above. " +
-      "Handle the result internally. Do not relay it to the user unless explicitly requested."
-    );
-  }
+export function buildExecEventPrompt(_opts?: { deliverToUser?: boolean }): string {
   return (
     "An async command you ran earlier has completed. The result is shown in the system messages above. " +
-    "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
-    "If it failed, explain what went wrong."
+    "Handle the result internally only. Do not relay it to the user, do not summarize it into a visible chat reply, " +
+    "and do not turn it into a reminder unless the user explicitly asks about that async command itself. " +
+    "Reply HEARTBEAT_OK when there is no separate user-facing follow-up."
   );
 }
 

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1653,4 +1653,100 @@ describe("runHeartbeatOnce", () => {
       replySpy.mockReset();
     }
   });
+
+  it("does not externally deliver HEARTBEAT_OK for exec completion events", async () => {
+    const tmpDir = await createCaseDir("hb-exec-no-heartbeat-ok");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "whatsapp" },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          lastChannel: "whatsapp",
+          lastTo: "120363401234567890@g.us",
+        },
+      }),
+    );
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup",
+    });
+
+    const replySpy = vi.fn().mockResolvedValue({ text: "HEARTBEAT_OK" });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    const res = await runHeartbeatOnce({
+      cfg,
+      reason: "exec-event",
+      deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+    });
+
+    expect(res.status).toBe("ran");
+    expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+  });
+
+  it("does not externally deliver reasoning payloads for exec completion events", async () => {
+    const tmpDir = await createCaseDir("hb-exec-no-reasoning");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "whatsapp", includeReasoning: true },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          lastChannel: "whatsapp",
+          lastTo: "120363401234567890@g.us",
+        },
+      }),
+    );
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup",
+    });
+
+    const replySpy = vi
+      .fn()
+      .mockResolvedValue([{ text: "Reasoning:\nBecause it helps" }, { text: "HEARTBEAT_OK" }]);
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    const res = await runHeartbeatOnce({
+      cfg,
+      reason: "exec-event",
+      deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+    });
+
+    expect(res.status).toBe("ran");
+    expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -687,7 +687,7 @@ After completing all due tasks, reply HEARTBEAT_OK.`;
 
   // Fallback to original behavior
   const basePrompt = hasExecCompletion
-    ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
+    ? buildExecEventPrompt()
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -972,7 +972,7 @@ export async function runHeartbeatOnce(opts: {
     sessionKey,
   });
   const canAttemptHeartbeatOk = Boolean(
-    visibility.showOk && delivery.channel !== "none" && delivery.to,
+    !hasExecCompletion && visibility.showOk && delivery.channel !== "none" && delivery.to,
   );
   const maybeSendHeartbeatOk = async () => {
     if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) {
@@ -1021,7 +1021,7 @@ export async function runHeartbeatOnce(opts: {
       opts.deps?.getReplyFromConfig ?? (await loadHeartbeatRunnerRuntime()).getReplyFromConfig;
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
-    const includeReasoning = heartbeat?.includeReasoning === true;
+    const includeReasoning = !hasExecCompletion && heartbeat?.includeReasoning === true;
     const reasoningPayloads = includeReasoning
       ? resolveHeartbeatReasoningPayloads(replyResult).filter((payload) => payload !== replyPayload)
       : [];
@@ -1050,19 +1050,7 @@ export async function runHeartbeatOnce(opts: {
 
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
     const normalized = normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars);
-    // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
-    // The model should be responding with exec results, not ack tokens.
-    // Also, if normalized.text is empty due to token stripping but we have exec completion,
-    // fall back to the original reply text.
-    const execFallbackText =
-      hasExecCompletion && !normalized.text.trim() && replyPayload.text?.trim()
-        ? replyPayload.text.trim()
-        : null;
-    if (execFallbackText) {
-      normalized.text = execFallbackText;
-      normalized.shouldSkip = false;
-    }
-    const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia && !hasExecCompletion;
+    const shouldSkipMain = hasExecCompletion || (normalized.shouldSkip && !normalized.hasMedia);
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
         storePath,


### PR DESCRIPTION
# PR-ready package: Fix heartbeat async exec delivery leaks

## Suggested PR title
Fix heartbeat async exec delivery leaks

## Suggested PR summary
This backports the heartbeat async-completion fix that was previously applied only as a live dist patch.

### Problem
Even after exec-event prompts were switched to internal-only, async command completion could still leak into user-visible chat because the heartbeat delivery path continued to special-case exec completion.

### Root cause
The remaining leak was in `src/infra/heartbeat-runner.ts`, not just in prompt wording:
- `execFallbackText` could revive text already suppressed by heartbeat token stripping
- `shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia && !hasExecCompletion` excluded exec completion from the silent main-delivery path
- `canAttemptHeartbeatOk` and reasoning delivery were still allowed to flow outward for exec completion events

### Fix
- make exec completion prompt internal-only in `src/infra/heartbeat-events-filter.ts`
- remove exec-completion text revival (`execFallbackText`)
- force exec completion into the silent main-delivery path
- prevent outward `HEARTBEAT_OK` delivery for exec completion
- prevent outward reasoning payload delivery for exec completion

### Tests
Updated / added regression coverage in:
- `src/infra/heartbeat-events-filter.test.ts`
- `src/infra/heartbeat-runner.returns-default-unset.test.ts`

Regression assertions now cover:
- internal-only exec prompt regardless of `deliverToUser`
- no external `HEARTBEAT_OK` delivery for exec completion
- no external reasoning payload delivery for exec completion

## Local validation already completed
- `corepack pnpm install --frozen-lockfile`
- `git diff --check`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/infra/heartbeat-events-filter.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
  - exit code: `0`

## Local source branch
- `fix/heartbeat-async-exec-delivery-backport`

## Commit
- `f83d4a15ddf2ca6c6d96c56f4baf27d1dc557c59`

## Transfer artifacts
- patch diff: `heartbeat-async-upstream-backport.patch`
- format-patch: `heartbeat-async-upstream-backport-formatpatch.patch`
- result note: `heartbeat-async-upstream-backport-result.md`

## Cherry-pick instruction
```bash
git cherry-pick f83d4a15ddf2ca6c6d96c56f4baf27d1dc557c59
```

## Push / PR note
No external push was performed in this step. This package is prepared for manual push / PR creation once explicitly approved.
