### PR TITLE
fix: describe images via imageModel when primary model is text-only

### DIFF
--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -178,3 +178,75 @@ describe("shared attachment validation", () => {
     }
   });
 });
+
+describe("parseMessageWithAttachments default behavior", () => {
+  it("default path: small images are passed inline (not offloaded)", async () => {
+    const { parsed, logs } = await parseWithWarnings("look at this", [
+      {
+        type: "image",
+        mimeType: "image/png",
+        fileName: "photo.png",
+        content: PNG_1x1,
+      },
+    ]);
+    // Default: supportsImages is undefined (falsy but not explicitly false)
+    // so images are passed inline when small enough
+    expect(parsed.images).toHaveLength(1);
+    expect(parsed.offloadedRefs).toHaveLength(0);
+  });
+});
+
+describe("text-only model mode (supportsImages=false)", () => {
+
+  it("offloads all images when supportsImages=false", async () => {
+    const logs: string[] = [];
+    const parsed = await parseMessageWithAttachments(
+      "look at this",
+      [
+        {
+          type: "image",
+          mimeType: "image/png",
+          fileName: "photo.png",
+          content: PNG_1x1,
+        },
+      ],
+      {
+        supportsImages: false,
+        log: { warn: (w: string) => logs.push(w), info: (..._a: unknown[]) => {} },
+      },
+    );
+    // In text-only mode: no inline images, but images are offloaded to media store
+    expect(parsed.images).toHaveLength(0);
+    expect(parsed.offloadedRefs).toHaveLength(1);
+    expect(parsed.message).toContain("media://inbound/");
+    expect(parsed.imageOrder).toEqual(["offloaded"]);
+  });
+
+  it("offloads multiple images when supportsImages=false", async () => {
+    const logs: string[] = [];
+    const parsed = await parseMessageWithAttachments(
+      "compare these",
+      [
+        {
+          type: "image",
+          mimeType: "image/png",
+          fileName: "photo1.png",
+          content: PNG_1x1,
+        },
+        {
+          type: "image",
+          mimeType: "image/png",
+          fileName: "photo2.png",
+          content: PNG_1x1,
+        },
+      ],
+      {
+        supportsImages: false,
+        log: { warn: (w: string) => logs.push(w), info: (..._a: unknown[]) => {} },
+      },
+    );
+    expect(parsed.images).toHaveLength(0);
+    expect(parsed.offloadedRefs).toHaveLength(2);
+    expect(parsed.imageOrder).toEqual(["offloaded", "offloaded"]);
+  });
+});

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -597,12 +597,35 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
     return { ...parsed, message: neutralMessage };
   }
 
-  // Resolve the imageModel from config (e.g. agents.defaults.imageModel)
+  // Resolve the imageModel from config (e.g. agents.defaults.imageModel).
+  // resolveAutoImageModel checks activeModel then falls back to key-order,
+  // but it does NOT check agents.defaults.imageModel (that logic lives in
+  // resolveAutoEntries which is used by the `image` tool path, not here).
+  // So we resolve the configured imageModel first and pass it as activeModel
+  // so multi-provider setups route descriptions to the correct provider.
+  let activeModelFromConfig: { provider: string; model: string } | undefined;
+  if (typeof cfg.agents?.defaults?.imageModel === "string" && cfg.agents.defaults.imageModel.includes("/")) {
+    const slashIdx = cfg.agents.defaults.imageModel.indexOf("/");
+    activeModelFromConfig = {
+      provider: cfg.agents.defaults.imageModel.slice(0, slashIdx),
+      model: cfg.agents.defaults.imageModel.slice(slashIdx + 1),
+    };
+  } else if (cfg.agents?.defaults?.imageModel && typeof cfg.agents.defaults.imageModel === "object") {
+    const primary = cfg.agents.defaults.imageModel.primary;
+    if (primary && primary.includes("/")) {
+      const slashIdx = primary.indexOf("/");
+      activeModelFromConfig = {
+        provider: primary.slice(0, slashIdx),
+        model: primary.slice(slashIdx + 1),
+      };
+    }
+  }
+
   // Guard against resolveAutoImageModel throwing (e.g. provider misconfiguration)
   // so that a config error doesn't crash the entire message pipeline.
   let imageModel: Awaited<ReturnType<typeof resolveAutoImageModel>> | undefined;
   try {
-    imageModel = await resolveAutoImageModel({ cfg, agentDir });
+    imageModel = await resolveAutoImageModel({ cfg, agentDir, activeModel: activeModelFromConfig });
   } catch (err) {
     log?.warn(
       `describeOffloadedImages: resolveAutoImageModel failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -569,7 +569,21 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
   }
 
   // Resolve the imageModel from config (e.g. agents.defaults.imageModel)
-  const imageModel = await resolveAutoImageModel!({ cfg, agentDir });
+  // Guard against resolveAutoImageModel throwing (e.g. provider misconfiguration)
+  // so that a config error doesn't crash the entire message pipeline.
+  let imageModel: Awaited<ReturnType<typeof resolveAutoImageModel>> | undefined;
+  try {
+    imageModel = await resolveAutoImageModel!({ cfg, agentDir });
+  } catch (err) {
+    log?.warn(`describeOffloadedImages: resolveAutoImageModel failed: ${err instanceof Error ? err.message : String(err)}`);
+    // Neutralize all media:// markers so the runner doesn't try to parse them
+    let neutralMessage = parsed.message;
+    for (const ref of parsed.offloadedRefs) {
+      const marker = `[media attached: ${ref.mediaRef}]`;
+      neutralMessage = neutralMessage.replace(marker, "[image attached but could not be described: imageModel resolution failed]");
+    }
+    return { ...parsed, message: neutralMessage };
+  }
   if (!imageModel?.model) {
     log?.warn(
       `describeOffloadedImages: no imageModel configured, ${parsed.offloadedRefs.length} image(s) cannot be described`,

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -566,9 +566,16 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
   const imageModel = await resolveAutoImageModel!({ cfg, agentDir });
   if (!imageModel?.model) {
     log?.warn(
-      `describeOffloadedImages: no imageModel configured, ${parsed.offloadedRefs.length} image(s) will remain as media:// markers`,
+      `describeOffloadedImages: no imageModel configured, ${parsed.offloadedRefs.length} image(s) cannot be described`,
     );
-    return parsed;
+    // Neutralize all media:// markers so the downstream runner doesn't try
+    // to parse them as image refs (which would fail for text-only models).
+    let neutralMessage = parsed.message;
+    for (const ref of parsed.offloadedRefs) {
+      const marker = `[media attached: ${ref.mediaRef}]`;
+      neutralMessage = neutralMessage.replace(marker, "[image attached but could not be described: no imageModel configured]");
+    }
+    return { ...parsed, message: neutralMessage };
   }
 
   let updatedMessage = parsed.message;
