### PR TITLE
fix(ollama): model picker shows wrong models after selecting Ollama

### DIFF
--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -18,7 +18,7 @@ import {
   ensureOllamaModelPulled,
   promptAndConfigureOllama,
 } from "./api.js";
-import { OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
+import { OLLAMA_DEFAULT_BASE_URL, OLLAMA_DEFAULT_MODEL } from "./src/defaults.js";
 import {
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
   createOllamaEmbeddingProvider,
@@ -248,6 +248,16 @@ export default definePluginEntry({
         });
       },
       ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
+      augmentModelCatalog: () => [
+        {
+          provider: PROVIDER_ID,
+          id: OLLAMA_DEFAULT_MODEL,
+          name: `Ollama (${OLLAMA_DEFAULT_MODEL})`,
+          reasoning: false,
+          input: ["text"],
+          contextWindow: undefined,
+        },
+      ],
       resolveReasoningOutputMode: () => "native",
       wrapStreamFn: createConfiguredOllamaCompatStreamWrapper,
       createEmbeddingProvider: async ({ config, model, remote }) => {

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -18,7 +18,7 @@ import {
   ensureOllamaModelPulled,
   promptAndConfigureOllama,
 } from "./api.js";
-import { OLLAMA_DEFAULT_BASE_URL, OLLAMA_DEFAULT_MODEL } from "./src/defaults.js";
+import { OLLAMA_DEFAULT_BASE_URL, OLLAMA_DEFAULT_CONTEXT_WINDOW, OLLAMA_DEFAULT_MODEL } from "./src/defaults.js";
 import {
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
   createOllamaEmbeddingProvider,
@@ -255,7 +255,7 @@ export default definePluginEntry({
           name: `Ollama (${OLLAMA_DEFAULT_MODEL})`,
           reasoning: false,
           input: ["text"],
-          contextWindow: undefined,
+          contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW,
         },
       ],
       resolveReasoningOutputMode: () => "native",


### PR DESCRIPTION
## Summary

- **Fix**: Model picker showed Amazon Bedrock models when Ollama was selected  
- **Cause**: Ollama plugin did not register any models in the catalog  
- **Solution**: Add `augmentModelCatalog` with default model (`ollama/gemma4`)  
- **Scope**: UI only; no changes to discovery, auth, or runtime behavior  
- **Note**: Recurring issue pattern (seen in Kimi / Moonshot), indicating a systemic gap in provider plugin requirements  


## Root Cause

Ollama plugin did not implement `augmentModelCatalog`, so no models were registered in the picker, causing a fallback to other providers.


## User-visible Changes

- Model picker now shows `ollama/gemma4` when selecting Ollama  
- Discovered models still load as before  


## Repro

1. Open setup wizard  
2. Select Ollama  
3. Check model picker  

## Screenshots

| Before | After |
|--------|-------|
| <img width="736" height="474" alt="ollama-bug-new-0416" src="https://github.com/user-attachments/assets/9f3e40a3-ede1-4084-82e3-81d0942e77b1" /> | <img width="464" height="264" alt="ollama-fix-new-0416" src="https://github.com/user-attachments/assets/9b9f9da5-477c-470b-94f3-f337990c7f64" /> |


## Notes

- Same issue pattern as Kimi / Moonshot  
- Indicates a systemic gap: provider plugins must implement `augmentModelCatalog`  
- Suggestion: enforce this via plugin contract or validation to prevent recurrence  
- No breaking changes  