### PR TITLE
fix(deps): bump dompurify to 3.4.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1282,8 +1282,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
       dompurify:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^3.4.0
+        version: 3.4.0
       lit:
         specifier: ^3.3.2
         version: 3.3.2
@@ -5040,8 +5040,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -12090,7 +12090,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@create-markdown/preview": "^2.0.3",
     "@noble/ed25519": "3.0.1",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.0",
     "lit": "^3.3.2",
     "markdown-it": "^14.1.1",
     "markdown-it-task-lists": "^2.1.1",


### PR DESCRIPTION
## Summary

- Bump `dompurify` from `^3.3.3` to `^3.4.0`

## Regression Risk Assessment

**Risk: Low**

- Minor version bump with no documented breaking changes
- The project uses `ALLOWED_TAGS`/`ALLOWED_ATTR` arrays; no usage of `ADD_TAGS` function form or `FORBID_TAGS`
- All 76 markdown sanitization tests pass with the upgraded version
- `DOMPurify.sanitize()` and `DOMPurify.addHook()` API surface is unchanged

## Test plan

- [x] All 76 existing markdown unit tests pass (`src/ui/markdown.test.ts`)
- [x] Pre-commit checks pass (lint, type-check, import cycles)
- [ ] CI green