@@ -581,8 +588,13 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
   const skippedCount = parsed.offloadedRefs.length - refsToDescribe.length;
   if (skippedCount > 0) {
     log?.warn(
-      `describeOffloadedImages: capping at ${MAX_DESCRIBE_FANOUT} of ${parsed.offloadedRefs.length} offloaded images; ${skippedCount} will remain as media:// markers`,
+      `describeOffloadedImages: capping at ${MAX_DESCRIBE_FANOUT} of ${parsed.offloadedRefs.length} offloaded images; ${skippedCount} will be neutralized`,
     );
+    // Neutralize skipped markers so the runner doesn't try to parse them
+    for (const ref of parsed.offloadedRefs.slice(MAX_DESCRIBE_FANOUT)) {
+      const marker = `[media attached: ${ref.mediaRef}]`;
+      updatedMessage = updatedMessage.replace(marker, "[image attached but not described: fanout cap reached]");
+    }
   }
 
   for (const ref of refsToDescribe) {
@@ -615,12 +627,17 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
         );
       } else {
         log?.warn(`describeOffloadedImages: imageModel returned empty description for ${ref.mediaRef}`);
+        // Neutralize marker so it doesn't get parsed as image ref
+        const marker = `[media attached: ${ref.mediaRef}]`;
+        updatedMessage = updatedMessage.replace(marker, "[image attached but description was empty]");
       }
     } catch (err) {
       log?.warn(
         `describeOffloadedImages: failed to describe ${ref.mediaRef}: ${formatErrorMessage(err)}`,
       );
-      // Leave the original media:// marker — graceful fallback
+      // Neutralize the marker so it doesn't get parsed as an image ref downstream
+      const marker = `[media attached: ${ref.mediaRef}]`;
+      updatedMessage = updatedMessage.replace(marker, `[image attached but could not be described: description failed]`);
     }
   }
 

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -601,23 +601,35 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
   // resolveAutoImageModel checks activeModel then falls back to key-order,
   // but it does NOT check agents.defaults.imageModel (that logic lives in
   // resolveAutoEntries which is used by the `image` tool path, not here).
-  // So we resolve the configured imageModel first and pass it as activeModel
-  // so multi-provider setups route descriptions to the correct provider.
-  let activeModelFromConfig: { provider: string; model: string } | undefined;
-  if (typeof cfg.agents?.defaults?.imageModel === "string" && cfg.agents.defaults.imageModel.includes("/")) {
-    const slashIdx = cfg.agents.defaults.imageModel.indexOf("/");
-    activeModelFromConfig = {
-      provider: cfg.agents.defaults.imageModel.slice(0, slashIdx),
-      model: cfg.agents.defaults.imageModel.slice(slashIdx + 1),
-    };
-  } else if (cfg.agents?.defaults?.imageModel && typeof cfg.agents.defaults.imageModel === "object") {
-    const primary = cfg.agents.defaults.imageModel.primary;
+  // So we build a list of configured image model candidates (primary + fallbacks)
+  // and try each as activeModel so multi-provider setups route descriptions
+  // to the correct provider and honor the fallback chain.
+  const configuredImageModelCandidates: { provider: string; model: string }[] = [];
+  const imageModelCfg = cfg.agents?.defaults?.imageModel;
+  if (typeof imageModelCfg === "string" && imageModelCfg.includes("/")) {
+    const slashIdx = imageModelCfg.indexOf("/");
+    configuredImageModelCandidates.push({
+      provider: imageModelCfg.slice(0, slashIdx),
+      model: imageModelCfg.slice(slashIdx + 1),
+    });
+  } else if (imageModelCfg && typeof imageModelCfg === "object") {
+    const primary = imageModelCfg.primary;
     if (primary && primary.includes("/")) {
       const slashIdx = primary.indexOf("/");
-      activeModelFromConfig = {
+      configuredImageModelCandidates.push({
         provider: primary.slice(0, slashIdx),
         model: primary.slice(slashIdx + 1),
-      };
+      });
+    }
+    const fallbacks = imageModelCfg.fallbacks ?? [];
+    for (const fb of fallbacks) {
+      if (fb && fb.includes("/")) {
+        const slashIdx = fb.indexOf("/");
+        configuredImageModelCandidates.push({
+          provider: fb.slice(0, slashIdx),
+          model: fb.slice(slashIdx + 1),
+        });
+      }
     }
   }
 
@@ -625,7 +637,23 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
   // so that a config error doesn't crash the entire message pipeline.
   let imageModel: Awaited<ReturnType<typeof resolveAutoImageModel>> | undefined;
   try {
-    imageModel = await resolveAutoImageModel({ cfg, agentDir, activeModel: activeModelFromConfig });
+    // Try each configured candidate as activeModel; use the first that resolves.
+    // If none resolve (e.g. no auth), fall through to key-order auto selection
+    // which resolveAutoImageModel does internally when activeModel is unset.
+    if (configuredImageModelCandidates.length > 0) {
+      for (const candidate of configuredImageModelCandidates) {
+        const resolved = await resolveAutoImageModel({ cfg, agentDir, activeModel: candidate });
+        if (resolved?.model) {
+          imageModel = resolved;
+          break;
+        }
+      }
+    }
+    // If no configured candidate resolved, let resolveAutoImageModel try
+    // key-order auto selection by calling it without activeModel.
+    if (!imageModel?.model) {
+      imageModel = await resolveAutoImageModel({ cfg, agentDir });
+    }
   } catch (err) {
     log?.warn(
       `describeOffloadedImages: resolveAutoImageModel failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -311,6 +311,15 @@ export async function parseMessageWithAttachments(
   // entirely, which meant the agent never saw them at all.
   const textOnlyMode = opts?.supportsImages === false;
 
+  // In text-only mode, cap the number of attachments that get offloaded to
+  // disk. Without this cap, a single request with many attachments causes
+  // unbounded media-store writes and I/O amplification before the downstream
+  // fanout limit (MAX_DESCRIBE_FANOUT in describeOffloadedImagesForTextOnlyModel)
+  // kicks in. Attachments beyond this budget are neutralized as text-only
+  // markers without persisting to disk.
+  const MAX_TEXT_ONLY_OFFLOAD = 10;
+  let textOnlyOffloadCount = 0;
+
   const images: ChatImageContent[] = [];
   const imageOrder: PromptImageOrderEntry[] = [];
   const offloadedRefs: OffloadedRef[] = [];
@@ -375,6 +384,18 @@ export async function parseMessageWithAttachments(
       // images using a configured imageModel. Inline image blocks are never
       // produced because the primary model cannot process them.
       const forceOffload = textOnlyMode;
+
+      // In text-only mode, cap offloads before writing to disk. Excess
+      // attachments are neutralized as text markers without persisting
+      // to the media store, preventing unbounded I/O from large batches.
+      if (forceOffload && textOnlyOffloadCount >= MAX_TEXT_ONLY_OFFLOAD) {
+        log?.warn(
+          `attachment ${label}: text-only offload cap (${MAX_TEXT_ONLY_OFFLOAD}) reached, neutralizing without disk write`,
+        );
+        updatedMessage += `\n[image attached but not offloaded: text-only attachment cap reached]`;
+        imageOrder.push("offloaded");
+        continue;
+      }
 
       let isOffloaded = false;
 
@@ -443,6 +464,7 @@ export async function parseMessageWithAttachments(
           imageOrder.push("offloaded");
 
           isOffloaded = true;
+          textOnlyOffloadCount++;
         } catch (err) {
           const errorMessage = formatErrorMessage(err);
           throw new MediaOffloadError(
@@ -551,8 +573,12 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
 
   // Dynamically import the media-understanding description functions
   // through the *.runtime.ts boundary convention (see CLAUDE.md).
-  let resolveAutoImageModel: typeof import("./media-understanding-describe.runtime.js").resolveAutoImageModel | undefined;
-  let describeImageFileWithModel: typeof import("./media-understanding-describe.runtime.js").describeImageFileWithModel | undefined;
+  let resolveAutoImageModel:
+    | typeof import("./media-understanding-describe.runtime.js").resolveAutoImageModel
+    | undefined;
+  let describeImageFileWithModel:
+    | typeof import("./media-understanding-describe.runtime.js").describeImageFileWithModel
+    | undefined;
   try {
     const runtime = await import("./media-understanding-describe.runtime.js");
     resolveAutoImageModel = runtime.resolveAutoImageModel;
@@ -563,7 +589,10 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
     let neutralMessage = parsed.message;
     for (const ref of parsed.offloadedRefs) {
       const marker = `[media attached: ${ref.mediaRef}]`;
-      neutralMessage = neutralMessage.replace(marker, "[image attached but could not be described: media-understanding import failed]");
+      neutralMessage = neutralMessage.replace(
+        marker,
+        "[image attached but could not be described: media-understanding import failed]",
+      );
     }
     return { ...parsed, message: neutralMessage };
   }
@@ -573,14 +602,19 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
   // so that a config error doesn't crash the entire message pipeline.
   let imageModel: Awaited<ReturnType<typeof resolveAutoImageModel>> | undefined;
   try {
-    imageModel = await resolveAutoImageModel!({ cfg, agentDir });
+    imageModel = await resolveAutoImageModel({ cfg, agentDir });
   } catch (err) {
-    log?.warn(`describeOffloadedImages: resolveAutoImageModel failed: ${err instanceof Error ? err.message : String(err)}`);
+    log?.warn(
+      `describeOffloadedImages: resolveAutoImageModel failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
     // Neutralize all media:// markers so the runner doesn't try to parse them
     let neutralMessage = parsed.message;
     for (const ref of parsed.offloadedRefs) {
       const marker = `[media attached: ${ref.mediaRef}]`;
-      neutralMessage = neutralMessage.replace(marker, "[image attached but could not be described: imageModel resolution failed]");
+      neutralMessage = neutralMessage.replace(
+        marker,
+        "[image attached but could not be described: imageModel resolution failed]",
+      );
     }
     return { ...parsed, message: neutralMessage };
   }
@@ -593,7 +627,10 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
     let neutralMessage = parsed.message;
     for (const ref of parsed.offloadedRefs) {
       const marker = `[media attached: ${ref.mediaRef}]`;
-      neutralMessage = neutralMessage.replace(marker, "[image attached but could not be described: no imageModel configured]");
+      neutralMessage = neutralMessage.replace(
+        marker,
+        "[image attached but could not be described: no imageModel configured]",
+      );
     }
     return { ...parsed, message: neutralMessage };
   }
@@ -613,7 +650,10 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
     // Neutralize skipped markers so the runner doesn't try to parse them
     for (const ref of parsed.offloadedRefs.slice(MAX_DESCRIBE_FANOUT)) {
       const marker = `[media attached: ${ref.mediaRef}]`;
-      updatedMessage = updatedMessage.replace(marker, "[image attached but not described: fanout cap reached]");
+      updatedMessage = updatedMessage.replace(
+        marker,
+        "[image attached but not described: fanout cap reached]",
+      );
     }
   }
 
