### PR TITLE
extensions(ollama): strip ollama/ prefix from model ID before API call

### DIFF
--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -627,7 +627,7 @@ export function createOllamaStreamFn(
         }
 
         const body = buildOllamaChatRequest({
-          modelId: model.id,
+          modelId: model.id.startsWith("ollama/") ? model.id.slice("ollama/".length) : model.id,
           messages: ollamaMessages,
           stream: true,
           tools: ollamaTools,


### PR DESCRIPTION
## Summary
Ollama provider was sending model IDs like `ollama/qwen3:14b-q8_0` to the Ollama API. The Ollama API expects bare model names and returns 404 when the prefix is present. This change strips the `ollama/` prefix before building the chat request.

Fixes #67435

## Type of change
- [x] Bug fix

## Testing
- `pnpm tsgo` passed
- `extensions/ollama/src/stream-runtime.test.ts` passed (42 tests)
- `extensions/ollama/index.test.ts` passed (15 tests)

## Checklist
- [x] I have read the project contribution guidelines
- [x] My changes generate no new type errors
- [x] I have added/updated tests where applicable (existing tests cover the stream path)
- [x] This PR fixes a single issue