### PR TITLE
fix: apply default timeoutSec to backgrounded/yieldMs exec (#67600)

### DIFF
--- a/src/agents/bash-tools.exec.background-abort.test.ts
+++ b/src/agents/bash-tools.exec.background-abort.test.ts
@@ -153,33 +153,28 @@ test("background exec still times out after tool signal abort", async () => {
   });
 });
 
-test("background exec without explicit timeout ignores default timeout", async () => {
+test("background exec without explicit timeout applies default timeout", async () => {
   const tool = createTestExecTool({
     allowBackground: true,
     backgroundMs: 0,
     timeoutSec: BACKGROUND_TIMEOUT_SEC,
   });
-  const result = await tool.execute("toolcall", { command: BACKGROUND_HOLD_CMD, background: true });
-  expect(result.details.status).toBe("running");
-  const sessionId = (result.details as { sessionId: string }).sessionId;
-  const waitMs = Math.max(ABORT_SETTLE_MS + 80, BACKGROUND_TIMEOUT_SEC * 1000 + 80);
+  await expectBackgroundSessionTimesOut({
+    tool,
+    executeParams: { command: BACKGROUND_HOLD_CMD, background: true },
+  });
+});
 
-  const startedAt = Date.now();
-  await expect
-    .poll(
-      () => {
-        const running = getSession(sessionId);
-        const finished = getFinishedSession(sessionId);
-        return Date.now() - startedAt >= waitMs && !finished && running?.exited === false;
-      },
-      {
-        timeout: waitMs + ABORT_WAIT_TIMEOUT_MS,
-        interval: POLL_INTERVAL_MS,
-      },
-    )
-    .toBe(true);
-
-  cleanupRunningSession(sessionId);
+test("yieldMs exec without explicit timeout applies default timeout", async () => {
+  const tool = createTestExecTool({
+    allowBackground: true,
+    backgroundMs: 10,
+    timeoutSec: BACKGROUND_TIMEOUT_SEC,
+  });
+  await expectBackgroundSessionTimesOut({
+    tool,
+    executeParams: { command: BACKGROUND_HOLD_CMD, yieldMs: 5 },
+  });
 });
 
 test("yielded background exec still times out", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1648,11 +1648,7 @@ export function createExecTool(
       }
 
       const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;
-      const backgroundTimeoutBypass =
-        allowBackground && explicitTimeoutSec === null && (backgroundRequested || yieldRequested);
-      const effectiveTimeout = backgroundTimeoutBypass
-        ? null
-        : (explicitTimeoutSec ?? defaultTimeoutSec);
+      const effectiveTimeout = explicitTimeoutSec ?? defaultTimeoutSec;
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
 


### PR DESCRIPTION
Fixes #67600

**Problem:** `tools.exec.timeoutSec` was ignored when exec auto-backgrounded via `yieldMs` or `background: true` without an explicit `timeout` parameter. The foreground path correctly applied the default timeout, but backgrounded exec silently disabled it.

**Fix:** Removed the `backgroundTimeoutBypass` logic that nullified the timeout for background/yieldMs modes. Now `effectiveTimeout` always falls back to `defaultTimeoutSec` (from config or 1800s default).

**Tests:** Updated and added tests to verify background and yieldMs exec respect the default timeout. All 6 tests pass.