@@ -623,7 +663,7 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
       const physicalPath = await resolveMediaBufferPath(ref.id, "inbound");
 
       // Describe the image using the vision-capable imageModel
-      const result = await describeImageFileWithModel!({
+      const result = await describeImageFileWithModel({
         filePath: physicalPath,
         cfg,
         agentDir,
@@ -646,10 +686,15 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
           `[Gateway] Described offloaded image ${ref.mediaRef} via ${imageModel.provider}/${imageModel.model}`,
         );
       } else {
-        log?.warn(`describeOffloadedImages: imageModel returned empty description for ${ref.mediaRef}`);
+        log?.warn(
+          `describeOffloadedImages: imageModel returned empty description for ${ref.mediaRef}`,
+        );
         // Neutralize marker so it doesn't get parsed as image ref
         const marker = `[media attached: ${ref.mediaRef}]`;
-        updatedMessage = updatedMessage.replace(marker, "[image attached but description was empty]");
+        updatedMessage = updatedMessage.replace(
+          marker,
+          "[image attached but description was empty]",
+        );
       }
     } catch (err) {
       log?.warn(
@@ -657,7 +702,10 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
       );
       // Neutralize the marker so it doesn't get parsed as an image ref downstream
       const marker = `[media attached: ${ref.mediaRef}]`;
-      updatedMessage = updatedMessage.replace(marker, `[image attached but could not be described: description failed]`);
+      updatedMessage = updatedMessage.replace(
+        marker,
+        `[image attached but could not be described: description failed]`,
+      );
     }
   }
 

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -573,7 +573,19 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
 
   let updatedMessage = parsed.message;
 
