### PR TITLE
fix(matrix): block DM pairing-store room command auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Matrix/commands: keep DM pairing-store approvals out of room control-command authorization so DM-paired-only senders can no longer run owner-style commands in Matrix rooms without explicit room sender authorization.
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
 - Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 - Cron/announce delivery: suppress mixed-content isolated cron announce replies that end with `NO_REPLY` so trailing silent sentinels no longer leak summary text to the target channel. (#65004) thanks @neo1027144-creator.

--- a/extensions/matrix/src/matrix/monitor/access-state.test.ts
+++ b/extensions/matrix/src/matrix/monitor/access-state.test.ts
@@ -28,6 +28,25 @@ describe("resolveMatrixMonitorAccessState", () => {
     ]);
   });
 
+  it("does not let DM pairing-store entries authorize room control commands", () => {
+    const state = resolveMatrixMonitorAccessState({
+      allowFrom: [],
+      storeAllowFrom: ["@attacker:example.org"],
+      groupAllowFrom: [],
+      roomUsers: [],
+      senderId: "@attacker:example.org",
+      isRoom: true,
+    });
+
+    expect(state.effectiveAllowFrom).toEqual(["@attacker:example.org"]);
+    expect(state.directAllowMatch.allowed).toBe(true);
+    expect(state.commandAuthorizers).toEqual([
+      { configured: false, allowed: false },
+      { configured: false, allowed: false },
+      { configured: false, allowed: false },
+    ]);
+  });
+
   it("keeps room-user matching disabled for dm traffic", () => {
     const state = resolveMatrixMonitorAccessState({
       allowFrom: [],

--- a/extensions/matrix/src/matrix/monitor/access-state.ts
+++ b/extensions/matrix/src/matrix/monitor/access-state.ts
@@ -25,12 +25,14 @@ export function resolveMatrixMonitorAccessState(params: {
   senderId: string;
   isRoom: boolean;
 }): MatrixMonitorAccessState {
+  const configuredAllowFrom = normalizeMatrixAllowList(params.allowFrom);
   const effectiveAllowFrom = normalizeMatrixAllowList([
-    ...params.allowFrom,
+    ...configuredAllowFrom,
     ...params.storeAllowFrom,
   ]);
   const effectiveGroupAllowFrom = normalizeMatrixAllowList(params.groupAllowFrom);
   const effectiveRoomUsers = normalizeMatrixAllowList(params.roomUsers);
+  const commandAllowFrom = params.isRoom ? configuredAllowFrom : effectiveAllowFrom;
 
   const directAllowMatch = resolveMatrixAllowListMatch({
     allowList: effectiveAllowFrom,
@@ -50,6 +52,13 @@ export function resolveMatrixMonitorAccessState(params: {
           userId: params.senderId,
         })
       : null;
+  const commandAllowMatch =
+    commandAllowFrom.length > 0
+      ? resolveMatrixAllowListMatch({
+          allowList: commandAllowFrom,
+          userId: params.senderId,
+        })
+      : null;
 
   return {
     effectiveAllowFrom,
@@ -61,8 +70,8 @@ export function resolveMatrixMonitorAccessState(params: {
     groupAllowMatch,
     commandAuthorizers: [
       {
-        configured: effectiveAllowFrom.length > 0,
-        allowed: directAllowMatch.allowed,
+        configured: commandAllowFrom.length > 0,
+        allowed: commandAllowMatch?.allowed ?? false,
       },
       {
         configured: effectiveRoomUsers.length > 0,

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -445,6 +445,36 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(recordInboundSession).not.toHaveBeenCalled();
   });
 
+  it("blocks room control commands from DM-only paired senders", async () => {
+    const { handler, finalizeInboundContext, recordInboundSession } =
+      createMatrixHandlerTestHarness({
+        isDirectMessage: false,
+        readAllowFromStore: vi.fn(async () => ["@user:example.org"]),
+        roomsConfig: {
+          "!room:example.org": { requireMention: false },
+        },
+        shouldHandleTextCommands: () => true,
+        hasControlCommand: () => true,
+        cfg: {
+          commands: {
+            useAccessGroups: true,
+          },
+        },
+        getMemberDisplayName: async () => "sender",
+      });
+
+    await handler(
+      "!room:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$dm-only-room-command",
+        body: "/config",
+      }),
+    );
+
+    expect(recordInboundSession).not.toHaveBeenCalled();
+    expect(finalizeInboundContext).not.toHaveBeenCalled();
+  });
+
   it("processes room messages mentioned via displayName in formatted_body", async () => {
     const recordInboundSession = vi.fn(async () => {});
     const { handler } = createMatrixHandlerTestHarness({


### PR DESCRIPTION
## Summary

- Problem: Matrix room control-command auth reused the DM effective allowlist, so DM pairing-store entries could satisfy room command authorization.
- Why it matters: a sender paired only for Matrix DMs could run owner-style room commands without explicit room sender authorization.
- What changed: room command authorization now ignores pairing-store entries and only uses explicitly configured Matrix allowlists in room scope; added focused regression coverage for the helper and handler paths.
- What did NOT change (scope boundary): DM pairing behavior is unchanged; explicit room sender allowlists and DM command auth keep their existing semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveMatrixMonitorAccessState()` merged DM pairing-store entries into `effectiveAllowFrom` and reused that merged list for room `commandAuthorizers`, so room control-command gating treated DM-only paired senders as command-authorized.
- Missing detection / guardrail: Matrix lacked a regression test that locked the DM-only vs room-command boundary.
- Contributing context (if known): shared auth code already documented the invariant that group command authorization must not inherit DM pairing-store approvals, but the Matrix-specific path bypassed that invariant.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/matrix/monitor/access-state.test.ts`, `extensions/matrix/src/matrix/monitor/handler.test.ts`
- Scenario the test should lock in: a Matrix sender present only in the DM pairing store must not gain room control-command authorization.
- Why this is the smallest reliable guardrail: the helper test locks the authorizer computation directly, and the handler test locks the real room block path without requiring broader Matrix E2E setup.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Matrix rooms now require explicit room sender authorization for owner-style control commands even when the sender is already DM-paired for the same account.

## Diagram (if applicable)

```text
Before:
[DM-paired sender in Matrix room] -> [pairing-store merged into room command authorizer] -> [room command allowed]

After:
[DM-paired sender in Matrix room] -> [room command authorizer uses explicit room-safe allowlists only] -> [room command blocked]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (Yes)
- If any `Yes`, explain risk + mitigation: narrows room command authorization so DM pairing-store entries no longer expand room command access.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo dev environment
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): `commands.useAccessGroups=true`, Matrix room traffic enabled, sender present only in the DM pairing store

### Steps

1. Pair a Matrix sender for DM access only.
2. Send a control command from that sender in a Matrix room without matching `groupAllowFrom` or per-room `users` authorization.
3. Evaluate room command authorization.

### Expected

- The room control command is blocked.

### Actual

- Before this patch, the room control command was treated as authorized because the DM pairing-store entry leaked into room command auth.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the focused Matrix regressions covering helper-level authorizer computation and the handler room block path.
- Edge cases checked: DM pairing-store entries still remain in `effectiveAllowFrom` for DM auth; room control-command auth now ignores them.
- What you did **not** verify: full `pnpm check` is currently blocked by unrelated existing lint failures in `scripts/update-clawtributors.ts` and `src/plugin-sdk/root-alias.cjs`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: room command auth could accidentally change DM auth semantics if the room/DM split is computed incorrectly.
  - Mitigation: the helper keeps `effectiveAllowFrom` unchanged for DM gating and the new regression tests lock both room and handler behavior.
