### PR TITLE
fix(whatsapp): harden creds saves during reconnects

### DIFF
--- a/extensions/whatsapp/src/auth-store.ts
+++ b/extensions/whatsapp/src/auth-store.ts
@@ -18,19 +18,51 @@ export function resolveDefaultWebAuthDir(): string {
 
 export const WA_WEB_AUTH_DIR = resolveDefaultWebAuthDir();
 
-export function readCredsJsonRaw(filePath: string): string | null {
+export type CredsJsonInspectResult =
+  | {
+      ok: true;
+      raw: string;
+      bytes: number;
+    }
+  | {
+      ok: false;
+      reason: "missing" | "not-file" | "empty" | "read-error" | "invalid-json";
+      bytes?: number;
+      error?: string;
+    };
+
+export function inspectCredsJson(filePath: string): CredsJsonInspectResult {
   try {
     if (!fsSync.existsSync(filePath)) {
-      return null;
+      return { ok: false, reason: "missing" };
     }
     const stats = fsSync.statSync(filePath);
-    if (!stats.isFile() || stats.size <= 1) {
-      return null;
+    if (!stats.isFile()) {
+      return { ok: false, reason: "not-file" };
     }
-    return fsSync.readFileSync(filePath, "utf-8");
-  } catch {
-    return null;
+    if (stats.size <= 1) {
+      return { ok: false, reason: "empty", bytes: stats.size };
+    }
+    const raw = fsSync.readFileSync(filePath, "utf-8");
+    try {
+      JSON.parse(raw);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: "invalid-json",
+        bytes: stats.size,
+        error: String(err),
+      };
+    }
+    return { ok: true, raw, bytes: stats.size };
+  } catch (err) {
+    return { ok: false, reason: "read-error", error: String(err) };
   }
+}
+
+export function readCredsJsonRaw(filePath: string): string | null {
+  const inspected = inspectCredsJson(filePath);
+  return inspected.ok ? inspected.raw : null;
 }
 
 export function maybeRestoreCredsFromBackup(authDir: string): void {
@@ -38,27 +70,45 @@ export function maybeRestoreCredsFromBackup(authDir: string): void {
   try {
     const credsPath = resolveWebCredsPath(authDir);
     const backupPath = resolveWebCredsBackupPath(authDir);
-    const raw = readCredsJsonRaw(credsPath);
-    if (raw) {
-      // Validate that creds.json is parseable.
-      JSON.parse(raw);
+    const current = inspectCredsJson(credsPath);
+    if (current.ok) {
       return;
     }
 
-    const backupRaw = readCredsJsonRaw(backupPath);
-    if (!backupRaw) {
+    const backup = inspectCredsJson(backupPath);
+    if (!backup.ok) {
+      if (current.reason !== "missing") {
+        logger.warn(
+          {
+            credsPath,
+            backupPath,
+            reason: current.reason,
+            backupReason: backup.reason,
+            credsBytes: current.bytes,
+            backupBytes: backup.bytes,
+          },
+          "WhatsApp creds.json is unusable and no valid backup is available",
+        );
+      }
       return;
     }
 
-    // Ensure backup is parseable before restoring.
-    JSON.parse(backupRaw);
     fsSync.copyFileSync(backupPath, credsPath);
     try {
       fsSync.chmodSync(credsPath, 0o600);
     } catch {
       // best-effort on platforms that support it
     }
-    logger.warn({ credsPath }, "restored corrupted WhatsApp creds.json from backup");
+    logger.warn(
+      {
+        credsPath,
+        backupPath,
+        reason: current.reason,
+        credsBytes: current.bytes,
+        backupBytes: backup.bytes,
+      },
+      "restored corrupted WhatsApp creds.json from backup",
+    );
   } catch {
     // ignore
   }

--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -1,18 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getRegisteredWhatsAppConnectionController } from "./connection-controller-registry.js";
 import { WhatsAppConnectionController } from "./connection-controller.js";
-import { createWaSocket, waitForWaConnection } from "./session.js";
+import {
+  createWaSocket,
+  waitForCredsSaveQueueWithTimeout,
+  waitForWaConnection,
+} from "./session.js";
 
 vi.mock("./session.js", async () => {
   const actual = await vi.importActual<typeof import("./session.js")>("./session.js");
   return {
     ...actual,
     createWaSocket: vi.fn(),
+    waitForCredsSaveQueueWithTimeout: vi.fn(),
     waitForWaConnection: vi.fn(),
   };
 });
 
 const createWaSocketMock = vi.mocked(createWaSocket);
+const waitForCredsSaveQueueWithTimeoutMock = vi.mocked(waitForCredsSaveQueueWithTimeout);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
 
 describe("WhatsAppConnectionController", () => {
@@ -62,8 +68,30 @@ describe("WhatsAppConnectionController", () => {
 
     expect(createListener).not.toHaveBeenCalled();
     expect(sock.ws.close).toHaveBeenCalledOnce();
+    expect(waitForCredsSaveQueueWithTimeoutMock).toHaveBeenCalledWith("/tmp/wa-auth");
     expect(controller.socketRef.current).toBeNull();
     expect(controller.getActiveListener()).toBeNull();
+  });
+
+  it("waits for pending credential saves when closing an active connection", async () => {
+    const sock = {
+      ws: {
+        close: vi.fn(),
+      },
+    };
+
+    createWaSocketMock.mockResolvedValueOnce(sock as never);
+    waitForWaConnectionMock.mockResolvedValueOnce(undefined);
+
+    await controller.openConnection({
+      connectionId: "conn-1",
+      createListener: async () => ({}) as never,
+    });
+
+    await controller.closeCurrentConnection();
+
+    expect(sock.ws.close).toHaveBeenCalledOnce();
+    expect(waitForCredsSaveQueueWithTimeoutMock).toHaveBeenCalledWith("/tmp/wa-auth");
   });
 
   it("keeps the previous registered controller until a replacement listener is ready", async () => {

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -376,6 +376,7 @@ export class WhatsAppConnectionController {
       if (connection?.unregisterUnhandled) {
         connection.unregisterUnhandled();
       }
+      await waitForCredsSaveQueueWithTimeout(this.authDir);
       throw err;
     }
   }
@@ -506,6 +507,7 @@ export class WhatsAppConnectionController {
       // best-effort close
     }
     closeWaSocket(connection.sock);
+    await waitForCredsSaveQueueWithTimeout(this.authDir);
   }
 
   async waitBeforeRetry(delayMs: number): Promise<void> {

--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import fsSync from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { resetLogger, setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -243,6 +244,38 @@ describe("web session", () => {
     creds.restore();
   });
 
+  it("restores the last valid creds when saveCreds leaves invalid JSON", async () => {
+    const authDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-creds-"));
+    const credsPath = path.join(authDir, "creds.json");
+    const backupPath = path.join(authDir, "creds.json.bak");
+    try {
+      fsSync.writeFileSync(credsPath, JSON.stringify({ session: "before" }), "utf-8");
+      fsSync.writeFileSync(backupPath, JSON.stringify({ session: "older" }), "utf-8");
+      const saveCreds = vi.fn(async () => {
+        fsSync.writeFileSync(credsPath, "{", "utf-8");
+      });
+      useMultiFileAuthStateMock.mockResolvedValueOnce({
+        state: { creds: {} as never, keys: {} as never },
+        saveCreds,
+      });
+
+      await createWaSocket(false, false, { authDir });
+      const sock = getLastSocket();
+      sock.ev.emit("creds.update", {});
+      await waitForCredsSaveQueue(authDir);
+
+      expect(saveCreds).toHaveBeenCalledOnce();
+      expect(JSON.parse(fsSync.readFileSync(credsPath, "utf-8"))).toEqual({
+        session: "before",
+      });
+      expect(JSON.parse(fsSync.readFileSync(backupPath, "utf-8"))).toEqual({
+        session: "before",
+      });
+    } finally {
+      fsSync.rmSync(authDir, { recursive: true, force: true });
+    }
+  });
+
   it("serializes creds.update saves to avoid overlapping writes", async () => {
     let inFlight = 0;
     let maxInFlight = 0;
@@ -351,7 +384,7 @@ describe("web session", () => {
     await createWaSocket(false, false);
     const saveCreds = await emitCredsUpdateAndReadSaveCreds();
 
-    expect(creds.copySpy).toHaveBeenCalledTimes(1);
+    expect(creds.copySpy).toHaveBeenCalledTimes(2);
     const args = creds.copySpy.mock.calls[0] ?? [];
     expect(String(args[0] ?? "")).toContain(creds.credsSuffix);
     expect(String(args[1] ?? "")).toContain(backupSuffix);

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -8,8 +8,8 @@ import { danger, success } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger, toPinoLikeLogger } from "openclaw/plugin-sdk/runtime-env";
 import { ensureDir, resolveUserPath } from "openclaw/plugin-sdk/text-runtime";
 import {
+  inspectCredsJson,
   maybeRestoreCredsFromBackup,
-  readCredsJsonRaw,
   resolveDefaultWebAuthDir,
   resolveWebCredsBackupPath,
   resolveWebCredsPath,
@@ -44,6 +44,33 @@ async function loadQrTerminal() {
 // Per-authDir queues so multi-account creds saves don't block each other.
 const credsSaveQueues = new Map<string, Promise<void>>();
 const CREDS_SAVE_FLUSH_TIMEOUT_MS = 15_000;
+
+function chmodCredsFile(filePath: string): void {
+  try {
+    fsSync.chmodSync(filePath, 0o600);
+  } catch {
+    // best-effort on platforms that support it
+  }
+}
+
+function rotateCredsBackupIfValid(
+  authDir: string,
+  logger: ReturnType<typeof getChildLogger>,
+): void {
+  const credsPath = resolveWebCredsPath(authDir);
+  const backupPath = resolveWebCredsBackupPath(authDir);
+  const inspected = inspectCredsJson(credsPath);
+  if (!inspected.ok) {
+    return;
+  }
+  try {
+    fsSync.copyFileSync(credsPath, backupPath);
+    chmodCredsFile(backupPath);
+  } catch (err) {
+    logger.warn({ error: String(err) }, "failed rotating WhatsApp creds backup");
+  }
+}
+
 function enqueueSaveCreds(
   authDir: string,
   saveCreds: () => Promise<void> | void,
@@ -68,37 +95,32 @@ async function safeSaveCreds(
   saveCreds: () => Promise<void> | void,
   logger: ReturnType<typeof getChildLogger>,
 ): Promise<void> {
-  try {
-    // Best-effort backup so we can recover after abrupt restarts.
-    // Important: don't clobber a good backup with a corrupted/truncated creds.json.
-    const credsPath = resolveWebCredsPath(authDir);
-    const backupPath = resolveWebCredsBackupPath(authDir);
-    const raw = readCredsJsonRaw(credsPath);
-    if (raw) {
-      try {
-        JSON.parse(raw);
-        fsSync.copyFileSync(credsPath, backupPath);
-        try {
-          fsSync.chmodSync(backupPath, 0o600);
-        } catch {
-          // best-effort on platforms that support it
-        }
-      } catch {
-        // keep existing backup
-      }
-    }
-  } catch {
-    // ignore backup failures
-  }
+  // Best-effort backup so we can recover after abrupt restarts.
+  // Important: don't clobber a good backup with a corrupted/truncated creds.json.
+  rotateCredsBackupIfValid(authDir, logger);
+
   try {
     await Promise.resolve(saveCreds());
-    try {
-      fsSync.chmodSync(resolveWebCredsPath(authDir), 0o600);
-    } catch {
-      // best-effort on platforms that support it
+    const credsPath = resolveWebCredsPath(authDir);
+    const inspected = inspectCredsJson(credsPath);
+    if (!inspected.ok) {
+      logger.warn(
+        {
+          credsPath,
+          reason: inspected.reason,
+          credsBytes: inspected.bytes,
+          error: inspected.error,
+        },
+        "WhatsApp creds save produced invalid creds.json; attempting backup restore",
+      );
+      maybeRestoreCredsFromBackup(authDir);
+      return;
     }
+    chmodCredsFile(credsPath);
+    rotateCredsBackupIfValid(authDir, logger);
   } catch (err) {
     logger.warn({ error: String(err) }, "failed saving WhatsApp creds");
+    maybeRestoreCredsFromBackup(authDir);
   }
 }
 

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -295,6 +295,25 @@ describe("channel-health-monitor", () => {
     monitor.stop();
   });
 
+  it("does not restart WhatsApp while its own reconnect loop is active", async () => {
+    const now = Date.now();
+    const manager = createSnapshotManager({
+      whatsapp: {
+        default: {
+          running: true,
+          connected: false,
+          enabled: true,
+          configured: true,
+          linked: true,
+          healthState: "reconnecting",
+          lastStartAt: now - 300_000,
+          lastEventAt: now - 5_000,
+        },
+      },
+    });
+    await expectNoRestart(manager);
+  });
+
   it("skips restart when channel is busy with active runs", async () => {
     const now = Date.now();
     const manager = createSnapshotManager({

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
   evaluateChannelHealth,
+  normalizeChannelHealthSnapshot,
   resolveChannelRestartReason,
   type ChannelHealthPolicy,
 } from "./channel-health-policy.js";
@@ -132,7 +133,8 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             channelConnectGraceMs: timing.channelConnectGraceMs,
             skipStaleSocketCheck: getChannelPlugin(channelId)?.status?.skipStaleSocketHealthCheck,
           };
-          const health = evaluateChannelHealth(status, healthPolicy);
+          const healthSnapshot = normalizeChannelHealthSnapshot(status);
+          const health = evaluateChannelHealth(healthSnapshot, healthPolicy);
           if (health.healthy) {
             continue;
           }
@@ -155,7 +157,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             continue;
           }
 
-          const reason = resolveChannelRestartReason(status, health);
+          const reason = resolveChannelRestartReason(healthSnapshot, health);
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -51,6 +51,48 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: true, reason: "startup-connect-grace" });
   });
 
+  it("allows a reconnecting channel to finish its own reconnect window", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: false,
+        enabled: true,
+        configured: true,
+        healthState: "reconnecting",
+        lastStartAt: 0,
+        lastEventAt: 95_000,
+      },
+      {
+        channelId: "whatsapp",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "reconnecting-grace" });
+  });
+
+  it("flags reconnecting channels after their reconnect grace expires", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: false,
+        enabled: true,
+        configured: true,
+        healthState: "reconnecting",
+        lastStartAt: 0,
+        lastEventAt: 80_000,
+      },
+      {
+        channelId: "whatsapp",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
+  });
+
   it("treats active runs as busy even when disconnected", () => {
     const now = 100_000;
     const evaluation = evaluateChannelHealth(

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -13,6 +13,7 @@ export type ChannelHealthSnapshot = {
   lastStartAt?: number | null;
   reconnectAttempts?: number;
   mode?: string;
+  healthState?: string;
 };
 
 export type ChannelHealthEvaluationReason =
@@ -22,6 +23,7 @@ export type ChannelHealthEvaluationReason =
   | "busy"
   | "stuck"
   | "startup-connect-grace"
+  | "reconnecting-grace"
   | "disconnected"
   | "stale-socket";
 
@@ -102,6 +104,15 @@ export function evaluateChannelHealth(
     const upDuration = policy.now - snapshot.lastStartAt;
     if (upDuration < policy.channelConnectGraceMs) {
       return { healthy: true, reason: "startup-connect-grace" };
+    }
+  }
+  if (snapshot.healthState === "reconnecting") {
+    const lastEventAt =
+      typeof snapshot.lastEventAt === "number" && Number.isFinite(snapshot.lastEventAt)
+        ? snapshot.lastEventAt
+        : null;
+    if (lastEventAt != null && policy.now - lastEventAt < policy.channelConnectGraceMs) {
+      return { healthy: true, reason: "reconnecting-grace" };
     }
   }
   if (snapshot.connected === false) {

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -1,5 +1,9 @@
 import type { ChannelId } from "../channels/plugins/types.public.js";
 
+export const CHANNEL_HEALTH_STATE_RECONNECTING = "reconnecting" as const;
+
+export type ChannelHealthState = typeof CHANNEL_HEALTH_STATE_RECONNECTING;
+
 export type ChannelHealthSnapshot = {
   running?: boolean;
   connected?: boolean;
@@ -13,8 +17,21 @@ export type ChannelHealthSnapshot = {
   lastStartAt?: number | null;
   reconnectAttempts?: number;
   mode?: string;
-  healthState?: string;
+  healthState?: ChannelHealthState;
 };
+
+export type ChannelHealthSnapshotInput = Omit<ChannelHealthSnapshot, "healthState"> & {
+  healthState?: unknown;
+};
+
+export function normalizeChannelHealthSnapshot(
+  snapshot: ChannelHealthSnapshotInput,
+): ChannelHealthSnapshot {
+  const { healthState, ...rest } = snapshot;
+  return healthState === CHANNEL_HEALTH_STATE_RECONNECTING
+    ? { ...rest, healthState: CHANNEL_HEALTH_STATE_RECONNECTING }
+    : rest;
+}
 
 export type ChannelHealthEvaluationReason =
   | "healthy"
@@ -106,7 +123,7 @@ export function evaluateChannelHealth(
       return { healthy: true, reason: "startup-connect-grace" };
     }
   }
-  if (snapshot.healthState === "reconnecting") {
+  if (snapshot.healthState === CHANNEL_HEALTH_STATE_RECONNECTING) {
     const lastEventAt =
       typeof snapshot.lastEventAt === "number" && Number.isFinite(snapshot.lastEventAt)
         ? snapshot.lastEventAt

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
   evaluateChannelHealth,
+  normalizeChannelHealthSnapshot,
   type ChannelHealthPolicy,
   type ChannelHealthEvaluation,
 } from "../channel-health-policy.js";
@@ -67,7 +68,10 @@ export function createReadinessChecker(deps: {
           channelId,
           skipStaleSocketCheck: getChannelPlugin(channelId)?.status?.skipStaleSocketHealthCheck,
         };
-        const health = evaluateChannelHealth(accountSnapshot, policy);
+        const health = evaluateChannelHealth(
+          normalizeChannelHealthSnapshot(accountSnapshot),
+          policy,
+        );
         if (!health.healthy && !shouldIgnoreReadinessFailure(accountSnapshot, health)) {
           failing.push(channelId);
           break;


### PR DESCRIPTION
## Summary
- validate WhatsApp creds.json after every Baileys save and restore the last valid backup when a save leaves invalid JSON
- flush pending credential saves before failed/open sockets and explicit closes finish
- let WhatsApp's own reconnect loop stay within the health-monitor grace window before forcing a restart

## Tests
- pnpm exec vitest run extensions/whatsapp/src/session.test.ts extensions/whatsapp/src/connection-controller.test.ts src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts
- pnpm exec oxfmt --check extensions/whatsapp/src/auth-store.ts extensions/whatsapp/src/session.ts extensions/whatsapp/src/connection-controller.ts extensions/whatsapp/src/session.test.ts extensions/whatsapp/src/connection-controller.test.ts src/gateway/channel-health-policy.ts src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts
- pnpm tsgo
- pnpm exec oxlint extensions/whatsapp/src/auth-store.ts extensions/whatsapp/src/session.ts extensions/whatsapp/src/connection-controller.ts extensions/whatsapp/src/session.test.ts extensions/whatsapp/src/connection-controller.test.ts src/gateway/channel-health-policy.ts src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts

Note: full `pnpm lint` currently fails on unrelated pre-existing issues outside this change set.