### PR TITLE
fix(gateway): enforce localRoots containment on webchat audio embedding path [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(gateway): enforce localRoots containment on webchat audio embedding path [AI-assisted]. (#67298) Thanks @pgondhi987.
 - fix(matrix): block DM pairing-store entries from authorizing room control commands [AI-assisted]. (#67294) Thanks @pgondhi987.
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
 - Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.

--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -15,12 +15,15 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     tmpDir = undefined;
   });
 
-  it("embeds a local audio file as a base64 gateway chat block", () => {
+  it("embeds a local audio file as a base64 gateway chat block when it is under localRoots", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-audio-"));
     const audioPath = path.join(tmpDir, "clip.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
 
-    const blocks = buildWebchatAudioContentBlocksFromReplyPayloads([{ mediaUrl: audioPath }]);
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+      [{ mediaUrl: audioPath }],
+      [tmpDir],
+    );
 
     expect(blocks).toHaveLength(1);
     const block = blocks[0] as {
@@ -36,48 +39,72 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     );
   });
 
-  it("skips remote URLs", () => {
-    const blocks = buildWebchatAudioContentBlocksFromReplyPayloads([
-      { mediaUrl: "https://example.com/a.mp3" },
-    ]);
+  it("skips remote URLs", async () => {
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+      [{ mediaUrl: "https://example.com/a.mp3" }],
+      undefined,
+    );
     expect(blocks).toHaveLength(0);
   });
 
-  it("skips non-audio local files", () => {
+  it("skips non-audio local files", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-audio-"));
     const imagePath = path.join(tmpDir, "clip.png");
     fs.writeFileSync(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
 
-    const blocks = buildWebchatAudioContentBlocksFromReplyPayloads([{ mediaUrl: imagePath }]);
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+      [{ mediaUrl: imagePath }],
+      [tmpDir],
+    );
 
     expect(blocks).toHaveLength(0);
   });
 
-  it("dedupes repeated paths", () => {
+  it("dedupes repeated paths", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-audio-"));
     const audioPath = path.join(tmpDir, "clip.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0x00]));
 
-    const blocks = buildWebchatAudioContentBlocksFromReplyPayloads([
-      { mediaUrl: audioPath },
-      { mediaUrl: audioPath },
-    ]);
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+      [{ mediaUrl: audioPath }, { mediaUrl: audioPath }],
+      [tmpDir],
+    );
     expect(blocks).toHaveLength(1);
   });
 
-  it("embeds file:// URLs pointing at a local file", () => {
+  it("embeds file:// URLs pointing at a local file within localRoots", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-audio-"));
     const audioPath = path.join(tmpDir, "clip.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0x01]));
 
     const fileUrl = pathToFileURL(audioPath).href;
-    const blocks = buildWebchatAudioContentBlocksFromReplyPayloads([{ mediaUrl: fileUrl }]);
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+      [{ mediaUrl: fileUrl }],
+      [tmpDir],
+    );
 
     expect(blocks).toHaveLength(1);
     expect((blocks[0] as { type?: string }).type).toBe("audio");
   });
 
-  it("does not read file contents when stat reports size over the cap", () => {
+  it("rejects a local audio file outside configured localRoots", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-audio-"));
+    const allowedRoot = path.join(tmpDir, "allowed");
+    const outsideRoot = path.join(tmpDir, "outside");
+    fs.mkdirSync(allowedRoot, { recursive: true });
+    fs.mkdirSync(outsideRoot, { recursive: true });
+    const audioPath = path.join(outsideRoot, "clip.mp3");
+    fs.writeFileSync(audioPath, Buffer.from([0x03]));
+
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+      [{ mediaUrl: audioPath }],
+      [allowedRoot],
+    );
+
+    expect(blocks).toHaveLength(0);
+  });
+
+  it("does not read file contents when stat reports size over the cap", async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-audio-"));
     const audioPath = path.join(tmpDir, "huge.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0x02]));
@@ -91,7 +118,10 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     });
     const readSpy = vi.spyOn(fs, "readFileSync");
 
-    const blocks = buildWebchatAudioContentBlocksFromReplyPayloads([{ mediaUrl: audioPath }]);
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+      [{ mediaUrl: audioPath }],
+      [tmpDir],
+    );
 
     expect(blocks).toHaveLength(0);
     expect(readSpy).not.toHaveBeenCalled();

--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getDefaultLocalRoots } from "../../media/local-media-access.js";
 import { buildWebchatAudioContentBlocksFromReplyPayloads } from "./chat-webchat-media.js";
 
 describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
@@ -22,7 +23,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
 
     const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
       [{ mediaUrl: audioPath }],
-      [tmpDir],
+      { localRoots: [tmpDir] },
     );
 
     expect(blocks).toHaveLength(1);
@@ -40,10 +41,9 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
   });
 
   it("skips remote URLs", async () => {
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
-      [{ mediaUrl: "https://example.com/a.mp3" }],
-      undefined,
-    );
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads([
+      { mediaUrl: "https://example.com/a.mp3" },
+    ]);
     expect(blocks).toHaveLength(0);
   });
 
