### PR TITLE
fix: avoid python preflight false positives for $ tokens in string literals

### DIFF
--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -78,6 +78,63 @@ describeNonWin("exec script preflight", () => {
     });
   });
 
+  it("allows dollar-prefixed text inside python strings and comments", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      const pyPath = path.join(tmp, "safe-dollar.py");
+      await fs.writeFile(
+        pyPath,
+        [
+          '"""',
+          "Guide for traders using $SIM labels.",
+          '"""',
+          "def main():",
+          "    total = 42.5",
+          '    # Keep $DM_JSON in docs only.',
+          '    print(f"Total: ${total:.2f}")',
+          "",
+          'if __name__ == "__main__":',
+          "    main()",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+      const result = await tool.execute("call-python-safe-dollar-strings", {
+        command: "python safe-dollar.py",
+        workdir: tmp,
+      });
+      const text = result.content.find((block) => block.type === "text")?.text ?? "";
+      expect(text).toContain("Total: $42.50");
+      expect(text).not.toMatch(/exec preflight:/);
+    });
+  });
+
+  it("still blocks python shell env var injection outside string literals", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      const pyPath = path.join(tmp, "mixed.py");
+      await fs.writeFile(
+        pyPath,
+        [
+          "def main():",
+          "    payload = $DM_JSON",
+          '    print("This label is fine: $SIM")',
+          "",
+          'if __name__ == "__main__":',
+          "    main()",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+      await expect(
+        tool.execute("call-python-mixed-dollar", {
+          command: "python mixed.py",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec preflight: detected likely shell variable injection \(\$DM_JSON\)/);
+    });
+  });
+
   it("blocks obvious shell-as-js output before node execution", async () => {
     await withTempDir("openclaw-exec-preflight-", async (tmp) => {
       const jsPath = path.join(tmp, "bad.js");

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1079,6 +1079,10 @@ function collectPythonIgnoredRanges(content: string): OffsetRange[] {
     if (isTriple) {
       i += 3;
       while (i < content.length) {
+        if (content[i] === "\\") {
+          i += 2;
+          continue;
+        }
         if (content[i] === quote && content[i + 1] === quote && content[i + 2] === quote) {
           i += 3;
           break;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -988,21 +988,21 @@ async function validateScriptFileForShellBleed(params: {
 
     // Common failure mode: shell env var syntax leaking into Python/JS.
     // We deliberately match all-caps/underscore vars to avoid false positives with `$` as a JS identifier.
-    const envVarRegex = /\$[A-Z_][A-Z0-9_]{1,}/g;
-    const first = envVarRegex.exec(content);
+    const first = findFirstLikelyShellEnvToken({
+      content,
+      scriptKind: target.kind,
+    });
     if (first) {
-      const idx = first.index;
-      const before = content.slice(0, idx);
+      const before = content.slice(0, first.index);
       const line = before.split("\n").length;
-      const token = first[0];
       throw new Error(
         [
-          `exec preflight: detected likely shell variable injection (${token}) in ${target.kind} script: ${path.basename(
+          `exec preflight: detected likely shell variable injection (${first.token}) in ${target.kind} script: ${path.basename(
             absPath,
           )}:${line}.`,
           target.kind === "python"
-            ? `In Python, use os.environ.get(${JSON.stringify(token.slice(1))}) instead of raw ${token}.`
-            : `In Node.js, use process.env[${JSON.stringify(token.slice(1))}] instead of raw ${token}.`,
+            ? `In Python, use os.environ.get(${JSON.stringify(first.token.slice(1))}) instead of raw ${first.token}.`
+            : `In Node.js, use process.env[${JSON.stringify(first.token.slice(1))}] instead of raw ${first.token}.`,
           "(If this is inside a string literal on purpose, escape it or restructure the code.)",
         ].join("\n"),
       );
@@ -1022,6 +1022,97 @@ async function validateScriptFileForShellBleed(params: {
       }
     }
   }
+}
+
+type ShellEnvTokenMatch = {
+  index: number;
+  token: string;
+};
+
+function findFirstLikelyShellEnvToken(params: {
+  content: string;
+  scriptKind: "python" | "node";
+}): ShellEnvTokenMatch | null {
+  const envVarRegex = /\$[A-Z_][A-Z0-9_]{1,}/g;
+  if (params.scriptKind === "node") {
+    const first = envVarRegex.exec(params.content);
+    return first ? { index: first.index, token: first[0] } : null;
+  }
+
+  const ignoredRanges = collectPythonIgnoredRanges(params.content);
+  for (const match of params.content.matchAll(envVarRegex)) {
+    const idx = match.index;
+    if (idx === undefined) {
+      continue;
+    }
+    if (!isOffsetInRanges(idx, ignoredRanges)) {
+      return { index: idx, token: match[0] };
+    }
+  }
+  return null;
+}
+
+type OffsetRange = { start: number; end: number };
+
+function collectPythonIgnoredRanges(content: string): OffsetRange[] {
+  const ranges: OffsetRange[] = [];
+  let i = 0;
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === "#") {
+      const start = i;
+      i += 1;
+      while (i < content.length && content[i] !== "\n") {
+        i += 1;
+      }
+      ranges.push({ start, end: i });
+      continue;
+    }
+    if (ch !== "'" && ch !== '"') {
+      i += 1;
+      continue;
+    }
+
+    const quote = ch;
+    const isTriple = content[i + 1] === quote && content[i + 2] === quote;
+    const start = i;
+    if (isTriple) {
+      i += 3;
+      while (i < content.length) {
+        if (content[i] === quote && content[i + 1] === quote && content[i + 2] === quote) {
+          i += 3;
+          break;
+        }
+        i += 1;
+      }
+      ranges.push({ start, end: i });
+      continue;
+    }
+
+    i += 1;
+    while (i < content.length) {
+      if (content[i] === "\\") {
+        i += 2;
+        continue;
+      }
+      if (content[i] === quote) {
+        i += 1;
+        break;
+      }
+      i += 1;
+    }
+    ranges.push({ start, end: i });
+  }
+  return ranges;
+}
+
+function isOffsetInRanges(offset: number, ranges: OffsetRange[]): boolean {
+  for (const range of ranges) {
+    if (offset >= range.start && offset < range.end) {
+      return true;
+    }
+  }
+  return false;
 }
 
 type ParsedExecApprovalCommand = {


### PR DESCRIPTION
﻿## Summary
- fix Python script preflight so $VAR detection only triggers outside Python string/comment ranges
- keep Node.js behavior unchanged while preserving existing shell-injection blocking for true Python code paths
- add regression tests for both the false-positive case (docstring/f-string/comment) and real injection case

## Test plan
- [x] pnpm test src/agents/bash-tools.exec.script-preflight.test.ts

Closes #67621
