### PR TITLE
fix(compaction): use reserveTokens instead of reserveTokensFloor for memoryFlush and preflight thresholds

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -379,10 +379,22 @@ export async function runPreflightCompactionIfNeeded(params: {
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
   const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
-  const reserveTokensFloor =
+  // Use the user-configured reserveTokens (the actual reserve budget) when available,
+  // falling back to reserveTokensFloor (the safety minimum). This keeps the flush
+  // threshold consistent with shouldPreemptivelyCompactBeforePrompt which reads
+  // settingsManager.getCompactionReserveTokens() — i.e. the resolved reserve budget.
+  const configuredReserveTokens =
+    typeof params.cfg.agents?.defaults?.compaction?.reserveTokens === "number" &&
+    Number.isFinite(params.cfg.agents.defaults.compaction.reserveTokens) &&
+    params.cfg.agents.defaults.compaction.reserveTokens > 0
+      ? params.cfg.agents.defaults.compaction.reserveTokens
+      : undefined;
+  const reserveTokensFloor = Math.max(
+    configuredReserveTokens ?? 0,
     memoryFlushPlan?.reserveTokensFloor ??
-    params.cfg.agents?.defaults?.compaction?.reserveTokensFloor ??
-    20_000;
+      params.cfg.agents?.defaults?.compaction?.reserveTokensFloor ??
+      20_000,
+  );
   const softThresholdTokens = memoryFlushPlan?.softThresholdTokens ?? 4_000;
   const freshPersistedTokens = resolveFreshSessionTotalTokens(entry);
   const persistedTotalTokens = entry.totalTokens;
@@ -563,8 +575,18 @@ export async function runMemoryFlushIfNeeded(params: {
   const hasFreshPersistedPromptTokens =
     typeof persistedPromptTokens === "number" && entry?.totalTokensFresh === true;
 
+  // Use the configured reserveTokens (actual reserve budget) when it exceeds the floor,
+  // consistent with the preflight path and shouldPreemptivelyCompactBeforePrompt.
+  const effectiveReserveTokensForFlush = Math.max(
+    typeof params.cfg.agents?.defaults?.compaction?.reserveTokens === "number" &&
+      Number.isFinite(params.cfg.agents.defaults.compaction.reserveTokens) &&
+      params.cfg.agents.defaults.compaction.reserveTokens > 0
+      ? params.cfg.agents.defaults.compaction.reserveTokens
+      : 0,
+    memoryFlushPlan.reserveTokensFloor,
+  );
   const flushThreshold =
-    contextWindowTokens - memoryFlushPlan.reserveTokensFloor - memoryFlushPlan.softThresholdTokens;
+    contextWindowTokens - effectiveReserveTokensForFlush - memoryFlushPlan.softThresholdTokens;
 
   // When totals are stale/unknown, derive prompt + last output from transcript so memory
   // flush can still be evaluated against projected next-input size.
@@ -691,7 +713,7 @@ export async function runMemoryFlushIfNeeded(params: {
         entry,
         tokenCount: tokenCountForFlush,
         contextWindowTokens,
-        reserveTokensFloor: memoryFlushPlan.reserveTokensFloor,
+        reserveTokensFloor: effectiveReserveTokensForFlush,
         softThresholdTokens: memoryFlushPlan.softThresholdTokens,
       })) ||
     (shouldForceFlushByTranscriptSize &&


### PR DESCRIPTION
## Summary

The memoryFlush trigger and preflight compaction threshold were computed against \compaction.reserveTokensFloor\ (the safety minimum, default 20k) rather than the user-configured \compaction.reserveTokens\. This meant raising \eserveTokens\ above the floor had no effect on flush/preflight timing, making the config knob effectively dead for the flush subsystem.

## Changes

In \src/auto-reply/reply/agent-runner-memory.ts\:

1. **Preflight compaction threshold** (line ~382): Now reads \gents.defaults.compaction.reserveTokens\ when available and takes the max of that and the floor, consistent with \shouldPreemptivelyCompactBeforePrompt\ which reads the resolved \eserveTokens\ from \settingsManager\.

2. **Flush threshold** (line ~579): Same fix — uses the effective reserve tokens (max of configured value and floor) instead of just the floor.

3. **shouldRunMemoryFlush call** (line ~716): Passes the effective reserve tokens instead of the raw plan floor.

## Test plan

- Set \gents.defaults.compaction.reserveTokens\ to a value above the default floor (e.g. 80000 vs floor of 20000)
- Verify memoryFlush triggers earlier (at contextWindow - 80000 - softThreshold) rather than at the old floor-based threshold
- Verify \shouldPreemptivelyCompactBeforePrompt\ and the flush/preflight paths now agree on the reserve budget

Fixes #66830

[AI-assisted]