@@ -54,7 +54,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
 
     const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
       [{ mediaUrl: imagePath }],
-      [tmpDir],
+      { localRoots: [tmpDir] },
     );
 
     expect(blocks).toHaveLength(0);
@@ -67,7 +67,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
 
     const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
       [{ mediaUrl: audioPath }, { mediaUrl: audioPath }],
-      [tmpDir],
+      { localRoots: [tmpDir] },
     );
     expect(blocks).toHaveLength(1);
   });
@@ -78,10 +78,9 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     fs.writeFileSync(audioPath, Buffer.from([0x01]));
 
     const fileUrl = pathToFileURL(audioPath).href;
-    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
-      [{ mediaUrl: fileUrl }],
-      [tmpDir],
-    );
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads([{ mediaUrl: fileUrl }], {
+      localRoots: [tmpDir],
+    });
 
     expect(blocks).toHaveLength(1);
     expect((blocks[0] as { type?: string }).type).toBe("audio");
@@ -96,12 +95,32 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     const audioPath = path.join(outsideRoot, "clip.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0x03]));
 
+    const onLocalAudioAccessDenied = vi.fn();
     const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
       [{ mediaUrl: audioPath }],
-      [allowedRoot],
+      {
+        localRoots: [allowedRoot],
+        onLocalAudioAccessDenied,
+      },
     );
 
     expect(blocks).toHaveLength(0);
