### PR TITLE
openclaw wouldn't install on Windows: fix pnpm.exe runner and Lobster embedded runtime fallback

### DIFF
--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -276,6 +276,28 @@ describe("createEmbeddedLobsterRunner", () => {
     expect(loadRuntime).toHaveBeenCalledTimes(1);
   });
 
+  it("loads the installed Lobster package through the default runtime loader", async () => {
+    const runner = createEmbeddedLobsterRunner();
+
+    const envelope = await runner.run({
+      action: "run",
+      pipeline: "commands.list",
+      cwd: process.cwd(),
+      timeoutMs: 5_000,
+      maxStdoutBytes: 65_536,
+    });
+
+    expect(envelope.ok).toBe(true);
+    if (!envelope.ok) {
+      throw new Error(envelope.error.message);
+    }
+    expect(envelope.status).toBe("ok");
+    expect(envelope.requiresApproval).toBeNull();
+    expect(envelope.output).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "commands.list" })]),
+    );
+  });
+
   it("requires a pipeline for run", async () => {
     const runner = createEmbeddedLobsterRunner({
       loadRuntime: vi.fn().mockResolvedValue({

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createCompatEmbeddedToolRuntime,
   createEmbeddedLobsterRunner,
   resolveLobsterCwd,
   withSerializedCompatCwd,
@@ -66,6 +67,63 @@ describe("withSerializedCompatCwd", () => {
     ).rejects.toThrow();
 
     await expect(withSerializedCompatCwd(process.cwd(), async () => "ok")).resolves.toBe("ok");
+  });
+});
+
+describe("createCompatEmbeddedToolRuntime", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes ctx.signal through compat pipeline execution for run and resume", async () => {
+    const runPipeline = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [], halted: false, rendered: false })
+      .mockResolvedValueOnce({ items: [], halted: false, rendered: false });
+
+    const runtime = createCompatEmbeddedToolRuntime({
+      parsePipeline: vi.fn().mockReturnValue([{ name: "exec", args: { _: [] } }]),
+      createDefaultRegistry: vi.fn().mockReturnValue({
+        get: vi.fn(),
+        list: vi.fn().mockReturnValue([]),
+      }),
+      runPipeline,
+      encodeToken: vi.fn(),
+      decodeResumeToken: vi.fn().mockReturnValue({
+        pipeline: [{ name: "exec", args: { _: [] } }],
+        resumeAtIndex: 0,
+        items: [],
+      }),
+      runWorkflowFile: vi.fn(),
+    });
+
+    const runSignal = new AbortController().signal;
+    await runtime.runToolRequest({
+      pipeline: "exec",
+      ctx: { cwd: process.cwd(), mode: "tool", signal: runSignal },
+    });
+
+    const resumeSignal = new AbortController().signal;
+    await runtime.resumeToolRequest({
+      token: "resume-token",
+      approved: true,
+      ctx: { cwd: process.cwd(), mode: "tool", signal: resumeSignal },
+    });
+
+    expect(runPipeline).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        cwd: process.cwd(),
+        signal: runSignal,
+      }),
+    );
+    expect(runPipeline).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        cwd: process.cwd(),
+        signal: resumeSignal,
+      }),
+    );
   });
 });
 

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createEmbeddedLobsterRunner, resolveLobsterCwd } from "./lobster-runner.js";
+import {
+  createEmbeddedLobsterRunner,
+  resolveLobsterCwd,
+  withSerializedCompatCwd,
+} from "./lobster-runner.js";
 
 describe("resolveLobsterCwd", () => {
   it("defaults to the current working directory", () => {
@@ -13,6 +17,55 @@ describe("resolveLobsterCwd", () => {
     expect(resolveLobsterCwd("extensions/lobster")).toBe(
       path.resolve(process.cwd(), "extensions/lobster"),
     );
+  });
+});
+
+describe("withSerializedCompatCwd", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("serializes compat runtime work even when cwd matches process.cwd()", async () => {
+    let releaseFirst: (() => void) | undefined;
+    let markFirstStarted: (() => void) | undefined;
+    const secondStarted = vi.fn();
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+
+    const first = withSerializedCompatCwd(process.cwd(), async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+        markFirstStarted?.();
+      });
+    });
+
+    await firstStarted;
+    const second = withSerializedCompatCwd(process.cwd(), async () => {
+      secondStarted();
+    });
+
+    await Promise.resolve();
+    expect(secondStarted).not.toHaveBeenCalled();
+
+    releaseFirst?.();
+    await Promise.all([first, second]);
+    expect(secondStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the cwd queue when chdir throws", async () => {
+    const missingCwd = path.join(
+      os.tmpdir(),
+      `openclaw-lobster-missing-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+
+    await expect(
+      withSerializedCompatCwd(missingCwd, async () => {
+        throw new Error("unreachable");
+      }),
+    ).rejects.toThrow();
+
+    await expect(withSerializedCompatCwd(process.cwd(), async () => "ok")).resolves.toBe("ok");
   });
 });
 

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -149,6 +149,8 @@ type LobsterPackageCompatModules = {
     stderr?: NodeJS.WritableStream;
     env?: Record<string, string | undefined>;
     mode?: "tool" | "human" | "sdk";
+    cwd?: string;
+    signal?: AbortSignal;
   }) => Promise<CompatPipelineResult>;
   encodeToken: (payload: unknown) => string;
   decodeResumeToken: (token: string) => ResumeTokenPayload;
@@ -347,7 +349,7 @@ async function importLobsterModule<T>(packageRoot: string, relativePath: string)
   return (await import(moduleUrl)) as T;
 }
 
-function createCompatEmbeddedToolRuntime(
+export function createCompatEmbeddedToolRuntime(
   modules: LobsterPackageCompatModules,
 ): EmbeddedToolRuntime {
   const registry = modules.createDefaultRegistry();
@@ -385,6 +387,8 @@ function createCompatEmbeddedToolRuntime(
               stderr: ctx.stderr,
               env: ctx.env,
               mode: ctx.mode,
+              cwd: ctx.cwd,
+              signal: ctx.signal,
             }),
           });
         });
@@ -442,6 +446,8 @@ function createCompatEmbeddedToolRuntime(
               stderr: ctx.stderr,
               env: ctx.env,
               mode: ctx.mode,
+              cwd: ctx.cwd,
+              signal: ctx.signal,
             }),
           });
         });

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -212,11 +212,10 @@ function toAsyncInput(items: unknown[]) {
   })();
 }
 
-async function withSerializedCompatCwd<T>(cwd: string | undefined, fn: () => Promise<T>): Promise<T> {
-  if (!cwd || cwd === process.cwd()) {
-    return await fn();
-  }
-
+export async function withSerializedCompatCwd<T>(
+  cwd: string | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
   const previous = compatRuntimeCwdQueue;
   let release: (() => void) | undefined;
   compatRuntimeCwdQueue = new Promise<void>((resolve) => {
@@ -225,12 +224,21 @@ async function withSerializedCompatCwd<T>(cwd: string | undefined, fn: () => Pro
 
   await previous.catch(() => {});
   const originalCwd = process.cwd();
-  process.chdir(cwd);
+  let changedCwd = false;
   try {
+    if (cwd && cwd !== originalCwd) {
+      process.chdir(cwd);
+      changedCwd = true;
+    }
     return await fn();
   } finally {
-    process.chdir(originalCwd);
-    release?.();
+    try {
+      if (changedCwd) {
+        process.chdir(originalCwd);
+      }
+    } finally {
+      release?.();
+    }
   }
 }
 
@@ -603,6 +611,7 @@ async function withTimeout<T>(
 async function loadEmbeddedToolRuntimeFromPackage(): Promise<EmbeddedToolRuntime> {
   let primaryLoadError: unknown;
   try {
+    // Split to prevent static bundler resolution of this optional entrypoint.
     const coreSpecifier = ["@clawdbot", "lobster", "core"].join("/");
     const coreModule = (await import(coreSpecifier)) as Partial<EmbeddedToolRuntime>;
     if (
@@ -661,8 +670,15 @@ async function loadEmbeddedToolRuntimeFromPackage(): Promise<EmbeddedToolRuntime
       runWorkflowFile: workflowFileModule.runWorkflowFile,
     });
   } catch (compatError) {
+    const cause =
+      primaryLoadError === undefined
+        ? compatError
+        : new AggregateError(
+            [primaryLoadError, compatError],
+            "Both Lobster embedded runtime load paths failed",
+          );
     throw new Error("Failed to load the Lobster embedded runtime", {
-      cause: compatError ?? primaryLoadError,
+      cause,
     });
   }
 }

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -1,9 +1,8 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
-import {
-  resumeToolRequest as embeddedResumeToolRequest,
-  runToolRequest as embeddedRunToolRequest,
-} from "@clawdbot/lobster/core";
+import { pathToFileURL } from "node:url";
 
 export type LobsterEnvelope =
   | {
@@ -92,6 +91,358 @@ type EmbeddedToolRuntime = {
 };
 
 type LoadEmbeddedToolRuntime = () => Promise<EmbeddedToolRuntime>;
+
+type ParsedPipelineStage = {
+  name: string;
+  args: Record<string, unknown> & {
+    _: string[];
+  };
+  raw?: string;
+};
+
+type CompatPipelineResult = {
+  items: unknown[];
+  halted: boolean;
+  haltedAt?: {
+    index?: number;
+  } | null;
+  rendered?: boolean;
+};
+
+type CompatRegistry = {
+  get: (name: string) => unknown;
+  list: () => string[];
+};
+
+type ApprovalRequestPayload = {
+  type: "approval_request";
+  prompt: string;
+  items: unknown[];
+  preview?: string;
+  resumeToken?: string;
+};
+
+type WorkflowFileResult = {
+  status: "ok" | "needs_approval";
+  output: unknown[];
+  requiresApproval?: ApprovalRequestPayload | null;
+};
+
+type ResumeTokenPayload = {
+  kind?: string;
+  filePath?: string;
+  stateKey?: string;
+  pipeline?: ParsedPipelineStage[];
+  resumeAtIndex?: number;
+  items?: unknown[];
+};
+
+type LobsterPackageCompatModules = {
+  parsePipeline: (input: string) => ParsedPipelineStage[];
+  createDefaultRegistry: () => CompatRegistry;
+  runPipeline: (params: {
+    pipeline: ParsedPipelineStage[];
+    registry: CompatRegistry;
+    input: AsyncIterable<unknown> | unknown[];
+    stdin?: NodeJS.ReadableStream;
+    stdout?: NodeJS.WritableStream;
+    stderr?: NodeJS.WritableStream;
+    env?: Record<string, string | undefined>;
+    mode?: "tool" | "human" | "sdk";
+  }) => Promise<CompatPipelineResult>;
+  encodeToken: (payload: unknown) => string;
+  decodeResumeToken: (token: string) => ResumeTokenPayload;
+  runWorkflowFile: (params: {
+    filePath?: string;
+    args?: Record<string, unknown>;
+    ctx: EmbeddedToolContext;
+    resume?: ResumeTokenPayload;
+    approved?: boolean;
+  }) => Promise<WorkflowFileResult>;
+};
+
+const lobsterRequire = createRequire(import.meta.url);
+let compatRuntimeCwdQueue: Promise<void> = Promise.resolve();
+
+function isApprovalRequestPayload(value: unknown): value is ApprovalRequestPayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<ApprovalRequestPayload>;
+  return (
+    candidate.type === "approval_request" &&
+    typeof candidate.prompt === "string" &&
+    Array.isArray(candidate.items)
+  );
+}
+
+function toEmbeddedToolError(
+  error: unknown,
+  type = "runtime_error",
+): Extract<EmbeddedToolEnvelope, { ok: false }> {
+  return {
+    ok: false,
+    error: {
+      type,
+      message: error instanceof Error ? error.message : String(error),
+    },
+  };
+}
+
+function toEmbeddedApprovalRequest(
+  payload: ApprovalRequestPayload | null | undefined,
+): EmbeddedToolEnvelope["requiresApproval"] {
+  if (!payload) {
+    return null;
+  }
+  return {
+    type: "approval_request",
+    prompt: payload.prompt,
+    items: payload.items,
+    ...(payload.preview ? { preview: payload.preview } : {}),
+    ...(payload.resumeToken ? { resumeToken: payload.resumeToken } : {}),
+  };
+}
+
+function toAsyncInput(items: unknown[]) {
+  return (async function* () {
+    for (const item of items) {
+      yield item;
+    }
+  })();
+}
+
+async function withSerializedCompatCwd<T>(cwd: string | undefined, fn: () => Promise<T>): Promise<T> {
+  if (!cwd || cwd === process.cwd()) {
+    return await fn();
+  }
+
+  const previous = compatRuntimeCwdQueue;
+  let release: (() => void) | undefined;
+  compatRuntimeCwdQueue = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous.catch(() => {});
+  const originalCwd = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(originalCwd);
+    release?.();
+  }
+}
+
+function createCompatContext(
+  ctx: EmbeddedToolContext | undefined,
+  registry: CompatRegistry,
+): EmbeddedToolContext & {
+  env: Record<string, string | undefined>;
+  mode: "tool" | "human" | "sdk";
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  registry: CompatRegistry;
+} {
+  return {
+    cwd: ctx?.cwd,
+    env: ctx?.env ?? ({ ...process.env } as Record<string, string | undefined>),
+    mode: ctx?.mode ?? "tool",
+    stdin: ctx?.stdin ?? Readable.from([]),
+    stdout: ctx?.stdout ?? createLimitedSink(1024 * 1024, "stdout"),
+    stderr: ctx?.stderr ?? createLimitedSink(1024 * 1024, "stderr"),
+    signal: ctx?.signal,
+    registry,
+    llmAdapters: ctx?.llmAdapters,
+  };
+}
+
+function normalizeWorkflowToolEnvelope(result: WorkflowFileResult): EmbeddedToolEnvelope {
+  if (result.status === "needs_approval") {
+    return {
+      ok: true,
+      status: "needs_approval",
+      output: [],
+      requiresApproval: toEmbeddedApprovalRequest(result.requiresApproval),
+    };
+  }
+
+  return {
+    ok: true,
+    status: "ok",
+    output: Array.isArray(result.output) ? result.output : [],
+    requiresApproval: null,
+  };
+}
+
+function normalizePipelineToolEnvelope(params: {
+  encodeToken: (payload: unknown) => string;
+  pipeline: ParsedPipelineStage[];
+  result: CompatPipelineResult;
+}): EmbeddedToolEnvelope {
+  const approvalCandidate =
+    params.result.halted && params.result.items.length === 1 ? params.result.items[0] : null;
+
+  if (isApprovalRequestPayload(approvalCandidate)) {
+    const resumeToken = params.encodeToken({
+      protocolVersion: 1,
+      v: 1,
+      pipeline: params.pipeline,
+      resumeAtIndex: (params.result.haltedAt?.index ?? -1) + 1,
+      items: approvalCandidate.items,
+      prompt: approvalCandidate.prompt,
+    });
+
+    return {
+      ok: true,
+      status: "needs_approval",
+      output: [],
+      requiresApproval: toEmbeddedApprovalRequest({
+        ...approvalCandidate,
+        resumeToken,
+      }),
+    };
+  }
+
+  return {
+    ok: true,
+    status: "ok",
+    output: Array.isArray(params.result.items) ? params.result.items : [],
+    requiresApproval: null,
+  };
+}
+
+function findLobsterPackageRoot(resolvedEntryPath: string): string {
+  let dir = path.dirname(resolvedEntryPath);
+  while (true) {
+    const packageJsonPath = path.join(dir, "package.json");
+    try {
+      const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { name?: string };
+      if (parsed.name === "@clawdbot/lobster") {
+        return dir;
+      }
+    } catch {
+      // Keep walking upward until we reach the package root.
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Could not locate @clawdbot/lobster package root from ${resolvedEntryPath}`);
+    }
+    dir = parent;
+  }
+}
+
+async function importLobsterModule<T>(packageRoot: string, relativePath: string): Promise<T> {
+  const moduleUrl = pathToFileURL(path.join(packageRoot, relativePath)).href;
+  return (await import(moduleUrl)) as T;
+}
+
+function createCompatEmbeddedToolRuntime(
+  modules: LobsterPackageCompatModules,
+): EmbeddedToolRuntime {
+  const registry = modules.createDefaultRegistry();
+
+  return {
+    async runToolRequest(params) {
+      try {
+        const ctx = createCompatContext(params.ctx, registry);
+        return await withSerializedCompatCwd(ctx.cwd, async () => {
+          if (params.filePath) {
+            return normalizeWorkflowToolEnvelope(
+              await modules.runWorkflowFile({
+                filePath: params.filePath,
+                args: params.args,
+                ctx,
+              }),
+            );
+          }
+
+          const pipeline = params.pipeline?.trim() ?? "";
+          if (!pipeline) {
+            return toEmbeddedToolError(new Error("pipeline required"), "parse_error");
+          }
+
+          const parsedPipeline = modules.parsePipeline(pipeline);
+          return normalizePipelineToolEnvelope({
+            encodeToken: modules.encodeToken,
+            pipeline: parsedPipeline,
+            result: await modules.runPipeline({
+              pipeline: parsedPipeline,
+              registry,
+              input: [],
+              stdin: ctx.stdin,
+              stdout: ctx.stdout,
+              stderr: ctx.stderr,
+              env: ctx.env,
+              mode: ctx.mode,
+            }),
+          });
+        });
+      } catch (error) {
+        return toEmbeddedToolError(error);
+      }
+    },
+    async resumeToolRequest(params) {
+      try {
+        if (!params.approved || params.cancel) {
+          return {
+            ok: true,
+            status: "cancelled",
+            output: [],
+            requiresApproval: null,
+          };
+        }
+
+        const token = params.token?.trim() ?? "";
+        if (!token) {
+          return toEmbeddedToolError(new Error("token required"), "parse_error");
+        }
+
+        const payload = modules.decodeResumeToken(token);
+        const ctx = createCompatContext(params.ctx, registry);
+
+        return await withSerializedCompatCwd(ctx.cwd, async () => {
+          if (payload.kind === "workflow-file") {
+            return normalizeWorkflowToolEnvelope(
+              await modules.runWorkflowFile({
+                filePath: payload.filePath,
+                ctx,
+                resume: payload,
+                approved: true,
+              }),
+            );
+          }
+
+          const pipeline = Array.isArray(payload.pipeline)
+            ? payload.pipeline.slice(payload.resumeAtIndex ?? 0)
+            : null;
+          if (!pipeline) {
+            return toEmbeddedToolError(new Error("Invalid token"), "parse_error");
+          }
+
+          return normalizePipelineToolEnvelope({
+            encodeToken: modules.encodeToken,
+            pipeline,
+            result: await modules.runPipeline({
+              pipeline,
+              registry,
+              input: toAsyncInput(Array.isArray(payload.items) ? payload.items : []),
+              stdin: ctx.stdin,
+              stdout: ctx.stdout,
+              stderr: ctx.stderr,
+              env: ctx.env,
+              mode: ctx.mode,
+            }),
+          });
+        });
+      } catch (error) {
+        return toEmbeddedToolError(error);
+      }
+    },
+  };
+}
 
 function normalizeForCwdSandbox(p: string): string {
   const normalized = path.normalize(p);
@@ -250,10 +601,70 @@ async function withTimeout<T>(
 }
 
 async function loadEmbeddedToolRuntimeFromPackage(): Promise<EmbeddedToolRuntime> {
-  return {
-    runToolRequest: embeddedRunToolRequest,
-    resumeToolRequest: embeddedResumeToolRequest,
-  };
+  let primaryLoadError: unknown;
+  try {
+    const coreSpecifier = ["@clawdbot", "lobster", "core"].join("/");
+    const coreModule = (await import(coreSpecifier)) as Partial<EmbeddedToolRuntime>;
+    if (
+      typeof coreModule.runToolRequest === "function" &&
+      typeof coreModule.resumeToolRequest === "function"
+    ) {
+      return {
+        runToolRequest: coreModule.runToolRequest,
+        resumeToolRequest: coreModule.resumeToolRequest,
+      };
+    }
+  } catch (error) {
+    primaryLoadError = error;
+  }
+
+  try {
+    const packageEntryPath = lobsterRequire.resolve("@clawdbot/lobster");
+    const packageRoot = findLobsterPackageRoot(packageEntryPath);
+    const [
+      parserModule,
+      registryModule,
+      runtimeModule,
+      tokenModule,
+      resumeModule,
+      workflowFileModule,
+    ] = await Promise.all([
+      importLobsterModule<{ parsePipeline: LobsterPackageCompatModules["parsePipeline"] }>(
+        packageRoot,
+        "dist/src/parser.js",
+      ),
+      importLobsterModule<{
+        createDefaultRegistry: LobsterPackageCompatModules["createDefaultRegistry"];
+      }>(packageRoot, "dist/src/commands/registry.js"),
+      importLobsterModule<{ runPipeline: LobsterPackageCompatModules["runPipeline"] }>(
+        packageRoot,
+        "dist/src/runtime.js",
+      ),
+      importLobsterModule<{ encodeToken: LobsterPackageCompatModules["encodeToken"] }>(
+        packageRoot,
+        "dist/src/token.js",
+      ),
+      importLobsterModule<{
+        decodeResumeToken: LobsterPackageCompatModules["decodeResumeToken"];
+      }>(packageRoot, "dist/src/resume.js"),
+      importLobsterModule<{
+        runWorkflowFile: LobsterPackageCompatModules["runWorkflowFile"];
+      }>(packageRoot, "dist/src/workflows/file.js"),
+    ]);
+
+    return createCompatEmbeddedToolRuntime({
+      parsePipeline: parserModule.parsePipeline,
+      createDefaultRegistry: registryModule.createDefaultRegistry,
+      runPipeline: runtimeModule.runPipeline,
+      encodeToken: tokenModule.encodeToken,
+      decodeResumeToken: resumeModule.decodeResumeToken,
+      runWorkflowFile: workflowFileModule.runWorkflowFile,
+    });
+  } catch (compatError) {
+    throw new Error("Failed to load the Lobster embedded runtime", {
+      cause: compatError ?? primaryLoadError,
+    });
+  }
 }
 
 export function createEmbeddedLobsterRunner(options?: {

--- a/scripts/pnpm-runner.mjs
+++ b/scripts/pnpm-runner.mjs
@@ -7,10 +7,12 @@ function getPortableBasename(value) {
   return value.split(/[/\\]/).at(-1) ?? value;
 }
 
-function isPnpmExecPath(value, platform = process.platform) {
-  return /^pnpm(?:-cli)?(?:\.(?:[cm]?js|cmd|exe))?$/.test(
-    getPortableBasename(value).toLowerCase(),
-  );
+function getPortableExtension(value) {
+  return path.posix.extname(getPortableBasename(value)).toLowerCase();
+}
+
+function isPnpmExecPath(value) {
+  return /^pnpm(?:-cli)?(?:\.(?:[cm]?js|cmd|exe))?$/.test(getPortableBasename(value).toLowerCase());
 }
 
 function hasScriptShebang(value) {
@@ -32,11 +34,11 @@ function hasScriptShebang(value) {
   }
 }
 
-function isNodeRunnablePnpmExecPath(value, platform = process.platform) {
-  if (!isPnpmExecPath(value, platform)) {
+function isNodeRunnablePnpmExecPath(value) {
+  if (!isPnpmExecPath(value)) {
     return false;
   }
-  const extension = path.posix.extname(getPortableBasename(value)).toLowerCase();
+  const extension = getPortableExtension(value);
   if (extension === ".js" || extension === ".cjs" || extension === ".mjs") {
     return true;
   }
@@ -57,23 +59,29 @@ export function resolvePnpmRunner(params = {}) {
   if (
     typeof npmExecPath === "string" &&
     npmExecPath.length > 0 &&
-    isPnpmExecPath(npmExecPath, platform)
+    isPnpmExecPath(npmExecPath)
   ) {
-    if (isNodeRunnablePnpmExecPath(npmExecPath, platform)) {
+    if (isNodeRunnablePnpmExecPath(npmExecPath)) {
       return {
         command: nodeExecPath,
         args: [...nodeArgs, npmExecPath, ...pnpmArgs],
         shell: false,
       };
     }
-    if (
-      platform === "win32" &&
-      path.posix.extname(getPortableBasename(npmExecPath)).toLowerCase() === ".exe"
-    ) {
+    const npmExecExtension = getPortableExtension(npmExecPath);
+    if (platform === "win32" && npmExecExtension === ".exe") {
       return {
         command: npmExecPath,
         args: pnpmArgs,
         shell: false,
+      };
+    }
+    if (platform === "win32" && npmExecExtension === ".cmd") {
+      return {
+        command: comSpec,
+        args: ["/d", "/s", "/c", buildCmdExeCommandLine(npmExecPath, pnpmArgs)],
+        shell: false,
+        windowsVerbatimArguments: true,
       };
     }
   }

--- a/scripts/pnpm-runner.mjs
+++ b/scripts/pnpm-runner.mjs
@@ -3,8 +3,14 @@ import { closeSync, openSync, readSync } from "node:fs";
 import path from "node:path";
 import { buildCmdExeCommandLine } from "./windows-cmd-helpers.mjs";
 
-function isPnpmExecPath(value) {
-  return /^pnpm(?:-cli)?(?:\.(?:[cm]?js|cmd|exe))?$/.test(path.basename(value).toLowerCase());
+function getPortableBasename(value) {
+  return value.split(/[/\\]/).at(-1) ?? value;
+}
+
+function isPnpmExecPath(value, platform = process.platform) {
+  return /^pnpm(?:-cli)?(?:\.(?:[cm]?js|cmd|exe))?$/.test(
+    getPortableBasename(value).toLowerCase(),
+  );
 }
 
 function hasScriptShebang(value) {
@@ -26,11 +32,11 @@ function hasScriptShebang(value) {
   }
 }
 
-function isNodeRunnablePnpmExecPath(value) {
-  if (!isPnpmExecPath(value)) {
+function isNodeRunnablePnpmExecPath(value, platform = process.platform) {
+  if (!isPnpmExecPath(value, platform)) {
     return false;
   }
-  const extension = path.extname(value).toLowerCase();
+  const extension = path.posix.extname(getPortableBasename(value)).toLowerCase();
   if (extension === ".js" || extension === ".cjs" || extension === ".mjs") {
     return true;
   }
@@ -51,16 +57,19 @@ export function resolvePnpmRunner(params = {}) {
   if (
     typeof npmExecPath === "string" &&
     npmExecPath.length > 0 &&
-    isPnpmExecPath(npmExecPath)
+    isPnpmExecPath(npmExecPath, platform)
   ) {
-    if (isNodeRunnablePnpmExecPath(npmExecPath)) {
+    if (isNodeRunnablePnpmExecPath(npmExecPath, platform)) {
       return {
         command: nodeExecPath,
         args: [...nodeArgs, npmExecPath, ...pnpmArgs],
         shell: false,
       };
     }
-    if (platform === "win32" && path.extname(npmExecPath).toLowerCase() === ".exe") {
+    if (
+      platform === "win32" &&
+      path.posix.extname(getPortableBasename(npmExecPath)).toLowerCase() === ".exe"
+    ) {
       return {
         command: npmExecPath,
         args: pnpmArgs,

--- a/scripts/pnpm-runner.mjs
+++ b/scripts/pnpm-runner.mjs
@@ -51,13 +51,22 @@ export function resolvePnpmRunner(params = {}) {
   if (
     typeof npmExecPath === "string" &&
     npmExecPath.length > 0 &&
-    isNodeRunnablePnpmExecPath(npmExecPath)
+    isPnpmExecPath(npmExecPath)
   ) {
-    return {
-      command: nodeExecPath,
-      args: [...nodeArgs, npmExecPath, ...pnpmArgs],
-      shell: false,
-    };
+    if (isNodeRunnablePnpmExecPath(npmExecPath)) {
+      return {
+        command: nodeExecPath,
+        args: [...nodeArgs, npmExecPath, ...pnpmArgs],
+        shell: false,
+      };
+    }
+    if (platform === "win32" && path.extname(npmExecPath).toLowerCase() === ".exe") {
+      return {
+        command: npmExecPath,
+        args: pnpmArgs,
+        shell: false,
+      };
+    }
   }
 
   if (platform === "win32") {

--- a/test/scripts/pnpm-runner.test.ts
+++ b/test/scripts/pnpm-runner.test.ts
@@ -131,6 +131,27 @@ describe("resolvePnpmRunner", () => {
     });
   });
 
+  it("wraps an explicit pnpm.cmd path via cmd.exe on Windows", () => {
+    expect(
+      resolvePnpmRunner({
+        comSpec: "C:\\Windows\\System32\\cmd.exe",
+        npmExecPath: "C:\\Program Files\\pnpm\\pnpm.cmd",
+        pnpmArgs: ["exec", "vitest", "run", "-t", "path with spaces"],
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        '"C:\\Program Files\\pnpm\\pnpm.cmd" exec vitest run -t "path with spaces"',
+      ],
+      shell: false,
+      windowsVerbatimArguments: true,
+    });
+  });
+
   it("falls back to bare pnpm on non-Windows when npm_execpath is missing", () => {
     expect(
       resolvePnpmRunner({

--- a/test/scripts/pnpm-runner.test.ts
+++ b/test/scripts/pnpm-runner.test.ts
@@ -110,6 +110,27 @@ describe("resolvePnpmRunner", () => {
     });
   });
 
+  it("uses pnpm.cjs through node for Windows-style paths", () => {
+    expect(
+      resolvePnpmRunner({
+        npmExecPath:
+          "C:\\Users\\test\\AppData\\Local\\node\\corepack\\v1\\pnpm\\10.32.1\\bin\\pnpm.cjs",
+        nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "C:\\Program Files\\nodejs\\node.exe",
+      args: [
+        "C:\\Users\\test\\AppData\\Local\\node\\corepack\\v1\\pnpm\\10.32.1\\bin\\pnpm.cjs",
+        "exec",
+        "vitest",
+        "run",
+      ],
+      shell: false,
+    });
+  });
+
   it("falls back to bare pnpm on non-Windows when npm_execpath is missing", () => {
     expect(
       resolvePnpmRunner({

--- a/test/scripts/pnpm-runner.test.ts
+++ b/test/scripts/pnpm-runner.test.ts
@@ -92,6 +92,24 @@ describe("resolvePnpmRunner", () => {
     }
   });
 
+  it("executes pnpm.exe directly on Windows", () => {
+    expect(
+      resolvePnpmRunner({
+        npmExecPath:
+          "C:\\Users\\test\\AppData\\Local\\pnpm\\.tools\\@pnpm+exe\\10.32.1\\node_modules\\@pnpm\\exe\\pnpm.exe",
+        nodeArgs: ["--no-maglev"],
+        nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "win32",
+      }),
+    ).toEqual({
+      command:
+        "C:\\Users\\test\\AppData\\Local\\pnpm\\.tools\\@pnpm+exe\\10.32.1\\node_modules\\@pnpm\\exe\\pnpm.exe",
+      args: ["exec", "vitest", "run"],
+      shell: false,
+    });
+  });
+
   it("falls back to bare pnpm on non-Windows when npm_execpath is missing", () => {
     expect(
       resolvePnpmRunner({


### PR DESCRIPTION
## Summary
- openclaw wouldn't install on Windows in this environment because the install/build path still tripped over Windows-specific pnpm and Lobster runtime behavior
- keep the Windows-specific `pnpm.exe` direct-exec path on top of the upstream native-binary pnpm fix
- restore a compatibility fallback for the Lobster embedded runtime when `@clawdbot/lobster/core` is not available from the installed package

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Root Cause
- On Windows with `@pnpm/exe`, `npm_execpath` can point at `pnpm.exe`, which still needs to be executed directly instead of being routed through the generic JS-entrypoint path.
- The Lobster plugin currently assumes `@clawdbot/lobster/core` is present from the installed package, but current Windows installs can still hit a missing embedded-runtime entrypoint and fail during build/install flows.

## User-visible / Behavior Changes
- Windows installs that expose `pnpm.exe` through `npm_execpath` can continue through the build path instead of trying the wrong execution mode.
- Lobster falls back to the installed package internals when the published `@clawdbot/lobster/core` runtime entrypoint is unavailable.

## Repro + Verification
### Environment
- OS: Windows 11
- Runtime/container: local pnpm workspace / global install path
- Model/provider: N/A
- Integration/channel (if any): Lobster bundled plugin

### Verified
- `pnpm test test/scripts/pnpm-runner.test.ts extensions/lobster/src/lobster-runner.test.ts`
- Added a Windows `pnpm.exe` regression test.
- Added Lobster installed-package fallback coverage using `commands.list`.

### Build Note
- `pnpm build` still hits the existing unrelated Windows `EPERM` rename failure during `runtime-postbuild` under `scripts/stage-bundled-plugin-runtime-deps.mjs`.
- That failure moved between different extensions across reruns and does not appear tied to the four files in this branch.
