### PR TITLE
fix(postinstall): prune stale dist plugin node_modules before dist traversal

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -643,6 +643,32 @@ export function pruneBundledPluginSourceNodeModules(params = {}) {
   }
 }
 
+// Removes stale plugin-local node_modules directories left under dist/extensions/*/
+// by older OpenClaw installs that installed runtime deps nested inside each plugin dir.
+// Since runtime deps are now installed at the package root, these nested directories
+// are obsolete. If left in place they shadow the correct package-root resolution and
+// cause the acpx binary to be resolved from a non-existent nested path.
+export function pruneBundledDistPluginNodeModules(params = {}) {
+  const extensionsDir = params.extensionsDir ?? DEFAULT_EXTENSIONS_DIR;
+  const pathExists = params.existsSync ?? existsSync;
+  const readDir = params.readdirSync ?? readdirSync;
+  const removePath = params.rmSync ?? rmSync;
+
+  if (!pathExists(extensionsDir)) {
+    return;
+  }
+
+  for (const entry of readDir(extensionsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
+      continue;
+    }
+    const pluginNodeModules = join(extensionsDir, entry.name, "node_modules");
+    if (pathExists(pluginNodeModules)) {
+      removePath(pluginNodeModules, { recursive: true, force: true });
+    }
+  }
+}
+
 function shouldRunBundledPluginPostinstall(params) {
   if (params.env?.[DISABLE_POSTINSTALL_ENV]?.trim()) {
     return false;
@@ -683,6 +709,21 @@ export function runBundledPluginPostinstall(params = {}) {
     });
     return;
   }
