### PR TITLE
fix(matrix): block DM pairing-store entries from authorizing room control commands [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(matrix): block DM pairing-store entries from authorizing room control commands [AI-assisted]. (#67294) Thanks @pgondhi987.
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
 - Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 - Cron/announce delivery: suppress mixed-content isolated cron announce replies that end with `NO_REPLY` so trailing silent sentinels no longer leak summary text to the target channel. (#65004) thanks @neo1027144-creator.

--- a/extensions/matrix/src/matrix/monitor/access-state.test.ts
+++ b/extensions/matrix/src/matrix/monitor/access-state.test.ts
@@ -28,6 +28,25 @@ describe("resolveMatrixMonitorAccessState", () => {
     ]);
   });
 
+  it("does not let DM pairing-store entries authorize room control commands", () => {
+    const state = resolveMatrixMonitorAccessState({
+      allowFrom: [],
+      storeAllowFrom: ["@attacker:example.org"],
+      groupAllowFrom: [],
+      roomUsers: [],
+      senderId: "@attacker:example.org",
+      isRoom: true,
+    });
+
+    expect(state.effectiveAllowFrom).toEqual(["@attacker:example.org"]);
+    expect(state.directAllowMatch.allowed).toBe(true);
+    expect(state.commandAuthorizers).toEqual([
+      { configured: false, allowed: false },
+      { configured: false, allowed: false },
+      { configured: false, allowed: false },
+    ]);
+  });
+
   it("keeps room-user matching disabled for dm traffic", () => {
     const state = resolveMatrixMonitorAccessState({
       allowFrom: [],

--- a/extensions/matrix/src/matrix/monitor/access-state.ts
+++ b/extensions/matrix/src/matrix/monitor/access-state.ts
@@ -1,9 +1,14 @@
 import { normalizeMatrixAllowList, resolveMatrixAllowListMatch } from "./allowlist.js";
-import type { MatrixAllowListMatch } from "./allowlist.js";
 
 type MatrixCommandAuthorizer = {
   configured: boolean;
   allowed: boolean;
+};
+
+type MatrixMonitorAllowListMatch = {
+  allowed: boolean;
+  matchKey?: string;
+  matchSource?: "wildcard" | "id" | "prefixed-id" | "prefixed-user";
 };
 
 export type MatrixMonitorAccessState = {
@@ -11,9 +16,9 @@ export type MatrixMonitorAccessState = {
   effectiveGroupAllowFrom: string[];
   effectiveRoomUsers: string[];
   groupAllowConfigured: boolean;
-  directAllowMatch: MatrixAllowListMatch;
-  roomUserMatch: MatrixAllowListMatch | null;
-  groupAllowMatch: MatrixAllowListMatch | null;
+  directAllowMatch: MatrixMonitorAllowListMatch;
+  roomUserMatch: MatrixMonitorAllowListMatch | null;
+  groupAllowMatch: MatrixMonitorAllowListMatch | null;
   commandAuthorizers: [MatrixCommandAuthorizer, MatrixCommandAuthorizer, MatrixCommandAuthorizer];
 };
 
@@ -25,12 +30,14 @@ export function resolveMatrixMonitorAccessState(params: {
   senderId: string;
   isRoom: boolean;
 }): MatrixMonitorAccessState {
+  const configuredAllowFrom = normalizeMatrixAllowList(params.allowFrom);
   const effectiveAllowFrom = normalizeMatrixAllowList([
-    ...params.allowFrom,
+    ...configuredAllowFrom,
     ...params.storeAllowFrom,
   ]);
   const effectiveGroupAllowFrom = normalizeMatrixAllowList(params.groupAllowFrom);
   const effectiveRoomUsers = normalizeMatrixAllowList(params.roomUsers);
+  const commandAllowFrom = params.isRoom ? configuredAllowFrom : effectiveAllowFrom;
 
   const directAllowMatch = resolveMatrixAllowListMatch({
     allowList: effectiveAllowFrom,
@@ -50,6 +57,13 @@ export function resolveMatrixMonitorAccessState(params: {
           userId: params.senderId,
         })
       : null;
+  const commandAllowMatch =
+    commandAllowFrom.length > 0
+      ? resolveMatrixAllowListMatch({
+          allowList: commandAllowFrom,
+          userId: params.senderId,
+        })
+      : null;
 
   return {
     effectiveAllowFrom,
@@ -61,8 +75,8 @@ export function resolveMatrixMonitorAccessState(params: {
     groupAllowMatch,
     commandAuthorizers: [
       {
-        configured: effectiveAllowFrom.length > 0,
-        allowed: directAllowMatch.allowed,
+        configured: commandAllowFrom.length > 0,
+        allowed: commandAllowMatch?.allowed ?? false,
       },
       {
         configured: effectiveRoomUsers.length > 0,

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -449,7 +449,7 @@ describe("matrix monitor handler pairing account scope", () => {
     const { handler, finalizeInboundContext, recordInboundSession } =
       createMatrixHandlerTestHarness({
         isDirectMessage: false,
-        storeAllowFrom: ["@user:example.org"],
+        readAllowFromStore: vi.fn(async () => ["@user:example.org"]),
         roomsConfig: {
           "!room:example.org": { requireMention: false },
         },

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -445,6 +445,36 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(recordInboundSession).not.toHaveBeenCalled();
   });
 
+  it("blocks room control commands from DM-only paired senders", async () => {
+    const { handler, finalizeInboundContext, recordInboundSession } =
+      createMatrixHandlerTestHarness({
+        isDirectMessage: false,
+        storeAllowFrom: ["@user:example.org"],
+        roomsConfig: {
+          "!room:example.org": { requireMention: false },
+        },
+        shouldHandleTextCommands: () => true,
+        hasControlCommand: () => true,
+        cfg: {
+          commands: {
+            useAccessGroups: true,
+          },
+        },
+        getMemberDisplayName: async () => "sender",
+      });
+
+    await handler(
+      "!room:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$dm-only-room-command",
+        body: "/config",
+      }),
+    );
+
+    expect(recordInboundSession).not.toHaveBeenCalled();
+    expect(finalizeInboundContext).not.toHaveBeenCalled();
+  });
+
   it("processes room messages mentioned via displayName in formatted_body", async () => {
     const recordInboundSession = vi.fn(async () => {});
     const { handler } = createMatrixHandlerTestHarness({


### PR DESCRIPTION
## Summary

- **Problem:** The Matrix access-state layer merged DM pairing-store entries (`storeAllowFrom`) into `effectiveAllowFrom` and then reused that merged list when building `commandAuthorizers[0]`. A sender approved only through DM pairing could therefore satisfy the room control-command gate and receive `CommandAuthorized: true` in room context — without appearing in `allowFrom`, `groupAllowFrom`, or per-room `users`.
- **Why it matters:** Room control commands include `/config`, `/mcp`, `/plugins`, `/restart`, `/debug`, `/exec`, `/bash`, and `/acp`. Unauthorized room command access grants full owner-style control over the gateway and potentially the host.
- **What changed:** `access-state.ts` now derives a separate `configuredAllowFrom` (explicit `allowFrom` only) and `commandAllowFrom` that excludes `storeAllowFrom` when `isRoom` is `true`. `commandAuthorizers[0]` is built from `commandAllowFrom` instead of `effectiveAllowFrom`, aligning with the invariant already enforced in `src/security/dm-policy-shared.ts`.
- **What did NOT change:** DM-scope authorization is unaffected. `effectiveAllowFrom` (config + store) still governs `directAllowMatch` and DM command auth. No handler logic or routing was modified.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Auth / tokens
- [x] Integrations

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `resolveMatrixMonitorAccessState` merged `storeAllowFrom` (account-scoped DM pairing store) into `effectiveAllowFrom` unconditionally, then used that same list for `commandAuthorizers[0]` regardless of whether the inbound message was in a room or a DM. The shared invariant that DM pairing-store approvals must not promote a sender to room/group command authority was established in `src/security/dm-policy-shared.ts` but never applied to the Matrix-specific code path.
- **Missing detection / guardrail:** No test covered the specific scenario of a room control command from a sender present only in `storeAllowFrom`.
- **Contributing context:** The room handler correctly passes `isRoom` to `resolveMatrixMonitorAccessState`, but the function did not act on it when computing command authorizers.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- **Target test or file:** `access-state.test.ts`, `handler.test.ts`
- **Scenario the test should lock in:** A room-context call with `storeAllowFrom` populated and all room/group allowlists empty must produce `commandAuthorizers` where every entry is `{ configured: false, allowed: false }`.
- **Why this is the smallest reliable guardrail:** The unit test exercises `resolveMatrixMonitorAccessState` directly at the authorization-state boundary; the integration test confirms the handler does not call `recordInboundSession` or `finalizeInboundContext` for the blocked command.
- **Existing test that already covered this:** None — this scenario was untested.

## User-visible / Behavior Changes

Senders whose only authorization source is a DM pairing-store entry can no longer execute room control commands. No change to DM behavior or to senders listed in `allowFrom`, `groupAllowFrom`, or per-room `users`.

## Diagram (if applicable)

```text
Before:
[room msg, sender in storeAllowFrom only]
  -> effectiveAllowFrom = configuredAllowFrom + storeAllowFrom
  -> commandAuthorizers[0].allowed = true
  -> CommandAuthorized: true (bypass)

After:
[room msg, sender in storeAllowFrom only]
  -> commandAllowFrom = configuredAllowFrom (store excluded for rooms)
  -> commandAuthorizers[0] = { configured: false, allowed: false }
  -> CommandAuthorized: false (blocked)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — this PR narrows the set of senders that can reach it
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux x86_64
- Runtime/container: Node v22
- Integration/channel: Matrix

### Steps

1. Call `resolveMatrixMonitorAccessState` with `allowFrom: []`, `storeAllowFrom: ["@attacker:example.org"]`, `groupAllowFrom: []`, `roomUsers: []`, `senderId: "@attacker:example.org"`, `isRoom: true`.
2. Pass the resulting `commandAuthorizers` into `resolveControlCommandGate` with `useAccessGroups: true` and `hasControlCommand: true`.
3. Assert `commandAuthorized === false`.

### Expected

- `commandAuthorizers` all `{ configured: false, allowed: false }`
- `commandAuthorized: false`, `shouldBlock: true`

### Actual (after fix)

- Assertions pass; room control command is blocked.

## Evidence

- [x] Failing test/log before + passing after — new unit test in `access-state.test.ts` and integration test in `handler.test.ts` cover the exact bypass scenario and pass after the fix.

## Human Verification (required)

- **Verified scenarios:** Unit test directly exercises `resolveMatrixMonitorAccessState` with `storeAllowFrom`-only authorization in room context; integration test confirms handler suppresses `recordInboundSession` and `finalizeInboundContext` for the blocked sender.
- **Edge cases checked:** DM context with `isRoom: false` continues to use `effectiveAllowFrom` (store + config) for command authorization, preserving existing DM behavior. Wildcard and prefixed-id entries in `allowFrom` continue to work for room commands.
- **What you did not verify:** Live end-to-end Matrix traffic; behavior under `useAccessGroups: false` (that path does not use `commandAuthorizers`).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — senders legitimately authorized via `allowFrom`, `groupAllowFrom`, or per-room `users` are unaffected.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Operators who (incorrectly) relied on DM pairing alone to grant room command access will find those senders blocked after upgrade.
  - **Mitigation:** This was never an intended or documented authorization path. The correct fix is to add the sender to `channels.matrix.allowFrom` or a per-room `users` list.