### PR TITLE
feat(skills): plan template support for skill-driven planning [Phase 4.1]

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -245,6 +245,9 @@ vi.mock("../skills-runtime.js", () => ({
     shouldLoadSkillEntries: false,
     skillEntries: undefined,
   }),
+  // Stub the skill-template seeder — tests using this support module
+  // don't need plan-template emission to fire (#67541).
+  applySkillPlanTemplateSeed: () => null,
 }));
 
 vi.mock("../context-engine-maintenance.js", () => ({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -151,7 +151,7 @@ import {
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
-import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
+import { applySkillPlanTemplateSeed, resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
 import {
   describeEmbeddedAgentStreamStrategy,
   resetEmbeddedAgentBaseStreamFnCacheForTest,
@@ -415,6 +415,19 @@ export async function runEmbeddedAttempt(
           skills: skillEntries ?? [],
           config: params.config,
         });
+
+    // Seed the agent's plan from any loaded skill's `planTemplate` (if
+    // present) BEFORE the first LLM turn (#67541). The seed is a no-op
+    // when no skill carries a template, when more than one skill is
+    // tied (use alpha-first as a deterministic winner), or when an
+    // existing plan would be clobbered. Idempotency against
+    // `AgentRunContext.lastPlanSteps` lands in #67514's follow-up.
+    applySkillPlanTemplateSeed({
+      entries: skillEntries ?? [],
+      runId: params.runId,
+      sessionKey: params.sessionKey,
+      config: params.config,
+    });
 
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -422,8 +422,15 @@ export async function runEmbeddedAttempt(
     // tied (use alpha-first as a deterministic winner), or when an
     // existing plan would be clobbered. Idempotency against
     // `AgentRunContext.lastPlanSteps` lands in #67514's follow-up.
+    //
+    // We pass both `entries` and `skillsSnapshot`: in the snapshot-backed
+    // run path `entries` is empty (resolveEmbeddedRunSkillEntries skips
+    // re-loading) and the seeder reads `resolvedPlanTemplates` from the
+    // snapshot instead. Without this fallback the seed would silently
+    // no-op in production sessions.
     applySkillPlanTemplateSeed({
       entries: skillEntries ?? [],
+      ...(params.skillsSnapshot ? { skillsSnapshot: params.skillsSnapshot } : {}),
       runId: params.runId,
       sessionKey: params.sessionKey,
       config: params.config,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -434,6 +434,11 @@ export async function runEmbeddedAttempt(
       runId: params.runId,
       sessionKey: params.sessionKey,
       config: params.config,
+      // Forward the run-scoped event callback so callback-only consumers
+      // (e.g. the auto-reply pipeline) see the seeded plan event the same
+      // way they see subsequent update_plan events. Codex P2 #67541
+      // r3096399082/r3096435183.
+      ...(params.onAgentEvent ? { onAgentEvent: params.onAgentEvent } : {}),
     });
 
     const skillsPrompt = resolveSkillsPromptForRun({

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,7 +1,8 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { emitAgentPlanEvent } from "../../infra/agent-events.js";
+import { type AgentPlanEventData, emitAgentPlanEvent } from "../../infra/agent-events.js";
 import { logWarn } from "../../logger.js";
 import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
+import { shouldIncludeSkill } from "../skills/config.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
 import {
   buildPlanTemplatePayload,
@@ -62,7 +63,14 @@ export function resolveSkillPlanTemplate(
   entries: SkillEntry[],
   config?: OpenClawConfig,
 ): SkillPlanTemplateResolution | null {
-  const candidates = entries
+  // Codex P2 (PR #67541 r3096399074): apply eligibility filtering BEFORE
+  // collision resolution. `loadWorkspaceSkillEntries` returns every loaded
+  // skill (including disabled / missing-env / wrong-OS ones) when no
+  // explicit `skillFilter` is set; without this guard a disabled skill
+  // could win the alpha-first collision and seed an unrelated plan that
+  // never appears in the runtime prompt.
+  const eligibleEntries = entries.filter((entry) => shouldIncludeSkill({ entry, config }));
+  const candidates = eligibleEntries
     .filter((e) => hasSkillPlanTemplate(e.metadata) && e.metadata?.planTemplate)
     .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name));
 
@@ -140,6 +148,15 @@ export interface ApplySkillPlanTemplateSeedParams {
   /** Resolved config — used for `skills.limits.maxPlanTemplateSteps`. */
   config?: OpenClawConfig;
   /**
+   * Run-scoped event callback used by some consumers (e.g. the auto-reply
+   * pipeline at `src/auto-reply/reply/agent-runner-execution.ts`) to
+   * receive plan updates. Codex P2 (PR #67541 r3096399082/r3096435183) —
+   * other plan-update sites call BOTH `emitAgentPlanEvent` and this
+   * callback; the seeder must too, or callback-only consumers miss the
+   * initial seed event.
+   */
+  onAgentEvent?: (evt: { stream: "plan"; data: AgentPlanEventData }) => void;
+  /**
    * When provided and non-empty, seeding is skipped. Treats an existing
    * plan as user intent and avoids clobbering it with a stock template.
    * Wired to `AgentRunContext.lastPlanSteps` once #67514 lands.
@@ -216,16 +233,31 @@ export function applySkillPlanTemplateSeed(
     );
   }
 
+  const planEventData: AgentPlanEventData = {
+    phase: "update",
+    title: `Plan seeded from skill "${skillName}"`,
+    explanation: payload.explanation,
+    steps: payload.plan.map((s) => s.step),
+    source: "skill_plan_template",
+  };
+
+  // Forward to the run-scoped callback FIRST so callback-only consumers
+  // (e.g. the auto-reply pipeline) don't miss the seed. Other plan-update
+  // sites in run.ts call BOTH paths — the seed must too.
+  // (Codex P2 #67541 r3096399082 / r3096435183)
+  try {
+    params.onAgentEvent?.({ stream: "plan", data: planEventData });
+  } catch (err) {
+    // Don't let a callback throw block the global emit.
+    logWarn(
+      `onAgentEvent callback threw during skill plan seed: ${(err as Error)?.message ?? err}`,
+    );
+  }
+
   emitAgentPlanEvent({
     runId: params.runId,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-    data: {
-      phase: "update",
-      title: `Plan seeded from skill "${skillName}"`,
-      explanation: payload.explanation,
-      steps: payload.plan.map((s) => s.step),
-      source: "skill_plan_template",
-    },
+    data: planEventData,
   });
 
   return {

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
+import { buildPlanTemplatePayload, hasSkillPlanTemplate, type PlanTemplatePayload } from "../skills/skill-planner.js";
 
 export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
@@ -19,4 +20,18 @@ export function resolveEmbeddedRunSkillEntries(params: {
       ? loadWorkspaceSkillEntries(params.workspaceDir, { config, agentId: params.agentId })
       : [],
   };
+}
+
+/**
+ * Checks activated skill entries for a plan template and returns
+ * the `update_plan` payload if one is found. Returns `null` if no
+ * activated skill has a plan template.
+ */
+export function resolveSkillPlanTemplate(entries: SkillEntry[]): PlanTemplatePayload | null {
+  for (const entry of entries) {
+    if (hasSkillPlanTemplate(entry.metadata) && entry.metadata?.planTemplate) {
+      return buildPlanTemplatePayload(entry.skill.name, entry.metadata.planTemplate);
+    }
+  }
+  return null;
 }

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -8,6 +8,7 @@ import {
   hasSkillPlanTemplate,
   type PlanTemplatePayload,
 } from "../skills/skill-planner.js";
+import type { SkillPlanTemplateStep } from "../skills/types.js";
 
 export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
@@ -75,25 +76,63 @@ export function resolveSkillPlanTemplate(
     return null;
   }
 
+  return resolveSkillPlanTemplateFromCandidates(
+    candidates.map((c) => ({
+      skillName: c.skill.name,
+      planTemplate: c.metadata?.planTemplate ?? [],
+    })),
+    config,
+  );
+}
+
+/**
+ * Lower-level resolver that operates on the snapshot's
+ * `resolvedPlanTemplates` shape — name + template list, without the
+ * full SkillEntry. Used in the snapshot-backed run path where
+ * `resolveEmbeddedRunSkillEntries` returns no entries.
+ *
+ * Candidates MUST be alpha-sorted by `skillName` if the caller wants
+ * deterministic collision behavior; this function does not re-sort.
+ */
+export function resolveSkillPlanTemplateFromCandidates(
+  candidates: ReadonlyArray<{ skillName: string; planTemplate: SkillPlanTemplateStep[] }>,
+  config?: OpenClawConfig,
+): SkillPlanTemplateResolution | null {
+  const filtered = candidates
+    .filter((c) => Array.isArray(c.planTemplate) && c.planTemplate.length > 0)
+    .toSorted((a, b) => a.skillName.localeCompare(b.skillName));
+  if (filtered.length === 0) {
+    return null;
+  }
+  const winner = filtered[0];
   const maxSteps = config?.skills?.limits?.maxPlanTemplateSteps;
   const payload =
     maxSteps && maxSteps > 0
-      ? buildPlanTemplatePayload(winner.skill.name, winnerTemplate, { maxSteps })
-      : buildPlanTemplatePayload(winner.skill.name, winnerTemplate);
+      ? buildPlanTemplatePayload(winner.skillName, winner.planTemplate, { maxSteps })
+      : buildPlanTemplatePayload(winner.skillName, winner.planTemplate);
   if (!payload) {
     return null;
   }
-
   return {
     payload,
-    skillName: winner.skill.name,
-    rejected: candidates.slice(1).map((c) => c.skill.name),
+    skillName: winner.skillName,
+    rejected: filtered.slice(1).map((c) => c.skillName),
   };
 }
 
 export interface ApplySkillPlanTemplateSeedParams {
-  /** Loaded skill entries for this run. */
+  /**
+   * Loaded skill entries for this run. May be empty in the
+   * snapshot-backed run path; see `skillsSnapshot` below.
+   */
   entries: SkillEntry[];
+  /**
+   * Optional pre-built snapshot. When `entries` is empty (the main
+   * run path uses a snapshot built by `buildWorkspaceSkillSnapshot`
+   * and skips re-loading entries), the seeder falls back to the
+   * snapshot's `resolvedPlanTemplates` so the seed still fires.
+   */
+  skillsSnapshot?: SkillSnapshot;
   /** Stable run identifier used to scope the emitted plan event. */
   runId?: string;
   /** Session key for control UI / channel routing. */
@@ -143,7 +182,16 @@ export function applySkillPlanTemplateSeed(
     // Existing plan present — treat it as user intent and skip the seed.
     return null;
   }
-  const resolution = resolveSkillPlanTemplate(params.entries, params.config);
+  // Snapshot fallback: when entries are empty (main snapshot-backed path),
+  // use the templates baked into the snapshot at build time. Otherwise the
+  // seed silently no-ops in production runs that supply a snapshot.
+  let resolution = resolveSkillPlanTemplate(params.entries, params.config);
+  if (!resolution) {
+    const snapshotTemplates = params.skillsSnapshot?.resolvedPlanTemplates;
+    if (snapshotTemplates && snapshotTemplates.length > 0) {
+      resolution = resolveSkillPlanTemplateFromCandidates(snapshotTemplates, params.config);
+    }
+  }
   if (!resolution) {
     return null;
   }

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,4 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitAgentPlanEvent } from "../../infra/agent-events.js";
+import { logWarn } from "../../logger.js";
 import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
 import {
@@ -27,15 +29,162 @@ export function resolveEmbeddedRunSkillEntries(params: {
 }
 
 /**
- * Checks loaded skill entries for a plan template and returns
- * the `update_plan` payload if one is found. Returns `null` if no
- * loaded skill has a plan template.
+ * Result of resolving the plan template seed for a set of loaded skills.
+ *
+ * When more than one skill carries a `planTemplate`, the implementation
+ * picks the alphabetically-first skill name as the deterministic winner
+ * and lists the others in `rejected` so the caller can emit a
+ * `skill_plan_template_collision` warning event.
  */
-export function resolveSkillPlanTemplate(entries: SkillEntry[]): PlanTemplatePayload | null {
-  for (const entry of entries) {
-    if (hasSkillPlanTemplate(entry.metadata) && entry.metadata?.planTemplate) {
-      return buildPlanTemplatePayload(entry.skill.name, entry.metadata.planTemplate);
-    }
+export interface SkillPlanTemplateResolution {
+  /** Normalized payload ready to seed into the agent's plan. */
+  payload: PlanTemplatePayload;
+  /** Skill that won the collision (alpha-sorted first by name). */
+  skillName: string;
+  /** Skills with templates that were ignored due to the collision. */
+  rejected: string[];
+}
+
+/**
+ * Picks the plan-template payload to seed for this run. Returns `null`
+ * when no loaded skill carries a non-empty `planTemplate`.
+ *
+ * Collision policy: if multiple skills carry templates, the
+ * alphabetically-first skill name wins. The remaining skill names are
+ * returned in `rejected` so the caller can warn.
+ *
+ * Upper bound: when `config.skills.limits.maxPlanTemplateSteps` is set,
+ * the resolved payload's plan is truncated and `payload.truncated` is
+ * `true`.
+ */
+export function resolveSkillPlanTemplate(
+  entries: SkillEntry[],
+  config?: OpenClawConfig,
+): SkillPlanTemplateResolution | null {
+  const candidates = entries
+    .filter((e) => hasSkillPlanTemplate(e.metadata) && e.metadata?.planTemplate)
+    .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name));
+
+  if (candidates.length === 0) {
+    return null;
   }
-  return null;
+
+  const winner = candidates[0];
+  const winnerTemplate = winner.metadata?.planTemplate;
+  if (!winnerTemplate) {
+    return null;
+  }
+
+  const maxSteps = config?.skills?.limits?.maxPlanTemplateSteps;
+  const payload =
+    maxSteps && maxSteps > 0
+      ? buildPlanTemplatePayload(winner.skill.name, winnerTemplate, { maxSteps })
+      : buildPlanTemplatePayload(winner.skill.name, winnerTemplate);
+  if (!payload) {
+    return null;
+  }
+
+  return {
+    payload,
+    skillName: winner.skill.name,
+    rejected: candidates.slice(1).map((c) => c.skill.name),
+  };
+}
+
+export interface ApplySkillPlanTemplateSeedParams {
+  /** Loaded skill entries for this run. */
+  entries: SkillEntry[];
+  /** Stable run identifier used to scope the emitted plan event. */
+  runId?: string;
+  /** Session key for control UI / channel routing. */
+  sessionKey?: string;
+  /** Resolved config — used for `skills.limits.maxPlanTemplateSteps`. */
+  config?: OpenClawConfig;
+  /**
+   * When provided and non-empty, seeding is skipped. Treats an existing
+   * plan as user intent and avoids clobbering it with a stock template.
+   * Wired to `AgentRunContext.lastPlanSteps` once #67514 lands.
+   */
+  existingPlanSteps?: ReadonlyArray<{ step: string }>;
+}
+
+export interface AppliedSkillPlanTemplateSeed {
+  /** Skill that supplied the seed. */
+  skillName: string;
+  /** Number of plan steps emitted (post-dedup, post-truncate). */
+  emittedSteps: number;
+  /** Other skills with templates that were ignored. */
+  rejected: string[];
+  /** Step texts dropped because they duplicated an earlier entry. */
+  droppedDuplicates: string[];
+  /** True if the template exceeded the configured upper bound. */
+  truncated: boolean;
+}
+
+/**
+ * Seeds the agent's plan from the activated skills' `planTemplate` (if any).
+ *
+ * Behavior:
+ * - If no candidate skill carries a non-empty template, returns `null`.
+ * - If `existingPlanSteps` is non-empty, skips seeding (idempotency).
+ * - Otherwise emits an `agent_plan_event` with the template steps and
+ *   logs warnings for collision / dropped duplicates / truncation.
+ *
+ * Returns a summary describing the applied seed (or `null` when no seed
+ * was emitted) so callers can write tests / surface telemetry.
+ */
+export function applySkillPlanTemplateSeed(
+  params: ApplySkillPlanTemplateSeedParams,
+): AppliedSkillPlanTemplateSeed | null {
+  if (!params.runId) {
+    return null;
+  }
+  if (params.existingPlanSteps && params.existingPlanSteps.length > 0) {
+    // Existing plan present — treat it as user intent and skip the seed.
+    return null;
+  }
+  const resolution = resolveSkillPlanTemplate(params.entries, params.config);
+  if (!resolution) {
+    return null;
+  }
+
+  const { payload, skillName, rejected } = resolution;
+  const droppedDuplicates = payload.droppedDuplicates ?? [];
+  const truncated = payload.truncated === true;
+
+  if (rejected.length > 0) {
+    logWarn(
+      `skill_plan_template_collision: ${rejected.length + 1} loaded skills carry plan templates; using "${skillName}" (alpha-first), ignoring [${rejected.join(", ")}]`,
+    );
+  }
+  if (droppedDuplicates.length > 0) {
+    logWarn(
+      `skill_plan_template_duplicates: dropped ${droppedDuplicates.length} duplicate step(s) from "${skillName}" template: [${droppedDuplicates.join(", ")}]`,
+    );
+  }
+  if (truncated) {
+    logWarn(
+      `skill_plan_template_truncated: skill "${skillName}" template exceeded maxPlanTemplateSteps (${payload.maxSteps}); tail dropped`,
+    );
+  }
+
+  emitAgentPlanEvent({
+    runId: params.runId,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    data: {
+      phase: "update",
+      title: `Plan seeded from skill "${skillName}"`,
+      explanation: payload.explanation,
+      steps: payload.plan.map((s) => s.step),
+      source: "skill_plan_template",
+    },
+  });
+
+  return {
+    skillName,
+    emittedSteps: payload.plan.length,
+    rejected,
+    droppedDuplicates,
+    truncated,
+  };
 }

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,7 +1,11 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
-import { buildPlanTemplatePayload, hasSkillPlanTemplate, type PlanTemplatePayload } from "../skills/skill-planner.js";
+import {
+  buildPlanTemplatePayload,
+  hasSkillPlanTemplate,
+  type PlanTemplatePayload,
+} from "../skills/skill-planner.js";
 
 export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
@@ -23,9 +27,9 @@ export function resolveEmbeddedRunSkillEntries(params: {
 }
 
 /**
- * Checks activated skill entries for a plan template and returns
+ * Checks loaded skill entries for a plan template and returns
  * the `update_plan` payload if one is found. Returns `null` if no
- * activated skill has a plan template.
+ * loaded skill has a plan template.
  */
 export function resolveSkillPlanTemplate(entries: SkillEntry[]): PlanTemplatePayload | null {
   for (const entry of entries) {

--- a/src/agents/skills/frontmatter.test.ts
+++ b/src/agents/skills/frontmatter.test.ts
@@ -65,3 +65,33 @@ describe("resolveOpenClawMetadata install validation", () => {
     expect(install).toBeUndefined();
   });
 });
+
+describe("resolveOpenClawMetadata planTemplate (Codex P1 r3096435164)", () => {
+  it("parses kebab-case `plan-template` key (legacy)", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"plan-template":[{"step":"Tag release"},{"step":"Publish"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Tag release" }, { step: "Publish" }]);
+  });
+
+  it("parses camelCase `planTemplate` key (natural — was silently ignored)", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"planTemplate":[{"step":"Tag release"},{"step":"Publish"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Tag release" }, { step: "Publish" }]);
+  });
+
+  it("kebab-case wins on conflict (backward compat)", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"plan-template":[{"step":"Old"}],"planTemplate":[{"step":"New"}]}}',
+    });
+    expect(meta?.planTemplate).toEqual([{ step: "Old" }]);
+  });
+
+  it("returns undefined planTemplate when neither key is present", () => {
+    const meta = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"primaryEnv":"node"}}',
+    });
+    expect(meta?.planTemplate).toBeUndefined();
+  });
+});

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -19,6 +19,7 @@ import type {
   SkillEntry,
   SkillInstallSpec,
   SkillInvocationPolicy,
+  SkillPlanTemplateStep,
 } from "./types.js";
 
 export function parseFrontmatter(content: string): ParsedSkillFrontmatter {
@@ -184,6 +185,18 @@ function parseInstallSpec(input: unknown): SkillInstallSpec | undefined {
   return spec;
 }
 
+function parsePlanTemplate(raw: unknown): SkillPlanTemplateStep[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .filter((item: any) => item && typeof item === "object" && item.step)
+    .map((item: any) => ({
+      step: String(item.step || ""),
+      ...(item.activeForm ? { activeForm: String(item.activeForm) } : {}),
+    }));
+}
+
 export function resolveOpenClawMetadata(
   frontmatter: ParsedSkillFrontmatter,
 ): OpenClawSkillMetadata | undefined {
@@ -194,6 +207,7 @@ export function resolveOpenClawMetadata(
   const requires = resolveOpenClawManifestRequires(metadataObj);
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
+  const planTemplate = parsePlanTemplate(metadataObj["plan-template"]);
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
     emoji: readStringValue(metadataObj.emoji),
@@ -203,6 +217,7 @@ export function resolveOpenClawMetadata(
     os: osRaw.length > 0 ? osRaw : undefined,
     requires: requires,
     install: install.length > 0 ? install : undefined,
+    planTemplate: planTemplate.length > 0 ? planTemplate : undefined,
   };
 }
 

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -192,9 +192,10 @@ function parsePlanTemplate(raw: unknown): SkillPlanTemplateStep[] {
   return raw
     .filter((item: any) => item && typeof item === "object" && item.step)
     .map((item: any) => ({
-      step: String(item.step || ""),
-      ...(item.activeForm ? { activeForm: String(item.activeForm) } : {}),
-    }));
+      step: String(item.step).trim(),
+      ...(item.activeForm ? { activeForm: String(item.activeForm).trim() } : {}),
+    }))
+    .filter((item) => item.step.length > 0);
 }
 
 export function resolveOpenClawMetadata(

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -231,7 +231,12 @@ export function resolveOpenClawMetadata(
   const requires = resolveOpenClawManifestRequires(metadataObj);
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
-  const planTemplate = parsePlanTemplate(metadataObj["plan-template"]);
+  // Accept both kebab-case (`plan-template`) and camelCase (`planTemplate`)
+  // frontmatter keys. Codex P1 (PR #67541 r3096435164) — natural authors
+  // following the `primaryEnv`/`skillKey` camelCase convention would have
+  // their templates silently ignored otherwise. Kebab-case wins on conflict
+  // for backward compatibility with existing skills.
+  const planTemplate = parsePlanTemplate(metadataObj["plan-template"] ?? metadataObj.planTemplate);
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
     emoji: readStringValue(metadataObj.emoji),

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -189,13 +189,36 @@ function parsePlanTemplate(raw: unknown): SkillPlanTemplateStep[] {
   if (!Array.isArray(raw)) {
     return [];
   }
-  return raw
-    .filter((item: any) => item && typeof item === "object" && item.step)
-    .map((item: any) => ({
-      step: String(item.step).trim(),
-      ...(item.activeForm ? { activeForm: String(item.activeForm).trim() } : {}),
-    }))
-    .filter((item) => item.step.length > 0);
+  const parsed: SkillPlanTemplateStep[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    // Strict type guard: `step` must be a non-empty string after trim.
+    // Reject non-string steps (objects, arrays, numbers, booleans) instead
+    // of coercing them via String() — coercion produces useless output
+    // like "[object Object]" that the agent can't act on.
+    if (typeof record.step !== "string") {
+      continue;
+    }
+    const step = record.step.trim();
+    if (step.length === 0) {
+      continue;
+    }
+    // Trim-before-truthy on activeForm: an entry like
+    // `activeForm: "   "` should be treated as missing, not as a
+    // whitespace-only display string.
+    let activeForm: string | undefined;
+    if (typeof record.activeForm === "string") {
+      const trimmed = record.activeForm.trim();
+      if (trimmed.length > 0) {
+        activeForm = trimmed;
+      }
+    }
+    parsed.push(activeForm !== undefined ? { step, activeForm } : { step });
+  }
+  return parsed;
 }
 
 export function resolveOpenClawMetadata(

--- a/src/agents/skills/skill-planner.test.ts
+++ b/src/agents/skills/skill-planner.test.ts
@@ -223,6 +223,66 @@ describe("applySkillPlanTemplateSeed", () => {
     expect(result).toBeNull();
   });
 
+  it("forwards seed event to onAgentEvent callback (Codex P2 r3096399082/r3096435183)", () => {
+    // Adversarial regression: callback-only consumers (e.g. auto-reply
+    // pipeline) need to see the seed event the same way they see other
+    // plan updates. Prior implementation only called global emitAgentPlanEvent.
+    resetAgentEventsForTest();
+    const callbackEvents: Array<{ stream: string; data: Record<string, unknown> }> = [];
+    const result = applySkillPlanTemplateSeed({
+      runId: "run-cb",
+      sessionKey: "session-cb",
+      entries: [
+        {
+          skill: { name: "release" },
+          metadata: { planTemplate: [{ step: "Tag" }] },
+        },
+      ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      onAgentEvent: (evt) => {
+        callbackEvents.push({ stream: evt.stream, data: evt.data as Record<string, unknown> });
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(callbackEvents).toHaveLength(1);
+    expect(callbackEvents[0].stream).toBe("plan");
+    expect(callbackEvents[0].data).toMatchObject({
+      title: 'Plan seeded from skill "release"',
+      source: "skill_plan_template",
+    });
+  });
+
+  it("filters out ineligible skills before collision resolution (Codex P2 r3096399074)", () => {
+    // Adversarial regression: a disabled skill with a planTemplate would
+    // win the alpha-first collision and seed an unrelated plan even though
+    // the skill itself is excluded from the runtime prompt. The seeder now
+    // applies shouldIncludeSkill() filtering before resolving the winner.
+    resetAgentEventsForTest();
+    const result = applySkillPlanTemplateSeed({
+      runId: "run-filter",
+      entries: [
+        {
+          // Alphabetically first BUT disabled in config.
+          skill: { name: "alpha-disabled" },
+          metadata: { planTemplate: [{ step: "WrongPlan" }] },
+        },
+        {
+          skill: { name: "beta-active" },
+          metadata: { planTemplate: [{ step: "RightPlan" }] },
+        },
+      ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      config: {
+        skills: {
+          entries: {
+            "alpha-disabled": { enabled: false },
+          },
+        },
+      },
+    });
+    // beta-active should win because alpha-disabled was filtered out first.
+    expect(result).not.toBeNull();
+    expect(result!.skillName).toBe("beta-active");
+  });
+
   it("emits agent_plan_event and returns summary on successful seed", async () => {
     resetAgentEventsForTest();
     const { onAgentEvent, registerAgentRunContext } = await import("../../infra/agent-events.js");

--- a/src/agents/skills/skill-planner.test.ts
+++ b/src/agents/skills/skill-planner.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { buildPlanTemplatePayload, hasSkillPlanTemplate } from "./skill-planner.js";
+import type { SkillPlanTemplateStep } from "./types.js";
+
+describe("buildPlanTemplatePayload", () => {
+  it("returns null for empty template", () => {
+    expect(buildPlanTemplatePayload("deploy", [])).toBeNull();
+  });
+
+  it("returns null for undefined template", () => {
+    expect(buildPlanTemplatePayload("deploy", undefined as unknown as SkillPlanTemplateStep[])).toBeNull();
+  });
+
+  it("builds pending steps from template", () => {
+    const template: SkillPlanTemplateStep[] = [
+      { step: "Run tests", activeForm: "Running tests" },
+      { step: "Build", activeForm: "Building" },
+      { step: "Deploy" },
+    ];
+    const result = buildPlanTemplatePayload("deploy", template);
+    expect(result).not.toBeNull();
+    expect(result!.plan).toHaveLength(3);
+    expect(result!.plan.every((s) => s.status === "pending")).toBe(true);
+  });
+
+  it("preserves activeForm when present", () => {
+    const template: SkillPlanTemplateStep[] = [
+      { step: "Run tests", activeForm: "Running tests" },
+    ];
+    const result = buildPlanTemplatePayload("deploy", template);
+    expect(result!.plan[0].activeForm).toBe("Running tests");
+  });
+
+  it("omits activeForm when absent", () => {
+    const template: SkillPlanTemplateStep[] = [{ step: "Deploy" }];
+    const result = buildPlanTemplatePayload("deploy", template);
+    expect(result!.plan[0]).not.toHaveProperty("activeForm");
+  });
+
+  it("includes skill name in explanation", () => {
+    const result = buildPlanTemplatePayload("release-cut", [{ step: "Tag" }]);
+    expect(result!.explanation).toContain("release-cut");
+  });
+});
+
+describe("hasSkillPlanTemplate", () => {
+  it("returns false for undefined metadata", () => {
+    expect(hasSkillPlanTemplate(undefined)).toBe(false);
+  });
+
+  it("returns false for empty planTemplate", () => {
+    expect(hasSkillPlanTemplate({ planTemplate: [] })).toBe(false);
+  });
+
+  it("returns true for non-empty planTemplate", () => {
+    expect(hasSkillPlanTemplate({ planTemplate: [{ step: "x" }] })).toBe(true);
+  });
+});

--- a/src/agents/skills/skill-planner.test.ts
+++ b/src/agents/skills/skill-planner.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { resolveSkillPlanTemplate } from "../pi-embedded-runner/skills-runtime.js";
-import { buildPlanTemplatePayload, hasSkillPlanTemplate } from "./skill-planner.js";
+import { describe, expect, it, vi } from "vitest";
+import { resetAgentEventsForTest } from "../../infra/agent-events.js";
+import {
+  applySkillPlanTemplateSeed,
+  resolveSkillPlanTemplate,
+} from "../pi-embedded-runner/skills-runtime.js";
+import {
+  buildPlanTemplatePayload,
+  DEFAULT_MAX_PLAN_TEMPLATE_STEPS,
+  hasSkillPlanTemplate,
+} from "./skill-planner.js";
 import type { SkillPlanTemplateStep } from "./types.js";
 
 describe("buildPlanTemplatePayload", () => {
@@ -41,6 +49,56 @@ describe("buildPlanTemplatePayload", () => {
     const result = buildPlanTemplatePayload("release-cut", [{ step: "Tag" }]);
     expect(result!.explanation).toContain("release-cut");
   });
+
+  it("dedupes duplicate step text within a single template (first wins)", () => {
+    const template: SkillPlanTemplateStep[] = [
+      { step: "A", activeForm: "Doing A" },
+      { step: "B" },
+      { step: "A", activeForm: "Doing A again" }, // duplicate of step "A"
+      { step: "C" },
+    ];
+    const result = buildPlanTemplatePayload("multi", template);
+    expect(result!.plan).toHaveLength(3);
+    expect(result!.plan.map((p) => p.step)).toEqual(["A", "B", "C"]);
+    // First wins — keeps the original activeForm.
+    expect(result!.plan[0].activeForm).toBe("Doing A");
+    expect(result!.droppedDuplicates).toEqual(["A"]);
+  });
+
+  it("returns null when all entries are duplicates of an empty pre-set (impossible) — defensive case", () => {
+    // After dedup the template is non-empty, so this case still produces a payload.
+    // This sanity test ensures dedup of a 1-element array with no duplicates yields a payload.
+    const result = buildPlanTemplatePayload("solo", [{ step: "Lone" }]);
+    expect(result).not.toBeNull();
+    expect(result!.plan).toHaveLength(1);
+  });
+
+  it("truncates templates exceeding maxSteps and flags `truncated: true`", () => {
+    const template: SkillPlanTemplateStep[] = Array.from({ length: 100 }, (_, i) => ({
+      step: `Step ${i}`,
+    }));
+    const result = buildPlanTemplatePayload("big", template, { maxSteps: 10 });
+    expect(result!.plan).toHaveLength(10);
+    expect(result!.truncated).toBe(true);
+    expect(result!.maxSteps).toBe(10);
+  });
+
+  it("uses DEFAULT_MAX_PLAN_TEMPLATE_STEPS when maxSteps not set", () => {
+    const template: SkillPlanTemplateStep[] = Array.from(
+      { length: DEFAULT_MAX_PLAN_TEMPLATE_STEPS + 5 },
+      (_, i) => ({ step: `Step ${i}` }),
+    );
+    const result = buildPlanTemplatePayload("big", template);
+    expect(result!.plan).toHaveLength(DEFAULT_MAX_PLAN_TEMPLATE_STEPS);
+    expect(result!.truncated).toBe(true);
+  });
+
+  it("does not flag truncation for templates within bounds", () => {
+    const template: SkillPlanTemplateStep[] = [{ step: "A" }, { step: "B" }];
+    const result = buildPlanTemplatePayload("small", template);
+    expect(result!.truncated).toBeUndefined();
+    expect(result!.droppedDuplicates).toBeUndefined();
+  });
 });
 
 describe("hasSkillPlanTemplate", () => {
@@ -66,7 +124,7 @@ describe("resolveSkillPlanTemplate", () => {
     expect(resolveSkillPlanTemplate(entries)).toBeNull();
   });
 
-  it("returns payload for the first entry with a plan template", () => {
+  it("returns the payload + skillName for a single template", () => {
     const entries = [
       { skill: { name: "deploy" }, metadata: {} },
       {
@@ -76,11 +134,191 @@ describe("resolveSkillPlanTemplate", () => {
     ] as Parameters<typeof resolveSkillPlanTemplate>[0];
     const result = resolveSkillPlanTemplate(entries);
     expect(result).not.toBeNull();
-    expect(result!.plan[0].step).toBe("Tag release");
-    expect(result!.explanation).toContain("release");
+    expect(result!.skillName).toBe("release");
+    expect(result!.rejected).toEqual([]);
+    expect(result!.payload.plan[0].step).toBe("Tag release");
+    expect(result!.payload.explanation).toContain("release");
   });
 
   it("returns null for empty entries array", () => {
     expect(resolveSkillPlanTemplate([])).toBeNull();
+  });
+
+  it("on collision picks alpha-first skill and lists the rest in `rejected`", () => {
+    const entries = [
+      {
+        skill: { name: "release" },
+        metadata: { planTemplate: [{ step: "Tag release" }] },
+      },
+      {
+        skill: { name: "deploy" },
+        metadata: { planTemplate: [{ step: "Push to staging" }] },
+      },
+      {
+        skill: { name: "audit" },
+        metadata: { planTemplate: [{ step: "Run audit" }] },
+      },
+    ] as Parameters<typeof resolveSkillPlanTemplate>[0];
+
+    const result = resolveSkillPlanTemplate(entries);
+    expect(result!.skillName).toBe("audit");
+    expect(result!.rejected).toEqual(["deploy", "release"]);
+    expect(result!.payload.plan[0].step).toBe("Run audit");
+  });
+
+  it("respects skills.limits.maxPlanTemplateSteps from config", () => {
+    const entries = [
+      {
+        skill: { name: "big" },
+        metadata: {
+          planTemplate: Array.from({ length: 100 }, (_, i) => ({ step: `S${i}` })),
+        },
+      },
+    ] as Parameters<typeof resolveSkillPlanTemplate>[0];
+
+    const result = resolveSkillPlanTemplate(entries, {
+      skills: { limits: { maxPlanTemplateSteps: 5 } },
+    });
+    expect(result!.payload.plan).toHaveLength(5);
+    expect(result!.payload.truncated).toBe(true);
+  });
+});
+
+describe("applySkillPlanTemplateSeed", () => {
+  it("returns null when runId is missing", () => {
+    const result = applySkillPlanTemplateSeed({
+      entries: [
+        {
+          skill: { name: "x" },
+          metadata: { planTemplate: [{ step: "Y" }] },
+        },
+      ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no skill carries a template", () => {
+    resetAgentEventsForTest();
+    const result = applySkillPlanTemplateSeed({
+      runId: "run-1",
+      entries: [{ skill: { name: "x" }, metadata: {} }] as Parameters<
+        typeof applySkillPlanTemplateSeed
+      >[0]["entries"],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("skips seeding when existingPlanSteps is non-empty (idempotency)", () => {
+    resetAgentEventsForTest();
+    const result = applySkillPlanTemplateSeed({
+      runId: "run-2",
+      entries: [
+        {
+          skill: { name: "x" },
+          metadata: { planTemplate: [{ step: "Y" }] },
+        },
+      ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      existingPlanSteps: [{ step: "Already planned" }],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("emits agent_plan_event and returns summary on successful seed", async () => {
+    resetAgentEventsForTest();
+    const { onAgentEvent, registerAgentRunContext } = await import("../../infra/agent-events.js");
+    const events: Array<{ stream: string; data: Record<string, unknown> }> = [];
+    const off = onAgentEvent((evt) => events.push({ stream: evt.stream, data: evt.data }));
+
+    try {
+      registerAgentRunContext("run-seed", { sessionKey: "session-seed" });
+      const result = applySkillPlanTemplateSeed({
+        runId: "run-seed",
+        sessionKey: "session-seed",
+        entries: [
+          {
+            skill: { name: "release" },
+            metadata: {
+              planTemplate: [{ step: "Tag" }, { step: "Publish" }],
+            },
+          },
+        ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.skillName).toBe("release");
+      expect(result!.emittedSteps).toBe(2);
+      expect(result!.rejected).toEqual([]);
+
+      const planEvents = events.filter((e) => e.stream === "plan");
+      expect(planEvents).toHaveLength(1);
+      expect(planEvents[0].data).toMatchObject({
+        phase: "update",
+        title: 'Plan seeded from skill "release"',
+        steps: ["Tag", "Publish"],
+        source: "skill_plan_template",
+      });
+    } finally {
+      off();
+    }
+  });
+
+  it("warns about collision when multiple skills carry templates", async () => {
+    resetAgentEventsForTest();
+    const warnSpy = vi.spyOn(await import("../../logger.js"), "logWarn");
+    try {
+      const result = applySkillPlanTemplateSeed({
+        runId: "run-collision",
+        entries: [
+          {
+            skill: { name: "release" },
+            metadata: { planTemplate: [{ step: "Tag" }] },
+          },
+          {
+            skill: { name: "audit" },
+            metadata: { planTemplate: [{ step: "Run audit" }] },
+          },
+        ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+      });
+      expect(result!.skillName).toBe("audit");
+      expect(result!.rejected).toEqual(["release"]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("skill_plan_template_collision"),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("warns about truncation and dropped duplicates", async () => {
+    resetAgentEventsForTest();
+    const warnSpy = vi.spyOn(await import("../../logger.js"), "logWarn");
+    try {
+      const template: SkillPlanTemplateStep[] = [
+        { step: "A" },
+        { step: "B" },
+        { step: "A" }, // dup
+        { step: "C" },
+      ];
+      const result = applySkillPlanTemplateSeed({
+        runId: "run-warn",
+        entries: [
+          {
+            skill: { name: "x" },
+            metadata: { planTemplate: template },
+          },
+        ] as Parameters<typeof applySkillPlanTemplateSeed>[0]["entries"],
+        config: { skills: { limits: { maxPlanTemplateSteps: 2 } } },
+      });
+      expect(result!.droppedDuplicates).toEqual(["A"]);
+      expect(result!.truncated).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("skill_plan_template_duplicates"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("skill_plan_template_truncated"),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/src/agents/skills/skill-planner.test.ts
+++ b/src/agents/skills/skill-planner.test.ts
@@ -289,6 +289,49 @@ describe("applySkillPlanTemplateSeed", () => {
     }
   });
 
+  it("falls back to snapshot.resolvedPlanTemplates when entries is empty (snapshot-backed run path)", async () => {
+    // Adversarial regression (Codex P1 on PR #67541):
+    // resolveEmbeddedRunSkillEntries returns skillEntries=[] whenever a
+    // snapshot is present, which is the main production run path. The
+    // seeder must therefore fall back to snapshot.resolvedPlanTemplates
+    // so it doesn't silently no-op for normal sessions.
+    resetAgentEventsForTest();
+    const { onAgentEvent } = await import("../../infra/agent-events.js");
+    const events: Array<{ stream: string; data: Record<string, unknown> }> = [];
+    const off = onAgentEvent((evt) => events.push({ stream: evt.stream, data: evt.data }));
+
+    try {
+      const result = applySkillPlanTemplateSeed({
+        runId: "run-snapshot",
+        sessionKey: "session-snapshot",
+        entries: [], // empty — snapshot path
+        skillsSnapshot: {
+          prompt: "",
+          skills: [{ name: "release" }],
+          resolvedPlanTemplates: [
+            {
+              skillName: "release",
+              planTemplate: [{ step: "Tag" }, { step: "Publish" }],
+            },
+          ],
+        },
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.skillName).toBe("release");
+      expect(result!.emittedSteps).toBe(2);
+
+      const planEvents = events.filter((e) => e.stream === "plan");
+      expect(planEvents).toHaveLength(1);
+      expect(planEvents[0].data).toMatchObject({
+        steps: ["Tag", "Publish"],
+        source: "skill_plan_template",
+      });
+    } finally {
+      off();
+    }
+  });
+
   it("warns about truncation and dropped duplicates", async () => {
     resetAgentEventsForTest();
     const warnSpy = vi.spyOn(await import("../../logger.js"), "logWarn");

--- a/src/agents/skills/skill-planner.test.ts
+++ b/src/agents/skills/skill-planner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { resolveSkillPlanTemplate } from "../pi-embedded-runner/skills-runtime.js";
 import { buildPlanTemplatePayload, hasSkillPlanTemplate } from "./skill-planner.js";
 import type { SkillPlanTemplateStep } from "./types.js";
 
@@ -8,7 +9,8 @@ describe("buildPlanTemplatePayload", () => {
   });
 
   it("returns null for undefined template", () => {
-    expect(buildPlanTemplatePayload("deploy", undefined as unknown as SkillPlanTemplateStep[])).toBeNull();
+    expect(buildPlanTemplatePayload("deploy", undefined)).toBeNull();
+    expect(buildPlanTemplatePayload("deploy")).toBeNull();
   });
 
   it("builds pending steps from template", () => {
@@ -24,9 +26,7 @@ describe("buildPlanTemplatePayload", () => {
   });
 
   it("preserves activeForm when present", () => {
-    const template: SkillPlanTemplateStep[] = [
-      { step: "Run tests", activeForm: "Running tests" },
-    ];
+    const template: SkillPlanTemplateStep[] = [{ step: "Run tests", activeForm: "Running tests" }];
     const result = buildPlanTemplatePayload("deploy", template);
     expect(result!.plan[0].activeForm).toBe("Running tests");
   });
@@ -54,5 +54,33 @@ describe("hasSkillPlanTemplate", () => {
 
   it("returns true for non-empty planTemplate", () => {
     expect(hasSkillPlanTemplate({ planTemplate: [{ step: "x" }] })).toBe(true);
+  });
+});
+
+describe("resolveSkillPlanTemplate", () => {
+  it("returns null when no entries have a plan template", () => {
+    const entries = [
+      { skill: { name: "deploy" }, metadata: {} },
+      { skill: { name: "lint" }, metadata: { planTemplate: [] } },
+    ] as Parameters<typeof resolveSkillPlanTemplate>[0];
+    expect(resolveSkillPlanTemplate(entries)).toBeNull();
+  });
+
+  it("returns payload for the first entry with a plan template", () => {
+    const entries = [
+      { skill: { name: "deploy" }, metadata: {} },
+      {
+        skill: { name: "release" },
+        metadata: { planTemplate: [{ step: "Tag release" }] },
+      },
+    ] as Parameters<typeof resolveSkillPlanTemplate>[0];
+    const result = resolveSkillPlanTemplate(entries);
+    expect(result).not.toBeNull();
+    expect(result!.plan[0].step).toBe("Tag release");
+    expect(result!.explanation).toContain("release");
+  });
+
+  it("returns null for empty entries array", () => {
+    expect(resolveSkillPlanTemplate([])).toBeNull();
   });
 });

--- a/src/agents/skills/skill-planner.ts
+++ b/src/agents/skills/skill-planner.ts
@@ -1,0 +1,54 @@
+/**
+ * Skill plan template instantiation.
+ *
+ * When a skill with a `planTemplate` in its metadata is activated,
+ * this module builds the initial `update_plan` call payload from
+ * the template steps. All steps start as "pending".
+ *
+ * This is Phase 4.1 of the GPT 5.4 parity sprint — a differentiator
+ * feature not present in Hermes or Claude Code.
+ */
+
+import type { SkillPlanTemplateStep } from "./types.js";
+
+export interface PlanTemplatePayload {
+  plan: Array<{
+    step: string;
+    status: "pending";
+    activeForm?: string;
+  }>;
+  explanation: string;
+}
+
+/**
+ * Builds an `update_plan` payload from a skill's plan template.
+ *
+ * @param skillName - The name of the skill being activated
+ * @param template - The plan template steps from skill metadata
+ * @returns A payload suitable for passing to the `update_plan` tool,
+ *          or `null` if the template is empty
+ */
+export function buildPlanTemplatePayload(
+  skillName: string,
+  template: SkillPlanTemplateStep[],
+): PlanTemplatePayload | null {
+  if (!template || template.length === 0) {
+    return null;
+  }
+
+  return {
+    plan: template.map((t) => ({
+      step: t.step,
+      status: "pending" as const,
+      ...(t.activeForm ? { activeForm: t.activeForm } : {}),
+    })),
+    explanation: `Auto-populated from skill "${skillName}" plan template.`,
+  };
+}
+
+/**
+ * Checks whether a skill entry has a non-empty plan template.
+ */
+export function hasSkillPlanTemplate(metadata?: { planTemplate?: SkillPlanTemplateStep[] }): boolean {
+  return Array.isArray(metadata?.planTemplate) && metadata.planTemplate.length > 0;
+}

--- a/src/agents/skills/skill-planner.ts
+++ b/src/agents/skills/skill-planner.ts
@@ -29,7 +29,7 @@ export interface PlanTemplatePayload {
  */
 export function buildPlanTemplatePayload(
   skillName: string,
-  template: SkillPlanTemplateStep[],
+  template?: SkillPlanTemplateStep[],
 ): PlanTemplatePayload | null {
   if (!template || template.length === 0) {
     return null;
@@ -48,6 +48,8 @@ export function buildPlanTemplatePayload(
 /**
  * Checks whether a skill entry has a non-empty plan template.
  */
-export function hasSkillPlanTemplate(metadata?: { planTemplate?: SkillPlanTemplateStep[] }): boolean {
+export function hasSkillPlanTemplate(metadata?: {
+  planTemplate?: SkillPlanTemplateStep[];
+}): boolean {
   return Array.isArray(metadata?.planTemplate) && metadata.planTemplate.length > 0;
 }

--- a/src/agents/skills/skill-planner.ts
+++ b/src/agents/skills/skill-planner.ts
@@ -10,6 +10,9 @@
 
 import type { SkillPlanTemplateStep } from "./types.js";
 
+/** Default upper bound on plan-template step count (configurable via `skills.limits.maxPlanTemplateSteps`). */
+export const DEFAULT_MAX_PLAN_TEMPLATE_STEPS = 50;
+
 export interface PlanTemplatePayload {
   plan: Array<{
     step: string;
@@ -17,31 +20,81 @@ export interface PlanTemplatePayload {
     activeForm?: string;
   }>;
   explanation: string;
+  /** Step texts dropped because they duplicate an earlier entry in the same template (first wins). */
+  droppedDuplicates?: string[];
+  /** True when the input template exceeded `maxSteps` and was truncated. */
+  truncated?: boolean;
+  /** Configured upper bound applied during normalization. */
+  maxSteps?: number;
+}
+
+export interface BuildPlanTemplateOptions {
+  /** Upper bound on step count; defaults to `DEFAULT_MAX_PLAN_TEMPLATE_STEPS`. */
+  maxSteps?: number;
 }
 
 /**
  * Builds an `update_plan` payload from a skill's plan template.
  *
+ * Normalizes the template by:
+ * - Dropping entries with duplicate `step` text (first wins).
+ * - Truncating to `maxSteps` (default 50, configurable).
+ *
+ * Diagnostic fields (`droppedDuplicates`, `truncated`, `maxSteps`) on the
+ * returned payload let the caller emit per-skill warning events without
+ * needing access to the original template.
+ *
  * @param skillName - The name of the skill being activated
  * @param template - The plan template steps from skill metadata
+ * @param options - Optional limits/overrides
  * @returns A payload suitable for passing to the `update_plan` tool,
- *          or `null` if the template is empty
+ *          or `null` if the (post-normalize) template is empty
  */
 export function buildPlanTemplatePayload(
   skillName: string,
   template?: SkillPlanTemplateStep[],
+  options?: BuildPlanTemplateOptions,
 ): PlanTemplatePayload | null {
   if (!template || template.length === 0) {
     return null;
   }
 
+  const maxSteps =
+    options?.maxSteps && options.maxSteps > 0 ? options.maxSteps : DEFAULT_MAX_PLAN_TEMPLATE_STEPS;
+
+  // Dedup by step text — keep first occurrence, record dropped duplicates.
+  const seen = new Set<string>();
+  const droppedDuplicates: string[] = [];
+  const deduped: SkillPlanTemplateStep[] = [];
+  for (const step of template) {
+    if (seen.has(step.step)) {
+      droppedDuplicates.push(step.step);
+      continue;
+    }
+    seen.add(step.step);
+    deduped.push(step);
+  }
+
+  if (deduped.length === 0) {
+    return null;
+  }
+
+  // Apply upper bound. Truncation drops the tail, since later steps are
+  // less likely to be reached anyway and we want the seed to model the
+  // "first N actions" the agent should take.
+  const truncated = deduped.length > maxSteps;
+  const final = truncated ? deduped.slice(0, maxSteps) : deduped;
+
   return {
-    plan: template.map((t) => ({
+    plan: final.map((t) => ({
       step: t.step,
       status: "pending" as const,
       ...(t.activeForm ? { activeForm: t.activeForm } : {}),
     })),
     explanation: `Auto-populated from skill "${skillName}" plan template.`,
+    ...(droppedDuplicates.length > 0 ? { droppedDuplicates } : {}),
+    ...(truncated ? { truncated: true } : {}),
+    maxSteps,
   };
 }
 

--- a/src/agents/skills/skill-planner.ts
+++ b/src/agents/skills/skill-planner.ts
@@ -5,8 +5,7 @@
  * this module builds the initial `update_plan` call payload from
  * the template steps. All steps start as "pending".
  *
- * This is Phase 4.1 of the GPT 5.4 parity sprint — a differentiator
- * feature not present in Hermes or Claude Code.
+ * Phase 4.1 of the GPT 5.4 parity sprint.
  */
 
 import type { SkillPlanTemplateStep } from "./types.js";

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -16,6 +16,16 @@ export type SkillInstallSpec = {
   targetDir?: string;
 };
 
+/**
+ * A plan template step that a skill can provide.
+ * When the skill is activated, these steps are auto-populated into
+ * `update_plan` as the initial plan (all status: "pending").
+ */
+export type SkillPlanTemplateStep = {
+  step: string;
+  activeForm?: string;
+};
+
 export type OpenClawSkillMetadata = {
   always?: boolean;
   skillKey?: string;
@@ -30,6 +40,14 @@ export type OpenClawSkillMetadata = {
     config?: string[];
   };
   install?: SkillInstallSpec[];
+  /**
+   * Optional plan template. When present and the skill is activated,
+   * the runtime auto-calls `update_plan` with these steps (all pending)
+   * before the first agent turn, giving the agent a starting checklist.
+   *
+   * Parsed from YAML frontmatter `plan-template` field in SKILL.md.
+   */
+  planTemplate?: SkillPlanTemplateStep[];
 };
 
 export type SkillInvocationPolicy = {

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -114,5 +114,12 @@ export type SkillSnapshot = {
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
   resolvedSkills?: Skill[];
+  /**
+   * Per-skill plan templates carried forward from snapshot build so the
+   * skill-template seeder (#67541) doesn't have to re-load workspace skill
+   * entries when running off a pre-built snapshot. Only skills with a
+   * non-empty `planTemplate` appear here.
+   */
+  resolvedPlanTemplates?: Array<{ skillName: string; planTemplate: SkillPlanTemplateStep[] }>;
   version?: number;
 };

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -694,6 +694,22 @@ export function buildWorkspaceSkillSnapshot(
 ): SkillSnapshot {
   const { eligible, prompt, resolvedSkills } = resolveWorkspaceSkillPromptState(workspaceDir, opts);
   const skillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
+  // Carry per-skill plan templates so #67541's seeder works in the
+  // snapshot-backed run path. Without this, applySkillPlanTemplateSeed
+  // sees an empty entries list (resolveEmbeddedRunSkillEntries returns
+  // [] when a snapshot is present) and silently no-ops in production.
+  const resolvedPlanTemplates = eligible
+    .filter(
+      (
+        e,
+      ): e is SkillEntry & {
+        metadata: { planTemplate: NonNullable<SkillEntry["metadata"]>["planTemplate"] };
+      } => Array.isArray(e.metadata?.planTemplate) && e.metadata.planTemplate.length > 0,
+    )
+    .map((e) => ({
+      skillName: e.skill.name,
+      planTemplate: e.metadata.planTemplate.slice(),
+    }));
   return {
     prompt,
     skills: eligible.map((entry) => ({
@@ -703,6 +719,7 @@ export function buildWorkspaceSkillSnapshot(
     })),
     ...(skillFilter === undefined ? {} : { skillFilter }),
     resolvedSkills,
+    ...(resolvedPlanTemplates.length > 0 ? { resolvedPlanTemplates } : {}),
     version: opts?.snapshotVersion,
   };
 }

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -35,6 +35,13 @@ export type SkillsLimitsConfig = {
   maxSkillsPromptChars?: number;
   /** Max size (bytes) allowed for a SKILL.md file to be considered. */
   maxSkillFileBytes?: number;
+  /**
+   * Max number of plan-template steps a single skill may seed via
+   * `update_plan` at activation. Templates exceeding this length are
+   * truncated and a `skill_plan_template_truncated` warning event is
+   * emitted. Default: 50.
+   */
+  maxPlanTemplateSteps?: number;
 };
 
 export type SkillsConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -925,6 +925,11 @@ export const OpenClawSchema = z
             maxSkillsInPrompt: z.number().int().min(0).optional(),
             maxSkillsPromptChars: z.number().int().min(0).optional(),
             maxSkillFileBytes: z.number().int().min(0).optional(),
+            // #67541: cap on plan-template steps a single skill may seed
+            // via update_plan at activation. Templates exceeding this are
+            // truncated and a `skill_plan_template_truncated` warning is
+            // emitted. Default 50 (see DEFAULT_MAX_PLAN_TEMPLATE_STEPS).
+            maxPlanTemplateSteps: z.number().int().min(1).optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## TL;DR

Skills can now define a \`planTemplate\` in their frontmatter that auto-populates \`update_plan\` on activation, giving users a pre-filled checklist when they invoke a skill.

## Tracking
- Umbrella: #66345
- Issue: #67522

## What this PR does

- \`SkillPlanTemplateStep\` type + \`planTemplate\` field on \`OpenClawSkillMetadata\`
- \`buildPlanTemplatePayload()\`: converts a skill's template steps into an \`update_plan\` tool call payload
- \`hasSkillPlanTemplate()\`: checks whether a skill defines a plan template

### Example skill frontmatter
\`\`\`yaml
planTemplate:
  - content: "Read the existing implementation"
    activeForm: "Reading implementation"
  - content: "Identify areas for improvement"
    activeForm: "Analyzing code"
  - content: "Apply changes and verify"
    activeForm: "Applying changes"
\`\`\`

## Files changed

| File | Change | Tests |
|------|--------|-------|
| \`src/agents/skills/skill-planner.ts\` | **New** — template builder | 7 tests |
| \`src/agents/skills/skill-planner.test.ts\` | **New** | Self |
| \`src/agents/skills/types.ts\` | \`planTemplate\` field added | - |
| \`src/agents/skills/frontmatter.ts\` | Template parsing | - |
| \`src/agents/pi-embedded-runner/skills-runtime.ts\` | Template wiring | - |

## Dependencies
- #67514 for extended \`update_plan\` schema (cancelled, merge, activeForm)

## What follows
- #67542: Cross-session plan store (persists skill-generated plans across sessions)