### PR TITLE
fix(tui): always reset status to idle when all streaming runs finalize regardless of event ordering

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -138,7 +138,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     noteFinalizedRun(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    if (params.wasActiveRun || !state.activeChatRunId) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();
@@ -153,7 +153,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
+    if (params.wasActiveRun || !state.activeChatRunId) {
       setActivityStatus(params.status);
     }
     void refreshSessionInfo?.();


### PR DESCRIPTION
## Summary

Race condition fix for TUI status bar getting stuck on 'streaming' after response completes.

## Root Cause

When lifecycle \nd\ fires before chat \inal\:
1. Lifecycle \nd\ clears \ctiveChatRunId\
2. Chat \inal\ arrives → \wasActiveRun\ evaluates false (since \ctiveChatRunId\ was already cleared)
3. \setActivityStatus('idle')\ never called → status bar stuck on 'streaming'

## Fix

In \src/tui/tui-event-handlers.ts\, changed both \inalizeRun\ and \	erminateRun\ conditions from:
\\\	s
if (params.wasActiveRun) {
\\\
to:
\\\	s
if (params.wasActiveRun || !state.activeChatRunId) {
\\\

When \ctiveChatRunId\ is null (no active run), status is always reset to idle.

Fixes #66876

[AI-assisted]