### PR TITLE
fix(amazon-bedrock-mantle): add config.discovery.enabled gate

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -406,6 +406,48 @@ describe("bedrock mantle discovery", () => {
     expect(provider).toBeNull();
   });
 
+  it("returns null when discovery is explicitly disabled via pluginConfig", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
+      }),
+    });
+
+    const provider = await resolveImplicitMantleProvider({
+      env: {
+        AWS_BEARER_TOKEN_BEDROCK: "my-token", // pragma: allowlist secret
+        AWS_REGION: "us-east-1",
+      } as NodeJS.ProcessEnv,
+      pluginConfig: { discovery: { enabled: false } },
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    expect(provider).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when discovery is explicitly disabled via config", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
+      }),
+    });
+
+    const provider = await resolveImplicitMantleProvider({
+      env: {
+        AWS_BEARER_TOKEN_BEDROCK: "my-token", // pragma: allowlist secret
+        AWS_REGION: "us-east-1",
+      } as NodeJS.ProcessEnv,
+      config: { bedrockMantleDiscovery: { enabled: false } },
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    expect(provider).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("defaults to us-east-1 when no region is set", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -255,12 +255,26 @@ export async function discoverMantleModels(params: {
  * - Models discovered from `/v1/models`
  */
 export async function resolveImplicitMantleProvider(params: {
+  config?: {
+    models?: { providers?: Record<string, unknown> };
+    bedrockMantleDiscovery?: { enabled?: boolean };
+  };
+  pluginConfig?: { discovery?: { enabled?: boolean } };
   env?: NodeJS.ProcessEnv;
   fetchFn?: typeof fetch;
 }): Promise<ModelProviderConfig | null> {
   const env = params.env ?? process.env;
   const region = env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? "us-east-1";
   const explicitBearerToken = resolveMantleBearerToken(env);
+
+  const discoveryConfig = {
+    ...params.config?.bedrockMantleDiscovery,
+    ...params.pluginConfig?.discovery,
+  };
+  const enabled = discoveryConfig?.enabled;
+  if (enabled === false) {
+    return null;
+  }
 
   if (!isSupportedRegion(region)) {
     log.debug?.("Mantle not available in region", { region });

--- a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
@@ -5,8 +5,15 @@ import {
   resolveMantleBearerToken,
 } from "./discovery.js";
 
+type AmazonBedrockMantlePluginConfig = {
+  discovery?: {
+    enabled?: boolean;
+  };
+};
+
 export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
   const providerId = "amazon-bedrock-mantle";
+  const pluginConfig = (api.pluginConfig ?? {}) as AmazonBedrockMantlePluginConfig;
 
   api.registerProvider({
     id: providerId,
@@ -17,6 +24,8 @@ export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
       order: "simple",
       run: async (ctx) => {
         const implicit = await resolveImplicitMantleProvider({
+          config: ctx.config,
+          pluginConfig,
           env: ctx.env,
         });
         if (!implicit) {


### PR DESCRIPTION
## Summary
Fixes openclaw#67288 - amazon-bedrock-mantle plugin was running IAM token discovery on every request without checking config.discovery.enabled.

## Root Cause
Unlike the amazon-bedrock plugin, amazon-bedrock-mantle did not respect the discovery.enabled configuration option. This meant discovery would run even when users explicitly wanted to disable it.

## Fix
1. Added AmazonBedrockMantlePluginConfig type with discovery.enabled option
2. Updated resolveImplicitMantleProvider to accept config and pluginConfig parameters
3. Added enabled check that returns null when explicitly disabled (matching amazon-bedrock behavior)
4. Updated register.sync.runtime.ts to pass config and pluginConfig to the resolver
5. Added tests for disabled discovery via both config paths

## Usage
Users can now disable discovery via:
- Plugin config: { discovery: { enabled: false } }
- Global config: { models: { bedrockMantleDiscovery: { enabled: false } } }

## Test Plan
- [x] Unit tests pass (25 tests in amazon-bedrock-mantle)
- [x] Added 2 new tests for disabled discovery scenario

Closes openclaw#67288