### PR TITLE
fix(whatsapp): flush creds queue before reconnect socket open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Agents/local models: clarify low-context preflight hints for self-hosted models, point config-backed caps at the relevant OpenClaw setting, and stop suggesting larger models when `agents.defaults.contextTokens` is the real limit. (#66236) Thanks @ImLukeF.
 - Dreaming/memory-core: change the default `dreaming.storage.mode` from `inline` to `separate` so Dreaming phase blocks (`## Light Sleep`, `## REM Sleep`) land in `memory/dreaming/{phase}/YYYY-MM-DD.md` instead of being injected into `memory/YYYY-MM-DD.md`. Daily memory files no longer get dominated by structured candidate output, and the daily-ingestion scanner that already strips dream marker blocks no longer has to compete with hundreds of phase-block lines on every run. Operators who want the previous behavior can opt in by setting `plugins.entries.memory-core.config.dreaming.storage.mode: "inline"`. (#66412) Thanks @mjamiv.
 - Control UI/Overview: fix false-positive "missing" alerts on the Model Auth status card for aliased providers, env-backed OAuth with auth.profiles, and unresolvable env SecretRefs. (#67253) Thanks @omarshahine.
+- WhatsApp/web-session: drain the pending per-auth creds save queue before reopening sockets so reconnect-time auth bootstrap no longer races in-flight `creds.json` writes and falsely restores from backup. (#67337)
 
 ## 2026.4.15-beta.1
 

--- a/extensions/whatsapp/src/connection-controller.test.ts
+++ b/extensions/whatsapp/src/connection-controller.test.ts
@@ -1,18 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getRegisteredWhatsAppConnectionController } from "./connection-controller-registry.js";
 import { WhatsAppConnectionController } from "./connection-controller.js";
-import { createWaSocket, waitForWaConnection } from "./session.js";
+import {
+  createWaSocket,
+  waitForCredsSaveQueueWithTimeout,
+  waitForWaConnection,
+} from "./session.js";
 
 vi.mock("./session.js", async () => {
   const actual = await vi.importActual<typeof import("./session.js")>("./session.js");
   return {
     ...actual,
     createWaSocket: vi.fn(),
+    waitForCredsSaveQueueWithTimeout: vi.fn(async () => {}),
     waitForWaConnection: vi.fn(),
   };
 });
 
 const createWaSocketMock = vi.mocked(createWaSocket);
+const waitForCredsSaveQueueWithTimeoutMock = vi.mocked(waitForCredsSaveQueueWithTimeout);
 const waitForWaConnectionMock = vi.mocked(waitForWaConnection);
 
 describe("WhatsAppConnectionController", () => {
@@ -64,6 +70,32 @@ describe("WhatsAppConnectionController", () => {
     expect(sock.ws.close).toHaveBeenCalledOnce();
     expect(controller.socketRef.current).toBeNull();
     expect(controller.getActiveListener()).toBeNull();
+  });
+
+  it("flushes pending creds saves before opening a socket", async () => {
+    const callOrder: string[] = [];
+    waitForCredsSaveQueueWithTimeoutMock.mockImplementationOnce(async () => {
+      callOrder.push("wait");
+    });
+    createWaSocketMock.mockImplementationOnce(async () => {
+      callOrder.push("create");
+      return { ws: { close: vi.fn() } } as never;
+    });
+    waitForWaConnectionMock.mockResolvedValueOnce(undefined);
+
+    await controller.openConnection({
+      connectionId: "conn-flush-first",
+      createListener: async () =>
+        ({
+          sendMessage: vi.fn(async () => ({ messageId: "ok" })),
+          sendPoll: vi.fn(async () => ({ messageId: "ok" })),
+          sendReaction: vi.fn(async () => {}),
+          sendComposingTo: vi.fn(async () => {}),
+        }) as never,
+    });
+
+    expect(waitForCredsSaveQueueWithTimeoutMock).toHaveBeenCalledWith("/tmp/wa-auth");
+    expect(callOrder).toEqual(["wait", "create"]);
   });
 
   it("keeps the previous registered controller until a replacement listener is ready", async () => {

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -347,6 +347,8 @@ export class WhatsAppConnectionController {
     let sock: WaSocket | null = null;
     let connection: WhatsAppLiveConnection | null = null;
     try {
+      // Avoid reading creds.json while a queued save is still flushing.
+      await waitForCredsSaveQueueWithTimeout(this.authDir);
       sock = await createWaSocket(false, this.verbose, {
         authDir: this.authDir,
       });


### PR DESCRIPTION
## Summary

- Problem: WhatsApp reconnect could reopen a socket while a prior queued `creds.update` save was still flushing `creds.json`.
- Why it matters: startup auth bootstrap reads `creds.json` immediately and can misclassify an in-flight write as corruption, triggering backup restore warnings and stale rollback risk.
- What changed: `WhatsAppConnectionController.openConnection` now awaits `waitForCredsSaveQueueWithTimeout(authDir)` before `createWaSocket(...)`, and regression coverage asserts this ordering.
- What did NOT change (scope boundary): no config/default changes, no auth model changes, no prompt/allowlist policy changes, no new network surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67337
- Related #67337
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: reconnect/open paths created a new WhatsApp socket without first draining the per-auth queued creds write pipeline, so auth bootstrap could read `creds.json` during an in-flight save window.
- Missing detection / guardrail: there was no reconnect-time ordering guard to force `creds.update` save completion before the next read-heavy bootstrap.
- Contributing context (if known): this path is especially visible when periodic watchdog/connection churn causes frequent reconnects.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/connection-controller.test.ts`
- Scenario the test should lock in: `openConnection` flushes pending creds queue before socket creation.
- Why this is the smallest reliable guardrail: it directly enforces the ordering contract at the reconnect orchestration seam where the bug occurs.
- Existing test that already covers this (if any): `session.test.ts` already verifies save queue serialization behavior; new test connects that guarantee to reconnect socket-open ordering.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Fewer false `restored corrupted WhatsApp creds.json from backup` warnings during reconnect windows where a save is still flushing.

## Diagram (if applicable)

```text
Before:
[disconnect/reconnect] -> [openConnection] -> [createWaSocket + auth bootstrap read] while [prior creds save still flushing]

After:
[disconnect/reconnect] -> [openConnection] -> [await creds queue flush] -> [createWaSocket + auth bootstrap read]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (darwin 25.3.0)
- Runtime/container: local Node/pnpm repo test lane
- Model/provider: N/A
- Integration/channel (if any): WhatsApp bundled plugin runtime
- Relevant config (redacted): N/A

### Steps

1. Trigger reconnect/open flow for WhatsApp connection controller.
2. Ensure pending `creds.update` save queue is still present.
3. Verify queue flush call happens before socket creation.

### Expected

- Reconnect/open path waits for pending creds queue flush before socket bootstrap.

### Actual

- Confirmed by regression test and focused runtime tests.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Focused WhatsApp tests pass with new ordering test.
  - Existing session/login tests still pass.
- Edge cases checked:
  - No-op queue wait path remains valid.
  - Existing reconnect/open failure handling still closes socket and cleans up.
- What you did **not** verify:
  - Live long-running WhatsApp reconnect windows against production credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: reconnect may wait up to timeout if a creds save stalls.
  - Mitigation: existing timeout-based helper is reused (`waitForCredsSaveQueueWithTimeout`) to avoid indefinite hangs.

## Focused self-review before PR (bot-finding categories)

- Test helper defaults vs production defaults: new mock default for `waitForCredsSaveQueueWithTimeout` is an async no-op, matching production behavior when no queue is pending.
- Config default/doc/generated alignment: no config/default/schema/help/generated surfaces changed.
- Security posture (prompt text vs runtime-enforced policy): fix is runtime ordering only in controller logic; no policy moved into prompt text and no trust-boundary rules changed.

AI-assisted: yes.
Testing depth: focused regression + nearby runtime unit coverage.

Made with [Cursor](https://cursor.com)