### PR TITLE
fix(openai-transport): handle Mistral reasoning_content as non-string delta content

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1118,7 +1118,7 @@ async function processOpenAICompletionsStream(
     if (!choice.delta) {
       continue;
     }
-    if (choice.delta.content) {
+    if (typeof choice.delta.content === "string") {
       flushPendingThinkingDelta();
       if (!currentBlock || currentBlock.type !== "text") {
         finishCurrentBlock();

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -3,6 +3,7 @@ import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.
 import type { CliDeps } from "../cli/deps.types.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
 import { isRestartEnabled } from "../config/commands.flags.js";
+import { setRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
@@ -140,6 +141,16 @@ export function createGatewayReloadHandlers(params: {
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
+
+    // logging.file is a no-op path (kind: "none" in reload rules), so it reaches
+    // here with plan.noopPaths = ["logging", "logging.file"]. Invalidate the
+    // runtime config snapshot so the next resolveSettings() call (via
+    // readLoggingConfig → loadConfig → loadPinnedRuntimeConfig) sees the updated
+    // logging.file value instead of the stale startup snapshot.
+    const loggingChanged = plan.noopPaths.some((p) => p === "logging" || p.startsWith("logging."));
+    if (loggingChanged) {
+      setRuntimeConfigSnapshot(nextConfig);
+    }
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);


### PR DESCRIPTION
## Fix #67192 — Mistral reasoning (/think) crashes channel with [object Object]

### Problem

When using `mistral/mistral-small-latest` with reasoning enabled (`/think high`), the channel crashes and outputs `NO_REPLY[object Object][object Object]...` which permanently corrupts the session.

### Root Cause

In `src/agents/openai-transport-stream.ts` line 1121:

```typescript
if (choice.delta.content) {
  currentBlock.text += choice.delta.content;
```

Mistral returns `choice.delta.content` as a JSON object, not a string. The truthy check passes, and `+=` coerces the object to `[object Object]`.

### Fix

Add a `typeof` guard so only actual string content is treated as text:

```typescript
if (typeof choice.delta.content === "string") {
```

Non-string content falls through to `getCompletionsReasoningDelta()`, which already handles `reasoning_content`.

---

## Fix #67168 — logging.file config is read but not applied

### Problem

Setting `logging.file` in `openclaw.json` has no effect — logs always write to `/tmp/openclaw/` regardless of configuration.

### Root Cause

In `src/gateway/config-reload-plan.ts`, `logging` is classified as `kind: "none"` in `BASE_RELOAD_RULES_TAIL`. When `logging.file` changes:

1. `applySnapshot(nextConfig)` updates `currentConfig` in memory
2. `buildGatewayReloadPlan()` puts `"logging.file"` in `noopPaths`
3. `applyHotReload()` runs with empty `hotReasons` — no subsystem is updated
4. `setRuntimeConfigSnapshot()` is **never called**
5. `resolveSettings()` → `readLoggingConfig()` → `loadConfig()` → `loadPinnedRuntimeConfig()` returns the **stale startup snapshot**

### Fix

In `applyHotReload()`, detect when `noopPaths` contains a `logging.*` key and call `setRuntimeConfigSnapshot(nextConfig)`:

```typescript
const loggingChanged = plan.noopPaths.some(
  (p) => p === "logging" || p.startsWith("logging.")
);
if (loggingChanged) {
  setRuntimeConfigSnapshot(nextConfig);
}
```

---

**Testing**

- [ ] Mistral Small with `/think` → no [object Object] output
- [ ] Change `logging.file` while gateway runs → logs switch to new path