### PR TITLE
fix(memory-core): stop dreaming from promoting transport metadata

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -448,7 +448,19 @@ jobs:
           if [[ -n "${OPENCLAW_DISCORD_SMOKE_BOT_TOKEN}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_GUILD_ID}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_CHANNEL_ID}" ]]; then
             DISCORD_ARGS+=(--run-discord-roundtrip true)
           fi
-          node --disable-warning=ExperimentalWarning scripts/openclaw-cross-os-release-checks.ts             --candidate-tgz "${CHECK_CANDIDATE_TGZ}"             --candidate-version "${CHECK_CANDIDATE_VERSION}"             --source-sha "${CHECK_SOURCE_SHA}"             --baseline-spec "${CHECK_BASELINE_SPEC}"             --previous-version "${CHECK_PREVIOUS_VERSION}"             --baseline-tgz "${CHECK_BASELINE_TGZ}"             --provider "${CHECK_PROVIDER}"             --mode "${CHECK_MODE}"             --suite "${CHECK_SUITE}"             --ref "${CHECK_REF}"             "${DISCORD_ARGS[@]}"             --output-dir "${CHECK_OUTPUT_DIR}"
+          node --disable-warning=ExperimentalWarning workflow/scripts/openclaw-cross-os-release-checks.ts \
+            --candidate-tgz "${CHECK_CANDIDATE_TGZ}" \
+            --candidate-version "${CHECK_CANDIDATE_VERSION}" \
+            --source-sha "${CHECK_SOURCE_SHA}" \
+            --baseline-spec "${CHECK_BASELINE_SPEC}" \
+            --previous-version "${CHECK_PREVIOUS_VERSION}" \
+            --baseline-tgz "${CHECK_BASELINE_TGZ}" \
+            --provider "${CHECK_PROVIDER}" \
+            --mode "${CHECK_MODE}" \
+            --suite "${CHECK_SUITE}" \
+            --ref "${CHECK_REF}" \
+            "${DISCORD_ARGS[@]}" \
+            --output-dir "${CHECK_OUTPUT_DIR}"
       - name: Summarize release checks
         if: always()
         shell: bash

--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -432,25 +432,23 @@ jobs:
           OPENCLAW_DISCORD_SMOKE_CHANNEL_ID: ${{ secrets.OPENCLAW_DISCORD_SMOKE_CHANNEL_ID }}
           OPENCLAW_RELEASE_CHECK_OS: ${{ matrix.os_id }}
           OPENCLAW_RELEASE_CHECK_RUNNER: ${{ matrix.runner }}
+          CHECK_CANDIDATE_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/candidate/${{ needs.prepare.outputs.candidate_file_name }}
+          CHECK_CANDIDATE_VERSION: ${{ needs.prepare.outputs.candidate_version }}
+          CHECK_SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+          CHECK_BASELINE_SPEC: ${{ needs.prepare.outputs.baseline_spec }}
+          CHECK_PREVIOUS_VERSION: ${{ inputs.previous_version }}
+          CHECK_BASELINE_TGZ: ${{ runner.temp }}/openclaw-cross-os-release-checks/baseline/${{ needs.prepare.outputs.baseline_file_name }}
+          CHECK_PROVIDER: ${{ inputs.provider }}
+          CHECK_MODE: ${{ matrix.lane }}
+          CHECK_SUITE: ${{ matrix.suite }}
+          CHECK_REF: ${{ inputs.ref }}
+          CHECK_OUTPUT_DIR: ${{ runner.temp }}/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}-${{ matrix.suite }}
         run: |
           DISCORD_ARGS=()
           if [[ -n "${OPENCLAW_DISCORD_SMOKE_BOT_TOKEN}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_GUILD_ID}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_CHANNEL_ID}" ]]; then
             DISCORD_ARGS+=(--run-discord-roundtrip true)
           fi
-          pnpm dlx "tsx@${TSX_VERSION}" workflow/scripts/openclaw-cross-os-release-checks.ts \
-            --candidate-tgz "$RUNNER_TEMP/openclaw-cross-os-release-checks/candidate/${{ needs.prepare.outputs.candidate_file_name }}" \
-            --candidate-version "${{ needs.prepare.outputs.candidate_version }}" \
-            --source-sha "${{ needs.prepare.outputs.source_sha }}" \
-            --baseline-spec "${{ needs.prepare.outputs.baseline_spec }}" \
-            --previous-version "${{ inputs.previous_version }}" \
-            --baseline-tgz "$RUNNER_TEMP/openclaw-cross-os-release-checks/baseline/${{ needs.prepare.outputs.baseline_file_name }}" \
-            --provider "${{ inputs.provider }}" \
-            --mode "${{ matrix.lane }}" \
-            --suite "${{ matrix.suite }}" \
-            --ref "${{ inputs.ref }}" \
-            "${DISCORD_ARGS[@]}" \
-            --output-dir "$RUNNER_TEMP/openclaw-cross-os-release-checks/${{ matrix.artifact_name }}-${{ matrix.suite }}"
-
+          node --disable-warning=ExperimentalWarning scripts/openclaw-cross-os-release-checks.ts             --candidate-tgz "${CHECK_CANDIDATE_TGZ}"             --candidate-version "${CHECK_CANDIDATE_VERSION}"             --source-sha "${CHECK_SOURCE_SHA}"             --baseline-spec "${CHECK_BASELINE_SPEC}"             --previous-version "${CHECK_PREVIOUS_VERSION}"             --baseline-tgz "${CHECK_BASELINE_TGZ}"             --provider "${CHECK_PROVIDER}"             --mode "${CHECK_MODE}"             --suite "${CHECK_SUITE}"             --ref "${CHECK_REF}"             "${DISCORD_ARGS[@]}"             --output-dir "${CHECK_OUTPUT_DIR}"
       - name: Summarize release checks
         if: always()
         shell: bash

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1328,6 +1328,54 @@ describe("memory-core dreaming phases", () => {
     });
   });
 
