### PR TITLE
fix(ui): suppress screen reader announcements during streaming via aria-busy

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1176,11 +1176,13 @@ export function renderChat(props: ChatProps) {
   };
   const isEmpty = chatItems.length === 0 && !props.loading;
 
+  const isStreaming = props.stream !== null;
   const thread = html`
     <div
       class="chat-thread"
       role="log"
       aria-live="polite"
+      aria-busy=${isStreaming ? "true" : "false"}
       @scroll=${props.onChatScroll}
       @click=${handleCodeBlockCopy}
     >


### PR DESCRIPTION
## Summary

Fixes #65538 — screen readers announced every streamed token because the `chat-thread` element has `role="log"` with `aria-live="polite"`, causing each DOM mutation during streaming to trigger a new announcement.

## Fix

Set `aria-busy="true"` on the `chat-thread` div while `props.stream !== null` (i.e. a response is actively streaming). According to the WAI-ARIA spec, screen readers should defer live region announcements while `aria-busy` is true. Once streaming completes, `aria-busy` returns to `"false"` and the completed response is announced as a single update.

**Before:** Screen reader announces every token fragment during streaming — constant fragmented speech.

**After:** Screen reader stays silent during streaming, then announces the completed response once.

## Files changed

- `ui/src/ui/views/chat.ts` — 2 lines added to `renderChat()`

## Test plan

- [ ] Start OpenClaw and open the Control UI
- [ ] Enable a screen reader (VoiceOver on macOS or NVDA on Windows)
- [ ] Send a message and observe that streaming tokens are no longer announced
- [ ] Confirm the completed response is announced once streaming finishes