### PR TITLE
fix(onboard): fix TypeError in init wizard for mixed-case channel IDs

### DIFF
--- a/src/channels/chat-meta-shared.test.ts
+++ b/src/channels/chat-meta-shared.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./bundled-channel-catalog-read.js", () => ({
+  listBundledChannelCatalogEntries: () => [
+    {
+      id: "QQ",
+      aliases: [],
+      order: 0,
+      channel: { label: "QQ Messenger", blurb: "QQ channel" },
+    },
+    {
+      id: "telegram",
+      aliases: ["tg"],
+      order: 1,
+      channel: { label: "Telegram", blurb: "Telegram channel" },
+    },
+  ],
+}));
+
+vi.mock("./ids.js", () => ({
+  CHAT_CHANNEL_ORDER: ["qq", "telegram"],
+}));
+
+vi.mock("./plugins/exposure.js", () => ({
+  resolveChannelExposure: () => "public",
+}));
+
+describe("buildChatChannelMetaById", () => {
+  it("normalizes mixed-case channel IDs to lowercase to match CHAT_CHANNEL_ORDER", async () => {
+    const { buildChatChannelMetaById } = await import("./chat-meta-shared.js");
+    const meta = buildChatChannelMetaById();
+
+    expect(meta["qq"]).toBeDefined();
+    expect(meta["qq"].label).toBe("QQ Messenger");
+    expect(meta["telegram"]).toBeDefined();
+  });
+});
+
+describe("listChatChannels", () => {
+  it("returns no undefined entries even if meta map has gaps", async () => {
+    const { listChatChannels } = await import("./chat-meta.js");
+    const channels = listChatChannels();
+
+    expect(channels.every(Boolean)).toBe(true);
+  });
+});

--- a/src/channels/chat-meta-shared.ts
+++ b/src/channels/chat-meta-shared.ts
@@ -1,5 +1,8 @@
 import type { PluginPackageChannel } from "../plugins/manifest.js";
-import { normalizeOptionalString } from "../shared/string-coerce.js";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 import { listBundledChannelCatalogEntries } from "./bundled-channel-catalog-read.js";
 import { CHAT_CHANNEL_ORDER, type ChatChannelId } from "./ids.js";
 import { resolveChannelExposure } from "./plugins/exposure.js";
@@ -66,7 +69,7 @@ export function buildChatChannelMetaById(): Record<ChatChannelId, ChatChannelMet
   const entries = new Map<ChatChannelId, ChatChannelMeta>();
 
   for (const entry of listBundledChannelCatalogEntries()) {
-    const rawId = normalizeOptionalString(entry.id);
+    const rawId = normalizeOptionalLowercaseString(entry.id);
     if (!rawId || !CHAT_CHANNEL_ID_SET.has(rawId)) {
       continue;
     }

--- a/src/channels/chat-meta.ts
+++ b/src/channels/chat-meta.ts
@@ -6,7 +6,7 @@ const CHAT_CHANNEL_META = buildChatChannelMetaById();
 export type { ChatChannelMeta };
 
 export function listChatChannels(): ChatChannelMeta[] {
-  return CHAT_CHANNEL_ORDER.map((id) => CHAT_CHANNEL_META[id]);
+  return CHAT_CHANNEL_ORDER.map((id) => CHAT_CHANNEL_META[id]).filter(Boolean);
 }
 
 export function getChatChannelMeta(id: ChatChannelId): ChatChannelMeta {


### PR DESCRIPTION
## Problem

Running `openclaw init` / `openclaw onboard` crashes with:

```
TypeError: Cannot read properties of undefined (reading 'trim')
```

The channel selection menu also shows `undefined: undefined` entries for certain channels.

## Root Cause

`buildChatChannelMetaById()` in `src/channels/chat-meta-shared.ts` used `normalizeOptionalString()` (case-preserving) to look up channel IDs, but `CHAT_CHANNEL_ID_SET` contains lowercased IDs (produced by `normalizeOptionalLowercaseString()` in `ids.ts`). Channels with mixed-case catalog IDs (e.g. `QQ`) were skipped during meta building, leaving `undefined` entries in the map.

`listChatChannels()` then mapped `CHAT_CHANNEL_ORDER` through this incomplete map, producing `undefined` array elements that propagated to the wizard UI and eventually crashed on `.trim()`.

## Fix

1. **`chat-meta-shared.ts`**: Use `normalizeOptionalLowercaseString()` for ID lookup so it matches the lowercased `CHAT_CHANNEL_ID_SET`
2. **`chat-meta.ts`**: Add defensive `.filter(Boolean)` in `listChatChannels()` to prevent undefined propagation

Closes #67482