### PR TITLE
refactor(memory-core): decouple file-based memory instructions from workspace templates

### DIFF
--- a/docs/reference/templates/AGENTS.dev.md
+++ b/docs/reference/templates/AGENTS.dev.md
@@ -18,8 +18,7 @@ This folder is the assistant's working directory.
 
 ## Backup tip (recommended)
 
-If you treat this workspace as the agent's "memory", make it a git repo (ideally private) so identity
-and notes are backed up.
+Make this workspace a git repo (ideally private) so identity and notes are backed up.
 
 ```bash
 git init
@@ -33,11 +32,11 @@ git commit -m "Add agent workspace"
 - Don't run destructive commands unless explicitly asked.
 - Be concise in chat; write longer output to files in this workspace.
 
-## Daily memory (recommended)
+## Memory
 
-- Keep a short daily log at memory/YYYY-MM-DD.md (create memory/ if needed).
-- On session start, read today + yesterday if present.
-- Capture durable facts, preferences, and decisions; avoid secrets.
+Memory persistence is handled by the active memory plugin. Use the memory tools
+available to you (visible in your tool list) to store and retrieve memories.
+If no memory plugin is active, you can use workspace files as a fallback.
 
 ## Heartbeats (optional)
 

--- a/docs/reference/templates/AGENTS.dev.md
+++ b/docs/reference/templates/AGENTS.dev.md
@@ -36,7 +36,6 @@ git commit -m "Add agent workspace"
 
 Memory persistence is handled by the active memory plugin. Use the memory tools
 available to you (visible in your tool list) to store and retrieve memories.
-If no memory plugin is active, you can use workspace files as a fallback.
 
 ## Heartbeats (optional)
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -32,11 +32,13 @@ Do not manually reread startup files unless:
 
 Memory persistence is handled by the active memory plugin. Use the memory tools
 available to you (visible in your tool list) to store and retrieve memories.
-If no memory plugin is active, you can use workspace files as a fallback.
+
+When you learn a lesson, update AGENTS.md, TOOLS.md, or the relevant skill file.
 
 ## Red Lines
 
 - Don't exfiltrate private data. Ever.
+- Don't expose personal memory content in shared/group contexts.
 - Don't run destructive commands without asking.
 - `trash` > `rm` (recoverable beats gone forever)
 - When in doubt, ask.

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -20,8 +20,7 @@ Use runtime-provided startup context first.
 That context may already include:
 
 - `AGENTS.md`, `SOUL.md`, and `USER.md`
-- recent daily memory such as `memory/YYYY-MM-DD.md`
-- `MEMORY.md` when this is the main session
+- memory context from the active memory plugin (if any)
 
 Do not manually reread startup files unless:
 
@@ -31,31 +30,9 @@ Do not manually reread startup files unless:
 
 ## Memory
 
-You wake up fresh each session. These files are your continuity:
-
-- **Daily notes:** `memory/YYYY-MM-DD.md` (create `memory/` if needed) — raw logs of what happened
-- **Long-term:** `MEMORY.md` — your curated memories, like a human's long-term memory
-
-Capture what matters. Decisions, context, things to remember. Skip the secrets unless asked to keep them.
-
-### 🧠 MEMORY.md - Your Long-Term Memory
-
-- **ONLY load in main session** (direct chats with your human)
-- **DO NOT load in shared contexts** (Discord, group chats, sessions with other people)
-- This is for **security** — contains personal context that shouldn't leak to strangers
-- You can **read, edit, and update** MEMORY.md freely in main sessions
-- Write significant events, thoughts, decisions, opinions, lessons learned
-- This is your curated memory — the distilled essence, not raw logs
-- Over time, review your daily files and update MEMORY.md with what's worth keeping
-
-### 📝 Write It Down - No "Mental Notes"!
-
-- **Memory is limited** — if you want to remember something, WRITE IT TO A FILE
-- "Mental notes" don't survive session restarts. Files do.
-- When someone says "remember this" → update `memory/YYYY-MM-DD.md` or relevant file
-- When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill
-- When you make a mistake → document it so future-you doesn't repeat it
-- **Text > Brain** 📝
+Memory persistence is handled by the active memory plugin. Use the memory tools
+available to you (visible in your tool list) to store and retrieve memories.
+If no memory plugin is active, you can use workspace files as a fallback.
 
 ## Red Lines
 
@@ -197,22 +174,10 @@ You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it
 
 **Proactive work you can do without asking:**
 
-- Read and organize memory files
+- Organize workspace files
 - Check on projects (git status, etc.)
 - Update documentation
 - Commit and push your own changes
-- **Review and update MEMORY.md** (see below)
-
-### 🔄 Memory Maintenance (During Heartbeats)
-
-Periodically (every few days), use a heartbeat to:
-
-1. Read through recent `memory/YYYY-MM-DD.md` files
-2. Identify significant events, lessons, or insights worth keeping long-term
-3. Update `MEMORY.md` with distilled learnings
-4. Remove outdated info from MEMORY.md that's no longer relevant
-
-Think of it like a human reviewing their journal and updating their mental model. Daily files are raw notes; MEMORY.md is curated wisdom.
 
 The goal: Be helpful without being annoying. Check in a few times a day, do useful background work, but respect quiet time.
 

--- a/docs/reference/templates/BOOTSTRAP.md
+++ b/docs/reference/templates/BOOTSTRAP.md
@@ -9,7 +9,7 @@ read_when:
 
 _You just woke up. Time to figure out who you are._
 
-There is no memory yet. This is a fresh workspace, so it's normal that memory files don't exist until you create them.
+There is no memory yet. This is a fresh workspace — memory will be managed by the active memory plugin once configured.
 
 ## The Conversation
 

--- a/docs/reference/templates/SOUL.md
+++ b/docs/reference/templates/SOUL.md
@@ -36,7 +36,7 @@ Be the assistant you'd actually want to talk to. Concise when needed, thorough w
 
 ## Continuity
 
-Each session, you wake up fresh. These files _are_ your memory. Read them. Update them. They're how you persist.
+Each session, you wake up fresh. Your memory plugin and workspace files are how you persist.
 
 If you change this file, tell the user — it's your soul, and they should know.
 

--- a/extensions/memory-core/src/prompt-section.ts
+++ b/extensions/memory-core/src/prompt-section.ts
@@ -63,7 +63,6 @@ export const buildPromptSection: MemoryPromptSectionBuilder = ({
     "- **Memory is limited** — if you want to remember something, WRITE IT TO A FILE",
     "- Mental notes don't survive session restarts. Files do.",
     "- When someone says \"remember this\" → update `memory/YYYY-MM-DD.md` or relevant file",
-    "- When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill",
     "- When you make a mistake → document it so future-you doesn't repeat it",
     "",
     "### Memory Maintenance (During Heartbeats)",

--- a/extensions/memory-core/src/prompt-section.ts
+++ b/extensions/memory-core/src/prompt-section.ts
@@ -33,6 +33,51 @@ export const buildPromptSection: MemoryPromptSectionBuilder = ({
       "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
     );
   }
-  lines.push("");
+
+  // File-based memory architecture instructions (moved from workspace templates
+  // so that memory-core owns its own persistence instructions and custom memory
+  // plugins can supply their own without conflicting with template content).
+  lines.push(
+    "",
+    "## Memory Persistence",
+    "",
+    "You wake up fresh each session. These files are your continuity:",
+    "",
+    "- **Daily notes:** `memory/YYYY-MM-DD.md` (create `memory/` if needed) — raw logs of what happened",
+    "- **Long-term:** `MEMORY.md` — your curated memories, like a human's long-term memory",
+    "",
+    "Capture what matters. Decisions, context, things to remember. Skip the secrets unless asked to keep them.",
+    "",
+    "### MEMORY.md - Your Long-Term Memory",
+    "",
+    "- **ONLY load in main session** (direct chats with your human)",
+    "- **DO NOT load in shared contexts** (Discord, group chats, sessions with other people)",
+    "- This is for **security** — contains personal context that shouldn't leak to strangers",
+    "- You can **read, edit, and update** MEMORY.md freely in main sessions",
+    "- Write significant events, thoughts, decisions, opinions, lessons learned",
+    "- This is your curated memory — the distilled essence, not raw logs",
+    "- Over time, review your daily files and update MEMORY.md with what's worth keeping",
+    "",
+    "### Write It Down - No Mental Notes",
+    "",
+    "- **Memory is limited** — if you want to remember something, WRITE IT TO A FILE",
+    "- Mental notes don't survive session restarts. Files do.",
+    "- When someone says \"remember this\" → update `memory/YYYY-MM-DD.md` or relevant file",
+    "- When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill",
+    "- When you make a mistake → document it so future-you doesn't repeat it",
+    "",
+    "### Memory Maintenance (During Heartbeats)",
+    "",
+    "Periodically (every few days), use a heartbeat to:",
+    "",
+    "1. Read through recent `memory/YYYY-MM-DD.md` files",
+    "2. Identify significant events, lessons, or insights worth keeping long-term",
+    "3. Update `MEMORY.md` with distilled learnings",
+    "4. Remove outdated info from MEMORY.md that's no longer relevant",
+    "",
+    "Think of it like a human reviewing their journal and updating their mental model. Daily files are raw notes; MEMORY.md is curated wisdom.",
+    "",
+  );
+
   return lines;
 };


### PR DESCRIPTION
## Summary

- **Problem:** Hardcoded file-based memory instructions in default workspace templates (AGENTS.md, SOUL.md, AGENTS.dev.md, BOOTSTRAP.md) conflict with custom memory plugins. When a user installs a plugin like formative-memory, the agent ignores the plugin's directives and edits workspace files instead, because AGENTS.md tells it to.
- **Why it matters:** Custom memory plugins need to own their own behavioral instructions without competing with template content.
- **What changed:** Moved file-based memory instructions from templates into memory-core's `buildPromptSection()`. Default users see identical behavior. Added platform-level privacy rule to Red Lines. Templates are now thinner.
- **What did NOT change (scope boundary):** memory-core's default prompt content is equivalent. Plugin SDK APIs. File conventions (MEMORY.md, `memory/YYYY-MM-DD.md`). Other workspace files (IDENTITY.md, USER.md, TOOLS.md, HEARTBEAT.md). **Existing workspaces are not modified — templates only apply to new workspace bootstraps.**

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #: None
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** The original architecture placed memory instructions in workspace templates before custom memory plugins existed. Template content shipped globally, overriding whatever a custom plugin's `promptBuilder` declared. Result: plugin instructions were effectively ignored by agents — when asked to "remember this", the agent edited workspace files (per AGENTS.md) instead of calling the plugin's tools.
- **Missing detection / guardrail:** No architectural rule preventing templates from encoding plugin-owned behavior.
- **Contributing context:** This only surfaced once custom memory plugins (e.g., formative-memory) began registering their own `promptBuilder` via `registerMemoryCapability`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: The change is string relocation, not logic. No branches were added or removed.
- Existing test that already covers this (if any): None at the string level — these are prompt-content strings.
- If no new test is added, why not: The change is string relocation, not logic. Live-verified with a real agent call — see Human Verification below.

## User-visible / Behavior Changes

- **New workspace bootstraps:** thinner templates; memory instructions come from the active memory plugin's prompt builder.
- **Existing workspaces:** AGENTS.md and other template files are NOT modified on upgrade. Users keep their current workspace content. memory-core still works identically because its `buildPromptSection` now emits the same instructions via the system prompt.
- **Custom memory plugin users with existing workspaces:** to fully benefit from plugin-owned instructions, manually remove the obsolete Memory section from existing `AGENTS.md` — otherwise template content continues to override the plugin.
- **New:** Red Lines in AGENTS.md includes \`Don't expose personal memory content in shared/group contexts.\` (platform-level safety rule, was previously inside the Memory section).

## Diagram (if applicable)

\`\`\`text
Before:
[agent wakes] -> reads AGENTS.md (contains file-based memory rules)
             -> plugin promptBuilder also emits rules
             -> conflict: template wins, plugin ignored

After:
[agent wakes] -> reads AGENTS.md (no memory-backend rules)
             -> plugin promptBuilder emits its own rules
             -> plugin owns memory behavior
\`\`\`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Note: The privacy rule "Don't expose personal memory content in shared/group contexts" moved from the Memory section to Red Lines. This makes it **more prominent** for all users, not tied to whichever memory plugin is active.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, isolated local test bot
- Model/provider: anthropic/claude-sonnet-4-6
- Integration/channel (if any): CLI (\`openclaw agent\`)
- Relevant config (redacted): default memory-core enabled, telegram/slack disabled

### Steps

1. Build versioned tarball from the PR branch (\`pnpm pack\` on top of \`v2026.4.14\`).
2. Install into an isolated test bot with memory-core enabled.
3. Run \`openclaw plugins list\` and verify memory-core is loaded.
4. Ask the agent to describe memory conventions and list Red Lines.

### Expected

- Agent describes file-based memory conventions (MEMORY.md, \`memory/YYYY-MM-DD.md\`), main-session-only rule, "write it down" discipline, and heartbeat-based maintenance.
- Red Lines includes the new privacy rule.

### Actual

- Matched expected. Agent output is quoted in Human Verification below.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

Built the tarball locally on top of \`v2026.4.14\`, installed into an isolated test bot with \`memory-core\` enabled, and ran a real agent turn.

**Verified scenarios:**

1. \`openclaw plugins list\` → \`@openclaw/memory-core\` shows as \`loaded\`.
2. Agent asked to describe memory conventions. Response (abridged):

   > **\`memory/YYYY-MM-DD.md\` — Päivämuistiinpanot**
   > Raaka loki siitä, mitä tapahtui: päätökset, konteksti, asiat joita pitää muistaa. [...] "Write it down, no mental notes" — muisti ei säily sessioiden välillä, tiedostot säilyvät.
   >
   > **\`MEMORY.md\` — Pitkäaikaismuisti**
   > Tislaus päivämuistiinpanoista: tärkeimmät oivallukset, opitut asiat [...] Käyn läpi päivätiedostoja heartbeat-sessioiden aikana ja päivitän MEMORY.md:n [...]
   >
   > **MEMORY.md ladataan vain pääsessiossa** — eli suorissa kahdenkeskisissä chateissa sinun kanssasi. **Ryhmächateissa sitä ei ladata.** Syy: MEMORY.md sisältää henkilökohtaista kontekstia [...]

3. Agent asked to list Red Lines verbatim. Response:

   > 1. Don't exfiltrate private data. Ever.
   > 2. Don't expose personal memory content in shared/group contexts.
   > 3. Don't run destructive commands without asking.
   > 4. \`trash\` > \`rm\` (recoverable beats gone forever)
   > 5. When in doubt, ask.

**Edge cases checked:**

- memory-core disabled: the plugin's \`buildPromptSection\` returns \`[]\` when memory tools are absent (pre-existing behavior, intentionally unchanged). Default users remain memory-core users.

**What I did NOT verify:**

- Custom memory plugin behavior (formative-memory, etc.) on top of the new templates. Expected to work since custom plugins already register their own \`promptBuilder\`.
- Upgrade-in-place of an existing workspace (templates only affect \`ensureAgentWorkspace\` for fresh workspaces; existing AGENTS.md is not overwritten).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes.** Existing workspaces are not patched by upgrade.
- Config/env changes? No
- Migration needed? **Only for custom memory plugin users with existing workspaces:** remove the obsolete Memory section from existing \`AGENTS.md\` manually if the plugin provides its own memory instructions. Fresh workspaces need no action.

## Risks and Mitigations

- Risk: Custom memory plugin users with existing workspaces may still see the agent follow outdated template content until they clean up their AGENTS.md.
  - Mitigation: Documented in the Compatibility / Migration section above. Future work could offer a \`openclaw doctor --fix\` path to migrate existing workspaces, but that is out of scope here.
- Risk: A custom memory plugin that replaces \`promptBuilder\` without re-emitting persistence/privacy instructions will omit those from the system prompt.
  - Mitigation: This is the intended plugin contract — plugins own their instructions. The platform-level privacy rule added to Red Lines (AGENTS.md) serves as a baseline safety guardrail that applies regardless of the active memory plugin.