### PR TITLE
fix(bluebubbles): retry attachment fetch when webhook arrives with empty array (#65430)

### DIFF
--- a/extensions/bluebubbles/src/attachments.test.ts
+++ b/extensions/bluebubbles/src/attachments.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-mocks.js";
-import { downloadBlueBubblesAttachment, sendBlueBubblesAttachment } from "./attachments.js";
+import {
+  downloadBlueBubblesAttachment,
+  fetchBlueBubblesMessageAttachments,
+  sendBlueBubblesAttachment,
+} from "./attachments.js";
 import { fetchBlueBubblesServerInfo, getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
 import type { PluginRuntime } from "./runtime-api.js";
 import { setBlueBubblesRuntime } from "./runtime.js";
@@ -767,5 +771,129 @@ describe("sendBlueBubblesAttachment", () => {
         opts: { serverUrl: "http://localhost:1234", password: "test" },
       }),
     ).rejects.toThrow("chatGuid not found");
+  });
+});
+
+describe("fetchBlueBubblesMessageAttachments", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("returns attachments when the API responds with attachment data", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            guid: "msg-123",
+            attachments: [
+              {
+                guid: "att-1",
+                mimeType: "image/jpeg",
+                transferName: "photo.jpg",
+                totalBytes: 12345,
+              },
+              {
+                guid: "att-2",
+                mime_type: "image/png",
+                transfer_name: "screenshot.png",
+              },
+            ],
+          },
+        }),
+    });
+
+    const result = await fetchBlueBubblesMessageAttachments("msg-123", {
+      baseUrl: "http://localhost:1234",
+      password: "test",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      guid: "att-1",
+      uti: undefined,
+      mimeType: "image/jpeg",
+      transferName: "photo.jpg",
+      totalBytes: 12345,
+      height: undefined,
+      width: undefined,
+      originalROWID: undefined,
+    });
+    expect(result[1]?.guid).toBe("att-2");
+    expect(result[1]?.mimeType).toBe("image/png");
+    expect(result[1]?.transferName).toBe("screenshot.png");
+  });
+
+  it("returns empty array when API response has no attachments", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: { guid: "msg-456", attachments: [] },
+        }),
+    });
+
+    const result = await fetchBlueBubblesMessageAttachments("msg-456", {
+      baseUrl: "http://localhost:1234",
+      password: "test",
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array when API returns non-OK status", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const result = await fetchBlueBubblesMessageAttachments("msg-missing", {
+      baseUrl: "http://localhost:1234",
+      password: "test",
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array on network error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network timeout"));
+
+    const result = await fetchBlueBubblesMessageAttachments("msg-timeout", {
+      baseUrl: "http://localhost:1234",
+      password: "test",
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array for empty GUID", async () => {
+    const result = await fetchBlueBubblesMessageAttachments("  ", {
+      baseUrl: "http://localhost:1234",
+      password: "test",
+    });
+
+    expect(result).toHaveLength(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("skips attachment entries without a guid", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            guid: "msg-789",
+            attachments: [
+              { mimeType: "image/jpeg", transferName: "no-guid.jpg" },
+              { guid: "att-valid", mimeType: "image/png" },
+            ],
+          },
+        }),
+    });
+
+    const result = await fetchBlueBubblesMessageAttachments("msg-789", {
+      baseUrl: "http://localhost:1234",
+      password: "test",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.guid).toBe("att-valid");
   });
 });

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -95,6 +95,104 @@ function readMediaFetchErrorCode(error: unknown): MediaFetchErrorCode | undefine
     : undefined;
 }
 
