### PR TITLE
fix(memory): guard against stale qmdManagerCache singleton causing memory_search TypeError

### DIFF
--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -239,6 +239,42 @@ describe("stale singleton cache guard", () => {
 
     await expect(closeAllMemorySearchManagers()).resolves.toBeUndefined();
   });
+
+  it("does not crash when global slot holds a primitive (string)", async () => {
+    poisonGlobalCacheStore("poisoned");
+    const cfg = createQmdCfg("primitive-agent");
+
+    const result = await getMemorySearchManager({ cfg, agentId: "primitive-agent" });
+
+    expect(result).toBeDefined();
+    expect(result.manager).toBeDefined();
+  });
+
+  it("does not crash when global slot holds null", async () => {
+    poisonGlobalCacheStore(null);
+    const cfg = createQmdCfg("null-agent");
+
+    const result = await getMemorySearchManager({ cfg, agentId: "null-agent" });
+
+    expect(result).toBeDefined();
+    expect(result.manager).toBeDefined();
+  });
+
+  it("does not crash when global slot holds a frozen object with non-Map qmdManagerCache", async () => {
+    poisonGlobalCacheStore(Object.freeze({ qmdManagerCache: "not-a-map" }));
+    const cfg = createQmdCfg("frozen-agent");
+
+    const result = await getMemorySearchManager({ cfg, agentId: "frozen-agent" });
+
+    expect(result).toBeDefined();
+    expect(result.manager).toBeDefined();
+  });
+
+  it("closeAllMemorySearchManagers does not throw when global slot is a primitive", async () => {
+    poisonGlobalCacheStore(42);
+
+    await expect(closeAllMemorySearchManagers()).resolves.toBeUndefined();
+  });
 });
 
 describe("getMemorySearchManager caching", () => {

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type { checkQmdBinaryAvailability as checkQmdBinaryAvailabilityFn } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type CheckQmdBinaryAvailability = typeof checkQmdBinaryAvailabilityFn;
 
@@ -196,6 +196,49 @@ beforeEach(async () => {
   checkQmdBinaryAvailability.mockClear();
   checkQmdBinaryAvailability.mockResolvedValue({ available: true });
   createQmdManagerMock.mockClear();
+});
+
+describe("stale singleton cache guard", () => {
+  const CACHE_KEY = Symbol.for("openclaw.memorySearchManagerCache");
+
+  function poisonGlobalCacheStore(staleValue: unknown) {
+    (globalThis as Record<PropertyKey, unknown>)[CACHE_KEY] = staleValue;
+  }
+
+  afterEach(() => {
+    // Restore a valid shape so other tests are not affected.
+    (globalThis as Record<PropertyKey, unknown>)[CACHE_KEY] = {
+      qmdManagerCache: new Map(),
+    };
+  });
+
+  it("does not crash getMemorySearchManager when qmdManagerCache is undefined", async () => {
+    poisonGlobalCacheStore({ qmdManagerCache: undefined });
+    const cfg = createQmdCfg("stale-agent");
+
+    const result = await getMemorySearchManager({ cfg, agentId: "stale-agent" });
+
+    expect(result).toBeDefined();
+    expect(result.manager).toBeDefined();
+  });
+
+  it("repairs a stale singleton missing qmdManagerCache to an empty Map", async () => {
+    poisonGlobalCacheStore({});
+    const cfg = createQmdCfg("repair-agent");
+
+    const result = await getMemorySearchManager({ cfg, agentId: "repair-agent" });
+
+    expect(result).toBeDefined();
+    // Verify the repaired cache is functional by fetching a second time (exercises .get())
+    const second = await getMemorySearchManager({ cfg, agentId: "repair-agent" });
+    expect(second.manager).toBe(result.manager);
+  });
+
+  it("closeAllMemorySearchManagers does not throw with stale qmdManagerCache", async () => {
+    poisonGlobalCacheStore({ qmdManagerCache: undefined });
+
+    await expect(closeAllMemorySearchManagers()).resolves.toBeUndefined();
+  });
 });
 
 describe("getMemorySearchManager caching", () => {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -23,16 +23,27 @@ type MemorySearchManagerCacheStore = {
 
 function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
   // Keep caches reachable across `vi.resetModules()` so later cleanup can close older instances.
-  return resolveGlobalSingleton<MemorySearchManagerCacheStore>(
+  const store = resolveGlobalSingleton<MemorySearchManagerCacheStore>(
     MEMORY_SEARCH_MANAGER_CACHE_KEY,
     () => ({
       qmdManagerCache: new Map<string, MemorySearchManager>(),
     }),
   );
+  // Guard against stale singleton from an older runtime that stored a different shape
+  // at the same Symbol key (e.g. missing `qmdManagerCache`). Repair in-place so all
+  // callers sharing this globalThis slot see the healed value.
+  if (!(store.qmdManagerCache instanceof Map)) {
+    store.qmdManagerCache = new Map<string, MemorySearchManager>();
+  }
+  return store;
 }
 
 const log = createSubsystemLogger("memory");
-const { qmdManagerCache: QMD_MANAGER_CACHE } = getMemorySearchManagerCacheStore();
+
+function getQmdManagerCache(): Map<string, MemorySearchManager> {
+  return getMemorySearchManagerCacheStore().qmdManagerCache;
+}
+
 let managerRuntimePromise: Promise<typeof import("../../manager-runtime.js")> | null = null;
 
 function loadManagerRuntime() {
@@ -55,12 +66,12 @@ export async function getMemorySearchManager(params: {
     const statusOnly = params.purpose === "status";
     const baseCacheKey = buildQmdCacheKey(params.agentId, resolved.qmd);
     const cacheKey = `${baseCacheKey}:${statusOnly ? "status" : "full"}`;
-    const cached = QMD_MANAGER_CACHE.get(cacheKey);
+    const cached = getQmdManagerCache().get(cacheKey);
     if (cached) {
       return { manager: cached };
     }
     if (statusOnly) {
-      const fullCached = QMD_MANAGER_CACHE.get(`${baseCacheKey}:full`);
+      const fullCached = getQmdManagerCache().get(`${baseCacheKey}:full`);
       if (fullCached) {
         // Status callers often close the manager they receive. Wrap the live
         // full manager with a no-op close so health/status probes do not tear
@@ -110,10 +121,10 @@ export async function getMemorySearchManager(params: {
               },
             },
             () => {
-              QMD_MANAGER_CACHE.delete(cacheKey);
+              getQmdManagerCache().delete(cacheKey);
             },
           );
-          QMD_MANAGER_CACHE.set(cacheKey, wrapper);
+          getQmdManagerCache().set(cacheKey, wrapper);
           return { manager: wrapper };
         }
       } catch (err) {
@@ -186,8 +197,9 @@ class BorrowedMemoryManager implements MemorySearchManager {
 }
 
 export async function closeAllMemorySearchManagers(): Promise<void> {
-  const managers = Array.from(QMD_MANAGER_CACHE.values());
-  QMD_MANAGER_CACHE.clear();
+  const cache = getQmdManagerCache();
+  const managers = Array.from(cache.values());
+  cache.clear();
   for (const manager of managers) {
     try {
       await manager.close?.();

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -21,21 +21,51 @@ type MemorySearchManagerCacheStore = {
   qmdManagerCache: Map<string, MemorySearchManager>;
 };
 
+function isPlainObject(x: unknown): x is Record<PropertyKey, unknown> {
+  return typeof x === "object" && x !== null;
+}
+
 function getMemorySearchManagerCacheStore(): MemorySearchManagerCacheStore {
   // Keep caches reachable across `vi.resetModules()` so later cleanup can close older instances.
-  const store = resolveGlobalSingleton<MemorySearchManagerCacheStore>(
-    MEMORY_SEARCH_MANAGER_CACHE_KEY,
-    () => ({
-      qmdManagerCache: new Map<string, MemorySearchManager>(),
-    }),
-  );
-  // Guard against stale singleton from an older runtime that stored a different shape
-  // at the same Symbol key (e.g. missing `qmdManagerCache`). Repair in-place so all
-  // callers sharing this globalThis slot see the healed value.
-  if (!(store.qmdManagerCache instanceof Map)) {
-    store.qmdManagerCache = new Map<string, MemorySearchManager>();
+  // Use the global slot directly so we can replace the whole value if the stored shape is
+  // a primitive, a frozen object, or a Proxy with throwing accessors.
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const key = MEMORY_SEARCH_MANAGER_CACHE_KEY;
+  const existing = Object.prototype.hasOwnProperty.call(globalStore, key)
+    ? globalStore[key]
+    : undefined;
+
+  const freshStore = (): MemorySearchManagerCacheStore => ({
+    qmdManagerCache: new Map<string, MemorySearchManager>(),
+  });
+
+  // If the stored value is not a plain object (primitive, null, etc.) replace the whole slot.
+  if (!isPlainObject(existing)) {
+    const created = freshStore();
+    globalStore[key] = created;
+    return created;
   }
-  return store;
+
+  // The slot holds an object — attempt a safe read and in-place repair of qmdManagerCache.
+  let cache: unknown;
+  try {
+    cache = existing.qmdManagerCache;
+  } catch {
+    cache = undefined;
+  }
+
+  if (!(cache instanceof Map)) {
+    try {
+      existing.qmdManagerCache = new Map<string, MemorySearchManager>();
+    } catch {
+      // Frozen, sealed, or accessor-based object — replace the whole slot.
+      const created = freshStore();
+      globalStore[key] = created;
+      return created;
+    }
+  }
+
+  return existing as MemorySearchManagerCacheStore;
 }
 
 const log = createSubsystemLogger("memory");


### PR DESCRIPTION
## Summary

Fixes #67549

`memory_search` agent tool throws `TypeError: Cannot read properties of undefined (reading 'get')` while `openclaw memory search` CLI works fine.

## Root Cause

Same class of defect as #67525 (fixed in #67528).

In `extensions/memory-core/src/memory/search-manager.ts`, the module-level constant `QMD_MANAGER_CACHE` was destructured from `getMemorySearchManagerCacheStore()` at **module initialization time**:

```ts
const { qmdManagerCache: QMD_MANAGER_CACHE } = getMemorySearchManagerCacheStore();
```

`getMemorySearchManagerCacheStore()` uses `resolveGlobalSingleton`, which returns the existing `globalThis` value if the key exists — **without validating the shape**. If an older runtime version stored a different object shape at `Symbol.for('openclaw.memorySearchManagerCache')` (e.g. missing or renamed `qmdManagerCache` field), the destructuring yields `undefined`. Any subsequent `QMD_MANAGER_CACHE.get(cacheKey)` then throws:

```
TypeError: Cannot read properties of undefined (reading 'get')
```

The CLI path is unaffected because it uses a fresh process (no stale globalThis) and accesses the memory search manager through a separate import chain that doesn't go through the module-level constant.

## Changes

### `extensions/memory-core/src/memory/search-manager.ts`

1. **Shape validation in `getMemorySearchManagerCacheStore`**: After `resolveGlobalSingleton` returns the store, validates that `qmdManagerCache` is a `Map` instance. If not, repairs it in-place, healing the singleton for all callers sharing the same `globalThis` slot.

2. **Lazy accessor replaces module-level constant**: `QMD_MANAGER_CACHE` (bound at module init) replaced by `getQmdManagerCache()` function. Every call site now goes through the validated store path instead of capturing a potentially `undefined` reference at startup.

### `extensions/memory-core/src/memory/search-manager.test.ts`

New `describe('stale singleton cache guard')` block with 3 tests:
- `getMemorySearchManager` does not crash when `qmdManagerCache` is `undefined`
- `getMemorySearchManagerCacheStore` repairs a stale singleton missing `qmdManagerCache` to an empty `Map`
- `closeAllMemorySearchManagers` does not throw with stale `qmdManagerCache`

## Relationship to #67525 / #67528

| | #67525 | #67549 |
|---|---|---|
| File | `src/plugins/interactive-state.ts` | `extensions/memory-core/src/memory/search-manager.ts` |
| Stale field | `callbackDedupe` | `qmdManagerCache` |
| Crash method | `.clear()` | `.get()` |
| Fix pattern | Optional chaining | instanceof guard + lazy accessor |