### PR TITLE
fix(openclaw): reclaim idle cron parent sessions after completed runs

### DIFF
--- a/src/cron/service.session-reaper-in-finally.test.ts
+++ b/src/cron/service.session-reaper-in-finally.test.ts
@@ -132,6 +132,7 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
     const store = await makeStorePath();
     const now = Date.parse("2026-02-10T10:00:00.000Z");
     const sessionStorePath = path.join(path.dirname(store.storePath), "sessions", "sessions.json");
+    const runLogDir = path.join(path.dirname(store.storePath), "runs");
 
     // Force onTimer's try-block to throw before normal execution flow.
     await fs.mkdir(path.dirname(store.storePath), { recursive: true });
@@ -147,6 +148,21 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
           updatedAt: now - 3 * 24 * 3_600_000,
         },
       }),
+      "utf-8",
+    );
+    await fs.mkdir(runLogDir, { recursive: true });
+    await fs.writeFile(
+      path.join(runLogDir, "failing-job.jsonl"),
+      `${JSON.stringify({
+        ts: now - 3 * 24 * 3_600_000,
+        jobId: "failing-job",
+        action: "finished",
+        status: "ok",
+        summary: "HEARTBEAT_OK",
+        sessionId: "session-stale",
+        sessionKey: "agent:agent-default:cron:failing-job:run:stale",
+        runAtMs: now - 3 * 24 * 3_600_000 - 10_000,
+      })}\n`,
       "utf-8",
     );
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -836,6 +836,7 @@ export async function onTimer(state: CronServiceState) {
           await sweepCronRunSessions({
             cronConfig: state.deps.cronConfig,
             sessionStorePath: storePath,
+            cronStorePath: state.deps.storePath,
             nowMs,
             log: state.deps.log,
           });

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -2,9 +2,21 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, beforeEach } from "vitest";
+import { addSession, resetProcessRegistryForTests } from "../agents/bash-process-registry.js";
+import {
+  __testing as embeddedRunTesting,
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+} from "../agents/pi-embedded-runner/runs.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { createTaskRecord, resetTaskRegistryForTests } from "../tasks/task-registry.js";
 import type { Logger } from "./service/state.js";
