### PR TITLE
fix(matrix): skip pairing-store reads for room auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Matrix/commands: skip DM pairing-store reads on room traffic now that room control-command authorization ignores pairing-store entries, keeping the room path narrower without changing room auth behavior.
 - fix(gateway): enforce localRoots containment on webchat audio embedding path [AI-assisted]. (#67298) Thanks @pgondhi987.
 - fix(matrix): block DM pairing-store entries from authorizing room control commands [AI-assisted]. (#67294) Thanks @pgondhi987.
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Matrix/commands: skip DM pairing-store reads on room traffic now that room control-command authorization ignores pairing-store entries, keeping the room path narrower without changing room auth behavior.
 - fix(gateway): enforce localRoots containment on webchat audio embedding path [AI-assisted]. (#67298) Thanks @pgondhi987.
 - fix(matrix): block DM pairing-store entries from authorizing room control commands [AI-assisted]. (#67294) Thanks @pgondhi987.
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
@@ -17,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/bundled channels: partition bundled channel lazy caches by active bundled root so `OPENCLAW_BUNDLED_PLUGINS_DIR` flips stop reusing stale plugin, setup, secrets, and runtime state. (#67200) Thanks @gumadeiras.
 - Packaging/plugins: prune common test/spec cargo from bundled plugin runtime dependencies and fail npm release validation if packaged test cargo reappears, keeping published tarballs leaner without plugin-specific special cases. (#67275) thanks @gumadeiras.
 - Agents/context + Memory: trim default startup/skills prompt budgets, cap `memory_get` excerpts by default with explicit continuation metadata, and keep QMD reads aligned with the same bounded excerpt contract so long sessions pull less context by default without losing deterministic follow-up reads.
+- Matrix/commands: skip DM pairing-store reads on room traffic now that room control-command authorization ignores pairing-store entries, keeping the room path narrower without changing room auth behavior. (#67325) Thanks @gumadeiras.
 
 ## 2026.4.15-beta.1
 

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -446,10 +446,11 @@ describe("matrix monitor handler pairing account scope", () => {
   });
 
   it("blocks room control commands from DM-only paired senders", async () => {
+    const readAllowFromStore = vi.fn(async () => ["@user:example.org"]);
     const { handler, finalizeInboundContext, recordInboundSession } =
       createMatrixHandlerTestHarness({
         isDirectMessage: false,
-        readAllowFromStore: vi.fn(async () => ["@user:example.org"]),
+        readAllowFromStore,
         roomsConfig: {
           "!room:example.org": { requireMention: false },
         },
@@ -473,6 +474,7 @@ describe("matrix monitor handler pairing account scope", () => {
 
     expect(recordInboundSession).not.toHaveBeenCalled();
     expect(finalizeInboundContext).not.toHaveBeenCalled();
+    expect(readAllowFromStore).not.toHaveBeenCalled();
   });
 
   it("processes room messages mentioned via displayName in formatted_body", async () => {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -586,7 +586,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           senderNamePromise ??= getMemberDisplayName(roomId, senderId).catch(() => senderId);
           return await senderNamePromise;
         };
-        const storeAllowFrom = await readStoreAllowFrom();
+        const storeAllowFrom = isDirectMessage ? await readStoreAllowFrom() : [];
         const roomUsers = roomConfig?.users ?? [];
         const accessState = resolveMatrixMonitorAccessState({
           allowFrom,


### PR DESCRIPTION
## Summary

- Problem: Matrix room traffic still read the DM pairing-store even after room control-command auth stopped using pairing-store entries.
- Why it matters: behavior was already safe, but the room path still pulled in irrelevant DM-only state.
- What changed: room traffic now passes an empty pairing-store list into the Matrix access-state resolver; the existing room command regression test now also asserts the pairing store is not read.
- What did NOT change (scope boundary): room command authorization semantics stay exactly as in #67294; this only narrows the room data path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #67294
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `handler.ts` still read `readStoreAllowFrom()` for Matrix room traffic even though room control-command authorization had already been hardened to ignore pairing-store entries.
- Missing detection / guardrail: the existing regression test covered the room command block, but it did not assert the dead read was removed.
- Contributing context (if known): this is a follow-up narrowing pass after the main auth fix landed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/matrix/monitor/handler.test.ts`
- Scenario the test should lock in: room control-command handling must not call the DM pairing-store reader.
- Why this is the smallest reliable guardrail: the handler test covers the real room path and can assert both the authorization outcome and the absence of the pairing-store read.
- Existing test that already covers this (if any): the room command regression from #67294 now carries the stronger assertion.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None. This narrows an internal room auth data path without changing room auth outcomes.

## Diagram (if applicable)

```text
Before:
[Matrix room message] -> [read DM pairing-store] -> [ignore result for room command auth]

After:
[Matrix room message] -> [skip DM pairing-store read] -> [same room auth result]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (Yes)
- If any `Yes`, explain risk + mitigation: room traffic no longer reads DM-only pairing-store state, reducing cross-scope coupling while preserving the existing room auth result.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo dev environment
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): room traffic, `commands.useAccessGroups=true`

### Steps

1. Trigger the Matrix room command path.
2. Observe whether the handler calls `readAllowFromStore()`.
3. Assert the room command outcome stays the same.

### Expected

- Room traffic skips the DM pairing-store read.

### Actual

- Before this patch, room traffic still called the DM pairing-store reader even though room command auth ignored the result.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the Matrix handler test suite locally and confirmed the strengthened room command regression passes.
- Edge cases checked: existing DM pairing-store behavior remains covered by the same handler suite.
- What you did **not** verify: skipped broader/full-suite gates per request; this PR is validated with targeted Matrix tests only.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: room traffic could accidentally stop reading the pairing store on a DM path if the room/DM split were wrong.
  - Mitigation: the change is a single `isDirectMessage` guard and the targeted Matrix handler suite still passes, covering both room and DM pairing paths.
