### PR TITLE
fix: tighten trusted tool media passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/tools: anchor trusted local `MEDIA:` tool-result passthrough on the exact raw name of this run's registered built-in tools, and reject client tool definitions whose names normalize-collide with a built-in or with another client tool in the same request (`400 invalid_request_error` on both JSON and SSE paths), so a client-supplied tool named like a built-in can no longer inherit its local-media trust. (#67303)
+
 ## 2026.4.15-beta.1
 
 ### Changes

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -973,7 +973,7 @@ export async function runEmbeddedAttempt(
       // emitted tool name must match an exact registration of this run.
       const builtinToolNames = new Set(
         effectiveTools.flatMap((tool) => {
-          const name = String(tool.name ?? "").trim();
+          const name = (tool.name ?? "").trim();
           return name ? [name] : [];
         }),
       );
@@ -984,7 +984,7 @@ export async function runEmbeddedAttempt(
       // tool cannot inherit the plugin's local-media trust.
       const coreBuiltinToolNames = new Set(
         effectiveTools.flatMap((tool) => {
-          const name = String(tool.name ?? "").trim();
+          const name = (tool.name ?? "").trim();
           if (!name || getPluginToolMeta(tool)) {
             return [];
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -29,6 +29,7 @@ import {
   resolveProviderTextTransforms,
   transformProviderSystemPrompt,
 } from "../../../plugins/provider-runtime.js";
+import { getPluginToolMeta } from "../../../plugins/tools.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { normalizeOptionalLowercaseString } from "../../../shared/string-coerce.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
@@ -86,7 +87,11 @@ import {
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
-import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
+import {
+  createClientToolNameConflictError,
+  findClientToolNameConflicts,
+  toClientToolDefinitions,
+} from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
 import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
@@ -962,6 +967,22 @@ export async function runEmbeddedAttempt(
         cfg: params.config,
         agentId: sessionAgentId,
       });
+      const builtinToolNames = new Set(
+        effectiveTools.flatMap((tool) => {
+          const name = String(tool.name ?? "").trim();
+          if (!name || getPluginToolMeta(tool)) {
+            return [];
+          }
+          return [name];
+        }),
+      );
+      const clientToolNameConflicts = findClientToolNameConflicts({
+        tools: clientTools ?? [],
+        existingToolNames: builtinToolNames,
+      });
+      if (clientToolNameConflicts.length > 0) {
+        throw createClientToolNameConflictError(clientToolNameConflicts);
+      }
       const clientToolDefs = clientTools
         ? toClientToolDefinitions(
             clientTools,
@@ -1529,6 +1550,7 @@ export async function runEmbeddedAttempt(
           sessionKey: sandboxSessionKey,
           sessionId: params.sessionId,
           agentId: sessionAgentId,
+          builtinToolNames,
           internalEvents: params.internalEvents,
         }),
       );

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -967,7 +967,22 @@ export async function runEmbeddedAttempt(
         cfg: params.config,
         agentId: sessionAgentId,
       });
+      // Exact raw names of every tool registered for this run, including
+      // bundled/plugin tools. Used as the raw-name set for the trusted local
+      // MEDIA: passthrough gate: a normalized alias is not sufficient — the
+      // emitted tool name must match an exact registration of this run.
       const builtinToolNames = new Set(
+        effectiveTools.flatMap((tool) => {
+          const name = String(tool.name ?? "").trim();
+          return name ? [name] : [];
+        }),
+      );
+      // Admission-time conflict check only against non-plugin core tools, to
+      // preserve prior behavior where client tools may coexist with unrelated
+      // plugin tool names. MEDIA passthrough is still gated by the raw-name
+      // set above, so a client tool that normalize-collides with a plugin
+      // tool cannot inherit the plugin's local-media trust.
+      const coreBuiltinToolNames = new Set(
         effectiveTools.flatMap((tool) => {
           const name = String(tool.name ?? "").trim();
           if (!name || getPluginToolMeta(tool)) {
@@ -978,7 +993,7 @@ export async function runEmbeddedAttempt(
       );
       const clientToolNameConflicts = findClientToolNameConflicts({
         tools: clientTools ?? [],
-        existingToolNames: builtinToolNames,
+        existingToolNames: coreBuiltinToolNames,
       });
       if (clientToolNameConflicts.length > 0) {
         throw createClientToolNameConflictError(clientToolNameConflicts);

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -10,6 +10,7 @@ function createMockContext(overrides?: {
   shouldEmitToolOutput?: boolean;
   onToolResult?: ReturnType<typeof vi.fn>;
   toolResultFormat?: "markdown" | "plain";
+  builtinToolNames?: ReadonlySet<string>;
 }): EmbeddedPiSubscribeContext {
   const onToolResult = overrides?.onToolResult ?? vi.fn();
   return {
@@ -39,6 +40,7 @@ function createMockContext(overrides?: {
       deterministicApprovalPromptSent: false,
     },
     log: { debug: vi.fn(), warn: vi.fn() },
+    builtinToolNames: overrides?.builtinToolNames,
     shouldEmitToolResult: vi.fn(() => false),
     shouldEmitToolOutput: vi.fn(() => overrides?.shouldEmitToolOutput ?? false),
     emitToolSummary: vi.fn(),
@@ -171,6 +173,46 @@ describe("handleToolExecutionEnd media emission", () => {
 
     expect(onToolResult).not.toHaveBeenCalled();
     expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+  });
+
+  it("does NOT emit local media for case-variant collisions with trusted built-ins", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: false,
+      onToolResult: vi.fn(),
+      builtinToolNames: new Set(["web_search"]),
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "Web_Search",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "MEDIA:/tmp/secret.png" }],
+      },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+  });
+
+  it("still emits remote media for case-variant collisions with trusted built-ins", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: false,
+      onToolResult: vi.fn(),
+      builtinToolNames: new Set(["web_search"]),
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "Web_Search",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "MEDIA:https://example.com/file.png" }],
+      },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toEqual(["https://example.com/file.png"]);
   });
 
   it("emits remote media for MCP-provenance results", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -433,12 +433,13 @@ function readExecApprovalUnavailableDetails(result: unknown): {
 async function emitToolResultOutput(params: {
   ctx: ToolHandlerContext;
   toolName: string;
+  rawToolName: string;
   meta?: string;
   isToolError: boolean;
   result: unknown;
   sanitizedResult: unknown;
 }) {
-  const { ctx, toolName, meta, isToolError, result, sanitizedResult } = params;
+  const { ctx, toolName, rawToolName, meta, isToolError, result, sanitizedResult } = params;
   const hasStructuredMedia =
     result &&
     typeof result === "object" &&
@@ -1105,7 +1106,15 @@ export async function handleToolExecutionEnd(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
 
-  await emitToolResultOutput({ ctx, toolName, meta, isToolError, result, sanitizedResult });
+  await emitToolResultOutput({
+    ctx,
+    toolName,
+    rawToolName,
+    meta,
+    isToolError,
+    result,
+    sanitizedResult,
+  });
 
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? (await loadHookRunnerGlobal()).getGlobalHookRunner();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -511,10 +511,10 @@ async function emitToolResultOutput(params: {
     ctx.shouldEmitToolOutput() || shouldEmitCompactToolOutput({ toolName, result, outputText });
   if (shouldEmitOutput) {
     if (outputText) {
-      ctx.emitToolOutput(toolName, meta, outputText, result);
+      ctx.emitToolOutput(rawToolName, meta, outputText, result);
       if (ctx.params.toolResultFormat === "plain") {
         emittedToolOutputMediaUrls = await collectEmittedToolOutputMediaUrls(
-          toolName,
+          rawToolName,
           outputText,
           result,
         );
@@ -533,7 +533,12 @@ async function emitToolResultOutput(params: {
   if (!mediaReply) {
     return;
   }
-  const mediaUrls = filterToolResultMediaUrls(toolName, mediaReply.mediaUrls, result);
+  const mediaUrls = filterToolResultMediaUrls(
+    rawToolName,
+    mediaReply.mediaUrls,
+    result,
+    ctx.builtinToolNames,
+  );
   const pendingMediaUrls =
     mediaReply.audioAsVoice || emittedToolOutputMediaUrls.length === 0
       ? mediaUrls
@@ -779,7 +784,8 @@ export async function handleToolExecutionEnd(
     result?: unknown;
   },
 ) {
-  const toolName = normalizeToolName(evt.toolName);
+  const rawToolName = evt.toolName;
+  const toolName = normalizeToolName(rawToolName);
   const toolCallId = evt.toolCallId;
   const runId = ctx.params.runId;
   const isError = evt.isError;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -93,6 +93,7 @@ export type EmbeddedPiSubscribeContext = {
   blockChunking?: BlockReplyChunking;
   blockChunker: EmbeddedBlockChunker | null;
   hookRunner?: HookRunner;
+  builtinToolNames?: ReadonlySet<string>;
   noteLastAssistant: (msg: AgentMessage) => void;
 
   shouldEmitToolResult: () => boolean;
@@ -179,6 +180,7 @@ export type ToolHandlerContext = {
   state: ToolHandlerState;
   log: EmbeddedSubscribeLogger;
   hookRunner?: HookRunner;
+  builtinToolNames?: ReadonlySet<string>;
   flushBlockReplyBuffer: () => void | Promise<void>;
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -209,6 +209,35 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(onPartialReply).not.toHaveBeenCalled();
   });
 
+  it("blocks local MEDIA urls from case-variant tool names in verbose output", async () => {
+    const onToolResult = vi.fn();
+    const { emit } = createSubscribedHarness({
+      runId: "run",
+      onToolResult,
+      verboseLevel: "full",
+      builtinToolNames: new Set(["web_search"]),
+    });
+
+    emitToolRun({
+      emit,
+      toolName: "Web_Search",
+      toolCallId: "tool-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Fetched page\nMEDIA:/tmp/secret.png" }],
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(onToolResult).toHaveBeenCalled();
+    });
+    const payload = onToolResult.mock.calls.at(-1)?.[0] as
+      | { text?: string; mediaUrls?: string[] }
+      | undefined;
+    expect(payload?.text ?? "").toContain("Fetched page");
+    expect(payload?.mediaUrls).toBeUndefined();
+  });
+
   it("attaches media from internal completion events even when assistant omits MEDIA lines", async () => {
     const onBlockReply = vi.fn();
     const { emit } = createSubscribedHarness({

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -302,6 +302,31 @@ describe("extractToolResultMediaPaths", () => {
     ).toEqual(["/tmp/screenshot.png"]);
   });
 
+  it("keeps local media for bundled plugin tool names registered in this run", () => {
+    // music_generate is a bundled-plugin trusted tool; when the runner
+    // registers it for this run, its raw name must be allowed through the
+    // exact-name gate just like a core built-in.
+    expect(
+      filterToolResultMediaUrls(
+        "music_generate",
+        ["/tmp/song.mp3"],
+        undefined,
+        new Set(["music_generate"]),
+      ),
+    ).toEqual(["/tmp/song.mp3"]);
+  });
+
+  it("strips local media for plugin-name collisions when the plugin is not registered", () => {
+    expect(
+      filterToolResultMediaUrls(
+        "Music_Generate",
+        ["/etc/passwd"],
+        undefined,
+        new Set(["music_generate"]),
+      ),
+    ).toEqual([]);
+  });
+
   it("still allows remote media for colliding aliases", () => {
     expect(
       filterToolResultMediaUrls(

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -277,6 +277,42 @@ describe("extractToolResultMediaPaths", () => {
     expect(isToolResultMediaTrusted("music_generate")).toBe(true);
   });
 
+  it("blocks trusted-media aliases that are not exact registered built-ins", () => {
+    expect(filterToolResultMediaUrls("bash", ["/etc/passwd"], undefined, new Set(["exec"]))).toEqual(
+      [],
+    );
+    expect(
+      filterToolResultMediaUrls(
+        "Web_Search",
+        ["/etc/passwd"],
+        undefined,
+        new Set(["web_search"]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps local media for exact registered built-in tool names", () => {
+    expect(
+      filterToolResultMediaUrls(
+        "web_search",
+        ["/tmp/screenshot.png"],
+        undefined,
+        new Set(["web_search"]),
+      ),
+    ).toEqual(["/tmp/screenshot.png"]);
+  });
+
+  it("still allows remote media for colliding aliases", () => {
+    expect(
+      filterToolResultMediaUrls(
+        "bash",
+        ["/etc/passwd", "https://example.com/file.png"],
+        undefined,
+        new Set(["exec"]),
+      ),
+    ).toEqual(["https://example.com/file.png"]);
+  });
+
   it("does not trust local MEDIA paths for MCP-provenance results", () => {
     expect(
       filterToolResultMediaUrls("browser", ["/tmp/screenshot.png"], {

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -211,11 +211,22 @@ export function filterToolResultMediaUrls(
   toolName: string | undefined,
   mediaUrls: string[],
   result?: unknown,
+  builtinToolNames?: ReadonlySet<string>,
 ): string[] {
   if (mediaUrls.length === 0) {
     return mediaUrls;
   }
   if (isToolResultMediaTrusted(toolName, result)) {
+    // When the current run provides its exact built-in registrations, require
+    // the raw emitted tool name to match one of them before allowing local
+    // MEDIA: paths. This blocks aliases and case-variant collisions such as
+    // "bash" -> "exec" or "Web_Search" -> "web_search".
+    if (builtinToolNames !== undefined) {
+      const registeredName = toolName?.trim();
+      if (!registeredName || !builtinToolNames.has(registeredName)) {
+        return mediaUrls.filter((url) => HTTP_URL_RE.test(url.trim()));
+      }
+    }
     return mediaUrls;
   }
   return mediaUrls.filter((url) => HTTP_URL_RE.test(url.trim()));

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -217,10 +217,12 @@ export function filterToolResultMediaUrls(
     return mediaUrls;
   }
   if (isToolResultMediaTrusted(toolName, result)) {
-    // When the current run provides its exact built-in registrations, require
-    // the raw emitted tool name to match one of them before allowing local
-    // MEDIA: paths. This blocks aliases and case-variant collisions such as
-    // "bash" -> "exec" or "Web_Search" -> "web_search".
+    // When the current run provides its exact registered tool names (core
+    // built-ins plus bundled/trusted plugin tools), require the raw emitted
+    // tool name to match one of them before allowing local MEDIA: paths.
+    // This blocks normalized aliases and case-variant collisions such as
+    // "Bash" -> "bash" or "Web_Search" -> "web_search" from inheriting a
+    // registered tool's media trust.
     if (builtinToolNames !== undefined) {
       const registeredName = toolName?.trim();
       if (!registeredName || !builtinToolNames.has(registeredName)) {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -415,7 +415,12 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       return;
     }
     const { text: cleanedText, mediaUrls } = parseReplyDirectives(message);
-    const filteredMediaUrls = filterToolResultMediaUrls(toolName, mediaUrls ?? [], result);
+    const filteredMediaUrls = filterToolResultMediaUrls(
+      toolName,
+      mediaUrls ?? [],
+      result,
+      params.builtinToolNames,
+    );
     if (!cleanedText && filteredMediaUrls.length === 0) {
       return;
     }
@@ -724,6 +729,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     blockChunking,
     blockChunker,
     hookRunner: params.hookRunner,
+    builtinToolNames: params.builtinToolNames,
     noteLastAssistant,
     shouldEmitToolResult,
     shouldEmitToolOutput,

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -39,5 +39,11 @@ export type SubscribeEmbeddedPiSessionParams = {
   sessionId?: string;
   /** Agent identity for hook context — resolved from session config in attempt.ts. */
   agentId?: string;
+  /**
+   * Exact raw names of non-plugin OpenClaw tools registered for this run.
+   * When provided, MEDIA: passthrough requires an exact match instead of only
+   * a normalized-name collision with a trusted built-in.
+   */
+  builtinToolNames?: ReadonlySet<string>;
   internalEvents?: AgentInternalEvent[];
 };

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -2,7 +2,14 @@ import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { describe, expect, it } from "vitest";
 import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
-import { toClientToolDefinitions, toToolDefinitions } from "./pi-tool-definition-adapter.js";
+import {
+  CLIENT_TOOL_NAME_CONFLICT_PREFIX,
+  createClientToolNameConflictError,
+  findClientToolNameConflicts,
+  isClientToolNameConflictError,
+  toClientToolDefinitions,
+  toToolDefinitions,
+} from "./pi-tool-definition-adapter.js";
 
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
 const extensionContext = {} as Parameters<ToolExecute>[4];
@@ -175,5 +182,31 @@ describe("toClientToolDefinitions – param coercion", () => {
       '{"action":"search","params":{"q":"test","page":1}}',
     );
     expect(calledWith).toEqual({ action: "search", params: { q: "test", page: 1 } });
+  });
+});
+
+describe("client tool name conflict checks", () => {
+  it("detects collisions with existing built-in names after normalization", () => {
+    expect(
+      findClientToolNameConflicts({
+        tools: [makeClientTool("Web_Search"), makeClientTool("exec")],
+        existingToolNames: ["web_search", "read"],
+      }),
+    ).toEqual(["Web_Search"]);
+  });
+
+  it("detects duplicate client tool names after normalization", () => {
+    expect(
+      findClientToolNameConflicts({
+        tools: [makeClientTool("Weather"), makeClientTool("weather")],
+      }),
+    ).toEqual(["Weather", "weather"]);
+  });
+
+  it("wraps conflict errors with a stable prefix", () => {
+    const err = createClientToolNameConflictError(["exec", "Web_Search"]);
+    expect(err.message).toBe(`${CLIENT_TOOL_NAME_CONFLICT_PREFIX} exec, Web_Search`);
+    expect(isClientToolNameConflictError(err)).toBe(true);
+    expect(isClientToolNameConflictError(new Error("other failure"))).toBe(false);
   });
 });

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -177,7 +177,7 @@ export function findClientToolNameConflicts(params: {
 }): string[] {
   const existingNormalized = new Set<string>();
   for (const name of params.existingToolNames ?? []) {
-    const trimmed = String(name).trim();
+    const trimmed = name.trim();
     if (trimmed) {
       existingNormalized.add(normalizeToolName(trimmed));
     }
@@ -186,7 +186,7 @@ export function findClientToolNameConflicts(params: {
   const conflicts = new Set<string>();
   const seenClientNames = new Map<string, string>();
   for (const tool of params.tools) {
-    const rawName = String(tool.function?.name ?? "").trim();
+    const rawName = (tool.function?.name ?? "").trim();
     if (!rawName) {
       continue;
     }

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -169,6 +169,50 @@ function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
   };
 }
 
+export const CLIENT_TOOL_NAME_CONFLICT_PREFIX = "client tool name conflict:";
+
+export function findClientToolNameConflicts(params: {
+  tools: ClientToolDefinition[];
+  existingToolNames?: Iterable<string>;
+}): string[] {
+  const existingNormalized = new Set<string>();
+  for (const name of params.existingToolNames ?? []) {
+    const trimmed = String(name).trim();
+    if (trimmed) {
+      existingNormalized.add(normalizeToolName(trimmed));
+    }
+  }
+
+  const conflicts = new Set<string>();
+  const seenClientNames = new Map<string, string>();
+  for (const tool of params.tools) {
+    const rawName = String(tool.function?.name ?? "").trim();
+    if (!rawName) {
+      continue;
+    }
+    const normalizedName = normalizeToolName(rawName);
+    if (existingNormalized.has(normalizedName)) {
+      conflicts.add(rawName);
+    }
+    const priorClientName = seenClientNames.get(normalizedName);
+    if (priorClientName) {
+      conflicts.add(priorClientName);
+      conflicts.add(rawName);
+      continue;
+    }
+    seenClientNames.set(normalizedName, rawName);
+  }
+  return Array.from(conflicts);
+}
+
+export function createClientToolNameConflictError(conflicts: string[]): Error {
+  return new Error(`${CLIENT_TOOL_NAME_CONFLICT_PREFIX} ${conflicts.join(", ")}`);
+}
+
+export function isClientToolNameConflictError(err: unknown): err is Error {
+  return err instanceof Error && err.message.startsWith(CLIENT_TOOL_NAME_CONFLICT_PREFIX);
+}
+
 export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
   return tools.map((tool) => {
     const name = tool.name || "tool";

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createClientToolNameConflictError } from "../agents/pi-tool-definition-adapter.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -322,6 +323,21 @@ describe("OpenResponses HTTP API (e2e)", () => {
       expect(invalidOverrideJson.error?.message).toBe("Invalid `x-openclaw-model`.");
       expect(agentCommand).toHaveBeenCalledTimes(0);
       await ensureResponseConsumed(resInvalidOverride);
+
+      agentCommand.mockClear();
+      agentCommand.mockRejectedValueOnce(createClientToolNameConflictError(["exec"]));
+      const resToolConflict = await postResponses(port, {
+        model: "openclaw",
+        input: "hi",
+        tools: WEATHER_TOOL,
+      });
+      expect(resToolConflict.status).toBe(400);
+      const toolConflictJson = (await resToolConflict.json()) as {
+        error?: { code?: string; message?: string };
+      };
+      expect(toolConflictJson.error?.code).toBe("invalid_request_error");
+      expect(toolConflictJson.error?.message).toBe("invalid tool configuration");
+      await ensureResponseConsumed(resToolConflict);
 
       mockAgentOnce([{ text: "hello" }]);
       const resUser = await postResponses(port, {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -10,6 +10,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ImageContent } from "../agents/command/types.js";
 import type { ClientToolDefinition } from "../agents/pi-embedded-runner/run/params.js";
+import { isClientToolNameConflictError } from "../agents/pi-tool-definition-adapter.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
@@ -779,6 +780,17 @@ export async function handleOpenResponsesHttpRequest(
         return true;
       }
       logWarn(`openresponses: non-stream response failed: ${String(err)}`);
+      if (isClientToolNameConflictError(err)) {
+        const response = createResponseResource({
+          id: responseId,
+          model,
+          status: "failed",
+          output: [],
+          error: { code: "invalid_request_error", message: "invalid tool configuration" },
+        });
+        sendJson(res, 400, response);
+        return true;
+      }
       const response = createResponseResource({
         id: responseId,
         model,
@@ -1101,6 +1113,24 @@ export async function handleOpenResponsesHttpRequest(
       logWarn(`openresponses: streaming response failed: ${String(err)}`);
 
       finalUsage = finalUsage ?? createEmptyUsage();
+      if (isClientToolNameConflictError(err)) {
+        const errorResponse = createResponseResource({
+          id: responseId,
+          model,
+          status: "failed",
+          output: [],
+          error: { code: "invalid_request_error", message: "invalid tool configuration" },
+          usage: finalUsage,
+        });
+
+        writeSseEvent(res, { type: "response.failed", response: errorResponse });
+        emitAgentEvent({
+          runId: responseId,
+          stream: "lifecycle",
+          data: { phase: "error" },
+        });
+        return;
+      }
       const errorResponse = createResponseResource({
         id: responseId,
         model,


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                               
                          
  - **Problem:** `filterToolResultMediaUrls` granted trusted local-`MEDIA:`                                                                                                                                
    passthrough based on a *normalized* tool-name check, so a client-supplied                                                                                                                              
    tool whose name normalized to the same key as a registered built-in                                                                                                                                    
    (e.g. `Bash` → `bash`, `Web_Search` → `web_search`) would inherit the                                                                                                                                  
    built-in's media trust and could round-trip local `MEDIA:file://…` paths                                                                                                                               
    to the agent-facing output.                                                                                                                                                                            
  - **Why it matters:** local-MEDIA passthrough is an operator-trust-boundary                                                                                                                              
    behavior that is only safe when the emitting tool is one of this run's                                                                                                                                 
    registered built-ins. A normalized-name alias was never meant to satisfy
    that gate — the trust was anchored on the exact registration, not on a                                                                                                                                 
    collapsed key.                                                                                                                                                                                         
  - **What changed:** the runner now computes the exact raw names of this                                                                                                                                  
    run's registered non-plugin tools, rejects any client tool definition                                                                                                                                  
    whose name normalize-collides with a built-in (or another client tool),                                                                                                                                
    and threads that exact-name set into the subscribe/tool-result pipeline                                                                                                                                
    so `MEDIA:` passthrough requires a raw-name match instead of just a                                                                                                                                    
    normalized alias. Conflicting tool payloads now fail admission with a                                                                                                                                  
    generic 400 on both the streaming and non-streaming gateway paths.                                                                                                                                     
  - **What did NOT change (scope boundary):** no change to the set of                                                                                                                                      
    built-in tools, their registrations, plugin-provided tools, the public-                                                                                                                                
    HTTP media filter (`HTTP_URL_RE`), the tool result format, or any on-                                                                                                                                  
    the-wire SSE shape other than the new `response.failed` + error body on                                                                                                                                
    conflict. Callers that do not pass `builtinToolNames` keep the previous                                                                                                                                
    behavior; the runner opts everyone in by passing the set.                                                                                                                                              
                                                                                                                                                                                                           
  ## Change Type (select all)                                                                                                                                                                              
                                                                                                                                                                                                           
  - [x] Bug fix                                             
  - [ ] Feature
  - [x] Refactor required for the fix                                                                                                                                                                      
  - [ ] Docs
  - [x] Security hardening                                                                                                                                                                                 
  - [ ] Chore/infra                                         

  ## Scope (select all touched areas)                                                                                                                                                                      
   
  - [x] Gateway / orchestration                                                                                                                                                                            
  - [x] Skills / tool execution                             
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations                                                                                                                                                                                       
  - [x] API / contracts
  - [ ] UI / DX                                                                                                                                                                                            
  - [ ] CI/CD / infra                                       

  ## Linked Issue/PR                                                                                                                                                                                       
   
  - Closes #<issue>                                                                                                                                                                                        
  - Related #<issue-or-pr>                                  
  - [x] This PR fixes a bug or regression
                                                                                                                                                                                                           
  ## Root Cause (if applicable)
                                                                                                                                                                                                           
  - **Root cause:** `filterToolResultMediaUrls` and its callers keyed the                                                                                                                                  
    trusted-media decision off the *normalized* tool name. Because name
    normalization collapses case and alias variants, any tool name that                                                                                                                                    
    normalized to a built-in's key was treated as that built-in for the                                                                                                                                    
    purposes of local-MEDIA passthrough, regardless of whether it was the                                                                                                                                  
    built-in itself or a client-supplied definition with a colliding name.                                                                                                                                 
  - **Missing detection / guardrail:**                                                                                                                                                                     
    1. The emit/collect/filter call sites on the tool-result path were                                                                                                                                     
       passing the normalized name rather than the raw invocation name, so                                                                                                                                 
       there was no way to disambiguate a real built-in from a name-colliding                                                                                                                              
       client tool at filter time.                                                                                                                                                                         
    2. Client tool admission did not check for name collisions with built-in                                                                                                                               
       tools or with other client tools in the same request, so two distinct                                                                                                                               
       definitions could coexist behind one normalized key.                                                                                                                                                
  - **Contributing context (if known):** the normalized-name check predates                                                                                                                                
    the openresponses-style flow where clients submit their own tool                                                                                                                                       
    definitions per request; in the earlier shape, tool names originated                                                                                                                                   
    from the runner and the normalized check was effectively an exact check.                                                                                                                               
                                                                                                                                                                                                           
  ## Regression Test Plan (if applicable)                                                                                                                                                                  
                                                                                                                                                                                                           
  - Coverage level that should have caught this:                                                                                                                                                           
    - [x] Unit test
    - [x] Seam / integration test                                                                                                                                                                          
    - [ ] End-to-end test                                   
    - [ ] Existing coverage already sufficient
  - **Target test or file:**
    - `src/agents/pi-embedded-subscribe.tools.media.test.ts`                                                                                                                                               
    - `src/agents/pi-tool-definition-adapter.test.ts`                                                                                                                                                      
    - `src/gateway/openresponses-http.test.ts`                                                                                                                                                             
  - **Scenario the test should lock in:**                                                                                                                                                                  
    1. A tool result whose raw name normalize-collides with a built-in but                                                                                                                                 
       is not in `builtinToolNames` must have local `MEDIA:` paths stripped                                                                                                                                
       (public-HTTP filter only).                                                                                                                                                                          
    2. A client tool payload whose `function.name` normalize-collides with a                                                                                                                               
       registered built-in (or with another client tool in the same request)                                                                                                                               
       is rejected at admission; the request surfaces `400                                                                                                                                                 
       invalid_request_error` / `"invalid tool configuration"` on both the
       JSON and SSE response paths.                                                                                                                                                                        
  - **Why this is the smallest reliable guardrail:** the two unit tests pin                                                                                                                                
    the trust gate itself (the filter) and the admission gate (the adapter),                                                                                                                               
    which is where the bypass lived. The gateway test pins the user-visible                                                                                                                                
    response shape on conflict, so a regression in either direction (missing                                                                                                                               
    filter or missing admission reject) fails loudly at the seam the client                                                                                                                                
    actually sees.                                                                                                                                                                                         
  - **Existing test that already covers this (if any):** none — the added                                                                                                                                  
    tests replace `toolName`-based assertions with `rawToolName` / built-in-                                                                                                                               
    set assertions, which the prior suite did not exercise.                                                                                                                                                
  - **If no new test is added, why not:** N/A (new tests added).                                                                                                                                           
                                                                                                                                                                                                           
  ## User-visible / Behavior Changes                                                                                                                                                                       
                                                                                                                                                                                                           
  - Client tool definitions whose `function.name` normalize-collides with a                                                                                                                                
    registered built-in or with another client tool in the same request are
    now rejected with HTTP 400 `invalid_request_error` and error message                                                                                                                                   
    `"invalid tool configuration"` (non-streaming) or a                                                                                                                                                    
    `response.failed` SSE event carrying the same error shape (streaming),                                                                                                                                 
    instead of being silently accepted and routed to a normalized name.                                                                                                                                    
  - Tool results whose raw tool name is not present in this run's exact                                                                                                                                    
    built-in registration set no longer get local `MEDIA:` passthrough;                                                                                                                                    
    they fall through the public-HTTP media filter.                                                                                                                                                        
  - No default/config changes; no new env vars; no new flags.                                                                                                                                              
                                                                                                                                                                                                           
  ## Diagram (if applicable)                                                                                                                                                                               
                                                                                                                                                                                                           
  ```text                                                   
  Before (tool-result media trust):
    tool result (raw name "Bash")
      -> normalizeToolName -> "bash"                                                                                                                                                                       
      -> "bash" matches trusted built-in key                                                                                                                                                               
      -> local MEDIA:file:// URL passed through as trusted                                                                                                                                                 
                                                                                                                                                                                                           
  After:                                                    
    tool result (raw name "Bash")                                                                                                                                                                          
      -> exact-match check against builtinToolNames = { "bash" }
      -> "Bash" ∉ set                                                                                                                                                                                      
      -> local MEDIA: stripped; only HTTP_URL_RE survives   
                                                                                                                                                                                                           
  Admission (client tool payload with name "Bash"):         
    runEmbeddedAttempt                                                                                                                                                                                     
      -> findClientToolNameConflicts(tools, existingToolNames=builtinToolNames)
      -> conflict on "Bash" (normalizes to existing "bash")                                                                                                                                                
      -> throw createClientToolNameConflictError([...])                                                                                                                                                    
      -> openresponses-http catches via isClientToolNameConflictError                                                                                                                                      
      -> 400 invalid_request_error / "invalid tool configuration"                                                                                                                                          
                                                                                                                                                                                                           
  Security Impact (required)                                                                                                                                                                               
                                                                                                                                                                                                           
  - New permissions/capabilities? No                        
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? Yes (admission-level                                                                                                                                           
  rejection of name-colliding client tool definitions; no change to which
  tools can run once admitted).                                                                                                                                                                            
  - Data access scope changed? Yes (local MEDIA: passthrough from tool                                                                                                                                     
  results is narrower — gated on exact raw-name match against this run's                                                                                                                                   
  registered built-ins rather than a normalized alias).                                                                                                                                                    
  - Risk + mitigation: the change removes a path by which a client-                                                                                                                                        
  supplied tool definition could ride on a built-in's media-trust grant.                                                                                                                                   
  The mitigation is twofold — admission-level rejection of collisions                                                                                                                                      
  (adapter-level) and exact-name enforcement at the filter (tool-result-                                                                                                                                   
  level). Call sites that do not opt in by passing builtinToolNames                                                                                                                                        
  preserve the previous behavior, so the change is localized to runs                                                                                                                                       
  driven by runEmbeddedAttempt, which is updated to always opt in.                                                                                                                                         
                                                                                                                                                                                                           
  Repro + Verification                                                                                                                                                                                     
                                                                                                                                                                                                           
  Environment                                                                                                                                                                                              
                                                            
  - OS:
  - Runtime/container:
  - Model/provider:                                                                                                                                                                                        
  - Integration/channel (if any): openresponses HTTP gateway
  - Relevant config (redacted): default                                                                                                                                                                    
                                                                                                                                                                                                           
  Steps
                                                                                                                                                                                                           
  1. Register at least one built-in tool for the run (e.g. bash).                                                                                                                                          
  2. Submit an openresponses request whose tools payload includes a
  client tool definition named with a case/alias variant of a built-in                                                                                                                                     
  (e.g. "Bash" or "BASH"), or two client tools whose names                                                                                                                                                 
  normalize-collide.                                                                                                                                                                                       
  3. Observe the response.                                                                                                                                                                                 
                                                                                                                                                                                                           
  Expected                                                  

  - Non-streaming: HTTP 400 with a response resource of status: "failed",                                                                                                                                  
  error.code: "invalid_request_error", error.message: "invalid tool configuration". No tool is invoked.
  - Streaming: a response.failed SSE event with the same error shape and                                                                                                                                   
  a lifecycle phase: "error".                                                                                                                                                                              
  - Separately, for a tool result whose raw name is not in                                                                                                                                                 
  builtinToolNames, local MEDIA: URLs are stripped; only HTTP-scheme                                                                                                                                       
  URLs survive the filter.                                                                                                                                                                                 
                                                                                                                                                                                                           
  Actual                                                                                                                                                                                                   
                                                                                                                                                                                                           
  - Matches expected on all three scenarios under the added unit and                                                                                                                                       
  integration tests.
                                                                                                                                                                                                           
  Evidence                                                  

  - Failing test/log before + passing after
  - Trace/log snippets
  - Screenshot/recording                                                                                                                                                                                   
  - Perf numbers (if relevant)
                                                                                                                                                                                                           
  New/updated tests exercise every branch of the trust gate and admission                                                                                                                                  
  path:
  - pi-embedded-subscribe.tools.media.test.ts — filter with/without                                                                                                                                        
  builtinToolNames, exact match, collision-only match.                                                                                                                                                     
  - pi-embedded-subscribe.handlers.tools.media.test.ts — raw-name is used
  for emitToolOutput, collectEmittedToolOutputMediaUrls, and                                                                                                                                               
  filterToolResultMediaUrls in the tool-end handler.                                                                                                                                                       
  - pi-tool-definition-adapter.test.ts — findClientToolNameConflicts                                                                                                                                       
  detects built-in and client/client collisions; sentinel error survives                                                                                                                                   
  isClientToolNameConflictError.                                                                                                                                                                           
  - openresponses-http.test.ts — conflict produces 400 /                                                                                                                                                   
  invalid_request_error on JSON path and response.failed on SSE path.                                                                                                                                      
                                                                                                                                                                                                           
  Human Verification (required)                                                                                                                                                                            
                                                            
  - Verified scenarios:                                                                                                                                                                                    
    - Local unit and integration tests pass against the branch
  (npx vitest run).                                                                                                                                                                                        
    - Manual inspection of runEmbeddedAttempt wiring to confirm                                                                                                                                            
  builtinToolNames is always populated for embedded runs and                                                                                                                                               
  threaded through to subscribeEmbeddedPiSession and the tool-end                                                                                                                                          
  handler context.                                                                                                                                                                                         
  - Edge cases checked:                                                                                                                                                                                    
    - Client tool with identical raw name to a built-in (normalizes to                                                                                                                                     
  same key) — rejected.                                     
    - Two client tools whose names normalize to the same key but differ                                                                                                                                    
  in case — both surfaced in the conflict list.             
    - Tool result emitted with a normalized-alias name not in                                                                                                                                              
  builtinToolNames — MEDIA stripped.                                                                                                                                                                       
    - No client tools, no conflicts — behavior unchanged.                                                                                                                                                  
  - What you did not verify:                                                                                                                                                                               
    - End-to-end run against a live provider with a real client submitting                                                                                                                                 
  a conflicting tools payload.                                                                                                                                                                             
    - Behavior on plugin-provided tools whose names also normalize-collide                                                                                                                                 
  with built-ins (plugin registrations go through                                                                                                                                                          
  getPluginToolMeta, which excludes them from builtinToolNames,                                                                                                                                            
  so the conflict gate does not fire for them by design; flag if this                                                                                                                                      
  should be tightened further).                                                                                                                                                                            
                                                                                                                                                                                                           
  Review Conversations                                                                                                                                                                                     
                                                                                                                                                                                                           
  - I replied to or resolved every bot review conversation I addressed
  in this PR.
  - I left unresolved only the conversations that still need reviewer
  or maintainer judgment.                                                                                                                                                                                  
   
  Compatibility / Migration                                                                                                                                                                                
                                                            
  - Backward compatible? Yes for legitimate callers: the only                                                                                                                                              
  user-visible change is that name-colliding client tool payloads are now
  rejected at admission instead of silently normalized — which is the                                                                                                                                      
  intended outcome. Tool results from actual registered built-ins                                                                                                                                          
  continue to pass MEDIA: through unchanged.                                                                                                                                                               
  - Config/env changes? No                                                                                                                                                                                 
  - Migration needed? No                                                                                                                                                                                   
                                                                                                                                                                                                           
  Risks and Mitigations                                                                                                                                                                                    
                                                            
  - Risk: existing integrations that happened to rely on name-colliding                                                                                                                                    
  client tool definitions being silently accepted will start receiving
  400 errors.                                                                                                                                                                                              
    - Mitigation: the rejection is the intended outcome; the error
  response is shaped as a standard invalid_request_error so clients                                                                                                                                        
  can detect and rename their tool. Title, summary, and                                                                                                                                                    
  What changed make the admission rule explicit.                                                                                                                                                           
  - Risk: a caller that constructs subscribeEmbeddedPiSession                                                                                                                                              
  directly (outside runEmbeddedAttempt) without supplying                                                                                                                                                  
  builtinToolNames preserves the old normalized-name trust behavior.                                                                                                                                       
    - Mitigation: the runner now always supplies the set; future                                                                                                                                           
  direct callers should follow suit. If the codebase later grows                                                                                                                                           
  another direct call site, it should pass builtinToolNames too or                                                                                                                                         
  an ESLint/CI rule should forbid omitting it.  