### PR TITLE
feat: add offline APNs chat reply alerts

### DIFF
--- a/src/gateway/chat-apns-notify.test.ts
+++ b/src/gateway/chat-apns-notify.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadApnsRegistrationMock = vi.fn();
+const resolveApnsAuthConfigFromEnvMock = vi.fn();
+const resolveApnsRelayConfigFromEnvMock = vi.fn();
+const sendApnsAlertMock = vi.fn();
+const clearApnsRegistrationIfCurrentMock = vi.fn();
+const shouldClearStoredApnsRegistrationMock = vi.fn();
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({ gateway: {}, session: { mainKey: "main" } })),
+}));
+
+vi.mock("../infra/push-apns.js", () => ({
+  loadApnsRegistration: loadApnsRegistrationMock,
+  resolveApnsAuthConfigFromEnv: resolveApnsAuthConfigFromEnvMock,
+  resolveApnsRelayConfigFromEnv: resolveApnsRelayConfigFromEnvMock,
+  sendApnsAlert: sendApnsAlertMock,
+  clearApnsRegistrationIfCurrent: clearApnsRegistrationIfCurrentMock,
+  shouldClearStoredApnsRegistration: shouldClearStoredApnsRegistrationMock,
+}));
+
+describe("maybeSendChatReplyApnsAlert", () => {
+  let maybeSendChatReplyApnsAlert: (typeof import("./chat-apns-notify.js"))["maybeSendChatReplyApnsAlert"];
+
+  beforeAll(async () => {
+    ({ maybeSendChatReplyApnsAlert } = await import("./chat-apns-notify.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadApnsRegistrationMock.mockResolvedValue({
+      nodeId: "ios-device-1",
+      transport: "direct",
+      token: "apns-token",
+      topic: "ai.openclaw.ios.test",
+      environment: "sandbox",
+      updatedAtMs: 1,
+    });
+    resolveApnsAuthConfigFromEnvMock.mockResolvedValue({
+      ok: true,
+      value: { teamId: "team", keyId: "key", privateKey: "private-key" },
+    });
+    resolveApnsRelayConfigFromEnvMock.mockReturnValue({ ok: false, error: "unused" });
+    sendApnsAlertMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      environment: "sandbox",
+      topic: "ai.openclaw.ios.test",
+      tokenSuffix: "token",
+      transport: "direct",
+    });
+    shouldClearStoredApnsRegistrationMock.mockReturnValue(false);
+  });
+
+  it("sends APNs alert for offline main-session reply devices", async () => {
+    await maybeSendChatReplyApnsAlert({
+      sessionKey: "main",
+      requestDeviceId: "ios-device-1",
+      requestConnId: "conn-1",
+      replyText: "  long\n\nreply body  ",
+      isConnIdConnected: () => false,
+      hasConnectedClientForDevice: () => false,
+    });
+
+    expect(loadApnsRegistrationMock).toHaveBeenCalledWith("ios-device-1");
+    expect(sendApnsAlertMock).toHaveBeenCalledTimes(1);
+    expect(sendApnsAlertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "ios-device-1",
+        title: "OpenClaw",
+        body: "long reply body",
+      }),
+    );
+  });
+
+  it("skips APNs while the requester connection is still active", async () => {
+    await maybeSendChatReplyApnsAlert({
+      sessionKey: "main",
+      requestDeviceId: "ios-device-1",
+      requestConnId: "conn-1",
+      replyText: "reply body",
+      isConnIdConnected: () => true,
+      hasConnectedClientForDevice: () => false,
+    });
+
+    expect(loadApnsRegistrationMock).not.toHaveBeenCalled();
+    expect(sendApnsAlertMock).not.toHaveBeenCalled();
+  });
+
+  it("skips APNs for non-main sessions", async () => {
+    await maybeSendChatReplyApnsAlert({
+      sessionKey: "subagent:demo",
+      requestDeviceId: "ios-device-1",
+      requestConnId: "conn-1",
+      replyText: "reply body",
+      isConnIdConnected: () => false,
+      hasConnectedClientForDevice: () => false,
+    });
+
+    expect(loadApnsRegistrationMock).not.toHaveBeenCalled();
+    expect(sendApnsAlertMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/chat-apns-notify.ts
+++ b/src/gateway/chat-apns-notify.ts
@@ -1,0 +1,116 @@
+import { loadConfig } from "../config/config.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import {
+  clearApnsRegistrationIfCurrent,
+  loadApnsRegistration,
+  resolveApnsAuthConfigFromEnv,
+  resolveApnsRelayConfigFromEnv,
+  sendApnsAlert,
+  shouldClearStoredApnsRegistration,
+} from "../infra/push-apns.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+const CHAT_REPLY_APNS_TITLE = "OpenClaw";
+const CHAT_REPLY_APNS_BODY_MAX_CHARS = 240;
+const CHAT_REPLY_MAIN_SESSION_FALLBACK = "main";
+
+export function normalizeChatReplyNotificationBody(rawText: string): string {
+  const collapsed = rawText.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= CHAT_REPLY_APNS_BODY_MAX_CHARS) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, CHAT_REPLY_APNS_BODY_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+export async function maybeSendChatReplyApnsAlert(params: {
+  sessionKey: string;
+  mainSessionKey?: string | null;
+  requestDeviceId?: string | null;
+  requestConnId?: string | null;
+  replyText: string;
+  isConnIdConnected?: (connId: string) => boolean;
+  hasConnectedClientForDevice?: (deviceId: string, opts?: { excludeConnId?: string }) => boolean;
+  logWarn?: (message: string) => void;
+}): Promise<void> {
+  const cfg = loadConfig();
+  const mainSessionKey =
+    normalizeOptionalString(params.mainSessionKey) ??
+    normalizeOptionalString(cfg.session?.mainKey) ??
+    CHAT_REPLY_MAIN_SESSION_FALLBACK;
+  if (params.sessionKey !== mainSessionKey) {
+    return;
+  }
+
+  const deviceId = normalizeOptionalString(params.requestDeviceId) ?? "";
+  if (!deviceId) {
+    return;
+  }
+
+  const requestConnId = normalizeOptionalString(params.requestConnId) ?? undefined;
+  if (requestConnId && params.isConnIdConnected?.(requestConnId)) {
+    return;
+  }
+  if (params.hasConnectedClientForDevice?.(deviceId, { excludeConnId: requestConnId })) {
+    return;
+  }
+
+  const body = normalizeChatReplyNotificationBody(params.replyText);
+  if (!body) {
+    return;
+  }
+
+  try {
+    const registration = await loadApnsRegistration(deviceId);
+    if (!registration) {
+      return;
+    }
+
+    let result;
+    if (registration.transport === "relay") {
+      const relay = resolveApnsRelayConfigFromEnv(process.env, cfg.gateway);
+      if (!relay.ok) {
+        params.logWarn?.(`chat APNs relay unavailable device=${deviceId}: ${relay.error}`);
+        return;
+      }
+      result = await sendApnsAlert({
+        registration,
+        nodeId: deviceId,
+        title: CHAT_REPLY_APNS_TITLE,
+        body,
+        relayConfig: relay.value,
+      });
+    } else {
+      const auth = await resolveApnsAuthConfigFromEnv(process.env);
+      if (!auth.ok) {
+        params.logWarn?.(`chat APNs auth unavailable device=${deviceId}: ${auth.error}`);
+        return;
+      }
+      result = await sendApnsAlert({
+        registration,
+        nodeId: deviceId,
+        title: CHAT_REPLY_APNS_TITLE,
+        body,
+        auth: auth.value,
+      });
+    }
+
+    if (
+      shouldClearStoredApnsRegistration({
+        registration,
+        result,
+      })
+    ) {
+      await clearApnsRegistrationIfCurrent({
+        nodeId: deviceId,
+        registration,
+      });
+    }
+    if (!result.ok) {
+      params.logWarn?.(
+        `chat APNs send failed device=${deviceId} status=${result.status} reason=${result.reason ?? "-"}`,
+      );
+    }
+  } catch (error) {
+    params.logWarn?.(`chat APNs send threw device=${deviceId}: ${formatErrorMessage(error)}`);
+  }
+}


### PR DESCRIPTION
## Summary

Adds Gateway-side offline APNs reply alerts for chat runs. When an agent-based chat reply completes after the requesting iOS client has disconnected, the Gateway sends an APNs push notification with the reply text.

This is a clean re-implementation of #63800 against latest main. The original PR was based on an older base and accumulated merge conflicts.

## What's included

- `src/gateway/chat-apns-notify.ts` — Core APNs notification logic
- `src/gateway/chat-apns-notify.test.ts` — Unit tests

## Integration points (not yet wired)

The following files need corresponding changes to wire `maybeSendChatReplyApnsAlert` into the chat lifecycle. These were part of the original PR but had extensive non-APNS diff overlap with current main. They will be submitted as a follow-up PR once this core module is merged:

- `src/gateway/server-chat.ts` — call site in agent-event lifecycle
- `src/gateway/server-methods/chat.ts` — call site in direct-reply path
- `src/gateway/server-methods/types.ts` — type additions
- `src/gateway/server-runtime-subscriptions.ts` — connection tracking
- `src/gateway/server.impl.ts` — wiring
- `src/infra/agent-events.ts` — context fields
- `src/gateway/server-chat.agent-events.test.ts` — test additions

## Companion

- iOS client PR: #63697

## CI note

Previous #63800 CI failures (security-fast, install-smoke) were runner infra issues, not code issues.