### PR TITLE
fix(amazon-bedrock-mantle): add config.discovery.enabled gate to skip unnecessary discovery (#67288)

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -348,6 +348,73 @@ describe("bedrock mantle discovery", () => {
     expect(provider).toBeNull();
   });
 
+  it("runs discovery when AWS_ROLE_ARN is set (EKS IRSA)", async () => {
+    const tokenProvider = vi.fn(async () => "bedrock-api-key-irsa"); // pragma: allowlist secret
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
+      }),
+    });
+    mocks.getTokenProvider.mockReturnValue(tokenProvider);
+
+    const provider = await resolveImplicitMantleProvider({
+      env: {
+        AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/my-role",
+        AWS_WEB_IDENTITY_TOKEN_FILE: "/var/run/secrets/token",
+        AWS_REGION: "us-east-1",
+      } as NodeJS.ProcessEnv,
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    expect(provider).not.toBeNull();
+    expect(provider?.models).toHaveLength(1);
+  });
+
+  it("runs discovery when AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is set (ECS)", async () => {
+    const tokenProvider = vi.fn(async () => "bedrock-api-key-ecs"); // pragma: allowlist secret
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
+      }),
+    });
+    mocks.getTokenProvider.mockReturnValue(tokenProvider);
+
+    const provider = await resolveImplicitMantleProvider({
+      env: {
+        AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/v2/credentials/uuid",
+        AWS_REGION: "us-east-1",
+      } as NodeJS.ProcessEnv,
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    expect(provider).not.toBeNull();
+    expect(provider?.models).toHaveLength(1);
+  });
+
+  it("runs discovery when AWS_CONTAINER_CREDENTIALS_FULL_URI is set", async () => {
+    const tokenProvider = vi.fn(async () => "bedrock-api-key-ecs-full"); // pragma: allowlist secret
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
+      }),
+    });
+    mocks.getTokenProvider.mockReturnValue(tokenProvider);
+
+    const provider = await resolveImplicitMantleProvider({
+      env: {
+        AWS_CONTAINER_CREDENTIALS_FULL_URI: "http://169.254.170.23/v1/credentials",
+        AWS_REGION: "us-east-1",
+      } as NodeJS.ProcessEnv,
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    expect(provider).not.toBeNull();
+    expect(provider?.models).toHaveLength(1);
+  });
+
   it("runs discovery when discoveryConfig.enabled is true even without env creds", async () => {
     const tokenProvider = vi.fn(async () => "bedrock-api-key-forced"); // pragma: allowlist secret
     const mockFetch = vi.fn().mockResolvedValue({

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -328,6 +328,46 @@ describe("bedrock mantle discovery", () => {
   // Implicit provider resolution
   // ---------------------------------------------------------------------------
 
+  it("skips discovery when discoveryConfig.enabled is false", async () => {
+    const provider = await resolveImplicitMantleProvider({
+      env: {
+        AWS_BEARER_TOKEN_BEDROCK: "my-token", // pragma: allowlist secret
+        AWS_REGION: "us-east-1",
+      } as NodeJS.ProcessEnv,
+      discoveryConfig: { enabled: false },
+    });
+
+    expect(provider).toBeNull();
+  });
+
+  it("skips discovery when enabled is not true and no AWS creds are present", async () => {
+    const provider = await resolveImplicitMantleProvider({
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(provider).toBeNull();
+  });
+
+  it("runs discovery when discoveryConfig.enabled is true even without env creds", async () => {
+    const tokenProvider = vi.fn(async () => "bedrock-api-key-forced"); // pragma: allowlist secret
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
+      }),
+    });
+    mocks.getTokenProvider.mockReturnValue(tokenProvider);
+
+    const provider = await resolveImplicitMantleProvider({
+      env: { AWS_REGION: "us-east-1" } as NodeJS.ProcessEnv,
+      fetchFn: mockFetch as unknown as typeof fetch,
+      discoveryConfig: { enabled: true },
+    });
+
+    expect(provider).not.toBeNull();
+    expect(provider?.models).toHaveLength(1);
+  });
+
   it("resolves implicit provider when bearer token is set", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -1,5 +1,6 @@
 import { createSubsystemLogger } from "openclaw/plugin-sdk/core";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { resolveAwsSdkEnvVarName } from "openclaw/plugin-sdk/provider-auth-runtime";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
@@ -257,10 +258,20 @@ export async function discoverMantleModels(params: {
 export async function resolveImplicitMantleProvider(params: {
   env?: NodeJS.ProcessEnv;
   fetchFn?: typeof fetch;
+  discoveryConfig?: { enabled?: boolean };
 }): Promise<ModelProviderConfig | null> {
+  const enabled = params.discoveryConfig?.enabled;
+  if (enabled === false) {
+    return null;
+  }
+
   const env = params.env ?? process.env;
   const region = env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? "us-east-1";
   const explicitBearerToken = resolveMantleBearerToken(env);
+
+  if (enabled !== true && !explicitBearerToken && resolveAwsSdkEnvVarName(env) === undefined) {
+    return null;
+  }
 
   if (!isSupportedRegion(region)) {
     log.debug?.("Mantle not available in region", { region });

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -269,7 +269,15 @@ export async function resolveImplicitMantleProvider(params: {
   const region = env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? "us-east-1";
   const explicitBearerToken = resolveMantleBearerToken(env);
 
-  if (enabled !== true && !explicitBearerToken && resolveAwsSdkEnvVarName(env) === undefined) {
+  // Also covers IRSA (EKS) and ECS task role credential env vars
+  if (
+    enabled !== true &&
+    !explicitBearerToken &&
+    resolveAwsSdkEnvVarName(env) === undefined &&
+    !env.AWS_ROLE_ARN &&
+    !env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI &&
+    !env.AWS_CONTAINER_CREDENTIALS_FULL_URI
+  ) {
     return null;
   }
 

--- a/extensions/amazon-bedrock-mantle/openclaw.plugin.json
+++ b/extensions/amazon-bedrock-mantle/openclaw.plugin.json
@@ -4,7 +4,15 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "discovery": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" }
+        }
+      }
+    }
   },
   "providers": ["amazon-bedrock-mantle"]
 }

--- a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
@@ -16,8 +16,10 @@ export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
     catalog: {
       order: "simple",
       run: async (ctx) => {
+        const pluginConfig = (api.pluginConfig ?? {}) as { discovery?: { enabled?: boolean } };
         const implicit = await resolveImplicitMantleProvider({
           env: ctx.env,
+          discoveryConfig: pluginConfig.discovery,
         });
         if (!implicit) {
           return null;


### PR DESCRIPTION
## Problem
Users who configure the Bedrock Mantle extension but don't need model discovery still trigger the discovery flow on startup, adding latency and potentially failing in restricted IAM environments (#67288).

## Fix
Added a `config.discovery.enabled` gate (default: `true`) that lets users explicitly disable discovery. When disabled, the extension skips the discovery call entirely.

### Changes
- `discovery.ts`: Early return when `config.discovery.enabled === false`
- `register.sync.runtime.ts`: Pass config to discovery
- `openclaw.plugin.json`: Added `discovery.enabled` config schema
- `discovery.test.ts`: 3 new tests

Fixes #67288