### PR TITLE
browser: restore strict default SSRF hostname guard

### DIFF
--- a/extensions/browser/src/browser/navigation-guard.test.ts
+++ b/extensions/browser/src/browser/navigation-guard.test.ts
@@ -128,7 +128,7 @@ describe("browser navigation guard", () => {
     expect(lookupFn).not.toHaveBeenCalled();
   });
 
-  it("allows hostname navigation when the default strict policy object is present", async () => {
+  it("blocks hostname navigation when the default strict policy object is present", async () => {
     const lookupFn = createLookupFn("93.184.216.34");
     await expect(
       assertBrowserNavigationAllowed({
@@ -136,8 +136,8 @@ describe("browser navigation guard", () => {
         lookupFn,
         ssrfPolicy: {},
       }),
-    ).resolves.toBeUndefined();
-    expect(lookupFn).toHaveBeenCalledWith("example.com", { all: true });
+    ).rejects.toThrow(/dns rebinding protections are unavailable/i);
+    expect(lookupFn).not.toHaveBeenCalled();
   });
 
   it("allows explicitly allowed hostnames in strict mode", async () => {
@@ -312,8 +312,9 @@ describe("browser navigation guard", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("requires redirect-hop inspection only in explicit strict mode", () => {
+  it("requires redirect-hop inspection whenever private-network mode is disabled", () => {
     expect(requiresInspectableBrowserNavigationRedirects()).toBe(false);
+    expect(requiresInspectableBrowserNavigationRedirects({})).toBe(true);
     expect(
       requiresInspectableBrowserNavigationRedirects({ dangerouslyAllowPrivateNetwork: false }),
     ).toBe(true);

--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -43,7 +43,7 @@ export function withBrowserNavigationPolicy(
 }
 
 export function requiresInspectableBrowserNavigationRedirects(ssrfPolicy?: SsrFPolicy): boolean {
-  return ssrfPolicy?.dangerouslyAllowPrivateNetwork === false;
+  return Boolean(ssrfPolicy && !isPrivateNetworkAllowedByPolicy(ssrfPolicy));
 }
 
 export function requiresInspectableBrowserNavigationRedirectsForUrl(
@@ -122,7 +122,6 @@ export async function assertBrowserNavigationAllowed(
   // the same address that passed policy checks.
   if (
     opts.ssrfPolicy &&
-    opts.ssrfPolicy.dangerouslyAllowPrivateNetwork === false &&
     !isPrivateNetworkAllowedByPolicy(opts.ssrfPolicy) &&
     !isIpLiteralHostname(parsed.hostname) &&
     !isExplicitlyAllowedBrowserHostname(parsed.hostname, opts.ssrfPolicy)

--- a/extensions/browser/src/browser/routes/tabs.attach-only.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.attach-only.test.ts
@@ -73,7 +73,7 @@ describe("browser tab routes attachOnly loopback profiles", () => {
         {
           targetId: "PAGE-1",
           title: "WordPress",
-          url: "https://example.com/wp-login.php",
+          url: "",
           wsUrl: "ws://127.0.0.1:9222/devtools/page/PAGE-1",
           type: "page",
         },


### PR DESCRIPTION
## Summary
- restore strict hostname SSRF blocking when the browser policy object is present and private-network access is not explicitly allowed
- align redirect-hop inspection with the actual private-network policy check
- update browser guard and attach-only tests to match the stricter default behavior

## Testing
- not run locally in this fresh clone