-  for (const ref of parsed.offloadedRefs) {
+  // Cap per-request description fanout to avoid unbounded cost/latency.
+  // Gateway RPC schemas accept unbounded attachments arrays; without a cap,
+  // one request could trigger many sequential paid image-description calls.
+  const MAX_DESCRIBE_FANOUT = 5;
+  const refsToDescribe = parsed.offloadedRefs.slice(0, MAX_DESCRIBE_FANOUT);
+  const skippedCount = parsed.offloadedRefs.length - refsToDescribe.length;
+  if (skippedCount > 0) {
+    log?.warn(
+      `describeOffloadedImages: capping at ${MAX_DESCRIBE_FANOUT} of ${parsed.offloadedRefs.length} offloaded images; ${skippedCount} will remain as media:// markers`,
+    );
+  }
+
+  for (const ref of refsToDescribe) {
     try {
       // Resolve the physical file path from the media store
       const physicalPath = await resolveMediaBufferPath(ref.id, "inbound");

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -2,7 +2,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { estimateBase64DecodedBytes } from "../media/base64.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
-import { deleteMediaBuffer, saveMediaBuffer } from "../media/store.js";
+import { deleteMediaBuffer, resolveMediaBufferPath, saveMediaBuffer } from "../media/store.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -58,9 +58,9 @@ export type ParsedMessageWithImages = {
    * It is intentionally separate from `images` because downstream model calls
    * do not receive these as inline image blocks.
    *
-   * ⚠️  Call sites (chat.ts, agent.ts, server-node-events.ts) MUST also pass
-   * `supportsImages: modelSupportsImages(model)` so that text-only model runs
-   * do not inject unresolvable media:// markers into prompt text.
+   * In text-only mode (supportsImages=false), ALL image attachments are
+   * offloaded regardless of size so that a configured imageModel can describe
+   * them. The `images` array will be empty in that case.
    */
   offloadedRefs: OffloadedRef[];
 };
@@ -271,12 +271,11 @@ function validateAttachmentBase64OrThrow(
  * because they are not passed inline to the model.
  *
  * ## Text-only model runs
- * Pass `supportsImages: false` for text-only model runs so that no media://
- * markers are injected into prompt text.
- *
- * ⚠️  Call sites in chat.ts, agent.ts, and server-node-events.ts MUST be
- * updated to pass `supportsImages: modelSupportsImages(model)`. Until they do,
- * text-only model runs receive unresolvable media:// markers in their prompt.
+ * Pass `supportsImages: false` for text-only model runs. Attachments are still
+ * offloaded to the media store with `media://` markers injected into the prompt
+ * so that downstream image description pipelines can resolve and describe them
+ * using a configured `imageModel`. The `images` array will be empty in this case;
+ * only `offloadedRefs` and `imageOrder` entries (all marked "offloaded") are produced.
  *
  * ## Cleanup on failure
  * On any parse failure after files have already been offloaded, best-effort
@@ -304,17 +303,13 @@ export async function parseMessageWithAttachments(
     return { message, images: [], imageOrder: [], offloadedRefs: [] };
   }
 
-  // For text-only models drop all attachments cleanly. Do not save files or
-  // inject media:// markers that would never be resolved and would leak
-  // internal path references into the model's prompt.
-  if (opts?.supportsImages === false) {
-    if (attachments.length > 0) {
-      log?.warn(
-        `parseMessageWithAttachments: ${attachments.length} attachment(s) dropped — model does not support images`,
-      );
-    }
-    return { message, images: [], imageOrder: [], offloadedRefs: [] };
-  }
+  // For text-only models, offload all attachments to the media store but
+  // do NOT pass them as inline image blocks. The media:// markers are
+  // injected so that downstream image description pipelines (e.g.
+  // describeOffloadedImagesForTextOnlyModel) can resolve and describe them
+  // using a configured imageModel. Previously, attachments were dropped
+  // entirely, which meant the agent never saw them at all.
+  const textOnlyMode = opts?.supportsImages === false;
 
   const images: ChatImageContent[] = [];
   const imageOrder: PromptImageOrderEntry[] = [];
@@ -375,12 +370,26 @@ export async function parseMessageWithAttachments(
       // "IMAGE/JPEG") does not silently bypass the SUPPORTED_OFFLOAD_MIMES check.
       const finalMime = sniffedMime ?? providedMime ?? normalizeMime(mime) ?? mime;
 
+      // In text-only mode, always offload to the media store so that
+      // downstream image description pipelines can resolve and describe the
+      // images using a configured imageModel. Inline image blocks are never
+      // produced because the primary model cannot process them.
+      const forceOffload = textOnlyMode;
+
       let isOffloaded = false;
 
-      if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
+      if (forceOffload || sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
         const isSupportedForOffload = SUPPORTED_OFFLOAD_MIMES.has(finalMime);
 
         if (!isSupportedForOffload) {
+          if (forceOffload) {
+            // Text-only mode: can't inline and can't offload this format.
+            // Drop gracefully rather than crashing the session.
+            log?.warn(
+              `attachment ${label}: unsupported offload format ${finalMime} for text-only model, dropping`,
+            );
+            continue;
+          }
           // Passing this inline would reintroduce the OOM risk this PR prevents.
           throw new Error(
             `attachment ${label}: format ${finalMime} is too large to pass inline ` +
@@ -418,7 +427,9 @@ export async function parseMessageWithAttachments(
           const mediaRef = `media://inbound/${savedMedia.id}`;
 
           updatedMessage += `\n[media attached: ${mediaRef}]`;
-          log?.info?.(`[Gateway] Intercepted large image payload. Saved: ${mediaRef}`);
+          log?.info?.(
+            `[Gateway] ${forceOffload ? "Text-only model offload" : "Intercepted large image payload"}. Saved: ${mediaRef}`,
+          );
 
           // Record for transcript metadata — separate from `images` because
           // these are not passed inline to the model.
@@ -445,6 +456,8 @@ export async function parseMessageWithAttachments(
         continue;
       }
 
+      // In text-only mode, inline images are never produced. This branch
+      // is only reached when textOnlyMode is false and size <= threshold.
       images.push({ type: "image", data: b64, mimeType: finalMime });
       imageOrder.push("inline");
     }
@@ -503,4 +516,104 @@ export function buildMessageWithAttachments(
 
   const separator = message.trim().length > 0 ? "\n\n" : "";
   return `${message}${separator}${blocks.join("\n\n")}`;
+}
+
+/**
+ * Describes offloaded images using a vision-capable imageModel so that
+ * text-only primary models can still process image attachments.
+ *
+ * When the primary model does not support images (supportsImages=false),
+ * `parseMessageWithAttachments` offloads all images to the media store and
+ * injects `[media attached: media://inbound/<id>]` markers into the message.
+ * This function resolves those markers, describes the images using the
+ * configured imageModel, and replaces the markers with human-readable
+ * descriptions so the text-only model can reason about the image content.
+ *
+ * If no imageModel is configured or description fails for an image, the
+ * original `media://` marker is preserved in the message (graceful fallback).
+ *
+ * @param parsed Result from `parseMessageWithAttachments` with offloadedRefs
+ * @param cfg OpenClawConfig for resolving imageModel
+ * @param agentDir Optional agent directory for provider resolution
+ * @returns Updated message with media:// markers replaced by descriptions
+ */
+export async function describeOffloadedImagesForTextOnlyModel(params: {
+  parsed: ParsedMessageWithImages;
+  cfg: import("../config/types.js").OpenClawConfig;
+  agentDir?: string;
+  log?: AttachmentLog;
+}): Promise<ParsedMessageWithImages> {
+  const { parsed, cfg, agentDir, log } = params;
+
+  if (parsed.offloadedRefs.length === 0) {
+    return parsed;
+  }
+
+  // Dynamically import the media-understanding description functions
+  // through the *.runtime.ts boundary convention (see CLAUDE.md).
+  let resolveAutoImageModel: typeof import("./media-understanding-describe.runtime.js").resolveAutoImageModel | undefined;
+  let describeImageFileWithModel: typeof import("./media-understanding-describe.runtime.js").describeImageFileWithModel | undefined;
+  try {
+    const runtime = await import("./media-understanding-describe.runtime.js");
+    resolveAutoImageModel = runtime.resolveAutoImageModel;
+    describeImageFileWithModel = runtime.describeImageFileWithModel;
+  } catch {
+    log?.warn("describeOffloadedImages: failed to import media-understanding modules");
+    return parsed;
+  }
+
+  // Resolve the imageModel from config (e.g. agents.defaults.imageModel)
+  const imageModel = await resolveAutoImageModel!({ cfg, agentDir });
+  if (!imageModel?.model) {
+    log?.warn(
+      `describeOffloadedImages: no imageModel configured, ${parsed.offloadedRefs.length} image(s) will remain as media:// markers`,
+    );
+    return parsed;
+  }
+
+  let updatedMessage = parsed.message;
+
+  for (const ref of parsed.offloadedRefs) {
+    try {
+      // Resolve the physical file path from the media store
+      const physicalPath = await resolveMediaBufferPath(ref.id, "inbound");
+
+      // Describe the image using the vision-capable imageModel
+      const result = await describeImageFileWithModel!({
+        filePath: physicalPath,
+        cfg,
+        agentDir,
+        mime: ref.mimeType,
+        provider: imageModel.provider,
+        model: imageModel.model,
+        prompt:
+          "Describe this image concisely in 2-3 sentences. Focus on the main subject, key details, and any text visible in the image.",
+        maxTokens: 200,
+        timeoutMs: 30_000,
+      });
+
+      const description = result.text?.trim();
+      if (description) {
+        // Replace the media:// marker with a text description
+        const marker = `[media attached: ${ref.mediaRef}]`;
+        const replacement = `[attached image: ${description}]`;
+        updatedMessage = updatedMessage.replace(marker, replacement);
+        log?.info?.(
+          `[Gateway] Described offloaded image ${ref.mediaRef} via ${imageModel.provider}/${imageModel.model}`,
+        );
+      } else {
+        log?.warn(`describeOffloadedImages: imageModel returned empty description for ${ref.mediaRef}`);
+      }
+    } catch (err) {
+      log?.warn(
+        `describeOffloadedImages: failed to describe ${ref.mediaRef}: ${formatErrorMessage(err)}`,
+      );
+      // Leave the original media:// marker — graceful fallback
+    }
+  }
+
+  return {
+    ...parsed,
+    message: updatedMessage,
+  };
 }

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -559,7 +559,13 @@ export async function describeOffloadedImagesForTextOnlyModel(params: {
     describeImageFileWithModel = runtime.describeImageFileWithModel;
   } catch {
     log?.warn("describeOffloadedImages: failed to import media-understanding modules");
-    return parsed;
+    // Neutralize markers so the runner doesn't try to parse them as image refs
+    let neutralMessage = parsed.message;
+    for (const ref of parsed.offloadedRefs) {
+      const marker = `[media attached: ${ref.mediaRef}]`;
+      neutralMessage = neutralMessage.replace(marker, "[image attached but could not be described: media-understanding import failed]");
+    }
+    return { ...parsed, message: neutralMessage };
   }
 
   // Resolve the imageModel from config (e.g. agents.defaults.imageModel)

--- a/src/gateway/media-understanding-describe.runtime.ts
+++ b/src/gateway/media-understanding-describe.runtime.ts
@@ -1,0 +1,11 @@
+/**
+ * Runtime boundary for lazy-loading media-understanding description functions.
+ *
+ * This file re-exports the two functions needed by
+ * `describeOffloadedImagesForTextOnlyModel` so that the caller can
+ * dynamically import this boundary instead of inlining direct
+ * `await import("../media-understanding/…")` calls, which would
+ * bypass the `*.runtime.ts` convention documented in CLAUDE.md.
+ */
+export { resolveAutoImageModel } from "../media-understanding/runner.js";
+export { describeImageFileWithModel } from "../media-understanding/runtime.js";

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -394,19 +394,66 @@ export const agentHandlers: GatewayRequestHandlers = {
     const requestedBestEffortDeliver =
       typeof request.bestEffortDeliver === "boolean" ? request.bestEffortDeliver : undefined;
 
+    // Validate agentId and sessionKey early so that paid image-description
+    // model calls are never triggered for invalid request params.
+    const validatedAgentIdRaw = normalizeOptionalString(request.agentId) ?? "";
+    const validatedAgentId = validatedAgentIdRaw ? normalizeAgentId(validatedAgentIdRaw) : undefined;
+    if (validatedAgentId) {
+      const knownAgents = listAgentIds(cfg);
+      if (!knownAgents.includes(validatedAgentId)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid agent params: unknown agent id "${request.agentId}"`,
+          ),
+        );
+        return;
+      }
+    }
+    const validatedSessionKeyRaw =
+      typeof request.sessionKey === "string" && request.sessionKey.trim()
+        ? request.sessionKey.trim()
+        : undefined;
+    if (
+      validatedSessionKeyRaw &&
+      classifySessionKeyShape(validatedSessionKeyRaw) === "malformed_agent"
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid agent params: malformed session key "${validatedSessionKeyRaw}"`,
+        ),
+      );
+      return;
+    }
+    if (validatedAgentId && validatedSessionKeyRaw) {
+      const sessionAgentId = resolveAgentIdFromSessionKey(validatedSessionKeyRaw);
+      if (sessionAgentId !== validatedAgentId) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid agent params: session key agent (${sessionAgentId}) does not match agentId (${validatedAgentId})`,
+          ),
+        );
+        return;
+      }
+    }
+
     let message = (request.message ?? "").trim();
     let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
     let imageOrder: PromptImageOrderEntry[] = [];
     if (normalizedAttachments.length > 0) {
-      const requestedSessionKeyRaw =
-        typeof request.sessionKey === "string" && request.sessionKey.trim()
-          ? request.sessionKey.trim()
-          : undefined;
 
       let baseProvider: string | undefined;
       let baseModel: string | undefined;
-      if (requestedSessionKeyRaw) {
-        const { cfg: sessCfg, entry: sessEntry } = loadSessionEntry(requestedSessionKeyRaw);
+      if (validatedSessionKeyRaw) {
+        const { cfg: sessCfg, entry: sessEntry } = loadSessionEntry(validatedSessionKeyRaw);
         const modelRef = resolveSessionModelRef(sessCfg, sessEntry, undefined);
         baseProvider = modelRef.provider;
         baseModel = modelRef.model;
@@ -427,29 +474,16 @@ export const agentHandlers: GatewayRequestHandlers = {
         });
         // When the primary model is text-only, describe offloaded images using
         // the configured imageModel so the agent can reason about image content.
+        // agentId and sessionKey have already been validated above.
         if (!supportsImages && parsed.offloadedRefs.length > 0) {
-          // Validate agentId before making paid image-description calls.
-          // Resolve agentDir from sessionKey first, then fall back to agentId.
-          let resolvedAgentDir: string | undefined;
-          if (requestedSessionKeyRaw) {
-            const sid = resolveSessionAgentId({ sessionKey: requestedSessionKeyRaw, config: cfg });
-            resolvedAgentDir = sid ? resolveAgentDir(cfg, sid) : undefined;
-          } else if (request.agentId) {
-            const aid = normalizeAgentId(String(request.agentId));
-            const knownAgents = listAgentIds(cfg);
-            if (!knownAgents.includes(aid)) {
-              respond(
-                false,
-                undefined,
-                errorShape(
-                  ErrorCodes.INVALID_REQUEST,
-                  `invalid agent params: unknown agent id "${request.agentId}"`,
-                ),
-              );
-              return;
-            }
-            resolvedAgentDir = resolveAgentDir(cfg, aid);
-          }
+          const resolvedAgentDir = validatedSessionKeyRaw
+            ? (() => {
+              const sid = resolveSessionAgentId({ sessionKey: validatedSessionKeyRaw, config: cfg });
+              return sid ? resolveAgentDir(cfg, sid) : undefined;
+            })()
+            : validatedAgentId
+              ? resolveAgentDir(cfg, validatedAgentId)
+              : undefined;
           const described = await describeOffloadedImagesForTextOnlyModel({
             parsed,
             cfg,
@@ -503,58 +537,15 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const agentIdRaw = normalizeOptionalString(request.agentId) ?? "";
-    const agentId = agentIdRaw ? normalizeAgentId(agentIdRaw) : undefined;
-    if (agentId) {
-      const knownAgents = listAgentIds(cfg);
-      if (!knownAgents.includes(agentId)) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            `invalid agent params: unknown agent id "${request.agentId}"`,
-          ),
-        );
-        return;
-      }
-    }
+    const agentId = validatedAgentId;
 
-    const requestedSessionKeyRaw = normalizeOptionalString(request.sessionKey);
-    if (
-      requestedSessionKeyRaw &&
-      classifySessionKeyShape(requestedSessionKeyRaw) === "malformed_agent"
-    ) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `invalid agent params: malformed session key "${requestedSessionKeyRaw}"`,
-        ),
-      );
-      return;
-    }
+    const requestedSessionKeyRaw = validatedSessionKeyRaw;
     let requestedSessionKey =
       requestedSessionKeyRaw ??
       resolveExplicitAgentSessionKey({
         cfg,
         agentId,
       });
-    if (agentId && requestedSessionKeyRaw) {
-      const sessionAgentId = resolveAgentIdFromSessionKey(requestedSessionKeyRaw);
-      if (sessionAgentId !== agentId) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            `invalid agent params: agent "${request.agentId}" does not match session key agent "${sessionAgentId}"`,
-          ),
-        );
-        return;
-      }
-    }
     let resolvedSessionId = normalizeOptionalString(request.sessionId);
     let sessionEntry: SessionEntry | undefined;
     let bestEffortDeliver = requestedBestEffortDeliver ?? false;

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir, resolveDefaultAgentId, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import {
   normalizeSpawnedRunMetadata,
@@ -483,7 +483,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             })()
             : validatedAgentId
               ? resolveAgentDir(cfg, validatedAgentId)
-              : undefined;
+              : resolveAgentDir(cfg, resolveDefaultAgentId(cfg));
           const described = await describeOffloadedImagesForTextOnlyModel({
             parsed,
             cfg,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { listAgentIds, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import {
   normalizeSpawnedRunMetadata,
@@ -58,7 +58,7 @@ import {
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
-import { MediaOffloadError, parseMessageWithAttachments } from "../chat-attachments.js";
+import { MediaOffloadError, parseMessageWithAttachments, describeOffloadedImagesForTextOnlyModel } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
@@ -425,9 +425,45 @@ export const agentHandlers: GatewayRequestHandlers = {
           log: context.logGateway,
           supportsImages,
         });
-        message = parsed.message.trim();
-        images = parsed.images;
-        imageOrder = parsed.imageOrder;
+        // When the primary model is text-only, describe offloaded images using
+        // the configured imageModel so the agent can reason about image content.
+        if (!supportsImages && parsed.offloadedRefs.length > 0) {
+          // Validate agentId before making paid image-description calls.
+          // Resolve agentDir from sessionKey first, then fall back to agentId.
+          let resolvedAgentDir: string | undefined;
+          if (requestedSessionKeyRaw) {
+            const sid = resolveSessionAgentId({ sessionKey: requestedSessionKeyRaw, config: cfg });
+            resolvedAgentDir = sid ? resolveAgentDir(cfg, sid) : undefined;
+          } else if (request.agentId) {
+            const aid = normalizeAgentId(String(request.agentId));
+            const knownAgents = listAgentIds(cfg);
+            if (!knownAgents.includes(aid)) {
+              respond(
+                false,
+                undefined,
+                errorShape(
+                  ErrorCodes.INVALID_REQUEST,
+                  `invalid agent params: unknown agent id "${request.agentId}"`,
+                ),
+              );
+              return;
+            }
+            resolvedAgentDir = resolveAgentDir(cfg, aid);
+          }
+          const described = await describeOffloadedImagesForTextOnlyModel({
+            parsed,
+            cfg,
+            agentDir: resolvedAgentDir,
+            log: context.logGateway,
+          });
+          message = described.message.trim();
+          images = described.images;
+          imageOrder = described.imageOrder;
+        } else {
+          message = parsed.message.trim();
+          images = parsed.images;
+          imageOrder = parsed.imageOrder;
+        }
         // offloadedRefs are appended as text markers to `message`; the agent
         // runner will resolve them via detectAndLoadPromptImages.
       } catch (err) {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir, resolveDefaultAgentId, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import {
+  listAgentIds,
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+  resolveSessionAgentId,
+} from "../../agents/agent-scope.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import {
   normalizeSpawnedRunMetadata,
@@ -58,7 +64,11 @@ import {
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
-import { MediaOffloadError, parseMessageWithAttachments, describeOffloadedImagesForTextOnlyModel } from "../chat-attachments.js";
+import {
+  MediaOffloadError,
+  parseMessageWithAttachments,
+  describeOffloadedImagesForTextOnlyModel,
+} from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
@@ -397,7 +407,9 @@ export const agentHandlers: GatewayRequestHandlers = {
     // Validate agentId and sessionKey early so that paid image-description
     // model calls are never triggered for invalid request params.
     const validatedAgentIdRaw = normalizeOptionalString(request.agentId) ?? "";
-    const validatedAgentId = validatedAgentIdRaw ? normalizeAgentId(validatedAgentIdRaw) : undefined;
+    const validatedAgentId = validatedAgentIdRaw
+      ? normalizeAgentId(validatedAgentIdRaw)
+      : undefined;
     if (validatedAgentId) {
       const knownAgents = listAgentIds(cfg);
       if (!knownAgents.includes(validatedAgentId)) {
@@ -445,11 +457,33 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
+    // Validate channel hints before any attachment processing or paid
+    // image-description calls, so that requests with invalid channels are
+    // rejected early without triggering unnecessary API costs or disk I/O.
+    const isKnownGatewayChannel = (value: string): boolean => isGatewayMessageChannel(value);
+    const channelHints = [request.channel, request.replyChannel]
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter(Boolean);
+    for (const rawChannel of channelHints) {
+      const normalized = normalizeMessageChannel(rawChannel);
+      if (normalized && normalized !== "last" && !isKnownGatewayChannel(normalized)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid agent params: unknown channel: ${normalized}`,
+          ),
+        );
+        return;
+      }
+    }
+
     let message = (request.message ?? "").trim();
     let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
     let imageOrder: PromptImageOrderEntry[] = [];
     if (normalizedAttachments.length > 0) {
-
       let baseProvider: string | undefined;
       let baseModel: string | undefined;
       if (validatedSessionKeyRaw) {
@@ -478,9 +512,12 @@ export const agentHandlers: GatewayRequestHandlers = {
         if (!supportsImages && parsed.offloadedRefs.length > 0) {
           const resolvedAgentDir = validatedSessionKeyRaw
             ? (() => {
-              const sid = resolveSessionAgentId({ sessionKey: validatedSessionKeyRaw, config: cfg });
-              return sid ? resolveAgentDir(cfg, sid) : undefined;
-            })()
+                const sid = resolveSessionAgentId({
+                  sessionKey: validatedSessionKeyRaw,
+                  config: cfg,
+                });
+                return sid ? resolveAgentDir(cfg, sid) : undefined;
+              })()
             : validatedAgentId
               ? resolveAgentDir(cfg, validatedAgentId)
               : resolveAgentDir(cfg, resolveDefaultAgentId(cfg));
@@ -511,26 +548,6 @@ export const agentHandlers: GatewayRequestHandlers = {
           errorShape(
             isServerFault ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
             String(err),
-          ),
-        );
-        return;
-      }
-    }
-
-    const isKnownGatewayChannel = (value: string): boolean => isGatewayMessageChannel(value);
-    const channelHints = [request.channel, request.replyChannel]
-      .filter((value): value is string => typeof value === "string")
-      .map((value) => value.trim())
-      .filter(Boolean);
-    for (const rawChannel of channelHints) {
-      const normalized = normalizeMessageChannel(rawChannel);
-      if (normalized && normalized !== "last" && !isKnownGatewayChannel(normalized)) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            `invalid agent params: unknown channel: ${normalized}`,
           ),
         );
         return;

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -63,6 +63,7 @@ import {
   isGatewayMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { deleteMediaBuffer } from "../../media/store.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
 import {
   MediaOffloadError,
@@ -527,6 +528,18 @@ export const agentHandlers: GatewayRequestHandlers = {
             agentDir: resolvedAgentDir,
             log: context.logGateway,
           });
+
+          // Text-only description is complete — the physical media files are no
+          // longer needed because the image content has been converted to text
+          // descriptions in the message. Clean up now to avoid orphaned files
+          // accumulating on disk (especially when media.cleanupTtlHours is unset).
+          // Best-effort: don't let cleanup failures block the message.
+          await Promise.allSettled(
+            parsed.offloadedRefs.map((ref) =>
+              deleteMediaBuffer(ref.id, "inbound").catch(() => {}),
+            ),
+          );
+
           message = described.message.trim();
           images = described.images;
           imageOrder = described.imageOrder;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -50,6 +50,7 @@ import {
   describeOffloadedImagesForTextOnlyModel,
 } from "../chat-attachments.js";
 import { MediaOffloadError } from "../chat-attachments.js";
+import { deleteMediaBuffer } from "../../media/store.js";
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
 import { augmentChatHistoryWithCliSessionImports } from "../cli-session-history.js";
 import { isSuppressedControlReplyText } from "../control-reply-text.js";
@@ -1947,6 +1948,18 @@ export const chatHandlers: GatewayRequestHandlers = {
             agentDir,
             log: context.logGateway,
           });
+
+          // Text-only description is complete — the physical media files are no
+          // longer needed because the image content has been converted to text
+          // descriptions. Clean up now to avoid orphaned files accumulating on
+          // disk, especially for ACP bridge clients where persistChatSendImages
+          // skips offloaded ref persistence entirely.
+          await Promise.allSettled(
+            parsed.offloadedRefs.map((ref) =>
+              deleteMediaBuffer(ref.id, "inbound").catch(() => {}),
+            ),
+          );
+
           parsedMessage = described.message;
           parsedImages = described.images;
           imageOrder = described.imageOrder;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
@@ -47,6 +47,7 @@ import {
   type ChatImageContent,
   type OffloadedRef,
   parseMessageWithAttachments,
+  describeOffloadedImagesForTextOnlyModel,
 } from "../chat-attachments.js";
 import { MediaOffloadError } from "../chat-attachments.js";
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
@@ -1936,10 +1937,26 @@ export const chatHandlers: GatewayRequestHandlers = {
           log: context.logGateway,
           supportsImages,
         });
-        parsedMessage = parsed.message;
-        parsedImages = parsed.images;
-        imageOrder = parsed.imageOrder;
-        offloadedRefs = parsed.offloadedRefs;
+        // When the primary model is text-only, describe offloaded images using
+        // the configured imageModel so the agent can reason about image content.
+        if (!supportsImages && parsed.offloadedRefs.length > 0) {
+          const agentDir = resolveAgentDir(cfg, agentId);
+          const described = await describeOffloadedImagesForTextOnlyModel({
+            parsed,
+            cfg,
+            agentDir,
+            log: context.logGateway,
+          });
+          parsedMessage = described.message;
+          parsedImages = described.images;
+          imageOrder = described.imageOrder;
+          offloadedRefs = described.offloadedRefs;
+        } else {
+          parsedMessage = parsed.message;
+          parsedImages = parsed.images;
+          imageOrder = parsed.imageOrder;
+          offloadedRefs = parsed.offloadedRefs;
+        }
       } catch (err) {
         respond(
           false,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1963,7 +1963,9 @@ export const chatHandlers: GatewayRequestHandlers = {
           parsedMessage = described.message;
           parsedImages = described.images;
           imageOrder = described.imageOrder;
-          offloadedRefs = described.offloadedRefs;
+          // Clear offloadedRefs so persistChatSendImages doesn't build transcript
+          // entries pointing to files that were already deleted during cleanup.
+          offloadedRefs = [];
         } else {
           parsedMessage = parsed.message;
           parsedImages = parsed.images;

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -1,4 +1,4 @@
-export { resolveSessionAgentId } from "../agents/agent-scope.js";
+export { resolveAgentDir, resolveSessionAgentId } from "../agents/agent-scope.js";
 export { sanitizeInboundSystemTags } from "../auto-reply/reply/inbound-text.js";
 export { normalizeChannelId } from "../channels/plugins/index.js";
 export { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
@@ -15,7 +15,7 @@ export { enqueueSystemEvent } from "../infra/system-events.js";
 export { deleteMediaBuffer } from "../media/store.js";
 export { normalizeMainKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 export { defaultRuntime } from "../runtime.js";
-export { parseMessageWithAttachments } from "./chat-attachments.js";
+export { parseMessageWithAttachments, describeOffloadedImagesForTextOnlyModel } from "./chat-attachments.js";
 export { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 export {
   loadSessionEntry,

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -24,9 +24,11 @@ import {
   normalizeMainKey,
   normalizeRpcAttachmentsToChatAttachments,
   parseMessageWithAttachments,
+  describeOffloadedImagesForTextOnlyModel,
   registerApnsRegistration,
   requestHeartbeatNow,
   resolveGatewayModelSupportsImages,
+  resolveAgentDir,
   resolveOutboundTarget,
   resolveSessionAgentId,
   resolveSessionModelRef,
@@ -438,9 +440,24 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
             log: ctx.logGateway,
             supportsImages,
           });
-          message = parsed.message.trim();
-          images = parsed.images;
-          imageOrder = parsed.imageOrder;
+          // When the primary model is text-only, describe offloaded images using
+          // the configured imageModel so the agent can reason about image content.
+          if (!supportsImages && parsed.offloadedRefs.length > 0) {
+            const agentDir = resolveAgentDir(cfg, sessionAgentId);
+            const described = await describeOffloadedImagesForTextOnlyModel({
+              parsed,
+              cfg,
+              agentDir,
+              log: ctx.logGateway,
+            });
+            message = described.message.trim();
+            images = described.images;
+            imageOrder = described.imageOrder;
+          } else {
+            message = parsed.message.trim();
+            images = parsed.images;
+            imageOrder = parsed.imageOrder;
+          }
           if (message.length > 20_000) {
             ctx.logGateway.warn(
               `agent.request message exceeds limit after attachment parsing (length=${message.length})`,

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -450,6 +450,18 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
               agentDir,
               log: ctx.logGateway,
             });
+
+            // Text-only description is complete — the physical media files are no
+            // longer needed because the image content has been converted to text
+            // descriptions in the message. Clean up now to avoid orphaned files
+            // accumulating on disk (especially when media.cleanupTtlHours is unset).
+            // Best-effort: don't let cleanup failures block the message.
+            await Promise.allSettled(
+              parsed.offloadedRefs.map((ref) =>
+                deleteMediaBuffer(ref.id).catch(() => {}),
+              ),
+            );
+
             message = described.message.trim();
             images = described.images;
             imageOrder = described.imageOrder;


### PR DESCRIPTION
## Problem

When the primary model does not support images (e.g. `ollama/glm-5.1:cloud`, `ollama/glm-4:cloud`), sending a photo via Telegram **crashes the session and blocks all subsequent messages**, even pure text.

Root cause: the text-only model rejects the image with an HTTP 400 → classified as `"format"` failure → auth profile cooldown activated (30s → 5min escalating) → **all** messages to that profile are rejected during cooldown, including normal text messages.

Fixes #67606

Related: #51392, #59943, #66095, #39690

## Root Cause

Three issues stack:

1. **`parseMessageWithAttachments`** (`src/gateway/chat-attachments.ts`): When `supportsImages=false`, all attachments are dropped with a log warning. The images never reach the media store, so no downstream pipeline can process them.

2. **No imageModel fallback in Gateway path**: The `media-understanding` pipeline (`runCapability` in `runner.ts`) already knows how to describe images using `imageModel` when the primary model is text-only. But this pipeline runs in the `getReplyFromConfig` (auto-reply) path. The Gateway chat path never calls it, so images are just gone.

3. **Format error triggers profile-wide cooldown**: When the image is (incorrectly) sent to a text-only model, the provider rejects with HTTP 400 → classified as `"format"` → auth profile cooldown → ALL subsequent messages fail, even pure text. This is what makes the session "stuck" — one bad image blocks everything.

## Fix

### 1. Offload instead of drop (`chat-attachments.ts`)

When `supportsImages=false`, `parseMessageWithAttachments` now **offloads** all image attachments to the media store and injects `media://` markers into the prompt. The `images` array is empty (no inline image blocks), but `offloadedRefs` and `imageOrder` are populated.

### 2. Describe offloaded images via imageModel (`describeOffloadedImagesForTextOnlyModel`)

New exported function in `chat-attachments.ts` that:
1. Resolves the `imageModel` from config using `resolveAutoImageModel`
2. For each offloaded ref, resolves the physical file path from the media store
3. Calls `describeImageFileWithModel` to describe the image via the vision-capable imageModel
4. Replaces `[media attached: media://inbound/<id>]` markers with `[attached image: <description>]`

If no `imageModel` is configured, or if description fails, the original `media://` marker is preserved (graceful fallback).

### 3. Call sites updated

All three `parseMessageWithAttachments` call sites now call `describeOffloadedImagesForTextOnlyModel` when `supportsImages=false` and there are offloaded refs.

## Example

**Before:** Send photo → image dropped OR leaks through → HTTP 400 "format" → profile cooldown → session stuck, ALL messages fail

**After:** Send photo → offloaded → described via imageModel → `[attached image: A cat sitting on a windowsill]` → text-only model reasons about content → no format error → session works normally

## Checklist

- [x] Code compiles without new TypeScript errors
- [x] Tests added for new behavior
- [x] Graceful fallback when `imageModel` is not configured
- [x] Graceful fallback when image description fails (original marker preserved)
- [x] No changes to behavior when `supportsImages=true`