### PR TITLE
test(qa): raise approval-turn-tool-followthrough timeouts for CI stability

### DIFF
--- a/qa/scenarios/approval-turn-tool-followthrough.md
+++ b/qa/scenarios/approval-turn-tool-followthrough.md
@@ -49,14 +49,14 @@ steps:
             message:
               expr: config.preActionPrompt
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 20000)
+              expr: liveTurnTimeoutMs(env, 35000)
       - call: waitForOutboundMessage
         args:
           - ref: state
           - lambda:
               params: [candidate]
               expr: "candidate.conversation.id === 'qa-operator'"
-          - expr: liveTurnTimeoutMs(env, 20000)
+          - expr: liveTurnTimeoutMs(env, 35000)
       - set: beforeApprovalCursor
         value:
           expr: state.getSnapshot().messages.length
@@ -67,7 +67,7 @@ steps:
             message:
               expr: config.approvalPrompt
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 30000)
+              expr: liveTurnTimeoutMs(env, 45000)
       - set: expectedReplyAny
         value:
           expr: config.expectedReplyAny.map(normalizeLowercaseStringOrEmpty)
@@ -76,7 +76,7 @@ steps:
         args:
           - lambda:
               expr: "state.getSnapshot().messages.slice(beforeApprovalCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && expectedReplyAny.some((needle) => normalizeLowercaseStringOrEmpty(candidate.text).includes(needle))).at(-1)"
-          - expr: liveTurnTimeoutMs(env, 20000)
+          - expr: liveTurnTimeoutMs(env, 35000)
           - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
       - assert:
           expr: "!env.mock || ([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].toReversed().find((request) => String(request.allInputText ?? '').includes('ok do it.') && !request.toolOutput)?.plannedToolName === 'read')"


### PR DESCRIPTION
Bumps timeouts in the approval-turn-tool-followthrough QA scenario to reduce flakiness under CI resource pressure.

- Pre-action and outbound-wait steps: 20 s → 35 s
- Approval turn timeout: 30 s → 45 s
- Final `waitForCondition`: 20 s → 35 s

The parity gate was flaking with a gateway timeout after 25000 ms (agent.wait outer guard = preActionPrompt timeout + 5 s) on the gpt-5.4 mock lane under CI resource pressure. No logic change — wider window only.