### PR TITLE
fix: add null guards in clearPluginInteractiveHandlersState to prevent doctor crash

### DIFF
--- a/src/plugins/interactive-state.test.ts
+++ b/src/plugins/interactive-state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+describe("clearPluginInteractiveHandlersState", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Clear the global singleton so each test starts fresh
+    const key = Symbol.for("openclaw.pluginInteractiveState");
+    const g = globalThis as Record<symbol, unknown>;
+    delete g[key];
+  });
+
+  it("should not throw when state fields are populated", async () => {
+    const mod = await import("./interactive-state.js");
+    // Populate some state first
+    mod.getPluginInteractiveHandlersState().set("test", {} as never);
+    expect(() => mod.clearPluginInteractiveHandlersState()).not.toThrow();
+    expect(mod.getPluginInteractiveHandlersState().size).toBe(0);
+  });
+
+  it("should not throw when callbackDedupe is undefined", async () => {
+    // Simulate a corrupted/partial global singleton where callbackDedupe is undefined
+    const key = Symbol.for("openclaw.pluginInteractiveState");
+    (globalThis as Record<symbol, unknown>)[key] = {
+      interactiveHandlers: new Map(),
+      callbackDedupe: undefined,
+      inflightCallbackDedupe: new Set(),
+    };
+    const mod = await import("./interactive-state.js");
+    expect(() => mod.clearPluginInteractiveHandlersState()).not.toThrow();
+  });
+
+  it("should not throw when inflightCallbackDedupe is undefined", async () => {
+    const key = Symbol.for("openclaw.pluginInteractiveState");
+    (globalThis as Record<symbol, unknown>)[key] = {
+      interactiveHandlers: new Map(),
+      callbackDedupe: { clear: () => {} },
+      inflightCallbackDedupe: undefined,
+    };
+    const mod = await import("./interactive-state.js");
+    expect(() => mod.clearPluginInteractiveHandlersState()).not.toThrow();
+  });
+});

--- a/src/plugins/interactive-state.ts
+++ b/src/plugins/interactive-state.ts
@@ -73,7 +73,8 @@ export function releasePluginInteractiveCallbackDedupe(dedupeKey: string | undef
 }
 
 export function clearPluginInteractiveHandlersState(): void {
-  getPluginInteractiveHandlersState().clear();
-  getPluginInteractiveCallbackDedupeState().clear();
-  getState().inflightCallbackDedupe.clear();
+  const state = getState();
+  state.interactiveHandlers?.clear();
+  state.callbackDedupe?.clear();
+  state.inflightCallbackDedupe?.clear();
 }


### PR DESCRIPTION
## Summary

Fixes #67525

`openclaw doctor` crashes with `TypeError: Cannot read properties of undefined (reading 'clear')` when `clearPluginInteractiveHandlersState()` is called and the global singleton has partial/corrupted state (e.g., `callbackDedupe` is undefined).

## Changes

- **`src/plugins/interactive-state.ts`**: Refactored `clearPluginInteractiveHandlersState()` to call `getState()` once and use optional chaining (`?.`) on all `.clear()` calls, preventing crashes when any state field is undefined.
- **`src/plugins/interactive-state.test.ts`**: Added tests covering normal clear, undefined `callbackDedupe`, and undefined `inflightCallbackDedupe` scenarios.

## Root Cause

The function called individual getters (`getPluginInteractiveHandlersState()`, `getPluginInteractiveCallbackDedupeState()`) which always return valid objects when initialized normally. However, if the global singleton was set by an older version or corrupted, these fields could be undefined, causing the crash during `openclaw doctor`'s memory audit phase.