### PR TITLE
fix(openai-codex): normalize stale transport metadata in resolution and discovery

### DIFF
--- a/extensions/openai/base-url.test.ts
+++ b/extensions/openai/base-url.test.ts
@@ -17,11 +17,15 @@ describe("openai base URL helpers", () => {
   it("recognizes Codex ChatGPT backend routes", () => {
     expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api")).toBe(true);
     expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/")).toBe(true);
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/v1")).toBe(true);
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/v1/")).toBe(true);
   });
 
   it("rejects non-Codex backend routes", () => {
     expect(isOpenAICodexBaseUrl("https://api.openai.com/v1")).toBe(false);
     expect(isOpenAICodexBaseUrl("https://chatgpt.com")).toBe(false);
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/v2")).toBe(false);
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/codex")).toBe(false);
     expect(isOpenAICodexBaseUrl(undefined)).toBe(false);
   });
 });

--- a/extensions/openai/base-url.ts
+++ b/extensions/openai/base-url.ts
@@ -13,5 +13,5 @@ export function isOpenAICodexBaseUrl(baseUrl?: string): boolean {
   if (!trimmed) {
     return false;
   }
-  return /^https?:\/\/chatgpt\.com\/backend-api\/?$/i.test(trimmed);
+  return /^https?:\/\/chatgpt\.com\/backend-api(?:\/v1)?\/?$/i.test(trimmed);
 }

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -375,4 +375,70 @@ describe("openai codex provider", () => {
       name: "gpt-5.4",
     });
   });
+
+  it("defaults missing codex api metadata to openai-codex-responses", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.normalizeResolvedModel?.({
+      provider: "openai-codex",
+      model: {
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      },
+    } as never);
+
+    expect(model).toMatchObject({
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+    });
+  });
+
+  it("normalizes stale /backend-api/v1 codex metadata to the canonical base url", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.normalizeResolvedModel?.({
+      provider: "openai-codex",
+      model: {
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      },
+    } as never);
+
+    expect(model).toMatchObject({
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+    });
+  });
+
+  it("normalizes transport metadata for stale /backend-api/v1 codex routes", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    expect(
+      provider.normalizeTransport?.({
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/v1",
+      } as never),
+    ).toEqual({
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+    });
+  });
 });

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -94,6 +94,25 @@ const OPENAI_CODEX_MODERN_MODEL_IDS = [
   OPENAI_CODEX_GPT_53_MODEL_ID,
   OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
 ] as const;
+
+function normalizeCodexTransportFields(params: {
+  api?: ProviderRuntimeModel["api"] | null;
+  baseUrl?: string;
+}): {
+  api?: ProviderRuntimeModel["api"];
+  baseUrl?: string;
+} {
+  const useCodexTransport =
+    !params.baseUrl || isOpenAIApiBaseUrl(params.baseUrl) || isOpenAICodexBaseUrl(params.baseUrl);
+  const api =
+    useCodexTransport && (!params.api || params.api === "openai-responses")
+      ? "openai-codex-responses"
+      : (params.api ?? undefined);
+  const baseUrl =
+    api === "openai-codex-responses" && useCodexTransport ? OPENAI_CODEX_BASE_URL : params.baseUrl;
+  return { api, baseUrl };
+}
+
 function normalizeCodexTransport(model: ProviderRuntimeModel): ProviderRuntimeModel {
   const lowerModelId = normalizeLowercaseStringOrEmpty(model.id);
   const canonicalModelId =
@@ -102,14 +121,12 @@ function normalizeCodexTransport(model: ProviderRuntimeModel): ProviderRuntimeMo
     normalizeLowercaseStringOrEmpty(model.name) === OPENAI_CODEX_GPT_54_LEGACY_MODEL_ID
       ? OPENAI_CODEX_GPT_54_MODEL_ID
       : model.name;
-  const useCodexTransport =
-    !model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl) || isOpenAICodexBaseUrl(model.baseUrl);
-  const api =
-    useCodexTransport && model.api === "openai-responses" ? "openai-codex-responses" : model.api;
-  const baseUrl =
-    api === "openai-codex-responses" && (!model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl))
-      ? OPENAI_CODEX_BASE_URL
-      : model.baseUrl;
+  const normalizedTransport = normalizeCodexTransportFields({
+    api: model.api,
+    baseUrl: model.baseUrl,
+  });
+  const api = normalizedTransport.api ?? model.api;
+  const baseUrl = normalizedTransport.baseUrl ?? model.baseUrl;
   if (
     api === model.api &&
     baseUrl === model.baseUrl &&
@@ -334,6 +351,16 @@ export function buildOpenAICodexProviderPlugin(): ProviderPlugin {
         return undefined;
       }
       return normalizeCodexTransport(ctx.model);
+    },
+    normalizeTransport: ({ provider, api, baseUrl }) => {
+      if (normalizeProviderId(provider) !== PROVIDER_ID) {
+        return undefined;
+      }
+      const normalized = normalizeCodexTransportFields({ api, baseUrl });
+      if (normalized.api === api && normalized.baseUrl === baseUrl) {
+        return undefined;
+      }
+      return normalized;
     },
     resolveUsageAuth: async (ctx) => await ctx.resolveOAuthToken(),
     fetchUsageSnapshot: async (ctx) =>

