### PR TITLE
fix: prevent crash in clearPluginInteractiveHandlersState when callbackDedupe is undefined

### DIFF
--- a/src/plugins/interactive-state.ts
+++ b/src/plugins/interactive-state.ts
@@ -74,6 +74,6 @@ export function releasePluginInteractiveCallbackDedupe(dedupeKey: string | undef
 
 export function clearPluginInteractiveHandlersState(): void {
   getPluginInteractiveHandlersState().clear();
-  getPluginInteractiveCallbackDedupeState().clear();
+  getPluginInteractiveCallbackDedupeState()?.clear();
   getState().inflightCallbackDedupe.clear();
 }


### PR DESCRIPTION
## Summary
Fixes a crash in `openclaw doctor` where `clearPluginInteractiveHandlersState` throws "Cannot read properties of undefined (reading 'clear')".

## Root Cause
In `src/plugins/interactive-state.ts`, the `clearPluginInteractiveHandlersState()` function calls `getPluginInteractiveCallbackDedupeState().clear()` without checking if the return value is undefined. When the plugin interactive state hasn't been fully initialized (e.g., during the doctor flow), this causes a TypeError.

## Fix
Added optional chaining (`?.`) when calling `.clear()` on the callback dedupe state, matching the pattern already used elsewhere in the codebase for defensive null checks.

## Test Plan
- [x] Build passes
- [x] Code follows existing patterns in the file

Closes openclaw#67525