### PR TITLE
fix: expand tilde paths in browser.executablePath before spawn

### DIFF
--- a/extensions/browser/src/browser/chrome.executables.test.ts
+++ b/extensions/browser/src/browser/chrome.executables.test.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
+import os from "node:os";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   parseBrowserMajorVersion,
+  resolveBrowserExecutableForPlatform,
   resolveGoogleChromeExecutableForPlatform,
 } from "./chrome.executables.js";
 
@@ -38,5 +40,35 @@ describe("chrome executables", () => {
       kind: "canary",
       path: "/usr/bin/google-chrome-unstable",
     });
+  });
+
+  it("expands tilde paths in browser.executablePath", () => {
+    const homeDir = os.homedir();
+    const tildePath = `/.local/chromium/chrome`;
+    const absolutePath = `${homeDir}${tildePath}`;
+
+    vi.spyOn(fs, "existsSync").mockImplementation((candidate) => {
+      return String(candidate) === absolutePath;
+    });
+
+    const result = resolveBrowserExecutableForPlatform(
+      { executablePath: `~${tildePath}` } as never,
+      "linux",
+    );
+    expect(result).toEqual({ kind: "custom", path: absolutePath });
+  });
+
+  it("passes through non-tilde executablePath unchanged", () => {
+    const absolutePath = "/opt/chromium/chrome";
+
+    vi.spyOn(fs, "existsSync").mockImplementation((candidate) => {
+      return String(candidate) === absolutePath;
+    });
+
+    const result = resolveBrowserExecutableForPlatform(
+      { executablePath: absolutePath } as never,
+      "linux",
+    );
+    expect(result).toEqual({ kind: "custom", path: absolutePath });
   });
 });

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -705,10 +705,14 @@ export function resolveBrowserExecutableForPlatform(
   platform: NodeJS.Platform,
 ): BrowserExecutable | null {
   if (resolved.executablePath) {
-    if (!exists(resolved.executablePath)) {
+    // Expand tilde paths — Node.js fs/spawn do not resolve ~ automatically
+    const execPath = resolved.executablePath.startsWith("~/")
+      ? path.join(os.homedir(), resolved.executablePath.slice(2))
+      : resolved.executablePath;
+    if (!exists(execPath)) {
       throw new Error(`browser.executablePath not found: ${resolved.executablePath}`);
     }
-    return { kind: "custom", path: resolved.executablePath };
+    return { kind: "custom", path: execPath };
   }
 
   const detected = detectDefaultChromiumExecutable(platform);


### PR DESCRIPTION
## Summary
Fixes ENOENT crash when browser.executablePath is set to a path under $HOME (e.g. /home/user/.local/chromium/.../chrome).

## Root Cause
The Gateway internally tilde-shortens absolute paths under the home directory (e.g. /home/user/.local/ → ~/.local/). However, Node.js child_process.spawn() and fs.existsSync() do not expand ~, causing browser launch to fail with ENOENT.

## Fix
Expand ~/ prefix to the absolute home directory path using os.homedir() in resolveBrowserExecutableForPlatform() before existence check and spawn.

## Test Plan
- [ ] Unit tests for tilde expansion pass
- [ ] Manual verification with browser executable under $HOME

Closes openclaw#67264