### PR TITLE
Android: modernize WebView and discovery API usage

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -9,8 +9,6 @@ import android.net.nsd.NsdServiceInfo
 import android.os.CancellationSignal
 import android.util.Log
 import java.io.IOException
-import java.lang.reflect.Proxy
-import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
@@ -46,6 +44,7 @@ import org.xbill.DNS.Type
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
+@Suppress("DEPRECATION")
 class GatewayDiscovery(
   context: Context,
   private val scope: CoroutineScope,
@@ -56,7 +55,6 @@ class GatewayDiscovery(
   private val serviceType = "_openclaw-gw._tcp."
   private val wideAreaDomain = System.getenv("OPENCLAW_WIDE_AREA_DOMAIN")
   private val logTag = "OpenClaw/GatewayDiscovery"
-  private val directExecutor = Executor { runnable -> runnable.run() }
 
   private val localById = ConcurrentHashMap<String, GatewayEndpoint>()
   private val unicastById = ConcurrentHashMap<String, GatewayEndpoint>()
@@ -130,128 +128,43 @@ class GatewayDiscovery(
   }
 
   private fun resolve(serviceInfo: NsdServiceInfo) {
-    if (registerServiceInfoCallbackCompat(serviceInfo)) return
-    resolveServiceCompat(serviceInfo)
-  }
+    nsd.resolveService(
+      serviceInfo,
+      object : NsdManager.ResolveListener {
+        override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {}
 
-  private fun registerServiceInfoCallbackCompat(serviceInfo: NsdServiceInfo): Boolean {
-    return try {
-      // compileSdk 36 marks resolveService/getHost as deprecated, but we still need
-      // a runtime-compatible path back to Android 12. Prefer the newer callback API
-      // when the device exposes it, and fall back without hard-linking deprecated calls.
-      val callbackClass = Class.forName("android.net.nsd.NsdManager\$ServiceInfoCallback")
-      var callbackRef: Any? = null
-      val callback =
-        Proxy.newProxyInstance(callbackClass.classLoader, arrayOf(callbackClass)) { _, method, args ->
-          when (method.name) {
-            "onServiceUpdated" -> {
-              val resolved = args?.getOrNull(0) as? NsdServiceInfo
-              if (resolved != null) {
-                onServiceResolved(resolved)
-              }
-              callbackRef?.let(::unregisterServiceInfoCallbackCompat)
-              null
-            }
-            "onServiceLost", "onServiceInfoCallbackRegistrationFailed" -> {
-              callbackRef?.let(::unregisterServiceInfoCallbackCompat)
-              null
-            }
-            else -> null
-          }
+        override fun onServiceResolved(resolved: NsdServiceInfo) {
+          val host = resolved.host?.hostAddress ?: return
+          val port = resolved.port
+          if (port <= 0) return
+
+          val rawServiceName = resolved.serviceName
+          val serviceName = BonjourEscapes.decode(rawServiceName)
+          val displayName = BonjourEscapes.decode(txt(resolved, "displayName") ?: serviceName)
+          val lanHost = txt(resolved, "lanHost")
+          val tailnetDns = txt(resolved, "tailnetDns")
+          val gatewayPort = txtInt(resolved, "gatewayPort")
+          val canvasPort = txtInt(resolved, "canvasPort")
+          val tlsEnabled = txtBool(resolved, "gatewayTls")
+          val tlsFingerprint = txt(resolved, "gatewayTlsSha256")
+          val id = stableId(serviceName, "local.")
+          localById[id] =
+            GatewayEndpoint(
+              stableId = id,
+              name = displayName,
+              host = host,
+              port = port,
+              lanHost = lanHost,
+              tailnetDns = tailnetDns,
+              gatewayPort = gatewayPort,
+              canvasPort = canvasPort,
+              tlsEnabled = tlsEnabled,
+              tlsFingerprintSha256 = tlsFingerprint,
+            )
+          publish()
         }
-      callbackRef = callback
-      nsd.javaClass
-        .getMethod(
-          "registerServiceInfoCallback",
-          NsdServiceInfo::class.java,
-          Executor::class.java,
-          callbackClass,
-        ).invoke(nsd, serviceInfo, directExecutor, callback)
-      true
-    } catch (_: Throwable) {
-      false
-    }
-  }
-
-  private fun unregisterServiceInfoCallbackCompat(callback: Any) {
-    try {
-      val callbackClass = Class.forName("android.net.nsd.NsdManager\$ServiceInfoCallback")
-      nsd.javaClass.getMethod("unregisterServiceInfoCallback", callbackClass).invoke(nsd, callback)
-    } catch (_: Throwable) {
-      // ignore (best-effort)
-    }
-  }
-
-  private fun resolveServiceCompat(serviceInfo: NsdServiceInfo) {
-    try {
-      val listenerClass = Class.forName("android.net.nsd.NsdManager\$ResolveListener")
-      val listener =
-        Proxy.newProxyInstance(listenerClass.classLoader, arrayOf(listenerClass)) { _, method, args ->
-          when (method.name) {
-            "onServiceResolved" -> {
-              val resolved = args?.getOrNull(0) as? NsdServiceInfo
-              if (resolved != null) {
-                onServiceResolved(resolved)
-              }
-              null
-            }
-            else -> null
-          }
-        }
-      nsd.javaClass.getMethod("resolveService", NsdServiceInfo::class.java, listenerClass).invoke(
-        nsd,
-        serviceInfo,
-        listener,
-      )
-    } catch (_: Throwable) {
-      // ignore (best-effort)
-    }
-  }
-
-  private fun onServiceResolved(resolved: NsdServiceInfo) {
-    val host = resolveServiceHostAddress(resolved) ?: return
-    val port = resolved.port
-    if (port <= 0) return
-
-    val rawServiceName = resolved.serviceName
-    val serviceName = BonjourEscapes.decode(rawServiceName)
-    val displayName = BonjourEscapes.decode(txt(resolved, "displayName") ?: serviceName)
-    val lanHost = txt(resolved, "lanHost")
-    val tailnetDns = txt(resolved, "tailnetDns")
-    val gatewayPort = txtInt(resolved, "gatewayPort")
-    val canvasPort = txtInt(resolved, "canvasPort")
-    val tlsEnabled = txtBool(resolved, "gatewayTls")
-    val tlsFingerprint = txt(resolved, "gatewayTlsSha256")
-    val id = stableId(serviceName, "local.")
-    localById[id] =
-      GatewayEndpoint(
-        stableId = id,
-        name = displayName,
-        host = host,
-        port = port,
-        lanHost = lanHost,
-        tailnetDns = tailnetDns,
-        gatewayPort = gatewayPort,
-        canvasPort = canvasPort,
-        tlsEnabled = tlsEnabled,
-        tlsFingerprintSha256 = tlsFingerprint,
-      )
-    publish()
-  }
-
-  private fun resolveServiceHostAddress(info: NsdServiceInfo): String? {
-    val modernHost =
-      runCatching {
-        @Suppress("UNCHECKED_CAST")
-        info.javaClass.getMethod("getHostAddresses").invoke(info) as? List<InetAddress>
-      }.getOrNull()
-        ?.firstOrNull()
-        ?.hostAddress
-    if (!modernHost.isNullOrBlank()) return modernHost
-
-    return runCatching {
-      (info.javaClass.getMethod("getHost").invoke(info) as? InetAddress)?.hostAddress
-    }.getOrNull()
+      },
+    )
   }
 
   private fun publish() {
@@ -477,7 +390,7 @@ class GatewayDiscovery(
     val cm = connectivity ?: return null
 
     // Prefer VPN (Tailscale) when present; otherwise use the active network.
-    allNetworksCompat(cm).firstOrNull { n ->
+    cm.allNetworks.firstOrNull { n ->
       val caps = cm.getNetworkCapabilities(n) ?: return@firstOrNull false
       caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
     }?.let { return it }
@@ -490,7 +403,7 @@ class GatewayDiscovery(
 
     val candidateNetworks =
       buildList {
-        allNetworksCompat(cm)
+        cm.allNetworks
           .firstOrNull { n ->
             val caps = cm.getNetworkCapabilities(n) ?: return@firstOrNull false
             caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
@@ -525,13 +438,6 @@ class GatewayDiscovery(
     } catch (_: Throwable) {
       null
     }
-  }
-
-  private fun allNetworksCompat(cm: ConnectivityManager): List<android.net.Network> {
-    return runCatching {
-      @Suppress("UNCHECKED_CAST")
-      (cm.javaClass.getMethod("getAllNetworks").invoke(cm) as? Array<android.net.Network>)?.toList()
-    }.getOrNull().orEmpty()
   }
 
   private suspend fun rawQuery(network: android.net.Network?, wireQuery: ByteArray): ByteArray =

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -9,9 +9,12 @@ import android.net.nsd.NsdServiceInfo
 import android.os.CancellationSignal
 import android.util.Log
 import java.io.IOException
+import java.lang.reflect.Proxy
+import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
@@ -43,7 +46,6 @@ import org.xbill.DNS.Type
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-@Suppress("DEPRECATION")
 class GatewayDiscovery(
   context: Context,
   private val scope: CoroutineScope,
@@ -54,6 +56,7 @@ class GatewayDiscovery(
   private val serviceType = "_openclaw-gw._tcp."
   private val wideAreaDomain = System.getenv("OPENCLAW_WIDE_AREA_DOMAIN")
   private val logTag = "OpenClaw/GatewayDiscovery"
+  private val directExecutor = Executor { runnable -> runnable.run() }
 
   private val localById = ConcurrentHashMap<String, GatewayEndpoint>()
   private val unicastById = ConcurrentHashMap<String, GatewayEndpoint>()
@@ -127,43 +130,128 @@ class GatewayDiscovery(
   }
 
   private fun resolve(serviceInfo: NsdServiceInfo) {
-    nsd.resolveService(
-      serviceInfo,
-      object : NsdManager.ResolveListener {
-        override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {}
+    if (registerServiceInfoCallbackCompat(serviceInfo)) return
+    resolveServiceCompat(serviceInfo)
+  }
 
-      override fun onServiceResolved(resolved: NsdServiceInfo) {
-        val host = resolved.host?.hostAddress ?: return
-        val port = resolved.port
-        if (port <= 0) return
+  private fun registerServiceInfoCallbackCompat(serviceInfo: NsdServiceInfo): Boolean {
+    return try {
+      // compileSdk 36 marks resolveService/getHost as deprecated, but we still need
+      // a runtime-compatible path back to Android 12. Prefer the newer callback API
+      // when the device exposes it, and fall back without hard-linking deprecated calls.
+      val callbackClass = Class.forName("android.net.nsd.NsdManager\$ServiceInfoCallback")
+      var callbackRef: Any? = null
+      val callback =
+        Proxy.newProxyInstance(callbackClass.classLoader, arrayOf(callbackClass)) { _, method, args ->
+          when (method.name) {
+            "onServiceUpdated" -> {
+              val resolved = args?.getOrNull(0) as? NsdServiceInfo
+              if (resolved != null) {
+                onServiceResolved(resolved)
+              }
+              callbackRef?.let(::unregisterServiceInfoCallbackCompat)
+              null
+            }
+            "onServiceLost", "onServiceInfoCallbackRegistrationFailed" -> {
+              callbackRef?.let(::unregisterServiceInfoCallbackCompat)
+              null
+            }
+            else -> null
+          }
+        }
+      callbackRef = callback
+      nsd.javaClass
+        .getMethod(
+          "registerServiceInfoCallback",
+          NsdServiceInfo::class.java,
+          Executor::class.java,
+          callbackClass,
+        ).invoke(nsd, serviceInfo, directExecutor, callback)
+      true
+    } catch (_: Throwable) {
+      false
+    }
+  }
 
-        val rawServiceName = resolved.serviceName
-        val serviceName = BonjourEscapes.decode(rawServiceName)
-        val displayName = BonjourEscapes.decode(txt(resolved, "displayName") ?: serviceName)
-        val lanHost = txt(resolved, "lanHost")
-        val tailnetDns = txt(resolved, "tailnetDns")
-        val gatewayPort = txtInt(resolved, "gatewayPort")
-        val canvasPort = txtInt(resolved, "canvasPort")
-        val tlsEnabled = txtBool(resolved, "gatewayTls")
-        val tlsFingerprint = txt(resolved, "gatewayTlsSha256")
-        val id = stableId(serviceName, "local.")
-        localById[id] =
-          GatewayEndpoint(
-            stableId = id,
-            name = displayName,
-            host = host,
-            port = port,
-            lanHost = lanHost,
-            tailnetDns = tailnetDns,
-            gatewayPort = gatewayPort,
-            canvasPort = canvasPort,
-            tlsEnabled = tlsEnabled,
-            tlsFingerprintSha256 = tlsFingerprint,
-          )
-        publish()
-      }
-    },
-  )
+  private fun unregisterServiceInfoCallbackCompat(callback: Any) {
+    try {
+      val callbackClass = Class.forName("android.net.nsd.NsdManager\$ServiceInfoCallback")
+      nsd.javaClass.getMethod("unregisterServiceInfoCallback", callbackClass).invoke(nsd, callback)
+    } catch (_: Throwable) {
+      // ignore (best-effort)
+    }
+  }
+
+  private fun resolveServiceCompat(serviceInfo: NsdServiceInfo) {
+    try {
+      val listenerClass = Class.forName("android.net.nsd.NsdManager\$ResolveListener")
+      val listener =
+        Proxy.newProxyInstance(listenerClass.classLoader, arrayOf(listenerClass)) { _, method, args ->
+          when (method.name) {
+            "onServiceResolved" -> {
+              val resolved = args?.getOrNull(0) as? NsdServiceInfo
+              if (resolved != null) {
+                onServiceResolved(resolved)
+              }
+              null
+            }
+            else -> null
+          }
+        }
+      nsd.javaClass.getMethod("resolveService", NsdServiceInfo::class.java, listenerClass).invoke(
+        nsd,
+        serviceInfo,
+        listener,
+      )
+    } catch (_: Throwable) {
+      // ignore (best-effort)
+    }
+  }
+
+  private fun onServiceResolved(resolved: NsdServiceInfo) {
+    val host = resolveServiceHostAddress(resolved) ?: return
+    val port = resolved.port
+    if (port <= 0) return
+
+    val rawServiceName = resolved.serviceName
+    val serviceName = BonjourEscapes.decode(rawServiceName)
+    val displayName = BonjourEscapes.decode(txt(resolved, "displayName") ?: serviceName)
+    val lanHost = txt(resolved, "lanHost")
+    val tailnetDns = txt(resolved, "tailnetDns")
+    val gatewayPort = txtInt(resolved, "gatewayPort")
+    val canvasPort = txtInt(resolved, "canvasPort")
+    val tlsEnabled = txtBool(resolved, "gatewayTls")
+    val tlsFingerprint = txt(resolved, "gatewayTlsSha256")
+    val id = stableId(serviceName, "local.")
+    localById[id] =
+      GatewayEndpoint(
+        stableId = id,
+        name = displayName,
+        host = host,
+        port = port,
+        lanHost = lanHost,
+        tailnetDns = tailnetDns,
+        gatewayPort = gatewayPort,
+        canvasPort = canvasPort,
+        tlsEnabled = tlsEnabled,
+        tlsFingerprintSha256 = tlsFingerprint,
+      )
+    publish()
+  }
+
+  private fun resolveServiceHostAddress(info: NsdServiceInfo): String? {
+    val modernHost =
+      runCatching {
+        @Suppress("UNCHECKED_CAST")
+        info.javaClass.getMethod("getHostAddresses").invoke(info) as? List<InetAddress>
+      }.getOrNull()
+        ?.firstOrNull()
+        ?.hostAddress
+    if (!modernHost.isNullOrBlank()) return modernHost
+
+    return runCatching {
+      (info.javaClass.getMethod("getHost").invoke(info) as? InetAddress)?.hostAddress
+    }.getOrNull()
   }
 
   private fun publish() {
@@ -350,7 +438,7 @@ class GatewayDiscovery(
   }
 
   private fun records(msg: Message?, section: Int): List<Record> {
-    return msg?.getSectionArray(section)?.toList() ?: emptyList()
+    return msg?.getSection(section).orEmpty()
   }
 
   private fun keyName(raw: String): String {
@@ -389,7 +477,7 @@ class GatewayDiscovery(
     val cm = connectivity ?: return null
 
     // Prefer VPN (Tailscale) when present; otherwise use the active network.
-    cm.allNetworks.firstOrNull { n ->
+    allNetworksCompat(cm).firstOrNull { n ->
       val caps = cm.getNetworkCapabilities(n) ?: return@firstOrNull false
       caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
     }?.let { return it }
@@ -402,7 +490,7 @@ class GatewayDiscovery(
 
     val candidateNetworks =
       buildList {
-        cm.allNetworks
+        allNetworksCompat(cm)
           .firstOrNull { n ->
             val caps = cm.getNetworkCapabilities(n) ?: return@firstOrNull false
             caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
@@ -426,17 +514,24 @@ class GatewayDiscovery(
           try {
             SimpleResolver().apply {
               setAddress(InetSocketAddress(addr, 53))
-              setTimeout(3)
+              setTimeout(Duration.ofSeconds(3))
             }
           } catch (_: Throwable) {
             null
           }
         }
       if (resolvers.isEmpty()) return null
-      ExtendedResolver(resolvers.toTypedArray()).apply { setTimeout(3) }
+      ExtendedResolver(resolvers.toTypedArray()).apply { setTimeout(Duration.ofSeconds(3)) }
     } catch (_: Throwable) {
       null
     }
+  }
+
+  private fun allNetworksCompat(cm: ConnectivityManager): List<android.net.Network> {
+    return runCatching {
+      @Suppress("UNCHECKED_CAST")
+      (cm.javaClass.getMethod("getAllNetworks").invoke(cm) as? Array<android.net.Network>)?.toList()
+    }.getOrNull().orEmpty()
   }
 
   private suspend fun rawQuery(network: android.net.Network?, wireQuery: ByteArray): ByteArray =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
@@ -9,6 +9,7 @@ import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
@@ -9,7 +9,6 @@ import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
-import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
@@ -56,10 +55,10 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
         settings.builtInZoomControls = false
         settings.displayZoomControls = false
         settings.setSupportZoom(false)
+        // targetSdk 33+ ignores Force Dark APIs, so only opt out through the supported
+        // algorithmic darkening flag when this WebView implementation exposes it.
         if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
           WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, false)
-        } else {
-          disableForceDarkIfSupported(settings)
         }
         if (isDebuggable) {
           Log.d("OpenClawWebView", "userAgent: ${settings.userAgentString}")
@@ -155,12 +154,6 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
       }
     },
   )
-}
-
-private fun disableForceDarkIfSupported(settings: WebSettings) {
-  if (!WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) return
-  @Suppress("DEPRECATION")
-  WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_OFF)
 }
 
 internal class CanvasA2UIActionBridge(


### PR DESCRIPTION
## Summary
- remove the old WebView force-dark fallback now that the app targets modern Android SDK levels
- switch DNS discovery helpers to current dnsjava timeout/section APIs
- route NSD and network enumeration through compatibility helpers so Android discovery can use newer APIs when available without dropping older-device behavior

## Testing
- `pnpm install`
- `git diff --check`
- `./gradlew --no-daemon --console=plain :app:tasks --all`
- attempted `./gradlew --no-daemon --console=plain :app:compilePlayDebugKotlin`
- attempted `./gradlew --no-daemon --console=plain :app:compileThirdPartyDebugKotlin`

## Notes
- the compile tasks are currently blocked in this environment because `ANDROID_HOME`/`sdk.dir` is not configured in `apps/android/local.properties`
