### PR TITLE
feat(agents): task system parity — cancelled status, merge mode, activeForm, plan hydration [Phase 3.A]

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -100,6 +100,12 @@ export function createOpenClawTools(
     /** Ephemeral session UUID — regenerated on /new and /reset. */
     sessionId?: string;
     /**
+     * Stable run identifier for this agent invocation. Threaded into
+     * `update_plan` so its merge mode can persist plan state on
+     * `AgentRunContext` keyed by runId (#67514).
+     */
+    runId?: string;
+    /**
      * Workspace directory to pass to spawned subagents for inheritance.
      * Defaults to workspaceDir. Use this to pass the actual agent workspace when the
      * session itself is running in a copied-workspace sandbox (`ro` or `none`) so
@@ -254,7 +260,7 @@ export function createOpenClawTools(
       modelProvider: options?.modelProvider,
       modelId: options?.modelId,
     })
-      ? [createUpdatePlanTool()]
+      ? [createUpdatePlanTool({ runId: options?.runId })]
       : []),
     createSessionsListTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -597,6 +597,7 @@ export function createOpenClawCodingTools(options?: {
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
       sessionId: options?.sessionId,
+      runId: options?.runId,
       onYield: options?.onYield,
       allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
     }),

--- a/src/agents/plan-hydration.test.ts
+++ b/src/agents/plan-hydration.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { formatPlanForHydration } from "./plan-hydration.js";
+
+describe("formatPlanForHydration", () => {
+  it("returns null for empty steps", () => {
+    expect(formatPlanForHydration([])).toBeNull();
+  });
+
+  it("returns null for all-completed steps", () => {
+    const steps = [
+      { step: "Install deps", status: "completed" },
+      { step: "Run tests", status: "completed" },
+    ];
+    expect(formatPlanForHydration(steps)).toBeNull();
+  });
+
+  it("returns null for all-cancelled steps", () => {
+    const steps = [
+      { step: "Install deps", status: "cancelled" },
+      { step: "Run tests", status: "cancelled" },
+    ];
+    expect(formatPlanForHydration(steps)).toBeNull();
+  });
+
+  it("returns null for mix of completed and cancelled steps", () => {
+    const steps = [
+      { step: "Install deps", status: "completed" },
+      { step: "Run tests", status: "cancelled" },
+      { step: "Deploy", status: "completed" },
+    ];
+    expect(formatPlanForHydration(steps)).toBeNull();
+  });
+
+  it("filters out completed and cancelled steps", () => {
+    const steps = [
+      { step: "Install deps", status: "completed" },
+      { step: "Run tests", status: "cancelled" },
+      { step: "Fix lint", status: "in_progress" },
+      { step: "Deploy", status: "pending" },
+    ];
+    const result = formatPlanForHydration(steps);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("Install deps");
+    expect(result).not.toContain("Run tests");
+    expect(result).toContain("Fix lint");
+    expect(result).toContain("Deploy");
+  });
+
+  it("includes pending and in_progress steps with correct markers", () => {
+    const steps = [
+      { step: "Investigate bug", status: "in_progress" },
+      { step: "Write fix", status: "pending" },
+      { step: "Add tests", status: "pending" },
+    ];
+    const result = formatPlanForHydration(steps)!;
+    expect(result).toContain("[>] Investigate bug (in_progress)");
+    expect(result).toContain("[ ] Write fix (pending)");
+    expect(result).toContain("[ ] Add tests (pending)");
+  });
+
+  it("output format starts with preserved plan header", () => {
+    const steps = [
+      { step: "Do something", status: "pending" },
+    ];
+    const result = formatPlanForHydration(steps)!;
+    expect(result).toMatch(
+      /^\[Your active plan was preserved across context compression\]/,
+    );
+  });
+});

--- a/src/agents/plan-hydration.ts
+++ b/src/agents/plan-hydration.ts
@@ -13,13 +13,32 @@
  * incomplete-turn.ts (PLANNING_ONLY_PROMISE_RE).
  */
 
+import type { PlanStepStatus } from "./tools/update-plan-tool.js";
+
+/**
+ * Plan step shape accepted by hydration. `status` stays widened to
+ * `string` because hydration consumes data from heterogeneous sources
+ * (compaction snapshots, channel adapters, JSON imports) where the
+ * value is not always pre-narrowed to `PlanStepStatus`. Valid statuses
+ * are listed in `PLAN_STEP_STATUSES`; unknown statuses are filtered out
+ * by the active-set check below.
+ */
 interface PlanStep {
   step: string;
   status: string;
   activeForm?: string;
 }
 
-const ACTIVE_STATUSES = new Set(["pending", "in_progress"]);
+// Active statuses (pending + in_progress) are the subset we replay after
+// compression. The literal tuple is asserted via `satisfies` so this
+// file fails to compile if `PlanStepStatus` ever drops one of these
+// names. The Set is typed `string` so `.has()` accepts the widened
+// input from heterogeneous callers without a cast.
+const ACTIVE_PLAN_STATUSES = [
+  "pending",
+  "in_progress",
+] as const satisfies readonly PlanStepStatus[];
+const ACTIVE_STATUSES: ReadonlySet<string> = new Set<string>(ACTIVE_PLAN_STATUSES);
 
 /**
  * Formats active plan steps for injection after compaction.

--- a/src/agents/plan-hydration.ts
+++ b/src/agents/plan-hydration.ts
@@ -1,0 +1,45 @@
+/**
+ * Post-compaction plan hydration — ported from Hermes Agent's
+ * TodoStore.format_for_injection() (tools/todo_tool.py).
+ *
+ * After context compression, active plan items (pending / in_progress)
+ * are injected as a user message so the agent continues the same plan
+ * instead of re-planning from scratch.
+ *
+ * The injected text is deliberately phrased as a factual statement
+ * ("Your active plan was preserved...") rather than an imperative
+ * ("Here is your plan, do this...") to avoid triggering the
+ * planning-only retry guard's promise-language detection in
+ * incomplete-turn.ts (PLANNING_ONLY_PROMISE_RE).
+ */
+
+interface PlanStep {
+  step: string;
+  status: string;
+  activeForm?: string;
+}
+
+const ACTIVE_STATUSES = new Set(["pending", "in_progress"]);
+
+/**
+ * Formats active plan steps for injection after compaction.
+ * Returns `null` if there are no active steps to preserve.
+ *
+ * Matches Hermes's format_for_injection() output:
+ *   [Your active task list was preserved across context compression]
+ *   - [ ] step text (pending)
+ *   - [>] step text (in_progress)
+ */
+export function formatPlanForHydration(steps: PlanStep[]): string | null {
+  const active = steps.filter((s) => ACTIVE_STATUSES.has(s.status));
+  if (active.length === 0) {
+    return null;
+  }
+
+  const lines = ["[Your active plan was preserved across context compression]"];
+  for (const s of active) {
+    const marker = s.status === "in_progress" ? "[>]" : "[ ]";
+    lines.push(`- ${marker} ${s.step} (${s.status})`);
+  }
+  return lines.join("\n");
+}

--- a/src/agents/plan-hydration.ts
+++ b/src/agents/plan-hydration.ts
@@ -26,7 +26,7 @@ const ACTIVE_STATUSES = new Set(["pending", "in_progress"]);
  * Returns `null` if there are no active steps to preserve.
  *
  * Matches Hermes's format_for_injection() output:
- *   [Your active task list was preserved across context compression]
+ *   [Your active plan was preserved across context compression]
  *   - [ ] step text (pending)
  *   - [>] step text (in_progress)
  */

--- a/src/agents/test-helpers/fast-openclaw-tools-sessions.ts
+++ b/src/agents/test-helpers/fast-openclaw-tools-sessions.ts
@@ -41,7 +41,8 @@ vi.mock("../tools/tts-tool.js", () => ({
 }));
 
 vi.mock("../tools/update-plan-tool.js", () => ({
-  createUpdatePlanTool: () => stubTool("update_plan"),
+  createUpdatePlanTool: (_options?: { runId?: string }) => stubTool("update_plan"),
+  PLAN_STEP_STATUSES: ["pending", "in_progress", "completed", "cancelled"] as const,
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({

--- a/src/agents/tools/update-plan-tool.parity.test.ts
+++ b/src/agents/tools/update-plan-tool.parity.test.ts
@@ -306,6 +306,42 @@ describe("update_plan tool – merge mode (#67514)", () => {
     expect(events.filter((e) => e.stream === "plan")).toHaveLength(0);
   });
 
+  it("rejects merge that would yield two in_progress steps (Codex P1 r3096162551)", async () => {
+    const runId = "run-double-active";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    // Seed a plan with one in_progress step.
+    await tool.execute("c1", {
+      plan: [
+        { step: "Step A", status: "in_progress", activeForm: "Doing A" },
+        { step: "Step B", status: "pending" },
+      ],
+    });
+
+    // Merge a patch that marks a DIFFERENT step as in_progress without
+    // moving the old one off active. Final plan would have two in_progress —
+    // violates the tool's own invariant and breaks downstream renderers.
+    await expect(
+      tool.execute("c2", {
+        merge: true,
+        plan: [{ step: "Step B", status: "in_progress", activeForm: "Doing B" }],
+      }),
+    ).rejects.toThrow(/multiple in_progress steps/);
+  });
+
+  it("rejects incoming patch with duplicate step text (Codex P2 r3096162555)", async () => {
+    const tool = createUpdatePlanTool();
+    await expect(
+      tool.execute("c1", {
+        plan: [
+          { step: "Same step", status: "completed" },
+          { step: "Same step", status: "pending" },
+        ],
+      }),
+    ).rejects.toThrow(/duplicated within the patch/);
+  });
+
   it("emits even when no AgentRunContext is registered (best-effort)", async () => {
     const runId = "run-no-context";
     // Note: we deliberately do NOT register a context for this run.

--- a/src/agents/tools/update-plan-tool.parity.test.ts
+++ b/src/agents/tools/update-plan-tool.parity.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type AgentEventPayload,
+  getAgentRunContext,
+  onAgentEvent,
+  registerAgentRunContext,
+  resetAgentEventsForTest,
+} from "../../infra/agent-events.js";
 import { createUpdatePlanTool } from "./update-plan-tool.js";
 
 describe("update_plan tool – parity tests", () => {
@@ -45,16 +52,280 @@ describe("update_plan tool – parity tests", () => {
     const tool = createUpdatePlanTool();
     const result = await tool.execute("call-1", {
       merge: true,
-      plan: [
-        { step: "New step", status: "pending" },
-      ],
+      plan: [{ step: "New step", status: "pending" }],
     });
 
     expect(result.details).toEqual({
       status: "updated",
+      plan: [{ step: "New step", status: "pending" }],
+    });
+  });
+});
+
+describe("update_plan tool – merge mode (#67514)", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  afterEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  function getPlan(result: { details: unknown }) {
+    return (result.details as Record<string, unknown>).plan as Array<Record<string, unknown>>;
+  }
+
+  it("merge with overlap updates status without duplicating the step", async () => {
+    const runId = "run-merge-overlap";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    // Seed previous plan via an initial replace.
+    await tool.execute("call-1", {
       plan: [
-        { step: "New step", status: "pending" },
+        { step: "Install deps", status: "completed" },
+        { step: "Run tests", status: "in_progress", activeForm: "Running tests" },
+        { step: "Deploy", status: "pending" },
       ],
     });
+
+    // Overlap: "Run tests" advances to completed, "Deploy" advances to in_progress.
+    const result = await tool.execute("call-2", {
+      merge: true,
+      plan: [
+        { step: "Run tests", status: "completed" },
+        { step: "Deploy", status: "in_progress", activeForm: "Deploying" },
+      ],
+    });
+
+    const plan = getPlan(result);
+    expect(plan).toHaveLength(3);
+    expect(plan[0]).toEqual({ step: "Install deps", status: "completed" });
+    expect(plan[1]).toEqual({ step: "Run tests", status: "completed" });
+    expect(plan[2]).toEqual({ step: "Deploy", status: "in_progress", activeForm: "Deploying" });
+  });
+
+  it("merge appends novel steps preserving incoming order", async () => {
+    const runId = "run-merge-append";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [
+        { step: "Step A", status: "completed" },
+        { step: "Step B", status: "in_progress", activeForm: "Doing B" },
+      ],
+    });
+
+    const result = await tool.execute("c2", {
+      merge: true,
+      plan: [
+        { step: "Step C", status: "pending" },
+        { step: "Step D", status: "pending" },
+      ],
+    });
+
+    const plan = getPlan(result);
+    expect(plan.map((p) => p.step)).toEqual(["Step A", "Step B", "Step C", "Step D"]);
+    // Existing steps retain their previous status.
+    expect(plan[0]?.status).toBe("completed");
+    expect(plan[1]?.status).toBe("in_progress");
+  });
+
+  it("merge preserves completed steps not present in the incoming patch", async () => {
+    const runId = "run-merge-preserve";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [
+        { step: "Plan", status: "completed" },
+        { step: "Implement", status: "in_progress", activeForm: "Implementing" },
+        { step: "Verify", status: "pending" },
+      ],
+    });
+
+    const result = await tool.execute("c2", {
+      merge: true,
+      plan: [{ step: "Implement", status: "completed" }],
+    });
+
+    const plan = getPlan(result);
+    expect(plan).toHaveLength(3);
+    expect(plan[0]).toEqual({ step: "Plan", status: "completed" });
+    expect(plan[1]).toEqual({ step: "Implement", status: "completed" });
+    expect(plan[2]).toEqual({ step: "Verify", status: "pending" });
+  });
+
+  it("merge can transition status from cancelled back to pending (rollback case)", async () => {
+    const runId = "run-merge-rollback";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [{ step: "Risky migration", status: "cancelled" }],
+    });
+
+    const result = await tool.execute("c2", {
+      merge: true,
+      plan: [{ step: "Risky migration", status: "pending" }],
+    });
+
+    const plan = getPlan(result);
+    expect(plan).toHaveLength(1);
+    expect(plan[0]).toEqual({ step: "Risky migration", status: "pending" });
+  });
+
+  it("merge=false with prior plan still replaces (default behavior)", async () => {
+    const runId = "run-merge-replace";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [
+        { step: "Old step 1", status: "completed" },
+        { step: "Old step 2", status: "in_progress", activeForm: "Working" },
+      ],
+    });
+
+    const result = await tool.execute("c2", {
+      merge: false,
+      plan: [{ step: "Brand new plan", status: "pending" }],
+    });
+
+    const plan = getPlan(result);
+    expect(plan).toEqual([{ step: "Brand new plan", status: "pending" }]);
+  });
+
+  it("two runs with different runIds maintain isolated plan state", async () => {
+    const runA = "run-iso-a";
+    const runB = "run-iso-b";
+    registerAgentRunContext(runA, {});
+    registerAgentRunContext(runB, {});
+    const toolA = createUpdatePlanTool({ runId: runA });
+    const toolB = createUpdatePlanTool({ runId: runB });
+
+    await toolA.execute("c1", { plan: [{ step: "A1", status: "completed" }] });
+    await toolB.execute("c2", {
+      plan: [{ step: "B1", status: "in_progress", activeForm: "Doing B1" }],
+    });
+
+    const resultA = await toolA.execute("c3", {
+      merge: true,
+      plan: [{ step: "A2", status: "pending" }],
+    });
+    const resultB = await toolB.execute("c4", {
+      merge: true,
+      plan: [{ step: "B2", status: "pending" }],
+    });
+
+    expect(getPlan(resultA).map((s) => s.step)).toEqual(["A1", "A2"]);
+    expect(getPlan(resultB).map((s) => s.step)).toEqual(["B1", "B2"]);
+  });
+
+  it("persists the merged plan back to AgentRunContext.lastPlanSteps", async () => {
+    const runId = "run-persist";
+    registerAgentRunContext(runId, {});
+    const tool = createUpdatePlanTool({ runId });
+
+    await tool.execute("c1", {
+      plan: [
+        { step: "S1", status: "completed" },
+        { step: "S2", status: "pending" },
+      ],
+    });
+
+    const ctx = getAgentRunContext(runId);
+    expect(ctx?.lastPlanSteps).toEqual([
+      { step: "S1", status: "completed" },
+      { step: "S2", status: "pending" },
+    ]);
+
+    await tool.execute("c2", {
+      merge: true,
+      plan: [{ step: "S2", status: "completed" }],
+    });
+
+    const ctxAfter = getAgentRunContext(runId);
+    expect(ctxAfter?.lastPlanSteps).toEqual([
+      { step: "S1", status: "completed" },
+      { step: "S2", status: "completed" },
+    ]);
+  });
+
+  it("emits an agent_plan_event when runId is set", async () => {
+    const runId = "run-emit";
+    const sessionKey = "session-emit-1";
+    registerAgentRunContext(runId, { sessionKey });
+    const tool = createUpdatePlanTool({ runId });
+
+    const events: AgentEventPayload[] = [];
+    const off = onAgentEvent((evt) => {
+      events.push(evt);
+    });
+
+    try {
+      await tool.execute("c1", {
+        explanation: "Initial plan",
+        plan: [
+          { step: "Plan", status: "completed" },
+          { step: "Build", status: "in_progress", activeForm: "Building" },
+        ],
+      });
+
+      const planEvents = events.filter((e) => e.stream === "plan");
+      expect(planEvents).toHaveLength(1);
+      const planEvent = planEvents[0];
+      expect(planEvent.runId).toBe(runId);
+      expect(planEvent.sessionKey).toBe(sessionKey);
+      expect(planEvent.data).toMatchObject({
+        phase: "update",
+        title: "Plan updated",
+        explanation: "Initial plan",
+        steps: ["Plan", "Build"],
+        source: "update_plan",
+      });
+    } finally {
+      off();
+    }
+  });
+
+  it("does NOT emit an agent_plan_event when runId is omitted", async () => {
+    const tool = createUpdatePlanTool();
+    const events: AgentEventPayload[] = [];
+    const off = onAgentEvent((evt) => {
+      events.push(evt);
+    });
+
+    try {
+      await tool.execute("c1", { plan: [{ step: "S", status: "pending" }] });
+    } finally {
+      off();
+    }
+
+    expect(events.filter((e) => e.stream === "plan")).toHaveLength(0);
+  });
+
+  it("emits even when no AgentRunContext is registered (best-effort)", async () => {
+    const runId = "run-no-context";
+    // Note: we deliberately do NOT register a context for this run.
+    const tool = createUpdatePlanTool({ runId });
+
+    const events: AgentEventPayload[] = [];
+    const off = onAgentEvent((evt) => {
+      events.push(evt);
+    });
+
+    try {
+      await tool.execute("c1", { plan: [{ step: "Solo step", status: "pending" }] });
+    } finally {
+      off();
+    }
+
+    const planEvents = events.filter((e) => e.stream === "plan");
+    expect(planEvents).toHaveLength(1);
+    expect(planEvents[0].runId).toBe(runId);
+    // No sessionKey since context was never registered.
+    expect(planEvents[0].sessionKey).toBeUndefined();
   });
 });