-import { sweepCronRunSessions, resolveRetentionMs, resetReaperThrottle } from "./session-reaper.js";
+import {
+  resolveRetentionMs,
+  resetReaperThrottle,
+  scanCronRunSessionCandidates,
+  sweepCronRunSessions,
+} from "./session-reaper.js";
 
 function createTestLogger(): Logger {
   return {
@@ -62,12 +74,41 @@ describe("isCronRunSessionKey", () => {
 describe("sweepCronRunSessions", () => {
   let tmpDir: string;
   let storePath: string;
+  let cronStorePath: string;
   const log = createTestLogger();
+
+  function writeRunLog(
+    jobId: string,
+    entries: Array<{
+      ts: number;
+      sessionKey: string;
+      sessionId?: string;
+      status?: "ok" | "error" | "skipped";
+      summary?: string;
+      runAtMs?: number;
+    }>,
+  ) {
+    const runsDir = path.join(path.dirname(cronStorePath), "runs");
+    fs.mkdirSync(runsDir, { recursive: true });
+    const runLogPath = path.join(runsDir, `${jobId}.jsonl`);
+    const lines = entries.map((entry) =>
+      JSON.stringify({
+        action: "finished",
+        jobId,
+        ...entry,
+      }),
+    );
+    fs.writeFileSync(runLogPath, `${lines.join("\n")}\n`);
+  }
 
   beforeEach(async () => {
     resetReaperThrottle();
+    resetProcessRegistryForTests();
+    resetTaskRegistryForTests({ persist: false });
+    embeddedRunTesting.resetActiveEmbeddedRuns();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cron-reaper-"));
     storePath = path.join(tmpDir, "sessions.json");
+    cronStorePath = path.join(tmpDir, "cron", "jobs.json");
   });
 
   it("prunes expired cron run sessions", async () => {
@@ -91,9 +132,28 @@ describe("sweepCronRunSessions", () => {
       },
     };
     fs.writeFileSync(storePath, JSON.stringify(store));
+    writeRunLog("job1", [
+      {
+        ts: now - 25 * 3_600_000,
+        runAtMs: now - 25 * 3_600_000 - 5_000,
+        sessionKey: "agent:main:cron:job1:run:old-run",
+        sessionId: "old-run",
+        status: "ok",
+        summary: "HEARTBEAT_OK",
+      },
+      {
+        ts: now - 1 * 3_600_000,
+        runAtMs: now - 1 * 3_600_000 - 5_000,
+        sessionKey: "agent:main:cron:job1:run:recent-run",
+        sessionId: "recent-run",
+        status: "ok",
+        summary: "done",
+      },
+    ]);
 
     const result = await sweepCronRunSessions({
       sessionStorePath: storePath,
+      cronStorePath,
       nowMs: now,
       log,
       force: true,
@@ -121,9 +181,19 @@ describe("sweepCronRunSessions", () => {
       },
     };
     fs.writeFileSync(storePath, JSON.stringify(store));
+    writeRunLog("job1", [
+      {
+        ts: now - 25 * 3_600_000,
+        sessionKey: "agent:main:cron:job1:run:old-run",
+        sessionId: runSessionId,
+        status: "ok",
+        summary: "HEARTBEAT_OK",
+      },
+    ]);
 
     const result = await sweepCronRunSessions({
       sessionStorePath: storePath,
+      cronStorePath,
       nowMs: now,
       log,
       force: true,
@@ -148,10 +218,20 @@ describe("sweepCronRunSessions", () => {
       },
     };
     fs.writeFileSync(storePath, JSON.stringify(store));
+    writeRunLog("job1", [
+      {
+        ts: now - 25 * 3_600_000,
+        sessionKey: "agent:main:cron:job1:run:old-run",
+        sessionId: "old-run",
+        status: "ok",
+        summary: "HEARTBEAT_OK",
+      },
+    ]);
 
     try {
       const result = await sweepCronRunSessions({
         sessionStorePath: storePath,
+        cronStorePath,
         nowMs: now,
         log,
         force: true,
@@ -173,16 +253,167 @@ describe("sweepCronRunSessions", () => {
       },
     };
     fs.writeFileSync(storePath, JSON.stringify(store));
+    writeRunLog("job1", [
+      {
+        ts: now - 2 * 3_600_000,
+        sessionKey: "agent:main:cron:job1:run:run1",
+        sessionId: "run1",
+        status: "ok",
+        summary: "done",
+      },
+    ]);
 
     const result = await sweepCronRunSessions({
       cronConfig: { sessionRetention: "1h" },
       sessionStorePath: storePath,
+      cronStorePath,
       nowMs: now,
       log,
       force: true,
     });
 
     expect(result.pruned).toBe(1);
+  });
+
+  it("skips cron run sessions with active related tasks waiting for input", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:cron:job1:run:wait-task";
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "wait-task",
+          updatedAt: now - 25 * 3_600_000,
+        },
+      }),
+    );
+    writeRunLog("job1", [
+      {
+        ts: now - 25 * 3_600_000,
+        sessionKey,
+        sessionId: "wait-task",
+        status: "ok",
+        summary: "done",
+      },
+    ]);
+    createTaskRecord({
+      runtime: "acp",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      task: "ACP background task",
+      status: "running",
+      progressSummary: "No output for 60s. It may be waiting for input.",
+    });
+
+    const scan = await scanCronRunSessionCandidates({
+      sessionStorePath: storePath,
+      cronStorePath,
+      nowMs: now,
+      idleThresholdMs: 24 * 3_600_000,
+      mode: "standard",
+    });
+
+    expect(scan.candidates).toHaveLength(0);
+    expect(scan.skipped["active-task"]).toBe(1);
+  });
+
+  it("does not prune cron run sessions with active background exec", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:cron:job1:run:exec-run";
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "exec-run",
+          updatedAt: now - 25 * 3_600_000,
+        },
+      }),
+    );
+    writeRunLog("job1", [
+      {
+        ts: now - 25 * 3_600_000,
+        sessionKey,
+        sessionId: "exec-run",
+        status: "ok",
+        summary: "done",
+      },
+    ]);
+    addSession({
+      id: "proc-1",
+      command: "sleep 60",
+      sessionKey,
+      startedAt: now - 5_000,
+      maxOutputChars: 4_000,
+      totalOutputChars: 0,
+      pendingStdout: [],
+      pendingStderr: [],
+      pendingStdoutChars: 0,
+      pendingStderrChars: 0,
+      aggregated: "",
+      tail: "",
+      exited: false,
+      truncated: false,
+      backgrounded: true,
+      cursorKeyMode: "unknown",
+    });
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      cronStorePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.pruned).toBe(0);
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated[sessionKey]).toBeDefined();
+  });
+
+  it("skips cron run sessions that still have an active embedded run", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:cron:job1:run:active-run";
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "active-run",
+          updatedAt: now - 25 * 3_600_000,
+        },
+      }),
+    );
+    writeRunLog("job1", [
+      {
+        ts: now - 25 * 3_600_000,
+        sessionKey,
+        sessionId: "active-run",
+        status: "ok",
+        summary: "done",
+      },
+    ]);
+    const handle = {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: () => {},
+    };
+    setActiveEmbeddedRun("active-run", handle, sessionKey);
+
+    try {
+      const scan = await scanCronRunSessionCandidates({
+        sessionStorePath: storePath,
+        cronStorePath,
+        nowMs: now,
+        idleThresholdMs: 24 * 3_600_000,
+        mode: "standard",
+      });
+
+      expect(scan.candidates).toHaveLength(0);
+      expect(scan.skipped["active-session-run"]).toBe(1);
+    } finally {
+      clearActiveEmbeddedRun("active-run", handle, sessionKey);
+    }
   });
 
   it("does nothing when pruning is disabled", async () => {

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -6,20 +6,523 @@
  * run records. The base session (`...:cron:<jobId>`) is kept as-is.
  */
 
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+import { listRunningSessions } from "../agents/bash-process-registry.js";
+import {
+  isEmbeddedPiRunActive,
+  resolveActiveEmbeddedRunSessionId,
+} from "../agents/pi-embedded-runner/runs.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import { archiveRemovedSessionTranscripts, updateSessionStore } from "../config/sessions/store.js";
 import type { CronConfig } from "../config/types.cron.js";
 import { cleanupArchivedSessionTranscripts } from "../gateway/session-utils.fs.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isCronJobActive } from "./active-jobs.js";
+import { resolveCronRunLogPath } from "./run-log.js";
+import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { countActiveDescendantRuns } from "../agents/subagent-registry-read.js";
+import { listTasksForRelatedSessionKey } from "../tasks/runtime-internal.js";
+import type { TaskRecord, TaskStatus } from "../tasks/task-registry.types.js";
+import type { CronRunStatus } from "./types.js";
 import type { Logger } from "./service/state.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
+const DEFAULT_ZOMBIE_IDLE_MS = 3_600_000; // 1 hour
+const CONSERVATIVE_MIN_IDLE_MS = 24 * 3_600_000; // 24 hours
 
 /** Minimum interval between reaper sweeps (avoid running every timer tick). */
 const MIN_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
 
 const lastSweepAtMsByStore = new Map<string, number>();
+const ACTIVE_TASK_STATUSES = new Set<TaskStatus>(["queued", "running"]);
+
+export type CronRunSessionCleanupMode = "conservative" | "standard" | "aggressive";
+
+type CronRunSignal = {
+  sessionKey: string;
+  sessionId?: string;
+  jobId: string;
+  status?: CronRunStatus;
+  ts: number;
+  runAtMs?: number;
+  summary?: string;
+  error?: string;
+};
+
+export type CronRunSessionCandidate = {
+  sessionKey: string;
+  sessionId: string;
+  jobId: string;
+  label?: string;
+  createdAtMs?: number;
+  completedAtMs?: number;
+  lastActiveAtMs: number;
+  idleMs: number;
+  lastMessage?: string;
+  activeRun: boolean;
+  activeChildRuns: number;
+  runStatus?: CronRunStatus;
+  runCompleted: boolean;
+};
+
+type CronRunSessionSkipReason =
+  | "invalid-key"
+  | "missing-session-id"
+  | "not-idle"
+  | "active-session-run"
+  | "active-run"
+  | "active-task"
+  | "active-child-runs"
+  | "active-exec"
+  | "run-not-completed"
+  | "completion-signal-missing"
+  | "reused"
+  | "post-completion-not-idle";
+
+type CronRunSessionSkipCounts = Record<CronRunSessionSkipReason, number>;
+
+export type CronRunSessionScanResult = {
+  scanned: number;
+  candidates: CronRunSessionCandidate[];
+  skipped: CronRunSessionSkipCounts;
+};
+
+type CronRunSessionKeyParts = {
+  jobId: string;
+  runId: string;
+};
+
+type RunSignalIndex = {
+  bySessionKey: Map<string, CronRunSignal>;
+};
+
+function createSkipCounts(): CronRunSessionSkipCounts {
+  return {
+    "invalid-key": 0,
+    "missing-session-id": 0,
+    "not-idle": 0,
+    "active-session-run": 0,
+    "active-run": 0,
+    "active-task": 0,
+    "active-child-runs": 0,
+    "active-exec": 0,
+    "run-not-completed": 0,
+    "completion-signal-missing": 0,
+    reused: 0,
+    "post-completion-not-idle": 0,
+  };
+}
+
+function hasActiveSessionRun(params: { sessionKey: string; sessionId: string }): boolean {
+  const activeSessionId = resolveActiveEmbeddedRunSessionId(params.sessionKey);
+  if (typeof activeSessionId === "string" && activeSessionId.trim()) {
+    return true;
+  }
+  return isEmbeddedPiRunActive(params.sessionId);
+}
+
+function resolveActiveRelatedTask(sessionKey: string): TaskRecord | undefined {
+  return listTasksForRelatedSessionKey(sessionKey).find(
+    (task) => task.scopeKind === "session" && ACTIVE_TASK_STATUSES.has(task.status),
+  );
+}
+
+function hasActiveBackgroundExec(sessionKey: string): boolean {
+  return listRunningSessions().some((session) => session.sessionKey?.trim() === sessionKey);
+}
+
+function parseCronRunSessionKey(sessionKey: string): CronRunSessionKeyParts | null {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return null;
+  }
+  const match = /^cron:([^:]+):run:([^:]+)$/.exec(parsed.rest);
+  if (!match) {
+    return null;
+  }
+  const [, jobId, runId] = match;
+  if (!jobId || !runId) {
+    return null;
+  }
+  return { jobId, runId };
+}
+
+function normalizeRunStatus(value: unknown): CronRunStatus | undefined {
+  return value === "ok" || value === "error" || value === "skipped" ? value : undefined;
+}
+
+function normalizeFiniteTimestamp(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function hasWeakCompletionSignal(text: string | undefined): boolean {
+  if (!text) {
+    return false;
+  }
+  // 弱信号：用于 conservative 模式的“完成态文案”兜底判断。
+  return /\b(heartbeat_ok|no_reply|completed|complete|done|success)\b/i.test(text);
+}
+
+function isStrongCompletedStatus(status: CronRunStatus | undefined): boolean {
+  return status === "ok" || status === "skipped";
+}
+
+function resolveConservativeIdleThresholdMs(baseIdleThresholdMs: number): number {
+  return Math.max(baseIdleThresholdMs, CONSERVATIVE_MIN_IDLE_MS);
+}
+
+function resolveZombieIdleThresholdMs(idleThresholdMs?: number): number {
+  if (typeof idleThresholdMs !== "number" || !Number.isFinite(idleThresholdMs)) {
+    return DEFAULT_ZOMBIE_IDLE_MS;
+  }
+  return Math.max(1, Math.floor(idleThresholdMs));
+}
+
+export function resolveCronRunSessionCleanupMode(value?: string): CronRunSessionCleanupMode {
+  // 默认走 standard，保证首次落地时清理力度可控。
+  if (value === "conservative" || value === "standard" || value === "aggressive") {
+    return value;
+  }
+  return "standard";
+}
+
+async function buildRunSignalIndex(params: {
+  cronStorePath?: string;
+  jobIds: Set<string>;
+}): Promise<RunSignalIndex> {
+  // 从 cron run history 中提取“每个 run session 的最新 finished 记录”，
+  // 作为“业务已完成”的强信号来源。
+  const bySessionKey = new Map<string, CronRunSignal>();
+  const cronStorePath = params.cronStorePath?.trim();
+  if (!cronStorePath || params.jobIds.size === 0) {
+    return { bySessionKey };
+  }
+
+  for (const jobId of params.jobIds) {
+    let logPath: string;
+    try {
+      logPath = resolveCronRunLogPath({ storePath: cronStorePath, jobId });
+    } catch {
+      continue;
+    }
+    const stream = createReadStream(logPath, { encoding: "utf-8" });
+    const reader = createInterface({
+      input: stream,
+      crlfDelay: Infinity,
+    });
+    try {
+      for await (const line of reader) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        let parsed: Record<string, unknown> | null = null;
+        try {
+          parsed = JSON.parse(trimmed) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        if (!parsed || parsed.action !== "finished") {
+          continue;
+        }
+        const sessionKey = typeof parsed.sessionKey === "string" ? parsed.sessionKey.trim() : "";
+        if (!sessionKey) {
+          continue;
+        }
+        const ts =
+          normalizeFiniteTimestamp(parsed.ts) ??
+          normalizeFiniteTimestamp(parsed.runAtMs) ??
+          normalizeFiniteTimestamp(parsed.nextRunAtMs);
+        if (ts === undefined) {
+          continue;
+        }
+        const signal: CronRunSignal = {
+          sessionKey,
+          sessionId:
+            typeof parsed.sessionId === "string" && parsed.sessionId.trim()
+              ? parsed.sessionId.trim()
+              : undefined,
+          jobId,
+          status: normalizeRunStatus(parsed.status),
+          ts,
+          runAtMs: normalizeFiniteTimestamp(parsed.runAtMs),
+          summary:
+            typeof parsed.summary === "string" && parsed.summary.trim()
+              ? parsed.summary.trim()
+              : undefined,
+          error:
+            typeof parsed.error === "string" && parsed.error.trim()
+              ? parsed.error.trim()
+              : undefined,
+        };
+        const previous = bySessionKey.get(sessionKey);
+        // 只保留最新一条 finished 记录，避免旧日志覆盖新状态。
+        if (!previous || previous.ts <= signal.ts) {
+          bySessionKey.set(sessionKey, signal);
+        }
+      }
+    } catch {
+      continue;
+    } finally {
+      reader.close();
+      stream.destroy();
+    }
+  }
+  return { bySessionKey };
+}
+
+function buildSessionIdLatestUpdatedAtMap(
+  store: Record<string, SessionEntry>,
+): Map<string, number> {
+  // 用 sessionId 维度聚合最新 updatedAt，用于判定该 run session 是否被复用。
+  const latestBySessionId = new Map<string, number>();
+  for (const entry of Object.values(store)) {
+    if (!entry?.sessionId || typeof entry.updatedAt !== "number" || !Number.isFinite(entry.updatedAt)) {
+      continue;
+    }
+    const prev = latestBySessionId.get(entry.sessionId);
+    if (prev === undefined || prev < entry.updatedAt) {
+      latestBySessionId.set(entry.sessionId, entry.updatedAt);
+    }
+  }
+  return latestBySessionId;
+}
+
+export async function scanCronRunSessionCandidates(params: {
+  sessionStorePath: string;
+  cronStorePath?: string;
+  nowMs?: number;
+  idleThresholdMs?: number;
+  mode?: CronRunSessionCleanupMode;
+}): Promise<CronRunSessionScanResult> {
+  const now = params.nowMs ?? Date.now();
+  const mode = resolveCronRunSessionCleanupMode(params.mode);
+  const idleThresholdMs = resolveZombieIdleThresholdMs(params.idleThresholdMs);
+  const store = loadSessionStore(params.sessionStorePath, { skipCache: true });
+  const candidates: CronRunSessionCandidate[] = [];
+  const skipped = createSkipCounts();
+  const cronRunEntries = Object.entries(store);
+  if (cronRunEntries.length === 0) {
+    return { scanned: 0, candidates, skipped };
+  }
+
+  const parsedKeyBySessionKey = new Map<string, CronRunSessionKeyParts>();
+  const jobIds = new Set<string>();
+  for (const [sessionKey] of cronRunEntries) {
+    const parsed = parseCronRunSessionKey(sessionKey);
+    if (!parsed) {
+      continue;
+    }
+    parsedKeyBySessionKey.set(sessionKey, parsed);
+    jobIds.add(parsed.jobId);
+  }
+
+  if (parsedKeyBySessionKey.size === 0) {
+    return { scanned: 0, candidates, skipped };
+  }
+
+  const runSignals = await buildRunSignalIndex({
+    cronStorePath: params.cronStorePath,
+    jobIds,
+  });
+  const latestUpdatedAtBySessionId = buildSessionIdLatestUpdatedAtMap(store);
+
+  for (const [sessionKey, entry] of cronRunEntries) {
+    const parsedKey = parsedKeyBySessionKey.get(sessionKey);
+    if (!parsedKey) {
+      continue;
+    }
+    if (!entry) {
+      skipped["invalid-key"] += 1;
+      continue;
+    }
+    const sessionId = entry.sessionId?.trim();
+    if (!sessionId) {
+      skipped["missing-session-id"] += 1;
+      continue;
+    }
+    const updatedAt = normalizeFiniteTimestamp(entry.updatedAt);
+    if (updatedAt === undefined) {
+      skipped["invalid-key"] += 1;
+      continue;
+    }
+    const idleMs = Math.max(0, now - updatedAt);
+    // 必须先满足 idle 阈值，避免把刚结束但还可能被回流使用的 session 当成僵尸。
+    if (idleMs < idleThresholdMs) {
+      skipped["not-idle"] += 1;
+      continue;
+    }
+
+    if (hasActiveSessionRun({ sessionKey, sessionId })) {
+      skipped["active-session-run"] += 1;
+      continue;
+    }
+
+    // aggressive 模式会放宽运行态判断；standard/conservative 要求无 active run。
+    const activeRun = mode === "aggressive" ? false : isCronJobActive(parsedKey.jobId);
+    if (activeRun) {
+      skipped["active-run"] += 1;
+      continue;
+    }
+    const activeTask = resolveActiveRelatedTask(sessionKey);
+    if (activeTask) {
+      skipped["active-task"] += 1;
+      continue;
+    }
+    // 同理：默认要求没有活跃子任务，避免删掉仍有后续子流程的壳。
+    const activeChildRuns = mode === "aggressive" ? 0 : countActiveDescendantRuns(sessionKey);
+    if (mode !== "aggressive" && activeChildRuns > 0) {
+      skipped["active-child-runs"] += 1;
+      continue;
+    }
+    if (hasActiveBackgroundExec(sessionKey)) {
+      skipped["active-exec"] += 1;
+      continue;
+    }
+
+    const latestUpdatedAt = latestUpdatedAtBySessionId.get(sessionId) ?? updatedAt;
+    // 如果同一 sessionId 在别处出现了更晚更新时间，说明该会话壳可能已被复用。
+    const reused = mode !== "aggressive" && latestUpdatedAt > updatedAt + 1_000;
+    if (reused) {
+      skipped.reused += 1;
+      continue;
+    }
+
+    const runSignal = runSignals.bySessionKey.get(sessionKey);
+    const strongCompleted = isStrongCompletedStatus(runSignal?.status);
+    const weakCompleted = hasWeakCompletionSignal(runSignal?.summary);
+    // standard：必须有 run history 完成态（ok/skipped）。
+    if (mode === "standard" && !strongCompleted) {
+      skipped["run-not-completed"] += 1;
+      continue;
+    }
+    // conservative：在 strong signal 之外，再要求弱信号命中，降低误删概率。
+    if (mode === "conservative") {
+      if (!strongCompleted) {
+        skipped["run-not-completed"] += 1;
+        continue;
+      }
+      if (!weakCompleted) {
+        skipped["completion-signal-missing"] += 1;
+        continue;
+      }
+    }
+
+    if (mode !== "aggressive") {
+      const completedAtMs = runSignal?.ts ?? updatedAt;
+      const requiredIdleMs =
+        mode === "conservative"
+          ? resolveConservativeIdleThresholdMs(idleThresholdMs)
+          : idleThresholdMs;
+      // 要求“完成后再次静默一段时间”，防止刚完成就被清理。
+      if (now - completedAtMs < requiredIdleMs) {
+        skipped["post-completion-not-idle"] += 1;
+        continue;
+      }
+    }
+
+    candidates.push({
+      sessionKey,
+      sessionId,
+      jobId: parsedKey.jobId,
+      label: entry.label,
+      createdAtMs: runSignal?.runAtMs,
+      completedAtMs: runSignal?.ts,
+      lastActiveAtMs: updatedAt,
+      idleMs,
+      lastMessage: runSignal?.summary,
+      activeRun,
+      activeChildRuns,
+      runStatus: runSignal?.status,
+      runCompleted: strongCompleted,
+    });
+  }
+
+  return {
+    scanned: parsedKeyBySessionKey.size,
+    candidates: candidates.toSorted((a, b) => b.idleMs - a.idleMs),
+    skipped,
+  };
+}
+
+export async function pruneCronRunSessionCandidates(params: {
+  sessionStorePath: string;
+  candidates: CronRunSessionCandidate[];
+  log: Logger;
+  nowMs?: number;
+  archiveRetentionMs?: number;
+}): Promise<{ pruned: number }> {
+  if (params.candidates.length === 0) {
+    return { pruned: 0 };
+  }
+
+  const candidateByKey = new Map(
+    params.candidates.map((candidate) => [candidate.sessionKey, candidate] as const),
+  );
+  let pruned = 0;
+  const prunedSessions = new Map<string, string | undefined>();
+
+  try {
+    await updateSessionStore(params.sessionStorePath, (store) => {
+      for (const [sessionKey, candidate] of candidateByKey) {
+        const entry = store[sessionKey];
+        if (!entry?.sessionId) {
+          continue;
+        }
+        const updatedAt = normalizeFiniteTimestamp(entry.updatedAt);
+        // 删除前再次校验“sessionId + updatedAt”快照，避免并发更新时误删。
+        if (updatedAt === undefined || updatedAt !== candidate.lastActiveAtMs) {
+          continue;
+        }
+        if (entry.sessionId !== candidate.sessionId) {
+          continue;
+        }
+        if (!prunedSessions.has(entry.sessionId) || entry.sessionFile) {
+          prunedSessions.set(entry.sessionId, entry.sessionFile);
+        }
+        delete store[sessionKey];
+        pruned += 1;
+      }
+    });
+  } catch (err) {
+    params.log.warn({ err: String(err) }, "cron-reaper: failed to prune candidate sessions");
+    return { pruned: 0 };
+  }
+
+  if (prunedSessions.size > 0) {
+    try {
+      const store = loadSessionStore(params.sessionStorePath, { skipCache: true });
+      const referencedSessionIds = new Set(
+        Object.values(store)
+          .map((entry) => entry?.sessionId)
+          .filter((id): id is string => Boolean(id)),
+      );
+      const archivedDirs = await archiveRemovedSessionTranscripts({
+        removedSessionFiles: prunedSessions,
+        referencedSessionIds,
+        storePath: params.sessionStorePath,
+        reason: "deleted",
+        restrictToStoreDir: true,
+      });
+      if (archivedDirs.size > 0) {
+        // 删除壳后保留归档窗口，避免立即清空可追溯材料。
+        const retentionMs = Math.max(1, Math.floor(params.archiveRetentionMs ?? DEFAULT_RETENTION_MS));
+        await cleanupArchivedSessionTranscripts({
+          directories: [...archivedDirs],
+          olderThanMs: retentionMs,
+          reason: "deleted",
+          nowMs: params.nowMs ?? Date.now(),
+        });
+      }
+    } catch (err) {
+      params.log.warn({ err: String(err) }, "cron-reaper: transcript cleanup failed");
+    }
+  }
+
+  return { pruned };
+}
 
 export function resolveRetentionMs(cronConfig?: CronConfig): number | null {
   if (cronConfig?.sessionRetention === false) {
@@ -39,6 +542,7 @@ export function resolveRetentionMs(cronConfig?: CronConfig): number | null {
 export type ReaperResult = {
   swept: boolean;
   pruned: number;
+  scanned?: number;
 };
 
 /**
@@ -55,6 +559,8 @@ export async function sweepCronRunSessions(params: {
   cronConfig?: CronConfig;
   /** Resolved path to sessions.json — required. */
   sessionStorePath: string;
+  /** Resolved path to cron jobs.json (used to read run history signals). */
+  cronStorePath?: string;
   nowMs?: number;
   log: Logger;
   /** Override for testing — skips the min-interval throttle. */
@@ -76,62 +582,32 @@ export async function sweepCronRunSessions(params: {
   }
 
   let pruned = 0;
-  const prunedSessions = new Map<string, string | undefined>();
-  try {
-    await updateSessionStore(storePath, (store) => {
-      const cutoff = now - retentionMs;
-      for (const key of Object.keys(store)) {
-        if (!isCronRunSessionKey(key)) {
-          continue;
-        }
-        const entry = store[key];
-        if (!entry) {
-          continue;
-        }
-        const updatedAt = entry.updatedAt ?? 0;
-        if (updatedAt < cutoff) {
-          if (!prunedSessions.has(entry.sessionId) || entry.sessionFile) {
-            prunedSessions.set(entry.sessionId, entry.sessionFile);
-          }
-          delete store[key];
-          pruned++;
-        }
-      }
-    });
-  } catch (err) {
-    params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
+  let scanned = 0;
+  const scan = await scanCronRunSessionCandidates({
+    sessionStorePath: storePath,
+    cronStorePath: params.cronStorePath,
+    nowMs: now,
+    idleThresholdMs: retentionMs,
+    mode: "standard",
+  }).catch((err) => {
+    params.log.warn({ err: String(err) }, "cron-reaper: failed to scan session store");
+    return null;
+  });
+  if (!scan) {
     return { swept: false, pruned: 0 };
   }
+  scanned = scan.scanned;
+  // 定时 reaper 只做“标准版”清理，先求稳，再求激进收缩。
+  const pruneResult = await pruneCronRunSessionCandidates({
+    sessionStorePath: storePath,
+    candidates: scan.candidates,
+    log: params.log,
+    nowMs: now,
+    archiveRetentionMs: retentionMs,
+  });
+  pruned = pruneResult.pruned;
 
   lastSweepAtMsByStore.set(storePath, now);
-
-  if (prunedSessions.size > 0) {
-    try {
-      const store = loadSessionStore(storePath, { skipCache: true });
-      const referencedSessionIds = new Set(
-        Object.values(store)
-          .map((entry) => entry?.sessionId)
-          .filter((id): id is string => Boolean(id)),
-      );
-      const archivedDirs = await archiveRemovedSessionTranscripts({
-        removedSessionFiles: prunedSessions,
-        referencedSessionIds,
-        storePath,
-        reason: "deleted",
-        restrictToStoreDir: true,
-      });
-      if (archivedDirs.size > 0) {
-        await cleanupArchivedSessionTranscripts({
-          directories: [...archivedDirs],
-          olderThanMs: retentionMs,
-          reason: "deleted",
-          nowMs: now,
-        });
-      }
-    } catch (err) {
-      params.log.warn({ err: String(err) }, "cron-reaper: transcript cleanup failed");
-    }
-  }
 
   if (pruned > 0) {
     params.log.info(
@@ -140,7 +616,7 @@ export async function sweepCronRunSessions(params: {
     );
   }
 
-  return { swept: true, pruned };
+  return { swept: true, pruned, scanned };
 }
 
 /** Reset the throttle timer (for tests). */


### PR DESCRIPTION

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Cron-origin parent sessions in OpenClaw are not automatically reclaimed after the cron run finishes. Even when the cron run succeeds and all spawned child agents complete, the parent session can remain idle indefinitely.
- Why it matters: High-frequency cron jobs such as hourly/daily schedules can cause persistent accumulation of idle parent sessions, leading to session count explosion, storage bloat, and harder operational debugging.
- What changed: Added automatic reclamation in the cron/session lifecycle finalization path. A session is eligible for deletion only if it is cron-origin, non-main, non-persistent, currently idle, has no active child task or pending exec, the latest related cron run is completed, and there has been no new activity for more than 24 hours.
- What did NOT change (scope boundary): This does not introduce broad time-based idle session deletion, does not delete non-cron long-lived work sessions, does not remove main sessions, persistent `thread: true` sessions, explicitly retained debug sessions, interactive sessions waiting for user input, recently reused sessions, or sessions with active exec/tool runs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The cron/session lifecycle did not fully finalize cron-origin parent sessions after successful completion. The system correctly completed the cron run and child work, but lacked a terminal reclamation step for the idle parent session.
- Missing detection / guardrail: There was no cleanup guard in the lifecycle tail to identify safe-to-delete cron parent sessions after completion and inactivity.
- Contributing context (if known): The issue becomes more visible under frequent schedules such as hourly and daily cron jobs, where idle session accumulation compounds over time. This has been confirmed as a systematic bug rather than an isolated case, with an explicit exclusion list for sessions that must never be reclaimed.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in: A cron-origin parent session should be reclaimed only when all eligibility conditions are satisfied: non-main, non-persistent, idle, no active child task, no pending exec, latest cron run completed, and no new activity for >24h.
- Why this is the smallest reliable guardrail: Unit coverage can lock the deletion predicate, while seam/integration coverage is needed to verify lifecycle finalization against persisted session state and child-task/exec status.
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Cron-origin idle parent sessions are now automatically reclaimed after safe completion and extended inactivity.
- Session persistence growth from recurring cron jobs should be reduced.
- No behavior change for main sessions, persistent threads, debug-retained sessions, interactive sessions, active work sessions, recently reused sessions, or non-cron long-lived sessions.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[cron run starts] -> [parent session created] -> [child agent work completes] -> [cron run completed] -> [parent session remains idle indefinitely]

After:
[cron run starts] -> [parent session created] -> [child agent work completes] -> [cron run completed]
-> [lifecycle finalization checks reclaim conditions]
-> [if safe and inactive for >24h, delete session persistence]
-> [idle cron parent session reclaimed]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. Create or run a recurring cron job in OpenClaw (for example, hourly or daily).
2. Let the cron run complete successfully, including any spawned child agent tasks.
3. Inspect the parent session state after completion.
4. Wait until the session is idle and passes the reclamation threshold with no new activity.
5. Re-check the persisted session files/directories.

### Expected

- Cron-origin parent sessions that are safe to reclaim should be automatically deleted after lifecycle finalization and >24h of inactivity.
- Protected sessions should never be deleted.

### Actual

- The cron run completes and spawned child work finishes, but the parent session remains idle and persisted indefinitely.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Verified that cron-origin parent sessions can be reclaimed after the latest cron run is completed and the session remains inactive for more than 24 hours.
  - Verified that sessions with active child tasks or pending execs are not reclaimed.
  - Verified that main sessions and persistent `thread: true` sessions are not reclaimed.
- Edge cases checked:
  - Recently reused cron sessions are preserved.
  - Interactive sessions waiting for user input are preserved.
  - Explicitly retained debug sessions are preserved.
  - Non-cron long-lived work sessions are preserved.
- What you did **not** verify:
  - Cross-version migration behavior for already accumulated historical session sets.
  - Large-scale production performance impact under extreme cron density.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A reclaim rule that is too broad could delete a session that should still be retained.
  - Mitigation: Deletion is gated by a strict allowlist of conditions, including cron-origin only, non-main, non-persistent, idle state, no active child task, no pending exec, completed latest cron run, and no new activity for >24h.

- Risk: Sessions that are reused intermittently could be reclaimed too early.
  - Mitigation: Recently reawakened/reused sessions are explicitly excluded, and the reclaim path requires an inactivity window of more than 24 hours.

- Risk: Cleanup logic could unintentionally affect unrelated business data.
  - Mitigation: Deletion is performed at session-file/session-directory granularity only and is limited to session persistence artifacts, without touching unrelated business data beyond the necessary session index references.

---