### PR TITLE
fix: prevent crash in clearPluginInteractiveHandlersState when callbackDedupe is undefined

### DIFF
--- a/src/plugins/interactive-state.ts
+++ b/src/plugins/interactive-state.ts
@@ -74,6 +74,9 @@ export function releasePluginInteractiveCallbackDedupe(dedupeKey: string | undef
 
 export function clearPluginInteractiveHandlersState(): void {
   getPluginInteractiveHandlersState().clear();
-  getPluginInteractiveCallbackDedupeState().clear();
+  const dedupe = getPluginInteractiveCallbackDedupeState();
+  if (dedupe) {
+    dedupe.clear();
+  }
   getState().inflightCallbackDedupe.clear();
 }


### PR DESCRIPTION
## Summary
Fixes a crash in `openclaw doctor` where `clearPluginInteractiveHandlersState()` calls `.clear()` on an undefined callbackDedupe object.

## Root Cause
The `getPluginInteractiveCallbackDedupeState()` function may return `undefined` in certain initialization scenarios (particularly during doctor memory search). When `clearPluginInteractiveHandlersState()` unconditionally calls `.clear()` on this potentially undefined value, it throws:
```
TypeError: Cannot read properties of undefined (reading 'clear')
```

## Fix
Add a null/undefined check before calling `dedupe.clear()`:
```typescript
const dedupe = getPluginInteractiveCallbackDedupeState();
if (dedupe) {
  dedupe.clear();
}
```

## Test Plan
- [x] Existing unit tests pass (src/plugins/interactive.test.ts)
- [x] Fix is minimal and defensive

Closes openclaw#67525