### PR TITLE
fix(session): clear auto-fallback model overrides on /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -306,6 +306,7 @@ export async function initSessionState(params: {
   let persistedReasoning: string | undefined;
   let persistedTtsAuto: TtsAutoMode | undefined;
   let persistedModelOverride: string | undefined;
+  let persistedModelOverrideSource: SessionEntry["modelOverrideSource"];
   let persistedProviderOverride: string | undefined;
   let persistedAuthProfileOverride: string | undefined;
   let persistedAuthProfileOverrideSource: SessionEntry["authProfileOverrideSource"];
@@ -461,6 +462,7 @@ export async function initSessionState(params: {
     persistedReasoning = entry.reasoningLevel;
     persistedTtsAuto = entry.ttsAuto;
     persistedModelOverride = entry.modelOverride;
+    persistedModelOverrideSource = entry.modelOverrideSource;
     persistedProviderOverride = entry.providerOverride;
     persistedAuthProfileOverride = entry.authProfileOverride;
     persistedAuthProfileOverrideSource = entry.authProfileOverrideSource;
@@ -480,11 +482,25 @@ export async function initSessionState(params: {
       persistedTrace = entry.traceLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
-      persistedAuthProfileOverride = entry.authProfileOverride;
-      persistedAuthProfileOverrideSource = entry.authProfileOverrideSource;
-      persistedAuthProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;
+      // Only preserve user-explicit model overrides across resets; auto-
+      // fallback overrides (modelOverrideSource === "auto") should be cleared
+      // so the session falls back to the configured default.  Legacy entries
+      // without a source field are treated as user-explicit for backward
+      // compatibility (same logic as gateway session-reset-service).
+      const preserveModelOverride =
+        entry.modelOverrideSource === "user" ||
+        (entry.modelOverrideSource === undefined && Boolean(entry.modelOverride));
+      if (preserveModelOverride) {
+        persistedModelOverride = entry.modelOverride;
+        persistedModelOverrideSource = "user";
+        persistedProviderOverride = entry.providerOverride;
+      }
+      // Same treatment for auth profile overrides.
+      if (entry.authProfileOverrideSource === "user" && entry.authProfileOverride) {
+        persistedAuthProfileOverride = entry.authProfileOverride;
+        persistedAuthProfileOverrideSource = entry.authProfileOverrideSource;
+        persistedAuthProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;
+      }
       // Explicit /new and /reset should rotate the underlying CLI conversation too.
       // Keep the model/auth choice, but force the next turn to mint a fresh CLI binding.
       persistedLabel = entry.label;
@@ -579,6 +595,7 @@ export async function initSessionState(params: {
     ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
     responseUsage: baseEntry?.responseUsage,
     modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
+    modelOverrideSource: persistedModelOverrideSource ?? baseEntry?.modelOverrideSource,
     providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
     authProfileOverride: persistedAuthProfileOverride ?? baseEntry?.authProfileOverride,
     authProfileOverrideSource:


### PR DESCRIPTION
## Summary

Aligns the reply pipeline's `/new` and `/reset` handling with the gateway's `sessions.reset` service by applying source-aware model override preservation during session resets.

## Problem

When the reply pipeline handles `/new` or `/reset` chat commands, it unconditionally carries over `modelOverride` and `providerOverride` from the previous session. This means auto-fallback model overrides (set by the system during rate-limit or error recovery) persist across explicit "start fresh" commands, preventing the session from falling back to the configured `agents.defaults.model`.

The gateway's `sessions.reset` RPC already handles this correctly via `resolveResetPreservedSelection()`, but the reply pipeline had no equivalent logic.

Fixes #67573

## Changes

**`src/auto-reply/reply/session.ts`** — single file, 22 insertions / 5 deletions:

1. **Source-aware model override preservation**: During `/new` or `/reset`, only user-explicit overrides (`modelOverrideSource === "user"`) are carried over. Auto-fallback overrides (`modelOverrideSource === "auto"`) are now cleared.

2. **Legacy backward compatibility**: Older sessions without a `modelOverrideSource` field but with a `modelOverride` present are treated as user-explicit (same as the gateway's logic).

3. **Auth profile override parity**: Same source-aware filtering applied to `authProfileOverride` — only user-set overrides survive resets.

4. **`modelOverrideSource` pipeline**: Added `persistedModelOverrideSource` to the session state pipeline so the source field is properly read, carried, and persisted through session entry construction. Backfills `"user"` for preserved overrides.

## Behavior

| Override source | Before this PR | After this PR |
|----------------|---------------|--------------|
| User (`/model gpt-5.4`) | Preserved ✅ | Preserved ✅ |
| Legacy (no source field) | Preserved ✅ | Preserved ✅ |
| Auto-fallback (rate limit) | Preserved ❌ | Cleared ✅ |
| No override | N/A | N/A |

## Testing

The logic mirrors `resolveResetPreservedSelection()` in `src/gateway/session-reset-service.ts`, which has existing test coverage in `server.sessions.gateway-server-sessions-a.test.ts` for all three scenarios (user override preserved, auto-fallback cleared, legacy backfilled).