--- a/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
@@ -3,6 +3,7 @@ import type { OpenRouterModelCapabilities } from "./openrouter-model-capabilitie
 
 const OPENAI_BASE_URL = "https://api.openai.com/v1";
 const OPENAI_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
+const OPENAI_CODEX_LEGACY_BASE_URL = "https://chatgpt.com/backend-api/v1";
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const ANTHROPIC_BASE_URL = "https://api.anthropic.com";
 const XAI_BASE_URL = "https://api.x.ai/v1";
@@ -64,20 +65,23 @@ function cloneTemplate(
   } as ResolvedModelLike;
 }
 
+function isNativeOpenAICodexBaseUrl(baseUrl?: string): boolean {
+  return baseUrl === OPENAI_CODEX_BASE_URL || baseUrl === OPENAI_CODEX_LEGACY_BASE_URL;
+}
+
 function normalizeDynamicModel(params: { provider: string; model: ResolvedModelLike }) {
   if (params.provider !== "openai-codex") {
     return undefined;
   }
   const baseUrl = typeof params.model.baseUrl === "string" ? params.model.baseUrl : undefined;
+  const useCodexTransport =
+    !baseUrl || baseUrl === OPENAI_BASE_URL || isNativeOpenAICodexBaseUrl(baseUrl);
   const nextApi =
-    params.model.api === "openai-responses" &&
-    (!baseUrl || baseUrl === OPENAI_BASE_URL || baseUrl === OPENAI_CODEX_BASE_URL)
+    useCodexTransport && (!params.model.api || params.model.api === "openai-responses")
       ? "openai-codex-responses"
       : params.model.api;
   const nextBaseUrl =
-    nextApi === "openai-codex-responses" && (!baseUrl || baseUrl === OPENAI_BASE_URL)
-      ? OPENAI_CODEX_BASE_URL
-      : baseUrl;
+    nextApi === "openai-codex-responses" && useCodexTransport ? OPENAI_CODEX_BASE_URL : baseUrl;
   if (nextApi !== params.model.api || nextBaseUrl !== baseUrl) {
     return { ...params.model, api: nextApi, baseUrl: nextBaseUrl };
   }
@@ -96,6 +100,14 @@ function normalizeTransport(params: {
     params.context.api === "openai-completions" &&
     (params.context.baseUrl === XAI_BASE_URL ||
       (params.provider === "xai" && !params.context.baseUrl));
+  const isNativeOpenAICodexTransport =
+    params.provider === "openai-codex" &&
+    ((!params.context.api &&
+      (!params.context.baseUrl || isNativeOpenAICodexBaseUrl(params.context.baseUrl))) ||
+      (params.context.api === "openai-responses" &&
+        (!params.context.baseUrl ||
+          params.context.baseUrl === OPENAI_BASE_URL ||
+          isNativeOpenAICodexBaseUrl(params.context.baseUrl))));
   if (
     params.context.api === "google-generative-ai" &&
     params.context.baseUrl === "https://generativelanguage.googleapis.com"
@@ -115,6 +127,12 @@ function normalizeTransport(params: {
     return {
       api: "openai-responses",
       baseUrl: params.context.baseUrl,
+    };
+  }
+  if (isNativeOpenAICodexTransport) {
+    return {
+      api: "openai-codex-responses",
+      baseUrl: OPENAI_CODEX_BASE_URL,
     };
   }
   return undefined;

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1069,6 +1069,50 @@ describe("resolveModel", () => {
     });
   });
 
+  it("normalizes stale discovered openai-codex /backend-api/v1 metadata", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      templateModel: {
+        ...buildOpenAICodexForwardCompatExpectation("gpt-5.4"),
+        name: "GPT-5.4",
+        baseUrl: "https://chatgpt.com/backend-api/v1",
+      },
+    });
+
+    const result = resolveModelForTest("openai-codex", "gpt-5.4", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+    });
+  });
+
+  it("normalizes discovered openai-codex metadata when api is missing", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      templateModel: {
+        ...buildOpenAICodexForwardCompatExpectation("gpt-5.4"),
+        name: "GPT-5.4",
+        api: undefined,
+      },
+    });
+
+    const result = resolveModelForTest("openai-codex", "gpt-5.4", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+    });
+  });
+
   it("passes configured workspaceDir to runtime preference hooks", () => {
     mockDiscoveredModel(discoverModels, {
       provider: "openai-codex",

--- a/src/agents/pi-model-discovery.auth.test.ts
+++ b/src/agents/pi-model-discovery.auth.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { resolvePiCredentialMapFromStore } from "./pi-auth-credentials.js";
 import {
   addEnvBackedPiCredentials,
+  normalizeDiscoveredPiModel,
   scrubLegacyStaticAuthJsonEntriesForDiscovery,
 } from "./pi-model-discovery.js";
 
@@ -152,5 +153,58 @@ describe("discoverAuthStorage", () => {
         process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS = previousDisableBundledPlugins;
       }
     }
+  });
+
+  it("normalizes stale discovered openai-codex rows when api metadata is missing", () => {
+    const normalized = normalizeDiscoveredPiModel(
+      {
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      },
+      "/tmp/agent",
+    ) as {
+      api?: string;
+      baseUrl?: string;
+    };
+
+    expect(normalized).toMatchObject({
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+    });
+  });
+
+  it("canonicalizes stale discovered openai-codex backend-api/v1 rows", () => {
+    const normalized = normalizeDiscoveredPiModel(
+      {
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      },
+      "/tmp/agent",
+    ) as {
+      api?: string;
+      baseUrl?: string;
+    };
+
+    expect(normalized).toMatchObject({
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+    });
   });
 });

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -29,6 +29,10 @@ type ProviderRuntimeModelLike = Model<Api> & {
   contextTokens?: number;
 };
 
