### PR TITLE
fix(plugin-sdk): route qa-channel facade through runtime-api seam

### DIFF
--- a/extensions/qa-channel/runtime-api.ts
+++ b/extensions/qa-channel/runtime-api.ts
@@ -1,3 +1,4 @@
+export * from "./src/bus-client.js";
+export * from "./src/channel.js";
 export * from "./src/runtime-api.js";
-export { getQaChannelRuntime, setQaChannelRuntime } from "./src/runtime.js";
 export * from "./src/runtime.js";

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -61,6 +61,7 @@ describe("buildQaGatewayConfig", () => {
     expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-channel"]);
     expect(cfg.plugins?.entries?.["memory-core"]).toEqual({ enabled: true });
     expect(cfg.plugins?.entries?.["qa-channel"]).toEqual({ enabled: true });
+    expect(cfg.plugins?.entries?.acpx).toBeUndefined();
     expect(cfg.plugins?.entries?.openai).toBeUndefined();
     expect(cfg.gateway?.reload?.deferralTimeoutMs).toBe(1_000);
     expect(cfg.channels?.["qa-channel"]).toMatchObject({

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -252,9 +252,6 @@ export function buildQaGatewayConfig(params: {
     plugins: {
       allow: allowedPlugins,
       entries: {
-        acpx: {
-          enabled: false,
-        },
         "memory-core": {
           enabled: true,
         },

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -645,6 +645,19 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(instruction).toContain("Do not recap or restate the plan");
   });
 
+  it("adds the ack-turn fast path for timestamped approval-prefixed action prompts", () => {
+    expect(isLikelyExecutionAckPrompt("[Wed 2026-04-15 20:35 PDT] ok do it")).toBe(true);
+
+    const instruction = resolveAckExecutionFastPathInstruction({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      prompt:
+        "[Wed 2026-04-15 20:35 PDT] ok do it. read `QA_KICKOFF_TASK.md` now and reply with the QA mission in one short sentence.",
+    });
+
+    expect(instruction).toContain("execute that directive first");
+  });
+
   it("applies the planning-only retry guard to prefixed GPT-5 ids", () => {
     const retryInstruction = resolvePlanningOnlyRetryInstruction({
       provider: "openai",

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -126,6 +126,11 @@ const ACTIONABLE_PROMPT_DIRECTIVE_RE =
   /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare)\b/i;
 const ACTIONABLE_PROMPT_REQUEST_RE =
   /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through)\b/i;
+const LEADING_TIMESTAMP_PREFIX_RE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\]\s*/;
+const ACK_EXECUTION_ACTIONABLE_PROMPT_MAX_VISIBLE_TEXT = 240;
+const ACK_EXECUTION_NORMALIZED_PREFIXES = [...ACK_EXECUTION_NORMALIZED_SET].toSorted(
+  (left, right) => right.length - left.length,
+);
 
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
@@ -134,7 +139,7 @@ export const REASONING_ONLY_RETRY_INSTRUCTION =
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 export const ACK_EXECUTION_FAST_PATH_INSTRUCTION =
-  "The latest user message is a short approval to proceed. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
+  "The latest user message is an approval to proceed. Do not recap or restate the plan. If the user named a specific tool, action, or file, execute that directive first. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
 export const STRICT_AGENTIC_BLOCKED_TEXT =
   "Agent stopped after repeated plan-only turns without taking a concrete action. No concrete tool action or external side effect advanced the task.";
 
@@ -368,8 +373,12 @@ function shouldApplyPlanningOnlyRetryGuard(params: {
   });
 }
 
+function stripLeadingPromptMetadata(text: string): string {
+  return text.replace(LEADING_TIMESTAMP_PREFIX_RE, "").trim();
+}
+
 function normalizeAckPrompt(text: string): string {
-  const normalized = text
+  const normalized = stripLeadingPromptMetadata(text)
     .normalize("NFKC")
     .trim()
     .replace(/[\p{P}\p{S}]+/gu, " ")
@@ -378,16 +387,43 @@ function normalizeAckPrompt(text: string): string {
   return normalizeLowercaseStringOrEmpty(normalized);
 }
 
-export function isLikelyExecutionAckPrompt(text: string): boolean {
-  const trimmed = text.trim();
+function isLikelyShortExecutionAckPrompt(text: string): boolean {
+  const trimmed = stripLeadingPromptMetadata(text);
   if (!trimmed || trimmed.length > 80 || trimmed.includes("\n") || trimmed.includes("?")) {
     return false;
   }
   return ACK_EXECUTION_NORMALIZED_SET.has(normalizeAckPrompt(trimmed));
 }
 
+export function isLikelyExecutionAckPrompt(text: string): boolean {
+  return isLikelyShortExecutionAckPrompt(text);
+}
+
+function isLikelyExecutionAckActionPrompt(text: string): boolean {
+  const trimmed = stripLeadingPromptMetadata(text);
+  if (
+    !trimmed ||
+    trimmed.length > ACK_EXECUTION_ACTIONABLE_PROMPT_MAX_VISIBLE_TEXT ||
+    trimmed.includes("\n") ||
+    trimmed.includes("?")
+  ) {
+    return false;
+  }
+  const normalized = normalizeAckPrompt(trimmed);
+  for (const ack of ACK_EXECUTION_NORMALIZED_PREFIXES) {
+    if (!normalized.startsWith(`${ack} `)) {
+      continue;
+    }
+    const remainder = normalized.slice(ack.length).trim();
+    if (remainder && isLikelyActionableUserPrompt(remainder)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isLikelyActionableUserPrompt(text: string): boolean {
-  const trimmed = text.trim();
+  const trimmed = stripLeadingPromptMetadata(text);
   if (!trimmed) {
     return false;
   }
@@ -407,7 +443,7 @@ export function resolveAckExecutionFastPathInstruction(params: {
       provider: params.provider,
       modelId: params.modelId,
     }) ||
-    !isLikelyExecutionAckPrompt(params.prompt)
+    (!isLikelyExecutionAckPrompt(params.prompt) && !isLikelyExecutionAckActionPrompt(params.prompt))
   ) {
     return null;
   }

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -260,7 +260,14 @@ describe("gateway server hooks", () => {
         messages: [{ id: "msg-1", from: "Ada", subject: "Hello", snippet: "Hi", body: "Body" }],
       });
       expect(response.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => expect(cronIsolatedRun).toHaveBeenCalledTimes(1), {
+        timeout: 5_000,
+      });
+      const runResult = cronIsolatedRun.mock.results[0];
+      if (runResult?.type !== "return") {
+        throw new Error("hook dispatch did not return a run promise");
+      }
+      await runResult.value;
 
       const call = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         sessionKey?: string;

--- a/src/plugin-sdk/qa-channel.test.ts
+++ b/src/plugin-sdk/qa-channel.test.ts
@@ -22,6 +22,17 @@ describe("plugin-sdk qa-channel", () => {
     });
   });
 
+  it("surfaces runtime seam resolution failures without fallback", async () => {
+    loadBundledPluginPublicSurfaceModuleSync.mockImplementation(() => {
+      throw new Error("Unable to resolve bundled plugin public surface qa-channel/runtime-api.js");
+    });
+    const { buildQaTarget } = await import("./qa-channel.js");
+
+    expect(() => buildQaTarget({ chatType: "direct", conversationId: "main" })).toThrow(
+      "Unable to resolve bundled plugin public surface qa-channel/runtime-api.js",
+    );
+  });
+
   it("keeps the qa facade cold until a value is used", async () => {
     const module = await import("./qa-channel.js");
 
@@ -30,7 +41,7 @@ describe("plugin-sdk qa-channel", () => {
     expect(loadBundledPluginPublicSurfaceModuleSync).toHaveBeenCalledTimes(1);
   });
 
-  it("delegates qa helpers through the bundled public surface", async () => {
+  it("delegates qa helpers through the bundled runtime seam", async () => {
     const { buildQaTarget, formatQaTarget } = await import("./qa-channel.js");
     const input = { chatType: "direct" as const, conversationId: "main" };
 
@@ -39,7 +50,7 @@ describe("plugin-sdk qa-channel", () => {
     expect(buildQaTargetImpl).toHaveBeenCalledTimes(2);
     expect(loadBundledPluginPublicSurfaceModuleSync).toHaveBeenCalledWith({
       dirName: "qa-channel",
-      artifactBasename: "api.js",
+      artifactBasename: "runtime-api.js",
     });
   });
 });

--- a/src/plugin-sdk/qa-channel.ts
+++ b/src/plugin-sdk/qa-channel.ts
@@ -1,5 +1,5 @@
 // Manual facade. Keep loader boundary explicit.
-type FacadeModule = typeof import("@openclaw/qa-channel/api.js");
+type FacadeModule = typeof import("@openclaw/qa-channel/runtime-api.js");
 import {
   createLazyFacadeObjectValue,
   loadBundledPluginPublicSurfaceModuleSync,
@@ -8,7 +8,7 @@ import {
 function loadFacadeModule(): FacadeModule {
   return loadBundledPluginPublicSurfaceModuleSync<FacadeModule>({
     dirName: "qa-channel",
-    artifactBasename: "api.js",
+    artifactBasename: "runtime-api.js",
   });
 }
 
@@ -63,25 +63,30 @@ export const sendQaBusMessage: FacadeModule["sendQaBusMessage"] = ((...args) =>
 export const setQaChannelRuntime: FacadeModule["setQaChannelRuntime"] = ((...args) =>
   loadFacadeModule().setQaChannelRuntime(...args)) as FacadeModule["setQaChannelRuntime"];
 
-export type QaBusAttachment = import("@openclaw/qa-channel/api.js").QaBusAttachment;
-export type QaBusConversation = import("@openclaw/qa-channel/api.js").QaBusConversation;
-export type QaBusConversationKind = import("@openclaw/qa-channel/api.js").QaBusConversationKind;
-export type QaBusCreateThreadInput = import("@openclaw/qa-channel/api.js").QaBusCreateThreadInput;
-export type QaBusDeleteMessageInput = import("@openclaw/qa-channel/api.js").QaBusDeleteMessageInput;
-export type QaBusEditMessageInput = import("@openclaw/qa-channel/api.js").QaBusEditMessageInput;
-export type QaBusEvent = import("@openclaw/qa-channel/api.js").QaBusEvent;
+export type QaBusAttachment = import("@openclaw/qa-channel/runtime-api.js").QaBusAttachment;
+export type QaBusConversation = import("@openclaw/qa-channel/runtime-api.js").QaBusConversation;
+export type QaBusConversationKind =
+  import("@openclaw/qa-channel/runtime-api.js").QaBusConversationKind;
+export type QaBusCreateThreadInput =
+  import("@openclaw/qa-channel/runtime-api.js").QaBusCreateThreadInput;
+export type QaBusDeleteMessageInput =
+  import("@openclaw/qa-channel/runtime-api.js").QaBusDeleteMessageInput;
+export type QaBusEditMessageInput =
+  import("@openclaw/qa-channel/runtime-api.js").QaBusEditMessageInput;
+export type QaBusEvent = import("@openclaw/qa-channel/runtime-api.js").QaBusEvent;
 export type QaBusInboundMessageInput =
-  import("@openclaw/qa-channel/api.js").QaBusInboundMessageInput;
-export type QaBusMessage = import("@openclaw/qa-channel/api.js").QaBusMessage;
+  import("@openclaw/qa-channel/runtime-api.js").QaBusInboundMessageInput;
+export type QaBusMessage = import("@openclaw/qa-channel/runtime-api.js").QaBusMessage;
 export type QaBusOutboundMessageInput =
-  import("@openclaw/qa-channel/api.js").QaBusOutboundMessageInput;
-export type QaBusPollInput = import("@openclaw/qa-channel/api.js").QaBusPollInput;
-export type QaBusPollResult = import("@openclaw/qa-channel/api.js").QaBusPollResult;
+  import("@openclaw/qa-channel/runtime-api.js").QaBusOutboundMessageInput;
+export type QaBusPollInput = import("@openclaw/qa-channel/runtime-api.js").QaBusPollInput;
+export type QaBusPollResult = import("@openclaw/qa-channel/runtime-api.js").QaBusPollResult;
 export type QaBusReactToMessageInput =
-  import("@openclaw/qa-channel/api.js").QaBusReactToMessageInput;
-export type QaBusReadMessageInput = import("@openclaw/qa-channel/api.js").QaBusReadMessageInput;
+  import("@openclaw/qa-channel/runtime-api.js").QaBusReactToMessageInput;
+export type QaBusReadMessageInput =
+  import("@openclaw/qa-channel/runtime-api.js").QaBusReadMessageInput;
 export type QaBusSearchMessagesInput =
-  import("@openclaw/qa-channel/api.js").QaBusSearchMessagesInput;
-export type QaBusStateSnapshot = import("@openclaw/qa-channel/api.js").QaBusStateSnapshot;
-export type QaBusThread = import("@openclaw/qa-channel/api.js").QaBusThread;
-export type QaBusWaitForInput = import("@openclaw/qa-channel/api.js").QaBusWaitForInput;
+  import("@openclaw/qa-channel/runtime-api.js").QaBusSearchMessagesInput;
+export type QaBusStateSnapshot = import("@openclaw/qa-channel/runtime-api.js").QaBusStateSnapshot;
+export type QaBusThread = import("@openclaw/qa-channel/runtime-api.js").QaBusThread;
+export type QaBusWaitForInput = import("@openclaw/qa-channel/runtime-api.js").QaBusWaitForInput;

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -107,6 +107,16 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export * from "openclaw/plugin-sdk/nextcloud-talk";',
     'export { setNextcloudTalkRuntime } from "./src/runtime.js";',
   ],
+  [bundledPluginFile({
+    rootDir: ROOT_DIR,
+    pluginId: "qa-channel",
+    relativePath: "runtime-api.ts",
+  })]: [
+    'export * from "./src/bus-client.js";',
+    'export * from "./src/channel.js";',
+    'export * from "./src/runtime-api.js";',
+    'export * from "./src/runtime.js";',
+  ],
   [bundledPluginFile({ rootDir: ROOT_DIR, pluginId: "signal", relativePath: "runtime-api.ts" })]: [
     'export * from "./src/runtime-api.js";',
     'export { setSignalRuntime } from "./src/runtime.js";',


### PR DESCRIPTION
## Summary
- switch `openclaw/plugin-sdk/qa-channel` from `qa-channel/api.js` to the already-packaged `qa-channel/runtime-api.js` seam
- expand `extensions/qa-channel/runtime-api.ts` to export the bus/channel/runtime symbols the facade actually uses
- add a negative-path seam test plus runtime-api guardrail coverage

## Why
The previous PR was closed because it changed CI/plugin architecture. This version stays within that constraint by reusing the existing packaged `dist/extensions/qa-channel/runtime-api.js` sidecar instead of widening packaging/CI surfaces.

## Verification
- `pnpm vitest run src/plugin-sdk/qa-channel.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`
