### PR TITLE
feat(agents): cross-session plan store with file-level locking [Phase 4.2]

### DIFF
--- a/src/agents/plan-store.test.ts
+++ b/src/agents/plan-store.test.ts
@@ -44,6 +44,15 @@ describe("PlanStore", () => {
       const result = await store.read("deep/nested/ns");
       expect(result).not.toBeNull();
     });
+
+    it("rejects namespace with path traversal", async () => {
+      await expect(store.read("../../etc")).rejects.toThrow("Invalid plan namespace");
+      await expect(store.write("../escape", SAMPLE_PLAN)).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("rejects namespace mismatch in write", async () => {
+      await expect(store.write("wrong-ns", SAMPLE_PLAN)).rejects.toThrow("namespace mismatch");
+    });
   });
 
   describe("lock", () => {

--- a/src/agents/plan-store.test.ts
+++ b/src/agents/plan-store.test.ts
@@ -1,7 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { PlanStore, type StoredPlan, type StoredPlanStep } from "./plan-store.js";
 
 let tmpDir: string;
@@ -39,15 +39,48 @@ describe("PlanStore", () => {
       expect(result).toEqual(SAMPLE_PLAN);
     });
 
-    it("creates nested directory if missing", async () => {
-      await store.write("deep/nested/ns", { ...SAMPLE_PLAN, namespace: "deep/nested/ns" });
-      const result = await store.read("deep/nested/ns");
+    it("creates the namespace directory if missing", async () => {
+      const ns = "fresh-ns";
+      await store.write(ns, { ...SAMPLE_PLAN, namespace: ns });
+      const result = await store.read(ns);
       expect(result).not.toBeNull();
     });
 
     it("rejects namespace with path traversal", async () => {
       await expect(store.read("../../etc")).rejects.toThrow("Invalid plan namespace");
       await expect(store.write("../escape", SAMPLE_PLAN)).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("rejects nested-path namespace (cross-namespace lock collision defense)", async () => {
+      await expect(store.read("foo/bar")).rejects.toThrow("Invalid plan namespace");
+      await expect(store.write("foo/.lock", SAMPLE_PLAN)).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("rejects namespace with backslash separator", async () => {
+      await expect(store.read("foo\\bar")).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("rejects namespace with null byte / control chars", async () => {
+      await expect(store.read("foo\x00bar")).rejects.toThrow("Invalid plan namespace");
+      await expect(store.read("foo\x01bar")).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("rejects Windows reserved device names", async () => {
+      for (const name of ["CON", "PRN", "AUX", "NUL", "COM1", "LPT9", "con.txt", "nul.json"]) {
+        await expect(store.read(name)).rejects.toThrow("Invalid plan namespace");
+      }
+    });
+
+    it("rejects namespace longer than 128 chars", async () => {
+      const tooLong = "a".repeat(129);
+      await expect(store.read(tooLong)).rejects.toThrow("Invalid plan namespace");
+    });
+
+    it("accepts standard namespace patterns", async () => {
+      for (const ns of ["session-abc", "user_123", "v2.plan", "Mixed-Case_99"]) {
+        await store.write(ns, { ...SAMPLE_PLAN, namespace: ns });
+        expect(await store.read(ns)).not.toBeNull();
+      }
     });
 
     it("rejects namespace mismatch in write", async () => {
@@ -83,9 +116,7 @@ describe("PlanStore", () => {
         { step: "Run tests", status: "pending" },
         { step: "Build", status: "pending" },
       ];
-      const incoming: StoredPlanStep[] = [
-        { step: "Run tests", status: "completed" },
-      ];
+      const incoming: StoredPlanStep[] = [{ step: "Run tests", status: "completed" }];
       const merged = store.mergeSteps(existing, incoming, "session-abc");
       expect(merged).toHaveLength(2);
       expect(merged[0].status).toBe("completed");
@@ -94,12 +125,8 @@ describe("PlanStore", () => {
     });
 
     it("appends new steps not in existing", () => {
-      const existing: StoredPlanStep[] = [
-        { step: "Run tests", status: "completed" },
-      ];
-      const incoming: StoredPlanStep[] = [
-        { step: "Deploy", status: "pending" },
-      ];
+      const existing: StoredPlanStep[] = [{ step: "Run tests", status: "completed" }];
+      const incoming: StoredPlanStep[] = [{ step: "Deploy", status: "pending" }];
       const merged = store.mergeSteps(existing, incoming);
       expect(merged).toHaveLength(2);
       expect(merged[1].step).toBe("Deploy");
@@ -111,9 +138,7 @@ describe("PlanStore", () => {
         { step: "B", status: "pending" },
         { step: "C", status: "pending" },
       ];
-      const incoming: StoredPlanStep[] = [
-        { step: "B", status: "completed" },
-      ];
+      const incoming: StoredPlanStep[] = [{ step: "B", status: "completed" }];
       const merged = store.mergeSteps(existing, incoming);
       expect(merged.map((s) => s.step)).toEqual(["A", "B", "C"]);
     });

--- a/src/agents/plan-store.test.ts
+++ b/src/agents/plan-store.test.ts
@@ -144,6 +144,98 @@ describe("PlanStore", () => {
     });
   });
 
+  describe("read() — full schema validation pre-parse (Codex P2 r3094816890)", () => {
+    async function writeRawPlanFile(namespace: string, contents: unknown): Promise<void> {
+      const dir = path.join(tmpDir, namespace);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, "plan.json"), JSON.stringify(contents), { mode: 0o600 });
+    }
+
+    it("rejects steps: [null] (was: silent pass, then TypeError downstream)", async () => {
+      await writeRawPlanFile("ns-bad-step", {
+        namespace: "ns-bad-step",
+        steps: [null],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-bad-step")).rejects.toThrow(/invalid step at index 0/);
+    });
+
+    it("rejects step with non-string `step` text", async () => {
+      await writeRawPlanFile("ns-bad-step-type", {
+        namespace: "ns-bad-step-type",
+        steps: [{ step: 42, status: "pending" }],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-bad-step-type")).rejects.toThrow(/non-empty string/);
+    });
+
+    it("rejects step with empty `step` text", async () => {
+      await writeRawPlanFile("ns-empty-step", {
+        namespace: "ns-empty-step",
+        steps: [{ step: "", status: "pending" }],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-empty-step")).rejects.toThrow(/non-empty string/);
+    });
+
+    it("rejects step with invalid `status` value", async () => {
+      await writeRawPlanFile("ns-bad-status", {
+        namespace: "ns-bad-status",
+        steps: [{ step: "x", status: "weirdo" }],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-bad-status")).rejects.toThrow(/status.*must be one of/);
+    });
+
+    it("rejects step with non-string `activeForm` when present", async () => {
+      await writeRawPlanFile("ns-bad-active", {
+        namespace: "ns-bad-active",
+        steps: [{ step: "x", status: "pending", activeForm: 42 }],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-bad-active")).rejects.toThrow(/activeForm.*must be a string/);
+    });
+
+    it("rejects file missing `createdAt`", async () => {
+      await writeRawPlanFile("ns-no-created", {
+        namespace: "ns-no-created",
+        steps: [{ step: "x", status: "pending" }],
+        updatedAt: 2,
+      });
+      await expect(store.read("ns-no-created")).rejects.toThrow(/createdAt/);
+    });
+
+    it("rejects file missing `updatedAt`", async () => {
+      await writeRawPlanFile("ns-no-updated", {
+        namespace: "ns-no-updated",
+        steps: [{ step: "x", status: "pending" }],
+        createdAt: 1,
+      });
+      await expect(store.read("ns-no-updated")).rejects.toThrow(/updatedAt/);
+    });
+
+    it("accepts a valid plan with all 4 status values", async () => {
+      await writeRawPlanFile("ns-valid", {
+        namespace: "ns-valid",
+        steps: [
+          { step: "a", status: "pending" },
+          { step: "b", status: "in_progress", activeForm: "B-ing" },
+          { step: "c", status: "completed" },
+          { step: "d", status: "cancelled" },
+        ],
+        createdAt: 1,
+        updatedAt: 2,
+      });
+      const result = await store.read("ns-valid");
+      expect(result?.steps).toHaveLength(4);
+    });
+  });
+
   describe("confine() — parent-symlink redirection (Codex P1 r3095586226)", () => {
     it("rejects a namespace directory that is a symlink pointing outside baseDir", async () => {
       // Create an attacker-controlled directory outside baseDir.

--- a/src/agents/plan-store.test.ts
+++ b/src/agents/plan-store.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PlanStore, type StoredPlan, type StoredPlanStep } from "./plan-store.js";
+
+let tmpDir: string;
+let store: PlanStore;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "plan-store-test-"));
+  store = new PlanStore(tmpDir);
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const SAMPLE_PLAN: StoredPlan = {
+  namespace: "test-ns",
+  steps: [
+    { step: "Run tests", status: "completed" },
+    { step: "Build", status: "in_progress", activeForm: "Building" },
+    { step: "Deploy", status: "pending" },
+  ],
+  createdAt: 1000,
+  updatedAt: 2000,
+};
+
+describe("PlanStore", () => {
+  describe("read/write", () => {
+    it("returns null for non-existent namespace", async () => {
+      expect(await store.read("nonexistent")).toBeNull();
+    });
+
+    it("round-trips a plan", async () => {
+      await store.write("test-ns", SAMPLE_PLAN);
+      const result = await store.read("test-ns");
+      expect(result).toEqual(SAMPLE_PLAN);
+    });
+
+    it("creates nested directory if missing", async () => {
+      await store.write("deep/nested/ns", { ...SAMPLE_PLAN, namespace: "deep/nested/ns" });
+      const result = await store.read("deep/nested/ns");
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("lock", () => {
+    it("acquires and releases a lock", async () => {
+      const release = await store.lock("test-ns");
+      // Lock file should exist.
+      const lockPath = path.join(tmpDir, "test-ns", ".lock");
+      await expect(fs.stat(lockPath)).resolves.toBeDefined();
+      await release();
+      // Lock file should be removed.
+      await expect(fs.stat(lockPath)).rejects.toThrow();
+    });
+
+    it("blocks concurrent lock acquisition", async () => {
+      const release1 = await store.lock("test-ns");
+      // Second lock should timeout/retry (we don't wait the full retry cycle).
+      const lock2Promise = store.lock("test-ns");
+      // Release first lock after a short delay.
+      setTimeout(() => release1(), 100);
+      const release2 = await lock2Promise;
+      await release2();
+    });
+  });
+
+  describe("mergeSteps", () => {
+    it("updates existing steps by matching text", () => {
+      const existing: StoredPlanStep[] = [
+        { step: "Run tests", status: "pending" },
+        { step: "Build", status: "pending" },
+      ];
+      const incoming: StoredPlanStep[] = [
+        { step: "Run tests", status: "completed" },
+      ];
+      const merged = store.mergeSteps(existing, incoming, "session-abc");
+      expect(merged).toHaveLength(2);
+      expect(merged[0].status).toBe("completed");
+      expect(merged[0].updatedBy).toBe("session-abc");
+      expect(merged[1].status).toBe("pending"); // Unchanged.
+    });
+
+    it("appends new steps not in existing", () => {
+      const existing: StoredPlanStep[] = [
+        { step: "Run tests", status: "completed" },
+      ];
+      const incoming: StoredPlanStep[] = [
+        { step: "Deploy", status: "pending" },
+      ];
+      const merged = store.mergeSteps(existing, incoming);
+      expect(merged).toHaveLength(2);
+      expect(merged[1].step).toBe("Deploy");
+    });
+
+    it("preserves order of existing steps", () => {
+      const existing: StoredPlanStep[] = [
+        { step: "A", status: "pending" },
+        { step: "B", status: "pending" },
+        { step: "C", status: "pending" },
+      ];
+      const incoming: StoredPlanStep[] = [
+        { step: "B", status: "completed" },
+      ];
+      const merged = store.mergeSteps(existing, incoming);
+      expect(merged.map((s) => s.step)).toEqual(["A", "B", "C"]);
+    });
+  });
+});

--- a/src/agents/plan-store.test.ts
+++ b/src/agents/plan-store.test.ts
@@ -143,4 +143,25 @@ describe("PlanStore", () => {
       expect(merged.map((s) => s.step)).toEqual(["A", "B", "C"]);
     });
   });
+
+  describe("confine() — parent-symlink redirection (Codex P1 r3095586226)", () => {
+    it("rejects a namespace directory that is a symlink pointing outside baseDir", async () => {
+      // Create an attacker-controlled directory outside baseDir.
+      const attackerDir = await fs.mkdtemp(path.join(os.tmpdir(), "plan-store-attacker-"));
+      try {
+        // Symlink <baseDir>/hostile -> <attackerDir>
+        const symlinkTarget = path.join(tmpDir, "hostile");
+        await fs.symlink(attackerDir, symlinkTarget);
+        // read() / write() must throw with a 'parent symlink' confinement error.
+        await expect(
+          store.write("hostile", { steps: [{ step: "x", status: "pending" }] }),
+        ).rejects.toThrow(/escapes base directory/);
+        // Also verify nothing was written into the attacker directory.
+        const filesInAttacker = await fs.readdir(attackerDir);
+        expect(filesInAttacker).toHaveLength(0);
+      } finally {
+        await fs.rm(attackerDir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -94,6 +94,9 @@ export class PlanStore {
    * Callers should acquire a lock first for concurrent safety.
    */
   async write(namespace: string, plan: StoredPlan): Promise<void> {
+    if (plan.namespace !== namespace) {
+      throw new Error(`Plan namespace mismatch: expected "${namespace}", got "${plan.namespace}"`);
+    }
     const planFile = this.planPath(namespace);
     const dir = path.dirname(planFile);
     await fs.mkdir(dir, { recursive: true });
@@ -183,18 +186,19 @@ export class PlanStore {
     sessionKey?: string,
   ): StoredPlanStep[] {
     const now = Date.now();
+    const attribution = sessionKey ? { updatedBy: sessionKey, updatedAt: now } : { updatedAt: now };
     const incomingMap = new Map(incoming.map((s) => [s.step, s]));
     const existingStepTexts = new Set(existing.map((s) => s.step));
     const merged = existing.map((s) => {
       const update = incomingMap.get(s.step);
       if (update) {
-        return { ...update, updatedBy: sessionKey, updatedAt: now };
+        return { ...update, ...attribution };
       }
       return s;
     });
     for (const s of incoming) {
       if (!existingStepTexts.has(s.step)) {
-        merged.push({ ...s, updatedBy: sessionKey, updatedAt: now });
+        merged.push({ ...s, ...attribution });
       }
     }
     return merged;

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -184,6 +184,7 @@ export class PlanStore {
   ): StoredPlanStep[] {
     const now = Date.now();
     const incomingMap = new Map(incoming.map((s) => [s.step, s]));
+    const existingStepTexts = new Set(existing.map((s) => s.step));
     const merged = existing.map((s) => {
       const update = incomingMap.get(s.step);
       if (update) {
@@ -192,7 +193,7 @@ export class PlanStore {
       return s;
     });
     for (const s of incoming) {
-      if (!existing.some((e) => e.step === s.step)) {
+      if (!existingStepTexts.has(s.step)) {
         merged.push({ ...s, updatedBy: sessionKey, updatedAt: now });
       }
     }

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -13,6 +13,7 @@
  */
 
 import crypto from "node:crypto";
+import { constants as fsConstants, realpathSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -31,54 +32,120 @@ export interface StoredPlan {
   updatedAt: number;
 }
 
-const LOCK_STALE_MS = 10_000;
-
 /**
- * Validates that a namespace cannot escape the base directory via
- * path traversal (e.g. "../../etc").
+ * Validates parsed JSON shape and strips prototype-pollution keys at every level.
+ * Defense-in-depth: Node's JSON.parse doesn't pollute prototypes by default,
+ * but explicitly removing __proto__/constructor/prototype keys prevents any
+ * future code path from accidentally trusting them.
  */
-function hasControlOrForbiddenChars(s: string): boolean {
-  for (let i = 0; i < s.length; i++) {
-    const code = s.charCodeAt(i);
-    // Block ASCII control chars (0x00-0x1F) and Windows-forbidden chars.
-    if (code <= 0x1f) {
-      return true;
-    }
-    if ('<>:"|?*'.includes(s[i])) {
-      return true;
-    }
+function sanitizePlanShape(parsed: unknown, expectedNamespace: string): StoredPlan {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Plan file for "${expectedNamespace}" has invalid shape — expected object`);
   }
-  return false;
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.namespace !== "string" || obj.namespace !== expectedNamespace) {
+    throw new Error(
+      `Plan namespace mismatch on read: expected "${expectedNamespace}", found "${String(obj.namespace)}"`,
+    );
+  }
+  if (!Array.isArray(obj.steps)) {
+    throw new Error(`Plan file for "${expectedNamespace}" has invalid shape — steps must be array`);
+  }
+  // Filter prototype-pollution keys defensively at the top level.
+  const safe: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (k === "__proto__" || k === "constructor" || k === "prototype") {
+      continue;
+    }
+    safe[k] = v;
+  }
+  return safe as unknown as StoredPlan;
 }
 
+// Stale-lock threshold bumped to 60s to reduce false-positive theft of
+// legitimate slow operations. Combined with PID liveness check, this gives
+// a much more conservative recovery model.
+const LOCK_STALE_MS = 60_000;
+// Max allowed plan file size (defense-in-depth against giant JSON parse).
+const MAX_PLAN_FILE_BYTES = 1_048_576; // 1 MiB
+// Windows reserved device names — case-insensitive, with optional extension.
+const WINDOWS_RESERVED_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+// Strict namespace pattern — prevents path separators, control chars,
+// trailing dots/spaces, and limits length.
+const NAMESPACE_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+
+/**
+ * Validates that a namespace is safe to use as a single directory name
+ * under baseDir. Rejects path separators, traversal, control chars,
+ * Windows reserved names, trailing dots/spaces, and over-length input.
+ *
+ * Hardened against:
+ * - Path traversal: rejects /, \, .., leading dots
+ * - Cross-namespace lock collision: rejects nested paths like "foo/.lock"
+ * - Windows device name attacks: CON, PRN, AUX, NUL, COM1-9, LPT1-9
+ * - Control char / null byte injection: only printable ASCII allowed
+ * - Length bound: 128 chars max
+ */
 function validateNamespace(namespace: string): void {
-  // Check raw input for traversal BEFORE normalizing — path.normalize()
-  // resolves "foo/../bar" to "bar" which would pass a post-normalize check.
-  if (!namespace || namespace === "." || namespace.includes("..")) {
+  if (!namespace || typeof namespace !== "string") {
     throw new Error(`Invalid plan namespace: "${namespace}"`);
   }
-  const normalized = path.normalize(namespace);
-  if (
-    !normalized ||
-    normalized === "." ||
-    path.isAbsolute(normalized) ||
-    hasControlOrForbiddenChars(normalized)
-  ) {
-    throw new Error(`Invalid plan namespace: "${namespace}"`);
+  // Strict character set — alphanumeric start, then alphanumeric/dot/underscore/hyphen.
+  // No /, \, control chars, spaces, or other risky characters.
+  if (!NAMESPACE_RE.test(namespace)) {
+    throw new Error(
+      `Invalid plan namespace: "${namespace}" — must match /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/`,
+    );
+  }
+  // Trailing dots/spaces are problematic on Windows (silently stripped).
+  if (/[.\s]$/.test(namespace)) {
+    throw new Error(`Invalid plan namespace: "${namespace}" — trailing dot or space not allowed`);
+  }
+  // Windows reserved device names (case-insensitive, with or without extension).
+  if (WINDOWS_RESERVED_RE.test(namespace)) {
+    throw new Error(
+      `Invalid plan namespace: "${namespace}" — matches Windows reserved device name`,
+    );
   }
 }
 
 export class PlanStore {
-  constructor(private readonly baseDir: string) {}
+  /** Realpath-resolved base directory — used for confinement checks. */
+  private readonly baseDir: string;
+
+  constructor(baseDir: string) {
+    // Resolve symlinks at construction. If baseDir doesn't exist yet, fall
+    // back to the literal path — confinement check at use time will still
+    // reject targets that escape this resolved root.
+    let resolved: string;
+    try {
+      resolved = realpathSync(baseDir);
+    } catch {
+      resolved = path.resolve(baseDir);
+    }
+    this.baseDir = resolved;
+  }
+
+  /**
+   * Confines a resolved path to baseDir. Throws if the resolved target
+   * escapes the realpathed base (defense against symlink redirection).
+   */
+  private confine(target: string): string {
+    const rel = path.relative(this.baseDir, target);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new Error(`Plan path escapes base directory: ${target}`);
+    }
+    return target;
+  }
 
   private planPath(namespace: string): string {
     validateNamespace(namespace);
-    return path.join(this.baseDir, namespace, "plan.json");
+    return this.confine(path.join(this.baseDir, namespace, "plan.json"));
   }
 
   private lockPath(namespace: string): string {
     validateNamespace(namespace);
-    return path.join(this.baseDir, namespace, ".lock");
+    return this.confine(path.join(this.baseDir, namespace, ".lock"));
   }
 
   /**
@@ -87,32 +154,44 @@ export class PlanStore {
    * so corruption is not silently ignored.
    */
   async read(namespace: string): Promise<StoredPlan | null> {
+    const planFile = this.planPath(namespace);
+    let handle: fs.FileHandle | undefined;
     try {
-      const content = await fs.readFile(this.planPath(namespace), "utf-8");
-      const plan = JSON.parse(content) as StoredPlan;
-      // Runtime shape validation — catch corrupt or manually-edited plan files.
-      if (
-        !plan ||
-        typeof plan !== "object" ||
-        typeof plan.namespace !== "string" ||
-        !Array.isArray(plan.steps)
-      ) {
+      // O_NOFOLLOW: refuse to follow symlinks at the leaf path.
+      handle = await fs.open(planFile, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+      const stat = await handle.stat();
+      if (!stat.isFile()) {
+        throw new Error(`Plan path is not a regular file: ${planFile}`);
+      }
+      // Pre-parse size guard — refuse oversized buffers before JSON.parse.
+      if (stat.size > MAX_PLAN_FILE_BYTES) {
         throw new Error(
-          `Plan file for "${namespace}" has invalid shape — expected {namespace, steps[]}`,
+          `Plan file exceeds max size ${MAX_PLAN_FILE_BYTES} bytes (got ${stat.size})`,
         );
       }
-      // Verify stored namespace matches requested namespace to catch corruption.
-      if (plan.namespace !== namespace) {
-        throw new Error(
-          `Plan namespace mismatch on read: expected "${namespace}", found "${plan.namespace}"`,
-        );
-      }
+      const content = await handle.readFile({ encoding: "utf-8" });
+      await handle.close();
+      handle = undefined;
+      const plan = sanitizePlanShape(JSON.parse(content), namespace);
       return plan;
     } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
         return null;
       }
+      // ELOOP / ENOTDIR from O_NOFOLLOW = symlink attack attempt; surface clearly.
+      if (code === "ELOOP" || code === "ENOTDIR") {
+        throw new Error(`Plan path symlink rejected (${code}): ${planFile}`, { cause: err });
+      }
       throw err;
+    } finally {
+      if (handle) {
+        try {
+          await handle.close();
+        } catch {
+          /* ignore close error in finally */
+        }
+      }
     }
   }
 
@@ -210,10 +289,61 @@ export class PlanStore {
           }
         }
         if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-          // Lock exists. Check if stale.
+          // Lock exists. Check if stale via mtime + PID liveness.
           try {
-            const stat = await fs.stat(lockFile);
-            if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+            // lstat (not stat) to detect symlink-attack at lock path.
+            const lstat = await fs.lstat(lockFile);
+            if (!lstat.isFile()) {
+              throw new Error(`Lock path is not a regular file: ${lockFile}`, { cause: err });
+            }
+            const ageMs = Date.now() - lstat.mtimeMs;
+            if (ageMs > LOCK_STALE_MS) {
+              // Stale by age — also verify the holder is dead.
+              // Read lock token to extract PID; if PID is alive, defer.
+              let holderPid: number | undefined;
+              try {
+                const content = await fs.readFile(lockFile, "utf-8");
+                // Token format: "{pid}-{timestamp}-{rand}"
+                const pidStr = content.split("-")[0];
+                const parsed = Number.parseInt(pidStr, 10);
+                if (Number.isFinite(parsed) && parsed > 0) {
+                  holderPid = parsed;
+                }
+              } catch {
+                // Couldn't read holder — proceed with mtime-based eviction.
+              }
+              if (holderPid !== undefined) {
+                let alive = false;
+                try {
+                  // process.kill(pid, 0) throws ESRCH if pid is dead, no-op if alive.
+                  process.kill(holderPid, 0);
+                  alive = true;
+                } catch (probeErr) {
+                  if ((probeErr as NodeJS.ErrnoException).code !== "ESRCH") {
+                    // EPERM means the process exists but we don't have permission
+                    // to signal it — treat as alive (don't steal).
+                    alive = true;
+                  }
+                }
+                if (alive) {
+                  // Holder is alive — wait, don't steal.
+                  await new Promise((r) => setTimeout(r, 200 * (i + 1)));
+                  continue;
+                }
+              }
+              // Re-stat just before unlink to detect a new owner that
+              // acquired between our stat and unlink (TOCTOU mitigation).
+              try {
+                const recheck = await fs.lstat(lockFile);
+                if (recheck.mtimeMs > lstat.mtimeMs) {
+                  // A new owner took it — back off and retry normally.
+                  await new Promise((r) => setTimeout(r, 200 * (i + 1)));
+                  continue;
+                }
+              } catch {
+                // Disappeared on its own — nothing to unlink.
+                continue;
+              }
               await fs.unlink(lockFile);
               continue; // Retry after removing stale lock.
             }

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -37,12 +37,22 @@ const LOCK_STALE_MS = 10_000;
  * Validates that a namespace cannot escape the base directory via
  * path traversal (e.g. "../../etc").
  */
+function hasControlOrForbiddenChars(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    // Block ASCII control chars (0x00-0x1F) and Windows-forbidden chars.
+    if (code <= 0x1f) { return true; }
+    if ("<>:\"|?*".includes(s[i])) { return true; }
+  }
+  return false;
+}
+
 function validateNamespace(namespace: string): void {
   if (
     !namespace ||
     namespace.includes("..") ||
     path.isAbsolute(namespace) ||
-    /[<>:"|?*\u0000-\u001F]/.test(namespace)
+    hasControlOrForbiddenChars(namespace)
   ) {
     throw new Error(`Invalid plan namespace: "${namespace}"`);
   }

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -52,12 +52,15 @@ function hasControlOrForbiddenChars(s: string): boolean {
 }
 
 function validateNamespace(namespace: string): void {
-  // Normalize dot segments (./foo → foo) before validation to prevent
-  // cross-namespace collisions from equivalent but differently-spelled paths.
+  // Check raw input for traversal BEFORE normalizing — path.normalize()
+  // resolves "foo/../bar" to "bar" which would pass a post-normalize check.
+  if (!namespace || namespace === "." || namespace.includes("..")) {
+    throw new Error(`Invalid plan namespace: "${namespace}"`);
+  }
   const normalized = path.normalize(namespace);
   if (
     !normalized ||
-    normalized.includes("..") ||
+    normalized === "." ||
     path.isAbsolute(normalized) ||
     hasControlOrForbiddenChars(normalized)
   ) {
@@ -124,7 +127,7 @@ export class PlanStore {
       throw new Error(`Plan namespace mismatch: expected "${namespace}", got "${plan.namespace}"`);
     }
     const dir = path.dirname(planFile);
-    await fs.mkdir(dir, { recursive: true });
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
 
     // Atomic write: write to a temp file in the same directory, then rename.
     const tmpFile = path.join(dir, `.plan-${crypto.randomBytes(4).toString("hex")}.tmp`);
@@ -153,7 +156,7 @@ export class PlanStore {
   async lock(namespace: string): Promise<() => Promise<void>> {
     const lockFile = this.lockPath(namespace);
     const dir = path.dirname(lockFile);
-    await fs.mkdir(dir, { recursive: true });
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
 
     // Generate a unique lock token so release can verify ownership.
     const lockToken = `${process.pid}-${Date.now()}-${crypto.randomBytes(4).toString("hex")}`;
@@ -165,7 +168,23 @@ export class PlanStore {
       let handle: fs.FileHandle | undefined;
       try {
         handle = await fs.open(lockFile, "wx");
-        await handle.writeFile(lockToken);
+        try {
+          await handle.writeFile(lockToken);
+        } catch {
+          // Write failed — clean up the empty/partial lock file immediately
+          // instead of waiting for stale-lock cleanup.
+          try {
+            await handle.close();
+          } catch {
+            /* ignore */
+          }
+          try {
+            await fs.unlink(lockFile);
+          } catch {
+            /* ignore */
+          }
+          throw new Error("Failed to write lock token");
+        }
         await handle.close();
         handle = undefined; // closed successfully
 

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -12,9 +12,9 @@
  * no change to existing flow).
  */
 
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import crypto from "node:crypto";
 
 export interface StoredPlanStep {
   step: string;
@@ -41,8 +41,12 @@ function hasControlOrForbiddenChars(s: string): boolean {
   for (let i = 0; i < s.length; i++) {
     const code = s.charCodeAt(i);
     // Block ASCII control chars (0x00-0x1F) and Windows-forbidden chars.
-    if (code <= 0x1f) { return true; }
-    if ("<>:\"|?*".includes(s[i])) { return true; }
+    if (code <= 0x1f) {
+      return true;
+    }
+    if ('<>:"|?*'.includes(s[i])) {
+      return true;
+    }
   }
   return false;
 }
@@ -82,7 +86,9 @@ export class PlanStore {
       const plan = JSON.parse(content) as StoredPlan;
       // Verify stored namespace matches requested namespace to catch corruption.
       if (plan.namespace !== undefined && plan.namespace !== namespace) {
-        throw new Error(`Plan namespace mismatch on read: expected "${namespace}", found "${plan.namespace}"`);
+        throw new Error(
+          `Plan namespace mismatch on read: expected "${namespace}", found "${plan.namespace}"`,
+        );
       }
       return plan;
     } catch (err: unknown) {
@@ -99,10 +105,10 @@ export class PlanStore {
    * Callers should acquire a lock first for concurrent safety.
    */
   async write(namespace: string, plan: StoredPlan): Promise<void> {
+    const planFile = this.planPath(namespace); // validates namespace first (path traversal, etc.)
     if (plan.namespace !== namespace) {
       throw new Error(`Plan namespace mismatch: expected "${namespace}", got "${plan.namespace}"`);
     }
-    const planFile = this.planPath(namespace);
     const dir = path.dirname(planFile);
     await fs.mkdir(dir, { recursive: true });
 
@@ -113,7 +119,11 @@ export class PlanStore {
       await fs.rename(tmpFile, planFile);
     } catch (err) {
       // Clean up temp file on failure.
-      try { await fs.unlink(tmpFile); } catch { /* ignore */ }
+      try {
+        await fs.unlink(tmpFile);
+      } catch {
+        /* ignore */
+      }
       throw err;
     }
   }
@@ -157,7 +167,11 @@ export class PlanStore {
       } catch (err: unknown) {
         // Ensure handle is closed on any error path.
         if (handle) {
-          try { await handle.close(); } catch { /* ignore */ }
+          try {
+            await handle.close();
+          } catch {
+            /* ignore */
+          }
         }
         if ((err as NodeJS.ErrnoException).code === "EEXIST") {
           // Lock exists. Check if stale.
@@ -177,7 +191,9 @@ export class PlanStore {
         }
       }
     }
-    throw new Error(`Failed to acquire plan lock for namespace "${namespace}" after ${maxRetries} retries`);
+    throw new Error(
+      `Failed to acquire plan lock for namespace "${namespace}" after ${maxRetries} retries`,
+    );
   }
 
   /**

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -115,7 +115,10 @@ export class PlanStore {
     // Atomic write: write to a temp file in the same directory, then rename.
     const tmpFile = path.join(dir, `.plan-${crypto.randomBytes(4).toString("hex")}.tmp`);
     try {
-      await fs.writeFile(tmpFile, JSON.stringify(plan, null, 2), "utf-8");
+      await fs.writeFile(tmpFile, JSON.stringify(plan, null, 2), {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
       await fs.rename(tmpFile, planFile);
     } catch (err) {
       // Clean up temp file on failure.

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -79,7 +79,12 @@ export class PlanStore {
   async read(namespace: string): Promise<StoredPlan | null> {
     try {
       const content = await fs.readFile(this.planPath(namespace), "utf-8");
-      return JSON.parse(content) as StoredPlan;
+      const plan = JSON.parse(content) as StoredPlan;
+      // Verify stored namespace matches requested namespace to catch corruption.
+      if (plan.namespace && plan.namespace !== namespace) {
+        throw new Error(`Plan namespace mismatch on read: expected "${namespace}", found "${plan.namespace}"`);
+      }
+      return plan;
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         return null;
@@ -196,9 +201,11 @@ export class PlanStore {
       }
       return s;
     });
+    const appended = new Set<string>();
     for (const s of incoming) {
-      if (!existingStepTexts.has(s.step)) {
+      if (!existingStepTexts.has(s.step) && !appended.has(s.step)) {
         merged.push({ ...s, ...attribution });
+        appended.add(s.step);
       }
     }
     return merged;

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -147,8 +147,8 @@ export class PlanStore {
 
   /**
    * Acquires a file-level lock for a namespace.
-   * Returns a release function. The lock auto-expires after 10s
-   * to prevent deadlocks from crashed processes.
+   * Returns a release function. Stale locks (older than 10s) are
+   * cleaned up opportunistically by the next lock() caller.
    */
   async lock(namespace: string): Promise<() => Promise<void>> {
     const lockFile = this.lockPath(namespace);
@@ -165,7 +165,7 @@ export class PlanStore {
       let handle: fs.FileHandle | undefined;
       try {
         handle = await fs.open(lockFile, "wx");
-        await handle.write(lockToken);
+        await handle.writeFile(lockToken);
         await handle.close();
         handle = undefined; // closed successfully
 

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -127,13 +127,52 @@ export class PlanStore {
   }
 
   /**
-   * Confines a resolved path to baseDir. Throws if the resolved target
-   * escapes the realpathed base (defense against symlink redirection).
+   * Confines a resolved path to baseDir. Throws if the lexical OR
+   * realpath-resolved target escapes the realpathed base.
+   *
+   * Codex P1 (PR #67542 r3095586226): the lexical-only check let a
+   * symlinked namespace dir bypass confinement. e.g.
+   *   `<baseDir>/ns -> /tmp/attacker`
+   * lexically resolves to `<baseDir>/ns/plan.json` (which IS under
+   * baseDir on paper), but every subsequent open() follows the symlink
+   * to `/tmp/attacker/plan.json`. The leaf `O_NOFOLLOW` we already
+   * apply only blocks the FINAL hop, not parent-directory symlinks.
+   *
+   * This walks the longest existing ancestor of `target`, realpath()s
+   * it, and rejects if the realpath escapes baseDir.
    */
   private confine(target: string): string {
     const rel = path.relative(this.baseDir, target);
     if (rel.startsWith("..") || path.isAbsolute(rel)) {
       throw new Error(`Plan path escapes base directory: ${target}`);
+    }
+    // Realpath the deepest existing ancestor (start from the parent and
+    // walk up). If it resolves outside baseDir, reject — a parent
+    // symlink would redirect us elsewhere.
+    let probe = path.dirname(target);
+    while (probe.startsWith(this.baseDir)) {
+      try {
+        const resolved = realpathSync(probe);
+        const ancestorRel = path.relative(this.baseDir, resolved);
+        if (ancestorRel.startsWith("..") || path.isAbsolute(ancestorRel)) {
+          throw new Error(
+            `Plan path escapes base directory via parent symlink: ${target} (resolves to ${resolved})`,
+          );
+        }
+        return target;
+      } catch (err: unknown) {
+        // ENOENT — this ancestor doesn't exist yet; walk up and try again.
+        if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+          const next = path.dirname(probe);
+          if (next === probe) {
+            break; // hit filesystem root
+          }
+          probe = next;
+          continue;
+        }
+        // Anything else (loop detection, permission denied) is hostile.
+        throw err;
+      }
     }
     return target;
   }

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -81,7 +81,7 @@ export class PlanStore {
       const content = await fs.readFile(this.planPath(namespace), "utf-8");
       const plan = JSON.parse(content) as StoredPlan;
       // Verify stored namespace matches requested namespace to catch corruption.
-      if (plan.namespace && plan.namespace !== namespace) {
+      if (plan.namespace !== undefined && plan.namespace !== namespace) {
         throw new Error(`Plan namespace mismatch on read: expected "${namespace}", found "${plan.namespace}"`);
       }
       return plan;

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -52,11 +52,14 @@ function hasControlOrForbiddenChars(s: string): boolean {
 }
 
 function validateNamespace(namespace: string): void {
+  // Normalize dot segments (./foo → foo) before validation to prevent
+  // cross-namespace collisions from equivalent but differently-spelled paths.
+  const normalized = path.normalize(namespace);
   if (
-    !namespace ||
-    namespace.includes("..") ||
-    path.isAbsolute(namespace) ||
-    hasControlOrForbiddenChars(namespace)
+    !normalized ||
+    normalized.includes("..") ||
+    path.isAbsolute(normalized) ||
+    hasControlOrForbiddenChars(normalized)
   ) {
     throw new Error(`Invalid plan namespace: "${namespace}"`);
   }
@@ -84,8 +87,19 @@ export class PlanStore {
     try {
       const content = await fs.readFile(this.planPath(namespace), "utf-8");
       const plan = JSON.parse(content) as StoredPlan;
+      // Runtime shape validation — catch corrupt or manually-edited plan files.
+      if (
+        !plan ||
+        typeof plan !== "object" ||
+        typeof plan.namespace !== "string" ||
+        !Array.isArray(plan.steps)
+      ) {
+        throw new Error(
+          `Plan file for "${namespace}" has invalid shape — expected {namespace, steps[]}`,
+        );
+      }
       // Verify stored namespace matches requested namespace to catch corruption.
-      if (plan.namespace !== undefined && plan.namespace !== namespace) {
+      if (plan.namespace !== namespace) {
         throw new Error(
           `Plan namespace mismatch on read: expected "${namespace}", found "${plan.namespace}"`,
         );

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -14,6 +14,8 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
+import os from "node:os";
+import crypto from "node:crypto";
 
 export interface StoredPlanStep {
   step: string;
@@ -32,42 +34,71 @@ export interface StoredPlan {
 
 const LOCK_STALE_MS = 10_000;
 
+/**
+ * Validates that a namespace cannot escape the base directory via
+ * path traversal (e.g. "../../etc").
+ */
+function validateNamespace(namespace: string): void {
+  if (
+    !namespace ||
+    namespace.includes("..") ||
+    path.isAbsolute(namespace) ||
+    /[<>:"|?*\x00-\x1f]/.test(namespace)
+  ) {
+    throw new Error(`Invalid plan namespace: "${namespace}"`);
+  }
+}
+
 export class PlanStore {
   constructor(private readonly baseDir: string) {}
 
   private planPath(namespace: string): string {
+    validateNamespace(namespace);
     return path.join(this.baseDir, namespace, "plan.json");
   }
 
   private lockPath(namespace: string): string {
+    validateNamespace(namespace);
     return path.join(this.baseDir, namespace, ".lock");
   }
 
   /**
    * Reads the current plan for a namespace.
-   * Returns null if no plan exists.
+   * Returns null if no plan exists. Throws on parse/permission errors
+   * so corruption is not silently ignored.
    */
   async read(namespace: string): Promise<StoredPlan | null> {
     try {
       const content = await fs.readFile(this.planPath(namespace), "utf-8");
       return JSON.parse(content) as StoredPlan;
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw err;
     }
   }
 
   /**
-   * Writes a plan for a namespace. Creates the directory if needed.
+   * Writes a plan for a namespace atomically (write to temp, then rename).
+   * Creates the directory if needed.
    * Callers should acquire a lock first for concurrent safety.
    */
   async write(namespace: string, plan: StoredPlan): Promise<void> {
-    const dir = path.dirname(this.planPath(namespace));
+    const planFile = this.planPath(namespace);
+    const dir = path.dirname(planFile);
     await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(
-      this.planPath(namespace),
-      JSON.stringify(plan, null, 2),
-      "utf-8",
-    );
+
+    // Atomic write: write to a temp file in the same directory, then rename.
+    const tmpFile = path.join(dir, `.plan-${crypto.randomBytes(4).toString("hex")}.tmp`);
+    try {
+      await fs.writeFile(tmpFile, JSON.stringify(plan, null, 2), "utf-8");
+      await fs.rename(tmpFile, planFile);
+    } catch (err) {
+      // Clean up temp file on failure.
+      try { await fs.unlink(tmpFile); } catch { /* ignore */ }
+      throw err;
+    }
   }
 
   /**
@@ -80,24 +111,37 @@ export class PlanStore {
     const dir = path.dirname(lockFile);
     await fs.mkdir(dir, { recursive: true });
 
+    // Generate a unique lock token so release can verify ownership.
+    const lockToken = `${process.pid}-${Date.now()}-${crypto.randomBytes(4).toString("hex")}`;
+
     // Try to acquire lock with O_EXCL (fails if file exists).
     // If lock exists but is stale (>10s), remove and retry.
     const maxRetries = 5;
     for (let i = 0; i < maxRetries; i++) {
+      let handle: fs.FileHandle | undefined;
       try {
-        const handle = await fs.open(lockFile, "wx");
-        await handle.write(String(Date.now()));
+        handle = await fs.open(lockFile, "wx");
+        await handle.write(lockToken);
         await handle.close();
+        handle = undefined; // closed successfully
 
-        // Lock acquired. Return release function.
+        // Lock acquired. Return release function that verifies ownership.
         return async () => {
           try {
-            await fs.unlink(lockFile);
+            const content = await fs.readFile(lockFile, "utf-8");
+            if (content === lockToken) {
+              await fs.unlink(lockFile);
+            }
+            // If token doesn't match, another process owns the lock — don't unlink.
           } catch {
             // Lock file may have been cleaned up already.
           }
         };
       } catch (err: unknown) {
+        // Ensure handle is closed on any error path.
+        if (handle) {
+          try { await handle.close(); } catch { /* ignore */ }
+        }
         if ((err as NodeJS.ErrnoException).code === "EEXIST") {
           // Lock exists. Check if stale.
           try {

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -38,6 +38,21 @@ export interface StoredPlan {
  * but explicitly removing __proto__/constructor/prototype keys prevents any
  * future code path from accidentally trusting them.
  */
+const VALID_STEP_STATUSES = new Set(["pending", "in_progress", "completed", "cancelled"]);
+
+/**
+ * Validates parsed JSON shape and strips prototype-pollution keys at every level.
+ * Defense-in-depth: Node's JSON.parse doesn't pollute prototypes by default,
+ * but explicitly removing __proto__/constructor/prototype keys prevents any
+ * future code path from accidentally trusting them.
+ *
+ * Codex P2 (PR #67542 r3094816890): the prior shallow check (namespace is
+ * string + steps is array) let malformed files like `steps: [null]` or
+ * missing `createdAt`/`updatedAt` slip through, then crashed downstream
+ * code (e.g. `mergeSteps()` reading `step.step`) instead of surfacing a
+ * clear read-time error. This function now validates EVERY field needed
+ * by downstream consumers.
+ */
 function sanitizePlanShape(parsed: unknown, expectedNamespace: string): StoredPlan {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error(`Plan file for "${expectedNamespace}" has invalid shape — expected object`);
@@ -50,6 +65,44 @@ function sanitizePlanShape(parsed: unknown, expectedNamespace: string): StoredPl
   }
   if (!Array.isArray(obj.steps)) {
     throw new Error(`Plan file for "${expectedNamespace}" has invalid shape — steps must be array`);
+  }
+  // Per-step validation — fail fast at read time instead of crashing in
+  // mergeSteps()/render() with a confusing TypeError later.
+  for (let i = 0; i < obj.steps.length; i += 1) {
+    const step: unknown = obj.steps[i];
+    if (!step || typeof step !== "object" || Array.isArray(step)) {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — expected object, got ${Array.isArray(step) ? "array" : typeof step}`,
+      );
+    }
+    const s = step as Record<string, unknown>;
+    if (typeof s.step !== "string" || s.step.length === 0) {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — \`step\` must be a non-empty string`,
+      );
+    }
+    if (typeof s.status !== "string" || !VALID_STEP_STATUSES.has(s.status)) {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — \`status\` must be one of ${[...VALID_STEP_STATUSES].join(", ")}, got "${String(s.status)}"`,
+      );
+    }
+    if (s.activeForm !== undefined && typeof s.activeForm !== "string") {
+      throw new Error(
+        `Plan file for "${expectedNamespace}" has invalid step at index ${i} — \`activeForm\` must be a string when present`,
+      );
+    }
+  }
+  // Required timestamps. Numeric only — string ISO timestamps would silently
+  // pass `typeof === "number"` checks downstream as NaN.
+  if (typeof obj.createdAt !== "number" || !Number.isFinite(obj.createdAt) || obj.createdAt < 0) {
+    throw new Error(
+      `Plan file for "${expectedNamespace}" has invalid \`createdAt\` — expected non-negative number`,
+    );
+  }
+  if (typeof obj.updatedAt !== "number" || !Number.isFinite(obj.updatedAt) || obj.updatedAt < 0) {
+    throw new Error(
+      `Plan file for "${expectedNamespace}" has invalid \`updatedAt\` — expected non-negative number`,
+    );
   }
   // Filter prototype-pollution keys defensively at the top level.
   const safe: Record<string, unknown> = {};

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -1,0 +1,148 @@
+/**
+ * Persistent plan store for cross-session task coordination.
+ *
+ * Phase 4.2 of the GPT 5.4 parity sprint. Modeled after Claude Code's
+ * Tasks API with `CLAUDE_CODE_TASK_LIST_ID` env var concept.
+ *
+ * When a namespace is configured, plan state is shared across all
+ * sessions using that namespace. Plans are persisted to disk at
+ * `~/.openclaw/plans/<namespace>/plan.json`.
+ *
+ * Default (no namespace): plan is session-scoped (current behavior,
+ * no change to existing flow).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface StoredPlanStep {
+  step: string;
+  status: "pending" | "in_progress" | "completed" | "cancelled";
+  activeForm?: string;
+  updatedBy?: string; // session key that last updated this step
+  updatedAt?: number;
+}
+
+export interface StoredPlan {
+  namespace: string;
+  steps: StoredPlanStep[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+const LOCK_STALE_MS = 10_000;
+
+export class PlanStore {
+  constructor(private readonly baseDir: string) {}
+
+  private planPath(namespace: string): string {
+    return path.join(this.baseDir, namespace, "plan.json");
+  }
+
+  private lockPath(namespace: string): string {
+    return path.join(this.baseDir, namespace, ".lock");
+  }
+
+  /**
+   * Reads the current plan for a namespace.
+   * Returns null if no plan exists.
+   */
+  async read(namespace: string): Promise<StoredPlan | null> {
+    try {
+      const content = await fs.readFile(this.planPath(namespace), "utf-8");
+      return JSON.parse(content) as StoredPlan;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Writes a plan for a namespace. Creates the directory if needed.
+   * Callers should acquire a lock first for concurrent safety.
+   */
+  async write(namespace: string, plan: StoredPlan): Promise<void> {
+    const dir = path.dirname(this.planPath(namespace));
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      this.planPath(namespace),
+      JSON.stringify(plan, null, 2),
+      "utf-8",
+    );
+  }
+
+  /**
+   * Acquires a file-level lock for a namespace.
+   * Returns a release function. The lock auto-expires after 10s
+   * to prevent deadlocks from crashed processes.
+   */
+  async lock(namespace: string): Promise<() => Promise<void>> {
+    const lockFile = this.lockPath(namespace);
+    const dir = path.dirname(lockFile);
+    await fs.mkdir(dir, { recursive: true });
+
+    // Try to acquire lock with O_EXCL (fails if file exists).
+    // If lock exists but is stale (>10s), remove and retry.
+    const maxRetries = 5;
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        const handle = await fs.open(lockFile, "wx");
+        await handle.write(String(Date.now()));
+        await handle.close();
+
+        // Lock acquired. Return release function.
+        return async () => {
+          try {
+            await fs.unlink(lockFile);
+          } catch {
+            // Lock file may have been cleaned up already.
+          }
+        };
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+          // Lock exists. Check if stale.
+          try {
+            const stat = await fs.stat(lockFile);
+            if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+              await fs.unlink(lockFile);
+              continue; // Retry after removing stale lock.
+            }
+          } catch {
+            continue; // Stat failed, retry.
+          }
+          // Lock is fresh. Wait and retry.
+          await new Promise((r) => setTimeout(r, 200 * (i + 1)));
+        } else {
+          throw err;
+        }
+      }
+    }
+    throw new Error(`Failed to acquire plan lock for namespace "${namespace}" after ${maxRetries} retries`);
+  }
+
+  /**
+   * Merges incoming steps into an existing plan by matching step text.
+   * New steps are appended; existing steps are updated.
+   * Returns the merged plan.
+   */
+  mergeSteps(
+    existing: StoredPlanStep[],
+    incoming: StoredPlanStep[],
+    sessionKey?: string,
+  ): StoredPlanStep[] {
+    const now = Date.now();
+    const incomingMap = new Map(incoming.map((s) => [s.step, s]));
+    const merged = existing.map((s) => {
+      const update = incomingMap.get(s.step);
+      if (update) {
+        return { ...update, updatedBy: sessionKey, updatedAt: now };
+      }
+      return s;
+    });
+    for (const s of incoming) {
+      if (!existing.some((e) => e.step === s.step)) {
+        merged.push({ ...s, updatedBy: sessionKey, updatedAt: now });
+      }
+    }
+    return merged;
+  }
+}

--- a/src/agents/plan-store.ts
+++ b/src/agents/plan-store.ts
@@ -14,7 +14,6 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
 import crypto from "node:crypto";
 
 export interface StoredPlanStep {
@@ -43,7 +42,7 @@ function validateNamespace(namespace: string): void {
     !namespace ||
     namespace.includes("..") ||
     path.isAbsolute(namespace) ||
-    /[<>:"|?*\x00-\x1f]/.test(namespace)
+    /[<>:"|?*\u0000-\u001F]/.test(namespace)
   ) {
     throw new Error(`Invalid plan namespace: "${namespace}"`);
   }


### PR DESCRIPTION
## TL;DR

Persistent \`PlanStore\` for sharing plans across multiple sessions and agents, with file-level exclusive locking and stale-lock cleanup.

## Tracking
- Umbrella: #66345
- Issue: #67523

## What this PR does

- \`PlanStore\` class: \`read()\`, \`write()\`, \`lock()\`, \`mergeSteps()\` operations
- File-level exclusive locking via \`O_EXCL\` + 10s stale-lock cleanup
- \`StoredPlan\` / \`StoredPlanStep\` types with per-step \`updatedBy\`/\`updatedAt\` tracking
- Atomic writes (write to temp file, then rename) to prevent corruption
- Namespace validation with path traversal protection

### Default behavior
No behavior change when unconfigured. Plans remain session-scoped. Cross-session coordination only activates when \`planStore.namespace\` is explicitly set.

### Path traversal fix
\`write()\` now validates namespace BEFORE checking plan.namespace mismatch, ensuring security-relevant validation runs first.

## Files changed

| File | Change | Tests |
|------|--------|-------|
| \`src/agents/plan-store.ts\` | **New** — PlanStore class | 10 tests |
| \`src/agents/plan-store.test.ts\` | **New** — round-trip, locking, merge, traversal | Self |

## Dependencies
- #67514 for extended update_plan schema
- #67538 for plan mode runtime

## What follows
- Integration with plan mode: approved plans can be persisted for cross-agent handoff
- Wiring into \`update_plan\` tool so plans auto-persist when namespace is configured