### PR TITLE
fix(gateway): block agent/chat broadcasts for node role

### DIFF
--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -220,6 +220,51 @@ describe("gateway broadcaster", () => {
     expect(approvalsSocket.send).toHaveBeenCalledTimes(1);
     expect(pairingSocket.send).toHaveBeenCalledTimes(1);
   });
+
+  it("blocks operator-only chat events for node-role clients", () => {
+    const operatorSocket: TestSocket = {
+      bufferedAmount: 0,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+    const nodeSocket: TestSocket = {
+      bufferedAmount: 0,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+
+    const clients = new Set<GatewayWsClient>([
+      {
+        socket: operatorSocket as unknown as GatewayWsClient["socket"],
+        connect: { role: "operator", scopes: [] } as GatewayWsClient["connect"],
+        connId: "c-operator",
+        usesSharedGatewayAuth: false,
+      },
+      {
+        socket: nodeSocket as unknown as GatewayWsClient["socket"],
+        connect: { role: "node", scopes: [] } as GatewayWsClient["connect"],
+        connId: "c-node",
+        usesSharedGatewayAuth: false,
+      },
+    ]);
+
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("agent", { runId: "r-1" });
+    broadcast("chat", { runId: "r-1" });
+    broadcast("chat.side_result", {
+      kind: "btw",
+      runId: "r-1",
+      sessionKey: "main",
+      question: "q",
+      text: "a",
+      ts: Date.now(),
+      seq: 1,
+    });
+
+    expect(operatorSocket.send).toHaveBeenCalledTimes(3);
+    expect(nodeSocket.send).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe("chat run registry", () => {

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -15,7 +15,7 @@ import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { logWs, shouldLogWs, summarizeAgentEventForWsLog } from "./ws-log.js";
 
-const OPERATOR_ONLY_EVENTS = new Set(["agent", "chat"]);
+const OPERATOR_ONLY_EVENTS = new Set(["agent", "chat", "chat.side_result"]);
 
 const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
   "exec.approval.requested": [APPROVALS_SCOPE],

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -15,6 +15,8 @@ import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { logWs, shouldLogWs, summarizeAgentEventForWsLog } from "./ws-log.js";
 
+const OPERATOR_ONLY_EVENTS = new Set(["agent", "chat"]);
+
 const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
   "exec.approval.requested": [APPROVALS_SCOPE],
   "exec.approval.resolved": [APPROVALS_SCOPE],
@@ -37,11 +39,15 @@ export type {
 } from "./server-broadcast-types.js";
 
 function hasEventScope(client: GatewayWsClient, event: string): boolean {
+  const role = client.connect.role ?? "operator";
+  if (OPERATOR_ONLY_EVENTS.has(event) && role !== "operator") {
+    return false;
+  }
+
   const required = EVENT_SCOPE_GUARDS[event];
   if (!required) {
     return true;
   }
-  const role = client.connect.role ?? "operator";
   if (role !== "operator") {
     return false;
   }


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/32964

This is a minimal, targeted fix in `src/gateway/server-broadcast.ts`:
- add `OPERATOR_ONLY_EVENTS = new Set(["agent", "chat"])`
- deny those events for non-`operator` roles in `hasEventScope`

No other behavior changes are included.