### PR TITLE
fix(elevenlabs): match Accept header to requested output format

### DIFF
--- a/extensions/elevenlabs/tts.test.ts
+++ b/extensions/elevenlabs/tts.test.ts
@@ -130,4 +130,64 @@ describe("elevenlabs tts diagnostics", () => {
 
     expect(streamed.getReadCount()).toBeLessThan(200);
   });
+
+  it("omits Accept: audio/mpeg header when outputFormat is PCM", async () => {
+    let capturedInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      capturedInit = init;
+      return new Response(Buffer.from("pcm-audio-data"), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await elevenLabsTTS({
+      text: "hello",
+      apiKey: "test-key",
+      baseUrl: "https://api.elevenlabs.io",
+      voiceId: "pMsXgVXv3BLzUgSXRplE",
+      modelId: "eleven_multilingual_v2",
+      outputFormat: "pcm_22050",
+      voiceSettings: {
+        stability: 0.5,
+        similarityBoost: 0.75,
+        style: 0,
+        useSpeakerBoost: true,
+        speed: 1.0,
+      },
+      timeoutMs: 5_000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers).not.toHaveProperty("Accept");
+  });
+
+  it("sends Accept: audio/mpeg header when outputFormat is MP3", async () => {
+    let capturedInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      capturedInit = init;
+      return new Response(Buffer.from("mp3-audio-data"), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await elevenLabsTTS({
+      text: "hello",
+      apiKey: "test-key",
+      baseUrl: "https://api.elevenlabs.io",
+      voiceId: "pMsXgVXv3BLzUgSXRplE",
+      modelId: "eleven_multilingual_v2",
+      outputFormat: "mp3_44100_128",
+      voiceSettings: {
+        stability: 0.5,
+        similarityBoost: 0.75,
+        style: 0,
+        useSpeakerBoost: true,
+        speed: 1.0,
+      },
+      timeoutMs: 5_000,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers).toHaveProperty("Accept", "audio/mpeg");
+  });
 });

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -118,7 +118,7 @@ export async function elevenLabsTTS(params: {
       headers: {
         "xi-api-key": apiKey,
         "Content-Type": "application/json",
-        Accept: "audio/mpeg",
+        ...(outputFormat && !outputFormat.startsWith("mp3_") ? {} : { Accept: "audio/mpeg" }),
       },
       body: JSON.stringify({
         text,


### PR DESCRIPTION
## Problem

`synthesizeTelephony` requests `pcm_22050` via the `output_format` query parameter, but `elevenLabsTTS` hardcodes `Accept: audio/mpeg` in the fetch headers. The ElevenLabs API honors the `Accept` header over the query parameter 
when they conflict, so it returns MP3 data regardless of the requested format. This produces garbled audio in telephony mode.

## Root Cause

`tts.ts:121` unconditionally sets `Accept: "audio/mpeg"`. The header was added assuming all callers want MP3, but `synthesizeTelephony` (`speech-provider.ts:510`) passes `outputFormat: "pcm_22050"` and expects raw PCM back.

## Fix

Only include `Accept: audio/mpeg` when the requested `outputFormat` is actually an `mp3_*` variant (or absent, preserving the existing default). For PCM, OPUS, and other non-MP3 formats the header is omitted so the server honors the `output_format` query parameter.

```diff
-        Accept: "audio/mpeg",
+        ...(outputFormat && !outputFormat.startsWith("mp3_") ? {} : { Accept: "audio/mpeg" }),
```

## Testing

- `pnpm test -- extensions/elevenlabs/tts.test.ts` — 5/5 pass
- New: PCM outputFormat → `Accept` header omitted
- New: MP3 outputFormat → `Accept: audio/mpeg` present
- Existing 3 tests unchanged (all use `mp3_44100_128`)

Fixes #67340