### PR TITLE
Fix onboarding trim guards and expose apply_patch error details

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -141,6 +141,18 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("always includes apply_patch error details even when verbose mode is off", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "apply_patch", error: "file is outside workspace root" },
+      verboseLevel: "off",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Apply Patch",
+      detail: "file is outside workspace root",
+    });
+  });
+
   it.each([
     {
       name: "includes details for mutating tool failures when verbose is on",

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -52,6 +52,8 @@ function isVerboseToolDetailEnabled(level?: VerboseLevel): boolean {
   return level === "on" || level === "full";
 }
 
+const ALWAYS_DETAILED_TOOL_ERRORS = new Set(["apply_patch"]);
+
 function shouldIncludeToolErrorDetails(params: {
   lastToolError: ToolErrorSummary;
   isCronTrigger?: boolean;
@@ -59,6 +61,13 @@ function shouldIncludeToolErrorDetails(params: {
   verboseLevel?: VerboseLevel;
 }): boolean {
   if (isVerboseToolDetailEnabled(params.verboseLevel)) {
+    return true;
+  }
+  if (
+    ALWAYS_DETAILED_TOOL_ERRORS.has(
+      normalizeOptionalLowercaseString(params.lastToolError.toolName) ?? "",
+    )
+  ) {
     return true;
   }
   return (

--- a/src/channels/plugins/setup-wizard-helpers.test.ts
+++ b/src/channels/plugins/setup-wizard-helpers.test.ts
@@ -505,6 +505,25 @@ describe("promptSingleChannelToken", () => {
     expect(result).toEqual(expected);
     expect(prompter.text).toHaveBeenCalledTimes(expectTextCalls);
   });
+
+  it("tolerates undefined text results without throwing", async () => {
+    const prompter = {
+      confirm: vi.fn(async () => false),
+      text: vi.fn(async () => undefined),
+    };
+
+    await expect(
+      promptSingleChannelToken({
+        prompter: prompter as never,
+        accountConfigured: false,
+        canUseEnv: false,
+        hasConfigToken: false,
+        envPrompt: "use env",
+        keepPrompt: "keep",
+        inputPrompt: "token",
+      }),
+    ).resolves.toEqual({ useEnv: false, token: "" });
+  });
 });
 
 describe("promptSingleChannelSecretInput", () => {

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -985,13 +985,13 @@ export async function promptSingleChannelToken(params: {
   keepPrompt: string;
   inputPrompt: string;
 }): Promise<{ useEnv: boolean; token: string | null }> {
-  const promptToken = async (): Promise<string> =>
-    (
-      await params.prompter.text({
-        message: params.inputPrompt,
-        validate: (value) => (value?.trim() ? undefined : "Required"),
-      })
-    ).trim();
+  const promptToken = async (): Promise<string> => {
+    const value = await params.prompter.text({
+      message: params.inputPrompt,
+      validate: (value) => (value?.trim() ? undefined : "Required"),
+    });
+    return normalizeOptionalString(value) ?? "";
+  };
 
   if (params.canUseEnv) {
     const keepEnv = await params.prompter.confirm({

--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -455,7 +455,7 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
               });
             },
           });
-          const trimmedValue = rawValue.trim();
+          const trimmedValue = normalizeOptionalString(rawValue) ?? initialValue ?? "";
           if (!trimmedValue && textInput.required === false) {
             if (textInput.applyEmptyValue) {
               next = await applyWizardTextInputValue({

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -168,6 +168,24 @@ describe("promptCustomApiConfig", () => {
     );
   });
 
+  it("tolerates undefined base URL text results by falling back to the initial value", async () => {
+    const prompter = createTestPrompter({
+      text: [] as string[],
+      select: ["plaintext", "openai"],
+    });
+    prompter.text
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("llama3")
+      .mockResolvedValueOnce("custom")
+      .mockResolvedValueOnce("");
+    stubFetchSequence([{ ok: true }]);
+
+    const result = await runPromptCustomApi(prompter);
+
+    expect(result.config.models?.providers?.custom?.baseUrl).toBe(OLLAMA_DEFAULT_BASE_URL_FOR_TEST);
+  });
+
   it("retries when verification fails", async () => {
     const prompter = createTestPrompter({
       text: ["http://localhost:11434/v1", "", "bad-model", "good-model", "custom", ""],

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -450,7 +450,10 @@ async function promptBaseUrlAndKey(params: {
       return URL.canParse(val) ? undefined : "Please enter a valid URL (e.g. http://...)";
     },
   });
-  const baseUrl = baseUrlInput.trim();
+  const baseUrl =
+    normalizeOptionalString(baseUrlInput) ??
+    normalizeOptionalString(params.initialBaseUrl) ??
+    OLLAMA_DEFAULT_BASE_URL;
   const providerHint = buildEndpointIdFromUrl(baseUrl) || "custom";
   let apiKeyInput: SecretInput | undefined;
   const resolvedApiKey = await ensureApiKeyFromEnvOrPrompt({
@@ -487,13 +490,12 @@ async function promptCustomApiRetryChoice(prompter: WizardPrompter): Promise<Cus
 }
 
 async function promptCustomApiModelId(prompter: WizardPrompter): Promise<string> {
-  return (
-    await prompter.text({
-      message: "Model ID",
-      placeholder: "e.g. llama3, claude-3-7-sonnet",
-      validate: (val) => (val.trim() ? undefined : "Model ID is required"),
-    })
-  ).trim();
+  const modelInput = await prompter.text({
+    message: "Model ID",
+    placeholder: "e.g. llama3, claude-3-7-sonnet",
+    validate: (val) => (val.trim() ? undefined : "Model ID is required"),
+  });
+  return normalizeOptionalString(modelInput) ?? "";
 }
 
 async function applyCustomApiRetryChoice(params: {

--- a/src/commands/onboard-remote.test.ts
+++ b/src/commands/onboard-remote.test.ts
@@ -199,6 +199,39 @@ describe("promptRemoteGatewayConfig", () => {
     expect(next.gateway?.remote?.tlsFingerprint).toBeUndefined();
   });
 
+  it("tolerates undefined token text results by keeping the existing token", async () => {
+    const text: WizardPrompter["text"] = vi.fn(async (params) => {
+      if (params.message === "Gateway WebSocket URL") {
+        return String(params.initialValue);
+      }
+      if (params.message === "Gateway token") {
+        return undefined as never;
+      }
+      return "" as never;
+    }) as WizardPrompter["text"];
+
+    const prompter = createPrompter({
+      confirm: vi.fn(async () => false),
+      select: createSelectPrompter({ "Gateway auth": "token" }),
+      text,
+    });
+
+    const next = await promptRemoteGatewayConfig(
+      {
+        gateway: {
+          remote: {
+            url: "wss://existing.example:18789",
+            token: "keep-me",
+          },
+        },
+      } as OpenClawConfig,
+      prompter,
+    );
+
+    expect(next.gateway?.remote?.url).toBe("wss://existing.example:18789");
+    expect(next.gateway?.remote?.token).toBe("keep-me");
+  });
+
   it("drops discovery tlsFingerprint when the URL is edited after trust confirmation", async () => {
     detectBinary.mockResolvedValue(true);
     discoverGatewayBeacons.mockResolvedValue([

--- a/src/commands/onboard-remote.ts
+++ b/src/commands/onboard-remote.ts
@@ -9,6 +9,7 @@ import {
 import { resolveWideAreaDiscoveryDomain } from "../infra/widearea-dns.js";
 import { resolveSecretInputModeForEnvSelection } from "../plugins/provider-auth-mode.js";
 import { promptSecretRefForSetup } from "../plugins/provider-auth-ref.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { detectBinary } from "./onboard-helpers.js";
 import type { SecretInputMode } from "./onboard-types.js";
@@ -19,8 +20,8 @@ function buildLabel(beacon: GatewayBonjourBeacon): string {
   return buildGatewayDiscoveryLabel(beacon);
 }
 
-function ensureWsUrl(value: string): string {
-  const trimmed = value.trim();
+function ensureWsUrl(value: string | undefined | null): string {
+  const trimmed = normalizeOptionalString(value) ?? "";
   if (!trimmed) {
     return DEFAULT_GATEWAY_URL;
   }
@@ -193,13 +194,12 @@ export async function promptRemoteGatewayConfig(
       });
       token = resolved.ref;
     } else {
-      token = (
-        await prompter.text({
-          message: "Gateway token",
-          initialValue: typeof token === "string" ? token : undefined,
-          validate: (value) => (value?.trim() ? undefined : "Required"),
-        })
-      ).trim();
+      const tokenInput = await prompter.text({
+        message: "Gateway token",
+        initialValue: typeof token === "string" ? token : undefined,
+        validate: (value) => (value?.trim() ? undefined : "Required"),
+      });
+      token = normalizeOptionalString(tokenInput) ?? normalizeOptionalString(token) ?? "";
     }
     password = undefined;
   } else if (authChoice === "password") {
@@ -225,13 +225,12 @@ export async function promptRemoteGatewayConfig(
       });
       password = resolved.ref;
     } else {
-      password = (
-        await prompter.text({
-          message: "Gateway password",
-          initialValue: typeof password === "string" ? password : undefined,
-          validate: (value) => (value?.trim() ? undefined : "Required"),
-        })
-      ).trim();
+      const passwordInput = await prompter.text({
+        message: "Gateway password",
+        initialValue: typeof password === "string" ? password : undefined,
+        validate: (value) => (value?.trim() ? undefined : "Required"),
+      });
+      password = normalizeOptionalString(passwordInput) ?? normalizeOptionalString(password) ?? "";
     }
     token = undefined;
   } else {

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -216,7 +216,7 @@ async function promptPluginFields(params: {
         initialValue: currentStr,
         placeholder: hint.placeholder ?? "value1, value2",
       });
-      const trimmed = input.trim();
+      const trimmed = typeof input === "string" ? input.trim() : currentStr;
       if (trimmed !== currentStr) {
         if (trimmed) {
           const values = trimmed
@@ -239,7 +239,7 @@ async function promptPluginFields(params: {
       initialValue: currentStr,
       placeholder: hint.placeholder,
     });
-    const trimmed = input.trim();
+    const trimmed = typeof input === "string" ? input.trim() : currentStr;
     if (trimmed !== currentStr) {
       // Coerce numeric text input when the schema expects a JSON number or integer.
       if (schemaProp?.type === "number" || schemaProp?.type === "integer") {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -16,6 +16,7 @@ import {
 } from "../plugins/status.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { resolveUserPath } from "../utils.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
 import { resolveSetupSecretInputString } from "./setup.secret-input.js";
@@ -485,7 +486,9 @@ export async function runSetupWizard(
           initialValue: baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE,
         }));
 
-  const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
+  const workspaceDir = resolveUserPath(
+    (normalizeOptionalString(workspaceInput) ?? "") || onboardHelpers.DEFAULT_WORKSPACE,
+  );
 
   const { applyLocalSetupWorkspaceConfig } = await import("../commands/onboard-config.js");
   let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(baseConfig, workspaceDir);


### PR DESCRIPTION
## Summary
- make onboarding/setup text prompts tolerate undefined `prompter.text()` results instead of crashing on `.trim()`
- preserve existing remote gateway tokens when the prompt returns no new plaintext value
- always include underlying `apply_patch` error details in embedded runner tool warning payloads

## What changed
- added null-safe trim guards in onboarding/setup flows covering channel token input, channel text inputs, remote gateway config, custom API config, workspace setup, and plugin config text/list fields
- added regression tests for undefined prompt results in the affected onboarding helpers
- added a payload test proving `apply_patch` warnings include the underlying error even when verbose mode is off

## Verification
- `pnpm exec node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/pi-embedded-runner/run/payloads.test.ts src/channels/plugins/setup-wizard-helpers.test.ts src/commands/onboard-remote.test.ts src/commands/onboard-custom.test.ts src/wizard/setup.test.ts`