+    expect(onLocalAudioAccessDenied).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to default localRoots when explicit roots are omitted", async () => {
+    const [defaultRoot] = getDefaultLocalRoots();
+    expect(defaultRoot).toBeTruthy();
+
+    fs.mkdirSync(defaultRoot, { recursive: true });
+    tmpDir = fs.mkdtempSync(path.join(defaultRoot, "openclaw-webchat-audio-default-"));
+    const audioPath = path.join(tmpDir, "clip.mp3");
+    fs.writeFileSync(audioPath, Buffer.from([0x04]));
+
+    const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads([{ mediaUrl: audioPath }]);
+
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { type?: string }).type).toBe("audio");
   });
 
   it("does not read file contents when stat reports size over the cap", async () => {
@@ -120,7 +139,7 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
 
     const blocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
       [{ mediaUrl: audioPath }],
-      [tmpDir],
+      { localRoots: [tmpDir] },
     );
 
     expect(blocks).toHaveLength(0);

--- a/src/gateway/server-methods/chat-webchat-media.ts
+++ b/src/gateway/server-methods/chat-webchat-media.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { assertLocalMediaAllowed } from "../../media/local-media-access.js";
 import { isAudioFileName } from "../../media/mime.js";
 import { resolveSendableOutboundReplyParts } from "../../plugin-sdk/reply-payload.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
@@ -50,7 +51,10 @@ function resolveLocalMediaPathForEmbedding(raw: string): string | null {
 }
 
 /** Returns a readable local file path when it is a regular file and within the size cap (single stat before read). */
-function resolveLocalAudioFileForEmbedding(raw: string): string | null {
+async function resolveLocalAudioFileForEmbedding(
+  raw: string,
+  localRoots: readonly string[] | "any" | undefined,
+): Promise<string | null> {
   const resolved = resolveLocalMediaPathForEmbedding(raw);
   if (!resolved) {
     return null;
@@ -63,6 +67,7 @@ function resolveLocalAudioFileForEmbedding(raw: string): string | null {
     if (!st.isFile() || st.size > MAX_WEBCHAT_AUDIO_BYTES) {
       return null;
     }
+    await assertLocalMediaAllowed(resolved, localRoots);
     return resolved;
   } catch {
     return null;
@@ -78,9 +83,10 @@ function mimeTypeForPath(filePath: string): string {
  * Build Control UI / transcript `content` blocks for local TTS (or other) audio files
  * referenced by slash-command / agent replies when the webchat path only had text aggregation.
  */
-export function buildWebchatAudioContentBlocksFromReplyPayloads(
+export async function buildWebchatAudioContentBlocksFromReplyPayloads(
   payloads: ReplyPayload[],
-): Array<Record<string, unknown>> {
+  localRoots: readonly string[] | "any" | undefined,
+): Promise<Array<Record<string, unknown>>> {
   const seen = new Set<string>();
   const blocks: Array<Record<string, unknown>> = [];
   for (const payload of payloads) {
@@ -90,7 +96,7 @@ export function buildWebchatAudioContentBlocksFromReplyPayloads(
       if (!url) {
         continue;
       }
-      const resolved = resolveLocalAudioFileForEmbedding(url);
+      const resolved = await resolveLocalAudioFileForEmbedding(url, localRoots);
       if (!resolved || seen.has(resolved)) {
         continue;
       }

--- a/src/gateway/server-methods/chat-webchat-media.ts
+++ b/src/gateway/server-methods/chat-webchat-media.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
-import { assertLocalMediaAllowed } from "../../media/local-media-access.js";
+import { assertLocalMediaAllowed, LocalMediaAccessError } from "../../media/local-media-access.js";
 import { isAudioFileName } from "../../media/mime.js";
 import { resolveSendableOutboundReplyParts } from "../../plugin-sdk/reply-payload.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
@@ -19,6 +19,11 @@ const MIME_BY_EXT: Record<string, string> = {
   ".opus": "audio/opus",
   ".wav": "audio/wav",
   ".webm": "audio/webm",
+};
+
+type WebchatAudioEmbeddingOptions = {
+  localRoots?: readonly string[];
+  onLocalAudioAccessDenied?: (err: LocalMediaAccessError) => void;
 };
 
 /** Map `mediaUrl` strings to an absolute filesystem path for local embedding (plain paths or `file:` URLs). */
@@ -53,7 +58,7 @@ function resolveLocalMediaPathForEmbedding(raw: string): string | null {
 /** Returns a readable local file path when it is a regular file and within the size cap (single stat before read). */
 async function resolveLocalAudioFileForEmbedding(
   raw: string,
-  localRoots: readonly string[] | "any" | undefined,
+  options: WebchatAudioEmbeddingOptions | undefined,
 ): Promise<string | null> {
   const resolved = resolveLocalMediaPathForEmbedding(raw);
   if (!resolved) {
@@ -63,13 +68,16 @@ async function resolveLocalAudioFileForEmbedding(
     return null;
   }
   try {
+    await assertLocalMediaAllowed(resolved, options?.localRoots);
     const st = fs.statSync(resolved);
     if (!st.isFile() || st.size > MAX_WEBCHAT_AUDIO_BYTES) {
       return null;
     }
-    await assertLocalMediaAllowed(resolved, localRoots);
     return resolved;
-  } catch {
+  } catch (err) {
+    if (err instanceof LocalMediaAccessError) {
+      options?.onLocalAudioAccessDenied?.(err);
+    }
     return null;
   }
 }
@@ -85,7 +93,7 @@ function mimeTypeForPath(filePath: string): string {
  */
 export async function buildWebchatAudioContentBlocksFromReplyPayloads(
   payloads: ReplyPayload[],
-  localRoots: readonly string[] | "any" | undefined,
+  options?: WebchatAudioEmbeddingOptions,
 ): Promise<Array<Record<string, unknown>>> {
   const seen = new Set<string>();
   const blocks: Array<Record<string, unknown>> = [];
@@ -96,7 +104,7 @@ export async function buildWebchatAudioContentBlocksFromReplyPayloads(
       if (!url) {
         continue;
       }
-      const resolved = await resolveLocalAudioFileForEmbedding(url, localRoots);
+      const resolved = await resolveLocalAudioFileForEmbedding(url, options);
       if (!resolved || seen.has(resolved)) {
         continue;
       }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -13,9 +13,9 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
+import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { isAudioFileName } from "../../media/mime.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
-import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { type SavedMedia, saveMediaBuffer } from "../../media/store.js";
 import { createChannelReplyPipeline } from "../../plugin-sdk/channel-reply-pipeline.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
@@ -2089,19 +2089,8 @@ export const chatHandlers: GatewayRequestHandlers = {
         if (!agentRunStarted || appendedWebchatAgentAudio || !isMediaBearingPayload(payload)) {
           return;
         }
-        const mediaAccess = resolveAgentScopedOutboundMediaAccess({
-          cfg,
-          agentId,
-          sessionKey,
-          messageProvider: originatingChannel,
-          accountId,
-          requesterSenderId: clientInfo?.id,
-          requesterSenderName: clientInfo?.displayName,
-          requesterSenderUsername: clientInfo?.displayName,
-          mediaSources: resolveSendableOutboundReplyParts(payload).mediaUrls,
-        });
         const audioMessage = await buildWebchatAudioOnlyAssistantMessage([payload], {
-          localRoots: mediaAccess.localRoots,
+          localRoots: getAgentScopedMediaLocalRoots(cfg, agentId),
           onLocalAudioAccessDenied: (message) => {
             context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
           },

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -124,9 +124,17 @@ function isMediaBearingPayload(payload: ReplyPayload): boolean {
 
 async function buildWebchatAudioOnlyAssistantMessage(
   payloads: ReplyPayload[],
-  localRoots: readonly string[] | "any" | undefined,
+  options?: {
+    localRoots?: readonly string[];
+    onLocalAudioAccessDenied?: (message: string) => void;
+  },
 ): Promise<{ content: Array<Record<string, unknown>>; transcriptText: string } | null> {
-  const audioBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads(payloads, localRoots);
+  const audioBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads(payloads, {
+    localRoots: options?.localRoots,
+    onLocalAudioAccessDenied: (err) => {
+      options?.onLocalAudioAccessDenied?.(formatForLog(err));
+    },
+  });
   if (audioBlocks.length === 0) {
     return null;
   }
@@ -2092,10 +2100,12 @@ export const chatHandlers: GatewayRequestHandlers = {
           requesterSenderUsername: clientInfo?.displayName,
           mediaSources: resolveSendableOutboundReplyParts(payload).mediaUrls,
         });
-        const audioMessage = await buildWebchatAudioOnlyAssistantMessage(
-          [payload],
-          mediaAccess.localRoots,
-        );
+        const audioMessage = await buildWebchatAudioOnlyAssistantMessage([payload], {
+          localRoots: mediaAccess.localRoots,
+          onLocalAudioAccessDenied: (message) => {
+            context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
+          },
+        });
         if (!audioMessage) {
           return;
         }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -15,6 +15,7 @@ import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { isAudioFileName } from "../../media/mime.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
+import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { type SavedMedia, saveMediaBuffer } from "../../media/store.js";
 import { createChannelReplyPipeline } from "../../plugin-sdk/channel-reply-pipeline.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
@@ -121,10 +122,11 @@ function isMediaBearingPayload(payload: ReplyPayload): boolean {
   return false;
 }
 
-function buildWebchatAudioOnlyAssistantMessage(
+async function buildWebchatAudioOnlyAssistantMessage(
   payloads: ReplyPayload[],
-): { content: Array<Record<string, unknown>>; transcriptText: string } | null {
-  const audioBlocks = buildWebchatAudioContentBlocksFromReplyPayloads(payloads);
+  localRoots: readonly string[] | "any" | undefined,
+): Promise<{ content: Array<Record<string, unknown>>; transcriptText: string } | null> {
+  const audioBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads(payloads, localRoots);
   if (audioBlocks.length === 0) {
     return null;
   }
@@ -2075,11 +2077,25 @@ export const chatHandlers: GatewayRequestHandlers = {
           savedImages: await persistedImagesPromise,
         });
       };
-      const appendWebchatAgentAudioTranscriptIfNeeded = (payload: ReplyPayload) => {
+      const appendWebchatAgentAudioTranscriptIfNeeded = async (payload: ReplyPayload) => {
         if (!agentRunStarted || appendedWebchatAgentAudio || !isMediaBearingPayload(payload)) {
           return;
         }
-        const audioMessage = buildWebchatAudioOnlyAssistantMessage([payload]);
+        const mediaAccess = resolveAgentScopedOutboundMediaAccess({
+          cfg,
+          agentId,
+          sessionKey,
+          messageProvider: originatingChannel,
+          accountId,
+          requesterSenderId: clientInfo?.id,
+          requesterSenderName: clientInfo?.displayName,
+          requesterSenderUsername: clientInfo?.displayName,
+          mediaSources: resolveSendableOutboundReplyParts(payload).mediaUrls,
+        });
+        const audioMessage = await buildWebchatAudioOnlyAssistantMessage(
+          [payload],
+          mediaAccess.localRoots,
+        );
         if (!audioMessage) {
           return;
         }
@@ -2113,7 +2129,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             case "block":
             case "final":
               deliveredReplies.push({ payload, kind: info.kind });
-              appendWebchatAgentAudioTranscriptIfNeeded(payload);
+              await appendWebchatAgentAudioTranscriptIfNeeded(payload);
               break;
             case "tool":
               // Tool results that carry audio (e.g. the TTS tool) must be promoted


### PR DESCRIPTION
## Summary

- **Problem:** `resolveLocalAudioFileForEmbedding` in `chat-webchat-media.ts` read and base64-encoded any host-local file with an audio extension and size under 15 MB without checking `assertLocalMediaAllowed`. Every other local media read path enforces this containment check; this one did not.
- **Why it matters:** A model or agent could direct `ReplyPayload.mediaUrl` at an arbitrary host file (e.g. via prompt injection or malicious tool output), causing file contents to be exfiltrated to the webchat client. The operator-configured `localRoots` boundary was bypassed entirely.
- **What changed:** `resolveLocalAudioFileForEmbedding` now calls `assertLocalMediaAllowed` before `stat`, using agent-scoped roots resolved by `resolveAgentScopedOutboundMediaAccess`. Access denials are surfaced via an `onLocalAudioAccessDenied` callback (logged as gateway warnings at the call site in `chat.ts`). The function and its callers are now async.
- **What did NOT change:** No changes to `assertLocalMediaAllowed` or `local-media-access.ts` logic; no changes to the localRoots computation or policy resolution for other media paths; no user-facing behavior change for files that are legitimately within configured roots.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveLocalAudioFileForEmbedding` was added without threading through the `localRoots` containment parameter that `assertLocalMediaAllowed` requires. The function predates the localRoots enforcement pattern being applied consistently.
- Missing detection / guardrail: No unit test covered an out-of-root path for this specific embedding helper.
- Contributing context (if known): The helper was introduced as a convenience path for webchat TTS audio; the security invariant (all model-influenced local reads must go through `assertLocalMediaAllowed`) was not applied.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/gateway/server-methods/chat-webchat-media.test.ts`
- Scenario the test should lock in: A local audio file outside configured `localRoots` must produce zero embedding blocks; the `onLocalAudioAccessDenied` callback must fire.
- Why this is the smallest reliable guardrail: Directly exercises `buildWebchatAudioContentBlocksFromReplyPayloads` with an out-of-root path; no gateway or session setup needed.
- Existing test that already covers this (if any): None — new test added: `"rejects a local audio file outside configured localRoots"`.
- Also added: `"falls back to default localRoots when explicit roots are omitted"` to cover the `undefined` options path.

## User-visible / Behavior Changes

None for files within operator-configured `localRoots`. Files outside `localRoots` are now silently dropped from webchat audio transcript blocks (same behavior as every other media path in the system). A `warn`-level gateway log entry is emitted for each denied path.

## Diagram (if applicable)

```text
Before:
[agent mediaUrl] -> resolveLocalAudioFileForEmbedding -> fs.statSync -> fs.readFileSync -> base64 in WS response
                                                          (no localRoots check)

After:
[agent mediaUrl] -> resolveLocalAudioFileForEmbedding -> assertLocalMediaAllowed -> [denied: log + skip]
                                                                                 -> fs.statSync -> fs.readFileSync -> base64 in WS response
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? **Yes** — webchat audio embedding is now restricted to agent-scoped `localRoots` (same as all other media read paths). Files outside configured roots are rejected instead of read.
- Risk + mitigation: The restriction is enforced using the existing `assertLocalMediaAllowed` + `resolveAgentScopedOutboundMediaAccess` infrastructure, which is already in use on every other local media path. No new policy logic was introduced.

## Repro + Verification

### Environment

- OS: Linux (CI)
- Runtime/container: Node 22+ / Bun
- Model/provider: N/A (unit test)
- Integration/channel: webchat
- Relevant config: default (no custom localRoots)

### Steps

1. Run `pnpm test src/gateway/server-methods/chat-webchat-media.test.ts`
2. Observe all tests pass, including the new `"rejects a local audio file outside configured localRoots"` case

### Expected

- Zero blocks returned for an out-of-root audio file path
- `onLocalAudioAccessDenied` callback invoked once

### Actual

- All assertions pass

## Evidence

- [x] Failing test/log before + passing after — new test `"rejects a local audio file outside configured localRoots"` was written against the pre-fix code path (which had no root check) and would fail on the original; it passes on the fixed code.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: all existing `chat-webchat-media.test.ts` tests continue to pass; new tests for access denial and default-roots fallback pass; `pnpm tsgo` clean on touched files.
- Edge cases checked: `file://` URL pointing outside roots (rejected); `undefined` options (falls back to `getDefaultLocalRoots()`); repeated paths (deduplication still works).
- What you did **not** verify: live gateway end-to-end with a real TTS agent producing audio replies.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — operators with files inside their configured `localRoots` see no change. Operators relying on unrestricted audio embedding (which was unintended) will see previously-embedded out-of-root files silently dropped.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Legitimate agent-generated TTS audio files stored outside the default `localRoots` directories are now silently dropped from webchat transcript blocks.
  - Mitigation: The `warn`-level log in `context.logGateway` surfaces the denial. Operators can adjust their agent workspace or localRoots config if needed. The roots computation uses `resolveAgentScopedOutboundMediaAccess`, which already includes the agent workspace directory.