### PR TITLE
Gateway: avoid hot-reload loop after plugin auto-enable persist (#67436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Gateway: after plugin auto-enable persists config at startup, seed the config-file watcher with that write hash so the first filesystem notification is not treated as an external edit (avoids hot-reload / SIGUSR1 loops that could interrupt SQLite manifest writes). (#67436)
 - Gateway/tools: anchor trusted local `MEDIA:` tool-result passthrough on the exact raw name of this run's registered built-in tools, and reject client tool definitions whose names normalize-collide with a built-in or with another client tool in the same request (`400 invalid_request_error` on both JSON and SSE paths), so a client-supplied tool named like a built-in can no longer inherit its local-media trust. (#67303)
 - Agents/replay recovery: classify the provider wording `401 input item ID does not belong to this connection` as replay-invalid, so users get the existing `/new` session reset guidance instead of a raw 401-style failure. (#66475) Thanks @dallylee.
 - Gateway/webchat: enforce localRoots containment on webchat audio embedding path [AI-assisted]. (#67298) Thanks @pgondhi987.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: after plugin auto-enable persists config at startup, seed the config-file watcher with that write hash so the first filesystem notification is not treated as an external edit (avoids hot-reload / SIGUSR1 loops that could interrupt SQLite manifest writes). (#67436)
 - Gateway/tools: anchor trusted local `MEDIA:` tool-result passthrough on the exact raw name of this run's registered built-in tools, and reject client tool definitions whose names normalize-collide with a built-in or with another client tool in the same request (`400 invalid_request_error` on both JSON and SSE paths), so a client-supplied tool named like a built-in can no longer inherit its local-media trust. (#67303)
 - Agents/replay recovery: classify the provider wording `401 input item ID does not belong to this connection` as replay-invalid, so users get the existing `/new` session reset guidance instead of a raw 401-style failure. (#66475) Thanks @dallylee.
 - Gateway/webchat: enforce localRoots containment on webchat audio embedding path [AI-assisted]. (#67298) Thanks @pgondhi987.

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -577,7 +577,7 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
-  it("dedupes the first watcher reread for startup internal writes", async () => {
+  it("dedupes the first watcher reread for startup internal writes (#67436 plugin auto-enable uses the same hash seam)", async () => {
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()
       .mockResolvedValueOnce(

--- a/src/gateway/server-startup-config.snapshot.test.ts
+++ b/src/gateway/server-startup-config.snapshot.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { buildTestConfigSnapshot } from "./test-helpers.config-snapshots.js";
+
+const startupMocks = vi.hoisted(() => ({
+  readConfigFileSnapshot: vi.fn(),
+  writeConfigFile: vi.fn(),
+  applyPluginAutoEnable: vi.fn(),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...mod,
+    readConfigFileSnapshot: startupMocks.readConfigFileSnapshot,
+    writeConfigFile: startupMocks.writeConfigFile,
+  };
+});
+
+vi.mock("../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable: (...args: unknown[]) => startupMocks.applyPluginAutoEnable(...args),
+}));
+
+import { loadGatewayStartupConfigSnapshot } from "./server-startup-config.js";
+
+function baseSnapshot(overrides: Partial<Parameters<typeof buildTestConfigSnapshot>[0]> = {}) {
+  const config: OpenClawConfig = {
+    gateway: { reload: { debounceMs: 0 } },
+  };
+  const raw = `${JSON.stringify(config, null, 2)}\n`;
+  return buildTestConfigSnapshot({
+    path: "/tmp/openclaw-gateway-startup-snapshot-test.json",
+    exists: true,
+    raw,
+    parsed: config,
+    valid: true,
+    config,
+    issues: [],
+    legacyIssues: [],
+    ...overrides,
+  });
+}
+
+describe("loadGatewayStartupConfigSnapshot", () => {
+  const log = { info: vi.fn(), warn: vi.fn() };
+
+  beforeEach(() => {
+    startupMocks.readConfigFileSnapshot.mockReset();
+    startupMocks.writeConfigFile.mockReset();
+    startupMocks.applyPluginAutoEnable.mockReset();
+    log.info.mockClear();
+    log.warn.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null persisted hash when minimalTestGateway skips auto-enable", async () => {
+    const snap = baseSnapshot();
+    startupMocks.readConfigFileSnapshot.mockResolvedValue(snap);
+    startupMocks.applyPluginAutoEnable.mockReturnValue({
+      config: snap.config,
+      changes: ["would-enable"],
+    });
+
+    const result = await loadGatewayStartupConfigSnapshot({
+      minimalTestGateway: true,
+      log,
+    });
+
+    expect(result.persistedStartupWriteHash).toBeNull();
+    expect(startupMocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("returns null persisted hash when auto-enable makes no changes", async () => {
+    const snap = baseSnapshot();
+    startupMocks.readConfigFileSnapshot.mockResolvedValue(snap);
+    startupMocks.applyPluginAutoEnable.mockReturnValue({ config: snap.config, changes: [] });
+
+    const result = await loadGatewayStartupConfigSnapshot({
+      minimalTestGateway: false,
+      log,
+    });
+
+    expect(result.persistedStartupWriteHash).toBeNull();
+    expect(startupMocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("returns post-write snapshot hash after persisting auto-enable (feeds config reloader dedupe; #67436)", async () => {
+    const before = baseSnapshot();
+    const afterWrite = baseSnapshot({
+      config: {
+        gateway: { reload: { debounceMs: 0 } },
+        plugins: { entries: { "test-plugin": { enabled: true } } },
+      },
+    });
+
+    startupMocks.readConfigFileSnapshot
+      .mockResolvedValueOnce(before)
+      .mockResolvedValueOnce(afterWrite);
+    startupMocks.writeConfigFile.mockResolvedValue(undefined);
+    startupMocks.applyPluginAutoEnable.mockReturnValue({
+      config: afterWrite.config,
+      changes: ["test-plugin: auto-enabled"],
+    });
+
+    const result = await loadGatewayStartupConfigSnapshot({
+      minimalTestGateway: false,
+      log,
+    });
+
+    expect(result.snapshot.hash).toBe(afterWrite.hash);
+    expect(result.persistedStartupWriteHash).toBe(afterWrite.hash);
+    expect(startupMocks.writeConfigFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null persisted hash when the persist write fails", async () => {
+    const snap = baseSnapshot();
+    startupMocks.readConfigFileSnapshot.mockResolvedValue(snap);
+    startupMocks.applyPluginAutoEnable.mockReturnValue({
+      config: { ...snap.config },
+      changes: ["x"],
+    });
+    startupMocks.writeConfigFile.mockRejectedValue(new Error("disk full"));
+
+    const result = await loadGatewayStartupConfigSnapshot({
+      minimalTestGateway: false,
+      log,
+    });
+
+    expect(result.persistedStartupWriteHash).toBeNull();
+    expect(result.snapshot).toBe(snap);
+    expect(log.warn).toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -47,10 +47,20 @@ type GatewayStartupConfigOverrides = {
   tailscale?: GatewayTailscaleConfig;
 };
 
+export type LoadGatewayStartupConfigSnapshotResult = {
+  snapshot: ConfigFileSnapshot;
+  /**
+   * When plugin auto-enable persists changes, this matches the on-disk config hash so the
+   * gateway config reloader can treat the subsequent filesystem notification as a no-op
+   * (avoids self-induced hot-reload / SIGUSR1 loops; see #67436).
+   */
+  persistedStartupWriteHash: string | null;
+};
+
 export async function loadGatewayStartupConfigSnapshot(params: {
   minimalTestGateway: boolean;
   log: GatewayStartupLog;
-}): Promise<ConfigFileSnapshot> {
+}): Promise<LoadGatewayStartupConfigSnapshotResult> {
   let configSnapshot = await readConfigFileSnapshot();
   if (configSnapshot.legacyIssues.length > 0 && isNixMode) {
     throw new Error(
@@ -65,7 +75,7 @@ export async function loadGatewayStartupConfigSnapshot(params: {
     ? { config: configSnapshot.config, changes: [] as string[] }
     : applyPluginAutoEnable({ config: configSnapshot.config, env: process.env });
   if (autoEnable.changes.length === 0) {
-    return configSnapshot;
+    return { snapshot: configSnapshot, persistedStartupWriteHash: null };
   }
 
   try {
@@ -75,11 +85,14 @@ export async function loadGatewayStartupConfigSnapshot(params: {
     params.log.info(
       `gateway: auto-enabled plugins:\n${autoEnable.changes.map((entry) => `- ${entry}`).join("\n")}`,
     );
+    return {
+      snapshot: configSnapshot,
+      persistedStartupWriteHash: configSnapshot.hash ?? null,
+    };
   } catch (err) {
     params.log.warn(`gateway: failed to persist plugin auto-enable changes: ${String(err)}`);
+    return { snapshot: configSnapshot, persistedStartupWriteHash: null };
   }
-
-  return configSnapshot;
 }
 
 export function createRuntimeSecretsActivator(params: {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -221,10 +221,11 @@ export async function startGatewayServer(
     description: "raw stream log path override",
   });
 
-  const configSnapshot = await loadGatewayStartupConfigSnapshot({
-    minimalTestGateway,
-    log,
-  });
+  const { snapshot: configSnapshot, persistedStartupWriteHash } =
+    await loadGatewayStartupConfigSnapshot({
+      minimalTestGateway,
+      log,
+    });
 
   const emitSecretsStateEvent = (
     code: "SECRETS_RELOADER_DEGRADED" | "SECRETS_RELOADER_RECOVERED",
@@ -242,7 +243,7 @@ export async function startGatewayServer(
   });
 
   let cfgAtStart: OpenClawConfig;
-  let startupInternalWriteHash: string | null = null;
+  let startupInternalWriteHash: string | null = persistedStartupWriteHash;
   const startupRuntimeConfig = applyConfigOverrides(configSnapshot.config);
   const authBootstrap = await prepareGatewayStartupConfig({
     configSnapshot,


### PR DESCRIPTION
## Summary

- Problem: Startup \pplyPluginAutoEnable\ writes \openclaw.json\; the config file watcher treated that as an external change, could hot-reload / SIGUSR1 repeatedly, and race SQLite manifest writes (#67436).
- Why it matters: Repeated restarts can corrupt \manifest.db\ / plugin registry state on disk.
- What changed: \loadGatewayStartupConfigSnapshot\ now returns \persistedStartupWriteHash\ after a successful auto-enable write; \server.impl\ seeds \startupInternalWriteHash\ with it (same seam as token / Control UI seed writes) so the reloader dedupes the first watcher notification.
- What did NOT change: Reload/restart policy, watcher debounce, or plugin auto-enable logic itself.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #67436
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: \startupInternalWriteHash\ was only set after auth token or Control UI allowed-origins seed writes, not after plugin auto-enable persistence, so \initialInternalWriteHash\ did not match the post-startup disk hash.
- Missing detection / guardrail: Startup internal writes were not uniformly represented for the config reloader.
- Contributing context: chokidar \change\ events after \writeConfigFile\ during gateway bring-up.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: \src/gateway/server-startup-config.snapshot.test.ts\; existing \config-reload.test.ts\ \dedupes the first watcher reread for startup internal writes\.
- Scenario the test should lock in: After persist, returned hash matches reloader initial hash so first watcher pass does not restart.
- Why this is the smallest reliable guardrail: Asserts the startup path exports the same hash the reloader uses for dedupe.
- Existing test that already covers this: \config-reload.test.ts\ reloader harness with \initialInternalWriteHash\.

## User-visible / Behavior Changes

None (startup stability only).

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows (local dev); CI Linux
- Runtime/container: Node 22 / Vitest

### Steps

1. \pnpm test src/gateway/server-startup-config.snapshot.test.ts\
2. \pnpm test src/gateway/config-reload.test.ts\

### Expected

Tests pass.

### Actual

Both pass locally.

## Evidence

- [x] Failing test/log before + passing after (new unit tests + existing reloader test documents the seam)

## Human Verification (required)

- Verified scenarios: Unit tests for hash return + existing reloader dedupe behavior.
- Edge cases checked: Write failure returns null hash; minimal test gateway skips persist.
- What I did not verify: Full gateway E2E on Linux VPS (issue environment).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.