### PR TITLE
fix(msteams): use explorer.exe for delegated OAuth on win32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1490,6 +1490,7 @@ Docs: https://docs.openclaw.ai
 - Agents/replay recovery: classify the provider wording `401 input item ID does not belong to this connection` as replay-invalid, so users get the existing `/new` session reset guidance instead of a raw 401-style failure. (#66475) Thanks @dallylee.
 - Gateway/webchat: enforce localRoots containment on webchat audio embedding path [AI-assisted]. (#67298) Thanks @pgondhi987.
 - Matrix/pairing: block DM pairing-store entries from authorizing room control commands [AI-assisted]. (#67294) Thanks @pgondhi987.
+- MS Teams/setup: launch delegated OAuth URLs with `explorer.exe` on Windows instead of `xdg-open`, keeping native Windows onboarding aligned with the shared browser-open path.
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
 - Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 - Cron/announce delivery: suppress mixed-content isolated cron announce replies that end with `NO_REPLY` so trailing silent sentinels no longer leak summary text to the target channel. (#65004) thanks @neo1027144-creator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1490,7 +1490,7 @@ Docs: https://docs.openclaw.ai
 - Agents/replay recovery: classify the provider wording `401 input item ID does not belong to this connection` as replay-invalid, so users get the existing `/new` session reset guidance instead of a raw 401-style failure. (#66475) Thanks @dallylee.
 - Gateway/webchat: enforce localRoots containment on webchat audio embedding path [AI-assisted]. (#67298) Thanks @pgondhi987.
 - Matrix/pairing: block DM pairing-store entries from authorizing room control commands [AI-assisted]. (#67294) Thanks @pgondhi987.
-- MS Teams/setup: launch delegated OAuth URLs with `explorer.exe` on Windows instead of `xdg-open`, keeping native Windows onboarding aligned with the shared browser-open path.
+- MS Teams/setup: launch delegated OAuth URLs with `explorer.exe` on Windows instead of `xdg-open`, keeping native Windows onboarding aligned with the shared browser-open path. (#67660) Thanks @shaun0927.
 - Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
 - Matrix/E2EE: keep startup bootstrap conservative for passwordless token-auth bots, still attempt the guarded repair pass without requiring `channels.matrix.password`, and document the remaining password-UIA limitation. (#66228) Thanks @SARAMALI15792.
 - Cron/announce delivery: suppress mixed-content isolated cron announce replies that end with `NO_REPLY` so trailing silent sentinels no longer leak summary text to the target channel. (#65004) thanks @neo1027144-creator.

--- a/extensions/msteams/src/setup-surface.test.ts
+++ b/extensions/msteams/src/setup-surface.test.ts
@@ -114,6 +114,25 @@ describe("msteams setup surface", () => {
     }
   });
 
+  it("rejects unexpected explorer.exe exit codes on Windows", async () => {
+    const url = "https://login.microsoftonline.com/auth";
+    const child = new EventEmitter();
+    spawn.mockReturnValue(child);
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    try {
+      const result = openDelegatedOAuthUrl(url);
+      child.emit("exit", 2, null);
+      await expect(result).rejects.toThrow("explorer.exe failed with code 2");
+      expect(spawn).toHaveBeenCalledWith("explorer.exe", [url], {
+        stdio: "ignore",
+        shell: false,
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
   it("enables the msteams channel without dropping existing config", () => {
     expect(
       msteamsSetupAdapter.applyAccountConfig?.({

--- a/extensions/msteams/src/setup-surface.test.ts
+++ b/extensions/msteams/src/setup-surface.test.ts
@@ -67,10 +67,51 @@ describe("msteams setup surface", () => {
     child.emit("exit", 0, null);
 
     await expect(result).resolves.toBeUndefined();
-    expect(spawn).toHaveBeenCalledWith(process.platform === "darwin" ? "open" : "xdg-open", [url], {
-      stdio: "ignore",
-      shell: false,
-    });
+    const expectedCommand =
+      process.platform === "darwin"
+        ? "open"
+        : process.platform === "win32"
+          ? "explorer.exe"
+          : "xdg-open";
+    expect(spawn).toHaveBeenCalledWith(expectedCommand, [url], { stdio: "ignore", shell: false });
+  });
+
+  it("uses explorer.exe for delegated OAuth on Windows", async () => {
+    const url = "https://login.microsoftonline.com/auth";
+    const child = new EventEmitter();
+    spawn.mockReturnValue(child);
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    try {
+      const result = openDelegatedOAuthUrl(url);
+      child.emit("exit", 0, null);
+      await expect(result).resolves.toBeUndefined();
+      expect(spawn).toHaveBeenCalledWith("explorer.exe", [url], {
+        stdio: "ignore",
+        shell: false,
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("treats explorer.exe exit code 1 as success on Windows", async () => {
+    const url = "https://login.microsoftonline.com/auth";
+    const child = new EventEmitter();
+    spawn.mockReturnValue(child);
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    try {
+      const result = openDelegatedOAuthUrl(url);
+      child.emit("exit", 1, null);
+      await expect(result).resolves.toBeUndefined();
+      expect(spawn).toHaveBeenCalledWith("explorer.exe", [url], {
+        stdio: "ignore",
+        shell: false,
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
   });
 
   it("enables the msteams channel without dropping existing config", () => {

--- a/extensions/msteams/src/setup-surface.ts
+++ b/extensions/msteams/src/setup-surface.ts
@@ -31,11 +31,16 @@ const setMSTeamsGroupPolicy = createTopLevelChannelGroupPolicySetter({
 
 export function openDelegatedOAuthUrl(url: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    const cmd = process.platform === "darwin" ? "open" : "xdg-open";
+    const cmd =
+      process.platform === "darwin"
+        ? "open"
+        : process.platform === "win32"
+          ? "explorer.exe"
+          : "xdg-open";
     const child = spawn(cmd, [url], { stdio: "ignore", shell: false });
     child.once("error", reject);
     child.once("exit", (code, signal) => {
-      if (code === 0) {
+      if (code === 0 || (process.platform === "win32" && signal == null)) {
         resolve();
         return;
       }

--- a/extensions/msteams/src/setup-surface.ts
+++ b/extensions/msteams/src/setup-surface.ts
@@ -31,16 +31,13 @@ const setMSTeamsGroupPolicy = createTopLevelChannelGroupPolicySetter({
 
 export function openDelegatedOAuthUrl(url: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    const cmd =
-      process.platform === "darwin"
-        ? "open"
-        : process.platform === "win32"
-          ? "explorer.exe"
-          : "xdg-open";
+    const isWindows = process.platform === "win32";
+    const cmd = process.platform === "darwin" ? "open" : isWindows ? "explorer.exe" : "xdg-open";
     const child = spawn(cmd, [url], { stdio: "ignore", shell: false });
     child.once("error", reject);
     child.once("exit", (code, signal) => {
-      if (code === 0 || (process.platform === "win32" && signal == null)) {
+      const explorerReportedSuccess = isWindows && cmd === "explorer.exe" && code === 1;
+      if (signal == null && (code === 0 || explorerReportedSuccess)) {
         resolve();
         return;
       }


### PR DESCRIPTION
## Summary

- Problem: `openDelegatedOAuthUrl()` in `extensions/msteams/src/setup-surface.ts` used `open` on macOS and `xdg-open` everywhere else, so native `win32` delegated OAuth setup tried the Linux launcher instead of the repository's normal Windows browser-open command.
- Why it matters: OpenClaw documents Windows support, and MS Teams delegated OAuth is part of setup/onboarding. Using `xdg-open` on `win32` breaks that path and diverges from the shared Windows browser-open behavior.
- What changed: add an explicit `win32 -> explorer.exe` branch for delegated OAuth launch, treat `explorer.exe` as a fire-and-forget Windows launcher when it exits without a signal, update the existing shell-safety test to reflect platform-specific commands, add Windows-specific regression coverage, and record the fix in the changelog.
- What did NOT change (scope boundary): no changes to OAuth scopes, token handling, prompt/setup flow logic, or the shared browser-open helper.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67659
- Related #67659
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the MS Teams setup surface hardcoded a two-way launcher split (`darwin -> open`, everything else -> `xdg-open`) instead of handling `win32` separately, and its generic non-zero exit rejection was not compatible with `explorer.exe`'s fire-and-forget exit behavior.
- Missing detection / guardrail: the existing test only asserted `shell: false` and mirrored the same incomplete platform split, so it never locked in a Windows command expectation or a Windows-specific exit-path expectation.
- Contributing context (if known): the repo already has a platform-aware browser-open helper that uses `explorer.exe` on Windows, but extension code cannot import core `src/**` helpers directly under the extensions boundary contract.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/setup-surface.test.ts`
- Scenario the test should lock in: delegated OAuth launch uses `explorer.exe` when `process.platform === "win32"`, preserves `shell: false`, and resolves on the observed Windows no-signal exit path.
- Why this is the smallest reliable guardrail: the bug is a platform selection + exit handling error in a small wrapper around `spawn`, so a focused unit test catches it without needing a live OAuth round trip.
- Existing test that already covers this (if any): the existing shell-safety test covers the no-shell invariant; this PR extends it and adds the missing win32 assertions.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Native Windows MS Teams delegated OAuth setup now launches with `explorer.exe` instead of `xdg-open`.
- The Windows launcher path no longer rejects on the observed clean `explorer.exe` exit path.

## Diagram (if applicable)

```text
Before:
[Windows delegated OAuth setup] -> [xdg-open URL] -> [launcher mismatch / broken setup path]
OR
[explorer.exe URL] -> [exit code rejected] -> [setup reports retry later]

After:
[Windows delegated OAuth setup] -> [explorer.exe URL] -> [native Windows browser launch]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS host for local tests; win32 behavior validated by stubbing `process.platform`
- Runtime/container: local pnpm workspace checkout
- Model/provider: N/A
- Integration/channel (if any): MS Teams setup surface
- Relevant config (redacted): N/A

### Steps

1. Stub `process.platform` to `"win32"` in `extensions/msteams/src/setup-surface.test.ts`.
2. Call `openDelegatedOAuthUrl("https://login.microsoftonline.com/auth")`.
3. Observe the spawned command and the resolved promise behavior.

### Expected

- `spawn("explorer.exe", [url], { stdio: "ignore", shell: false })`
- Promise resolves on the observed no-signal Windows exit path.

### Actual

- Before this fix, the code selected `xdg-open` for all non-darwin platforms and rejected any non-zero exit.
- After this fix, the win32 path selects `explorer.exe`, and the regression tests pass for both command selection and the Windows exit-path behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - ran `node scripts/test-projects.mjs extensions/msteams/src/setup-surface.test.ts`
  - confirmed the updated shell-safety test still passes on the current platform
  - confirmed the win32 regression test passes with `process.platform` stubbed to `win32`
  - confirmed the win32 exit-path regression test passes when `explorer.exe` exits with code `1` and no signal
- Edge cases checked:
  - macOS path still uses `open`
  - non-macOS / non-win32 path still uses `xdg-open`
  - launcher still uses `shell: false`
- What you did **not** verify:
  - a live delegated OAuth flow on a native Windows machine

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the Windows launcher now accepts the clean no-signal `explorer.exe` exit path instead of treating it as fatal.
  - Mitigation: scope is limited to the win32 delegated OAuth path, and the test suite locks in the command selection plus the Windows-specific exit behavior.