+type DiscoveredProviderRuntimeModelLike = Omit<ProviderRuntimeModelLike, "api"> & {
+  api?: string | null;
+};
+
 type InMemoryAuthStorageBackendLike = {
   withLock<T>(
     update: (current: string) => {
@@ -65,19 +69,18 @@ export function normalizeDiscoveredPiModel<T>(value: T, agentDir: string): T {
   if (
     typeof value.id !== "string" ||
     typeof value.name !== "string" ||
-    typeof value.provider !== "string" ||
-    typeof value.api !== "string"
+    typeof value.provider !== "string"
   ) {
     return value;
   }
-  const model = value as unknown as ProviderRuntimeModelLike;
+  const model = value as unknown as DiscoveredProviderRuntimeModelLike;
   const pluginNormalized =
     normalizeProviderResolvedModelWithPlugin({
       provider: model.provider,
       context: {
         provider: model.provider,
         modelId: model.id,
-        model,
+        model: model as unknown as ProviderRuntimeModelLike,
         agentDir,
       },
     }) ?? model;
@@ -87,7 +90,7 @@ export function normalizeDiscoveredPiModel<T>(value: T, agentDir: string): T {
       context: {
         provider: model.provider,
         modelId: model.id,
-        model: pluginNormalized,
+        model: pluginNormalized as unknown as ProviderRuntimeModelLike,
         agentDir,
       },
     }) ?? pluginNormalized;
@@ -97,10 +100,19 @@ export function normalizeDiscoveredPiModel<T>(value: T, agentDir: string): T {
       context: {
         provider: model.provider,
         modelId: model.id,
-        model: compatNormalized,
+        model: compatNormalized as unknown as ProviderRuntimeModelLike,
         agentDir,
       },
     }) ?? compatNormalized;
+  if (
+    !isRecord(transportNormalized) ||
+    typeof transportNormalized.id !== "string" ||
+    typeof transportNormalized.name !== "string" ||
+    typeof transportNormalized.provider !== "string" ||
+    typeof transportNormalized.api !== "string"
+  ) {
+    return value;
+  }
   return normalizeModelCompat(transportNormalized as Model<Api>) as T;
 }
 


### PR DESCRIPTION
## Summary

- Problem: stale `openai-codex` model metadata could survive in both runtime resolution and discovery/listing flows, especially when `api` was missing or the stored base URL was `https://chatgpt.com/backend-api/v1`.
- Why it matters: OpenClaw could route Codex requests through broken transport metadata, leading to HTML/Cloudflare failures that were surfaced downstream as misleading provider errors.
- What changed: `openai-codex` now canonicalizes native transport metadata to `api: "openai-codex-responses"` and `baseUrl: "https://chatgpt.com/backend-api"` across both model resolution and discovery normalization, with regression tests for missing-`api` and stale-`/v1` rows.
- What did NOT change (scope boundary): this PR does not change user-facing HTML/DNS error copy; it fixes the stale Codex transport metadata that triggers the broken request path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66674
- Closes #67131
- Related #66633, #66969
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `openai-codex` transport normalization only repaired some stale native metadata paths during model resolution, and discovery normalization returned early unless `api` was already a string.
- Missing detection / guardrail: native Codex routes with missing `api` or legacy `https://chatgpt.com/backend-api/v1` were not normalized consistently across both execution and discovery/listing seams.
- Contributing context (if known): users could carry stale agent-scoped `models.json` entries forward from earlier versions, so the bug persisted even after auth and probes looked healthy.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/openai/base-url.test.ts`
  - `extensions/openai/openai-codex-provider.test.ts`
  - `src/agents/pi-embedded-runner/model.test.ts`
  - `src/agents/pi-model-discovery.auth.test.ts`
  - manual CLI validation via `openclaw infer model run`
- Scenario the test should lock in: stale `openai-codex` rows with missing `api` or `/backend-api/v1` normalize to the canonical native Codex transport in both runtime resolution and discovery/listing flows, and the live CLI path succeeds with local Codex OAuth credentials.
- Why this is the smallest reliable guardrail: the bug lives in normalization seams, so focused provider + model/discovery tests catch it cheaply, and a single live CLI run confirms the end-to-end request path.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openai-codex` models with stale native metadata now self-heal during resolution and discovery/listing.
- Agent and CLI flows that depend on those normalized rows will use the canonical Codex transport without requiring manual config overrides.

## Diagram (if applicable)

```text
Before:
[stale openai-codex row] -> [missing api or /backend-api/v1] -> [broken Codex request path]

After:
[stale openai-codex row] -> [normalize to openai-codex-responses + /backend-api] -> [canonical Codex transport]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local `pnpm` workspace checkout
- Model/provider: `openai-codex/gpt-5.4`
- Integration/channel (if any): embedded runner model resolution + discovery/listing seams, plus local CLI infer path
- Relevant config (redacted): stale native Codex metadata represented as missing `api` or `https://chatgpt.com/backend-api/v1`; local `openai-codex:default` OAuth profile present in `~/.openclaw/agents/main/agent/auth-profiles.json`

### Steps

1. Resolve or discover an `openai-codex` model row with missing `api`.
2. Resolve or discover an `openai-codex` model row using `https://chatgpt.com/backend-api/v1`.
3. Run the local CLI infer path with temporary agent dirs that contain those stale `models.json` variants and the local Codex OAuth profile:
   - `OPENCLAW_AGENT_DIR=<temp-agent-dir> pnpm openclaw infer model run --model openai-codex/gpt-5.4 --prompt 'Reply with exactly OK.' --json`
4. Observe the CLI response.

### Expected

- Native Codex rows normalize to `api: "openai-codex-responses"` and `baseUrl: "https://chatgpt.com/backend-api"`.
- The live local CLI infer path succeeds for both stale metadata variants.

### Actual

- Matches expected in provider normalization, embedded runner resolution, and discovery normalization tests.
- Live CLI validation succeeded for both stale metadata variants and returned `OK`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence notes:

- Manual live CLI results on this branch:
  - missing `api` case returned:
    - `{ "provider": "openai-codex", "model": "gpt-5.4", "outputs": [{ "text": "OK" }] }`
  - stale `/backend-api/v1` case returned:
    - `{ "provider": "openai-codex", "model": "gpt-5.4", "outputs": [{ "text": "OK" }] }`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - stale `openai-codex` rows with missing `api` normalize correctly in provider tests
  - stale `/backend-api/v1` rows normalize correctly in provider tests
  - embedded runner resolution normalizes both stale cases
  - discovery normalization now repairs the same stale cases instead of returning them unchanged
  - live `pnpm openclaw infer model run --model openai-codex/gpt-5.4` succeeds against local Codex OAuth credentials when the temp agent dir contains a missing-`api` stale row
  - live `pnpm openclaw infer model run --model openai-codex/gpt-5.4` succeeds against local Codex OAuth credentials when the temp agent dir contains a stale `/backend-api/v1` row
- Edge cases checked:
  - canonical `https://chatgpt.com/backend-api` remains recognized
  - `/backend-api/v2` and `/backend-api/codex` remain rejected by the base URL helper
  - custom/non-native routes are not rewritten by these new tests
  - unrelated `memory-lancedb` recall warnings did not block Codex inference during manual verification
- What you did **not** verify:
  - user-facing DNS/HTML error copy changes (not in scope)
  - gateway/UI-specific flows beyond the local CLI infer path

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: normalization could accidentally rewrite non-native Codex-like routes.
  - Mitigation: normalization stays scoped to known native OpenAI/Codex base URLs, and tests explicitly reject `/backend-api/v2` and `/backend-api/codex`.