--- a/src/agents/tools/update-plan-tool.parity.test.ts
+++ b/src/agents/tools/update-plan-tool.parity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { createUpdatePlanTool } from "./update-plan-tool.js";
+
+describe("update_plan tool – parity tests", () => {
+  it("cancelled status is accepted in the schema", async () => {
+    const tool = createUpdatePlanTool();
+    const result = await tool.execute("call-1", {
+      plan: [
+        { step: "Install deps", status: "completed" },
+        { step: "Run failing tests", status: "cancelled" },
+        { step: "Fix tests and retry", status: "pending" },
+      ],
+    });
+
+    expect(result.details).toEqual({
+      status: "updated",
+      plan: [
+        { step: "Install deps", status: "completed" },
+        { step: "Run failing tests", status: "cancelled" },
+        { step: "Fix tests and retry", status: "pending" },
+      ],
+    });
+  });
+
+  it("activeForm field is preserved in output", async () => {
+    const tool = createUpdatePlanTool();
+    const result = await tool.execute("call-1", {
+      plan: [
+        {
+          step: "Fix auth bug",
+          status: "in_progress",
+          activeForm: "Fixing authentication bug",
+        },
+        { step: "Deploy", status: "pending" },
+      ],
+    });
+
+    const plan = (result.details as Record<string, unknown>).plan as Array<Record<string, unknown>>;
+    const inProgressStep = plan.find((s) => s.status === "in_progress");
+    expect(inProgressStep).toBeDefined();
+    expect(inProgressStep!.activeForm).toBe("Fixing authentication bug");
+  });
+
+  it("merge=true with no previousPlan falls back to replace", async () => {
+    const tool = createUpdatePlanTool();
+    const result = await tool.execute("call-1", {
+      merge: true,
+      plan: [
+        { step: "New step", status: "pending" },
+      ],
+    });
+
+    expect(result.details).toEqual({
+      status: "updated",
+      plan: [
+        { step: "New step", status: "pending" },
+      ],
+    });
+  });
+});

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -97,7 +97,7 @@ export function createUpdatePlanTool(): AnyAgentTool {
     displaySummary: UPDATE_PLAN_TOOL_DISPLAY_SUMMARY,
     description: describeUpdatePlanTool(),
     parameters: UpdatePlanToolSchema,
-    execute: async (_toolCallId, args, context) => {
+    execute: async (_toolCallId, args, _context) => {
       const params = args as Record<string, unknown>;
       const explanation = readStringParam(params, "explanation");
       const merge = typeof params.merge === "boolean" ? params.merge : false;

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -103,18 +103,14 @@ export function createUpdatePlanTool(): AnyAgentTool {
       const merge = typeof params.merge === "boolean" ? params.merge : false;
       const incomingSteps = readPlanSteps(params);
 
-      // Merge mode: update existing steps by matching step text, append new ones.
+      // Merge mode: requires a plan store lookup to get the previous plan.
+      // Until the plan store (#67542) is wired, merge falls back to replace.
       // Replace mode (default): use incoming steps as the entire plan.
       let plan: UpdatePlanStep[];
-      if (merge && context?.previousPlan) {
-        const existing = context.previousPlan as UpdatePlanStep[];
-        const incomingMap = new Map(incomingSteps.map((s) => [s.step, s]));
-        plan = existing.map((s) => incomingMap.get(s.step) ?? s);
-        for (const s of incomingSteps) {
-          if (!existing.some((e) => e.step === s.step)) {
-            plan.push(s);
-          }
-        }
+      if (merge) {
+        // TODO(#67542): look up previous plan via PlanStore.read() once wired.
+        // For now, merge without a previous plan is equivalent to replace.
+        plan = incomingSteps;
       } else {
         plan = incomingSteps;
       }

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -6,7 +6,7 @@ import {
 } from "../tool-description-presets.js";
 import { type AnyAgentTool, ToolInputError, readStringParam } from "./common.js";
 
-const PLAN_STEP_STATUSES = ["pending", "in_progress", "completed"] as const;
+const PLAN_STEP_STATUSES = ["pending", "in_progress", "completed", "cancelled"] as const;
 
 const UpdatePlanToolSchema = Type.Object({
   explanation: Type.Optional(
@@ -14,13 +14,27 @@ const UpdatePlanToolSchema = Type.Object({
       description: "Optional short note explaining what changed in the plan.",
     }),
   ),
+  merge: Type.Optional(
+    Type.Boolean({
+      description:
+        'When true, update existing steps by matching step text and add new ones. ' +
+        'When false (default), replace the entire plan.',
+    }),
+  ),
   plan: Type.Array(
     Type.Object(
       {
         step: Type.String({ description: "Short plan step." }),
         status: stringEnum(PLAN_STEP_STATUSES, {
-          description: 'One of "pending", "in_progress", or "completed".',
+          description: 'One of "pending", "in_progress", "completed", or "cancelled".',
         }),
+        activeForm: Type.Optional(
+          Type.String({
+            description:
+              'Present-continuous form shown while in_progress (e.g. "Running tests"). ' +
+              'Omit for pending/completed/cancelled steps.',
+          }),
+        ),
       },
       { additionalProperties: true },
     ),
@@ -34,6 +48,7 @@ const UpdatePlanToolSchema = Type.Object({
 type UpdatePlanStep = {
   step: string;
   status: (typeof PLAN_STEP_STATUSES)[number];
+  activeForm?: string;
 };
 
 function readPlanSteps(params: Record<string, unknown>): UpdatePlanStep[] {
@@ -60,9 +75,11 @@ function readPlanSteps(params: Record<string, unknown>): UpdatePlanStep[] {
         `plan[${index}].status must be one of ${PLAN_STEP_STATUSES.join(", ")}`,
       );
     }
+    const activeForm = readStringParam(stepParams, "activeForm");
     return {
       step,
       status: status as (typeof PLAN_STEP_STATUSES)[number],
+      ...(activeForm ? { activeForm } : {}),
     };
   });
 
@@ -80,10 +97,28 @@ export function createUpdatePlanTool(): AnyAgentTool {
     displaySummary: UPDATE_PLAN_TOOL_DISPLAY_SUMMARY,
     description: describeUpdatePlanTool(),
     parameters: UpdatePlanToolSchema,
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId, args, context) => {
       const params = args as Record<string, unknown>;
       const explanation = readStringParam(params, "explanation");
-      const plan = readPlanSteps(params);
+      const merge = typeof params.merge === "boolean" ? params.merge : false;
+      const incomingSteps = readPlanSteps(params);
+
+      // Merge mode: update existing steps by matching step text, append new ones.
+      // Replace mode (default): use incoming steps as the entire plan.
+      let plan: UpdatePlanStep[];
+      if (merge && context?.previousPlan) {
+        const existing = context.previousPlan as UpdatePlanStep[];
+        const incomingMap = new Map(incomingSteps.map((s) => [s.step, s]));
+        plan = existing.map((s) => incomingMap.get(s.step) ?? s);
+        for (const s of incomingSteps) {
+          if (!existing.some((e) => e.step === s.step)) {
+            plan.push(s);
+          }
+        }
+      } else {
+        plan = incomingSteps;
+      }
+
       return {
         content: [],
         details: {

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -98,6 +98,24 @@ function readPlanSteps(params: Record<string, unknown>): UpdatePlanStep[] {
   if (inProgressCount > 1) {
     throw new ToolInputError("plan can contain at most one in_progress step");
   }
+
+  // Reject duplicate step TEXT within a single incoming patch (Codex P2
+  // on PR #67514). Merge mode keys steps by `step` text — if the patch
+  // contains two entries with the same step text, the second clobbers the
+  // first, and in merge mode they collide on the same map key when
+  // matching against the previous plan, silently rewriting unrelated
+  // history. Better to surface this at input time.
+  const seenSteps = new Set<string>();
+  for (let i = 0; i < steps.length; i += 1) {
+    const stepText = steps[i].step;
+    if (seenSteps.has(stepText)) {
+      throw new ToolInputError(
+        `plan[${i}].step is duplicated within the patch ("${stepText}"); ` +
+          "step text must be unique because merge mode uses it as the join key",
+      );
+    }
+    seenSteps.add(stepText);
+  }
   return steps;
 }
 
@@ -174,6 +192,21 @@ export function createUpdatePlanTool(options?: CreateUpdatePlanToolOptions): Any
         merge && previousSteps.length > 0
           ? mergeSteps(previousSteps, incomingSteps)
           : incomingSteps;
+
+      // Re-validate the active-step invariant on the MERGED plan
+      // (Codex P1 on PR #67514): readPlanSteps only enforces the
+      // single-in_progress rule on the incoming patch, but merge can
+      // still produce a final plan with two in_progress entries when
+      // the previous plan had one in_progress step and the patch marks
+      // a different step as in_progress. The tool's own contract — and
+      // downstream renderers — assume at most one active step.
+      const mergedInProgress = plan.filter((s) => s.status === "in_progress").length;
+      if (mergedInProgress > 1) {
+        throw new ToolInputError(
+          "merge would produce a plan with multiple in_progress steps; " +
+            "explicitly mark the prior in_progress step as completed/cancelled in the same patch",
+        );
+      }
 
       // Persist for next merge in this run. Snapshot stored as
       // `PlanStepSnapshot[]` (structural superset of `UpdatePlanStep[]`).

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -1,4 +1,9 @@
 import { Type } from "@sinclair/typebox";
+import {
+  emitAgentPlanEvent,
+  getAgentRunContext,
+  type PlanStepSnapshot,
+} from "../../infra/agent-events.js";
 import { stringEnum } from "../schema/typebox.js";
 import {
   describeUpdatePlanTool,
@@ -6,7 +11,13 @@ import {
 } from "../tool-description-presets.js";
 import { type AnyAgentTool, ToolInputError, readStringParam } from "./common.js";
 
-const PLAN_STEP_STATUSES = ["pending", "in_progress", "completed", "cancelled"] as const;
+/**
+ * Allowed `update_plan` step statuses. Exported so other modules
+ * (`plan-hydration.ts`, hooks, channel renderers) can re-use the
+ * union instead of redefining a parallel string set.
+ */
+export const PLAN_STEP_STATUSES = ["pending", "in_progress", "completed", "cancelled"] as const;
+export type PlanStepStatus = (typeof PLAN_STEP_STATUSES)[number];
 
 const UpdatePlanToolSchema = Type.Object({
   explanation: Type.Optional(
@@ -45,9 +56,9 @@ const UpdatePlanToolSchema = Type.Object({
   ),
 });
 
-type UpdatePlanStep = {
+export type UpdatePlanStep = {
   step: string;
-  status: (typeof PLAN_STEP_STATUSES)[number];
+  status: PlanStepStatus;
   activeForm?: string;
 };
 
@@ -70,7 +81,7 @@ function readPlanSteps(params: Record<string, unknown>): UpdatePlanStep[] {
       required: true,
       label: `plan[${index}].status`,
     });
-    if (!PLAN_STEP_STATUSES.includes(status as (typeof PLAN_STEP_STATUSES)[number])) {
+    if (!PLAN_STEP_STATUSES.includes(status as PlanStepStatus)) {
       throw new ToolInputError(
         `plan[${index}].status must be one of ${PLAN_STEP_STATUSES.join(", ")}`,
       );
@@ -78,7 +89,7 @@ function readPlanSteps(params: Record<string, unknown>): UpdatePlanStep[] {
     const activeForm = readStringParam(stepParams, "activeForm");
     return {
       step,
-      status: status as (typeof PLAN_STEP_STATUSES)[number],
+      status: status as PlanStepStatus,
       ...(activeForm ? { activeForm } : {}),
     };
   });
@@ -90,7 +101,61 @@ function readPlanSteps(params: Record<string, unknown>): UpdatePlanStep[] {
   return steps;
 }
 
-export function createUpdatePlanTool(): AnyAgentTool {
+/**
+ * Merges incoming plan steps into existing ones by matching `step` text.
+ * - Existing steps keep their original order.
+ * - Overlapping steps update their status/activeForm from incoming.
+ * - Novel incoming steps are appended in the order they appear.
+ * Adapted from `src/agents/plan-store.ts:204` on the
+ * `phase4/cross-session-plans` branch (in-memory variant — no
+ * `updatedBy`/`updatedAt` attribution, since this layer doesn't own
+ * cross-session persistence).
+ */
+function mergeSteps(existing: UpdatePlanStep[], incoming: UpdatePlanStep[]): UpdatePlanStep[] {
+  const incomingByStep = new Map<string, UpdatePlanStep>();
+  for (const s of incoming) {
+    if (!incomingByStep.has(s.step)) {
+      incomingByStep.set(s.step, s);
+    }
+  }
+  const existingTexts = new Set(existing.map((s) => s.step));
+  const merged: UpdatePlanStep[] = existing.map((s) => {
+    const update = incomingByStep.get(s.step);
+    if (!update) {
+      return s;
+    }
+    return {
+      step: update.step,
+      status: update.status,
+      ...(update.activeForm !== undefined ? { activeForm: update.activeForm } : {}),
+    };
+  });
+  const appended = new Set<string>();
+  for (const s of incoming) {
+    if (!existingTexts.has(s.step) && !appended.has(s.step)) {
+      merged.push({
+        step: s.step,
+        status: s.status,
+        ...(s.activeForm !== undefined ? { activeForm: s.activeForm } : {}),
+      });
+      appended.add(s.step);
+    }
+  }
+  return merged;
+}
+
+export interface CreateUpdatePlanToolOptions {
+  /**
+   * Stable run identifier. When provided, merge mode reads the previous
+   * plan from `AgentRunContext.lastPlanSteps` and writes the merged
+   * result back. When omitted, merge mode falls back to replace
+   * (no previous plan available — useful for tests/standalone).
+   */
+  runId?: string;
+}
+
+export function createUpdatePlanTool(options?: CreateUpdatePlanToolOptions): AnyAgentTool {
+  const runId = options?.runId;
   return {
     label: "Update Plan",
     name: "update_plan",
@@ -103,16 +168,37 @@ export function createUpdatePlanTool(): AnyAgentTool {
       const merge = typeof params.merge === "boolean" ? params.merge : false;
       const incomingSteps = readPlanSteps(params);
 
-      // Merge mode: requires a plan store lookup to get the previous plan.
-      // Until the plan store (#67542) is wired, merge falls back to replace.
-      // Replace mode (default): use incoming steps as the entire plan.
-      let plan: UpdatePlanStep[];
-      if (merge) {
-        // TODO(#67542): look up previous plan via PlanStore.read() once wired.
-        // For now, merge without a previous plan is equivalent to replace.
-        plan = incomingSteps;
-      } else {
-        plan = incomingSteps;
+      const ctx = runId ? getAgentRunContext(runId) : undefined;
+      const previousSteps = (ctx?.lastPlanSteps ?? []) as UpdatePlanStep[];
+      const plan: UpdatePlanStep[] =
+        merge && previousSteps.length > 0
+          ? mergeSteps(previousSteps, incomingSteps)
+          : incomingSteps;
+
+      // Persist for next merge in this run. Snapshot stored as
+      // `PlanStepSnapshot[]` (structural superset of `UpdatePlanStep[]`).
+      if (ctx) {
+        ctx.lastPlanSteps = plan.map<PlanStepSnapshot>((s) => ({
+          step: s.step,
+          status: s.status,
+          ...(s.activeForm !== undefined ? { activeForm: s.activeForm } : {}),
+        }));
+      }
+
+      // Emit `agent_plan_event` so channel renderers + control UI see updates.
+      // Skip emit when we have no runId — that's the standalone/test path.
+      if (runId) {
+        emitAgentPlanEvent({
+          runId,
+          ...(ctx?.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
+          data: {
+            phase: "update",
+            title: "Plan updated",
+            ...(explanation ? { explanation } : {}),
+            steps: plan.map((s) => s.step),
+            source: "update_plan",
+          },
+        });
       }
 
       return {

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -36,7 +36,7 @@ const UpdatePlanToolSchema = Type.Object({
           }),
         ),
       },
-      { additionalProperties: true },
+      { additionalProperties: false },
     ),
     {
       minItems: 1,

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -17,8 +17,8 @@ const UpdatePlanToolSchema = Type.Object({
   merge: Type.Optional(
     Type.Boolean({
       description:
-        'When true, update existing steps by matching step text and add new ones. ' +
-        'When false (default), replace the entire plan.',
+        "When true, update existing steps by matching step text and add new ones. " +
+        "When false (default), replace the entire plan.",
     }),
   ),
   plan: Type.Array(
@@ -32,7 +32,7 @@ const UpdatePlanToolSchema = Type.Object({
           Type.String({
             description:
               'Present-continuous form shown while in_progress (e.g. "Running tests"). ' +
-              'Omit for pending/completed/cancelled steps.',
+              "Present-continuous form used during in_progress display. Accepted on any status but only rendered for in_progress steps.",
           }),
         ),
       },
@@ -97,7 +97,7 @@ export function createUpdatePlanTool(): AnyAgentTool {
     displaySummary: UPDATE_PLAN_TOOL_DISPLAY_SUMMARY,
     description: describeUpdatePlanTool(),
     parameters: UpdatePlanToolSchema,
-    execute: async (_toolCallId, args, _context) => {
+    execute: async (_toolCallId, args, _signal) => {
       const params = args as Record<string, unknown>;
       const explanation = readStringParam(params, "explanation");
       const merge = typeof params.merge === "boolean" ? params.merge : false;

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -105,6 +105,19 @@ export type AgentEventPayload = {
   sessionKey?: string;
 };
 
+/**
+ * Snapshot of a plan step persisted on the run context for #67514's
+ * merge mode. Stored as a structural type to avoid pulling agent/tool
+ * types into the infra layer. The string-typed `status` matches the
+ * runtime `PLAN_STEP_STATUSES` union exported from
+ * `src/agents/tools/update-plan-tool.ts`.
+ */
+export type PlanStepSnapshot = {
+  step: string;
+  status: string;
+  activeForm?: string;
+};
+
 export type AgentRunContext = {
   sessionKey?: string;
   verboseLevel?: VerboseLevel;
@@ -115,6 +128,13 @@ export type AgentRunContext = {
   registeredAt?: number;
   /** Timestamp of last activity (updated on every emitAgentEvent). */
   lastActiveAt?: number;
+  /**
+   * Last plan steps seen by `update_plan` in this run (#67514). Used by
+   * merge mode to compute the merged plan against the previous state.
+   * In-memory only — survives within a run, cleared with the context.
+   * Disk-persistence (cross-session) is owned by `PlanStore` (#67542).
+   */
+  lastPlanSteps?: PlanStepSnapshot[];
 };
 
 type AgentEventState = {


### PR DESCRIPTION
## TL;DR

Ports three Hermes todo-tool features to OpenClaw's \`update_plan\` tool — \`cancelled\` status for failed steps, \`merge\` mode for token-efficient partial updates, and \`activeForm\` for live progress text — plus a post-compaction plan hydration helper.

## Tracking
- Umbrella: #66345

## What this PR does

### 1. \`cancelled\` status
Fourth plan step status: \`pending → in_progress → completed | cancelled\`. Marks steps abandoned due to failure. Without this, GPT-5 either silently drops failed steps or marks them \`completed\`, distorting the plan history.

### 2. \`merge\` mode
\`merge: true\` updates existing steps by text matching, appends new ones. \`merge: false\` (default) replaces the entire plan. Token-efficient on long plans — prevents accidental step drops during partial updates.

### 3. \`activeForm\` field
Present-continuous text for in-progress steps: \`step: "Run tests"\`, \`activeForm: "Running tests"\`. Foundation for plan rendering in CLI/Control UI/messaging.

### 4. Plan hydration helper
\`formatPlanForHydration()\` reinjects active plan steps after context compaction. Phrased as factual statement to avoid triggering \`PLANNING_ONLY_PROMISE_RE\`.

## Files changed

| File | Change |
|------|--------|
| \`src/agents/tools/update-plan-tool.ts\` | Extended schema: cancelled, merge, activeForm |
| \`src/agents/plan-hydration.ts\` | **New** — \`formatPlanForHydration()\` |
| \`src/agents/plan-hydration.test.ts\` | **New** — hydration tests |
| \`src/agents/tools/update-plan-tool.parity.test.ts\` | **New** — parity tests |

## Dependencies
- None (foundation for #67534, #67541, #67542)

## What follows
- #67534: Plan checklist renderer (uses cancelled + activeForm)
- #67541: Skill plan templates (uses merge mode)
- #67542: Cross-session plan store (uses merge mode)