### PR TITLE
fix: suppress self-induced config hot-reload loop

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,6 +3,7 @@ export {
   ConfigRuntimeRefreshError,
   clearRuntimeConfigSnapshot,
   registerConfigWriteListener,
+  registerPendingConfigWriteNotifier,
   createConfigIO,
   getRuntimeConfig,
   getRuntimeConfigSnapshot,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -75,7 +75,9 @@ import {
   getRuntimeConfigSnapshot as getRuntimeConfigSnapshotState,
   getRuntimeConfigSourceSnapshot as getRuntimeConfigSourceSnapshotState,
   loadPinnedRuntimeConfig,
+  notifyPendingConfigWrite,
   notifyRuntimeConfigWriteListeners,
+  registerPendingConfigWriteListener,
   registerRuntimeConfigWriteListener,
   resetConfigRuntimeState as resetConfigRuntimeStateState,
   setRuntimeConfigSnapshot as setRuntimeConfigSnapshotState,
@@ -1668,6 +1670,12 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         await maintainConfigBackups(configPath, deps.fs.promises);
       }
 
+      // Notify watchers of the pending write hash before the atomic rename so
+      // the config reloader can suppress the self-induced file-change event.
+      // On Linux (inotify), chokidar can fire before the post-write
+      // notification arrives, causing a spurious hot-reload cycle (#67436).
+      notifyPendingConfigWrite({ configPath, persistedHash: nextHash });
+
       try {
         await deps.fs.promises.rename(tmp, configPath);
       } catch (err) {
@@ -1734,6 +1742,14 @@ export function registerConfigWriteListener(
   listener: (event: ConfigWriteNotification) => void,
 ): () => void {
   return registerRuntimeConfigWriteListener(listener);
+}
+
+export type { PendingConfigWriteNotification } from "./runtime-snapshot.js";
+
+export function registerPendingConfigWriteNotifier(
+  listener: (event: { configPath: string; persistedHash: string }) => void,
+): () => void {
+  return registerPendingConfigWriteListener(listener);
 }
 
 function isCompatibleTopLevelRuntimeProjectionShape(params: {

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -17,10 +17,16 @@ export type RuntimeConfigWriteNotification = {
   writtenAtMs: number;
 };
 
+export type PendingConfigWriteNotification = {
+  configPath: string;
+  persistedHash: string;
+};
+
 let runtimeConfigSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSourceSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSnapshotRefreshHandler: RuntimeConfigSnapshotRefreshHandler | null = null;
 const runtimeConfigWriteListeners = new Set<(event: RuntimeConfigWriteNotification) => void>();
+const pendingConfigWriteListeners = new Set<(event: PendingConfigWriteNotification) => void>();
 
 export function setRuntimeConfigSnapshot(
   config: OpenClawConfig,
@@ -72,6 +78,25 @@ export function notifyRuntimeConfigWriteListeners(event: RuntimeConfigWriteNotif
       listener(event);
     } catch {
       // Best-effort observer path only; successful writes must still complete.
+    }
+  }
+}
+
+export function registerPendingConfigWriteListener(
+  listener: (event: PendingConfigWriteNotification) => void,
+): () => void {
+  pendingConfigWriteListeners.add(listener);
+  return () => {
+    pendingConfigWriteListeners.delete(listener);
+  };
+}
+
+export function notifyPendingConfigWrite(event: PendingConfigWriteNotification): void {
+  for (const listener of pendingConfigWriteListeners) {
+    try {
+      listener(event);
+    } catch {
+      // Best-effort; must not block the write path.
     }
   }
 }

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -370,6 +370,9 @@ function createReloaderHarness(
   const onHotReload = vi.fn(async () => {});
   const onRestart = vi.fn();
   let writeListener: ((event: ConfigWriteNotification) => void) | null = null;
+  let pendingWriteListener:
+    | ((event: { configPath: string; persistedHash: string }) => void)
+    | null = null;
   const subscribeToWrites = vi.fn((listener: (event: ConfigWriteNotification) => void) => {
     writeListener = listener;
     return () => {
@@ -378,6 +381,16 @@ function createReloaderHarness(
       }
     };
   });
+  const subscribeToPendingWrites = vi.fn(
+    (listener: (event: { configPath: string; persistedHash: string }) => void) => {
+      pendingWriteListener = listener;
+      return () => {
+        if (pendingWriteListener === listener) {
+          pendingWriteListener = null;
+        }
+      };
+    },
+  );
   const log = {
     info: vi.fn(),
     warn: vi.fn(),
@@ -388,6 +401,7 @@ function createReloaderHarness(
     initialInternalWriteHash: options.initialInternalWriteHash,
     readSnapshot,
     subscribeToWrites,
+    subscribeToPendingWrites,
     onHotReload,
     onRestart,
     log,
@@ -401,6 +415,9 @@ function createReloaderHarness(
     reloader,
     emitWrite(event: ConfigWriteNotification) {
       writeListener?.(event);
+    },
+    emitPendingWrite(event: { configPath: string; persistedHash: string }) {
+      pendingWriteListener?.(event);
     },
   };
 }
@@ -612,6 +629,33 @@ describe("startGatewayConfigReloader", () => {
 
     expect(readSnapshot).toHaveBeenCalledTimes(2);
     expect(harness.onRestart).toHaveBeenCalledTimes(1);
+
+    await harness.reloader.stop();
+  });
+
+  it("suppresses watcher reload when pending write hash matches snapshot (#67436)", async () => {
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValue(
+      makeSnapshot({
+        config: { gateway: { reload: { debounceMs: 0 }, port: 19999 } },
+        hash: "self-write-hash-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot);
+
+    // Simulate the pre-write notification arriving before chokidar fires
+    harness.emitPendingWrite({
+      configPath: "/tmp/openclaw.json",
+      persistedHash: "self-write-hash-1",
+    });
+
+    // chokidar fires after the atomic rename
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    // The snapshot was read but the reload was suppressed because the hash matched
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(harness.onHotReload).not.toHaveBeenCalled();
+    expect(harness.onRestart).not.toHaveBeenCalled();
 
     await harness.reloader.stop();
   });

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -81,6 +81,9 @@ export function startGatewayConfigReloader(opts: {
   onHotReload: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => Promise<void>;
   onRestart: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
   subscribeToWrites?: (listener: (event: ConfigWriteNotification) => void) => () => void;
+  subscribeToPendingWrites?: (
+    listener: (event: { configPath: string; persistedHash: string }) => void,
+  ) => () => void;
   log: {
     info: (msg: string) => void;
     warn: (msg: string) => void;
@@ -256,6 +259,17 @@ export function startGatewayConfigReloader(opts: {
       scheduleAfter(0);
     }) ?? (() => {});
 
+  // Subscribe to pre-write notifications so the hash is set before the atomic
+  // rename hits disk.  This closes the race where chokidar fires before the
+  // post-write notification arrives, causing a spurious reload (#67436).
+  const unsubscribeFromPendingWrites =
+    opts.subscribeToPendingWrites?.((event) => {
+      if (event.configPath !== opts.watchPath) {
+        return;
+      }
+      lastAppliedWriteHash = event.persistedHash;
+    }) ?? (() => {});
+
   watcher.on("add", scheduleFromWatcher);
   watcher.on("change", scheduleFromWatcher);
   watcher.on("unlink", scheduleFromWatcher);
@@ -278,6 +292,7 @@ export function startGatewayConfigReloader(opts: {
       debounceTimer = null;
       watcherClosed = true;
       unsubscribeFromWrites();
+      unsubscribeFromPendingWrites();
       await watcher.close().catch(() => {});
     },
   };

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -253,6 +253,7 @@ export function startManagedGatewayConfigReloader(params: {
   watchPath: string;
   readSnapshot: typeof import("../config/config.js").readConfigFileSnapshot;
   subscribeToWrites: typeof import("../config/config.js").registerConfigWriteListener;
+  subscribeToPendingWrites: typeof import("../config/config.js").registerPendingConfigWriteNotifier;
   deps: CliDeps;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   getState: () => GatewayHotReloadState;
@@ -304,6 +305,7 @@ export function startManagedGatewayConfigReloader(params: {
     initialInternalWriteHash: params.initialInternalWriteHash,
     readSnapshot: params.readSnapshot,
     subscribeToWrites: params.subscribeToWrites,
+    subscribeToPendingWrites: params.subscribeToPendingWrites,
     onHotReload: async (plan, nextConfig) => {
       const previousSharedGatewaySessionGeneration =
         params.sharedGatewaySessionGenerationState.current;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -12,6 +12,7 @@ import {
   loadConfig,
   readConfigFileSnapshot,
   registerConfigWriteListener,
+  registerPendingConfigWriteNotifier,
   writeConfigFile,
 } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -777,6 +778,7 @@ export async function startGatewayServer(
       watchPath: configSnapshot.path,
       readSnapshot: readConfigFileSnapshot,
       subscribeToWrites: registerConfigWriteListener,
+      subscribeToPendingWrites: registerPendingConfigWriteNotifier,
       deps,
       broadcast,
       getState: () => ({


### PR DESCRIPTION
## Summary

Fixes #67436 — Gateway self-induced hot-reload loop corrupts manifest.db on Linux VPS.

## Problem

When the gateway auto-provisions plugins on boot, it writes `openclaw.json` via atomic rename (`.tmp.<PID>`). On Linux with inotify, chokidar fires *before* the post-write notification arrives in the same process, so the config reloader sees the change as external → schedules SIGUSR1 → restart → repeat every 3-6 min. If Manifest/SQLite is mid-write during SIGUSR1, `manifest.db` gets corrupted.

## Fix

Added a **pre-write notification** (`notifyPendingConfigWrite`) that sets `lastAppliedWriteHash` *before* the atomic rename hits disk. This closes the race window: when chokidar fires, the reloader already knows the hash and skips the reload.

### Changes:
- `src/config/runtime-snapshot.ts`: New `PendingConfigWriteNotification` type + listener set
- `src/config/io.ts`: Call `notifyPendingConfigWrite()` before `fs.rename()`, export `registerPendingConfigWriteNotifier()`
- `src/config/config.ts`: Re-export the new API
- `src/gateway/config-reload.ts`: Accept `subscribeToPendingWrites` option, set hash on pre-write
- `src/gateway/server-reload-handlers.ts`: Wire up the pending write subscriber
- `src/gateway/server.impl.ts`: Pass the subscriber through

## Testing

All 32 existing config-reload tests pass + new test added for the pre-write suppression path.