+  it("keeps legitimate daily snippets that include JSON examples with metadata keys", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "Review the retry payload format:",
+        "```json",
+        '{"message_id":"evt_123","type":"webhook","content":"Hello"}',
+        "```",
+        "Notes: use the id to correlate retries.",
+      ]);
+
+      const { beforeAgentReply } = createLightDreamingHarness(workspaceDir);
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+
+      const snippets = await readCandidateSnippets(workspaceDir, "2026-04-05T10:05:00.000Z");
+      expect(snippets.some((snippet) => snippet.includes("Review the retry payload format:"))).toBe(
+        true,
+      );
+      expect(snippets.some((snippet) => snippet.includes('"message_id":"evt_123"'))).toBe(true);
+      expect(
+        snippets.some((snippet) => snippet.includes("Notes: use the id to correlate retries.")),
+      ).toBe(true);
+    });
+  });
+
+  it("sanitizes mixed daily snippets before they become recall candidates", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"5417","sender_id":"289522496"}',
+        "```",
+        "Keep gateway on localhost only.",
+      ]);
+
+      const { beforeAgentReply } = createLightDreamingHarness(workspaceDir);
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+
+      const snippets = await readCandidateSnippets(workspaceDir, "2026-04-05T10:05:00.000Z");
+      expect(snippets).toEqual(["Keep gateway on localhost only."]);
+    });
+  });
+
   it("blocks metadata contamination from reaching MEMORY.md in a dreaming sweep", async () => {
     const workspaceDir = await createDreamingWorkspace();
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -10,6 +10,7 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import { __testing } from "./dreaming-phases.js";
 import {
+  applyShortTermPromotions,
   rankShortTermPromotionCandidates,
   recordShortTermRecalls,
   resolveShortTermPhaseSignalStorePath,
@@ -619,6 +620,176 @@ describe("memory-core dreaming phases", () => {
     expect(corpus).toContain("OPENAI_API_KEY=sk-123…cdef");
   });
 
+  it("strips inbound metadata wrappers before writing session corpus", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:01:00.000Z",
+            content: [
+              {
+                type: "text",
+                text: [
+                  "Conversation info (untrusted metadata):",
+                  "```json",
+                  '{"message_id":"5417","sender_id":"289522496"}',
+                  "```",
+                ].join("\n"),
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:02:00.000Z",
+            content: [{ type: "text", text: "Move backups to S3 Glacier. [[reply_to_current]]" }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const mtime = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, mtime, mtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await withDreamingTestClock(async () => {
+        await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const corpusPath = path.join(
+      workspaceDir,
+      "memory",
+      ".dreams",
+      "session-corpus",
+      "2026-04-05.txt",
+    );
+    const corpus = await fs.readFile(corpusPath, "utf-8");
+    expect(corpus).toContain("Move backups to S3 Glacier.");
+    expect(corpus).not.toContain("Conversation info (untrusted metadata)");
+    expect(corpus).not.toContain('"message_id":"5417"');
+    expect(corpus).not.toContain("[[reply_to_current]]");
+  });
+
+  it("preserves inline reply tags when the message is discussing them literally", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:02:00.000Z",
+            content: [
+              {
+                type: "text",
+                text: "Parser should strip [[reply_to_current]] before sending the final message body.",
+              },
+            ],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const mtime = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, mtime, mtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await withDreamingTestClock(async () => {
+        await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const corpusPath = path.join(
+      workspaceDir,
+      "memory",
+      ".dreams",
+      "session-corpus",
+      "2026-04-05.txt",
+    );
+    const corpus = await fs.readFile(corpusPath, "utf-8");
+    expect(corpus).toContain("Parser should strip [[reply_to_current]] before sending");
+  });
+
   it("skips dreaming-generated narrative transcripts during session ingestion", async () => {
     const workspaceDir = await createDreamingWorkspace();
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
@@ -1133,6 +1304,135 @@ describe("memory-core dreaming phases", () => {
     const dayCorpus = await fs.readFile(path.join(corpusDir, "2026-04-05.txt"), "utf-8");
     expect(dayCorpus).toContain("Current reminder that should be in today corpus.");
     expect(dayCorpus).not.toContain("Old planning note that should stay out of lookback.");
+  });
+
+  it("does not re-ingest polluted daily metadata chunks into recall candidates", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "Conversation info (untrusted metadata):",
+        "```json",
+        '{"message_id":"5417","sender_id":"289522496"}',
+        "```",
+        "",
+        "- Keep gateway on localhost only.",
+      ]);
+
+      const { beforeAgentReply } = createLightDreamingHarness(workspaceDir);
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+
+      const snippets = await readCandidateSnippets(workspaceDir, "2026-04-05T10:05:00.000Z");
+      expect(snippets).toEqual(["Keep gateway on localhost only."]);
+    });
+  });
+
+  it("blocks metadata contamination from reaching MEMORY.md in a dreaming sweep", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:01:00.000Z",
+            content: [
+              {
+                type: "text",
+                text: [
+                  "Sender (untrusted metadata):",
+                  "```json",
+                  '{"sender_id":"289522496","message_id":"5421"}',
+                  "```",
+                ].join("\n"),
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            timestamp: "2026-04-05T18:02:00.000Z",
+            content: [{ type: "text", text: "Keep gateway on localhost only." }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const mtime = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, mtime, mtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await withDreamingTestClock(async () => {
+        await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const ranked = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-05T19:00:00.000Z"),
+    });
+    expect(ranked.map((candidate) => candidate.snippet)).toEqual([
+      "Assistant: Keep gateway on localhost only.",
+    ]);
+
+    const applied = await applyShortTermPromotions({
+      workspaceDir,
+      candidates: ranked,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-05T19:00:00.000Z"),
+    });
+    expect(applied.applied).toBe(1);
+
+    const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+    expect(memoryText).toContain("Keep gateway on localhost only.");
+    expect(memoryText).not.toContain("Sender (untrusted metadata)");
+    expect(memoryText).not.toContain("message_id");
+    expect(memoryText).not.toContain("5421");
   });
 
   it("drains >80 unseen transcript messages across multiple unchanged sweeps", async () => {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -52,13 +52,15 @@ type RunPhaseIfTriggeredParams = {
 } & (
   | {
       phase: "light";
-      config: MemoryLightDreamingConfig & DreamingPhaseStorageConfig;
+      config: DreamingPhaseLightConfig;
     }
   | {
       phase: "rem";
-      config: MemoryRemDreamingConfig & DreamingPhaseStorageConfig;
+      config: DreamingPhaseRemConfig;
     }
 );
+interface DreamingPhaseLightConfig extends MemoryLightDreamingConfig, DreamingPhaseStorageConfig {}
+interface DreamingPhaseRemConfig extends MemoryRemDreamingConfig, DreamingPhaseStorageConfig {}
 const LIGHT_SLEEP_EVENT_TEXT = "__openclaw_memory_core_light_sleep__";
 const REM_SLEEP_EVENT_TEXT = "__openclaw_memory_core_rem_sleep__";
 const DAILY_MEMORY_FILENAME_RE = /^(\d{4}-\d{2}-\d{2})\.md$/;
@@ -166,6 +168,9 @@ function normalizeDailySnippet(line: string): string | null {
   const trimmed = line.trim();
   if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("<!--")) {
     return null;
+  }
+  if (trimmed === "```json" || trimmed === "```") {
+    return trimmed;
   }
   const withoutListMarker = normalizeDailyListMarker(trimmed);
   if (withoutListMarker.length < DAILY_INGESTION_MIN_SNIPPET_CHARS) {
@@ -612,10 +617,7 @@ function buildSessionRenderedLine(params: {
   return `[${source}] ${params.snippet}`.slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS + 64);
 }
 
-function resolveSessionAgentsForWorkspace(
-  cfg: OpenClawConfig | undefined,
-  workspaceDir: string,
-): string[] {
+function resolveSessionAgentsForWorkspace(workspaceDir: string, cfg?: OpenClawConfig): string[] {
   if (!cfg) {
     return [];
   }
@@ -692,7 +694,7 @@ async function collectSessionIngestionBatches(params: {
         Object.keys(params.state.seenMessages).length > 0,
     };
   }
-  const agentIds = resolveSessionAgentsForWorkspace(params.cfg, params.workspaceDir);
+  const agentIds = resolveSessionAgentsForWorkspace(params.workspaceDir, params.cfg);
   const cutoffMs = calculateLookbackCutoffMs(params.nowMs, params.lookbackDays);
   const batchByDay = new Map<string, SessionIngestionMessage[]>();
   const nextFiles: Record<string, SessionIngestionFileState> = {};
@@ -1081,7 +1083,8 @@ async function collectDailyIngestionBatches(params: {
     const chunks = buildDailySnippetChunks(lines, perFileCap);
     const results: MemorySearchResult[] = [];
     for (const chunk of chunks) {
-      if (isMetadataGarbageText(chunk.snippet)) {
+      const snippet = sanitizeDreamingMetadataText(chunk.snippet);
+      if (!snippet || isMetadataGarbageText(snippet)) {
         continue;
       }
       results.push({
@@ -1089,7 +1092,7 @@ async function collectDailyIngestionBatches(params: {
         startLine: chunk.startLine,
         endLine: chunk.endLine,
         score: DAILY_INGESTION_SCORE,
-        snippet: chunk.snippet,
+        snippet,
         source: "memory",
       });
       if (results.length >= perFileCap || total + results.length >= totalCap) {
@@ -1231,7 +1234,8 @@ export async function seedHistoricalDailyMemorySignals(params: {
     const chunks = buildDailySnippetChunks(lines, perFileCap);
     const results: MemorySearchResult[] = [];
     for (const chunk of chunks) {
-      if (isMetadataGarbageText(chunk.snippet)) {
+      const snippet = sanitizeDreamingMetadataText(chunk.snippet);
+      if (!snippet || isMetadataGarbageText(snippet)) {
         continue;
       }
       results.push({
@@ -1239,7 +1243,7 @@ export async function seedHistoricalDailyMemorySignals(params: {
         startLine: chunk.startLine,
         endLine: chunk.endLine,
         score: DAILY_INGESTION_SCORE,
-        snippet: chunk.snippet,
+        snippet,
         source: "memory",
       });
       if (results.length >= perFileCap || importedSignalCount + results.length >= totalCap) {
@@ -1489,10 +1493,7 @@ export function previewRemDreaming(params: {
 async function runLightDreaming(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
-  config: MemoryLightDreamingConfig & {
-    timezone?: string;
-    storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
-  };
+  config: DreamingPhaseLightConfig;
   logger: Logger;
   subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
   nowMs?: number;
@@ -1569,10 +1570,7 @@ async function runLightDreaming(params: {
 async function runRemDreaming(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
-  config: MemoryRemDreamingConfig & {
-    timezone?: string;
-    storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
-  };
+  config: DreamingPhaseRemConfig;
   logger: Logger;
   subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
   nowMs?: number;

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -22,7 +22,13 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
 import { generateAndAppendDreamNarrative, type NarrativePhaseData } from "./dreaming-narrative.js";
-import { asRecord, formatErrorMessage, normalizeTrimmedString } from "./dreaming-shared.js";
+import {
+  asRecord,
+  formatErrorMessage,
+  isMetadataGarbageText,
+  normalizeTrimmedString,
+  sanitizeDreamingMetadataText,
+} from "./dreaming-shared.js";
 import {
   readShortTermRecallEntries,
   recordDreamingPhaseSignals,
@@ -546,7 +552,10 @@ function trimTrackedSessionScopes(
 }
 
 function normalizeSessionCorpusSnippet(value: string): string {
-  return value.replace(/\s+/g, " ").trim().slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS);
+  return sanitizeDreamingMetadataText(value)
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS);
 }
 
 function hashSessionMessageId(value: string): string {
@@ -830,7 +839,7 @@ async function collectSessionIngestionBatches(params: {
       lastScannedContentLine = index + 1;
       const rawSnippet = lines[index] ?? "";
       const snippet = normalizeSessionCorpusSnippet(rawSnippet);
-      if (snippet.length < SESSION_INGESTION_MIN_SNIPPET_CHARS) {
+      if (snippet.length < SESSION_INGESTION_MIN_SNIPPET_CHARS || isMetadataGarbageText(snippet)) {
         continue;
       }
       const lineNumber = entry.lineMap[index] ?? index + 1;
@@ -1072,6 +1081,9 @@ async function collectDailyIngestionBatches(params: {
     const chunks = buildDailySnippetChunks(lines, perFileCap);
     const results: MemorySearchResult[] = [];
     for (const chunk of chunks) {
+      if (isMetadataGarbageText(chunk.snippet)) {
+        continue;
+      }
       results.push({
         path: relativePath,
         startLine: chunk.startLine,
@@ -1219,6 +1231,9 @@ export async function seedHistoricalDailyMemorySignals(params: {
     const chunks = buildDailySnippetChunks(lines, perFileCap);
     const results: MemorySearchResult[] = [];
     for (const chunk of chunks) {
+      if (isMetadataGarbageText(chunk.snippet)) {
+        continue;
+      }
       results.push({
         path: `memory/${entry.day}.md`,
         startLine: chunk.startLine,

--- a/extensions/memory-core/src/dreaming-shared.test.ts
+++ b/extensions/memory-core/src/dreaming-shared.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isMetadataGarbageText, sanitizeDreamingMetadataText } from "./dreaming-shared.js";
+
+describe("memory-core dreaming shared helpers", () => {
+  it("preserves non-transcript bracket prefixes when no role follows", () => {
+    expect(sanitizeDreamingMetadataText("[P1] rotate keys weekly")).toBe("[P1] rotate keys weekly");
+    expect(sanitizeDreamingMetadataText("[Fri 2026-04-17 09:00] outage recap")).toBe(
+      "[Fri 2026-04-17 09:00] outage recap",
+    );
+  });
+
+  it("still strips transcript scaffolding when a chat role follows", () => {
+    expect(
+      sanitizeDreamingMetadataText(
+        "[slack] [Fri 2026-04-17 09:00] User: Move backups to S3 Glacier. [[reply_to_current]]",
+      ),
+    ).toBe("User: Move backups to S3 Glacier.");
+  });
+
+  it("treats reordered JSON metadata payloads as transport garbage", () => {
+    expect(isMetadataGarbageText('{"type":"message","message_id":"5417"}')).toBe(true);
+    expect(isMetadataGarbageText("Webhook parser expects message_id: 5417 for retries.")).toBe(
+      false,
+    );
+  });
+});

--- a/extensions/memory-core/src/dreaming-shared.test.ts
+++ b/extensions/memory-core/src/dreaming-shared.test.ts
@@ -23,4 +23,33 @@ describe("memory-core dreaming shared helpers", () => {
       false,
     );
   });
+
+  it("strips sentinel-only wrappers that continue in a fenced JSON block", () => {
+    const snippet = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      "{",
+      '  "type": "message",',
+      '  "message_id": "5417",',
+      '  "sender_id": "289522496"',
+      "}",
+      "```",
+    ].join("\n");
+
+    expect(sanitizeDreamingMetadataText(snippet)).toBe("");
+    expect(isMetadataGarbageText(snippet)).toBe(true);
+  });
+
+  it("strips sentinel-wrapped pretty JSON and preserves trailing content", () => {
+    const snippet = [
+      "Conversation info (untrusted metadata): ```json",
+      "{",
+      '  "type": "message",',
+      '  "message_id": "5417"',
+      "}",
+      "``` Keep the follow-up note.",
+    ].join("\n");
+
+    expect(sanitizeDreamingMetadataText(snippet)).toBe("Keep the follow-up note.");
+  });
 });

--- a/extensions/memory-core/src/dreaming-shared.ts
+++ b/extensions/memory-core/src/dreaming-shared.ts
@@ -128,6 +128,60 @@ function unwrapMetadataFence(text: string): string {
   return (fencedMatch[1] ?? "").trim();
 }
 
+function hasJsonMetadataPayload(text: string): boolean {
+  const trimmed = unwrapMetadataFence(text);
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return false;
+  }
+  return JSON_METADATA_KEY_RE.test(trimmed);
+}
+
+function consumeSentinelWrappedJsonBlock(
+  lines: string[],
+  startIndex: number,
+): {
+  endIndex: number;
+  trailingText: string | null;
+} | null {
+  const line = (lines[startIndex] ?? "").trim();
+  const sentinel = METADATA_BLOCK_SENTINELS.find((candidate) => line.startsWith(candidate));
+  if (!sentinel) {
+    return null;
+  }
+
+  const remainder = line.slice(sentinel.length).trim();
+  let payloadStartIndex = -1;
+  if (remainder === "") {
+    if ((lines[startIndex + 1] ?? "").trim() !== "```json") {
+      return null;
+    }
+    payloadStartIndex = startIndex + 2;
+  } else if (remainder === "```json") {
+    payloadStartIndex = startIndex + 1;
+  } else {
+    return null;
+  }
+
+  let payloadEndIndex = payloadStartIndex;
+  while (payloadEndIndex < lines.length) {
+    const closingLine = (lines[payloadEndIndex] ?? "").trim();
+    if (closingLine.startsWith("```")) {
+      const payload = lines.slice(payloadStartIndex, payloadEndIndex).join("\n").trim();
+      if (payload && !isStandaloneMetadataText(payload) && !hasJsonMetadataPayload(payload)) {
+        return null;
+      }
+      const trailingText = closingLine.slice(3).trim();
+      return {
+        endIndex: payloadEndIndex,
+        trailingText: trailingText || null,
+      };
+    }
+    payloadEndIndex += 1;
+  }
+
+  return null;
+}
+
 function stripLeadingMetadataWrapper(text: string): string | null {
   const { body } = stripRolePrefix(text);
   const trimmed = body.trim();
@@ -143,13 +197,16 @@ function stripLeadingMetadataWrapper(text: string): string | null {
     if (fencedWithTailMatch) {
       const payload = (fencedWithTailMatch[1] ?? "").trim();
       const trailing = (fencedWithTailMatch[2] ?? "").trim();
-      if (!payload || !isStandaloneMetadataText(payload)) {
+      if (!payload) {
+        return trailing;
+      }
+      if (!isStandaloneMetadataText(payload) && !hasJsonMetadataPayload(payload)) {
         return null;
       }
       return trailing;
     }
     const unfenced = unwrapMetadataFence(rest);
-    if (isStandaloneMetadataText(unfenced)) {
+    if (isStandaloneMetadataText(unfenced) || hasJsonMetadataPayload(unfenced)) {
       return "";
     }
     return null;
@@ -169,20 +226,21 @@ export function sanitizeDreamingMetadataText(text: string): string {
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
     const trimmed = line.trim();
+    const consumedBlock = consumeSentinelWrappedJsonBlock(lines, index);
+    if (consumedBlock) {
+      if (consumedBlock.trailingText) {
+        result.push(consumedBlock.trailingText);
+      }
+      index = consumedBlock.endIndex;
+      continue;
+    }
+    if (isMetadataSentinelLine(trimmed)) {
+      continue;
+    }
     const strippedWrapper = stripLeadingMetadataWrapper(trimmed);
     if (strippedWrapper !== null) {
       if (strippedWrapper) {
         result.push(strippedWrapper);
-      }
-      continue;
-    }
-    if (isMetadataSentinelLine(trimmed)) {
-      if ((lines[index + 1] ?? "").trim() === "```json") {
-        index += 2;
-        while (index < lines.length && (lines[index] ?? "").trim() !== "```") {
-          index += 1;
-        }
-        continue;
       }
       continue;
     }

--- a/extensions/memory-core/src/dreaming-shared.ts
+++ b/extensions/memory-core/src/dreaming-shared.ts
@@ -21,12 +21,11 @@ const INLINE_METADATA_TAG_TRAILING_RE = new RegExp(
   `\\s+${INLINE_METADATA_TAG_RE.source}\\s*$`,
   "i",
 );
+const JSON_METADATA_LINE_START_RE = /^\s*(?:[{[]|,|")/;
 const JSON_METADATA_KEY_RE =
   /"(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|timestamp|thread_id)"\s*:/i;
 const TEXT_METADATA_KEY_RE =
   /\b(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|thread_id)\s*[:=]/i;
-const JSON_METADATA_LINE_RE =
-  /^\s*(?:[{[,]|\s)*"(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|timestamp|thread_id)"\s*:\s*.+$/i;
 const TEXT_METADATA_LINE_RE =
   /^\s*(?:[-*]\s*)?(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|thread_id)\s*[:=]\s*.+$/i;
 
@@ -60,7 +59,7 @@ function stripRolePrefix(text: string): { prefix: string; body: string } {
   const timestampStripped = sourceStripped.replace(LEADING_TIMESTAMP_PREFIX_RE, "");
   const match = timestampStripped.match(ROLE_PREFIX_RE);
   if (!match) {
-    return { prefix: "", body: timestampStripped };
+    return { prefix: "", body: text };
   }
   return { prefix: match[0], body: timestampStripped.slice(match[0].length) };
 }
@@ -84,7 +83,7 @@ function isStandaloneMetadataLine(line: string): boolean {
   if (/^[{}[\],]+$/.test(line) || line === "```json" || line === "```") {
     return true;
   }
-  if (JSON_METADATA_LINE_RE.test(line)) {
+  if (JSON_METADATA_LINE_START_RE.test(line) && JSON_METADATA_KEY_RE.test(line)) {
     return true;
   }
   if (TEXT_METADATA_LINE_RE.test(line)) {

--- a/extensions/memory-core/src/dreaming-shared.ts
+++ b/extensions/memory-core/src/dreaming-shared.ts
@@ -1,6 +1,25 @@
 export { asNullableRecord as asRecord } from "openclaw/plugin-sdk/text-runtime";
 export { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
+const LEADING_TIMESTAMP_PREFIX_RE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] */;
+const ROLE_PREFIX_RE = /^(User|Assistant):\s*/;
+const METADATA_BLOCK_SENTINELS = [
+  "Conversation info (untrusted metadata):",
+  "Sender (untrusted metadata):",
+  "Thread starter (untrusted, for context):",
+  "Replied message (untrusted, for context):",
+  "Forwarded message context (untrusted metadata):",
+  "Chat history since last reply (untrusted, for context):",
+  "System (untrusted metadata):",
+  "System (untrusted):",
+  "## Inbound Context (trusted metadata)",
+] as const;
+const INLINE_METADATA_TAG_RE = /\[\[\s*reply_to(?:_current|:[^[\]]+)\s*]]/i;
+const JSON_METADATA_KEY_RE =
+  /"(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|timestamp|thread_id)"\s*:/i;
+const TEXT_METADATA_KEY_RE =
+  /\b(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|thread_id)\s*[:=]/i;
+
 export function normalizeTrimmedString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -19,4 +38,146 @@ export function includesSystemEventToken(cleanedBody: string, eventText: string)
     return true;
   }
   return normalizedBody.split(/\r?\n/).some((line) => line.trim() === normalizedEventText);
+}
+
+function isMetadataSentinelLine(line: string): boolean {
+  const trimmed = line.trim();
+  return METADATA_BLOCK_SENTINELS.some((sentinel) => sentinel === trimmed);
+}
+
+function extractMetadataWrapperPayload(text: string): string | null {
+  const trimmed = text.trim();
+  for (const sentinel of METADATA_BLOCK_SENTINELS) {
+    if (!trimmed.startsWith(sentinel)) {
+      continue;
+    }
+    return trimmed.slice(sentinel.length).trim();
+  }
+  return null;
+}
+
+function stripRolePrefix(text: string): { prefix: string; body: string } {
+  const timestampStripped = text.replace(LEADING_TIMESTAMP_PREFIX_RE, "");
+  const match = timestampStripped.match(ROLE_PREFIX_RE);
+  if (!match) {
+    return { prefix: "", body: timestampStripped };
+  }
+  return { prefix: match[0], body: timestampStripped.slice(match[0].length) };
+}
+
+function normalizeSanitizedText(text: string): string {
+  return text.replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function stripInlineMetadataTag(line: string): string {
+  const trimmed = line.trim();
+  if (!INLINE_METADATA_TAG_RE.test(trimmed)) {
+    return line;
+  }
+  if (trimmed.match(new RegExp(`^${INLINE_METADATA_TAG_RE.source}$`, "i"))) {
+    return "";
+  }
+  return line.replace(
+    new RegExp(`\\s+${INLINE_METADATA_TAG_RE.source}\\s*$`, "i"),
+    "",
+  );
+}
+
+function isStandaloneMetadataText(text: string): boolean {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return false;
+  }
+
+  let matchedMetadataLine = false;
+  for (const line of lines) {
+    if (/^[{}[\],]+$/.test(line) || line === "```json" || line === "```") {
+      continue;
+    }
+    if (JSON_METADATA_KEY_RE.test(line) || TEXT_METADATA_KEY_RE.test(line)) {
+      matchedMetadataLine = true;
+      continue;
+    }
+    return false;
+  }
+
+  return matchedMetadataLine;
+}
+
+export function sanitizeDreamingMetadataText(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  const { prefix, body } = stripRolePrefix(text);
+  const lines = body.split(/\r?\n/);
+  const result: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const trimmed = line.trim();
+    if (isMetadataSentinelLine(trimmed)) {
+      if ((lines[index + 1] ?? "").trim() === "```json") {
+        index += 2;
+        while (index < lines.length && (lines[index] ?? "").trim() !== "```") {
+          index += 1;
+        }
+        continue;
+      }
+      continue;
+    }
+    if (trimmed === "```json" && JSON_METADATA_KEY_RE.test(lines[index + 1] ?? "")) {
+      index += 1;
+      while (index < lines.length && (lines[index] ?? "").trim() !== "```") {
+        index += 1;
+      }
+      continue;
+    }
+    result.push(line);
+  }
+
+  let sanitized = result.join("\n");
+  sanitized = sanitized
+    .split(/\r?\n/)
+    .map((line) => stripInlineMetadataTag(line))
+    .filter((line) => line.trim().length > 0)
+    .join("\n");
+  sanitized = normalizeSanitizedText(sanitized);
+  if (!sanitized) {
+    return "";
+  }
+  return prefix ? `${prefix}${sanitized}` : sanitized;
+}
+
+export function isMetadataGarbageText(text: string): boolean {
+  const normalized = normalizeTrimmedString(text);
+  if (!normalized) {
+    return false;
+  }
+  if (isStandaloneMetadataText(normalized)) {
+    return true;
+  }
+
+  const wrapperPayload = extractMetadataWrapperPayload(normalized);
+  if (wrapperPayload !== null) {
+    if (!wrapperPayload) {
+      return true;
+    }
+    if (isStandaloneMetadataText(wrapperPayload)) {
+      return true;
+    }
+  }
+
+  const sanitized = sanitizeDreamingMetadataText(normalized);
+  const sanitizedNormalized = normalizeTrimmedString(sanitized);
+  if (!sanitizedNormalized) {
+    return true;
+  }
+  if (sanitizedNormalized !== normalized && isStandaloneMetadataText(sanitizedNormalized)) {
+    return true;
+  }
+  return false;
 }

--- a/extensions/memory-core/src/dreaming-shared.ts
+++ b/extensions/memory-core/src/dreaming-shared.ts
@@ -2,6 +2,7 @@ export { asNullableRecord as asRecord } from "openclaw/plugin-sdk/text-runtime";
 export { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 const LEADING_TIMESTAMP_PREFIX_RE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] */;
+const LEADING_TRANSCRIPT_SOURCE_PREFIX_RE = /^\[[^\]\n]+]\s*/;
 const ROLE_PREFIX_RE = /^(User|Assistant):\s*/;
 const METADATA_BLOCK_SENTINELS = [
   "Conversation info (untrusted metadata):",
@@ -15,10 +16,19 @@ const METADATA_BLOCK_SENTINELS = [
   "## Inbound Context (trusted metadata)",
 ] as const;
 const INLINE_METADATA_TAG_RE = /\[\[\s*reply_to(?:_current|:[^[\]]+)\s*]]/i;
+const INLINE_METADATA_TAG_FULL_RE = new RegExp(`^${INLINE_METADATA_TAG_RE.source}$`, "i");
+const INLINE_METADATA_TAG_TRAILING_RE = new RegExp(
+  `\\s+${INLINE_METADATA_TAG_RE.source}\\s*$`,
+  "i",
+);
 const JSON_METADATA_KEY_RE =
   /"(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|timestamp|thread_id)"\s*:/i;
 const TEXT_METADATA_KEY_RE =
   /\b(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|thread_id)\s*[:=]/i;
+const JSON_METADATA_LINE_RE =
+  /^\s*(?:[{[,]|\s)*"(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|timestamp|thread_id)"\s*:\s*.+$/i;
+const TEXT_METADATA_LINE_RE =
+  /^\s*(?:[-*]\s*)?(?:message_id|message_id_full|sender_id|chat_id|reply_to|reply_to_id|thread_id)\s*[:=]\s*.+$/i;
 
 export function normalizeTrimmedString(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -45,19 +55,9 @@ function isMetadataSentinelLine(line: string): boolean {
   return METADATA_BLOCK_SENTINELS.some((sentinel) => sentinel === trimmed);
 }
 
-function extractMetadataWrapperPayload(text: string): string | null {
-  const trimmed = text.trim();
-  for (const sentinel of METADATA_BLOCK_SENTINELS) {
-    if (!trimmed.startsWith(sentinel)) {
-      continue;
-    }
-    return trimmed.slice(sentinel.length).trim();
-  }
-  return null;
-}
-
 function stripRolePrefix(text: string): { prefix: string; body: string } {
-  const timestampStripped = text.replace(LEADING_TIMESTAMP_PREFIX_RE, "");
+  const sourceStripped = text.replace(LEADING_TRANSCRIPT_SOURCE_PREFIX_RE, "");
+  const timestampStripped = sourceStripped.replace(LEADING_TIMESTAMP_PREFIX_RE, "");
   const match = timestampStripped.match(ROLE_PREFIX_RE);
   if (!match) {
     return { prefix: "", body: timestampStripped };
@@ -74,13 +74,26 @@ function stripInlineMetadataTag(line: string): string {
   if (!INLINE_METADATA_TAG_RE.test(trimmed)) {
     return line;
   }
-  if (trimmed.match(new RegExp(`^${INLINE_METADATA_TAG_RE.source}$`, "i"))) {
+  if (INLINE_METADATA_TAG_FULL_RE.test(trimmed)) {
     return "";
   }
-  return line.replace(
-    new RegExp(`\\s+${INLINE_METADATA_TAG_RE.source}\\s*$`, "i"),
-    "",
-  );
+  return line.replace(INLINE_METADATA_TAG_TRAILING_RE, "");
+}
+
+function isStandaloneMetadataLine(line: string): boolean {
+  if (/^[{}[\],]+$/.test(line) || line === "```json" || line === "```") {
+    return true;
+  }
+  if (JSON_METADATA_LINE_RE.test(line)) {
+    return true;
+  }
+  if (TEXT_METADATA_LINE_RE.test(line)) {
+    return true;
+  }
+  if (JSON_METADATA_KEY_RE.test(line) || TEXT_METADATA_KEY_RE.test(line)) {
+    return false;
+  }
+  return false;
 }
 
 function isStandaloneMetadataText(text: string): boolean {
@@ -94,10 +107,10 @@ function isStandaloneMetadataText(text: string): boolean {
 
   let matchedMetadataLine = false;
   for (const line of lines) {
-    if (/^[{}[\],]+$/.test(line) || line === "```json" || line === "```") {
-      continue;
-    }
-    if (JSON_METADATA_KEY_RE.test(line) || TEXT_METADATA_KEY_RE.test(line)) {
+    if (isStandaloneMetadataLine(line)) {
+      if (/^[{}[\],]+$/.test(line) || line === "```json" || line === "```") {
+        continue;
+      }
       matchedMetadataLine = true;
       continue;
     }
@@ -105,6 +118,44 @@ function isStandaloneMetadataText(text: string): boolean {
   }
 
   return matchedMetadataLine;
+}
+
+function unwrapMetadataFence(text: string): string {
+  const trimmed = text.trim();
+  const fencedMatch = trimmed.match(/^```json\s*([\s\S]*?)\s*```$/i);
+  if (!fencedMatch) {
+    return trimmed;
+  }
+  return (fencedMatch[1] ?? "").trim();
+}
+
+function stripLeadingMetadataWrapper(text: string): string | null {
+  const { body } = stripRolePrefix(text);
+  const trimmed = body.trim();
+  for (const sentinel of METADATA_BLOCK_SENTINELS) {
+    if (!trimmed.startsWith(sentinel)) {
+      continue;
+    }
+    const rest = trimmed.slice(sentinel.length).trim();
+    if (!rest) {
+      return "";
+    }
+    const fencedWithTailMatch = rest.match(/^```json\s*([\s\S]*?)\s*```\s*(.*)$/i);
+    if (fencedWithTailMatch) {
+      const payload = (fencedWithTailMatch[1] ?? "").trim();
+      const trailing = (fencedWithTailMatch[2] ?? "").trim();
+      if (!payload || !isStandaloneMetadataText(payload)) {
+        return null;
+      }
+      return trailing;
+    }
+    const unfenced = unwrapMetadataFence(rest);
+    if (isStandaloneMetadataText(unfenced)) {
+      return "";
+    }
+    return null;
+  }
+  return null;
 }
 
 export function sanitizeDreamingMetadataText(text: string): string {
@@ -119,6 +170,13 @@ export function sanitizeDreamingMetadataText(text: string): string {
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
     const trimmed = line.trim();
+    const strippedWrapper = stripLeadingMetadataWrapper(trimmed);
+    if (strippedWrapper !== null) {
+      if (strippedWrapper) {
+        result.push(strippedWrapper);
+      }
+      continue;
+    }
     if (isMetadataSentinelLine(trimmed)) {
       if ((lines[index + 1] ?? "").trim() === "```json") {
         index += 2;
@@ -126,13 +184,6 @@ export function sanitizeDreamingMetadataText(text: string): string {
           index += 1;
         }
         continue;
-      }
-      continue;
-    }
-    if (trimmed === "```json" && JSON_METADATA_KEY_RE.test(lines[index + 1] ?? "")) {
-      index += 1;
-      while (index < lines.length && (lines[index] ?? "").trim() !== "```") {
-        index += 1;
       }
       continue;
     }
@@ -161,12 +212,9 @@ export function isMetadataGarbageText(text: string): boolean {
     return true;
   }
 
-  const wrapperPayload = extractMetadataWrapperPayload(normalized);
-  if (wrapperPayload !== null) {
-    if (!wrapperPayload) {
-      return true;
-    }
-    if (isStandaloneMetadataText(wrapperPayload)) {
+  const strippedWrapper = stripLeadingMetadataWrapper(normalized);
+  if (strippedWrapper !== null) {
+    if (!strippedWrapper) {
       return true;
     }
   }

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1136,6 +1136,17 @@ describe("short-term promotion", () => {
         "Conversation info (untrusted metadata): wrappers should be stripped before indexing.",
       ),
     ).toBe(false);
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        [
+          "Review the retry payload format:",
+          "```json",
+          '{"message_id":"evt_123","type":"webhook","content":"Hello"}',
+          "```",
+          "Notes: use the id to correlate retries.",
+        ].join("\n"),
+      ),
+    ).toBe(false);
   });
 
   it("does not record transport metadata snippets as short-term recalls", async () => {

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1109,6 +1109,118 @@ describe("short-term promotion", () => {
     ).toBe(true);
   });
 
+  it("treats transport metadata wrappers as contaminated", () => {
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        'Conversation info (untrusted metadata):\n```json\n{"message_id":"5417","sender_id":"289522496"}\n```',
+      ),
+    ).toBe(true);
+    expect(
+      __testing.isContaminatedDreamingSnippet('Sender (untrusted metadata): {"sender_id":"42"}'),
+    ).toBe(true);
+  });
+
+  it("keeps normal technical notes that mention metadata fields or reply tags", () => {
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "Parser should strip [[reply_to_current]] before sending the final message body.",
+      ),
+    ).toBe(false);
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        'Webhook example keeps the "message_id" field so we can correlate retries.',
+      ),
+    ).toBe(false);
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "Conversation info (untrusted metadata): wrappers should be stripped before indexing.",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not record transport metadata snippets as short-term recalls", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "metadata noise",
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 1,
+            endLine: 1,
+            score: 0.92,
+            snippet:
+              'Conversation info (untrusted metadata):\n```json\n{"message_id":"5417","sender_id":"289522496"}\n```',
+          },
+          {
+            path: "memory/2026-04-03.md",
+            source: "memory",
+            startLine: 2,
+            endLine: 2,
+            score: 0.93,
+            snippet: "Gateway binds loopback and port 18789",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      expect(ranked.map((candidate) => candidate.snippet)).toEqual([
+        "Gateway binds loopback and port 18789",
+      ]);
+    });
+  });
+
+  it("refuses to append contaminated manual candidates to MEMORY.md", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        candidates: [
+          {
+            key: "memory:memory/2026-04-03.md:1:1",
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            source: "memory",
+            snippet:
+              'Conversation info (untrusted metadata): {"message_id":"5417","sender_id":"289522496"}',
+            recallCount: 3,
+            avgScore: 0.92,
+            maxScore: 0.92,
+            uniqueQueries: 2,
+            firstRecalledAt: "2026-04-03T00:00:00.000Z",
+            lastRecalledAt: "2026-04-03T01:00:00.000Z",
+            ageDays: 0,
+            score: 0.92,
+            recallDays: ["2026-04-03"],
+            conceptTags: [],
+            components: {
+              frequency: 0.2,
+              relevance: 0.2,
+              diversity: 0.2,
+              recency: 0.2,
+              consolidation: 0.1,
+              conceptual: 0.1,
+            },
+          },
+        ],
+      });
+
+      expect(applied.applied).toBe(0);
+      await expect(fs.access(path.join(workspaceDir, "MEMORY.md"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
   it("skips direct candidates that exceed maxAgeDays during apply", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const applied = await applyShortTermPromotions({

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -11,7 +11,7 @@ import {
   summarizeConceptTagScriptCoverage,
   type ConceptTagScriptCoverage,
 } from "./concept-vocabulary.js";
-import { asRecord } from "./dreaming-shared.js";
+import { asRecord, isMetadataGarbageText } from "./dreaming-shared.js";
 
 const SHORT_TERM_PATH_RE = /(?:^|\/)memory\/(?:[^/]+\/)*(\d{4})-(\d{2})-(\d{2})\.md$/;
 const DREAMING_MEMORY_PATH_RE = /(?:^|\/)memory\/dreaming\//;
@@ -276,6 +276,9 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   const snippet = normalizeSnippet(raw);
   if (!snippet) {
     return false;
+  }
+  if (isMetadataGarbageText(snippet)) {
+    return true;
   }
   if (
     /<!--\s*openclaw-memory-promotion:/i.test(snippet) ||

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -116,7 +116,7 @@ async function expectHookAgentSessionRouting(params: {
     sessionKey: params.requestSessionKey,
   });
   expect(resAgent.status).toBe(200);
-  await waitForSystemEvent();
+  await waitForSystemEvent(5_000);
 
   const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
     | { sessionKey?: string; job?: { agentId?: string } }


### PR DESCRIPTION
## Summary

- Problem: Dreaming could promote transport/session wrapper metadata into `MEMORY.md`.
- Why it matters: transient wrapper noise could become durable memory and degrade long-term memory quality.
- What changed: added deterministic metadata stripping/rejection during dreaming ingestion and kept a final promotion-time safety gate.
- What did NOT change (scope boundary): no Plugin SDK changes, no docs/changelog updates, and no attempt to redesign durable-memory distillation in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67442
- Related #63921
- Related #66947
- Related #67363
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: dreaming session ingestion normalized transcript lines into corpus snippets without treating transport/session wrappers as non-memory content (`extensions/memory-core/src/dreaming-phases.ts:554`, `extensions/memory-core/src/dreaming-phases.ts:839`).
- Missing detection / guardrail: promotion contamination checks only recognized dreaming-generated artifact shapes, not transport metadata shapes, so wrapper-heavy snippets could still survive to promotion (`extensions/memory-core/src/short-term-promotion.ts:275`, `extensions/memory-core/src/short-term-promotion.ts:1545`).
- Contributing context (if known): dreaming re-ingests both session corpus and daily memory, so once metadata leaked in it could be amplified by later passes. This PR centralizes the metadata heuristics in `extensions/memory-core/src/dreaming-shared.ts:4`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming-phases.test.ts`, `extensions/memory-core/src/short-term-promotion.test.ts`
- Scenario the test should lock in: transport metadata is stripped at ingestion and contaminated snippets are rejected before ranking or final promotion.
- Why this is the smallest reliable guardrail: the bug spans session ingestion, daily re-ingestion, and promotion, so plugin-level tests are the narrowest place that exercises the full path.
- Existing test that already covers this (if any): none directly covered wrapper-metadata contamination into promotion.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Dreaming no longer persists transport/session wrapper metadata as promotable memory candidates, and contaminated snippets are refused before writing `MEMORY.md`.

## Diagram (if applicable)

```text
Before:
transport metadata -> session/daily dreaming artifacts -> short-term candidates -> MEMORY.md contamination

After:
transport metadata -> strip/reject at ingestion -> reject during ranking/promotion -> real memory only reaches MEMORY.md
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: local Node/pnpm test environment
- Model/provider: N/A for automated regression tests
- Integration/channel (if any): Dreaming / memory-core
- Relevant config (redacted): Dreaming enabled in `memory-core`

### Steps

1. Feed Dreaming session or daily-memory content that includes transport wrappers like `Conversation info (untrusted metadata)`, raw `message_id`, or `[[reply_to_current]]`.
2. Run the dreaming ingestion / ranking / promotion flow.
3. Inspect short-term candidates and `MEMORY.md`.

### Expected

- Metadata wrappers are stripped or rejected.
- Only real memory content remains promotable.
- `MEMORY.md` contains no transport/session wrapper noise.

### Actual

- Before this fix, metadata garbage could survive and be promoted into `MEMORY.md`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Issue reference: #67442

Before:
- Issue #67442 reports a live contamination path where Dreaming promoted transport/session wrapper metadata into `MEMORY.md`, including:
  - `Conversation info (untrusted metadata)`
  - `Sender (untrusted metadata)`
  - raw `message_id` values such as `5417` / `5421`
  - reply wrapper tags such as `[[reply_to_current]]`
- Reported path in the issue:
  - raw transport metadata -> dreaming/session corpus pollution -> daily memory pollution -> erroneous promotion into `MEMORY.md`

After:
- Added deterministic metadata sanitizing + rejection in the shared dreaming filter layer:
  - `extensions/memory-core/src/dreaming-shared.ts`
- Applied that filter at all relevant stages:
  - session corpus ingestion in `extensions/memory-core/src/dreaming-phases.ts`
  - daily snippet re-ingestion in `extensions/memory-core/src/dreaming-phases.ts`
  - final promotion safety gate in `extensions/memory-core/src/short-term-promotion.ts`

Passing verification:
- `pnpm test extensions/memory-core/src/dreaming-phases.test.ts`
- `pnpm test extensions/memory-core/src/short-term-promotion.test.ts`

Result:
- 2 test files passed
- 74 tests passed
- 0 failures

Targeted proof added in tests:
- `extensions/memory-core/src/dreaming-phases.test.ts`
  - verifies inbound metadata wrappers are stripped before session corpus is written
  - verifies polluted daily metadata chunks are not re-ingested into recall candidates
  - verifies a dreaming sweep can still promote the real content while blocking metadata contamination from reaching `MEMORY.md`
- `extensions/memory-core/src/short-term-promotion.test.ts`
  - verifies transport metadata wrappers are classified as contaminated
  - verifies metadata snippets are not recorded as short-term recall candidates
  - verifies contaminated candidates are refused during final append to `MEMORY.md`

Net effect:
- The contamination chain described in #67442 is now blocked with defense in depth:
  - strip metadata at ingestion
  - skip metadata-only daily/session snippets
  - refuse contaminated promotion candidates before writing `MEMORY.md`

## Human Verification (required)

- Verified scenarios: targeted memory-core regression tests for session ingestion, daily re-ingestion, ranking, and final promotion.
- Edge cases checked: reply tags, JSON metadata blocks, raw metadata keys, and mixed valid/invalid content in the same sweep.
- What you did **not** verify: manual UI/production-channel reproduction outside the automated plugin tests.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: metadata heuristics could reject a legitimate note that looks too wrapper-like.
  - Mitigation: filtering is constrained to known transport/session metadata patterns and backed by targeted regression tests.
