### PR TITLE
fix(sandbox): use globalThis registry so plugin-registered backends survive across module instances

### DIFF
--- a/src/agents/sandbox/backend.test.ts
+++ b/src/agents/sandbox/backend.test.ts
@@ -1,18 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   getSandboxBackendFactory,
   getSandboxBackendManager,
   registerSandboxBackend,
+  requireSandboxBackendFactory,
 } from "./backend.js";
 
 describe("sandbox backend registry", () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    for (const fn of cleanups.splice(0)) {
+      fn();
+    }
+  });
+
   it("registers and restores backend factories", () => {
     const factory = async () => {
       throw new Error("not used");
     };
     const restore = registerSandboxBackend("test-backend", factory);
+    cleanups.push(restore);
     expect(getSandboxBackendFactory("test-backend")).toBe(factory);
     restore();
+    cleanups.length = 0;
     expect(getSandboxBackendFactory("test-backend")).toBeNull();
   });
 
@@ -31,9 +41,55 @@ describe("sandbox backend registry", () => {
       factory,
       manager,
     });
+    cleanups.push(restore);
     expect(getSandboxBackendFactory("test-managed")).toBe(factory);
     expect(getSandboxBackendManager("test-managed")).toBe(manager);
     restore();
+    cleanups.length = 0;
     expect(getSandboxBackendManager("test-managed")).toBeNull();
+  });
+
+  it("requireSandboxBackendFactory throws for unregistered backend", () => {
+    expect(() => requireSandboxBackendFactory("nonexistent")).toThrow(
+      'Sandbox backend "nonexistent" is not registered.',
+    );
+  });
+
+  it("requireSandboxBackendFactory returns factory for registered backend", () => {
+    const factory = async () => {
+      throw new Error("not used");
+    };
+    const restore = registerSandboxBackend("test-require", factory);
+    cleanups.push(restore);
+    expect(requireSandboxBackendFactory("test-require")).toBe(factory);
+  });
+
+  it("uses globalThis so registrations survive across module instances", () => {
+    // Simulate what happens when a plugin loaded via Jiti writes to the
+    // globalThis-backed map directly — core's lookup must see it.
+    const key = Symbol.for("openclaw.sandboxBackendFactories");
+    const factory = async () => {
+      throw new Error("not used");
+    };
+    const map = (globalThis as Record<symbol, unknown>)[key] as Map<string, { factory: unknown }>;
+    expect(map).toBeInstanceOf(Map);
+
+    // Write via the global map (simulating a separate module instance)
+    map.set("cross-instance-test", { factory });
+    cleanups.push(() => map.delete("cross-instance-test"));
+
+    // Core lookup must find it
+    expect(getSandboxBackendFactory("cross-instance-test")).toBe(factory);
+    expect(requireSandboxBackendFactory("cross-instance-test")).toBe(factory);
+  });
+
+  it("normalizes backend ids to lowercase", () => {
+    const factory = async () => {
+      throw new Error("not used");
+    };
+    const restore = registerSandboxBackend("MyBackend", factory);
+    cleanups.push(restore);
+    expect(getSandboxBackendFactory("mybackend")).toBe(factory);
+    expect(getSandboxBackendFactory("MYBACKEND")).toBe(factory);
   });
 });

--- a/src/agents/sandbox/backend.ts
+++ b/src/agents/sandbox/backend.ts
@@ -23,7 +23,23 @@ export type {
   SandboxFsBridgeContext,
 } from "./backend-handle.types.js";
 
-const SANDBOX_BACKEND_FACTORIES = new Map<SandboxBackendId, RegisteredSandboxBackend>();
+// Use globalThis + Symbol.for so that plugin Jiti loaders (which may create a
+// separate module instance of this file) share the same registry as core.
+const SANDBOX_BACKEND_FACTORIES_KEY = Symbol.for("openclaw.sandboxBackendFactories");
+
+type GlobalWithSandboxBackends = typeof globalThis & {
+  [key: symbol]: Map<SandboxBackendId, RegisteredSandboxBackend> | undefined;
+};
+
+function getSandboxBackendFactoriesMap(): Map<SandboxBackendId, RegisteredSandboxBackend> {
+  const g = globalThis as GlobalWithSandboxBackends;
+  let map = g[SANDBOX_BACKEND_FACTORIES_KEY];
+  if (!map) {
+    map = new Map();
+    g[SANDBOX_BACKEND_FACTORIES_KEY] = map;
+  }
+  return map;
+}
 
 function normalizeSandboxBackendId(id: string): SandboxBackendId {
   const normalized = normalizeOptionalLowercaseString(id);
@@ -39,23 +55,24 @@ export function registerSandboxBackend(
 ): () => void {
   const normalizedId = normalizeSandboxBackendId(id);
   const resolved = typeof registration === "function" ? { factory: registration } : registration;
-  const previous = SANDBOX_BACKEND_FACTORIES.get(normalizedId);
-  SANDBOX_BACKEND_FACTORIES.set(normalizedId, resolved);
+  const factories = getSandboxBackendFactoriesMap();
+  const previous = factories.get(normalizedId);
+  factories.set(normalizedId, resolved);
   return () => {
     if (previous) {
-      SANDBOX_BACKEND_FACTORIES.set(normalizedId, previous);
+      getSandboxBackendFactoriesMap().set(normalizedId, previous);
       return;
     }
-    SANDBOX_BACKEND_FACTORIES.delete(normalizedId);
+    getSandboxBackendFactoriesMap().delete(normalizedId);
   };
 }
 
 export function getSandboxBackendFactory(id: string): SandboxBackendFactory | null {
-  return SANDBOX_BACKEND_FACTORIES.get(normalizeSandboxBackendId(id))?.factory ?? null;
+  return getSandboxBackendFactoriesMap().get(normalizeSandboxBackendId(id))?.factory ?? null;
 }
 
 export function getSandboxBackendManager(id: string): SandboxBackendManager | null {
-  return SANDBOX_BACKEND_FACTORIES.get(normalizeSandboxBackendId(id))?.manager ?? null;
+  return getSandboxBackendFactoriesMap().get(normalizeSandboxBackendId(id))?.manager ?? null;
 }
 
 export function requireSandboxBackendFactory(id: string): SandboxBackendFactory {


### PR DESCRIPTION
## Problem

Fixes #67610.

`requireSandboxBackendFactory()` throws "not registered" even though the sandbox backend plugin registered successfully during startup. This happens because plugins loaded via Jiti create a **separate module instance** of `backend.ts`, which gets its own module-scoped `Map`. When core later calls `requireSandboxBackendFactory()`, it reads from a different `Map` instance that was never populated.

## Solution

Replace the module-scoped `Map` with a `globalThis`-backed registry using `Symbol.for('openclaw.sandboxBackendFactories')`. This ensures all module instances (core and Jiti-loaded plugins) share the same registry map.

## Changes

- **`src/agents/sandbox/backend.ts`**: Replace module-level `SANDBOX_BACKEND_FACTORIES` map with a `globalThis + Symbol.for()` backed getter function. All read/write operations go through the shared global map.
- **`src/agents/sandbox/backend.test.ts`**: Add tests for `requireSandboxBackendFactory`, cross-instance registration via globalThis, and case-insensitive ID normalization.