### PR TITLE
Fix Slack cron delivery inference for agentTurn jobs

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -541,6 +541,21 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
           }
 
           if (
+            job &&
+            typeof job === "object" &&
+            "payload" in job &&
+            (job as { payload?: { kind?: string; timeoutSeconds?: number } }).payload?.kind ===
+              "agentTurn"
+          ) {
+            const payload = (job as {
+              payload: { kind: "agentTurn"; timeoutSeconds?: number };
+            }).payload;
+            if (typeof payload.timeoutSeconds !== "number") {
+              payload.timeoutSeconds = 240;
+            }
+          }
+
+          if (
             opts?.agentSessionKey &&
             job &&
             typeof job === "object" &&
@@ -566,10 +581,14 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             const hasTarget =
               (typeof delivery?.channel === "string" && delivery.channel.trim()) ||
               (typeof delivery?.to === "string" && delivery.to.trim());
+            const hasSessionKey =
+              typeof (job as { sessionKey?: unknown }).sessionKey === "string" &&
+              (job as { sessionKey?: string }).sessionKey!.trim().length > 0;
             const shouldInfer =
               (deliveryValue == null || delivery) &&
               (mode === "" || mode === "announce") &&
-              !hasTarget;
+              !hasTarget &&
+              !hasSessionKey;
             if (shouldInfer) {
               const inferred = inferDeliveryFromSessionKey(opts.agentSessionKey);
               if (inferred) {


### PR DESCRIPTION
## Summary
- stop inferring announce delivery targets from the lowercased session key once a cron job already has a resolved session key
- preserve session-backed Slack delivery metadata so cron jobs can use the stored canonical channel target instead of a lowercased channel id
- default cron `agentTurn` payloads to `timeoutSeconds: 240` when callers omit the timeout

## Changes
- update `src/agents/tools/cron-tool.ts` to set a 240 second default timeout for `agentTurn` cron payloads
- update `src/agents/tools/cron-tool.ts` to skip session-key delivery inference when `job.sessionKey` is already populated

## Testing
- [x] `git diff --check`
- [ ] Full test suite not run
- [ ] Dependency-backed lint/typecheck not run in this environment (no installed `node_modules`)
