### PR TITLE
fix: add discovery.enabled config gate to amazon-bedrock-mantle

### DIFF
--- a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
@@ -5,8 +5,16 @@ import {
   resolveMantleBearerToken,
 } from "./discovery.js";
 
+type MantlePluginConfig = {
+  discovery?: {
+    enabled?: boolean;
+  };
+};
+
 export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
   const providerId = "amazon-bedrock-mantle";
+  const pluginConfig = (api.pluginConfig ?? {}) as MantlePluginConfig;
+  const discoveryEnabled = pluginConfig.discovery?.enabled;
 
   api.registerProvider({
     id: providerId,
@@ -16,6 +24,11 @@ export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
     catalog: {
       order: "simple",
       run: async (ctx) => {
+        // Honor explicit discovery.enabled gate — when set to false, skip
+        // discovery entirely so the plugin stays quiet when not in use.
+        if (discoveryEnabled === false) {
+          return null;
+        }
         const implicit = await resolveImplicitMantleProvider({
           env: ctx.env,
         });


### PR DESCRIPTION
## Summary
Adds config.discovery.enabled gate to amazon-bedrock-mantle plugin, matching the pattern used by amazon-bedrock.

## Root Cause
amazon-bedrock-mantle runs IAM token discovery on every request even when Bedrock is not in use. Unlike amazon-bedrock, there was no config.discovery.enabled option to suppress discovery.

## Fix
- Add MantlePluginConfig type with discovery.enabled field
- When discovery.enabled is explicitly set to false, skip discovery entirely
- Plugin remains available but stays quiet when not in use

## Test Plan
- [ ] Plugin loads correctly with default config (discovery runs when auth available)
- [ ] Setting discovery.enabled: false skips discovery

Closes openclaw#67288