### PR TITLE
fix(google): respect allowPrivateNetwork for image generation

### DIFF
--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -243,6 +243,6 @@ describe("google generative ai helpers", () => {
       transport: "http",
       request: { allowPrivateNetwork: true } as unknown as ProviderRequestTransportOverrides,
     });
-    expect(config.allowPrivateNetwork).toBe(false);
+    expect(config.allowPrivateNetwork).toBe(true);
   });
 });

--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -217,7 +217,7 @@ describe("google generative ai helpers", () => {
     expect(normalized).toBe("https://generativelanguage.googleapis.com/v1beta/openai");
   });
 
-  it("rejects non-Google Gemini base URLs and ignores smuggled private-network flags", () => {
+  it("rejects non-Google Gemini base URLs and respects explicit allowPrivateNetwork opt-in", () => {
     expect(() =>
       resolveGoogleGenerativeAiHttpRequestConfig({
         apiKey: "api-key-123",

--- a/extensions/google/api.ts
+++ b/extensions/google/api.ts
@@ -78,7 +78,7 @@ export function resolveGoogleGenerativeAiHttpRequestConfig(params: {
   return resolveProviderHttpRequestConfig({
     baseUrl: resolveTrustedGoogleGenerativeAiBaseUrl(params.baseUrl),
     defaultBaseUrl: DEFAULT_GOOGLE_API_BASE_URL,
-    allowPrivateNetwork: false,
+    allowPrivateNetwork: params.request?.allowPrivateNetwork ?? false,
     headers: params.headers,
     request: params.request,
     defaultHeaders: parseGeminiAuth(params.apiKey).headers,

--- a/extensions/google/image-generation-provider.ts
+++ b/extensions/google/image-generation-provider.ts
@@ -132,6 +132,7 @@ export function buildGoogleImageGenerationProvider(): ImageGenerationProvider {
         resolveGoogleGenerativeAiHttpRequestConfig({
           apiKey: auth.apiKey,
           baseUrl: req.cfg?.models?.providers?.google?.baseUrl,
+          request: req.cfg?.models?.providers?.google?.request,
           capability: "image",
           transport: "http",
         });


### PR DESCRIPTION
## Summary
- `resolveGoogleGenerativeAiHttpRequestConfig` hardcoded `allowPrivateNetwork: false`, ignoring the user's `request.allowPrivateNetwork` config
- This blocked Google Generative AI image generation for users with private network proxy setups
- Now reads from `params.request?.allowPrivateNetwork ?? false` — secure by default, but respects explicit opt-in

Fixes #67216

## Test plan
- [ ] Verify image generation works with default config (allowPrivateNetwork remains false)
- [ ] Verify image generation works when `request.allowPrivateNetwork: true` is set with a private network proxy
- [ ] Updated existing test to reflect the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)