### PR TITLE
test(ui): remove console.log fixture snippets from markdown tests

### DIFF
--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -82,14 +82,14 @@ describe("extractCodeBlocks", () => {
 
 \`\`\`javascript
 const x = 1;
-console.log(x);
+printValue(x);
 \`\`\`
 
 And more text.`;
     const withLanguageResult = extractCodeBlocks(withLanguage);
     expect(withLanguageResult.codeBlocks).toHaveLength(1);
     expect(withLanguageResult.codeBlocks[0].language).toBe("javascript");
-    expect(withLanguageResult.codeBlocks[0].code).toBe("const x = 1;\nconsole.log(x);");
+    expect(withLanguageResult.codeBlocks[0].code).toBe("const x = 1;\nprintValue(x);");
     expect(withLanguageResult.textWithoutCode).toContain("Here is some code:");
     expect(withLanguageResult.textWithoutCode).toContain("And more text.");
     expect(withLanguageResult.textWithoutCode).not.toContain("```");
@@ -270,7 +270,7 @@ describe("processLineMessage", () => {
     const text = `Check this code:
 
 \`\`\`js
-console.log("hi");
+emit("hi");
 \`\`\`
 
 That's it.`;

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -28,6 +28,7 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("<pre>");
     expect(html).toContain("<code");
     expect(html).toContain("const value = 1");
+    expect(html).not.toContain("console.log(");
   });
 
   it("flattens remote markdown images into alt text", () => {

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -24,10 +24,10 @@ describe("toSanitizedMarkdownHtml", () => {
   });
 
   it("renders fenced code blocks", () => {
-    const html = toSanitizedMarkdownHtml(["```ts", "console.log(1)", "```"].join("\n"));
+    const html = toSanitizedMarkdownHtml(["```ts", "const value = 1", "```"].join("\n"));
     expect(html).toContain("<pre>");
     expect(html).toContain("<code");
-    expect(html).toContain("console.log(1)");
+    expect(html).toContain("const value = 1");
   });
 
   it("flattens remote markdown images into alt text", () => {
@@ -441,10 +441,10 @@ describe("toSanitizedMarkdownHtml", () => {
 
   describe("code blocks", () => {
     it("renders fenced code blocks", () => {
-      const html = toSanitizedMarkdownHtml("```ts\nconsole.log(1)\n```");
+      const html = toSanitizedMarkdownHtml("```ts\nconst value = 1\n```");
       expect(html).toContain("<pre>");
       expect(html).toContain("<code");
-      expect(html).toContain("console.log(1)");
+      expect(html).toContain("const value = 1");
     });
 
     it("renders indented code blocks", () => {


### PR DESCRIPTION
## Summary
- replace `console.log(1)` fixture strings in `ui/src/ui/markdown.test.ts` with neutral code snippets
- keep expectations aligned with the updated fixture text

## Validation
- `pnpm format:check ui/src/ui/markdown.test.ts`
- attempted: `pnpm --dir ui test src/ui/markdown.test.ts` (fails in this local env due unresolved module `markdown-it-task-lists`, unrelated to this diff)

Closes #67246
