### PR TITLE
fix: add root guard to prevent CLI execution as root (#67478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI/chat: hide retired and non-public Google Gemini model IDs from chat model catalogs and route the bare `gemini-3-pro` alias to Gemini 3.1 Pro Preview instead of the shut-down Gemini 3 Pro Preview. Thanks @BunsDev.
+- CLI/install: refuse state-mutating OpenClaw CLI runs as root by default, keep an explicit `OPENCLAW_ALLOW_ROOT=1` escape hatch for intentional root/container use, and update DigitalOcean setup guidance to run OpenClaw as a non-root user. Fixes #67478. Thanks @Jerry-Xin and @natechicago.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/docs/install/digitalocean.md
+++ b/docs/install/digitalocean.md
@@ -50,8 +50,17 @@ DigitalOcean is the simplest paid VPS path. If you prefer cheaper or free option
 
     # Install OpenClaw
     curl -fsSL https://openclaw.ai/install.sh | bash
+
+    # Create the non-root user that will own OpenClaw state and services.
+    adduser openclaw
+    usermod -aG sudo openclaw
+    loginctl enable-linger openclaw
+
+    su - openclaw
     openclaw --version
     ```
+
+    Use the root shell only for system bootstrap. Run OpenClaw commands as the non-root `openclaw` user so state lives under `/home/openclaw/.openclaw/` and the Gateway installs as that user's systemd service.
 
   </Step>
 
@@ -97,8 +106,8 @@ DigitalOcean is the simplest paid VPS path. If you prefer cheaper or free option
     **Option B: Tailscale Serve**
 
     ```bash
-    curl -fsSL https://tailscale.com/install.sh | sh
-    tailscale up
+    curl -fsSL https://tailscale.com/install.sh | sudo sh
+    sudo tailscale up
     openclaw config set gateway.tailscale.mode serve
     openclaw gateway restart
     ```

--- a/src/cli/root-guard.test.ts
+++ b/src/cli/root-guard.test.ts
@@ -32,10 +32,16 @@ describe("assertNotRoot", () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("does not exit when uid is 0 and OPENCLAW_CLI_CONTAINER_BYPASS=1", () => {
+  it("does not exit when uid is 0 and OPENCLAW_CLI_CONTAINER_BYPASS=1 with container hint", () => {
+    process.getuid = () => 0;
+    assertNotRoot({ OPENCLAW_CLI_CONTAINER_BYPASS: "1", OPENCLAW_CONTAINER_HINT: "my-container" });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits when uid is 0 and OPENCLAW_CLI_CONTAINER_BYPASS=1 without container hint", () => {
     process.getuid = () => 0;
     assertNotRoot({ OPENCLAW_CLI_CONTAINER_BYPASS: "1" });
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it("does not exit when uid is non-zero", () => {

--- a/src/cli/root-guard.test.ts
+++ b/src/cli/root-guard.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("assertNotRoot", () => {
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+  // Save and restore real getuid so we can replace it per test.
+  const realGetuid = process.getuid;
+
+  beforeEach(() => {
+    exitSpy.mockClear();
+    stderrSpy.mockClear();
+    process.getuid = realGetuid;
+  });
+
+  afterAll(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    process.getuid = realGetuid;
+  });
+
+  // Use a fresh import each time to avoid module-level caching issues.
+  async function loadAssertNotRoot() {
+    const mod = await import("./root-guard.js");
+    return mod.assertNotRoot;
+  }
+
+  it("exits with code 1 when uid is 0 and no env override", async () => {
+    process.getuid = () => 0;
+    const assertNotRoot = await loadAssertNotRoot();
+    assertNotRoot({});
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("does not exit when uid is 0 and OPENCLAW_ALLOW_ROOT=1", async () => {
+    process.getuid = () => 0;
+    const assertNotRoot = await loadAssertNotRoot();
+    assertNotRoot({ OPENCLAW_ALLOW_ROOT: "1" });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not exit when uid is non-zero", async () => {
+    process.getuid = () => 1000;
+    const assertNotRoot = await loadAssertNotRoot();
+    assertNotRoot({});
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not exit when getuid is undefined (Windows)", async () => {
+    process.getuid = undefined as unknown as typeof process.getuid;
+    const assertNotRoot = await loadAssertNotRoot();
+    assertNotRoot({});
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("error message mentions OPENCLAW_ALLOW_ROOT", async () => {
+    process.getuid = () => 0;
+    const assertNotRoot = await loadAssertNotRoot();
+    assertNotRoot({});
+    const output = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(output).toContain("OPENCLAW_ALLOW_ROOT");
+  });
+
+  it("error message mentions running as a non-root user", async () => {
+    process.getuid = () => 0;
+    const assertNotRoot = await loadAssertNotRoot();
+    assertNotRoot({});
+    const output = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(output).toContain("non-root user");
+  });
+});

--- a/src/cli/root-guard.test.ts
+++ b/src/cli/root-guard.test.ts
@@ -32,6 +32,12 @@ describe("assertNotRoot", () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  it("does not exit when uid is 0 and OPENCLAW_CLI_CONTAINER_BYPASS=1", () => {
+    process.getuid = () => 0;
+    assertNotRoot({ OPENCLAW_CLI_CONTAINER_BYPASS: "1" });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
   it("does not exit when uid is non-zero", () => {
     process.getuid = () => 1000;
     assertNotRoot({});

--- a/src/cli/root-guard.test.ts
+++ b/src/cli/root-guard.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { assertNotRoot } from "./root-guard.js";
 
 describe("assertNotRoot", () => {
   const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
@@ -19,51 +20,39 @@ describe("assertNotRoot", () => {
     process.getuid = realGetuid;
   });
 
-  // Use a fresh import each time to avoid module-level caching issues.
-  async function loadAssertNotRoot() {
-    const mod = await import("./root-guard.js");
-    return mod.assertNotRoot;
-  }
-
-  it("exits with code 1 when uid is 0 and no env override", async () => {
+  it("exits with code 1 when uid is 0 and no env override", () => {
     process.getuid = () => 0;
-    const assertNotRoot = await loadAssertNotRoot();
     assertNotRoot({});
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("does not exit when uid is 0 and OPENCLAW_ALLOW_ROOT=1", async () => {
+  it("does not exit when uid is 0 and OPENCLAW_ALLOW_ROOT=1", () => {
     process.getuid = () => 0;
-    const assertNotRoot = await loadAssertNotRoot();
     assertNotRoot({ OPENCLAW_ALLOW_ROOT: "1" });
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("does not exit when uid is non-zero", async () => {
+  it("does not exit when uid is non-zero", () => {
     process.getuid = () => 1000;
-    const assertNotRoot = await loadAssertNotRoot();
     assertNotRoot({});
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("does not exit when getuid is undefined (Windows)", async () => {
+  it("does not exit when getuid is undefined (Windows)", () => {
     process.getuid = undefined as unknown as typeof process.getuid;
-    const assertNotRoot = await loadAssertNotRoot();
     assertNotRoot({});
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it("error message mentions OPENCLAW_ALLOW_ROOT", async () => {
+  it("error message mentions OPENCLAW_ALLOW_ROOT", () => {
     process.getuid = () => 0;
-    const assertNotRoot = await loadAssertNotRoot();
     assertNotRoot({});
     const output = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
     expect(output).toContain("OPENCLAW_ALLOW_ROOT");
   });
 
-  it("error message mentions running as a non-root user", async () => {
+  it("error message mentions running as a non-root user", () => {
     process.getuid = () => 0;
-    const assertNotRoot = await loadAssertNotRoot();
     assertNotRoot({});
     const output = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
     expect(output).toContain("non-root user");

--- a/src/cli/root-guard.test.ts
+++ b/src/cli/root-guard.test.ts
@@ -5,19 +5,22 @@ describe("assertNotRoot", () => {
   const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
   const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
-  // Save and restore real getuid so we can replace it per test.
+  // Save and restore real getuid/geteuid so we can replace them per test.
   const realGetuid = process.getuid;
+  const realGeteuid = process.geteuid;
 
   beforeEach(() => {
     exitSpy.mockClear();
     stderrSpy.mockClear();
     process.getuid = realGetuid;
+    process.geteuid = realGeteuid;
   });
 
   afterAll(() => {
     exitSpy.mockRestore();
     stderrSpy.mockRestore();
     process.getuid = realGetuid;
+    process.geteuid = realGeteuid;
   });
 
   it("exits with code 1 when uid is 0 and no env override", () => {
@@ -47,6 +50,27 @@ describe("assertNotRoot", () => {
   it("does not exit when uid is non-zero", () => {
     process.getuid = () => 1000;
     assertNotRoot({});
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits when real uid is non-zero but effective uid is 0 (setuid-root)", () => {
+    process.getuid = () => 1000;
+    process.geteuid = () => 0;
+    assertNotRoot({});
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("does not exit when real uid is non-zero and effective uid is non-zero", () => {
+    process.getuid = () => 1000;
+    process.geteuid = () => 1000;
+    assertNotRoot({});
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not exit when euid is 0 but OPENCLAW_ALLOW_ROOT=1", () => {
+    process.getuid = () => 1000;
+    process.geteuid = () => 0;
+    assertNotRoot({ OPENCLAW_ALLOW_ROOT: "1" });
     expect(exitSpy).not.toHaveBeenCalled();
   });
 

--- a/src/cli/root-guard.ts
+++ b/src/cli/root-guard.ts
@@ -1,0 +1,34 @@
+import process from "node:process";
+
+/**
+ * Block CLI execution when running as root (uid 0) unless explicitly opted in.
+ *
+ * Running as root causes:
+ * - Separate state dir (/root/.openclaw/ vs /home/<user>/.openclaw/)
+ * - Conflicting systemd user services (port 18789 race)
+ * - Root-owned files in the service user's state dir (EACCES)
+ */
+export function assertNotRoot(env: NodeJS.ProcessEnv = process.env): void {
+  if (typeof process.getuid !== "function") {
+    return;
+  }
+  if (process.getuid() !== 0) {
+    return;
+  }
+  if (env.OPENCLAW_ALLOW_ROOT === "1") {
+    return;
+  }
+  process.stderr.write(
+    "[openclaw] Refusing to run as root.\n" +
+      "\n" +
+      "Running the CLI as root causes:\n" +
+      "  - A separate state directory under /root/.openclaw/ instead of the service user's\n" +
+      "  - Conflicting systemd user services that race on port 18789\n" +
+      "  - Root-owned files in the service user's state dir (EACCES errors)\n" +
+      "\n" +
+      "Run as a non-root user (e.g. su - <service-user>),\n" +
+      "or override this check:\n" +
+      "  OPENCLAW_ALLOW_ROOT=1 openclaw ...\n",
+  );
+  process.exit(1);
+}

--- a/src/cli/root-guard.ts
+++ b/src/cli/root-guard.ts
@@ -15,7 +15,10 @@ export function assertNotRoot(env: NodeJS.ProcessEnv = process.env): void {
   if (process.getuid() !== 0) {
     return;
   }
-  if (env.OPENCLAW_ALLOW_ROOT === "1" || env.OPENCLAW_CLI_CONTAINER_BYPASS === "1") {
+  if (
+    env.OPENCLAW_ALLOW_ROOT === "1" ||
+    (env.OPENCLAW_CLI_CONTAINER_BYPASS === "1" && env.OPENCLAW_CONTAINER_HINT)
+  ) {
     return;
   }
   process.stderr.write(

--- a/src/cli/root-guard.ts
+++ b/src/cli/root-guard.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 
 /**
- * Block CLI execution when running as root (uid 0) unless explicitly opted in.
+ * Block CLI execution when running as root (uid 0 or euid 0) unless explicitly opted in.
  *
  * Running as root causes:
  * - Separate state dir (/root/.openclaw/ vs /home/<user>/.openclaw/)
@@ -12,7 +12,9 @@ export function assertNotRoot(env: NodeJS.ProcessEnv = process.env): void {
   if (typeof process.getuid !== "function") {
     return;
   }
-  if (process.getuid() !== 0) {
+  const uid = process.getuid();
+  const euid = typeof process.geteuid === "function" ? process.geteuid() : uid;
+  if (uid !== 0 && euid !== 0) {
     return;
   }
   if (

--- a/src/cli/root-guard.ts
+++ b/src/cli/root-guard.ts
@@ -15,7 +15,7 @@ export function assertNotRoot(env: NodeJS.ProcessEnv = process.env): void {
   if (process.getuid() !== 0) {
     return;
   }
-  if (env.OPENCLAW_ALLOW_ROOT === "1") {
+  if (env.OPENCLAW_ALLOW_ROOT === "1" || env.OPENCLAW_CLI_CONTAINER_BYPASS === "1") {
     return;
   }
   process.stderr.write(

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { isRootHelpInvocation } from "./cli/argv.js";
+import { isRootHelpInvocation, isRootVersionInvocation } from "./cli/argv.js";
+import { assertNotRoot } from "./cli/root-guard.js";
 import { parseCliContainerArgs, resolveCliContainerTarget } from "./cli/container-target.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
@@ -91,6 +92,13 @@ if (
     ensureOpenClawExecMarkerOnProcess();
     installProcessWarningFilter();
     normalizeEnv();
+
+    // Block root execution early, before any state/config operations.
+    // Allow --help and --version so users can still discover the override env var.
+    if (!isRootHelpInvocation(process.argv) && !isRootVersionInvocation(process.argv)) {
+      assertNotRoot();
+    }
+
     enableOpenClawCompileCache({
       installRoot,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { isRootHelpInvocation, isRootVersionInvocation } from "./cli/argv.js";
+
 import { assertNotRoot } from "./cli/root-guard.js";
 import { formatUncaughtError } from "./infra/errors.js";
 import { runFatalErrorHooks } from "./infra/fatal-error-hooks.js";
@@ -52,10 +52,12 @@ export async function runLegacyCliEntry(
   deps?: LegacyCliDeps,
 ): Promise<void> {
   // Block root execution on the legacy path too, matching src/entry.ts.
-  // Allow --help and --version so users can still discover the override env var.
-  if (!isRootHelpInvocation(argv) && !isRootVersionInvocation(argv)) {
-    assertNotRoot();
-  }
+  // Unlike entry.ts (which has fast-path help/version exits before startup),
+  // this path always calls runCli() which runs startup work (dotenv loading,
+  // debug capture init) before rendering help/version output.  Block
+  // unconditionally — the assertNotRoot error message already shows the
+  // OPENCLAW_ALLOW_ROOT=1 escape hatch.
+  assertNotRoot();
 
   const { runCli } = deps ?? (await loadLegacyCliDeps());
   await runCli(argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { isRootHelpInvocation, isRootVersionInvocation } from "./cli/argv.js";
+import { assertNotRoot } from "./cli/root-guard.js";
 import { formatUncaughtError } from "./infra/errors.js";
 import { runFatalErrorHooks } from "./infra/fatal-error-hooks.js";
 import { isMainModule } from "./infra/is-main.js";
@@ -49,6 +51,12 @@ export async function runLegacyCliEntry(
   argv: string[] = process.argv,
   deps?: LegacyCliDeps,
 ): Promise<void> {
+  // Block root execution on the legacy path too, matching src/entry.ts.
+  // Allow --help and --version so users can still discover the override env var.
+  if (!isRootHelpInvocation(argv) && !isRootVersionInvocation(argv)) {
+    assertNotRoot();
+  }
+
   const { runCli } = deps ?? (await loadLegacyCliDeps());
   await runCli(argv);
 }


### PR DESCRIPTION
## Summary

Add an early OpenClaw CLI root guard to prevent direct root execution from creating root-owned state, installing root-scoped user services, or racing the intended Gateway service.

Closes #67478.

## Changes

- Add `assertNotRoot()` with real/effective UID checks, an explicit `OPENCLAW_ALLOW_ROOT=1` override, and a narrowed container-forwarding bypass.
- Wire the guard into both `src/entry.ts` and the legacy `src/index.ts` entrypoint before state/config/service work.
- Cover root, non-root, euid, Windows-safe, container-bypass, and override cases in `src/cli/root-guard.test.ts`.
- Update DigitalOcean setup docs so root is used only for system bootstrap and OpenClaw commands run as a non-root `openclaw` user.
- Add a changelog entry for the user-facing root refusal and override.

## Real behavior proof

- **Behavior or issue addressed**: Direct root invocation of the packaged CLI now refuses before resolving OpenClaw state, while non-root usage still works and intentional root use requires `OPENCLAW_ALLOW_ROOT=1`.
- **Real environment tested**: Blacksmith Testbox Ubuntu 24.04 runner via Crabbox, PR head `0fbe2f507acbd149545dc91c9fa5b70dcb614ca6`, Node runtime from the OpenClaw CI image.
- **Exact steps or command run after this patch**:

```bash
pnpm build >/tmp/openclaw-build.log
node dist/entry.js config file
sudo -n env PATH="$PATH" HOME=/root node dist/entry.js config file
sudo -n env PATH="$PATH" HOME=/root OPENCLAW_ALLOW_ROOT=1 node dist/entry.js config file
```

- **After-fix evidence**: Copied terminal output from the real Linux Testbox run: https://github.com/openclaw/openclaw/actions/runs/25534466129

```text
non-root uid: 1001
~/.openclaw/openclaw.json

root refusal:
[openclaw] Refusing to run as root.

Running the CLI as root causes:
  - A separate state directory under /root/.openclaw/ instead of the service user's
  - Conflicting systemd user services that race on port 18789
  - Root-owned files in the service user's state dir (EACCES errors)

Run as a non-root user (e.g. su - <service-user>),
or override this check:
  OPENCLAW_ALLOW_ROOT=1 openclaw ...

root override:
~/.openclaw/openclaw.json
blacksmith run summary sync=delegated command=1m4.527s total=1m6.716s exit=0
```

- **Observed result after fix**: The non-root packaged CLI command printed the user's config path, the same command as root refused with the new root-guard message, and the explicit `OPENCLAW_ALLOW_ROOT=1` override allowed the root command to proceed.
- **What was not tested**: I did not rerun the destructive DigitalOcean `openclaw doctor --fix` corruption scenario; the Testbox proof verifies the preventive CLI behavior on real Linux without creating a rogue service.

## Verification

```text
pnpm test src/cli/root-guard.test.ts src/entry.test.ts src/entry.version-fast-path.test.ts
[test] passed 2 Vitest shards in 4.38s

git diff --check
```