+  // Remove stale plugin-local node_modules from dist/ before traversing for pruning.
+  // Older installs placed acpx and other runtime deps inside dist/extensions/*/node_modules/;
+  // those directories contain .bin/ symlinks that cause listInstalledDistFiles to throw
+  // "unsafe dist entry" and abort the rest of postinstall, leaving acpx uninstalled at root.
+  try {
+    pruneBundledDistPluginNodeModules({
+      extensionsDir,
+      existsSync: pathExists,
+      readdirSync: params.readdirSync,
+      rmSync: params.rmSync,
+    });
+  } catch (e) {
+    log.warn(`[postinstall] could not prune stale dist plugin node_modules: ${String(e)}`);
+  }
+
   const prunedDistFiles = pruneInstalledPackageDist({
     packageRoot,
     existsSync: pathExists,

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -5,6 +5,7 @@ import {
   createNestedNpmInstallEnv,
   pruneInstalledPackageDist,
   discoverBundledPluginRuntimeDeps,
+  pruneBundledDistPluginNodeModules,
   pruneBundledPluginSourceNodeModules,
   restoreLegacyUpdaterCompatSidecars,
   runBundledPluginPostinstall,
@@ -705,5 +706,96 @@ describe("bundled plugin postinstall", () => {
     });
 
     expect(removePath).not.toHaveBeenCalled();
+  });
+
+  it("prunes stale node_modules from dist plugin directories", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-dist-prune-");
+    const extensionsDir = path.join(packageRoot, "dist", "extensions");
+    // Simulate stale nested node_modules left by an older install
+    await fs.mkdir(path.join(extensionsDir, "acpx", "node_modules", ".bin"), { recursive: true });
+    await fs.mkdir(path.join(extensionsDir, "acpx", "node_modules", "acpx"), { recursive: true });
+    await fs.writeFile(
+      path.join(extensionsDir, "acpx", "node_modules", "acpx", "package.json"),
+      JSON.stringify({ name: "acpx", version: "0.4.1" }),
+    );
+
+    pruneBundledDistPluginNodeModules({ extensionsDir });
+
+    await expect(
+      fs.stat(path.join(extensionsDir, "acpx", "node_modules")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("leaves dist plugin directories without node_modules untouched", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-dist-prune-clean-");
+    const extensionsDir = path.join(packageRoot, "dist", "extensions");
+    await fs.mkdir(path.join(extensionsDir, "acpx"), { recursive: true });
+    await fs.writeFile(
+      path.join(extensionsDir, "acpx", "runtime-api.js"),
+      "export {};\n",
+    );
+
+    pruneBundledDistPluginNodeModules({ extensionsDir });
+
+    await expect(
+      fs.stat(path.join(extensionsDir, "acpx", "runtime-api.js")),
+    ).resolves.toBeTruthy();
+  });
+
+  it("skips symlink entries when pruning dist plugin node_modules", () => {
+    const removePath = vi.fn();
+
+    pruneBundledDistPluginNodeModules({
+      extensionsDir: "/dist/extensions",
+      existsSync: vi.fn((value) => value === "/dist/extensions"),
+      readdirSync: vi.fn(() => [
+        {
+          name: "acpx",
+          isDirectory: () => true,
+          isSymbolicLink: () => true,
+        },
+      ]),
+      rmSync: removePath,
+    });
+
+    expect(removePath).not.toHaveBeenCalled();
+  });
+
+  it("prunes stale dist plugin node_modules before dist prune so symlinks do not abort postinstall", async () => {
+    // Regression: stale dist/extensions/*/node_modules/ left by older installs
+    // caused listInstalledDistFiles to throw "unsafe dist entry" on any symlinks inside
+    // them (e.g. .bin/acpx), aborting postinstall before acpx could be installed at root.
+    // pruneBundledDistPluginNodeModules must run first to remove those directories.
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "acpx", {
+      dependencies: { acpx: "0.5.3" },
+    });
+
+    // Simulate stale plugin-local node_modules left by an older OpenClaw install
+    await fs.mkdir(path.join(extensionsDir, "acpx", "node_modules", ".bin"), { recursive: true });
+    await fs.writeFile(
+      path.join(extensionsDir, "acpx", "node_modules", ".bin", "acpx"),
+      "#!/usr/bin/env node\n",
+    );
+
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
+
+    // postinstall should complete and install acpx despite the stale node_modules
+    runBundledPluginPostinstall({
+      env: {
+        npm_config_global: "true",
+        npm_config_location: "global",
+        npm_config_prefix: "/opt/homebrew",
+        HOME: "/tmp/home",
+      },
+      extensionsDir,
+      packageRoot,
+      npmRunner: createBareNpmRunner(["acpx@0.5.3"]),
+      spawnSync,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expectNpmInstallSpawn(spawnSync, packageRoot, ["acpx@0.5.3"]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #65921 — ACP launcher resolves bundled acpx from wrong path after update.

**Root cause:** On `npm install -g openclaw` upgrade, npm does not remove directories absent from the new tarball. Older OpenClaw installs placed runtime deps (including `acpx`) inside `dist/extensions/acpx/node_modules/`. After upgrading, this stale directory remained. When postinstall called `listInstalledDistFiles`, it recursively traversed `dist/` and threw `"unsafe dist entry"` on any symlinks inside `.bin/` (e.g. `dist/extensions/acpx/node_modules/.bin/acpx`), aborting the rest of postinstall before `acpx` could be installed at the package root. Node.js then resolved the `acpx` binary from the stale nested path instead of `node_modules/.bin/acpx` at the package root.

**Fix:** Add `pruneBundledDistPluginNodeModules` — mirroring the existing `pruneBundledPluginSourceNodeModules` for source checkouts — and call it in `runBundledPluginPostinstall` immediately before `pruneInstalledPackageDist`, so stale `dist/extensions/*/node_modules/` directories are removed before `listInstalledDistFiles` traverses `dist/`.

## Changes

- `scripts/postinstall-bundled-plugins.mjs` — new exported `pruneBundledDistPluginNodeModules` function; called with a try/catch guard in `runBundledPluginPostinstall` before the dist prune step
- `test/scripts/postinstall-bundled-plugins.test.ts` — four new test cases covering: prune removes stale dirs, clean dirs are untouched, symlink plugin entries are skipped, and a regression test that postinstall completes and installs `acpx` even when stale nested `node_modules` are present

## Test plan

- [x] `pnpm test test/scripts/postinstall-bundled-plugins.test.ts` — 4 new tests pass, 0 regressions introduced
- [ ] Manual: install an older version of openclaw globally, then upgrade to this branch's build and confirm `node_modules/.bin/acpx` resolves correctly and ACP launches succeed