### PR TITLE
fix: use EX_CONFIG (78) exit code in config-guard to prevent crash loop

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -111,7 +111,7 @@ describe("ensureConfigReady", () => {
 
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Config invalid"));
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("doctor --fix"));
-    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.exit).toHaveBeenCalledWith(78);
   });
 
   it("does not exit for invalid config on allowlisted commands", async () => {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -3,6 +3,13 @@ import type { RuntimeEnv } from "../../runtime.js";
 import { shouldMigrateStateFromPath } from "../argv.js";
 
 const ALLOWED_INVALID_COMMANDS = new Set(["doctor", "logs", "health", "help", "status"]);
+
+/**
+ * EX_CONFIG (78) from sysexits.h — tells supervisors (systemd, launchd) to
+ * stop restarting instead of entering a crash loop that can render hosts
+ * unresponsive.  Matches the convention already used in gateway run.ts.
+ */
+const EXIT_CONFIG_ERROR = 78;
 const ALLOWED_INVALID_GATEWAY_SUBCOMMANDS = new Set([
   "status",
   "probe",
@@ -120,7 +127,7 @@ export async function ensureConfigReady(params: {
     `${muted("Run:")} ${commandText(formatCliCommand("openclaw doctor --fix"))}`,
   );
   if (!allowInvalid) {
-    params.runtime.exit(1);
+    params.runtime.exit(EXIT_CONFIG_ERROR);
   }
 }
 


### PR DESCRIPTION
## Summary
- config-guard exits with code 1 on invalid config, which supervisors treat as transient and retry — causing an infinite crash loop that pins CPU
- Changed to exit code 78 (EX_CONFIG from sysexits.h), matching the convention already used in `gateway/run.ts`
- Updated test assertion to expect exit code 78

## Reproduction
1. Set an invalid value in `openclaw.json` (e.g. `agents.defaults.thinkingDefault: "max"` — previously valid, removed in a recent update)
2. Start gateway: `openclaw gateway --port 18789`
3. Gateway enters infinite crash loop logging "Config invalid" every ~10s at 100%+ CPU

## Test plan
- [x] `pnpm vitest run src/cli/program/config-guard.test.ts` — all 10 tests pass
- [x] Pre-commit hooks pass (lint, type check, import cycles)