### PR TITLE
fix: package qa-channel public surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
     "!dist/**/*.map",
     "!dist/plugin-sdk/.tsbuildinfo",
     "!dist/extensions/*/node_modules/**",
-    "!dist/extensions/qa-channel/**",
-    "dist/extensions/qa-channel/runtime-api.js",
     "!dist/extensions/qa-lab/**",
     "!dist/extensions/qa-matrix/**",
     "!dist/plugin-sdk/extensions/qa-lab/**",

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -8,7 +8,7 @@ import {
 import { shouldBuildBundledCluster } from "./optional-bundled-clusters.mjs";
 
 const TOP_LEVEL_PUBLIC_SURFACE_EXTENSIONS = new Set([".ts", ".js", ".mts", ".cts", ".mjs", ".cjs"]);
-export const NON_PACKAGED_BUNDLED_PLUGIN_DIRS = new Set(["qa-channel", "qa-lab", "qa-matrix"]);
+export const NON_PACKAGED_BUNDLED_PLUGIN_DIRS = new Set(["qa-lab", "qa-matrix"]);
 const toPosixPath = (value) => value.replaceAll("\\", "/");
 
 function readBundledPluginPackageJson(packageJsonPath) {

--- a/scripts/lib/bundled-runtime-sidecar-paths.json
+++ b/scripts/lib/bundled-runtime-sidecar-paths.json
@@ -23,6 +23,7 @@
   "dist/extensions/nostr/runtime-api.js",
   "dist/extensions/ollama/runtime-api.js",
   "dist/extensions/open-prose/runtime-api.js",
+  "dist/extensions/qa-channel/runtime-api.js",
   "dist/extensions/qqbot/runtime-api.js",
   "dist/extensions/signal/runtime-api.js",
   "dist/extensions/slack/runtime-api.js",

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -44,15 +44,9 @@ type InstalledBundledExtensionManifestRecord = {
 const MAX_BUNDLED_EXTENSION_MANIFEST_BYTES = 1024 * 1024;
 const LEGACY_CONTEXT_ENGINE_UNRESOLVED_RUNTIME_MARKER =
   "Failed to load legacy context engine runtime.";
-const LEGACY_UPDATE_COMPAT_RUNTIME_SIDECAR_PATHS = [
-  "dist/extensions/qa-channel/runtime-api.js",
-] as const;
-const PUBLISHED_BUNDLED_RUNTIME_SIDECAR_PATHS = [
-  ...BUNDLED_RUNTIME_SIDECAR_PATHS.filter((relativePath) =>
-    listBundledPluginPackArtifacts().includes(relativePath),
-  ),
-  ...LEGACY_UPDATE_COMPAT_RUNTIME_SIDECAR_PATHS,
-] as const;
+const PUBLISHED_BUNDLED_RUNTIME_SIDECAR_PATHS = BUNDLED_RUNTIME_SIDECAR_PATHS.filter(
+  (relativePath) => listBundledPluginPackArtifacts().includes(relativePath),
+);
 
 export type PublishedInstallScenario = {
   name: string;

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -74,11 +74,6 @@ const FORBIDDEN_PACKED_PATH_RULES = [
       `npm package must not include generated docs artifact "${packedPath}".`,
   },
   {
-    prefix: "dist/extensions/qa-channel/",
-    describe: (packedPath: string) =>
-      `npm package must not include private QA channel artifact "${packedPath}".`,
-  },
-  {
     prefix: "dist/extensions/qa-lab/",
     describe: (packedPath: string) =>
       `npm package must not include private QA lab artifact "${packedPath}".`,

--- a/src/infra/npm-update-compat-sidecars.ts
+++ b/src/infra/npm-update-compat-sidecars.ts
@@ -1,10 +1,9 @@
-export const NPM_UPDATE_COMPAT_SIDECARS = [
-  {
-    path: "dist/extensions/qa-channel/runtime-api.js",
-    content:
-      "// Compatibility stub for older OpenClaw updaters. The QA channel implementation is not packaged.\nexport {};\n",
-  },
-] as const;
+type NpmUpdateCompatSidecar = {
+  path: string;
+  content: string;
+};
+
+export const NPM_UPDATE_COMPAT_SIDECARS: readonly NpmUpdateCompatSidecar[] = [];
 
 export const NPM_UPDATE_COMPAT_SIDECAR_PATHS = new Set<string>(
   NPM_UPDATE_COMPAT_SIDECARS.map((entry) => entry.path),

--- a/src/infra/package-dist-inventory.test.ts
+++ b/src/infra/package-dist-inventory.test.ts
@@ -44,7 +44,15 @@ describe("package dist inventory", () => {
         "qa-channel",
         "runtime-api.js",
       );
-      const omittedQaChunk = path.join(packageRoot, "dist", "extensions", "qa-channel", "cli.js");
+      const packagedQaApi = path.join(packageRoot, "dist", "extensions", "qa-channel", "api.js");
+      const packagedQaManifest = path.join(
+        packageRoot,
+        "dist",
+        "extensions",
+        "qa-channel",
+        "package.json",
+      );
+      const packagedQaCli = path.join(packageRoot, "dist", "extensions", "qa-channel", "cli.js");
       const omittedQaMatrixChunk = path.join(
         packageRoot,
         "dist",
@@ -78,7 +86,9 @@ describe("package dist inventory", () => {
       await fs.mkdir(path.dirname(omittedExtensionNodeModuleSymlink), { recursive: true });
       await fs.writeFile(path.join(packageRoot, "color-support.js"), "export {};\n", "utf8");
       await fs.writeFile(packagedQaRuntime, "export {};\n", "utf8");
-      await fs.writeFile(omittedQaChunk, "export {};\n", "utf8");
+      await fs.writeFile(packagedQaApi, "export {};\n", "utf8");
+      await fs.writeFile(packagedQaManifest, "{}\n", "utf8");
+      await fs.writeFile(packagedQaCli, "export {};\n", "utf8");
       await fs.writeFile(omittedQaMatrixChunk, "export {};\n", "utf8");
       await fs.writeFile(omittedQaLabPluginSdk, "export {};\n", "utf8");
       await fs.writeFile(omittedQaLabTypes, "export {};\n", "utf8");
@@ -90,6 +100,9 @@ describe("package dist inventory", () => {
       await fs.writeFile(omittedMap, "{}", "utf8");
 
       await expect(writePackageDistInventory(packageRoot)).resolves.toEqual([
+        "dist/extensions/qa-channel/api.js",
+        "dist/extensions/qa-channel/cli.js",
+        "dist/extensions/qa-channel/package.json",
         "dist/extensions/qa-channel/runtime-api.js",
       ]);
     });

--- a/src/infra/package-dist-inventory.ts
+++ b/src/infra/package-dist-inventory.ts
@@ -2,12 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 export const PACKAGE_DIST_INVENTORY_RELATIVE_PATH = "dist/postinstall-inventory.json";
-const PACKAGED_QA_RUNTIME_PATHS = new Set(["dist/extensions/qa-channel/runtime-api.js"]);
-const OMITTED_QA_EXTENSION_PREFIXES = [
-  "dist/extensions/qa-channel/",
-  "dist/extensions/qa-lab/",
-  "dist/extensions/qa-matrix/",
-];
+const OMITTED_QA_EXTENSION_PREFIXES = ["dist/extensions/qa-lab/", "dist/extensions/qa-matrix/"];
 const OMITTED_PRIVATE_QA_PLUGIN_SDK_PREFIXES = ["dist/plugin-sdk/extensions/qa-lab/"];
 const OMITTED_PRIVATE_QA_PLUGIN_SDK_FILES = new Set([
   "dist/plugin-sdk/qa-lab.d.ts",
@@ -50,7 +45,7 @@ function isPackagedDistPath(relativePath: string): boolean {
     return false;
   }
   if (OMITTED_QA_EXTENSION_PREFIXES.some((prefix) => relativePath.startsWith(prefix))) {
-    return PACKAGED_QA_RUNTIME_PATHS.has(relativePath);
+    return false;
   }
   return true;
 }

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -415,11 +415,20 @@ describe("update global helpers", () => {
         JSON.stringify({ name: "openclaw", version: "1.0.0" }),
         "utf-8",
       );
-      for (const relativePath of NPM_UPDATE_COMPAT_SIDECAR_PATHS) {
-        const absolutePath = path.join(packageRoot, relativePath);
-        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-        await fs.writeFile(absolutePath, "export {};\n", "utf-8");
-      }
+      const qaChannelPackageJson = path.join(
+        packageRoot,
+        "dist",
+        "extensions",
+        "qa-channel",
+        "package.json",
+      );
+      await fs.mkdir(path.dirname(qaChannelPackageJson), { recursive: true });
+      await fs.writeFile(
+        qaChannelPackageJson,
+        JSON.stringify({ name: "@openclaw/qa-channel" }),
+        "utf-8",
+      );
+      await fs.writeFile(path.join(packageRoot, QA_CHANNEL_RUNTIME_API), "export {};\n", "utf-8");
 
       await expect(collectInstalledGlobalPackageErrors({ packageRoot })).resolves.toEqual([]);
 

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -131,10 +131,8 @@ describe("bundled plugin metadata", () => {
     },
   );
 
-  it("excludes non-packaged QA sidecars from the packaged runtime sidecar baseline", () => {
-    expect(BUNDLED_RUNTIME_SIDECAR_PATHS).not.toContain(
-      "dist/extensions/qa-channel/runtime-api.js",
-    );
+  it("keeps only the private QA sidecars out of the packaged runtime sidecar baseline", () => {
+    expect(BUNDLED_RUNTIME_SIDECAR_PATHS).toContain("dist/extensions/qa-channel/runtime-api.js");
     expect(BUNDLED_RUNTIME_SIDECAR_PATHS).not.toContain("dist/extensions/qa-lab/runtime-api.js");
     expect(BUNDLED_RUNTIME_SIDECAR_PATHS).not.toContain("dist/extensions/qa-matrix/runtime-api.js");
   });

--- a/src/plugins/runtime-sidecar-paths-baseline.ts
+++ b/src/plugins/runtime-sidecar-paths-baseline.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { listBundledPluginMetadata } from "./bundled-plugin-metadata.js";
 
-const NON_PACKAGED_RUNTIME_SIDECAR_PLUGIN_DIRS = new Set(["qa-channel", "qa-lab", "qa-matrix"]);
+const NON_PACKAGED_RUNTIME_SIDECAR_PLUGIN_DIRS = new Set(["qa-lab", "qa-matrix"]);
 
 function buildBundledDistArtifactPath(dirName: string, artifact: string): string {
   return ["dist", "extensions", dirName, artifact].join("/");

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -17,13 +17,7 @@ import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../src/plugins/runtime-sidecar-pa
 const PUBLISHED_BUNDLED_RUNTIME_SIDECAR_PATHS = BUNDLED_RUNTIME_SIDECAR_PATHS.filter(
   (relativePath) => listBundledPluginPackArtifacts().includes(relativePath),
 );
-const LEGACY_UPDATE_COMPAT_RUNTIME_SIDECAR_PATHS = [
-  "dist/extensions/qa-channel/runtime-api.js",
-] as const;
-const REQUIRED_INSTALLED_RUNTIME_SIDECAR_PATHS = [
-  ...PUBLISHED_BUNDLED_RUNTIME_SIDECAR_PATHS,
-  ...LEGACY_UPDATE_COMPAT_RUNTIME_SIDECAR_PATHS,
-] as const;
+const REQUIRED_INSTALLED_RUNTIME_SIDECAR_PATHS = PUBLISHED_BUNDLED_RUNTIME_SIDECAR_PATHS;
 
 describe("buildPublishedInstallScenarios", () => {
   it("uses a single fresh scenario for plain stable releases", () => {
@@ -315,7 +309,7 @@ describe("collectInstalledMirroredRootDependencyManifestErrors", () => {
     }
   });
 
-  it("accepts legacy qa channel sidecar directories without package.json", () => {
+  it("flags bundled extension directories that are missing package.json", () => {
     const packageRoot = makeInstalledPackageRoot();
 
     try {
@@ -330,7 +324,9 @@ describe("collectInstalledMirroredRootDependencyManifestErrors", () => {
         "utf8",
       );
 
-      expect(collectInstalledMirroredRootDependencyManifestErrors(packageRoot)).toEqual([]);
+      expect(collectInstalledMirroredRootDependencyManifestErrors(packageRoot)).toEqual([
+        `installed bundled extension manifest missing: ${join(packageRoot, "dist/extensions/qa-channel/package.json")}.`,
+      ]);
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });
     }

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -328,11 +328,12 @@ describe("collectForbiddenPackedPathErrors", () => {
     ]);
   });
 
-  it("rejects private qa artifacts in npm pack output", () => {
+  it("allows the packaged qa-channel surface but rejects private qa artifacts", () => {
     expect(
       collectForbiddenPackedPathErrors([
-        "dist/extensions/qa-channel/runtime-api.js",
+        "dist/extensions/qa-channel/api.js",
         "dist/extensions/qa-channel/package.json",
+        "dist/extensions/qa-channel/runtime-api.js",
         "dist/extensions/qa-lab/runtime-api.js",
         "dist/extensions/qa-lab/src/cli.js",
         "dist/plugin-sdk/extensions/qa-lab/cli.d.ts",
@@ -340,7 +341,6 @@ describe("collectForbiddenPackedPathErrors", () => {
         "qa/scenarios/index.md",
       ]),
     ).toEqual([
-      'npm package must not include private QA channel artifact "dist/extensions/qa-channel/package.json".',
       'npm package must not include private QA lab artifact "dist/extensions/qa-lab/runtime-api.js".',
       'npm package must not include private QA lab artifact "dist/extensions/qa-lab/src/cli.js".',
       'npm package must not include private QA lab type artifact "dist/plugin-sdk/extensions/qa-lab/cli.d.ts".',
@@ -349,15 +349,13 @@ describe("collectForbiddenPackedPathErrors", () => {
     ]);
   });
 
-  it("allows only the legacy update verifier QA channel runtime sidecar", () => {
+  it("allows packaged qa-channel sidecars", () => {
     expect(
       collectForbiddenPackedPathErrors([
+        "dist/extensions/qa-channel/api.js",
         "dist/extensions/qa-channel/runtime-api.js",
-        "dist/extensions/qa-lab/runtime-api.js",
       ]),
-    ).toEqual([
-      'npm package must not include private QA lab artifact "dist/extensions/qa-lab/runtime-api.js".',
-    ]);
+    ).toEqual([]);
   });
 
   it("rejects root dist chunks that still reference the private qa lab", () => {

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -73,11 +73,17 @@ describe("bundled plugin build entries", () => {
     expect(artifacts).toContain("dist/extensions/matrix/plugin-entry.handlers.runtime.js");
   });
 
-  it("keeps private QA bundles out of required npm pack artifacts", () => {
+  it("packs the qa-channel public surface while keeping private QA bundles out", () => {
     const artifacts = listBundledPluginPackArtifacts();
 
-    expect(artifacts.some((artifact) => artifact.startsWith("dist/extensions/qa-channel/"))).toBe(
-      false,
+    expect(artifacts).toEqual(
+      expect.arrayContaining([
+        "dist/extensions/qa-channel/api.js",
+        "dist/extensions/qa-channel/openclaw.plugin.json",
+        "dist/extensions/qa-channel/package.json",
+        "dist/extensions/qa-channel/runtime-api.js",
+        "dist/extensions/qa-channel/test-api.js",
+      ]),
     );
     expect(artifacts.some((artifact) => artifact.startsWith("dist/extensions/qa-lab/"))).toBe(
       false,


### PR DESCRIPTION
## Summary
- restore packaged QA CLI / plugin-sdk public-surface expectations on top of current `origin/main`
- cherry-pick the accepted `bd-8al5` fix onto latest upstream as commit `6278a99799e58659c6b2a6767e208abeb6a57ee2`
- convert the direct-push auth blocker into a mergeable fork-backed PR path

## Proof status
- previously verifier-accepted on local `main` before upstream advanced:
  - `reports/benchmark-audit/2026-04-15-phase2-architecture-first/bd-8al5-1630pt-qa-channel-public-surface-verifier.md`
- no new validation reruns launched in this handoff tick because the active upstream non-validation seam remained live; this branch only rebases the accepted fix over unrelated upstream docs/CI commits

## Context
- direct push to `openclaw/openclaw` is blocked for `RLTree` (`push=false` / prior 403)
- fork branch: `RLTree:bd-8al5-pr`
- original accepted local commit: `95e65698ba322cb4d13953bac4e3f0abcbe3580e`
- rebased PR commit: `6278a99799e58659c6b2a6767e208abeb6a57ee2`
