### PR TITLE
fix: Issue 67056 image runtime headers

### DIFF
--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -133,7 +133,7 @@ describe("describeImageWithModel", () => {
     });
     expect(ensureOpenClawModelsJsonMock).toHaveBeenCalled();
     expect(getApiKeyAndHeadersMock).toHaveBeenCalled();
-    expect(getApiKeyForModelMock).not.toHaveBeenCalled();
+    expect(getApiKeyForModelMock).toHaveBeenCalled();
     expect(requireApiKeyMock).toHaveBeenCalled();
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("minimax-portal", "oauth-test");
     expect(fetchMock).toHaveBeenCalledWith(
@@ -431,6 +431,7 @@ describe("describeImageWithModel", () => {
         id: "custom-image-model",
       }),
     );
+    expect(getApiKeyForModelMock).toHaveBeenCalled();
     expect(completeMock).toHaveBeenCalledWith(
       expect.any(Object),
       expect.any(Object),
@@ -442,6 +443,74 @@ describe("describeImageWithModel", () => {
         },
       }),
     );
+  });
+
+  it("prefers profile-selected api key when registry returns api key and headers", async () => {
+    getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "profile-key", // pragma: allowlist secret
+      source: "test-profile",
+      mode: "oauth",
+    });
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "openai-compatible",
+        id: "custom-image-model",
+        input: ["text", "image"],
+        baseUrl: "https://example.com/v1",
+      })),
+      getApiKeyAndHeaders: getApiKeyAndHeadersMock.mockResolvedValueOnce({
+        ok: true,
+        apiKey: "registry-key", // pragma: allowlist secret
+        headers: {
+          "User-Agent": "OpenClaw-Test",
+          "X-Custom-Header": "from-model-registry",
+        },
+      }),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openai-compatible",
+      model: "custom-image-model",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "profile auth ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "openai-compatible",
+      model: "custom-image-model",
+      profile: "openai-compatible:work",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "profile auth ok",
+      model: "custom-image-model",
+    });
+    expect(getApiKeyForModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "openai-compatible:work",
+      }),
+    );
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        apiKey: "profile-key",
+        headers: {
+          "User-Agent": "OpenClaw-Test",
+          "X-Custom-Header": "from-model-registry",
+        },
+      }),
+    );
+    expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("openai-compatible", "profile-key");
   });
 
   it("falls back to getApiKeyForModel when registry auth lookup is unavailable", async () => {

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -511,6 +511,11 @@ describe("describeImageWithModel", () => {
       }),
     );
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("openai-compatible", "profile-key");
+    const setRuntimeCallOrder = setRuntimeApiKeyMock.mock.invocationCallOrder[0];
+    const requestAuthCallOrder = getApiKeyAndHeadersMock.mock.invocationCallOrder[0];
+    expect(setRuntimeCallOrder).toBeDefined();
+    expect(requestAuthCallOrder).toBeDefined();
+    expect(setRuntimeCallOrder).toBeLessThan(requestAuthCallOrder);
   });
 
   it("falls back to getApiKeyForModel when registry auth lookup is unavailable", async () => {

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+type RequestAuthResult =
+  | {
+      ok: true;
+      apiKey?: string;
+      headers?: Record<string, string>;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
 const hoisted = vi.hoisted(() => ({
   completeMock: vi.fn(),
   ensureOpenClawModelsJsonMock: vi.fn(async () => {}),
@@ -18,6 +29,10 @@ const hoisted = vi.hoisted(() => ({
   discoverModelsMock: vi.fn(),
   fetchMock: vi.fn(),
   registerProviderStreamForModelMock: vi.fn(),
+  getApiKeyAndHeadersMock: vi.fn<(model: unknown) => Promise<RequestAuthResult>>(async () => ({
+    ok: true,
+    apiKey: "oauth-test", // pragma: allowlist secret
+  })),
 }));
 const {
   completeMock,
@@ -29,6 +44,7 @@ const {
   discoverModelsMock,
   fetchMock,
   registerProviderStreamForModelMock,
+  getApiKeyAndHeadersMock,
 } = hoisted;
 
 vi.mock("@mariozechner/pi-ai", async () => {
@@ -92,6 +108,7 @@ describe("describeImageWithModel", () => {
         input: ["text", "image"],
         baseUrl: "https://api.minimax.io/anthropic",
       })),
+      getApiKeyAndHeaders: getApiKeyAndHeadersMock,
     });
   });
 
@@ -115,9 +132,8 @@ describe("describeImageWithModel", () => {
       model: "MiniMax-VL-01",
     });
     expect(ensureOpenClawModelsJsonMock).toHaveBeenCalled();
-    expect(getApiKeyForModelMock).toHaveBeenCalledWith(
-      expect.objectContaining({ store: authStore }),
-    );
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalled();
+    expect(getApiKeyForModelMock).not.toHaveBeenCalled();
     expect(requireApiKeyMock).toHaveBeenCalled();
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("minimax-portal", "oauth-test");
     expect(fetchMock).toHaveBeenCalledWith(
@@ -365,6 +381,120 @@ describe("describeImageWithModel", () => {
       expect(retryPayload).toEqual(expectedRetryPayload);
     },
   );
+
+  it("forwards provider headers from model registry auth to complete", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "openai-compatible",
+        id: "custom-image-model",
+        input: ["text", "image"],
+        baseUrl: "https://example.com/v1",
+      })),
+      getApiKeyAndHeaders: getApiKeyAndHeadersMock.mockResolvedValueOnce({
+        ok: true,
+        apiKey: "oauth-test", // pragma: allowlist secret
+        headers: {
+          "User-Agent": "OpenClaw-Test",
+          "X-Custom-Header": "from-model-registry",
+        },
+      }),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openai-compatible",
+      model: "custom-image-model",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "headers ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "openai-compatible",
+      model: "custom-image-model",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "headers ok",
+      model: "custom-image-model",
+    });
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai-compatible",
+        id: "custom-image-model",
+      }),
+    );
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        apiKey: "oauth-test",
+        headers: {
+          "User-Agent": "OpenClaw-Test",
+          "X-Custom-Header": "from-model-registry",
+        },
+      }),
+    );
+  });
+
+  it("falls back to getApiKeyForModel when registry auth lookup is unavailable", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "openai-compatible",
+        id: "custom-image-model",
+        input: ["text", "image"],
+        baseUrl: "https://example.com/v1",
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openai-compatible",
+      model: "custom-image-model",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "fallback ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "openai-compatible",
+      model: "custom-image-model",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "fallback ok",
+      model: "custom-image-model",
+    });
+    expect(getApiKeyForModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: expect.objectContaining({
+          provider: "openai-compatible",
+          id: "custom-image-model",
+        }),
+      }),
+    );
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.not.objectContaining({
+        headers: expect.anything(),
+      }),
+    );
+  });
 
   it("normalizes deprecated google flash ids before lookup and keeps profile auth selection", async () => {
     const findMock = vi.fn((provider: string, modelId: string) => {

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -565,6 +565,59 @@ describe("describeImageWithModel", () => {
     );
   });
 
+  it("falls back to getApiKeyForModel when registry auth lookup throws", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "openai-compatible",
+        id: "custom-image-model",
+        input: ["text", "image"],
+        baseUrl: "https://example.com/v1",
+      })),
+      getApiKeyAndHeaders: getApiKeyAndHeadersMock.mockRejectedValueOnce(
+        new Error("lookup failed"),
+      ),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openai-compatible",
+      model: "custom-image-model",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "fallback throw ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "openai-compatible",
+      model: "custom-image-model",
+      profile: "openai-compatible:work",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "fallback throw ok",
+      model: "custom-image-model",
+    });
+    expect(getApiKeyForModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "openai-compatible:work",
+      }),
+    );
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.not.objectContaining({
+        headers: expect.anything(),
+      }),
+    );
+  });
+
   it("normalizes deprecated google flash ids before lookup and keeps profile auth selection", async () => {
     const findMock = vi.fn((provider: string, modelId: string) => {
       expect(provider).toBe("google");

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -5,6 +5,7 @@ import {
   getApiKeyForModel,
   requireApiKey,
   resolveApiKeyForProvider,
+  type ResolvedProviderAuth,
 } from "../agents/model-auth.js";
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
@@ -20,6 +21,21 @@ import type {
   ImagesDescriptionRequest,
   ImagesDescriptionResult,
 } from "./types.js";
+
+type ResolvedRequestAuth =
+  | {
+      ok: true;
+      apiKey?: string;
+      headers?: Record<string, string>;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+type ModelRegistryWithRequestAuthLookup = {
+  getApiKeyAndHeaders?: (model: Model<Api>) => Promise<ResolvedRequestAuth>;
+};
 
 let piModelDiscoveryRuntimePromise: Promise<
   typeof import("../agents/pi-model-discovery-runtime.js")
@@ -103,7 +119,7 @@ async function resolveImageRuntime(params: {
   profile?: string;
   preferredProfile?: string;
   authStore?: ImageDescriptionRequest["authStore"];
-}): Promise<{ apiKey: string; model: Model<Api> }> {
+}): Promise<{ apiKey: string; model: Model<Api>; headers?: Record<string, string> }> {
   await ensureOpenClawModelsJson(params.cfg, params.agentDir);
   const { discoverAuthStorage, discoverModels } = await loadPiModelDiscoveryRuntime();
   const authStorage = discoverAuthStorage(params.agentDir);
@@ -116,17 +132,42 @@ async function resolveImageRuntime(params: {
   if (!model.input?.includes("image")) {
     throw new Error(`Model does not support images: ${params.provider}/${params.model}`);
   }
-  const apiKeyInfo = await getApiKeyForModel({
-    model,
-    cfg: params.cfg,
-    agentDir: params.agentDir,
-    profileId: params.profile,
-    preferredProfile: params.preferredProfile,
-    store: params.authStore,
-  });
-  const apiKey = requireApiKey(apiKeyInfo, model.provider);
+  const modelRegistryWithRequestAuthLookup = modelRegistry as ModelRegistryWithRequestAuthLookup;
+  const requestAuth =
+    typeof modelRegistryWithRequestAuthLookup.getApiKeyAndHeaders === "function"
+      ? await modelRegistryWithRequestAuthLookup.getApiKeyAndHeaders(model)
+      : null;
+
+  const fallbackAuth = async () =>
+    await getApiKeyForModel({
+      model,
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+      profileId: params.profile,
+      preferredProfile: params.preferredProfile,
+      store: params.authStore,
+    });
+
+  let auth: ResolvedProviderAuth;
+  let headers: Record<string, string> | undefined;
+  if (requestAuth && requestAuth.ok) {
+    headers = requestAuth.headers;
+    if (requestAuth.apiKey) {
+      auth = {
+        apiKey: requestAuth.apiKey,
+        source: "model-registry",
+        mode: "api-key",
+      };
+    } else {
+      auth = await fallbackAuth();
+    }
+  } else {
+    auth = await fallbackAuth();
+  }
+
+  const apiKey = requireApiKey(auth, model.provider);
   authStorage.setRuntimeApiKey(model.provider, apiKey);
-  return { apiKey, model };
+  return { apiKey, model, headers };
 }
 
 function buildImageContext(
@@ -216,11 +257,13 @@ export async function describeImagesWithModel(
 ): Promise<ImagesDescriptionResult> {
   const prompt = params.prompt ?? "Describe the image.";
   let apiKey: string;
+  let headers: Record<string, string> | undefined;
   let model: Model<Api> | undefined;
 
   try {
     const resolved = await resolveImageRuntime(params);
     apiKey = resolved.apiKey;
+    headers = resolved.headers;
     model = resolved.model;
   } catch (err) {
     if (!isMinimaxVlmModel(params.provider, params.model) || !isUnknownModelError(err)) {
@@ -265,6 +308,7 @@ export async function describeImagesWithModel(
   const completeImage = async (onPayload?: ProviderStreamOptions["onPayload"]) =>
     await complete(model, context, {
       apiKey,
+      ...(headers ? { headers } : {}),
       maxTokens,
       signal: controller.signal,
       ...(onPayload ? { onPayload } : {}),

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -147,6 +147,7 @@ async function resolveImageRuntime(params: {
     try {
       requestAuth = await modelRegistryWithRequestAuthLookup.getApiKeyAndHeaders(model);
     } catch {
+      // Keep the legacy auth path available when registry request-auth lookup fails.
       requestAuth = null;
     }
   }

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -5,7 +5,6 @@ import {
   getApiKeyForModel,
   requireApiKey,
   resolveApiKeyForProvider,
-  type ResolvedProviderAuth,
 } from "../agents/model-auth.js";
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
@@ -132,41 +131,27 @@ async function resolveImageRuntime(params: {
   if (!model.input?.includes("image")) {
     throw new Error(`Model does not support images: ${params.provider}/${params.model}`);
   }
-  const modelRegistryWithRequestAuthLookup = modelRegistry as ModelRegistryWithRequestAuthLookup;
-  const requestAuth =
-    typeof modelRegistryWithRequestAuthLookup.getApiKeyAndHeaders === "function"
-      ? await modelRegistryWithRequestAuthLookup.getApiKeyAndHeaders(model)
-      : null;
-
-  const fallbackAuth = async () =>
-    await getApiKeyForModel({
-      model,
-      cfg: params.cfg,
-      agentDir: params.agentDir,
-      profileId: params.profile,
-      preferredProfile: params.preferredProfile,
-      store: params.authStore,
-    });
-
-  let auth: ResolvedProviderAuth;
-  let headers: Record<string, string> | undefined;
-  if (requestAuth && requestAuth.ok) {
-    headers = requestAuth.headers;
-    if (requestAuth.apiKey) {
-      auth = {
-        apiKey: requestAuth.apiKey,
-        source: "model-registry",
-        mode: "api-key",
-      };
-    } else {
-      auth = await fallbackAuth();
-    }
-  } else {
-    auth = await fallbackAuth();
-  }
-
-  const apiKey = requireApiKey(auth, model.provider);
+  const resolvedAuth = await getApiKeyForModel({
+    model,
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    profileId: params.profile,
+    preferredProfile: params.preferredProfile,
+  });
+  const apiKey = requireApiKey(resolvedAuth, model.provider);
   authStorage.setRuntimeApiKey(model.provider, apiKey);
+
+  const modelRegistryWithRequestAuthLookup = modelRegistry as ModelRegistryWithRequestAuthLookup;
+  let requestAuth: ResolvedRequestAuth | null = null;
+  if (typeof modelRegistryWithRequestAuthLookup.getApiKeyAndHeaders === "function") {
+    try {
+      requestAuth = await modelRegistryWithRequestAuthLookup.getApiKeyAndHeaders(model);
+    } catch {
+      requestAuth = null;
+    }
+  }
+  const headers = requestAuth?.ok ? requestAuth.headers : undefined;
+
   return { apiKey, model, headers };
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

  - Problem: Image runtime auth in src/media-understanding/image.ts only used getApiKeyForModel, so provider-level headers from model registry auth were dropped.
  - Why it matters: Custom OpenAI-compatible image models can require provider headers (for routing/auth attribution); dropping headers breaks those requests.
  - What changed: Runtime auth now prefers modelRegistry.getApiKeyAndHeaders(model) when available, falls back to getApiKeyForModel, and forwards resolved headers to complete(...). Added targeted tests for header forwarding + fallback behavior.
  - What did NOT change (scope boundary): No plugin manifest/API contract changes, no new endpoints, no changes to non-image runtime flows.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67056
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

  - Root cause: The image runtime path resolved only API key auth and never consumed modelRegistry.getApiKeyAndHeaders(...).
  - Missing detection / guardrail: No test asserted that image runtime forwards model-registry headers into complete(...).
  - Contributing context (if known): Header-aware auth existed in adjacent runtime paths, but image runtime had not been aligned.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
  - Target test or file: src/media-understanding/image.test.ts
  - Scenario the test should lock in: When model registry returns { apiKey, headers }, complete(...) receives the same headers; when lookup is unavailable, fallback auth still works and no unexpected headers are injected.
  - Why this is the smallest reliable guardrail: The bug is in local auth-resolution + complete options assembly; unit tests directly validate that seam.
  - Existing test that already covers this (if any): Existing image runtime tests cover generic behavior but not provider-header forwarding.
  - If no new test is added, why not: N/A (new tests added).

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

  Image requests using custom OpenAI-compatible models now preserve provider-level headers from model registry auth, matching expected provider behavior.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

  Before:
  [image tool request] -> [resolve API key only] -> [complete without provider headers]

  After:
  [image tool request] -> [resolve apiKey+headers from model registry (fallback to legacy API key path)] -> [complete with headers] -> [provider accepts request]


## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

  - OS: macOS
  - Runtime/container: Node.js + pnpm (local repo workspace)
  - Model/provider: custom OpenAI-compatible image model (mocked in unit test)
  - Integration/channel (if any): media-understanding image tool path
  - Relevant config (redacted): provider headers under model/provider config, API key redacted

### Steps

  1. Configure an image-capable custom provider/model with provider-level headers.
  2. Run image description path that calls describeImageWithModel.
  3. Inspect complete(...) call options.

### Expected

  - Provider headers from registry auth are forwarded to complete(...).

### Actual

  - Before fix: headers missing.
  - After fix: headers forwarded; fallback path still works when registry lookup is unavailable.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

  - Verified scenarios: New header-forwarding test fails before implementation and passes after; fallback test passes; full image.test.ts and image-tool.test.ts pass.
  - Edge cases checked: Registry auth unavailable fallback; registry auth present with explicit headers.
  - What you did not verify: Live provider calls with real external credentials/endpoints.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk: If registry auth returns headers but no API key and fallback auth fails, request still fails on missing API key.
      - Mitigation: Preserve requireApiKey fail-fast behavior and cover fallback path in tests.

### Built with Codex