### PR TITLE
fix(browser): expand tilde in executablePath before spawning

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -459,4 +459,26 @@ describe("browser config", () => {
       expect(resolved.defaultProfile).toBe("custom");
     });
   });
+
+  describe("executablePath tilde expansion", () => {
+    it("expands ~ prefix to home directory", () => {
+      const resolved = resolveBrowserConfig({
+        executablePath: "~/.local/chromium/chrome",
+      });
+      expect(resolved.executablePath).not.toContain("~");
+      expect(resolved.executablePath).toContain(".local/chromium/chrome");
+    });
+
+    it("preserves absolute paths without tilde", () => {
+      const resolved = resolveBrowserConfig({
+        executablePath: "/usr/bin/chromium",
+      });
+      expect(resolved.executablePath).toBe("/usr/bin/chromium");
+    });
+
+    it("returns undefined when executablePath is not set", () => {
+      const resolved = resolveBrowserConfig({});
+      expect(resolved.executablePath).toBeUndefined();
+    });
+  });
 });

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -244,7 +244,8 @@ export function resolveBrowserConfig(
   const headless = cfg?.headless === true;
   const noSandbox = cfg?.noSandbox === true;
   const attachOnly = cfg?.attachOnly === true;
-  const executablePath = normalizeOptionalString(cfg?.executablePath);
+  const rawExecutablePath = normalizeOptionalString(cfg?.executablePath);
+  const executablePath = rawExecutablePath ? resolveUserPath(rawExecutablePath) : undefined;
   const defaultProfileFromConfig = normalizeOptionalString(cfg?.defaultProfile);
 
   const legacyCdpPort = rawCdpUrl ? cdpInfo.port : undefined;


### PR DESCRIPTION
## Summary

Fixes #67264

When `browser.executablePath` in `openclaw.json` contains a `~` prefix (e.g. `~/.local/chromium/chrome-linux/chrome`), Node.js `child_process.spawn()` does not expand the tilde, causing an `ENOENT` error and the browser failing to start.

## Root Cause

`resolveBrowserConfig()` used `normalizeOptionalString()` (which only trims) for `executablePath`, while other path configs in the codebase use `resolveUserPath()` which properly expands `~` to `os.homedir()`.

## Fix

Replace `normalizeOptionalString()` with `resolveUserPath()` for the `executablePath` config value. `resolveUserPath` was already imported in the file.

## Changes

- **`extensions/browser/src/browser/config.ts`**: Expand tilde in `executablePath` using `resolveUserPath()`
- **`extensions/browser/src/browser/config.test.ts`**: Add tests for tilde expansion, absolute paths, and undefined executablePath

## Testing

All 42 tests in `config.test.ts` pass, including 3 new tests for this fix.