### PR TITLE
test: avoid hanging boundary+tooling shard

### DIFF
--- a/test/vitest-project-shard-config.test.ts
+++ b/test/vitest-project-shard-config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createProjectShardVitestConfig } from "./vitest/vitest.project-shard-config.ts";
+import { nonIsolatedRunnerPath } from "./vitest/vitest.shared.config.ts";
+
+describe("project shard vitest config", () => {
+  it("lets child projects own their runner", () => {
+    const config = createProjectShardVitestConfig([
+      "test/vitest/vitest.boundary.config.ts",
+      "test/vitest/vitest.tooling.config.ts",
+    ]);
+
+    expect(config.test?.projects).toEqual([
+      "test/vitest/vitest.boundary.config.ts",
+      "test/vitest/vitest.tooling.config.ts",
+    ]);
+    expect(config.test?.runner).toBeUndefined();
+    expect(nonIsolatedRunnerPath).toContain("test/non-isolated-runner.ts");
+  });
+});

--- a/test/vitest/vitest.project-shard-config.ts
+++ b/test/vitest/vitest.project-shard-config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vitest/config";
-import { nonIsolatedRunnerPath, sharedVitestConfig } from "./vitest.shared.config.ts";
+import { sharedVitestConfig } from "./vitest.shared.config.ts";
 
 export function createProjectShardVitestConfig(projects: readonly string[]) {
   const maxWorkers = sharedVitestConfig.test.maxWorkers;
@@ -10,7 +10,11 @@ export function createProjectShardVitestConfig(projects: readonly string[]) {
     ...sharedVitestConfig,
     test: {
       ...sharedVitestConfig.test,
-      runner: nonIsolatedRunnerPath,
+      // Let each child project own its runner. Forcing the shared non-isolated
+      // runner at the root combined-project layer can leave Vitest hanging after
+      // boundary+tooling completes, even though the child projects exit cleanly
+      // when run directly.
+      runner: undefined,
       projects: [...projects],
     },
   });


### PR DESCRIPTION
## Summary
- stop forcing the non-isolated runner at the root combined-project shard config
- let each child Vitest project own its runner
- add a regression test for the project-shard runner behavior

## Problem
`test/vitest/vitest.full-core-support-boundary.config.ts` could finish all boundary+tooling tests and then hang with no more output until the CI watchdog killed it. Locally I could reproduce this deterministically when the root shard config forced `runner: nonIsolatedRunnerPath`.

The same child projects (`boundary` + `tooling`) exit cleanly when the root combined-project config leaves `runner` unset.

## Testing
- `CI=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=15000 node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts` x3
- `CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/vitest-project-shard-config.test.ts test/scripts/write-cli-startup-metadata.test.ts` x3
- `CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.boundary.config.ts test/extension-import-boundaries.test.ts test/plugin-extension-import-boundary.test.ts test/web-provider-boundary.test.ts` x3
