### PR TITLE
fix(cli): refuse to run as root without OPENCLAW_ALLOW_ROOT override

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -38,6 +38,22 @@ const ensureSupportedNodeVersion = () => {
 
 ensureSupportedNodeVersion();
 
+const ensureNotRoot = () => {
+  if (
+    typeof process.getuid === "function" &&
+    process.getuid() === 0 &&
+    !process.env.OPENCLAW_ALLOW_ROOT
+  ) {
+    process.stderr.write(
+      "openclaw: refusing to run as root. Running as root causes state corruption and crash loops.\n" +
+        "If you really need this (Docker, CI), set OPENCLAW_ALLOW_ROOT=1.\n",
+    );
+    process.exit(1);
+  }
+};
+
+ensureNotRoot();
+
 // https://nodejs.org/api/module.html#module-compile-cache
 if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   try {

--- a/src/cli/root-guard.test.ts
+++ b/src/cli/root-guard.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const entryPoint = resolve(repoRoot, "openclaw.mjs");
+
+describe("root guard in openclaw.mjs", () => {
+  it("contains the root-user guard that checks getuid and OPENCLAW_ALLOW_ROOT", () => {
+    const content = readFileSync(entryPoint, "utf8");
+    expect(content).toContain("ensureNotRoot");
+    expect(content).toContain("OPENCLAW_ALLOW_ROOT");
+    expect(content).toContain("process.getuid() === 0");
+    // Guard runs before any command loading
+    const guardIndex = content.indexOf("ensureNotRoot()");
+    const importIndex = content.indexOf("tryImport");
+    expect(guardIndex).toBeLessThan(importIndex);
+  });
+
+  it("guard exits with a clear error message when running as root", () => {
+    const content = readFileSync(entryPoint, "utf8");
+    expect(content).toContain("refusing to run as root");
+    expect(content).toContain("OPENCLAW_ALLOW_ROOT=1");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a root-user guard to the CLI entry point (`openclaw.mjs`). When `process.getuid() === 0` and `OPENCLAW_ALLOW_ROOT` is not set, the CLI prints a clear error and exits with code 1.

## Problem

On DigitalOcean 1-Click Droplets (and similar setups), the default SSH user is root. Running `openclaw` as root silently corrupts state ownership, installs a rogue systemd user gateway, and causes crash loops as two instances race for port 18789.

## Solution

- Guard runs early in `openclaw.mjs`, right after the Node version check and before any command loading
- Checks `process.getuid() === 0` (only on platforms that support it)
- Escape hatch: `OPENCLAW_ALLOW_ROOT=1` for Docker/CI environments
- Clear error message pointing users to the workaround

## Testing

- Added `src/cli/root-guard.test.ts` verifying the guard is present and positioned correctly

Closes #67478