### PR TITLE
Gateway: ignore plugins.installs timestamp-only paths for reload (#49474)

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -1,4 +1,6 @@
+import { isDeepStrictEqual } from "node:util";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 
 export type ChannelKind = ChannelId;
@@ -16,6 +18,89 @@ export type GatewayReloadPlan = {
   restartChannels: Set<ChannelKind>;
   noopPaths: string[];
 };
+
+const INSTALL_RECORD_METADATA_FIELDS = ["resolvedAt", "installedAt"] as const;
+type InstallRecordMetadataField = (typeof INSTALL_RECORD_METADATA_FIELDS)[number];
+const INSTALL_RECORD_METADATA_FIELD_SET = new Set<string>(INSTALL_RECORD_METADATA_FIELDS);
+
+/**
+ * Plugin install records (`plugins.installs.<id>.*`) refresh `resolvedAt` / `installedAt` during
+ * npm installs and runtime self-updates without changing `plugins.entries` or other effective
+ * gateway config. Only suppress leaf-field updates when the same install record exists on both
+ * sides and every changed field is metadata, so dotted plugin ids like `foo.resolvedAt` do not
+ * cause whole-record additions/removals to be misclassified as metadata-only changes (#49474).
+ */
+export function listPluginInstallRecordMetadataOnlyPaths(params: {
+  prevInstalls?: Record<string, PluginInstallRecord>;
+  nextInstalls?: Record<string, PluginInstallRecord>;
+}): Set<string> {
+  const prevInstalls = params.prevInstalls ?? {};
+  const nextInstalls = params.nextInstalls ?? {};
+  const suppressedPaths = new Set<string>();
+  const pluginIds = new Set([...Object.keys(prevInstalls), ...Object.keys(nextInstalls)]);
+
+  for (const pluginId of pluginIds) {
+    const prevRecord = prevInstalls[pluginId];
+    const nextRecord = nextInstalls[pluginId];
+    if (!prevRecord || !nextRecord) {
+      continue;
+    }
+
+    const changedFields: InstallRecordMetadataField[] = [];
+    const recordKeys = new Set([...Object.keys(prevRecord), ...Object.keys(nextRecord)]);
+    let hasNonMetadataChange = false;
+
+    for (const key of recordKeys) {
+      const typedKey = key as keyof PluginInstallRecord;
+      if (isDeepStrictEqual(prevRecord[typedKey], nextRecord[typedKey])) {
+        continue;
+      }
+      if (!INSTALL_RECORD_METADATA_FIELD_SET.has(key)) {
+        hasNonMetadataChange = true;
+        break;
+      }
+      changedFields.push(key as InstallRecordMetadataField);
+    }
+
+    if (hasNonMetadataChange || changedFields.length === 0) {
+      continue;
+    }
+
+    for (const field of changedFields) {
+      suppressedPaths.add(`plugins.installs.${pluginId}.${field}`);
+    }
+  }
+
+  return suppressedPaths;
+}
+
+/**
+ * Paths emitted as a single prefix when an install record is added or removed
+ * (`diffConfigPaths` returns `plugins.installs.<id>` when one side is missing and the other is an object).
+ * These strings collide with metadata leaf paths like `plugins.installs.foo.resolvedAt` when the plugin id
+ * is literally `foo.resolvedAt` (whole record) vs plugin `foo` field `resolvedAt` (metadata).
+ */
+export function listPluginInstallRecordWholeRecordPaths(params: {
+  prevInstalls?: Record<string, PluginInstallRecord>;
+  nextInstalls?: Record<string, PluginInstallRecord>;
+}): Set<string> {
+  const prevInstalls = params.prevInstalls ?? {};
+  const nextInstalls = params.nextInstalls ?? {};
+  const paths = new Set<string>();
+  const pluginIds = new Set([...Object.keys(prevInstalls), ...Object.keys(nextInstalls)]);
+
+  for (const pluginId of pluginIds) {
+    const prevRecord = prevInstalls[pluginId];
+    const nextRecord = nextInstalls[pluginId];
+    const hasPrev = prevRecord !== undefined;
+    const hasNext = nextRecord !== undefined;
+    if (hasPrev !== hasNext) {
+      paths.add(`plugins.installs.${pluginId}`);
+    }
+  }
+
+  return paths;
+}
 
 type ReloadRule = {
   prefix: string;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -6,9 +6,18 @@ import {
 } from "../agents/skills/refresh-state.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
-import type { ConfigFileSnapshot, ConfigWriteNotification } from "../config/config.js";
+import type {
+  ConfigFileSnapshot,
+  ConfigWriteNotification,
+  OpenClawConfig,
+} from "../config/config.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import {
+  listPluginInstallRecordMetadataOnlyPaths,
+  listPluginInstallRecordWholeRecordPaths,
+} from "./config-reload-plan.js";
 import {
   buildGatewayReloadPlan,
   diffConfigPaths,
@@ -87,6 +96,132 @@ describe("diffConfigPaths", () => {
     };
 
     expect(diffConfigPaths(prev, next)).toEqual(["agents.list"]);
+  });
+
+  it("emits duplicate path strings when dotted plugin ids collide with metadata leaves (#49474)", () => {
+    const prev = {
+      plugins: {
+        installs: {
+          foo: {
+            source: "npm",
+            resolvedAt: "2026-01-01T00:00:00.000Z",
+            installedAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      },
+    };
+    const next = {
+      plugins: {
+        installs: {
+          foo: {
+            source: "npm",
+            resolvedAt: "2026-03-17T21:01:05.607Z",
+            installedAt: "2026-01-01T00:00:00.000Z",
+          },
+          "foo.resolvedAt": { source: "npm", version: "1.0.0" },
+        },
+      },
+    };
+    const paths = diffConfigPaths(prev, next);
+    expect(paths.filter((p) => p === "plugins.installs.foo.resolvedAt").length).toBe(2);
+  });
+});
+
+describe("listPluginInstallRecordWholeRecordPaths", () => {
+  it("lists prefix paths for added or removed install records", () => {
+    expect(
+      listPluginInstallRecordWholeRecordPaths({
+        prevInstalls: { a: { source: "npm" } },
+        nextInstalls: { a: { source: "npm" }, b: { source: "npm" } },
+      }),
+    ).toEqual(new Set(["plugins.installs.b"]));
+    expect(
+      listPluginInstallRecordWholeRecordPaths({
+        prevInstalls: { a: { source: "npm" } },
+        nextInstalls: {},
+      }),
+    ).toEqual(new Set(["plugins.installs.a"]));
+  });
+
+  it("flags dotted ids whose path collides with metadata leaves (#49474)", () => {
+    expect(
+      listPluginInstallRecordWholeRecordPaths({
+        prevInstalls: { foo: { source: "npm", resolvedAt: "a", installedAt: "b" } },
+        nextInstalls: {
+          foo: { source: "npm", resolvedAt: "c", installedAt: "b" },
+          "foo.resolvedAt": { source: "npm", version: "1.0.0" },
+        },
+      }),
+    ).toEqual(new Set(["plugins.installs.foo.resolvedAt"]));
+  });
+});
+
+describe("listPluginInstallRecordMetadataOnlyPaths", () => {
+  it("returns install-record timestamp leaves when metadata is the only change (#49474)", () => {
+    const initialInstall: PluginInstallRecord = {
+      source: "npm",
+      resolvedAt: "2026-01-01T00:00:00.000Z",
+      installedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    expect(
+      listPluginInstallRecordMetadataOnlyPaths({
+        prevInstalls: {
+          "lossless-claw": initialInstall,
+          "@scoped/pkg": initialInstall,
+        },
+        nextInstalls: {
+          "lossless-claw": {
+            ...initialInstall,
+            resolvedAt: "2026-03-17T21:01:05.607Z",
+            installedAt: "2026-03-17T21:01:29.442Z",
+          },
+          "@scoped/pkg": {
+            ...initialInstall,
+            resolvedAt: "2026-03-18T00:00:00.000Z",
+          },
+        },
+      }),
+    ).toEqual(
+      new Set([
+        "plugins.installs.lossless-claw.resolvedAt",
+        "plugins.installs.lossless-claw.installedAt",
+        "plugins.installs.@scoped/pkg.resolvedAt",
+      ]),
+    );
+  });
+
+  it("does not suppress whole-record changes for dotted plugin ids ending in metadata names", () => {
+    const suppressed = listPluginInstallRecordMetadataOnlyPaths({
+      prevInstalls: {},
+      nextInstalls: {
+        "demo.resolvedAt": { source: "npm", version: "1.0.0" },
+        "demo.installedAt": { source: "npm", version: "1.0.0" },
+      },
+    });
+
+    expect(suppressed).toEqual(new Set());
+  });
+
+  it("does not treat non-metadata install fields as metadata-only", () => {
+    const initialInstall: PluginInstallRecord = {
+      source: "npm",
+      version: "1.0.0",
+      resolvedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    expect(
+      listPluginInstallRecordMetadataOnlyPaths({
+        prevInstalls: { demo: initialInstall },
+        nextInstalls: {
+          demo: {
+            ...initialInstall,
+            version: "2.0.0",
+            resolvedAt: "2026-03-18T00:00:00.000Z",
+          },
+        },
+      }),
+    ).toEqual(new Set());
   });
 });
 
@@ -400,6 +535,7 @@ function createReloaderHarness(
   readSnapshot: () => Promise<ConfigFileSnapshot>,
   options: {
     initialInternalWriteHash?: string | null;
+    initialConfig?: OpenClawConfig;
     recoverSnapshot?: (snapshot: ConfigFileSnapshot, reason: string) => Promise<boolean>;
     promoteSnapshot?: (snapshot: ConfigFileSnapshot, reason: string) => Promise<boolean>;
     onRecovered?: (params: {
@@ -428,7 +564,7 @@ function createReloaderHarness(
     error: vi.fn(),
   };
   const reloader = startGatewayConfigReloader({
-    initialConfig: { gateway: { reload: { debounceMs: 0 } } },
+    initialConfig: options.initialConfig ?? { gateway: { reload: { debounceMs: 0 } } },
     initialInternalWriteHash: options.initialInternalWriteHash,
     readSnapshot,
     recoverSnapshot: options.recoverSnapshot,
@@ -505,6 +641,146 @@ describe("startGatewayConfigReloader", () => {
     expect(log.warn).toHaveBeenCalledWith("config reload skipped (config file not found)");
 
     await reloader.stop();
+  });
+
+  it("ignores plugins.installs timestamp-only disk changes for reload (#49474)", async () => {
+    const initialInstall: PluginInstallRecord = {
+      source: "npm",
+      resolvedAt: "2026-01-01T00:00:00.000Z",
+      installedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const initialConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      plugins: {
+        installs: {
+          "lossless-claw": initialInstall,
+        },
+      },
+    };
+    const nextConfig: OpenClawConfig = {
+      ...initialConfig,
+      plugins: {
+        installs: {
+          "lossless-claw": {
+            ...initialInstall,
+            resolvedAt: "2026-03-17T21:01:05.607Z",
+            installedAt: "2026-03-17T21:01:29.442Z",
+          },
+        },
+      },
+    };
+    const readSnapshot = vi.fn().mockResolvedValue(makeSnapshot({ config: nextConfig }));
+    const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(harness.onHotReload).not.toHaveBeenCalled();
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    expect(harness.log.info).toHaveBeenCalledWith(
+      expect.stringContaining("config change suppressed (install-record metadata only:"),
+    );
+    await harness.reloader.stop();
+  });
+
+  it("restarts when install metadata collides with a dotted plugin id add (#49474)", async () => {
+    const initialInstall: PluginInstallRecord = {
+      source: "npm",
+      resolvedAt: "2026-01-01T00:00:00.000Z",
+      installedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const initialConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      plugins: {
+        installs: {
+          foo: initialInstall,
+        },
+      },
+    };
+    const nextConfig: OpenClawConfig = {
+      ...initialConfig,
+      plugins: {
+        installs: {
+          foo: {
+            ...initialInstall,
+            resolvedAt: "2026-03-17T21:01:05.607Z",
+          },
+          "foo.resolvedAt": { source: "npm", version: "1.0.0" },
+        },
+      },
+    };
+    const readSnapshot = vi.fn().mockResolvedValue(makeSnapshot({ config: nextConfig }));
+    const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(harness.log.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("config change suppressed (install-record metadata only:"),
+    );
+    await harness.reloader.stop();
+  });
+
+  it("does not restart when install timestamps change alongside noop metadata", async () => {
+    const initialInstall: PluginInstallRecord = {
+      source: "npm",
+      resolvedAt: "2026-01-01T00:00:00.000Z",
+      installedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const initialConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      meta: { lastTouchedAt: "2026-01-01T00:00:00.000Z" },
+      plugins: {
+        installs: {
+          "lossless-claw": initialInstall,
+        },
+      },
+    };
+    const nextConfig: OpenClawConfig = {
+      ...initialConfig,
+      meta: { lastTouchedAt: "2026-03-17T21:02:00.000Z" },
+      plugins: {
+        installs: {
+          "lossless-claw": {
+            ...initialInstall,
+            resolvedAt: "2026-03-17T21:01:05.607Z",
+            installedAt: "2026-03-17T21:01:29.442Z",
+          },
+        },
+      },
+    };
+    const readSnapshot = vi.fn().mockResolvedValue(makeSnapshot({ config: nextConfig }));
+    const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    expect(harness.onHotReload).toHaveBeenCalledTimes(1);
+    expect(harness.log.info).toHaveBeenCalledWith(
+      "config change detected; evaluating reload (meta.lastTouchedAt)",
+    );
+    await harness.reloader.stop();
+  });
+
+  it("still restarts when plugins.installs changes a non-metadata field", async () => {
+    const initialConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      plugins: {
+        installs: {
+          "lossless-claw": { source: "npm", version: "1.0.0" },
+        },
+      },
+    };
+    const nextConfig: OpenClawConfig = {
+      ...initialConfig,
+      plugins: {
+        installs: {
+          "lossless-claw": { source: "npm", version: "2.0.0" },
+        },
+      },
+    };
+    const readSnapshot = vi.fn().mockResolvedValue(makeSnapshot({ config: nextConfig }));
+    const harness = createReloaderHarness(readSnapshot, { initialConfig });
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    await harness.reloader.stop();
   });
 
   it("contains restart callback failures and retries on subsequent changes", async () => {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -9,7 +9,12 @@ import type {
 } from "../config/config.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { isPlainObject } from "../utils.js";
-import { buildGatewayReloadPlan, type GatewayReloadPlan } from "./config-reload-plan.js";
+import {
+  buildGatewayReloadPlan,
+  listPluginInstallRecordMetadataOnlyPaths,
+  listPluginInstallRecordWholeRecordPaths,
+  type GatewayReloadPlan,
+} from "./config-reload-plan.js";
 
 export { buildGatewayReloadPlan };
 export type { ChannelKind, GatewayReloadPlan } from "./config-reload-plan.js";
@@ -214,10 +219,32 @@ export function startGatewayConfigReloader(opts: {
   };
 
   const applySnapshot = async (nextConfig: OpenClawConfig) => {
-    const changedPaths = diffConfigPaths(currentConfig, nextConfig);
+    const rawChangedPaths = diffConfigPaths(currentConfig, nextConfig);
+    const metadataOnlyPaths = listPluginInstallRecordMetadataOnlyPaths({
+      prevInstalls: currentConfig.plugins?.installs,
+      nextInstalls: nextConfig.plugins?.installs,
+    });
+    const wholeRecordPaths = listPluginInstallRecordWholeRecordPaths({
+      prevInstalls: currentConfig.plugins?.installs,
+      nextInstalls: nextConfig.plugins?.installs,
+    });
     currentConfig = nextConfig;
     settings = resolveGatewayReloadSettings(nextConfig);
+    const changedPaths = rawChangedPaths.filter((path) => {
+      if (wholeRecordPaths.has(path)) {
+        return true;
+      }
+      if (metadataOnlyPaths.has(path)) {
+        return false;
+      }
+      return true;
+    });
     if (changedPaths.length === 0) {
+      if (rawChangedPaths.length > 0) {
+        opts.log.info(
+          `config change suppressed (install-record metadata only: ${rawChangedPaths.join(", ")})`,
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

- **Problem:** Runtime plugin installs only bump `plugins.installs.<id>.resolvedAt` / `.installedAt`. The reload plan used a broad `plugins → restart` rule, so hybrid mode scheduled a full gateway restart for timestamp-only churn (#49474).
- **Why it matters:** Install bookkeeping is not the same as changing `plugins.entries` or loading new plugins; timestamp-only updates should not stop the process.
- **What changed:** Before building the reload plan, drop diff paths that are **only** install-record metadata leaves, using structural comparison of `plugins.installs` records (`listPluginInstallRecordMetadataOnlyPaths`) so dotted plugin ids do not collide with whole-record add/remove. Emit an info log when all changes are suppressed. Rebase conflict in `config-reload.test.ts` harness merged `initialConfig` with upstream `recoverSnapshot` / `promoteSnapshot` / `onRecovered` options.
- **What did NOT change:** Other `plugins.installs` field edits (for example version bumps) still trigger restart under the existing rule.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49474
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** The `plugins` prefix matched all `plugins.*` paths, including install-metadata timestamps.
- **Missing detection / guardrail:** No filtering of metadata-only install record diffs before evaluating restart.

## Regression Test Plan (if applicable)

- **Coverage level:** Unit tests in `src/gateway/config-reload.test.ts` (including reloader integration and `listPluginInstallRecordMetadataOnlyPaths` cases).

## User-visible / Behavior Changes

- Gateway no longer treats timestamp-only updates under `plugins.installs` as a restart trigger when that is the only effective change; other install-record changes can still restart.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
