### PR TITLE
fix(channels): improve error logging for bundled channel entry loading failures

### DIFF
--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -79,11 +79,21 @@ function resolveChannelPluginModuleEntry(
     return null;
   }
   const missingFields: string[] = [];
-  if (typeof record.id !== "string") missingFields.push("id");
-  if (typeof record.name !== "string") missingFields.push("name");
-  if (typeof record.description !== "string") missingFields.push("description");
-  if (typeof record.register !== "function") missingFields.push("register");
-  if (typeof record.loadChannelPlugin !== "function") missingFields.push("loadChannelPlugin");
+  if (typeof record.id !== "string") {
+    missingFields.push("id");
+  }
+  if (typeof record.name !== "string") {
+    missingFields.push("name");
+  }
+  if (typeof record.description !== "string") {
+    missingFields.push("description");
+  }
+  if (typeof record.register !== "function") {
+    missingFields.push("register");
+  }
+  if (typeof record.loadChannelPlugin !== "function") {
+    missingFields.push("loadChannelPlugin");
+  }
   if (missingFields.length > 0) {
     log.warn(
       `[channels] bundled channel entry missing required fields: ${missingFields.join(", ")}; skipping`,

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -66,19 +66,28 @@ function resolveChannelPluginModuleEntry(
 ): BundledChannelEntryRuntimeContract | null {
   const resolved = unwrapDefaultModuleExport(moduleExport);
   if (!resolved || typeof resolved !== "object") {
+    log.warn(
+      `[channels] bundled channel entry missing or not an object; skipping`,
+    );
     return null;
   }
   const record = resolved as Partial<BundledChannelEntryRuntimeContract>;
   if (record.kind !== "bundled-channel-entry") {
+    log.warn(
+      `[channels] bundled channel entry missing bundled-channel-entry kind marker; skipping (found: ${String(record.kind)})`,
+    );
     return null;
   }
-  if (
-    typeof record.id !== "string" ||
-    typeof record.name !== "string" ||
-    typeof record.description !== "string" ||
-    typeof record.register !== "function" ||
-    typeof record.loadChannelPlugin !== "function"
-  ) {
+  const missingFields: string[] = [];
+  if (typeof record.id !== "string") missingFields.push("id");
+  if (typeof record.name !== "string") missingFields.push("name");
+  if (typeof record.description !== "string") missingFields.push("description");
+  if (typeof record.register !== "function") missingFields.push("register");
+  if (typeof record.loadChannelPlugin !== "function") missingFields.push("loadChannelPlugin");
+  if (missingFields.length > 0) {
+    log.warn(
+      `[channels] bundled channel entry missing required fields: ${missingFields.join(", ")}; skipping`,
+    );
     return null;
   }
   return record as BundledChannelEntryRuntimeContract;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2198,8 +2198,19 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       }
 
       if (typeof register !== "function") {
-        logger.error(`[plugins] ${record.id} missing register/activate export`);
-        pushPluginLoadError("plugin export missing register/activate");
+        // Check if this is a bundled channel entry that uses the new contract
+        const resolvedModule = resolved?.definition ?? {};
+        const isBundledChannelEntry =
+          resolvedModule.kind === "bundled-channel-entry";
+        if (isBundledChannelEntry) {
+          logger.error(
+            `[plugins] ${record.id} is a bundled channel entry that requires setup-runtime; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+          );
+          pushPluginLoadError("bundled channel entry requires setup-runtime loader");
+        } else {
+          logger.error(`[plugins] ${record.id} missing register/activate export`);
+          pushPluginLoadError("plugin export missing register/activate");
+        }
         continue;
       }
 
@@ -2611,8 +2622,19 @@ export async function loadOpenClawPluginCliRegistry(
     }
 
     if (typeof register !== "function") {
-      logger.error(`[plugins] ${record.id} missing register/activate export`);
-      pushPluginLoadError("plugin export missing register/activate");
+      // Check if this is a bundled channel entry that uses the new contract
+      const resolvedModule = resolved?.definition ?? {};
+      const isBundledChannelEntry =
+        resolvedModule.kind === "bundled-channel-entry";
+      if (isBundledChannelEntry) {
+        logger.error(
+          `[plugins] ${record.id} is a bundled channel entry that requires setup-runtime; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+        );
+        pushPluginLoadError("bundled channel entry requires setup-runtime loader");
+      } else {
+        logger.error(`[plugins] ${record.id} missing register/activate export`);
+        pushPluginLoadError("plugin export missing register/activate");
+      }
       continue;
     }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2199,7 +2199,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
       if (typeof register !== "function") {
         // Check if this is a bundled channel entry that uses the new contract
-        const resolvedModule = resolved?.definition ?? {};
+        const resolvedModule = (resolved?.definition ?? {}) as { kind?: unknown };
         const isBundledChannelEntry =
           resolvedModule.kind === "bundled-channel-entry";
         if (isBundledChannelEntry) {
@@ -2623,7 +2623,7 @@ export async function loadOpenClawPluginCliRegistry(
 
     if (typeof register !== "function") {
       // Check if this is a bundled channel entry that uses the new contract
-      const resolvedModule = resolved?.definition ?? {};
+      const resolvedModule = (resolved?.definition ?? {}) as { kind?: unknown };
       const isBundledChannelEntry =
         resolvedModule.kind === "bundled-channel-entry";
       if (isBundledChannelEntry) {


### PR DESCRIPTION
## Summary

- Problem: Bundled channel plugins like Telegram fail silently on macOS npm installs with generic "missing register/activate export" error, making diagnosis difficult
- Why it matters: Users can't tell why Telegram isn't appearing in `openclaw channels list` or `capabilities`
- What changed: 
  - Added detailed field-by-field logging in `resolveChannelPluginModuleEntry` to show exactly which required field is missing
  - Added distinction in `loader.ts` between bundled channel entries (new contract) vs legacy plugins
- What did NOT change: No plugin loading architecture changes

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Channels / plugins
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62610
- Related #
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: Bundled channel entries (using `defineBundledChannelEntry`) have a different contract than legacy plugins. When they fall through to the legacy loader path, the generic "missing register/activate" error is misleading and doesn't help diagnose the actual problem.
- Missing detection / guardrail: No logging to show which specific field was missing from the bundled entry contract validation
- Contributing context: On macOS npm installs, the bundled plugin discovery may fail or the plugin may be processed through the wrong loading path

## Regression Test Plan

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/channels/plugins/bundled.test.ts`
- Scenario the test should lock in: Bundled channel entry validation with missing fields
- Why this is the smallest reliable guardrail: Better logging only, no behavior change
- Existing test that already covers this (if any): Basic bundled channel loading tests exist

## User-visible / Behavior Changes

- Before: "telegram missing register/activate export" (generic, misleading)
- After: "bundled channel entry missing required fields: register; skipping" or "is a bundled channel entry that requires setup-runtime" (actionable)

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification

What you personally verified (not just CI), and how:

- Verified scenarios: Code review of validation paths and error message branches
- Edge cases checked: Both legacy plugin and bundled channel entry paths
- What you did not verify: Full end-to-end with macOS npm install environment