### PR TITLE
feat(agents): plan checklist renderer — 4 formats, all statuses, activeForm [Phase 3.B]

### DIFF
--- a/src/agents/plan-render.test.ts
+++ b/src/agents/plan-render.test.ts
@@ -211,6 +211,25 @@ describe("mention neutralization", () => {
     const result = renderPlanChecklist(steps, "plaintext");
     expect(result).toContain("@alice");
   });
+
+  it("plaintext renderPlanWithHeader: neutralizes @everyone in TITLE (Codex P2 r3095517064)", () => {
+    // Adversarial regression: prior implementation neutralized step labels
+    // but emitted the title verbatim. A model-derived title like
+    // `@everyone release plan` would still trigger mentions.
+    const steps: PlanStepForRender[] = [{ step: "Tag release", status: "pending" }];
+    const result = renderPlanWithHeader("@everyone release plan", steps, "plaintext");
+    expect(result).not.toMatch(/@everyone\b/);
+    expect(result).toContain("release plan");
+  });
+
+  it("plaintext renderPlanWithHeader: neutralizes @channel and @here in TITLE", () => {
+    const steps: PlanStepForRender[] = [{ step: "S", status: "pending" }];
+    const result1 = renderPlanWithHeader("@channel deploy now", steps, "plaintext");
+    expect(result1).not.toMatch(/@channel\b/);
+
+    const result2 = renderPlanWithHeader("@here urgent", steps, "plaintext");
+    expect(result2).not.toMatch(/@here\b/);
+  });
 });
 
 describe("activeForm fallback", () => {

--- a/src/agents/plan-render.test.ts
+++ b/src/agents/plan-render.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderPlanChecklist,
+  renderPlanWithHeader,
+  type PlanStepForRender,
+  type PlanRenderFormat,
+} from "./plan-render.js";
+
+const SAMPLE_STEPS: PlanStepForRender[] = [
+  { step: "Run tests", status: "completed" },
+  { step: "Build artifacts", status: "in_progress", activeForm: "Building artifacts" },
+  { step: "Deploy to staging", status: "pending" },
+  { step: "Fix broken migration", status: "cancelled" },
+];
+
+describe("renderPlanChecklist", () => {
+  it("returns empty string for empty steps", () => {
+    expect(renderPlanChecklist([], "markdown")).toBe("");
+  });
+
+  const formats: PlanRenderFormat[] = ["html", "markdown", "plaintext", "slack-mrkdwn"];
+
+  for (const format of formats) {
+    describe(`format: ${format}`, () => {
+      it("renders all four statuses", () => {
+        const result = renderPlanChecklist(SAMPLE_STEPS, format);
+        const lines = result.split("\n");
+        expect(lines).toHaveLength(4);
+      });
+
+      it("uses activeForm for in_progress steps", () => {
+        const result = renderPlanChecklist(SAMPLE_STEPS, format);
+        expect(result).toContain("Building artifacts");
+        expect(result).not.toContain("Build artifacts");
+      });
+
+      it("falls back to step text when activeForm is absent", () => {
+        const steps: PlanStepForRender[] = [
+          { step: "Deploy", status: "in_progress" },
+        ];
+        const result = renderPlanChecklist(steps, format);
+        expect(result).toContain("Deploy");
+      });
+    });
+  }
+
+  it("html: escapes HTML in step text", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Check <script>alert(1)</script>", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "html");
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("&lt;script&gt;");
+  });
+
+  it("html: renders completed with ✅", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "html");
+    expect(result).toMatch(/✅.*Run tests/);
+  });
+
+  it("html: renders cancelled with strikethrough", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "html");
+    expect(result).toMatch(/❌.*<s>.*Fix broken migration.*<\/s>/);
+  });
+
+  it("markdown: renders checkboxes", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "markdown");
+    expect(result).toContain("- [x] Run tests");
+    expect(result).toContain("- [>] **Building artifacts**");
+    expect(result).toContain("- [ ] Deploy to staging");
+    expect(result).toContain("- [~] ~~Fix broken migration~~");
+  });
+
+  it("plaintext: renders ASCII markers", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "plaintext");
+    expect(result).toContain("[x] Run tests");
+    expect(result).toContain("[>] Building artifacts");
+    expect(result).toContain("[ ] Deploy to staging");
+    expect(result).toContain("[~] Fix broken migration");
+  });
+
+  it("slack-mrkdwn: renders Slack formatting", () => {
+    const result = renderPlanChecklist(SAMPLE_STEPS, "slack-mrkdwn");
+    expect(result).toContain("✅ Run tests");
+    expect(result).toContain("⏳ *Building artifacts*");
+    expect(result).toContain("⬚ Deploy to staging");
+    expect(result).toContain("❌ ~Fix broken migration~");
+  });
+});
+
+describe("renderPlanWithHeader", () => {
+  it("renders header + checklist for each format", () => {
+    for (const format of ["html", "markdown", "plaintext", "slack-mrkdwn"] as const) {
+      const result = renderPlanWithHeader("Agent Plan", SAMPLE_STEPS, format);
+      expect(result).toContain("Agent Plan");
+      expect(result.split("\n").length).toBeGreaterThan(4);
+    }
+  });
+
+  it("returns empty string when no steps", () => {
+    expect(renderPlanWithHeader("Empty", [], "markdown")).toBe("");
+  });
+
+  it("html header uses bold", () => {
+    const result = renderPlanWithHeader("My Plan", SAMPLE_STEPS, "html");
+    expect(result).toMatch(/^<b>My Plan<\/b>/);
+  });
+
+  it("markdown header uses h3", () => {
+    const result = renderPlanWithHeader("My Plan", SAMPLE_STEPS, "markdown");
+    expect(result).toMatch(/^### My Plan/);
+  });
+});

--- a/src/agents/plan-render.test.ts
+++ b/src/agents/plan-render.test.ts
@@ -65,7 +65,7 @@ describe("renderPlanChecklist", () => {
     ];
     for (const format of ["html", "markdown", "plaintext", "slack-mrkdwn"] as const) {
       const result = renderPlanChecklist(steps, format);
-      expect(result).not.toContain("\n" + " ");
+      expect(result).not.toContain("\n ");
       expect(result).not.toContain("\r");
       expect(result).toContain("Run tests then check results");
       expect(result).toContain("Building artifacts");

--- a/src/agents/plan-render.test.ts
+++ b/src/agents/plan-render.test.ts
@@ -35,9 +35,7 @@ describe("renderPlanChecklist", () => {
       });
 
       it("falls back to step text when activeForm is absent", () => {
-        const steps: PlanStepForRender[] = [
-          { step: "Deploy", status: "in_progress" },
-        ];
+        const steps: PlanStepForRender[] = [{ step: "Deploy", status: "in_progress" }];
         const result = renderPlanChecklist(steps, format);
         expect(result).toContain("Deploy");
       });
@@ -99,6 +97,27 @@ describe("renderPlanChecklist", () => {
     expect(result).toContain("⏳ *Building artifacts*");
     expect(result).toContain("⬚ Deploy to staging");
     expect(result).toContain("❌ ~Fix broken migration~");
+  });
+
+  it("slack-mrkdwn: escapes control characters and mention tokens", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Check *bold* and _italic_ text", status: "pending" },
+      { step: "Handle <@U123> mention and <!here>", status: "pending" },
+      { step: "Test `backtick` and ~strike~ and @channel", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "slack-mrkdwn");
+    // Must not contain raw Slack formatting chars
+    expect(result).not.toContain("<@U123>");
+    expect(result).not.toContain("<!here>");
+    expect(result).not.toMatch(/(?<!\u2217)\*(?!\u2217)/); // no raw asterisks
+    expect(result).not.toContain("@channel");
+  });
+
+  it("slack-mrkdwn: title escaping in renderPlanWithHeader", () => {
+    const steps: PlanStepForRender[] = [{ step: "Step one", status: "pending" }];
+    const result = renderPlanWithHeader("Plan *with* <@mention>", steps, "slack-mrkdwn");
+    expect(result).not.toContain("<@mention>");
+    expect(result).toContain("Plan");
   });
 });
 

