### PR TITLE
feat(media-understanding): add native Kesha Voice Kit CLI output parser

### DIFF
--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -75,6 +75,36 @@ function trimOutput(text: string, maxChars?: number): string {
   return trimmed.slice(0, maxChars).trim();
 }
 
+/** Kesha Voice Kit (`kesha --json`): `[{ text, lang, textLanguage?, audioLanguage? }]` */
+function extractKeshaText(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("[")) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return null;
+    }
+    const first = parsed[0] as Record<string, unknown>;
+    if (typeof first.text !== "string" || !first.text.trim()) {
+      return null;
+    }
+    const text = first.text.trim();
+    const langObj = (first.textLanguage ?? first.audioLanguage) as
+      | { code?: unknown; confidence?: unknown }
+      | undefined;
+    const code = typeof langObj?.code === "string" ? langObj.code : typeof first.lang === "string" ? first.lang : null;
+    if (!code) {
+      return text;
+    }
+    const conf = typeof langObj?.confidence === "number" ? `, confidence: ${langObj.confidence.toFixed(2)}` : "";
+    return `${text}\n[lang: ${code}${conf}]`;
+  } catch {
+    return null;
+  }
+}
+
 function extractSherpaOnnxText(raw: string): string | null {
   const tryParse = (value: string): string | null => {
     const trimmed = value.trim();
@@ -209,6 +239,13 @@ async function resolveCliOutput(params: {
 
   if (commandId === "sherpa-onnx-offline") {
     const response = extractSherpaOnnxText(params.stdout);
+    if (response) {
+      return response;
+    }
+  }
+
+  if (commandId === "kesha" || commandId === "parakeet") {
+    const response = extractKeshaText(params.stdout);
     if (response) {
       return response;
     }


### PR DESCRIPTION
## Summary

Add native CLI output parsing for [Kesha Voice Kit](https://github.com/drakulavich/kesha-voice-kit) — a local speech-to-text tool (NVIDIA Parakeet TDT 0.6B, 25 languages, CoreML on Apple Silicon / ONNX elsewhere, ~19x faster than Whisper).

When `kesha` is used with `--json` as a `type: "cli"` audio model, it outputs structured JSON:

```json
[{"file":"voice.ogg","text":"Таити, Таити!","lang":"ru","textLanguage":{"code":"ru","confidence":1.0}}]
```

Without this patch, the raw JSON blob is passed to the agent context. With it, `resolveCliOutput` recognizes `kesha` (and its backward-compat alias `parakeet`) and extracts a clean transcript:

```
Таити, Таити!
[lang: ru, confidence: 1.00]
```

## How it works

`extractKeshaText()` in `runner.entries.ts`:
- Fires only when stdout starts with `[` and parses as a JSON array
- Extracts `.text` from the first element
- Appends `[lang: xx, confidence: N.NN]` from `.textLanguage` or `.audioLanguage` when available
- Falls through to `stdout.trim()` on any parse failure — plain-text mode (`kesha` without `--json`) continues unchanged

## Recommended user config

```json5
{
  tools: {
    media: {
      audio: {
        enabled: true,
        models: [
          { type: "cli", command: "kesha", args: ["--json", "{{MediaPath}}"] }
        ],
      },
    },
  },
}
```

Or for plain text without language metadata:
```json5
{ type: "cli", command: "kesha", args: ["{{MediaPath}}"] }
```

## Install

```bash
curl -fsSL https://bun.sh/install | bash   # Bun runtime
bun add -g @drakulavich/kesha-voice-kit
kesha install
```

## Changes

- `src/media-understanding/runner.entries.ts`: add `extractKeshaText()` function + `kesha`/`parakeet` cases in `resolveCliOutput`