### PR TITLE
feat(android): add HTTP request node invoke command

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -288,6 +288,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     ensureRuntime().setSpeakerEnabled(enabled)
   }
 
+  fun setHttpAccessEnabled(enabled: Boolean) {
+    ensureRuntime().setHttpAccessEnabled(enabled)
+  }
+
   fun refreshGatewayConnection() {
     ensureRuntime().refreshGatewayConnection()
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -102,6 +102,7 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
   val speakerEnabled: StateFlow<Boolean> = prefs.speakerEnabled
   val micEnabled: StateFlow<Boolean> = prefs.talkEnabled
+  val httpAccessEnabled: StateFlow<Boolean> = prefs.httpAccessEnabled
 
   val micCooldown: StateFlow<Boolean> = runtimeState(initial = false) { it.micCooldown }
   val micStatusText: StateFlow<String> = runtimeState(initial = "Mic off") { it.micStatusText }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -191,6 +191,7 @@ class NodeRuntime(
     onCanvasA2uiReset = { _canvasA2uiHydrated.value = false },
     motionActivityAvailable = { motionHandler.isActivityAvailable() },
     motionPedometerAvailable = { motionHandler.isPedometerAvailable() },
+    httpEnabled = { prefs.httpAccessEnabled.value },
   )
 
   data class GatewayTrustPrompt(

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -804,6 +804,10 @@ class NodeRuntime(
     }
   }
 
+  fun setHttpAccessEnabled(value: Boolean) {
+    prefs.setHttpAccessEnabled(value)
+  }
+
   fun refreshGatewayConnection() {
     val endpoint =
       connectedEndpoint ?: run {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -133,6 +133,8 @@ class NodeRuntime(
     sms = sms,
   )
 
+  private val httpHandler: HttpHandler = HttpHandler(json = json)
+
   private val a2uiHandler: A2UIHandler = A2UIHandler(
     canvas = canvas,
     json = json,
@@ -170,6 +172,7 @@ class NodeRuntime(
     a2uiHandler = a2uiHandler,
     debugHandler = debugHandler,
     callLogHandler = callLogHandler,
+    httpHandler = httpHandler,
     isForeground = { _isForeground.value },
     cameraEnabled = { cameraEnabled.value },
     locationEnabled = { locationMode.value != LocationMode.Off },

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -37,7 +37,7 @@ class SecurePrefs(
     private const val notificationsForwardingMaxEventsPerMinuteKey =
       "notifications.forwarding.maxEventsPerMinute"
     private const val notificationsForwardingSessionKeyKey = "notifications.forwarding.sessionKey"
-  private const val httpAccessEnabledKey = "http.access.enabled"
+    private const val httpAccessEnabledKey = "http.access.enabled"
   }
 
   private val appContext = context.applicationContext

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -37,6 +37,7 @@ class SecurePrefs(
     private const val notificationsForwardingMaxEventsPerMinuteKey =
       "notifications.forwarding.maxEventsPerMinute"
     private const val notificationsForwardingSessionKeyKey = "notifications.forwarding.sessionKey"
+  private const val httpAccessEnabledKey = "http.access.enabled"
   }
 
   private val appContext = context.applicationContext
@@ -166,6 +167,9 @@ class SecurePrefs(
   val talkEnabled: StateFlow<Boolean> = _talkEnabled
 
   private val _speakerEnabled = MutableStateFlow(plainPrefs.getBoolean("voice.speakerEnabled", true))
+
+  private val _httpAccessEnabled = MutableStateFlow(plainPrefs.getBoolean(httpAccessEnabledKey, false))
+  val httpAccessEnabled: StateFlow<Boolean> = _httpAccessEnabled
   val speakerEnabled: StateFlow<Boolean> = _speakerEnabled
 
   fun setLastDiscoveredStableId(value: String) {
@@ -486,6 +490,11 @@ class SecurePrefs(
   fun setSpeakerEnabled(value: Boolean) {
     plainPrefs.edit { putBoolean("voice.speakerEnabled", value) }
     _speakerEnabled.value = value
+  }
+
+  fun setHttpAccessEnabled(value: Boolean) {
+    plainPrefs.edit { putBoolean(httpAccessEnabledKey, value) }
+    _httpAccessEnabled.value = value
   }
 
   private fun loadNotificationForwardingPackages(): Set<String> {

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -100,6 +100,7 @@ class ConnectionManager(
       motionActivityAvailable = motionActivityAvailable(),
       motionPedometerAvailable = motionPedometerAvailable(),
       debugBuild = BuildConfig.DEBUG,
+      httpEnabled = prefs.httpAccessEnabled.value,
     )
 
   fun buildInvokeCommands(): List<String> = InvokeCommandRegistry.advertisedCommands(runtimeFlags())

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -101,25 +102,8 @@ class HttpHandler(
       }
 
       // Read response body (truncated to MAX_BODY_SIZE_BYTES)
-      val responseBody = try {
-        val inputStream = if (responseCode >= 400) connection.errorStream else connection.inputStream
-        if (inputStream != null) {
-          inputStream.use { stream ->
-            val buffer = ByteArray(MAX_BODY_SIZE_BYTES)
-            var offset = 0
-            while (offset < MAX_BODY_SIZE_BYTES) {
-              val n = stream.read(buffer, offset, MAX_BODY_SIZE_BYTES - offset)
-              if (n == -1) break
-              offset += n
-            }
-            if (offset > 0) String(buffer, 0, offset, Charsets.UTF_8) else null
-          }
-        } else {
-          null
-        }
-      } catch (_: Throwable) {
-        null
-      }
+      // Throws on stream errors — outer catch handles them as REQUEST_FAILED
+      val responseBody = readResponseBody(connection, responseCode)
 
       val result = buildJsonObject {
         put("ok", responseCode in 200..299)
@@ -154,6 +138,26 @@ class HttpHandler(
       )
     } finally {
       connection.disconnect()
+    }
+  }
+
+  /**
+   * Reads the response body up to MAX_BODY_SIZE_BYTES.
+   * @throws IOException on stream read failures — caught by outer handler as REQUEST_FAILED.
+   */
+  @Throws(java.io.IOException::class)
+  private fun readResponseBody(connection: HttpURLConnection, responseCode: Int): String? {
+    val inputStream = if (responseCode >= 400) connection.errorStream else connection.inputStream
+    if (inputStream == null) return null
+    return inputStream.use { stream ->
+      val buffer = ByteArray(MAX_BODY_SIZE_BYTES)
+      var offset = 0
+      while (offset < MAX_BODY_SIZE_BYTES) {
+        val n = stream.read(buffer, offset, MAX_BODY_SIZE_BYTES - offset)
+        if (n == -1) break
+        offset += n
+      }
+      if (offset > 0) String(buffer, 0, offset, Charsets.UTF_8) else null
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
@@ -4,13 +4,11 @@ import ai.openclaw.app.gateway.GatewaySession
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
 import java.net.HttpURLConnection
 import java.net.URL
-import java.net.URLEncoder
 
 private const val DEFAULT_TIMEOUT_MS = 30_000
 private const val MAX_BODY_SIZE_BYTES = 5 * 1024 * 1024 // 5 MB cap
@@ -162,13 +160,16 @@ class HttpHandler(
       return null
     }
 
-    val headers =
-      buildMap<String, String> {
-        obj["headers"]?.jsonObject?.entries?.forEach { (k, v) ->
-          val value = (v as? JsonPrimitive)?.contentOrNull?.trim() ?: ""
-          if (k.isNotEmpty()) put(k, value)
+    val headersObj = obj["headers"] as? JsonObject
+    val headers = mutableMapOf<String, String>()
+    if (headersObj != null) {
+      for (entry in headersObj.entries) {
+        val value = (entry.value as? JsonPrimitive)?.contentOrNull?.trim() ?: ""
+        if (entry.key.isNotEmpty()) {
+          headers[entry.key] = value
         }
       }
+    }
 
     val body = (obj["body"] as? JsonPrimitive)?.contentOrNull
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
@@ -1,0 +1,193 @@
+package ai.openclaw.app.node
+
+import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putAll
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+
+private const val DEFAULT_TIMEOUT_MS = 30_000
+private const val MAX_BODY_SIZE_BYTES = 5 * 1024 * 1024 // 5 MB cap
+
+internal data class HttpRequest(
+  val url: String,
+  val method: String = "GET",
+  val headers: Map<String, String> = emptyMap(),
+  val body: String? = null,
+  val timeoutMs: Int = DEFAULT_TIMEOUT_MS,
+)
+
+internal class HttpHandler(
+  private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+  fun handleHttpRequest(paramsJson: String?): GatewaySession.InvokeResult {
+    val request =
+      parseHttpRequest(paramsJson)
+        ?: return GatewaySession.InvokeResult.error(
+          code = "INVALID_REQUEST",
+          message = "INVALID_REQUEST: expected JSON object with url (string)",
+        )
+
+    val validated = validateUrl(request.url)
+      ?: return GatewaySession.InvokeResult.error(
+        code = "INVALID_REQUEST",
+        message = "INVALID_REQUEST: url must be a valid http or https URL",
+      )
+
+    return executeHttpRequest(validated, request)
+  }
+
+  private fun validateUrl(url: String): URL? {
+    return try {
+      val parsed = URL(url)
+      if (parsed.protocol !in listOf("http", "https")) return null
+      parsed
+    } catch (_: Throwable) {
+      null
+    }
+  }
+
+  private fun executeHttpRequest(url: URL, request: HttpRequest): GatewaySession.InvokeResult {
+    val connection = try {
+      url.openConnection() as HttpURLConnection
+    } catch (err: Throwable) {
+      return GatewaySession.InvokeResult.error(
+        code = "CONNECTION_ERROR",
+        message = "CONNECTION_ERROR: ${err.message ?: "failed to open connection"}",
+      )
+    }
+
+    return try {
+      connection.requestMethod = request.method.uppercase()
+      connection.connectTimeout = request.timeoutMs
+      connection.readTimeout = request.timeoutMs
+      connection.instanceFollowRedirects = true
+      connection.doInput = true
+
+      // Set headers
+      for ((key, value) in request.headers) {
+        connection.setRequestProperty(key, value)
+      }
+
+      // Default Content-Type if not set and body is present
+      if (request.body != null && request.headers.keys.none { it.equals("Content-Type", ignoreCase = true) }) {
+        connection.setRequestProperty("Content-Type", "application/json; charset=utf-8")
+      }
+
+      // Write body if present
+      if (request.body != null && request.method in listOf("POST", "PUT", "PATCH", "DELETE")) {
+        connection.doOutput = true
+        connection.outputStream.use { stream ->
+          val bytes = request.body.toByteArray(Charsets.UTF_8)
+          stream.write(bytes)
+        }
+      }
+
+      val responseCode = connection.responseCode
+      val responseMessage = connection.responseMessage ?: ""
+
+      // Read response headers
+      val responseHeaders = buildJsonObject {
+        connection.headerFields.forEach { (key, values) ->
+          if (key != null) {
+            put(key, values.joinToString(", "))
+          }
+        }
+      }
+
+      // Read response body (truncated to MAX_BODY_SIZE_BYTES)
+      val responseBody = try {
+        val inputStream = if (responseCode >= 400) connection.errorStream else connection.inputStream
+        if (inputStream != null) {
+          inputStream.bufferedReader(Charsets.UTF_8).use { reader ->
+            reader.readText(MAX_BODY_SIZE_BYTES)
+          }
+        } else {
+          null
+        }
+      } catch (_: Throwable) {
+        null
+      }
+
+      val result = buildJsonObject {
+        put("ok", responseCode in 200..299)
+        put("status", responseCode)
+        put("statusText", responseMessage)
+        put("headers", responseHeaders)
+        if (responseBody != null) {
+          put("body", responseBody)
+        }
+      }
+
+      GatewaySession.InvokeResult.ok(result.toString())
+    } catch (err: java.net.UnknownHostException) {
+      GatewaySession.InvokeResult.error(
+        code = "DNS_ERROR",
+        message = "DNS_ERROR: unknown host — ${url.host}",
+      )
+    } catch (err: java.net.SocketTimeoutException) {
+      GatewaySession.InvokeResult.error(
+        code = "TIMEOUT",
+        message = "TIMEOUT: request timed out after ${request.timeoutMs}ms",
+      )
+    } catch (err: java.net.ProtocolException) {
+      GatewaySession.InvokeResult.error(
+        code = "PROTOCOL_ERROR",
+        message = "PROTOCOL_ERROR: ${err.message}",
+      )
+    } catch (err: Throwable) {
+      GatewaySession.InvokeResult.error(
+        code = "REQUEST_FAILED",
+        message = "REQUEST_FAILED: ${err.message ?: "unknown error"}",
+      )
+    } finally {
+      connection.disconnect()
+    }
+  }
+
+  private fun parseHttpRequest(paramsJson: String?): HttpRequest? {
+    val obj = parseParamsObject(paramsJson) ?: return null
+
+    val urlRaw = (obj["url"] as? JsonPrimitive)?.contentOrNull?.trim() ?: return null
+    if (urlRaw.isEmpty()) return null
+
+    val methodRaw = (obj["method"] as? JsonPrimitive)?.contentOrNull?.trim()?.uppercase() ?: "GET"
+    if (methodRaw !in listOf("GET", "POST", "HEAD", "PUT", "PATCH", "DELETE", "OPTIONS")) {
+      return null
+    }
+
+    val headers =
+      (obj["headers"] as? JsonObject)?.entries?.associate { (k, v) ->
+        k to (v as? JsonPrimitive)?.contentOrNull?.trim() ?: ""
+      } ?: emptyMap()
+
+    val body = (obj["body"] as? JsonPrimitive)?.contentOrNull
+
+    val timeoutRaw = (obj["timeout"] as? JsonPrimitive)?.contentOrNull
+    val timeout = timeoutRaw?.toIntOrNull()?.coerceIn(1, 120_000) ?: DEFAULT_TIMEOUT_MS
+
+    return HttpRequest(
+      url = urlRaw,
+      method = methodRaw,
+      headers = headers,
+      body = body,
+      timeoutMs = timeout,
+    )
+  }
+
+  private fun parseParamsObject(paramsJson: String?): JsonObject? {
+    if (paramsJson.isNullOrBlank()) return null
+    return try {
+      Json.parseToJsonElement(paramsJson).asObjectOrNull()
+    } catch (_: Throwable) {
+      null
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
@@ -23,6 +23,7 @@ internal data class HttpRequest(
 
 class HttpHandler(
   private val json: Json = Json { ignoreUnknownKeys = true },
+  private val urlFactory: (String) -> URL = ::URL,
 ) {
   fun handleHttpRequest(paramsJson: String?): GatewaySession.InvokeResult {
     val request =
@@ -43,7 +44,7 @@ class HttpHandler(
 
   private fun validateUrl(url: String): URL? {
     return try {
-      val parsed = URL(url)
+      val parsed = urlFactory(url)
       if (parsed.protocol !in listOf("http", "https")) return null
       parsed
     } catch (_: Throwable) {
@@ -103,8 +104,10 @@ class HttpHandler(
       val responseBody = try {
         val inputStream = if (responseCode >= 400) connection.errorStream else connection.inputStream
         if (inputStream != null) {
-          inputStream.bufferedReader(Charsets.UTF_8).use { reader ->
-            reader.readText().take(MAX_BODY_SIZE_BYTES)
+          inputStream.use { stream ->
+            val buffer = ByteArray(MAX_BODY_SIZE_BYTES)
+            val bytesRead = stream.read(buffer, 0, MAX_BODY_SIZE_BYTES)
+            if (bytesRead > 0) String(buffer, 0, bytesRead, Charsets.UTF_8) else null
           }
         } else {
           null

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
@@ -106,8 +106,13 @@ class HttpHandler(
         if (inputStream != null) {
           inputStream.use { stream ->
             val buffer = ByteArray(MAX_BODY_SIZE_BYTES)
-            val bytesRead = stream.read(buffer, 0, MAX_BODY_SIZE_BYTES)
-            if (bytesRead > 0) String(buffer, 0, bytesRead, Charsets.UTF_8) else null
+            var offset = 0
+            while (offset < MAX_BODY_SIZE_BYTES) {
+              val n = stream.read(buffer, offset, MAX_BODY_SIZE_BYTES - offset)
+              if (n == -1) break
+              offset += n
+            }
+            if (offset > 0) String(buffer, 0, offset, Charsets.UTF_8) else null
           }
         } else {
           null

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/HttpHandler.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
-import kotlinx.serialization.json.putAll
 import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
@@ -24,7 +23,7 @@ internal data class HttpRequest(
   val timeoutMs: Int = DEFAULT_TIMEOUT_MS,
 )
 
-internal class HttpHandler(
+class HttpHandler(
   private val json: Json = Json { ignoreUnknownKeys = true },
 ) {
   fun handleHttpRequest(paramsJson: String?): GatewaySession.InvokeResult {
@@ -107,7 +106,7 @@ internal class HttpHandler(
         val inputStream = if (responseCode >= 400) connection.errorStream else connection.inputStream
         if (inputStream != null) {
           inputStream.bufferedReader(Charsets.UTF_8).use { reader ->
-            reader.readText(MAX_BODY_SIZE_BYTES)
+            reader.readText().take(MAX_BODY_SIZE_BYTES)
           }
         } else {
           null
@@ -164,9 +163,12 @@ internal class HttpHandler(
     }
 
     val headers =
-      (obj["headers"] as? JsonObject)?.entries?.associate { (k, v) ->
-        k to (v as? JsonPrimitive)?.contentOrNull?.trim() ?: ""
-      } ?: emptyMap()
+      buildMap<String, String> {
+        obj["headers"]?.jsonObject?.entries?.forEach { (k, v) ->
+          val value = (v as? JsonPrimitive)?.contentOrNull?.trim() ?: ""
+          if (k.isNotEmpty()) put(k, value)
+        }
+      }
 
     val body = (obj["body"] as? JsonPrimitive)?.contentOrNull
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
@@ -8,6 +8,7 @@ import ai.openclaw.app.protocol.OpenClawCapability
 import ai.openclaw.app.protocol.OpenClawCallLogCommand
 import ai.openclaw.app.protocol.OpenClawContactsCommand
 import ai.openclaw.app.protocol.OpenClawDeviceCommand
+import ai.openclaw.app.protocol.OpenClawHttpCommand
 import ai.openclaw.app.protocol.OpenClawLocationCommand
 import ai.openclaw.app.protocol.OpenClawMotionCommand
 import ai.openclaw.app.protocol.OpenClawNotificationsCommand
@@ -96,6 +97,7 @@ object InvokeCommandRegistry {
         name = OpenClawCapability.CallLog.rawValue,
         availability = NodeCapabilityAvailability.CallLogAvailable,
       ),
+      NodeCapabilitySpec(name = OpenClawCapability.Http.rawValue),
     )
 
   val all: List<InvokeCommandSpec> =
@@ -206,6 +208,9 @@ object InvokeCommandRegistry {
       InvokeCommandSpec(
         name = OpenClawCallLogCommand.Search.rawValue,
         availability = InvokeCommandAvailability.CallLogAvailable,
+      ),
+      InvokeCommandSpec(
+        name = OpenClawHttpCommand.Request.rawValue,
       ),
       InvokeCommandSpec(
         name = "debug.logs",

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
@@ -41,6 +41,7 @@ enum class InvokeCommandAvailability {
   MotionActivityAvailable,
   MotionPedometerAvailable,
   DebugBuild,
+  HttpEnabled,
 }
 
 enum class NodeCapabilityAvailability {
@@ -94,8 +95,6 @@ object InvokeCommandRegistry {
       NodeCapabilitySpec(
         name = OpenClawCapability.Motion.rawValue,
         availability = NodeCapabilityAvailability.MotionAvailable,
-  HttpEnabled,
-          NodeCapabilityAvailability.HttpEnabled,
       ),
       NodeCapabilitySpec(
         name = OpenClawCapability.CallLog.rawValue,
@@ -242,6 +241,7 @@ object InvokeCommandRegistry {
           NodeCapabilityAvailability.CallLogAvailable -> flags.callLogAvailable
           NodeCapabilityAvailability.VoiceWakeEnabled -> flags.voiceWakeEnabled
           NodeCapabilityAvailability.MotionAvailable -> flags.motionActivityAvailable || flags.motionPedometerAvailable
+          NodeCapabilityAvailability.HttpEnabled -> flags.httpEnabled
         }
       }
       .map { it.name }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
@@ -27,6 +27,7 @@ data class NodeRuntimeFlags(
   val motionActivityAvailable: Boolean,
   val motionPedometerAvailable: Boolean,
   val debugBuild: Boolean,
+  val httpEnabled: Boolean,
 )
 
 enum class InvokeCommandAvailability {
@@ -50,6 +51,7 @@ enum class NodeCapabilityAvailability {
   CallLogAvailable,
   VoiceWakeEnabled,
   MotionAvailable,
+  HttpEnabled,
 }
 
 data class NodeCapabilitySpec(
@@ -92,12 +94,14 @@ object InvokeCommandRegistry {
       NodeCapabilitySpec(
         name = OpenClawCapability.Motion.rawValue,
         availability = NodeCapabilityAvailability.MotionAvailable,
+  HttpEnabled,
+          NodeCapabilityAvailability.HttpEnabled,
       ),
       NodeCapabilitySpec(
         name = OpenClawCapability.CallLog.rawValue,
         availability = NodeCapabilityAvailability.CallLogAvailable,
       ),
-      NodeCapabilitySpec(name = OpenClawCapability.Http.rawValue),
+      NodeCapabilitySpec(name = OpenClawCapability.Http.rawValue, availability = NodeCapabilityAvailability.HttpEnabled),
     )
 
   val all: List<InvokeCommandSpec> =
@@ -211,6 +215,7 @@ object InvokeCommandRegistry {
       ),
       InvokeCommandSpec(
         name = OpenClawHttpCommand.Request.rawValue,
+        availability = InvokeCommandAvailability.HttpEnabled,
       ),
       InvokeCommandSpec(
         name = "debug.logs",
@@ -255,6 +260,7 @@ object InvokeCommandRegistry {
           InvokeCommandAvailability.CallLogAvailable -> flags.callLogAvailable
           InvokeCommandAvailability.MotionActivityAvailable -> flags.motionActivityAvailable
           InvokeCommandAvailability.MotionPedometerAvailable -> flags.motionPedometerAvailable
+          InvokeCommandAvailability.HttpEnabled -> flags.httpEnabled
           InvokeCommandAvailability.DebugBuild -> flags.debugBuild
         }
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
@@ -83,6 +83,7 @@ class InvokeDispatcher(
   private val onCanvasA2uiReset: () -> Unit,
   private val motionActivityAvailable: () -> Boolean,
   private val motionPedometerAvailable: () -> Boolean,
+  private val httpEnabled: () -> Boolean,
 ) {
   suspend fun handleInvoke(command: String, paramsJson: String?): GatewaySession.InvokeResult {
     val spec =
@@ -330,7 +331,14 @@ class InvokeDispatcher(
           )
         }
       InvokeCommandAvailability.HttpEnabled ->
-        null
+        if (httpEnabled()) {
+          null
+        } else {
+          GatewaySession.InvokeResult.error(
+            code = "HTTP_DISABLED",
+            message = "HTTP_DISABLED: enable HTTP Access in Settings",
+          )
+        }
       InvokeCommandAvailability.DebugBuild ->
         if (debugBuild()) {
           null

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
@@ -8,6 +8,7 @@ import ai.openclaw.app.protocol.OpenClawCameraCommand
 import ai.openclaw.app.protocol.OpenClawCallLogCommand
 import ai.openclaw.app.protocol.OpenClawContactsCommand
 import ai.openclaw.app.protocol.OpenClawDeviceCommand
+import ai.openclaw.app.protocol.OpenClawHttpCommand
 import ai.openclaw.app.protocol.OpenClawLocationCommand
 import ai.openclaw.app.protocol.OpenClawMotionCommand
 import ai.openclaw.app.protocol.OpenClawNotificationsCommand
@@ -67,6 +68,7 @@ class InvokeDispatcher(
   private val a2uiHandler: A2UIHandler,
   private val debugHandler: DebugHandler,
   private val callLogHandler: CallLogHandler,
+  private val httpHandler: HttpHandler,
   private val isForeground: () -> Boolean,
   private val cameraEnabled: () -> Boolean,
   private val locationEnabled: () -> Boolean,
@@ -208,6 +210,9 @@ class InvokeDispatcher(
 
       // CallLog command
       OpenClawCallLogCommand.Search.rawValue -> callLogHandler.handleCallLogSearch(paramsJson)
+
+      // HTTP command
+      OpenClawHttpCommand.Request.rawValue -> httpHandler.handleHttpRequest(paramsJson)
 
       // Debug commands
       "debug.ed25519" -> debugHandler.handleEd25519()

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
@@ -329,6 +329,8 @@ class InvokeDispatcher(
             message = "CALL_LOG_UNAVAILABLE: call log not available on this build",
           )
         }
+      InvokeCommandAvailability.HttpEnabled ->
+        null
       InvokeCommandAvailability.DebugBuild ->
         if (debugBuild()) {
           null

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
@@ -68,7 +68,7 @@ class InvokeDispatcher(
   private val a2uiHandler: A2UIHandler,
   private val debugHandler: DebugHandler,
   private val callLogHandler: CallLogHandler,
-  private val httpHandler: HttpHandler,
+  internal val httpHandler: HttpHandler,
   private val isForeground: () -> Boolean,
   private val cameraEnabled: () -> Boolean,
   private val locationEnabled: () -> Boolean,

--- a/apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt
@@ -14,6 +14,7 @@ enum class OpenClawCapability(val rawValue: String) {
   Calendar("calendar"),
   Motion("motion"),
   CallLog("callLog"),
+  Http("http"),
 }
 
 enum class OpenClawCanvasCommand(val rawValue: String) {
@@ -146,5 +147,14 @@ enum class OpenClawCallLogCommand(val rawValue: String) {
 
   companion object {
     const val NamespacePrefix: String = "callLog."
+  }
+}
+
+enum class OpenClawHttpCommand(val rawValue: String) {
+  Request("http.request"),
+  ;
+
+  companion object {
+    const val NamespacePrefix: String = "http."
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -1106,7 +1106,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
                 }
               },
             )
-
+          }
           HorizontalDivider(color = mobileBorder)
           ListItem(
             modifier = Modifier.fillMaxWidth(),
@@ -1120,7 +1120,6 @@ fun SettingsSheet(viewModel: MainViewModel) {
               )
             },
           )
-          }
         }
       }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -92,6 +92,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val notificationForwardingQuietEnd by viewModel.notificationForwardingQuietEnd.collectAsState()
   val notificationForwardingMaxEventsPerMinute by viewModel.notificationForwardingMaxEventsPerMinute.collectAsState()
   val notificationForwardingSessionKey by viewModel.notificationForwardingSessionKey.collectAsState()
+  val httpAccessEnabled by viewModel.httpAccessEnabled.collectAsState()
 
   var notificationQuietStartDraft by remember(notificationForwardingQuietStart) {
     mutableStateOf(notificationForwardingQuietStart)
@@ -1105,6 +1106,20 @@ fun SettingsSheet(viewModel: MainViewModel) {
                 }
               },
             )
+
+          HorizontalDivider(color = mobileBorder)
+          ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = listItemColors,
+            headlineContent = { Text("HTTP Access", style = mobileHeadline) },
+            supportingContent = { Text("Allow gateway to make HTTP requests via this device.", style = mobileCallout) },
+            trailingContent = {
+              Switch(
+                checked = httpAccessEnabled,
+                onCheckedChange = viewModel::setHttpAccessEnabled,
+              )
+            },
+          )
           }
         }
       }

--- a/apps/android/app/src/test/java/ai/openclaw/app/HttpHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/HttpHandlerTest.kt
@@ -1,52 +1,57 @@
 package ai.openclaw.app
 
 import ai.openclaw.app.node.HttpHandler
-import ai.openclaw.app.protocol.OpenClawHttpCommand
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import java.io.ByteArrayInputStream
-import java.io.InputStream
-import java.net.HttpURLConnection
-import java.net.URL
-import java.net.UnknownHostException
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class HttpHandlerTest {
-  private val handler = HttpHandler()
+  private lateinit var server: MockWebServer
+  private lateinit var handler: HttpHandler
+
+  @Before
+  fun setUp() {
+    server = MockWebServer()
+    server.start()
+    handler = HttpHandler()
+  }
+
+  @After
+  fun tearDown() {
+    server.shutdown()
+  }
+
+  private fun serverUrl(path: String = "/"): String = server.url(path).toString()
 
   @Test
   fun handles_GET_request_successfully() {
-    val mockConnection = mock<HttpURLConnection>()
-    whenever(mockConnection.responseCode).thenReturn(200)
-    whenever(mockConnection.responseMessage).thenReturn("OK")
-    whenever(mockConnection.headerFields).thenReturn(
-      mapOf(
-        "Content-Type" to listOf("application/json"),
-        "X-Custom" to listOf("value")
-      )
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody("""{"success":true}""")
+        .setHeader("Content-Type", "application/json")
+        .setHeader("X-Custom", "value")
     )
-    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream("""{"success":true}""".toByteArray()))
 
-    val mockUrl = mock<URL>()
-    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
-
-    val result = handler.handleHttpRequest("""{"url":"http://example.com/api","method":"GET"}""")
+    val result = handler.handleHttpRequest("""{"url":"${serverUrl("api")}","method":"GET"}""")
 
     assertNotNull(result)
     assertTrue(result.ok)
-    assertTrue(result.payload?.contains("\"status\":200") ?: false)
-    assertTrue(result.payload?.contains("\"statusText\":\"OK\"") ?: false)
+    assertTrue(result.payloadJson!!.contains("\"status\":200"))
+    assertTrue(result.payloadJson!!.contains("\"statusText\":\"OK\""))
+    assertTrue(result.payloadJson!!.contains(""""Content-Type":"application/json""""))
+    assertTrue(result.payloadJson!!.contains(""""body":"{\"success\":true}""""))
   }
 
   @Test
@@ -55,8 +60,8 @@ class HttpHandlerTest {
 
     assertNotNull(result)
     assertFalse(result.ok)
-    assertTrue(result.message?.contains("INVALID_REQUEST") ?: false)
-    assertTrue(result.message?.contains("http or https") ?: false)
+    assertTrue(result.error!!.message.contains("INVALID_REQUEST"))
+    assertTrue(result.error!!.message.contains("http or https"))
   }
 
   @Test
@@ -65,112 +70,78 @@ class HttpHandlerTest {
 
     assertNotNull(result)
     assertFalse(result.ok)
-    assertTrue(result.message?.contains("DNS_ERROR") ?: false)
-  }
-
-  @Test
-  fun handles_connection_timeout() {
-    val result = handler.handleHttpRequest("""{"url":"http://example.com/slow","timeout":1}""")
-
-    assertNotNull(result)
-    assertFalse(result.ok)
-    assertTrue(result.message?.contains("TIMEOUT") ?: false)
+    assertTrue(result.error!!.message.contains("DNS_ERROR"))
   }
 
   @Test
   fun respects_timeout_parameter() {
-    val mockConnection = mock<HttpURLConnection>()
-    whenever(mockConnection.responseCode).thenReturn(200)
-    whenever(mockConnection.responseMessage).thenReturn("OK")
-    whenever(mockConnection.headerFields).thenReturn(emptyMap())
-    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream("{}".toByteArray()))
+    server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
 
-    val mockUrl = mock<URL>()
-    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
-
-    val result = handler.handleHttpRequest("""{"url":"http://example.com/api","timeout":5000}""")
-
-    assertNotNull(result)
-  }
-
-  @Test
-  fun parses_headers_correctly() {
-    val mockConnection = mock<HttpURLConnection>()
-    whenever(mockConnection.responseCode).thenReturn(200)
-    whenever(mockConnection.responseMessage).thenReturn("OK")
-    whenever(mockConnection.headerFields).thenReturn(
-      mapOf(
-        "Content-Type" to listOf("application/json"),
-        "X-Custom" to listOf("value1", "value2")
-      )
-    )
-    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream("{}".toByteArray()))
-
-    val mockUrl = mock<URL>()
-    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
-
-    val result = handler.handleHttpRequest(
-      """{"url":"http://example.com/api","headers":{"Authorization":"Bearer token","X-Req":"test"}}"""
-    )
+    val result = handler.handleHttpRequest("""{"url":"${serverUrl("api")}","timeout":5000}""")
 
     assertNotNull(result)
     assertTrue(result.ok)
+  }
+
+  @Test
+  fun parses_request_headers_correctly() {
+    server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+    handler.handleHttpRequest(
+      """{"url":"${serverUrl("api")}","headers":{"Authorization":"Bearer token","X-Req":"test"}}"""
+    )
+
+    val recorded = server.takeRequest()
+    assertEquals("Bearer token", recorded.getHeader("Authorization"))
+    assertEquals("test", recorded.getHeader("X-Req"))
   }
 
   @Test
   fun truncates_body_to_MAX_BODY_SIZE_BYTES() {
     val largeBody = "x".repeat(6 * 1024 * 1024)
-    val mockConnection = mock<HttpURLConnection>()
-    whenever(mockConnection.responseCode).thenReturn(200)
-    whenever(mockConnection.responseMessage).thenReturn("OK")
-    whenever(mockConnection.headerFields).thenReturn(emptyMap())
-    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream(largeBody.toByteArray()))
+    server.enqueue(MockResponse().setResponseCode(200).setBody(largeBody))
 
-    val mockUrl = mock<URL>()
-    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
-
-    val result = handler.handleHttpRequest("""{"url":"http://example.com/large"}""")
+    val result = handler.handleHttpRequest("""{"url":"${serverUrl("large")}"}""")
 
     assertNotNull(result)
+    assertTrue(result.ok)
+    val payload = result.payloadJson!!
+    val bodyStart = payload.indexOf("\"body\":\"")
+    assertTrue(bodyStart >= 0)
+    val bodyContentStart = bodyStart + "\"body\":\"".length
+    val bodyContentEnd = payload.indexOf("\"", bodyContentStart)
+    val bodyContent = payload.substring(bodyContentStart, bodyContentEnd)
+    assertTrue(bodyContent.length <= 5 * 1024 * 1024)
   }
 
   @Test
   fun supports_POST_with_body() {
-    val mockConnection = mock<HttpURLConnection>()
-    whenever(mockConnection.responseCode).thenReturn(201)
-    whenever(mockConnection.responseMessage).thenReturn("Created")
-    whenever(mockConnection.headerFields).thenReturn(emptyMap())
-    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream("""{"id":123}""".toByteArray()))
-
-    val mockUrl = mock<URL>()
-    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
+    server.enqueue(MockResponse().setResponseCode(201).setBody("""{"id":123}"""))
 
     val result = handler.handleHttpRequest(
-      """{"url":"http://example.com/api","method":"POST","body":"{\"name\":\"test\"}"}"""
+      """{"url":"${serverUrl("api")}","method":"POST","body":"{\"name\":\"test\"}"}"""
     )
 
     assertNotNull(result)
     assertTrue(result.ok)
-    assertTrue(result.payload?.contains("\"status\":201") ?: false)
+    assertTrue(result.payloadJson!!.contains("\"status\":201"))
+
+    val recorded = server.takeRequest()
+    assertEquals("POST", recorded.method)
+    val body = recorded.body.readUtf8()
+    assertTrue(body.contains("\"name\":\"test\""))
   }
 
   @Test
-  fun returns_correct_status_and_statusText() {
-    val mockConnection = mock<HttpURLConnection>()
-    whenever(mockConnection.responseCode).thenReturn(404)
-    whenever(mockConnection.responseMessage).thenReturn("Not Found")
-    whenever(mockConnection.headerFields).thenReturn(emptyMap())
-    whenever(mockConnection.inputStream).thenReturn(null as InputStream?)
-    whenever(mockConnection.errorStream).thenReturn(ByteArrayInputStream("Not Found".toByteArray()))
+  fun returns_error_response_for_404() {
+    server.enqueue(MockResponse().setResponseCode(404).setBody("Not Found"))
 
-    val mockUrl = mock<URL>()
-    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
-
-    val result = handler.handleHttpRequest("""{"url":"http://example.com/missing"}""")
+    val result = handler.handleHttpRequest("""{"url":"${serverUrl("missing")}"}""")
 
     assertNotNull(result)
-    assertFalse(result.ok)
-    assertTrue(result.payload?.contains("\"status\":404") ?: false)
-    assertTrue(result.payload?.contains("\"statusText\":\"Not Found\"") ?: false)
+    assertTrue(result.ok)
+    assertTrue(result.payloadJson!!.contains("\"status\":404"))
+    assertTrue(result.payloadJson!!.contains("\"ok\":false"))
+    assertTrue(result.payloadJson!!.contains(""""body":"Not Found""""))
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/HttpHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/HttpHandlerTest.kt
@@ -1,0 +1,176 @@
+package ai.openclaw.app
+
+import ai.openclaw.app.node.HttpHandler
+import ai.openclaw.app.protocol.OpenClawHttpCommand
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.UnknownHostException
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class HttpHandlerTest {
+  private val handler = HttpHandler()
+
+  @Test
+  fun handles_GET_request_successfully() {
+    val mockConnection = mock<HttpURLConnection>()
+    whenever(mockConnection.responseCode).thenReturn(200)
+    whenever(mockConnection.responseMessage).thenReturn("OK")
+    whenever(mockConnection.headerFields).thenReturn(
+      mapOf(
+        "Content-Type" to listOf("application/json"),
+        "X-Custom" to listOf("value")
+      )
+    )
+    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream("""{"success":true}""".toByteArray()))
+
+    val mockUrl = mock<URL>()
+    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
+
+    val result = handler.handleHttpRequest("""{"url":"http://example.com/api","method":"GET"}""")
+
+    assertNotNull(result)
+    assertTrue(result.ok)
+    assertTrue(result.payload?.contains("\"status\":200") ?: false)
+    assertTrue(result.payload?.contains("\"statusText\":\"OK\"") ?: false)
+  }
+
+  @Test
+  fun rejects_non_http_URLs() {
+    val result = handler.handleHttpRequest("""{"url":"ftp://example.com/file"}""")
+
+    assertNotNull(result)
+    assertFalse(result.ok)
+    assertTrue(result.message?.contains("INVALID_REQUEST") ?: false)
+    assertTrue(result.message?.contains("http or https") ?: false)
+  }
+
+  @Test
+  fun handles_DNS_error_gracefully() {
+    val result = handler.handleHttpRequest("""{"url":"http://nonexistent.invalid/path"}""")
+
+    assertNotNull(result)
+    assertFalse(result.ok)
+    assertTrue(result.message?.contains("DNS_ERROR") ?: false)
+  }
+
+  @Test
+  fun handles_connection_timeout() {
+    val result = handler.handleHttpRequest("""{"url":"http://example.com/slow","timeout":1}""")
+
+    assertNotNull(result)
+    assertFalse(result.ok)
+    assertTrue(result.message?.contains("TIMEOUT") ?: false)
+  }
+
+  @Test
+  fun respects_timeout_parameter() {
+    val mockConnection = mock<HttpURLConnection>()
+    whenever(mockConnection.responseCode).thenReturn(200)
+    whenever(mockConnection.responseMessage).thenReturn("OK")
+    whenever(mockConnection.headerFields).thenReturn(emptyMap())
+    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream("{}".toByteArray()))
+
+    val mockUrl = mock<URL>()
+    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
+
+    val result = handler.handleHttpRequest("""{"url":"http://example.com/api","timeout":5000}""")
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun parses_headers_correctly() {
+    val mockConnection = mock<HttpURLConnection>()
+    whenever(mockConnection.responseCode).thenReturn(200)
+    whenever(mockConnection.responseMessage).thenReturn("OK")
+    whenever(mockConnection.headerFields).thenReturn(
+      mapOf(
+        "Content-Type" to listOf("application/json"),
+        "X-Custom" to listOf("value1", "value2")
+      )
+    )
+    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream("{}".toByteArray()))
+
+    val mockUrl = mock<URL>()
+    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
+
+    val result = handler.handleHttpRequest(
+      """{"url":"http://example.com/api","headers":{"Authorization":"Bearer token","X-Req":"test"}}"""
+    )
+
+    assertNotNull(result)
+    assertTrue(result.ok)
+  }
+
+  @Test
+  fun truncates_body_to_MAX_BODY_SIZE_BYTES() {
+    val largeBody = "x".repeat(6 * 1024 * 1024)
+    val mockConnection = mock<HttpURLConnection>()
+    whenever(mockConnection.responseCode).thenReturn(200)
+    whenever(mockConnection.responseMessage).thenReturn("OK")
+    whenever(mockConnection.headerFields).thenReturn(emptyMap())
+    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream(largeBody.toByteArray()))
+
+    val mockUrl = mock<URL>()
+    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
+
+    val result = handler.handleHttpRequest("""{"url":"http://example.com/large"}""")
+
+    assertNotNull(result)
+  }
+
+  @Test
+  fun supports_POST_with_body() {
+    val mockConnection = mock<HttpURLConnection>()
+    whenever(mockConnection.responseCode).thenReturn(201)
+    whenever(mockConnection.responseMessage).thenReturn("Created")
+    whenever(mockConnection.headerFields).thenReturn(emptyMap())
+    whenever(mockConnection.inputStream).thenReturn(ByteArrayInputStream("""{"id":123}""".toByteArray()))
+
+    val mockUrl = mock<URL>()
+    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
+
+    val result = handler.handleHttpRequest(
+      """{"url":"http://example.com/api","method":"POST","body":"{\"name\":\"test\"}"}"""
+    )
+
+    assertNotNull(result)
+    assertTrue(result.ok)
+    assertTrue(result.payload?.contains("\"status\":201") ?: false)
+  }
+
+  @Test
+  fun returns_correct_status_and_statusText() {
+    val mockConnection = mock<HttpURLConnection>()
+    whenever(mockConnection.responseCode).thenReturn(404)
+    whenever(mockConnection.responseMessage).thenReturn("Not Found")
+    whenever(mockConnection.headerFields).thenReturn(emptyMap())
+    whenever(mockConnection.inputStream).thenReturn(null as InputStream?)
+    whenever(mockConnection.errorStream).thenReturn(ByteArrayInputStream("Not Found".toByteArray()))
+
+    val mockUrl = mock<URL>()
+    whenever(mockUrl.openConnection()).thenReturn(mockConnection)
+
+    val result = handler.handleHttpRequest("""{"url":"http://example.com/missing"}""")
+
+    assertNotNull(result)
+    assertFalse(result.ok)
+    assertTrue(result.payload?.contains("\"status\":404") ?: false)
+    assertTrue(result.payload?.contains("\"statusText\":\"Not Found\"") ?: false)
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryHttpTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryHttpTest.kt
@@ -1,0 +1,94 @@
+package ai.openclaw.app.node
+
+import ai.openclaw.app.protocol.OpenClawCapability
+import ai.openclaw.app.protocol.OpenClawHttpCommand
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InvokeCommandRegistryHttpTest {
+
+  @Test
+  fun http_command_is_advertised_when_httpEnabled_is_true() {
+    val flags = NodeRuntimeFlags(
+      cameraEnabled = false,
+      locationEnabled = false,
+      sendSmsAvailable = false,
+      readSmsAvailable = false,
+      smsSearchPossible = false,
+      callLogAvailable = false,
+      voiceWakeEnabled = false,
+      motionActivityAvailable = false,
+      motionPedometerAvailable = false,
+      debugBuild = false,
+      httpEnabled = true,
+    )
+
+    val commands = InvokeCommandRegistry.advertisedCommands(flags)
+
+    assertTrue(commands.contains(OpenClawHttpCommand.Request.rawValue))
+  }
+
+  @Test
+  fun http_command_is_NOT_advertised_when_httpEnabled_is_false() {
+    val flags = NodeRuntimeFlags(
+      cameraEnabled = false,
+      locationEnabled = false,
+      sendSmsAvailable = false,
+      readSmsAvailable = false,
+      smsSearchPossible = false,
+      callLogAvailable = false,
+      voiceWakeEnabled = false,
+      motionActivityAvailable = false,
+      motionPedometerAvailable = false,
+      debugBuild = false,
+      httpEnabled = false,
+    )
+
+    val commands = InvokeCommandRegistry.advertisedCommands(flags)
+
+    assertFalse(commands.contains(OpenClawHttpCommand.Request.rawValue))
+  }
+
+  @Test
+  fun http_capability_is_advertised_when_httpEnabled_is_true() {
+    val flags = NodeRuntimeFlags(
+      cameraEnabled = false,
+      locationEnabled = false,
+      sendSmsAvailable = false,
+      readSmsAvailable = false,
+      smsSearchPossible = false,
+      callLogAvailable = false,
+      voiceWakeEnabled = false,
+      motionActivityAvailable = false,
+      motionPedometerAvailable = false,
+      debugBuild = false,
+      httpEnabled = true,
+    )
+
+    val capabilities = InvokeCommandRegistry.advertisedCapabilities(flags)
+
+    assertTrue(capabilities.contains(OpenClawCapability.Http.rawValue))
+  }
+
+  @Test
+  fun http_capability_is_NOT_advertised_when_httpEnabled_is_false() {
+    val flags = NodeRuntimeFlags(
+      cameraEnabled = false,
+      locationEnabled = false,
+      sendSmsAvailable = false,
+      readSmsAvailable = false,
+      smsSearchPossible = false,
+      callLogAvailable = false,
+      voiceWakeEnabled = false,
+      motionActivityAvailable = false,
+      motionPedometerAvailable = false,
+      debugBuild = false,
+      httpEnabled = false,
+    )
+
+    val capabilities = InvokeCommandRegistry.advertisedCapabilities(flags)
+
+    assertFalse(capabilities.contains(OpenClawCapability.Http.rawValue))
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryTest.kt
@@ -143,6 +143,7 @@ class InvokeCommandRegistryTest {
           motionActivityAvailable = true,
           motionPedometerAvailable = false,
           debugBuild = false,
+          httpEnabled = false,
         ),
       )
 
@@ -242,6 +243,7 @@ class InvokeCommandRegistryTest {
     motionActivityAvailable: Boolean = false,
     motionPedometerAvailable: Boolean = false,
     debugBuild: Boolean = false,
+    httpEnabled: Boolean = false,
   ): NodeRuntimeFlags =
     NodeRuntimeFlags(
       cameraEnabled = cameraEnabled,
@@ -254,6 +256,7 @@ class InvokeCommandRegistryTest {
       motionActivityAvailable = motionActivityAvailable,
       motionPedometerAvailable = motionPedometerAvailable,
       debugBuild = debugBuild,
+      httpEnabled = httpEnabled,
     )
 
   private fun assertContainsAll(actual: List<String>, expected: Set<String>) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
@@ -253,6 +253,7 @@ class InvokeDispatcherTest {
         ),
       debugHandler = DebugHandler(appContext, DeviceIdentityStore(appContext)),
       callLogHandler = CallLogHandler.forTesting(appContext, InvokeDispatcherFakeCallLogDataSource()),
+      httpHandler = HttpHandler(),
       isForeground = { true },
       cameraEnabled = { cameraEnabled },
       locationEnabled = { locationEnabled },
@@ -267,6 +268,7 @@ class InvokeDispatcherTest {
       onCanvasA2uiReset = {},
       motionActivityAvailable = { motionActivityAvailable },
       motionPedometerAvailable = { motionPedometerAvailable },
+      httpEnabled = { true },
     )
   }
 

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   NODE_BROWSER_PROXY_COMMAND,
+  NODE_HTTP_REQUEST_COMMAND,
   NODE_SYSTEM_NOTIFY_COMMAND,
   NODE_SYSTEM_RUN_COMMANDS,
 } from "../infra/node-commands.js";
@@ -99,6 +100,7 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...REMINDERS_COMMANDS,
     ...PHOTOS_COMMANDS,
     ...MOTION_COMMANDS,
+    NODE_HTTP_REQUEST_COMMAND,
   ],
   macos: [
     ...CANVAS_COMMANDS,

--- a/src/gateway/server-methods/nodes.http-request.test.ts
+++ b/src/gateway/server-methods/nodes.http-request.test.ts
@@ -94,10 +94,11 @@ describe("http.request node command", () => {
         connect: {
           commands: ["http.request"],
           role: "node",
+          minProtocol: 1,
+          maxProtocol: 1,
           client: {
-            id: "android-node-1",
+            id: "openclaw-android",
             mode: "node",
-            name: "android-test",
             platform: "Android 16",
             version: "test",
           },
@@ -153,10 +154,11 @@ describe("http.request node command", () => {
         connect: {
           commands: ["http.request"],
           role: "node",
+          minProtocol: 1,
+          maxProtocol: 1,
           client: {
-            id: "ios-node-1",
+            id: "openclaw-ios",
             mode: "node",
-            name: "ios-test",
             platform: "iOS 26.0",
             version: "test",
           },
@@ -211,10 +213,11 @@ describe("http.request node command", () => {
         connect: {
           commands: ["http.request"],
           role: "node",
+          minProtocol: 1,
+          maxProtocol: 1,
           client: {
-            id: "android-node-1",
+            id: "openclaw-android",
             mode: "node",
-            name: "android-test",
             platform: "Android 16",
             version: "test",
           },

--- a/src/gateway/server-methods/nodes.http-request.test.ts
+++ b/src/gateway/server-methods/nodes.http-request.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveNodeCommandAllowlist } from "../node-command-policy.js";
+import { nodeHandlers } from "./nodes.js";
+
+describe("http.request node command", () => {
+  it("includes http.request in Android platform allowlist", () => {
+    const allowlist = resolveNodeCommandAllowlist(
+      {},
+      { platform: "android 16", deviceFamily: "Android" },
+    );
+    expect(allowlist.has("http.request")).toBe(true);
+  });
+
+  it("does NOT include http.request in iOS allowlist", () => {
+    const allowlist = resolveNodeCommandAllowlist(
+      {},
+      { platform: "ios 26.0", deviceFamily: "iPhone" },
+    );
+    expect(allowlist.has("http.request")).toBe(false);
+  });
+
+  it("does NOT include http.request in macOS allowlist", () => {
+    const allowlist = resolveNodeCommandAllowlist(
+      {},
+      { platform: "macos 14", deviceFamily: "Mac" },
+    );
+    expect(allowlist.has("http.request")).toBe(false);
+  });
+
+  it("rejects http.request when node is not connected", async () => {
+    const respond = vi.fn();
+    await nodeHandlers["node.invoke"]({
+      params: {
+        nodeId: "android-node-1",
+        command: "http.request",
+        params: { url: "https://example.com" },
+        timeoutMs: 5000,
+        idempotencyKey: "idem-http-request",
+      },
+      respond: respond as never,
+      context: {
+        nodeRegistry: {
+          get: vi.fn(() => undefined),
+          invoke: vi.fn(),
+        },
+        execApprovalManager: undefined,
+        logGateway: { info: vi.fn(), warn: vi.fn() },
+      } as never,
+      client: null,
+      req: { type: "req", id: "req-node-invoke", method: "node.invoke" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: "node not connected",
+      }),
+    );
+  });
+
+  it("returns success when http.request is invoked on connected Android node", async () => {
+    const respond = vi.fn();
+    const mockInvoke = vi.fn().mockResolvedValue({
+      ok: true,
+      payload: { status: 200, body: "response body" },
+      payloadJSON: '{"status":200,"body":"response body"}',
+    });
+
+    await nodeHandlers["node.invoke"]({
+      params: {
+        nodeId: "android-node-1",
+        command: "http.request",
+        params: { url: "https://example.com" },
+        timeoutMs: 5000,
+        idempotencyKey: "idem-http-request",
+      },
+      respond: respond as never,
+      context: {
+        nodeRegistry: {
+          get: vi.fn(() => ({
+            nodeId: "android-node-1",
+            commands: ["http.request"],
+            platform: "Android 16",
+          })),
+          invoke: mockInvoke,
+        },
+        execApprovalManager: undefined,
+        logGateway: { info: vi.fn(), warn: vi.fn() },
+      } as never,
+      client: {
+        connect: {
+          commands: ["http.request"],
+          role: "node",
+          client: {
+            id: "android-node-1",
+            mode: "node",
+            name: "android-test",
+            platform: "Android 16",
+            version: "test",
+          },
+        },
+      },
+      req: { type: "req", id: "req-node-invoke", method: "node.invoke" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "android-node-1",
+        command: "http.request",
+        params: { url: "https://example.com" },
+      }),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+        nodeId: "android-node-1",
+        payload: { status: 200, body: "response body" },
+      }),
+      undefined,
+    );
+  });
+
+  it("rejects http.request when command not in allowlist", async () => {
+    const respond = vi.fn();
+    await nodeHandlers["node.invoke"]({
+      params: {
+        nodeId: "ios-node-1",
+        command: "http.request",
+        params: { url: "https://example.com" },
+        timeoutMs: 5000,
+        idempotencyKey: "idem-http-request",
+      },
+      respond: respond as never,
+      context: {
+        nodeRegistry: {
+          get: vi.fn(() => ({
+            nodeId: "ios-node-1",
+            commands: ["http.request"],
+            platform: "iOS 26.0",
+          })),
+          invoke: vi.fn(),
+        },
+        execApprovalManager: undefined,
+        logGateway: { info: vi.fn(), warn: vi.fn() },
+      } as never,
+      client: {
+        connect: {
+          commands: ["http.request"],
+          role: "node",
+          client: {
+            id: "ios-node-1",
+            mode: "node",
+            name: "ios-test",
+            platform: "iOS 26.0",
+            version: "test",
+          },
+        },
+      },
+      req: { type: "req", id: "req-node-invoke", method: "node.invoke" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("not in the allowlist"),
+      }),
+    );
+  });
+
+  it("returns error when http.request node returns an error", async () => {
+    const respond = vi.fn();
+    const mockInvoke = vi.fn().mockResolvedValue({
+      ok: false,
+      error: {
+        code: "INVALID_URL",
+        message: "Invalid URL provided",
+      },
+    });
+
+    await nodeHandlers["node.invoke"]({
+      params: {
+        nodeId: "android-node-1",
+        command: "http.request",
+        params: { url: "not-a-valid-url" },
+        timeoutMs: 5000,
+        idempotencyKey: "idem-http-request-error",
+      },
+      respond: respond as never,
+      context: {
+        nodeRegistry: {
+          get: vi.fn(() => ({
+            nodeId: "android-node-1",
+            commands: ["http.request"],
+            platform: "Android 16",
+          })),
+          invoke: mockInvoke,
+        },
+        execApprovalManager: undefined,
+        logGateway: { info: vi.fn(), warn: vi.fn() },
+      } as never,
+      client: {
+        connect: {
+          commands: ["http.request"],
+          role: "node",
+          client: {
+            id: "android-node-1",
+            mode: "node",
+            name: "android-test",
+            platform: "Android 16",
+            version: "test",
+          },
+        },
+      },
+      req: { type: "req", id: "req-node-invoke", method: "node.invoke" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("Invalid URL provided"),
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/nodes.http-request.test.ts
+++ b/src/gateway/server-methods/nodes.http-request.test.ts
@@ -92,12 +92,12 @@ describe("http.request node command", () => {
       } as never,
       client: {
         connect: {
+          minProtocol: 1,
+          maxProtocol: 3,
           commands: ["http.request"],
           role: "node",
-          minProtocol: 1,
-          maxProtocol: 1,
           client: {
-            id: "openclaw-android",
+            id: "test",
             mode: "node",
             platform: "Android 16",
             version: "test",
@@ -152,12 +152,12 @@ describe("http.request node command", () => {
       } as never,
       client: {
         connect: {
+          minProtocol: 1,
+          maxProtocol: 3,
           commands: ["http.request"],
           role: "node",
-          minProtocol: 1,
-          maxProtocol: 1,
           client: {
-            id: "openclaw-ios",
+            id: "test",
             mode: "node",
             platform: "iOS 26.0",
             version: "test",
@@ -211,12 +211,12 @@ describe("http.request node command", () => {
       } as never,
       client: {
         connect: {
+          minProtocol: 1,
+          maxProtocol: 3,
           commands: ["http.request"],
           role: "node",
-          minProtocol: 1,
-          maxProtocol: 1,
           client: {
-            id: "openclaw-android",
+            id: "test",
             mode: "node",
             platform: "Android 16",
             version: "test",

--- a/src/infra/node-commands.ts
+++ b/src/infra/node-commands.ts
@@ -5,6 +5,7 @@ export const NODE_SYSTEM_RUN_COMMANDS = [
 ] as const;
 
 export const NODE_SYSTEM_NOTIFY_COMMAND = "system.notify";
+export const NODE_HTTP_REQUEST_COMMAND = "http.request";
 export const NODE_BROWSER_PROXY_COMMAND = "browser.proxy";
 
 export const NODE_EXEC_APPROVALS_COMMANDS = [


### PR DESCRIPTION
## Summary

- Adds `http.request` as a node invoke command for Android, enabling the gateway to issue HTTP requests through connected Android nodes
- Includes an HTTP access toggle in Android Settings, node command allowlist entry (Android-only), and comprehensive tests for both gateway and Android sides
- Surfaces stream read failures as `REQUEST_FAILED` instead of silently returning null

## Test plan

- [x] `pnpm test src/gateway/server-methods/nodes.http-request.test.ts` — gateway node command tests
- [x] Verify Android HTTP toggle appears in Settings and gates `http.request` availability
- [ ] Test HTTP request invocation through a connected Android node