### PR TITLE
fix(reply): apply agent thinkingDefault in run-time fallback chain

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -452,7 +452,9 @@ export async function runPreparedReply(
   const skillsSnapshot = skillResult.skillsSnapshot;
   let { prefixedCommandBody, queuedBody } = await rebuildPromptBodies();
   if (!resolvedThinkLevel) {
-    resolvedThinkLevel = await modelState.resolveDefaultThinkingLevel();
+    resolvedThinkLevel =
+      (await modelState.resolveDefaultThinkingLevel()) ??
+      (agentCfg?.thinkingDefault as ThinkLevel | undefined);
   }
   if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
     const explicitThink = directives.hasThinkDirective && directives.thinkLevel !== undefined;


### PR DESCRIPTION
## Summary

- When the fast directive execution path is used (e.g. non-group, non-heartbeat messages), `resolvedThinkLevel` arrives as `undefined` in `runPreparedReply`
- The run-time fallback at line 454 only checked `modelState.resolveDefaultThinkingLevel()` but did **not** fall back to `agentCfg.thinkingDefault`
- This caused agents with an explicit `thinkingDefault` (e.g. `"minimal"`) to silently fall through to `adaptive` → `medium`, increasing latency and token usage
- The fix mirrors the same fallback chain already used in `get-reply-directives.ts:460-463`

## Root Cause

`get-reply.ts` has two code paths:
1. **Normal directives path** → calls `getReplyDirectives()` which correctly resolves `resolvedThinkLevelWithDefault` including `agentCfg?.thinkingDefault` (line 460-463)
2. **Fast directive execution path** → bypasses directives, passes `resolvedThinkLevel: undefined` directly to `runPreparedReply` (line 384)

In path 2, `runPreparedReply` tried to recover the default but only checked model-level defaults, not agent-level `thinkingDefault`.

## Fix

```typescript
// Before:
if (!resolvedThinkLevel) {
  resolvedThinkLevel = await modelState.resolveDefaultThinkingLevel();
}

// After:
if (!resolvedThinkLevel) {
  resolvedThinkLevel =
    (await modelState.resolveDefaultThinkingLevel()) ??
    (agentCfg?.thinkingDefault as ThinkLevel | undefined);
}
```

## Test plan

- [ ] Agent with `thinkingDefault: "minimal"` should start sessions at `minimal` instead of falling back to `medium`
- [ ] Agent without `thinkingDefault` should continue to use model default or `adaptive` → `medium` as before
- [ ] Explicit per-message `/think high` still overrides the agent default

Fixes #67199

🤖 Generated with [Claude Code](https://claude.com/claude-code)