### PR TITLE
doc: add assistant_view in features

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -188,6 +188,7 @@ openclaw gateway
     "event_subscriptions": {
       "bot_events": [
         "app_mention",
+        "assistant_thread_started",
         "channel_rename",
         "member_joined_channel",
         "member_left_channel",
@@ -275,6 +276,7 @@ openclaw gateway
       "request_url": "https://gateway-host.example.com/slack/events",
       "bot_events": [
         "app_mention",
+        "assistant_thread_started",
         "channel_rename",
         "member_joined_channel",
         "member_left_channel",

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -138,6 +138,15 @@ openclaw gateway
       "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
     },
+    "assistant_view": {
+      "assistant_description": "this is a string description of the app assistant. What does your assistant do?",
+      "suggested_prompts": [
+        {
+          "title": "User help",
+          "message": "How do I use this awesome app?"
+        }
+      ]
+    },
     "slash_commands": [
       {
         "command": "/openclaw",
@@ -214,6 +223,15 @@ openclaw gateway
     "app_home": {
       "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
+    },
+    "assistant_view": {
+      "assistant_description": "this is a string description of the app assistant. What does your assistant do?",
+      "suggested_prompts": [
+        {
+          "title": "User help",
+          "message": "How do I use this awesome app?"
+        }
+      ]
     },
     "slash_commands": [
       {


### PR DESCRIPTION
## Summary

<img width="595" height="172" alt="image" src="https://github.com/user-attachments/assets/7a1039b6-98d6-4f30-8e10-715b979edb0d" />

<img width="703" height="145" alt="image" src="https://github.com/user-attachments/assets/9ccac0c7-0f3c-45c2-a7ad-594503dc0173" />


Add `assistant_view` in sample manifest

- Problem: Slack required assistant_view listed in features so that we can use of `assistant:write` oauth scope
- Why it matters: it matters so that assistant:write oauth access can be used
- What changed: adding assistant_view in list of features
- What did NOT change (scope boundary): - 

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

Not applicable

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `assistant_view` feature should be listed when `assistant:write` is in oauth scope
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

Not applicable

## User-visible / Behavior Changes

No behavior changes

## Diagram (if applicable)

Not applicable

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: No

## Repro + Verification

Not applicable

## Evidence

Not applicable

## Human Verification (required)

I verified by creating an app with the manifest I just changed, and it doesn't show any warning

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: No

## Risks and Mitigations

No risk