--- a/src/agents/plan-render.test.ts
+++ b/src/agents/plan-render.test.ts
@@ -58,6 +58,20 @@ describe("renderPlanChecklist", () => {
     expect(result).toMatch(/✅.*Run tests/);
   });
 
+  it("strips newlines from step labels", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Run tests\nthen check results", status: "pending" },
+      { step: "Build\r\nartifacts", status: "in_progress", activeForm: "Building\nartifacts" },
+    ];
+    for (const format of ["html", "markdown", "plaintext", "slack-mrkdwn"] as const) {
+      const result = renderPlanChecklist(steps, format);
+      expect(result).not.toContain("\n" + " ");
+      expect(result).not.toContain("\r");
+      expect(result).toContain("Run tests then check results");
+      expect(result).toContain("Building artifacts");
+    }
+  });
+
   it("html: renders cancelled with strikethrough", () => {
     const result = renderPlanChecklist(SAMPLE_STEPS, "html");
     expect(result).toMatch(/❌.*<s>.*Fix broken migration.*<\/s>/);

--- a/src/agents/plan-render.test.ts
+++ b/src/agents/plan-render.test.ts
@@ -144,3 +144,112 @@ describe("renderPlanWithHeader", () => {
     expect(result).toMatch(/^### My Plan/);
   });
 });
+
+describe("markdown injection hardening", () => {
+  it("escapes backticks in step text (no code spans from user input)", () => {
+    const steps: PlanStepForRender[] = [{ step: "Deploy `rm -rf /`", status: "pending" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    // No raw backticks left that would form a code span
+    expect(md).not.toMatch(/[^\\]`/);
+    // Backticks are escaped
+    expect(md).toContain("\\`");
+  });
+
+  it("escapes link syntax (no clickable links from user input)", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Click [here](https://evil.example)", status: "pending" },
+    ];
+    const md = renderPlanChecklist(steps, "markdown");
+    expect(md).not.toMatch(/\[here\]\(https/);
+    expect(md).toContain("\\[here\\]");
+  });
+
+  it("escapes emphasis markers (no bold/italic from user input)", () => {
+    const steps: PlanStepForRender[] = [{ step: "*shouting* and _whispering_", status: "pending" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    expect(md).not.toMatch(/\*shouting\*/);
+    expect(md).toContain("\\*shouting\\*");
+  });
+
+  it("escapes heading markers (no inline h1 from user input)", () => {
+    const steps: PlanStepForRender[] = [{ step: "# Important note", status: "pending" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    expect(md).toContain("\\# Important note");
+  });
+
+  it("cancelled status with markdown injection: both strikethrough and escaping applied", () => {
+    const steps: PlanStepForRender[] = [{ step: "Deploy `prod`", status: "cancelled" }];
+    const md = renderPlanChecklist(steps, "markdown");
+    expect(md).toContain("~~Deploy \\`prod\\`~~");
+  });
+});
+
+describe("mention neutralization", () => {
+  it("plaintext: neutralizes @channel", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Notify @channel about deploy", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "plaintext");
+    expect(result).not.toContain("@channel");
+    expect(result).toContain("@\uFE6Bchannel");
+  });
+
+  it("plaintext: neutralizes @here and @everyone", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "@here review needed", status: "pending" },
+      { step: "@everyone please respond", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "plaintext");
+    expect(result).not.toMatch(/@here\b/);
+    expect(result).not.toMatch(/@everyone\b/);
+  });
+
+  it("plaintext: leaves regular @mentions of users alone", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Assign @alice to investigate", status: "pending" },
+    ];
+    const result = renderPlanChecklist(steps, "plaintext");
+    expect(result).toContain("@alice");
+  });
+});
+
+describe("activeForm fallback", () => {
+  it("uses step text when activeForm is whitespace-only", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Run tests", status: "in_progress", activeForm: "   " },
+    ];
+    const result = renderPlanChecklist(steps, "markdown");
+    expect(result).toContain("Run tests");
+    expect(result).not.toContain("   ");
+  });
+
+  it("uses step text when activeForm is empty string", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Build artifacts", status: "in_progress", activeForm: "" },
+    ];
+    const result = renderPlanChecklist(steps, "markdown");
+    expect(result).toContain("Build artifacts");
+  });
+
+  it("uses activeForm when present and non-empty", () => {
+    const steps: PlanStepForRender[] = [
+      { step: "Run tests", status: "in_progress", activeForm: "Running tests" },
+    ];
+    const result = renderPlanChecklist(steps, "markdown");
+    expect(result).toContain("Running tests");
+    expect(result).not.toContain("Run tests");
+  });
+});
+
+describe("HTML escaping", () => {
+  it("escapes quotes in addition to angle brackets and ampersand", () => {
+    const steps: PlanStepForRender[] = [
+      { step: `Quote: "double" and 'single' & <tag>`, status: "pending" },
+    ];
+    const html = renderPlanChecklist(steps, "html");
+    expect(html).toContain("&quot;");
+    expect(html).toContain("&#39;");
+    expect(html).toContain("&amp;");
+    expect(html).toContain("&lt;tag&gt;");
+  });
+});

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -1,9 +1,11 @@
 /**
  * Plan checklist renderer for the GPT-5 parity sprint.
  *
- * Takes structured plan step data (from `AgentPlanEventData`) and renders
- * it as a native checklist for each delivery surface. Channel adapters
- * call {@link renderPlanChecklist} with the appropriate format.
+ * Takes structured plan step data and renders it as a native checklist
+ * for each delivery surface. Channel adapters call
+ * {@link renderPlanChecklist} with the appropriate format.
+ *
+ * Step shape matches the `update_plan` tool output (step, status, activeForm).
  */
 
 export type PlanRenderFormat = "html" | "markdown" | "plaintext" | "slack-mrkdwn";
