### PR TITLE
feat(google): add Gemini execution guidance via prompt overlay [v3 final 2/3]

### DIFF
--- a/extensions/google/gemini-cli-provider.ts
+++ b/extensions/google/gemini-cli-provider.ts
@@ -7,6 +7,7 @@ import { buildOauthProviderAuthResult } from "openclaw/plugin-sdk/provider-auth-
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
 import { fetchGeminiUsage } from "openclaw/plugin-sdk/provider-usage";
 import { formatGoogleOauthApiKey, parseGoogleUsageToken } from "./oauth-token-shared.js";
+import { resolveGoogleSystemPromptContribution } from "./prompt-overlay.js";
 import { GOOGLE_GEMINI_PROVIDER_HOOKS } from "./provider-hooks.js";
 import { isModernGoogleModel, resolveGoogleGeminiForwardCompatModel } from "./provider-models.js";
 
@@ -116,6 +117,11 @@ export function registerGoogleGeminiCliProvider(api: OpenClawPluginApi) {
       }),
     ...GOOGLE_GEMINI_CLI_PROVIDER_HOOKS,
     isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
+    resolveSystemPromptContribution: (ctx) =>
+      resolveGoogleSystemPromptContribution({
+        modelProviderId: PROVIDER_ID,
+        modelId: ctx.modelId,
+      }),
     formatApiKey: (cred) => formatGoogleOauthApiKey(cred),
     resolveUsageAuth: async (ctx) => {
       const auth = await ctx.resolveOAuthToken();

--- a/extensions/google/prompt-overlay.ts
+++ b/extensions/google/prompt-overlay.ts
@@ -1,0 +1,47 @@
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
+
+const GOOGLE_PROVIDER_IDS = new Set(["google", "google-vertex", "google-antigravity", "google-gemini-cli"]);
+
+// Ported from Hermes Agent's GOOGLE_MODEL_OPERATIONAL_GUIDANCE
+// (agent/prompt_builder.py lines 258-276).
+//
+// Deviation from Hermes: the "Absolute paths" bullet is omitted because
+// OpenClaw runs exec inside a sandbox container whose workdir differs from
+// the host workspace. The core system prompt at src/agents/system-prompt.ts
+// explicitly tells the model to prefer relative paths so both sandboxed exec
+// and file tools work consistently.
+//
+// Tool ID substitutions: read_file/search_files -> read or exec
+export const GOOGLE_GEMINI_EXECUTION_GUIDANCE = `# Google model operational directives
+Follow these operational rules strictly:
+- **Verify first:** Use read or exec to check file contents and project structure before making changes. Never guess at file contents.
+- **Dependency checks:** Never assume a library is available. Check package.json, requirements.txt, Cargo.toml, etc. before importing.
+- **Conciseness:** Keep explanatory text brief — a few sentences, not paragraphs. Focus on actions and results over narration.
+- **Parallel tool calls:** When you need to perform multiple independent operations (e.g. reading several files), make all the tool calls in a single response rather than sequentially.
+- **Non-interactive commands:** Use flags like -y, --yes, --non-interactive to prevent CLI tools from hanging on prompts.
+- **Keep going:** Work autonomously until the task is fully resolved. Don't stop with a plan — execute it.
+`;
+
+export function shouldApplyGooglePromptOverlay(params: {
+  modelProviderId?: string;
+}): boolean {
+  return GOOGLE_PROVIDER_IDS.has(normalizeLowercaseStringOrEmpty(params.modelProviderId ?? ""));
+}
+
+/**
+ * Returns a system prompt contribution for Google/Gemini models.
+ * Uses inline return type to respect extension boundary (no src/ imports).
+ */
+export function resolveGoogleSystemPromptContribution(params: {
+  modelProviderId?: string;
+  modelId?: string;
+}): { sectionOverrides: Record<string, string> } | undefined {
+  if (!shouldApplyGooglePromptOverlay({ modelProviderId: params.modelProviderId })) {
+    return undefined;
+  }
+  return {
+    sectionOverrides: {
+      tool_enforcement: GOOGLE_GEMINI_EXECUTION_GUIDANCE,
+    },
+  };
+}

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -7,6 +7,7 @@ import {
   normalizeGoogleModelId,
   resolveGoogleGenerativeAiTransport,
 } from "./api.js";
+import { resolveGoogleSystemPromptContribution } from "./prompt-overlay.js";
 import { GOOGLE_GEMINI_PROVIDER_HOOKS } from "./provider-hooks.js";
 import { isModernGoogleModel, resolveGoogleGeminiForwardCompatModel } from "./provider-models.js";
 
@@ -50,5 +51,10 @@ export function registerGoogleProvider(api: OpenClawPluginApi) {
       }),
     ...GOOGLE_GEMINI_PROVIDER_HOOKS,
     isModernModelRef: ({ modelId }) => isModernGoogleModel(modelId),
+    resolveSystemPromptContribution: (ctx) =>
+      resolveGoogleSystemPromptContribution({
+        modelProviderId: "google",
+        modelId: ctx.modelId,
+      }),
   });
 }

--- a/src/agents/system-prompt-contribution.ts
+++ b/src/agents/system-prompt-contribution.ts
@@ -1,7 +1,8 @@
 export type ProviderSystemPromptSectionId =
   | "interaction_style"
   | "tool_call_style"
-  | "execution_bias";
+  | "execution_bias"
+  | "tool_enforcement";
 
 export type ProviderSystemPromptContribution = {
   /**

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -697,6 +697,10 @@ export function buildAgentSystemPrompt(params: {
       }),
     }),
     ...buildOverridablePromptSection({
+      override: providerSectionOverrides.tool_enforcement,
+      fallback: [],
+    }),
+    ...buildOverridablePromptSection({
       override: providerStablePrefix,
       fallback: [],
     }),


### PR DESCRIPTION
## GPT 5.4 Enhancement v3 — Final Sprint PR 2/3
**Tracking: #66345**
**Supersedes: #66379**

Rebased on current `main` (incorporates `356110c5` provider-hooks refactor). Ports Hermes Agent's Google model operational directives.

### What this PR adds

**Gemini operational directives** (Hermes `prompt_builder.py:258-276`)
- Verify first, dependency checks, conciseness, parallel tool calls, non-interactive commands, keep going
- Em dashes and exact Hermes wording preserved
- One documented deviation: "Absolute paths" bullet omitted (OpenClaw sandbox prefers relative paths per `system-prompt.ts:600`)

**Provider wiring**
- `resolveSystemPromptContribution` wired to both `google` and `google-gemini-cli` providers
- Uses `sectionOverrides.tool_enforcement` (requires `tool_enforcement` section ID from PR 1/3 or includes it independently)

### Files changed (5)
- `extensions/google/prompt-overlay.ts` (new)
- `extensions/google/provider-registration.ts`
- `extensions/google/gemini-cli-provider.ts`
- `src/agents/system-prompt-contribution.ts`
- `src/agents/system-prompt.ts`

### Parity constraint
Hermes-verbatim text with documented tool-ID substitutions only.