### PR TITLE
Build: prune packaged runtime test cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 - Cron/announce delivery: suppress mixed-content isolated cron announce replies that end with `NO_REPLY` so trailing silent sentinels no longer leak summary text to the target channel. (#65004) thanks @neo1027144-creator.
 - Plugins/bundled channels: partition bundled channel lazy caches by active bundled root so `OPENCLAW_BUNDLED_PLUGINS_DIR` flips stop reusing stale plugin, setup, secrets, and runtime state. (#67200) Thanks @gumadeiras.
-- Packaging/plugins: keep packaged runtime-dependency pruning and npm release validation from deleting or rejecting legitimate nested packages named `test`/`tests` under `node_modules`. (#67275) thanks @gumadeiras.
+- Packaging/plugins: prune common test/spec cargo from bundled plugin runtime dependencies and fail npm release validation if packaged test cargo reappears, keeping published tarballs leaner without plugin-specific special cases. (#67275) thanks @gumadeiras.
 
 ## 2026.4.15-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 - Cron/announce delivery: suppress mixed-content isolated cron announce replies that end with `NO_REPLY` so trailing silent sentinels no longer leak summary text to the target channel. (#65004) thanks @neo1027144-creator.
 - Plugins/bundled channels: partition bundled channel lazy caches by active bundled root so `OPENCLAW_BUNDLED_PLUGINS_DIR` flips stop reusing stale plugin, setup, secrets, and runtime state. (#67200) Thanks @gumadeiras.
+- Packaging/plugins: keep packaged runtime-dependency pruning and npm release validation from deleting or rejecting legitimate nested packages named `test`/`tests` under `node_modules`. (#67275) thanks @gumadeiras.
 
 ## 2026.4.15-beta.1
 

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -105,8 +105,40 @@ const FORBIDDEN_PRIVATE_QA_CONTENT_MARKERS = [
   "qa-lab/runtime-api.js",
 ] as const;
 const FORBIDDEN_PRIVATE_QA_CONTENT_SCAN_PREFIXES = ["dist/"] as const;
+const PACKED_TEST_CARGO_DIRECTORY_SEGMENTS = new Set([
+  "__snapshots__",
+  "__tests__",
+  "test",
+  "tests",
+]);
+const PACKED_TEST_CARGO_FILE_RE = /(?:^|\/)[^/]+\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/u;
 const NPM_PACK_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 const skipPackValidationEnv = "OPENCLAW_NPM_RELEASE_SKIP_PACK_CHECK";
+
+function normalizePackedPath(packedPath: string): string {
+  return packedPath.replace(/\\/g, "/");
+}
+
+function isNodeModulesPackageRoot(segments: string[], index: number): boolean {
+  const parent = segments[index - 1];
+  if (parent === "node_modules") {
+    return true;
+  }
+  return parent?.startsWith("@") && segments[index - 2] === "node_modules";
+}
+
+function pathContainsPackedTestCargo(packedPath: string): boolean {
+  const normalizedPath = normalizePackedPath(packedPath);
+  if (PACKED_TEST_CARGO_FILE_RE.test(normalizedPath)) {
+    return true;
+  }
+  const segments = normalizedPath.split("/").filter(Boolean);
+  return segments.some(
+    (segment, index) =>
+      PACKED_TEST_CARGO_DIRECTORY_SEGMENTS.has(segment) &&
+      !isNodeModulesPackageRoot(segments, index),
+  );
+}
 
 function normalizeRepoUrl(value: unknown): string {
   if (typeof value !== "string") {
@@ -489,7 +521,11 @@ function collectPackedTarballErrors(): string[] {
   return [
     ...collectControlUiPackErrors(packedPaths),
     ...collectForbiddenPackedPathErrors(packedPaths),
+<<<<<<< HEAD
     ...collectForbiddenPackedContentErrors(packedPaths),
+=======
+    ...collectPackedTestCargoErrors(packedPaths),
+>>>>>>> caafdea0bb (Build: prune packaged runtime test cargo)
   ];
 }
 
@@ -544,7 +580,22 @@ export function collectForbiddenPackedContentErrors(
   return errors.toSorted((left, right) => left.localeCompare(right));
 }
 
+export function collectPackedTestCargoErrors(paths: Iterable<string>): string[] {
+  const errors: string[] = [];
+  for (const packedPath of paths) {
+    if (!pathContainsPackedTestCargo(packedPath)) {
+      continue;
+    }
+    errors.push(`npm package must not include test cargo "${packedPath}".`);
+  }
+  return errors.toSorted((left, right) => left.localeCompare(right));
+}
+
+<<<<<<< HEAD
 async function main(): Promise<number> {
+=======
+function main(): number {
+>>>>>>> caafdea0bb (Build: prune packaged runtime test cargo)
   const pkg = loadPackageJson();
   const now = new Date();
   const skipPackValidation = shouldSkipPackedTarballValidation();

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -588,7 +588,6 @@ export function collectPackedTestCargoErrors(paths: Iterable<string>): string[] 
 }
 
 async function main(): Promise<number> {
-async function main(): Promise<number> {
   const pkg = loadPackageJson();
   const now = new Date();
   const skipPackValidation = shouldSkipPackedTarballValidation();

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -118,7 +118,6 @@ const skipPackValidationEnv = "OPENCLAW_NPM_RELEASE_SKIP_PACK_CHECK";
 function normalizePackedPath(packedPath: string): string {
   return packedPath.replace(/\\/g, "/");
 }
-
 function isNodeModulesPackageRoot(segments: string[], index: number): boolean {
   const parent = segments[index - 1];
   if (parent === "node_modules") {
@@ -521,11 +520,8 @@ function collectPackedTarballErrors(): string[] {
   return [
     ...collectControlUiPackErrors(packedPaths),
     ...collectForbiddenPackedPathErrors(packedPaths),
-<<<<<<< HEAD
     ...collectForbiddenPackedContentErrors(packedPaths),
-=======
     ...collectPackedTestCargoErrors(packedPaths),
->>>>>>> caafdea0bb (Build: prune packaged runtime test cargo)
   ];
 }
 
@@ -591,11 +587,8 @@ export function collectPackedTestCargoErrors(paths: Iterable<string>): string[] 
   return errors.toSorted((left, right) => left.localeCompare(right));
 }
 
-<<<<<<< HEAD
 async function main(): Promise<number> {
-=======
-function main(): number {
->>>>>>> caafdea0bb (Build: prune packaged runtime test cargo)
+async function main(): Promise<number> {
   const pkg = loadPackageJson();
   const now = new Date();
   const skipPackValidation = shouldSkipPackedTarballValidation();

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -504,6 +504,18 @@ function pruneDependencyFilesBySuffixes(depRoot, suffixes) {
   });
 }
 
+function relativePathSegments(rootDir, fullPath) {
+  return path.relative(rootDir, fullPath).split(path.sep).filter(Boolean);
+}
+
+function isNodeModulesPackageRoot(segments, index) {
+  const parent = segments[index - 1];
+  if (parent === "node_modules") {
+    return true;
+  }
+  return parent?.startsWith("@") === true && segments[index - 2] === "node_modules";
+}
+
 function pruneDependencyDirectoriesByBasename(depRoot, basenames) {
   if (!basenames || basenames.length === 0 || !fs.existsSync(depRoot)) {
     return;
@@ -517,7 +529,8 @@ function pruneDependencyDirectoriesByBasename(depRoot, basenames) {
         continue;
       }
       const fullPath = path.join(currentDir, entry.name);
-      if (basenameSet.has(entry.name)) {
+      const segments = relativePathSegments(depRoot, fullPath);
+      if (basenameSet.has(entry.name) && !isNodeModulesPackageRoot(segments, segments.length - 1)) {
         removePathIfExists(fullPath);
         continue;
       }
@@ -531,7 +544,7 @@ function pruneDependencyFilesByPatterns(depRoot, patterns) {
     return;
   }
   walkFiles(depRoot, (fullPath) => {
-    const relativePath = path.relative(depRoot, fullPath).replace(/\\/g, "/");
+    const relativePath = relativePathSegments(depRoot, fullPath).join("/");
     if (patterns.some((pattern) => pattern.test(relativePath))) {
       removePathIfExists(fullPath);
     }

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -142,6 +142,15 @@ function readInstalledDependencyVersionFromRoot(depRoot) {
 }
 
 const defaultStagedRuntimeDepGlobalPruneSuffixes = [".d.ts", ".map"];
+const defaultStagedRuntimeDepGlobalPruneDirectories = [
+  "__snapshots__",
+  "__tests__",
+  "test",
+  "tests",
+];
+const defaultStagedRuntimeDepGlobalPruneFilePatterns = [
+  /(?:^|\/)[^/]+\.(?:test|spec)\.(?:[cm]?[jt]sx?)$/u,
+];
 const defaultStagedRuntimeDepPruneRules = new Map([
   // Type declarations only; runtime resolves through lib/es entrypoints.
   ["@larksuiteoapi/node-sdk", { paths: ["types"] }],
@@ -182,11 +191,17 @@ const defaultStagedRuntimeDepPruneRules = new Map([
   ["@jimp/plugin-quantize", { paths: ["src/__image_snapshots__"] }],
   ["@jimp/plugin-threshold", { paths: ["src/__image_snapshots__"] }],
 ]);
-const runtimeDepsStagingVersion = 5;
+const runtimeDepsStagingVersion = 6;
 const exactVersionSpecRe = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
 
 function resolveRuntimeDepPruneConfig(params = {}) {
   return {
+    globalPruneDirectories:
+      params.stagedRuntimeDepGlobalPruneDirectories ??
+      defaultStagedRuntimeDepGlobalPruneDirectories,
+    globalPruneFilePatterns:
+      params.stagedRuntimeDepGlobalPruneFilePatterns ??
+      defaultStagedRuntimeDepGlobalPruneFilePatterns,
     globalPruneSuffixes:
       params.stagedRuntimeDepGlobalPruneSuffixes ?? defaultStagedRuntimeDepGlobalPruneSuffixes,
     pruneRules: params.stagedRuntimeDepPruneRules ?? defaultStagedRuntimeDepPruneRules,
@@ -489,6 +504,40 @@ function pruneDependencyFilesBySuffixes(depRoot, suffixes) {
   });
 }
 
+function pruneDependencyDirectoriesByBasename(depRoot, basenames) {
+  if (!basenames || basenames.length === 0 || !fs.existsSync(depRoot)) {
+    return;
+  }
+  const basenameSet = new Set(basenames);
+  const queue = [depRoot];
+  while (queue.length > 0) {
+    const currentDir = queue.shift();
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const fullPath = path.join(currentDir, entry.name);
+      if (basenameSet.has(entry.name)) {
+        removePathIfExists(fullPath);
+        continue;
+      }
+      queue.push(fullPath);
+    }
+  }
+}
+
+function pruneDependencyFilesByPatterns(depRoot, patterns) {
+  if (!patterns || patterns.length === 0 || !fs.existsSync(depRoot)) {
+    return;
+  }
+  walkFiles(depRoot, (fullPath) => {
+    const relativePath = path.relative(depRoot, fullPath).replace(/\\/g, "/");
+    if (patterns.some((pattern) => pattern.test(relativePath))) {
+      removePathIfExists(fullPath);
+    }
+  });
+}
+
 function pruneStagedInstalledDependencyCargo(nodeModulesDir, depName, pruneConfig) {
   const depRoot = dependencyNodeModulesPath(nodeModulesDir, depName);
   if (depRoot === null) {
@@ -498,6 +547,8 @@ function pruneStagedInstalledDependencyCargo(nodeModulesDir, depName, pruneConfi
   for (const relativePath of pruneRule?.paths ?? []) {
     removePathIfExists(path.join(depRoot, relativePath));
   }
+  pruneDependencyDirectoriesByBasename(depRoot, pruneConfig.globalPruneDirectories);
+  pruneDependencyFilesByPatterns(depRoot, pruneConfig.globalPruneFilePatterns);
   pruneDependencyFilesBySuffixes(depRoot, pruneConfig.globalPruneSuffixes);
   pruneDependencyFilesBySuffixes(depRoot, pruneRule?.suffixes ?? []);
 }
@@ -784,6 +835,10 @@ function createRuntimeDepsFingerprint(packageJson, pruneConfig, params = {}) {
   return createHash("sha256")
     .update(
       JSON.stringify({
+        globalPruneDirectories: pruneConfig.globalPruneDirectories,
+        globalPruneFilePatterns: pruneConfig.globalPruneFilePatterns.map((pattern) =>
+          pattern.toString(),
+        ),
         globalPruneSuffixes: pruneConfig.globalPruneSuffixes,
         packageJson,
         pruneRules: [...pruneConfig.pruneRules.entries()],

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -478,8 +478,8 @@ function walkFiles(rootDir, visitFile) {
     return;
   }
   const queue = [rootDir];
-  while (queue.length > 0) {
-    const currentDir = queue.shift();
+  for (let index = 0; index < queue.length; index += 1) {
+    const currentDir = queue[index];
     for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
       const fullPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
@@ -522,8 +522,8 @@ function pruneDependencyDirectoriesByBasename(depRoot, basenames) {
   }
   const basenameSet = new Set(basenames);
   const queue = [depRoot];
-  while (queue.length > 0) {
-    const currentDir = queue.shift();
+  for (let index = 0; index < queue.length; index += 1) {
+    const currentDir = queue[index];
     for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) {
         continue;

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -415,6 +415,19 @@ describe("collectPackedTestCargoErrors", () => {
       ]),
     ).toEqual([]);
   });
+
+  it("normalizes Windows or mixed separators before classifying test cargo", () => {
+    expect(
+      collectPackedTestCargoErrors([
+        String.raw`dist\extensions\fixture-plugin\node_modules\direct\__tests__\index.js`,
+        String.raw`dist/extensions/fixture-plugin\node_modules/direct/src/runtime.spec.ts`,
+        String.raw`dist\extensions\fixture-plugin\node_modules\direct\node_modules\test\index.js`,
+      ]),
+    ).toEqual([
+      `npm package must not include test cargo "${String.raw`dist/extensions/fixture-plugin\node_modules/direct/src/runtime.spec.ts`}".`,
+      `npm package must not include test cargo "${String.raw`dist\extensions\fixture-plugin\node_modules\direct\__tests__\index.js`}".`,
+    ]);
+  });
 });
 
 describe("collectReleaseTagErrors", () => {

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -406,6 +406,15 @@ describe("collectPackedTestCargoErrors", () => {
       ]),
     ).toEqual([]);
   });
+
+  it("allows legitimate package roots named test under node_modules", () => {
+    expect(
+      collectPackedTestCargoErrors([
+        "dist/extensions/fixture-plugin/node_modules/direct/node_modules/test/index.js",
+        "dist/extensions/fixture-plugin/node_modules/direct/node_modules/@scope/tests/index.js",
+      ]),
+    ).toEqual([]);
+  });
 });
 
 describe("collectReleaseTagErrors", () => {

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -8,6 +8,7 @@ import {
   collectControlUiPackErrors,
   collectForbiddenPackedContentErrors,
   collectForbiddenPackedPathErrors,
+  collectPackedTestCargoErrors,
   collectReleasePackageMetadataErrors,
   collectReleaseTagErrors,
   parseNpmPackJsonOutput,
@@ -377,6 +378,33 @@ describe("collectForbiddenPackedPathErrors", () => {
     } finally {
       rmSync(rootDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("collectPackedTestCargoErrors", () => {
+  it("rejects packed test files and test directories", () => {
+    expect(
+      collectPackedTestCargoErrors([
+        "dist/extensions/webhooks/node_modules/zod/src/v3/tests/all-errors.test.ts",
+        "dist/extensions/whatsapp/node_modules/pino/test/basic.test.js",
+        "dist/extensions/whatsapp/node_modules/@jimp/plugin-crop/src/__snapshots__/crop.test.ts.snap",
+        "dist/index.js",
+      ]),
+    ).toEqual([
+      'npm package must not include test cargo "dist/extensions/webhooks/node_modules/zod/src/v3/tests/all-errors.test.ts".',
+      'npm package must not include test cargo "dist/extensions/whatsapp/node_modules/@jimp/plugin-crop/src/__snapshots__/crop.test.ts.snap".',
+      'npm package must not include test cargo "dist/extensions/whatsapp/node_modules/pino/test/basic.test.js".',
+    ]);
+  });
+
+  it("allows normal runtime files", () => {
+    expect(
+      collectPackedTestCargoErrors([
+        "dist/index.js",
+        "dist/extensions/whatsapp/node_modules/pino/lib/proto.js",
+        "dist/extensions/webhooks/node_modules/zod/v4/core/api.js",
+      ]),
+    ).toEqual([]);
   });
 });
 

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -415,6 +415,67 @@ describe("stageBundledPluginRuntimeDeps", () => {
     ).toBe(false);
   });
 
+  it("preserves nested runtime dependencies named test or tests", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { direct: "1.0.0" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const directDir = path.join(repoRoot, "node_modules", "direct");
+    const nestedTestDir = path.join(directDir, "node_modules", "test");
+    const scopedTestsDir = path.join(directDir, "node_modules", "@scope", "tests");
+    fs.mkdirSync(nestedTestDir, { recursive: true });
+    fs.mkdirSync(scopedTestsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(directDir, "package.json"),
+      '{ "name": "direct", "version": "1.0.0", "dependencies": { "test": "^1.0.0", "@scope/tests": "^1.0.0" } }\n',
+      "utf8",
+    );
+    fs.writeFileSync(path.join(directDir, "index.js"), "module.exports = 'direct';\n", "utf8");
+    fs.writeFileSync(
+      path.join(nestedTestDir, "package.json"),
+      '{ "name": "test", "version": "1.0.0" }\n',
+      "utf8",
+    );
+    fs.writeFileSync(path.join(nestedTestDir, "index.js"), "module.exports = 'test';\n", "utf8");
+    fs.writeFileSync(
+      path.join(scopedTestsDir, "package.json"),
+      '{ "name": "@scope/tests", "version": "1.0.0" }\n',
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(scopedTestsDir, "index.js"),
+      "module.exports = 'scoped-tests';\n",
+      "utf8",
+    );
+
+    stageBundledPluginRuntimeDeps({ cwd: repoRoot });
+
+    expect(
+      fs.readFileSync(
+        path.join(pluginDir, "node_modules", "direct", "node_modules", "test", "index.js"),
+        "utf8",
+      ),
+    ).toBe("module.exports = 'test';\n");
+    expect(
+      fs.readFileSync(
+        path.join(
+          pluginDir,
+          "node_modules",
+          "direct",
+          "node_modules",
+          "@scope",
+          "tests",
+          "index.js",
+        ),
+        "utf8",
+      ),
+    ).toBe("module.exports = 'scoped-tests';\n");
+  });
+
   it("stages hoisted transitive runtime deps from the root node_modules", () => {
     const { pluginDir, repoRoot } = createBundledPluginFixture({
       packageJson: {

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -362,6 +362,59 @@ describe("stageBundledPluginRuntimeDeps", () => {
     expect(fs.existsSync(path.join(pluginDir, ".openclaw-runtime-deps-stamp.json"))).toBe(true);
   });
 
+  it("prunes staged test cargo from copied runtime dependencies", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { direct: "1.0.0" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const directDir = path.join(repoRoot, "node_modules", "direct");
+    fs.mkdirSync(path.join(directDir, "test"), { recursive: true });
+    fs.mkdirSync(path.join(directDir, "__snapshots__"), { recursive: true });
+    fs.mkdirSync(path.join(directDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(directDir, "package.json"),
+      '{ "name": "direct", "version": "1.0.0" }\n',
+      "utf8",
+    );
+    fs.writeFileSync(path.join(directDir, "index.js"), "module.exports = 'runtime';\n", "utf8");
+    fs.writeFileSync(
+      path.join(directDir, "test", "index.test.js"),
+      "module.exports = 'remove';\n",
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(directDir, "__snapshots__", "index.test.ts.snap"),
+      "snapshot\n",
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(directDir, "src", "runtime.spec.js"),
+      "module.exports = 'remove';\n",
+      "utf8",
+    );
+
+    stageBundledPluginRuntimeDeps({ cwd: repoRoot });
+
+    expect(
+      fs.readFileSync(path.join(pluginDir, "node_modules", "direct", "index.js"), "utf8"),
+    ).toBe("module.exports = 'runtime';\n");
+    expect(
+      fs.existsSync(path.join(pluginDir, "node_modules", "direct", "test", "index.test.js")),
+    ).toBe(false);
+    expect(
+      fs.existsSync(
+        path.join(pluginDir, "node_modules", "direct", "__snapshots__", "index.test.ts.snap"),
+      ),
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.join(pluginDir, "node_modules", "direct", "src", "runtime.spec.js")),
+    ).toBe(false);
+  });
+
   it("stages hoisted transitive runtime deps from the root node_modules", () => {
     const { pluginDir, repoRoot } = createBundledPluginFixture({
       packageJson: {


### PR DESCRIPTION
## Summary

- Problem: bundled plugin runtime deps were carrying third-party test/spec cargo into the packed npm tarball.
- Why it matters: release tarballs grew with files that are never needed at runtime, and the leak was happening through the shared staged-runtime-deps seam.
- What changed: added generic runtime-dependency pruning for common test cargo in `scripts/stage-bundled-plugin-runtime-deps.mjs`, bumped the staging fingerprint, and added an npm release-check guard that fails if packed test cargo reappears.
- What did NOT change (scope boundary): no plugin-specific allowlists or special cases; no runtime behavior changes beyond packaging contents.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the shared bundled-runtime-deps staging flow copied third-party runtime dependency trees into `dist/extensions/*/node_modules` without stripping common test/spec cargo.
- Missing detection / guardrail: npm release validation did not fail when packed tarballs still contained test/spec files.
- Contributing context (if known): the leak came from vendored dependency trees, not repo-owned test files.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/stage-bundled-plugin-runtime-deps.test.ts`, `test/openclaw-npm-release-check.test.ts`
- Scenario the test should lock in: staged runtime deps drop common test cargo, and release-pack validation rejects any packed test cargo.
- Why this is the smallest reliable guardrail: both failure modes live at packaging seams, so direct seam tests cover the contract without needing a full publish flow.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): npm packaging path for bundled plugins
- Relevant config (redacted): default local repo config

### Steps

1. Stage bundled plugin runtime deps into `dist/extensions/*/node_modules`.
2. Run targeted tests for the staging seam and npm release-check seam.
3. Run `npm pack --dry-run --json --ignore-scripts` and scan packed paths for test/spec cargo.

### Expected

- Bundled runtime deps omit common test/spec cargo.
- npm pack output contains no test/spec cargo.

### Actual

- After this patch, `npm pack --dry-run --json --ignore-scripts` reported `matches=0` for the packed test/spec scan.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test test/scripts/stage-bundled-plugin-runtime-deps.test.ts test/openclaw-npm-release-check.test.ts`; `npm pack --dry-run --json --ignore-scripts` + test/spec scan (`matches=0`).
- Edge cases checked: direct staged dependency with `test/`, `__snapshots__/`, and `*.spec.*` files; packed path guard catches both directory-based and filename-based cargo.
- What you did **not** verify: full `pnpm build` in this dirty local worktree; local run hit an unrelated unstaged type error in `extensions/qa-channel/src/runtime.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: generic prune rules could remove a runtime file from a dependency that uses `test`-like naming for shipped assets.
  - Mitigation: scope is limited to common test directories and `*.test.*` / `*.spec.*` filenames, plus regression coverage at both staging and pack-validation seams.
