### PR TITLE
fix: prevent onboarding crash when workspaceInput is undefined

### DIFF
--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -485,7 +485,9 @@ export async function runSetupWizard(
           initialValue: baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE,
         }));
 
-  const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
+  const workspaceDir = resolveUserPath(
+    (workspaceInput ?? "").trim() || onboardHelpers.DEFAULT_WORKSPACE,
+  );
 
   const { applyLocalSetupWorkspaceConfig } = await import("../commands/onboard-config.js");
   let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(baseConfig, workspaceDir);


### PR DESCRIPTION
## Summary
Fixes onboarding crash when selecting channel or skipping during QuickStart setup.

## Root Cause
In `src/wizard/setup.ts`, `workspaceInput` could be `undefined` when `prompter.text()` returns `undefined` (e.g., when user cancels input or skips). Calling `workspaceInput.trim()` on `undefined` throws:
```
TypeError: Cannot read properties of undefined (reading 'trim')
```

## Fix
Use nullish coalescing `(workspaceInput ?? "")` before calling `trim()` to guarantee we always call `trim()` on a string.

## Test Plan
- [x] Unit tests pass (`pnpm test src/wizard/setup.test.ts`)
- [x] Lint checks pass

## Related Issues
- Fixes #67347
- Fixes #67291

## Bug Pattern
This follows Pattern 6 from the bug pattern library: Null/undefined parameter in utility functions.