@@ -22,38 +24,46 @@ export interface PlanStepForRender {
  * - `plaintext`: ASCII markers for iMessage / BlueBubbles / SMS
  * - `slack-mrkdwn`: Slack's mrkdwn format (`*bold*`, `~strike~`)
  */
-export function renderPlanChecklist(
-  steps: PlanStepForRender[],
-  format: PlanRenderFormat,
-): string {
+export function renderPlanChecklist(steps: PlanStepForRender[], format: PlanRenderFormat): string {
   if (steps.length === 0) {
     return "";
   }
 
   const lines = steps.map((s) => {
-    const rawLabel =
-      s.status === "in_progress" && s.activeForm ? s.activeForm : s.step;
+    const rawLabel = s.status === "in_progress" && s.activeForm ? s.activeForm : s.step;
     // Strip newlines from model-generated step text to prevent broken checklists.
     const label = rawLabel.replace(/[\n\r]+/g, " ").trim();
 
     switch (format) {
       case "html": {
         const esc = escapeHtml(label);
-        if (s.status === "completed") { return `✅ ${esc}`; }
-        if (s.status === "in_progress") { return `⏳ <b>${esc}</b>`; }
-        if (s.status === "cancelled") { return `❌ <s>${esc}</s>`; }
+        if (s.status === "completed") {
+          return `✅ ${esc}`;
+        }
+        if (s.status === "in_progress") {
+          return `⏳ <b>${esc}</b>`;
+        }
+        if (s.status === "cancelled") {
+          return `❌ <s>${esc}</s>`;
+        }
         return `⬚ ${esc}`;
       }
 
       case "markdown": {
-        if (s.status === "completed") { return `- [x] ${label}`; }
-        if (s.status === "in_progress") { return `- [>] **${label}**`; }
-        if (s.status === "cancelled") { return `- [~] ~~${label}~~`; }
+        if (s.status === "completed") {
+          return `- [x] ${label}`;
+        }
+        if (s.status === "in_progress") {
+          return `- [>] **${label}**`;
+        }
+        if (s.status === "cancelled") {
+          return `- [~] ~~${label}~~`;
+        }
         return `- [ ] ${label}`;
       }
 
       case "plaintext": {
-        const markers: Record<string, string> = {
+        const markers: Record<PlanStepForRender["status"], string> = {
           completed: "[x]",
           in_progress: "[>]",
           cancelled: "[~]",
@@ -64,9 +74,15 @@ export function renderPlanChecklist(
 
       case "slack-mrkdwn": {
         const escaped = escapeSlackMrkdwn(label);
-        if (s.status === "completed") { return `✅ ${escaped}`; }
-        if (s.status === "in_progress") { return `⏳ *${escaped}*`; }
-        if (s.status === "cancelled") { return `❌ ~${escaped}~`; }
+        if (s.status === "completed") {
+          return `✅ ${escaped}`;
+        }
+        if (s.status === "in_progress") {
+          return `⏳ *${escaped}*`;
+        }
+        if (s.status === "cancelled") {
+          return `❌ ~${escaped}~`;
+        }
         return `⬚ ${escaped}`;
       }
 
@@ -92,16 +108,18 @@ export function renderPlanWithHeader(
   if (!checklist) {
     return "";
   }
+  // Strip newlines from title to prevent broken headings/formatting.
+  const safeTitle = title.replace(/[\n\r]+/g, " ").trim();
 
   switch (format) {
     case "html":
-      return `<b>${escapeHtml(title)}</b>\n${checklist}`;
+      return `<b>${escapeHtml(safeTitle)}</b>\n${checklist}`;
     case "markdown":
-      return `### ${title}\n${checklist}`;
+      return `### ${safeTitle}\n${checklist}`;
     case "plaintext":
-      return `${title}\n${checklist}`;
+      return `${safeTitle}\n${checklist}`;
     case "slack-mrkdwn":
-      return `*${escapeSlackMrkdwn(title)}*\n${checklist}`;
+      return `*${escapeSlackMrkdwn(safeTitle)}*\n${checklist}`;
     default: {
       const _exhaustive: never = format;
       return `${title}\n${checklist}`;
@@ -124,8 +142,5 @@ function escapeSlackMrkdwn(text: string): string {
 }
 
 function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -128,7 +128,12 @@ export function renderPlanWithHeader(
     case "markdown":
       return `### ${safeTitle}\n${checklist}`;
     case "plaintext":
-      return `${safeTitle}\n${checklist}`;
+      // Codex P2 #67534 r3095517064: neutralize @mentions in the title
+      // path too — checklist labels are already protected by
+      // neutralizeMentions() above, but a model-derived title like
+      // `@everyone release plan` would still trigger mentions on
+      // platforms that follow plaintext mention conventions.
+      return `${neutralizeMentions(safeTitle)}\n${checklist}`;
     case "slack-mrkdwn":
       return `*${escapeSlackMrkdwn(safeTitle)}*\n${checklist}`;
     default: {
@@ -185,7 +190,6 @@ function warnUnknownStatus(status: string): void {
     return;
   }
   warnedStatuses.add(status);
-  // eslint-disable-next-line no-console
   console.warn(
     `[plan-render] Unknown plan step status "${status}", falling back to pending rendering.`,
   );

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -35,17 +35,20 @@ export function renderPlanChecklist(
       s.status === "in_progress" && s.activeForm ? s.activeForm : s.step;
 
     switch (format) {
-      case "html":
-        if (s.status === "completed") return `✅ ${escapeHtml(label)}`;
-        if (s.status === "in_progress") return `⏳ <b>${escapeHtml(label)}</b>`;
-        if (s.status === "cancelled") return `❌ <s>${escapeHtml(label)}</s>`;
-        return `⬚ ${escapeHtml(label)}`;
+      case "html": {
+        const esc = escapeHtml(label);
+        if (s.status === "completed") { return `✅ ${esc}`; }
+        if (s.status === "in_progress") { return `⏳ <b>${esc}</b>`; }
+        if (s.status === "cancelled") { return `❌ <s>${esc}</s>`; }
+        return `⬚ ${esc}`;
+      }
 
-      case "markdown":
-        if (s.status === "completed") return `- [x] ${label}`;
-        if (s.status === "in_progress") return `- [>] **${label}**`;
-        if (s.status === "cancelled") return `- [~] ~~${label}~~`;
+      case "markdown": {
+        if (s.status === "completed") { return `- [x] ${label}`; }
+        if (s.status === "in_progress") { return `- [>] **${label}**`; }
+        if (s.status === "cancelled") { return `- [~] ~~${label}~~`; }
         return `- [ ] ${label}`;
+      }
 
       case "plaintext": {
         const markers: Record<string, string> = {
@@ -59,10 +62,15 @@ export function renderPlanChecklist(
 
       case "slack-mrkdwn": {
         const escaped = escapeSlackMrkdwn(label);
-        if (s.status === "completed") return `✅ ${escaped}`;
-        if (s.status === "in_progress") return `⏳ *${escaped}*`;
-        if (s.status === "cancelled") return `❌ ~${escaped}~`;
+        if (s.status === "completed") { return `✅ ${escaped}`; }
+        if (s.status === "in_progress") { return `⏳ *${escaped}*`; }
+        if (s.status === "cancelled") { return `❌ ~${escaped}~`; }
         return `⬚ ${escaped}`;
+      }
+
+      default: {
+        const _exhaustive: never = format;
+        return `[ ] ${label}`;
       }
     }
   });
@@ -92,6 +100,10 @@ export function renderPlanWithHeader(
       return `${title}\n${checklist}`;
     case "slack-mrkdwn":
       return `*${escapeSlackMrkdwn(title)}*\n${checklist}`;
+    default: {
+      const _exhaustive: never = format;
+      return `${title}\n${checklist}`;
+    }
   }
 }
 

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -30,7 +30,9 @@ export function renderPlanChecklist(steps: PlanStepForRender[], format: PlanRend
   }
 
   const lines = steps.map((s) => {
-    const rawLabel = s.status === "in_progress" && s.activeForm ? s.activeForm : s.step;
+    // Treat whitespace-only activeForm as missing — fall back to step text.
+    const hasUsableActiveForm = typeof s.activeForm === "string" && s.activeForm.trim().length > 0;
+    const rawLabel = s.status === "in_progress" && hasUsableActiveForm ? s.activeForm! : s.step;
     // Strip newlines from model-generated step text to prevent broken checklists.
     const label = rawLabel.replace(/[\n\r]+/g, " ").trim();
 
@@ -50,26 +52,35 @@ export function renderPlanChecklist(steps: PlanStepForRender[], format: PlanRend
       }
 
       case "markdown": {
+        // Escape user-controlled text to prevent markdown injection
+        // (links, code spans, emphasis, headings).
+        const md = escapeMarkdown(label);
         if (s.status === "completed") {
-          return `- [x] ${label}`;
+          return `- [x] ${md}`;
         }
         if (s.status === "in_progress") {
-          return `- [>] **${label}**`;
+          return `- [>] **${md}**`;
         }
         if (s.status === "cancelled") {
-          return `- [~] ~~${label}~~`;
+          return `- [~] ~~${md}~~`;
         }
-        return `- [ ] ${label}`;
+        return `- [ ] ${md}`;
       }
 
       case "plaintext": {
+        // Neutralize @channel/@here/@everyone mention triggers even in
+        // plaintext (some clients still parse them).
+        const safe = neutralizeMentions(label);
         const markers: Record<PlanStepForRender["status"], string> = {
           completed: "[x]",
           in_progress: "[>]",
           cancelled: "[~]",
           pending: "[ ]",
         };
-        return `${markers[s.status] ?? "[ ]"} ${label}`;
+        if (!Object.hasOwn(markers, s.status)) {
+          warnUnknownStatus(s.status);
+        }
+        return `${markers[s.status] ?? "[ ]"} ${safe}`;
       }
 
       case "slack-mrkdwn": {
@@ -142,5 +153,40 @@ function escapeSlackMrkdwn(text: string): string {
 }
 
 function escapeHtml(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Escapes markdown meta-characters in user-controlled text so a step like
+ * "Deploy `rm -rf /`" or "[click](evil)" doesn't render as a code span or link.
+ */
+function escapeMarkdown(text: string): string {
+  // Order matters: backslash first so we don't re-escape our own escapes.
+  return text.replace(/[\\`*_{}[\]()#+\-.!<>|]/g, "\\$&");
+}
+
+/**
+ * Inserts U+FE6B between '@' and known mention triggers to prevent
+ * @channel / @here / @everyone notifications from user-controlled text.
+ * Mirrors the slack-mrkdwn approach but applied across plaintext too.
+ */
+function neutralizeMentions(text: string): string {
+  return text.replace(/@(channel|here|everyone)\b/gi, "@\uFE6B$1");
+}
+
+const warnedStatuses = new Set<string>();
+function warnUnknownStatus(status: string): void {
+  if (warnedStatuses.has(status)) {
+    return;
+  }
+  warnedStatuses.add(status);
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[plan-render] Unknown plan step status "${status}", falling back to pending rendering.`,
+  );
 }

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -31,8 +31,10 @@ export function renderPlanChecklist(
   }
 
   const lines = steps.map((s) => {
-    const label =
+    const rawLabel =
       s.status === "in_progress" && s.activeForm ? s.activeForm : s.step;
+    // Strip newlines from model-generated step text to prevent broken checklists.
+    const label = rawLabel.replace(/[\n\r]+/g, " ").trim();
 
     switch (format) {
       case "html": {

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -1,0 +1,101 @@
+/**
+ * Plan checklist renderer for the GPT-5 parity sprint.
+ *
+ * Takes structured plan step data (from `AgentPlanEventData`) and renders
+ * it as a native checklist for each delivery surface. Channel adapters
+ * call {@link renderPlanChecklist} with the appropriate format.
+ */
+
+export type PlanRenderFormat = "html" | "markdown" | "plaintext" | "slack-mrkdwn";
+
+export interface PlanStepForRender {
+  step: string;
+  status: "pending" | "in_progress" | "completed" | "cancelled";
+  activeForm?: string;
+}
+
+/**
+ * Renders an array of plan steps into a formatted checklist string.
+ *
+ * - `html`: Telegram HTML parse mode (`<b>`, `<s>`, emoji markers)
+ * - `markdown`: GitHub-flavored markdown checkboxes
+ * - `plaintext`: ASCII markers for iMessage / BlueBubbles / SMS
+ * - `slack-mrkdwn`: Slack's mrkdwn format (`*bold*`, `~strike~`)
+ */
+export function renderPlanChecklist(
+  steps: PlanStepForRender[],
+  format: PlanRenderFormat,
+): string {
+  if (steps.length === 0) {
+    return "";
+  }
+
+  const lines = steps.map((s) => {
+    const label =
+      s.status === "in_progress" && s.activeForm ? s.activeForm : s.step;
+
+    switch (format) {
+      case "html":
+        if (s.status === "completed") return `✅ ${escapeHtml(label)}`;
+        if (s.status === "in_progress") return `⏳ <b>${escapeHtml(label)}</b>`;
+        if (s.status === "cancelled") return `❌ <s>${escapeHtml(label)}</s>`;
+        return `⬚ ${escapeHtml(label)}`;
+
+      case "markdown":
+        if (s.status === "completed") return `- [x] ${label}`;
+        if (s.status === "in_progress") return `- [>] **${label}**`;
+        if (s.status === "cancelled") return `- [~] ~~${label}~~`;
+        return `- [ ] ${label}`;
+
+      case "plaintext": {
+        const markers: Record<string, string> = {
+          completed: "[x]",
+          in_progress: "[>]",
+          cancelled: "[~]",
+          pending: "[ ]",
+        };
+        return `${markers[s.status] ?? "[ ]"} ${label}`;
+      }
+
+      case "slack-mrkdwn":
+        if (s.status === "completed") return `✅ ${label}`;
+        if (s.status === "in_progress") return `⏳ *${label}*`;
+        if (s.status === "cancelled") return `❌ ~${label}~`;
+        return `⬚ ${label}`;
+    }
+  });
+
+  return lines.join("\n");
+}
+
+/**
+ * Renders a plan checklist with a header line.
+ */
+export function renderPlanWithHeader(
+  title: string,
+  steps: PlanStepForRender[],
+  format: PlanRenderFormat,
+): string {
+  const checklist = renderPlanChecklist(steps, format);
+  if (!checklist) {
+    return "";
+  }
+
+  switch (format) {
+    case "html":
+      return `<b>${escapeHtml(title)}</b>\n${checklist}`;
+    case "markdown":
+      return `### ${title}\n${checklist}`;
+    case "plaintext":
+      return `${title}\n${checklist}`;
+    case "slack-mrkdwn":
+      return `*${title}*\n${checklist}`;
+  }
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -57,11 +57,13 @@ export function renderPlanChecklist(
         return `${markers[s.status] ?? "[ ]"} ${label}`;
       }
 
-      case "slack-mrkdwn":
-        if (s.status === "completed") return `✅ ${label}`;
-        if (s.status === "in_progress") return `⏳ *${label}*`;
-        if (s.status === "cancelled") return `❌ ~${label}~`;
-        return `⬚ ${label}`;
+      case "slack-mrkdwn": {
+        const escaped = escapeSlackMrkdwn(label);
+        if (s.status === "completed") return `✅ ${escaped}`;
+        if (s.status === "in_progress") return `⏳ *${escaped}*`;
+        if (s.status === "cancelled") return `❌ ~${escaped}~`;
+        return `⬚ ${escaped}`;
+      }
     }
   });
 
@@ -89,8 +91,20 @@ export function renderPlanWithHeader(
     case "plaintext":
       return `${title}\n${checklist}`;
     case "slack-mrkdwn":
-      return `*${title}*\n${checklist}`;
+      return `*${escapeSlackMrkdwn(title)}*\n${checklist}`;
   }
+}
+
+/** Escapes Slack mrkdwn control characters: *, ~, `, _, and angle brackets. */
+function escapeSlackMrkdwn(text: string): string {
+  // Replace angle-bracket tokens first, then mrkdwn formatting chars.
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\*/g, "\u2217") // ∗ (asterisk operator, visually similar)
+    .replace(/~/g, "\u223C") // ∼ (tilde operator)
+    .replace(/`/g, "\u2018"); // ' (left single quote)
 }
 
 function escapeHtml(text: string): string {

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -119,7 +119,8 @@ function escapeSlackMrkdwn(text: string): string {
     .replace(/\*/g, "\u2217") // ∗ (asterisk operator, visually similar)
     .replace(/~/g, "\u223C") // ∼ (tilde operator)
     .replace(/`/g, "\u2018") // ' (left single quote)
-    .replace(/_/g, "\uFF3F"); // ＿ (fullwidth low line, prevents italic parse)
+    .replace(/_/g, "\uFF3F") // ＿ (fullwidth low line, prevents italic parse)
+    .replace(/@/g, "\uFE6B"); // ﹫ (small form variant, prevents mention parsing)
 }
 
 function escapeHtml(text: string): string {

--- a/src/agents/plan-render.ts
+++ b/src/agents/plan-render.ts
@@ -104,7 +104,8 @@ function escapeSlackMrkdwn(text: string): string {
     .replace(/>/g, "&gt;")
     .replace(/\*/g, "\u2217") // ∗ (asterisk operator, visually similar)
     .replace(/~/g, "\u223C") // ∼ (tilde operator)
-    .replace(/`/g, "\u2018"); // ' (left single quote)
+    .replace(/`/g, "\u2018") // ' (left single quote)
+    .replace(/_/g, "\uFF3F"); // ＿ (fullwidth low line, prevents italic parse)
 }
 
 function escapeHtml(text: string): string {


### PR DESCRIPTION
## TL;DR

Core plan rendering utility that formats plan checklists for HTML (Telegram), Markdown (GitHub), plaintext (SMS), and Slack mrkdwn. Supports all 4 statuses (pending, in_progress, completed, cancelled) with \`activeForm\` live progress text.

## Tracking
- Umbrella: #66345
- Issue: #67519

## What this PR does

\`renderPlanChecklist()\` + \`renderPlanWithHeader()\` utilities that take a plan's step array and produce formatted output for any channel:

| Format | Channel | Example output |
|--------|---------|---------------|
| HTML | Telegram | \`<b>✅</b> Deploy to staging\` |
| Markdown | GitHub, CLI | \`- [x] Deploy to staging\` |
| Plaintext | SMS, logs | \`[✓] Deploy to staging\` |
| Slack mrkdwn | Slack | \`~Deploy to staging~\` (cancelled) |

\`activeForm\` renders live progress: shows "Building artifacts" instead of "Build artifacts" during \`in_progress\`.

## Files changed

| File | Change | Tests |
|------|--------|-------|
| \`src/agents/plan-render.ts\` | **New** — renderer utilities | 23 tests |
| \`src/agents/plan-render.test.ts\` | **New** — all formats × statuses × edge cases | Self |

## 23 unit tests
- All 4 formats × all 4 statuses
- activeForm rendering
- HTML escaping for injection prevention
- Empty plan edge case
- Header formatting

## Dependencies
- #67514 for \`cancelled\` status + \`activeForm\` field

## What follows
- Channel adapters wire \`renderPlanChecklist()\` when handling plan events