### PR TITLE
fix(skills): remove unused model-usage import

### DIFF
--- a/skills/model-usage/scripts/model_usage.py
+++ b/skills/model-usage/scripts/model_usage.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 from dataclasses import dataclass


### PR DESCRIPTION
## Summary

- Problem: GitHub code scanning reports `code-scanning / CodeQL (python)` alert `#75` (`py/unused-import`) because `skills/model-usage/scripts/model_usage.py` still imports `os` without using it.
- Why it matters: This keeps a real but low-risk static-analysis alert open and adds noise around the `model-usage` skill.
- What changed: Removed the unused `os` import from `skills/model-usage/scripts/model_usage.py`.
- What did NOT change (scope boundary): No behavior, CLI arguments, JSON output, or CodexBar integration logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #75
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: A previous refactor removed the need for `os`, but the import list in `model_usage.py` was not cleaned up.
- Missing detection / guardrail: The visible Python test coverage imports the module and checks helper behavior, but there is no in-scope unused-import guard on this script.
- Contributing context (if known): This is a static-analysis-only issue; there was no user-visible failure pushing it to the surface earlier.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `skills/model-usage/scripts/test_model_usage.py`
- Scenario the test should lock in: The script module still imports cleanly and helper behavior remains unchanged after removing the dead import.
- Why this is the smallest reliable guardrail: This PR is a one-line static cleanup; behavior coverage already exists for the touched helper module, and a dedicated new test would not add meaningful signal.
- Existing test that already covers this (if any): `python3 skills/model-usage/scripts/test_model_usage.py`
- If no new test is added, why not: The alert is about an unused import rather than runtime behavior, so removing the import is the whole fix.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

```text
Before:
code-scanning / CodeQL (python) -> alert #75 on unused os import

After:
unused import removed -> same script behavior -> alert can close on next scan
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Python 3 on local worktree
- Model/provider: N/A
- Integration/channel (if any): `model-usage` skill script
- Relevant config (redacted): N/A

### Steps

1. Inspect `skills/model-usage/scripts/model_usage.py` on `upstream/main`.
2. Observe `import os` with no later `os` usage, matching alert `#75`.
3. Remove the import and rerun the direct script checks.

### Expected

- `code-scanning / CodeQL (python)` alert `#75` (`py/unused-import`) is resolved without behavior changes.

### Actual

- The only code change is removing `import os`; direct Python validation remains green.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Pipeline/problem called out explicitly:

- `code-scanning / CodeQL (python)` -> alert `#75`
- Exact problem: `py/unused-import` in `skills/model-usage/scripts/model_usage.py:12` (`Import of 'os' is not used.`)

## Human Verification (required)

- Verified scenarios:
  - Ran `python3 skills/model-usage/scripts/test_model_usage.py`
  - Ran `python3 -m py_compile skills/model-usage/scripts/model_usage.py skills/model-usage/scripts/test_model_usage.py`
  - Ran `python3 skills/model-usage/scripts/model_usage.py --help`
- Edge cases checked:
  - Module still imports cleanly after dropping the unused dependency.
- What you did **not** verify:
  - Live `codexbar` integration paths that require an installed CodexBar CLI and real local usage data.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: The PR could accidentally change script behavior if more than the dead import were touched.
  - Mitigation: The diff is a single-line import removal and direct script checks were rerun.
