### PR TITLE
docs(gateway): correct protocol.md schema path, hello-ok example, auth precedence, and add client constants table

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -73,9 +73,23 @@ Gateway → Client:
   "type": "res",
   "id": "…",
   "ok": true,
-  "payload": { "type": "hello-ok", "protocol": 3, "policy": { "tickIntervalMs": 15000 } }
+  "payload": {
+    "type": "hello-ok",
+    "protocol": 3,
+    "server": { "version": "…", "connId": "…" },
+    "features": { "methods": ["…"], "events": ["…"] },
+    "snapshot": { "…": "…" },
+    "policy": {
+      "maxPayload": 26214400,
+      "maxBufferedBytes": 26214400,
+      "tickIntervalMs": 15000
+    }
+  }
 }
 ```
+
+`server`, `features`, `snapshot`, and `policy` are all required by the schema
+(`src/gateway/protocol/schema/frames.ts`). `auth` and `canvasHostUrl` are optional.
 
 When a device token is issued, `hello-ok` also includes:
 
@@ -492,12 +506,35 @@ implemented in `src/gateway/server-methods/*.ts`.
 
 ## Versioning
 
-- `PROTOCOL_VERSION` lives in `src/gateway/protocol/schema.ts`.
+- `PROTOCOL_VERSION` lives in `src/gateway/protocol/schema/protocol-schemas.ts`.
 - Clients send `minProtocol` + `maxProtocol`; the server rejects mismatches.
 - Schemas + models are generated from TypeBox definitions:
   - `pnpm protocol:gen`
   - `pnpm protocol:gen:swift`
   - `pnpm protocol:check`
+
+### Client constants
+
+The reference client in `src/gateway/client.ts` uses these defaults. Values are
+stable across protocol v3 and are the expected baseline for third-party clients.
+
+| Constant                                  | Default                                               | Source                                                     |
+| ----------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------- |
+| `PROTOCOL_VERSION`                        | `3`                                                   | `src/gateway/protocol/schema/protocol-schemas.ts`          |
+| Request timeout (per RPC)                 | `30_000` ms                                           | `src/gateway/client.ts` (`requestTimeoutMs`)               |
+| Preauth / connect-challenge timeout       | `10_000` ms                                           | `src/gateway/handshake-timeouts.ts` (clamp `250`–`10_000`) |
+| Initial reconnect backoff                 | `1_000` ms                                            | `src/gateway/client.ts` (`backoffMs`)                      |
+| Max reconnect backoff                     | `30_000` ms                                           | `src/gateway/client.ts` (`scheduleReconnect`)              |
+| Fast-retry clamp after device-token close | `250` ms                                              | `src/gateway/client.ts`                                    |
+| Force-stop grace before `terminate()`     | `250` ms                                              | `FORCE_STOP_TERMINATE_GRACE_MS`                            |
+| `stopAndWait()` default timeout           | `1_000` ms                                            | `STOP_AND_WAIT_TIMEOUT_MS`                                 |
+| Default tick interval (pre `hello-ok`)    | `30_000` ms                                           | `src/gateway/client.ts`                                    |
+| Tick-timeout close                        | code `4000` when silence exceeds `tickIntervalMs * 2` | `src/gateway/client.ts`                                    |
+| `MAX_PAYLOAD_BYTES`                       | `25 * 1024 * 1024` (25 MB)                            | `src/gateway/server-constants.ts`                          |
+
+The server advertises the effective `policy.tickIntervalMs`, `policy.maxPayload`,
+and `policy.maxBufferedBytes` in `hello-ok`; clients should honor those values
+rather than the pre-handshake defaults.
 
 ## Auth
 
@@ -518,8 +555,18 @@ implemented in `src/gateway/server-methods/*.ts`.
   approved scope set for that token. This preserves read/probe/status access
   that was already granted and avoids silently collapsing reconnects to a
   narrower implicit admin-only scope.
-- Normal connect auth precedence is explicit shared token/password first, then
-  explicit `deviceToken`, then stored per-device token, then bootstrap token.
+- Client-side connect auth assembly (`selectConnectAuth` in
+  `src/gateway/client.ts`):
+  - `auth.password` is orthogonal and is always forwarded when set.
+  - `auth.token` is populated in priority order: explicit shared token first,
+    then an explicit `deviceToken`, then a stored per-device token (keyed by
+    `deviceId` + `role`).
+  - `auth.bootstrapToken` is sent only when none of the above resolved an
+    `auth.token`. A shared token or any resolved device token suppresses it.
+  - Auto-promotion of a stored device token on the one-shot
+    `AUTH_TOKEN_MISMATCH` retry is gated to **trusted endpoints only** —
+    loopback, or `wss://` with a pinned `tlsFingerprint`. Public `wss://`
+    without pinning does not qualify.
 - Additional `hello-ok.auth.deviceTokens` entries are bootstrap handoff tokens.
   Persist them only when the connect used bootstrap auth on a trusted transport
   such as `wss://` or loopback/local pairing.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -81,7 +81,7 @@ Gateway → Client:
     "snapshot": { "…": "…" },
     "policy": {
       "maxPayload": 26214400,
-      "maxBufferedBytes": 26214400,
+      "maxBufferedBytes": 52428800,
       "tickIntervalMs": 15000
     }
   }


### PR DESCRIPTION
## Summary

Corrects four sources of drift in `docs/gateway/protocol.md` against the current source:

- Fix `PROTOCOL_VERSION` path: `src/gateway/protocol/schema.ts` → `src/gateway/protocol/schema/protocol-schemas.ts` (the old path exists but does not export the constant).
- Expand the `hello-ok` example to match the schema in `src/gateway/protocol/schema/frames.ts`: add `server`, `features`, `snapshot`, and full `policy` fields. The previous minimal example would fail schema validation (`additionalProperties: false`).
- Rewrite the "connect auth precedence" bullet to match `selectConnectAuth` in `src/gateway/client.ts`: password is orthogonal and always forwarded; bootstrap is suppressed whenever any token path resolves; stored-device-token auto-promotion on `AUTH_TOKEN_MISMATCH` retry is gated to trusted endpoints (loopback or `wss://` + pinned fingerprint).
- Add a "Client constants" subsection with the timeouts, backoff, tick-timeout close code, and max payload used by the reference client, each linked to source.

Thanks @stevenic for catching this.

## Test plan

- [ ] Docs-only change; pre-commit hook skipped `pnpm check` automatically for a docs-only diff.
- [ ] Render in Mintlify preview to confirm table + code blocks look right.