### PR TITLE
Plugins: repair legacy interactive singleton for doctor clear (#67525)

### DIFF
--- a/src/plugins/interactive-state.test.ts
+++ b/src/plugins/interactive-state.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveGlobalDedupeCache } from "../infra/dedupe.js";
+import { clearPluginInteractiveHandlersState } from "./interactive-state.js";
+
+const PLUGIN_INTERACTIVE_STATE_KEY = Symbol.for("openclaw.pluginInteractiveState");
+
+describe("clearPluginInteractiveHandlersState (#67525)", () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, PLUGIN_INTERACTIVE_STATE_KEY);
+  });
+
+  it("repairs legacy singletons missing callbackDedupe before clearing", () => {
+    (globalThis as Record<PropertyKey, unknown>)[PLUGIN_INTERACTIVE_STATE_KEY] = {
+      interactiveHandlers: new Map(),
+      inflightCallbackDedupe: new Set<string>(),
+    };
+
+    expect(() => clearPluginInteractiveHandlersState()).not.toThrow();
+  });
+
+  it("repairs legacy singletons missing inflightCallbackDedupe before clearing", () => {
+    (globalThis as Record<PropertyKey, unknown>)[PLUGIN_INTERACTIVE_STATE_KEY] = {
+      interactiveHandlers: new Map(),
+      callbackDedupe: resolveGlobalDedupeCache(Symbol.for("openclaw.pluginInteractiveCallbackDedupe"), {
+        ttlMs: 5 * 60_000,
+        maxSize: 4096,
+      }),
+    };
+
+    expect(() => clearPluginInteractiveHandlersState()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** Older or partially initialized global plugin interactive singletons could omit `callbackDedupe` or `inflightCallbackDedupe`. `clearPluginInteractiveHandlersState()` then called `.clear()` on missing fields, crashing `openclaw doctor` during plugin load / memory paths (#67525).
- **Why it matters:** Doctor and plugin reload must stay safe on legacy in-process state left from prior versions.
- **What changed:** After resolving the singleton, `getState()` defensively assigns `callbackDedupe` and `inflightCallbackDedupe` when absent, before any `.clear()` runs.
- **What did NOT change:** Normal singleton creation path, dedupe semantics, or public APIs beyond making clear safe.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67525
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Legacy/partial `InteractiveState` objects on `globalThis` did not always include the dedupe fields expected by `clearPluginInteractiveHandlersState`.
- **Missing detection / guardrail:** No repair step before calling `.clear()` on optional-shaped singletons.
- **Contributing context (if known):** Reported on 2026.4.14-class installs where singleton shape predated full fields.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:** Unit test
- **Target test or file:** `src/plugins/interactive-state.test.ts`
- **Scenario the test should lock in:** Legacy global state missing `callbackDedupe` only; missing `inflightCallbackDedupe` only (with valid `callbackDedupe`); both paths call `clearPluginInteractiveHandlersState()` without throwing.
- **Why this is the smallest reliable guardrail:** Crash is isolated to `getState()` shape vs `clear()`; no need for full doctor E2E.
- **Existing test that already covers this (if any):** None before this PR.
- **If no new test is added, why not:** N/A (tests added).

## User-visible / Behavior Changes

- `openclaw doctor` no longer crashes when clearing plugin interactive handler state if the process carried a legacy singleton missing dedupe caches.

## Diagram (if applicable)

```text
Before:
[doctor / clear] -> [getState] -> [.clear() on undefined] -> crash

After:
[doctor / clear] -> [getState] -> [repair missing fields] -> [.clear()] -> ok
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
