### PR TITLE
fix: guard against undefined docsPath in formatDocsLink and formatChannelSelectionLine

### DIFF
--- a/src/channels/registry.helpers.test.ts
+++ b/src/channels/registry.helpers.test.ts
@@ -66,6 +66,12 @@ describe("channel registry helpers", () => {
     expect(normalizeAnyChannelId("weixin")).toBe("openclaw-weixin");
   });
 
+  it("falls back to /channels/{id} when meta.docsPath is undefined", () => {
+    const meta = { id: "test-channel", label: "Test", blurb: "A test channel" };
+    const line = formatChannelSelectionLine(meta as never, (path) => path);
+    expect(line).toContain("/channels/test-channel");
+  });
+
   it("falls back to the active registry when the pinned channel registry has no channels", () => {
     const startupRegistry = createEmptyPluginRegistry();
     setActivePluginRegistry(startupRegistry);

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -103,10 +103,11 @@ export function formatChannelSelectionLine(
   docsLink: (path: string, label?: string) => string,
 ): string {
   const docsPrefix = meta.selectionDocsPrefix ?? "Docs:";
+  const docsPath = meta.docsPath ?? `/channels/${meta.id}`;
   const docsLabel = meta.docsLabel ?? meta.id;
   const docs = meta.selectionDocsOmitLabel
-    ? docsLink(meta.docsPath)
-    : docsLink(meta.docsPath, docsLabel);
+    ? docsLink(docsPath)
+    : docsLink(docsPath, docsLabel);
   const extras = (meta.selectionExtras ?? []).filter(Boolean).join(" ");
   return `${meta.label} — ${meta.blurb} ${docsPrefix ? `${docsPrefix} ` : ""}${docs}${extras ? ` ${extras}` : ""}`;
 }

--- a/src/terminal/links.ts
+++ b/src/terminal/links.ts
@@ -5,11 +5,19 @@ function resolveDocsRoot(): string {
 }
 
 export function formatDocsLink(
-  path: string,
+  path: string | undefined,
   label?: string,
   opts?: { fallback?: string; force?: boolean },
 ): string {
+  if (!path) {
+    const root = resolveDocsRoot();
+    return opts?.fallback ?? root;
+  }
   const trimmed = path.trim();
+  if (!trimmed) {
+    const root = resolveDocsRoot();
+    return opts?.fallback ?? root;
+  }
   const docsRoot = resolveDocsRoot();
   const url = trimmed.startsWith("http")
     ? trimmed


### PR DESCRIPTION
## Summary
Fixes onboarding crash with "Cannot read properties of undefined (reading 'trim')" during channel setup.

## Root Cause
formatDocsLink(path) crashes with TypeError when path is undefined, and formatChannelSelectionLine passes meta.docsPath without a fallback during channel selection in onboarding.

## Fix
1. Add null/undefined guard in formatDocsLink returning docs root as fallback
2. Add default docsPath fallback '/channels/{id}' in formatChannelSelectionLine

## Test Plan
- [ ] Relevant unit tests pass
- [ ] Onboarding channel selection works with channels that have missing docsPath

Closes openclaw#67291
Closes openclaw#66945