### PR TITLE
fix: handle undefined rawValue in setup wizard text input

### DIFF
--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -455,7 +455,7 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
               });
             },
           });
-          const trimmedValue = rawValue.trim();
+          const trimmedValue = rawValue?.trim() ?? "";
           if (!trimmedValue && textInput.required === false) {
             if (textInput.applyEmptyValue) {
               next = await applyWizardTextInputValue({


### PR DESCRIPTION
## Summary

Prevent `TypeError: Cannot read properties of undefined (reading 'trim')` when the setup wizard prompter returns an undefined value during text input (observed when replacing a Telegram bot token during onboarding).

## Changes

- Added optional chaining and nullish coalescing to `rawValue.trim()` in `src/channels/plugins/setup-wizard.ts`

## Testing

- Unable to run full test suite in shallow clone environment (missing `node_modules`), but the change is a minimal defensive fix that safely handles the `undefined` case by falling back to an empty string.

Fixes openclaw/openclaw#67366