+/**
+ * Fetch attachment metadata for a message from the BlueBubbles server by GUID.
+ *
+ * When the initial webhook arrives with an empty `attachments` array (common
+ * when Private API is disabled), this function can be called after a short
+ * delay to re-fetch the message and extract any attachments that BlueBubbles
+ * has since indexed.
+ */
+export async function fetchBlueBubblesMessageAttachments(
+  messageGuid: string,
+  opts: {
+    baseUrl: string;
+    password: string;
+    allowPrivateNetwork?: boolean;
+    timeoutMs?: number;
+  },
+): Promise<BlueBubblesAttachment[]> {
+  const trimmedGuid = messageGuid.trim();
+  if (!trimmedGuid) {
+    return [];
+  }
+  const url = buildBlueBubblesApiUrl({
+    baseUrl: opts.baseUrl,
+    path: `/api/v1/message/${encodeURIComponent(trimmedGuid)}`,
+    password: opts.password,
+  });
+  const ssrfPolicy: SsrFPolicy = opts.allowPrivateNetwork
+    ? { allowPrivateNetwork: true }
+    : {};
+  try {
+    const res = await blueBubblesFetchWithTimeout(
+      url,
+      { method: "GET", headers: { "Content-Type": "application/json" } },
+      opts.timeoutMs ?? 10_000,
+      ssrfPolicy,
+    );
+    if (!res.ok) {
+      return [];
+    }
+    const json = (await res.json().catch(() => null)) as {
+      data?: Record<string, unknown>;
+    } | null;
+    const data = json?.data;
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+      return [];
+    }
+    const rawAttachments = data["attachments"];
+    if (!Array.isArray(rawAttachments) || rawAttachments.length === 0) {
+      return [];
+    }
+    const attachments: BlueBubblesAttachment[] = [];
+    for (const entry of rawAttachments) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        continue;
+      }
+      const rec = entry as Record<string, unknown>;
+      const guid =
+        typeof rec["guid"] === "string" ? rec["guid"].trim() || undefined : undefined;
+      if (!guid) {
+        continue;
+      }
+      attachments.push({
+        guid,
+        uti: typeof rec["uti"] === "string" ? rec["uti"] : undefined,
+        mimeType:
+          typeof rec["mimeType"] === "string"
+            ? rec["mimeType"]
+            : typeof rec["mime_type"] === "string"
+              ? rec["mime_type"]
+              : undefined,
+        transferName:
+          typeof rec["transferName"] === "string"
+            ? rec["transferName"]
+            : typeof rec["transfer_name"] === "string"
+              ? rec["transfer_name"]
+              : undefined,
+        totalBytes:
+          typeof rec["totalBytes"] === "number"
+            ? rec["totalBytes"]
+            : typeof rec["total_bytes"] === "number"
+              ? rec["total_bytes"]
+              : undefined,
+        height: typeof rec["height"] === "number" ? rec["height"] : undefined,
+        width: typeof rec["width"] === "number" ? rec["width"] : undefined,
+        originalROWID:
+          typeof rec["originalROWID"] === "number"
+            ? rec["originalROWID"]
+            : typeof rec["rowid"] === "number"
+              ? rec["rowid"]
+              : undefined,
+      });
+    }
+    return attachments;
+  } catch {
+    return [];
+  }
+}
+
 export async function downloadBlueBubblesAttachment(
   attachment: BlueBubblesAttachment,
   opts: BlueBubblesAttachmentOpts & { maxBytes?: number } = {},

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -9,7 +9,10 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/text-runtime";
-import { downloadBlueBubblesAttachment } from "./attachments.js";
+import {
+  downloadBlueBubblesAttachment,
+  fetchBlueBubblesMessageAttachments,
+} from "./attachments.js";
 import { markBlueBubblesChatRead, sendBlueBubblesTyping } from "./chat.js";
 import { resolveBlueBubblesConversationRoute } from "./conversation-route.js";
 import { fetchBlueBubblesHistory } from "./history.js";
@@ -1068,11 +1071,50 @@ async function processMessageAfterDedupe(
   let mediaUrls: string[] = [];
   let mediaPaths: string[] = [];
   let mediaTypes: string[] = [];
-  if (attachments.length > 0) {
+  // Resolve which attachments to download.  When the webhook carries a
+  // populated array we use it directly.  When the array is empty and we have a
+  // message GUID, re-fetch the message from the BlueBubbles server after a
+  // short delay — BlueBubbles may not have indexed the attachment yet when the
+  // webhook fires (common when Private API is disabled).  (#65430)
+  let resolvedAttachments = attachments;
+  if (
+    resolvedAttachments.length === 0 &&
+    message.messageId &&
+    baseUrl &&
+    password
+  ) {
+    try {
+      // Give BlueBubbles time to index the attachment before re-fetching.
+      await new Promise<void>((resolve) => setTimeout(resolve, 2_000));
+      const fetched = await fetchBlueBubblesMessageAttachments(
+        message.messageId,
+        {
+          baseUrl,
+          password,
+          allowPrivateNetwork: isPrivateNetworkOptInEnabled(account.config),
+        },
+      );
+      if (fetched.length > 0) {
+        logVerbose(
+          core,
+          runtime,
+          `attachment retry found ${fetched.length} attachment(s) for msgId=${message.messageId}`,
+        );
+        resolvedAttachments = fetched;
+      }
+    } catch (err) {
+      logVerbose(
+        core,
+        runtime,
+        `attachment retry failed msgId=${message.messageId}: ${String(err)}`,
+      );
+    }
+  }
+  if (resolvedAttachments.length > 0) {
     if (!baseUrl || !password) {
       logVerbose(core, runtime, "attachment download skipped (missing serverUrl/password)");
     } else {
-      for (const attachment of attachments) {
+      for (const attachment of resolvedAttachments) {
         if (!attachment.guid) {
           continue;
         }


### PR DESCRIPTION
## Summary
When BlueBubbles Private API is disabled, inbound image webhooks arrive with an empty `attachments: []` array because BlueBubbles has not yet indexed the attachment. This causes OpenClaw to skip the attachment download entirely, so the agent never receives the image.

## Root Cause
In `extensions/bluebubbles/src/monitor-processing.ts`, the attachment download block is gated on `attachments.length > 0`. When the webhook fires before BlueBubbles indexes the attachment, the array is empty and the entire download path is skipped with no fallback.

## Changes
- `extensions/bluebubbles/src/attachments.ts`: Add `fetchBlueBubblesMessageAttachments()` helper that fetches a message by GUID from the BlueBubbles API and extracts attachment metadata from the response.
- `extensions/bluebubbles/src/monitor-processing.ts`: When the webhook attachment array is empty and a message GUID is available, wait 2 seconds and re-fetch the message from the BlueBubbles server to recover any newly-indexed attachments.
- `extensions/bluebubbles/src/attachments.test.ts`: Add 6 test cases covering the new fetch helper (success, empty, HTTP error, network error, empty GUID, entries without guid).

## Test
```
pnpm test extensions/bluebubbles/src/attachments.test.ts
# 40 tests passed (including 6 new)
```

Closes #65430