### PR TITLE
fix: guard against undefined trim() crashes in onboard QuickStart flow

### DIFF
--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -221,8 +221,8 @@ function createInstallSuccess(result: CommandResult): SkillInstallResult {
   return {
     ok: true,
     message: "Installed",
-    stdout: result.stdout.trim(),
-    stderr: result.stderr.trim(),
+    stdout: (result.stdout ?? "").trim(),
+    stderr: (result.stderr ?? "").trim(),
     code: result.code,
   };
 }

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -416,9 +416,9 @@ async function requestAnthropicVerification(params: {
   // Use a base URL with /v1 injected for this raw fetch only. The rest of the app uses the
   // Anthropic client, which appends /v1 itself; config should store the base URL
   // without /v1 to avoid /v1/v1/messages at runtime. See docs/gateway/configuration-reference.md.
-  const baseUrlForRequest = /\/v1\/?$/.test(params.baseUrl.trim())
-    ? params.baseUrl.trim()
-    : params.baseUrl.trim().replace(/\/?$/, "") + "/v1";
+  const baseUrlForRequest = /\/v1\/?$/.test((params.baseUrl ?? "").trim())
+    ? (params.baseUrl ?? "").trim()
+    : (params.baseUrl ?? "").trim().replace(/\/?$/, "") + "/v1";
   const endpoint = resolveVerificationEndpoint({
     baseUrl: baseUrlForRequest,
     modelId: params.modelId,
@@ -450,7 +450,7 @@ async function promptBaseUrlAndKey(params: {
       return URL.canParse(val) ? undefined : "Please enter a valid URL (e.g. http://...)";
     },
   });
-  const baseUrl = baseUrlInput.trim();
+  const baseUrl = (baseUrlInput ?? "").trim();
   const providerHint = buildEndpointIdFromUrl(baseUrl) || "custom";
   let apiKeyInput: SecretInput | undefined;
   const resolvedApiKey = await ensureApiKeyFromEnvOrPrompt({
@@ -545,7 +545,7 @@ export function resolveCustomProviderId(
   params: ResolveCustomProviderIdParams,
 ): ResolvedCustomProviderId {
   const providers = params.config.models?.providers ?? {};
-  const baseUrl = params.baseUrl.trim();
+  const baseUrl = (params.baseUrl ?? "").trim();
   const explicitProviderId = params.providerId?.trim();
   if (explicitProviderId && !normalizeEndpointId(explicitProviderId)) {
     throw new CustomApiError(

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -222,7 +222,7 @@ export async function probeGatewayReachable(params: {
   password?: string;
   timeoutMs?: number;
 }): Promise<{ ok: boolean; detail?: string }> {
-  const url = params.url.trim();
+  const url = (params.url ?? "").trim();
   const timeoutMs = params.timeoutMs ?? 1500;
   try {
     const probe = await probeGateway({

--- a/src/plugins/provider-model-helpers.ts
+++ b/src/plugins/provider-model-helpers.ts
@@ -18,7 +18,7 @@ export function cloneFirstTemplateModel(params: {
   ctx: ProviderResolveDynamicModelContext;
   patch?: Partial<ProviderRuntimeModel>;
 }): ProviderRuntimeModel | undefined {
-  const trimmedModelId = params.modelId.trim();
+  const trimmedModelId = (params.modelId ?? "").trim();
   for (const templateId of [...new Set(params.templateIds)].filter(Boolean)) {
     const template = params.ctx.modelRegistry.find(
       params.providerId,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -485,7 +485,7 @@ export async function runSetupWizard(
           initialValue: baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE,
         }));
 
-  const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
+  const workspaceDir = resolveUserPath((workspaceInput ?? "").trim() || onboardHelpers.DEFAULT_WORKSPACE);
 
   const { applyLocalSetupWorkspaceConfig } = await import("../commands/onboard-config.js");
   let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(baseConfig, workspaceDir);


### PR DESCRIPTION
## Summary

Fixes #67516 — `TypeError: Cannot read properties of undefined (reading 'trim')` crash during `openclaw onboard` QuickStart flow after the channel selection step.

## Problem

The QuickStart flow skips certain configuration steps (e.g. plugin config via `setupPluginConfig`), which means values that downstream code expects to be populated strings may be `undefined`. Several `.trim()` calls in the post-channel-setup code path do not guard against this.

## Changes

Adds defensive `(value ?? "").trim()` guards to all `.trim()` calls in the QuickStart onboarding code path:

| File | Change |
|------|--------|
| `src/wizard/setup.ts` | `workspaceInput` resolution |
| `src/commands/onboard-helpers.ts` | `probeGatewayReachable` URL param |
| `src/commands/onboard-custom.ts` | `baseUrl` params in verification & setup |
| `src/agents/skills-install.ts` | Install stdout/stderr handling |
| `src/plugins/provider-model-helpers.ts` | Model ID resolution |

All changes are no-op when values are already strings (the common case), but prevent crashes when a value is undefined due to skipped config steps.

## Testing

- Verified the fix compiles against the current codebase
- Each guard preserves existing behavior when values are present