### PR TITLE
fix(discord): normalize prefixed conversation ids in resolveChannelIdForBinding

### DIFF
--- a/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
@@ -134,6 +134,40 @@ describe("resolveChannelIdForBinding", () => {
 
     expect(resolved).toBe("forum-1");
   });
+
+  it("strips channel: prefix before calling Discord API", async () => {
+    restGet.mockResolvedValueOnce({
+      id: "123456789",
+      type: ChannelType.GuildText,
+    });
+
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "channel:123456789",
+    });
+
+    expect(resolved).toBe("123456789");
+    const [calledRoute] = restGet.mock.calls[0] ?? [];
+    expect(String(calledRoute)).toContain("123456789");
+    expect(String(calledRoute)).not.toContain("channel:");
+  });
+
+  it("strips user: prefix before calling Discord API", async () => {
+    restGet.mockResolvedValueOnce({
+      id: "987654321",
+      type: ChannelType.DM,
+    });
+
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "user:987654321",
+    });
+
+    expect(resolved).toBe("987654321");
+    const [calledRoute] = restGet.mock.calls[0] ?? [];
+    expect(String(calledRoute)).toContain("987654321");
+    expect(String(calledRoute)).not.toContain("user:");
+  });
 });
 
 describe("maybeSendBindingMessage", () => {

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.ts
@@ -5,6 +5,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { createDiscordRestClient } from "../client.js";
 import { sendMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
 import { createThreadDiscord } from "../send.messages.js";
+import { parseDiscordTarget } from "../target-parsing.js";
 import { resolveThreadBindingPersonaFromRecord } from "./thread-bindings.persona.js";
 import {
   BINDINGS_BY_THREAD_ID,
@@ -237,6 +238,9 @@ export async function resolveChannelIdForBinding(params: {
   if (explicit) {
     return explicit;
   }
+  // Strip "channel:"/"user:" prefix so Discord API receives a raw snowflake.
+  const rawThreadId =
+    parseDiscordTarget(params.threadId, { defaultKind: "channel" })?.id ?? params.threadId;
   try {
     const rest = createDiscordRestClient(
       {
@@ -245,7 +249,7 @@ export async function resolveChannelIdForBinding(params: {
       },
       params.cfg,
     ).rest;
-    const channel = (await rest.get(Routes.channel(params.threadId))) as {
+    const channel = (await rest.get(Routes.channel(rawThreadId))) as {
       id?: string;
       type?: number;
       parent_id?: string;
@@ -267,7 +271,7 @@ export async function resolveChannelIdForBinding(params: {
     return channelId || null;
   } catch (err) {
     logVerbose(
-      `discord thread binding channel resolve failed for ${params.threadId}: ${summarizeDiscordError(err)}`,
+      `discord thread binding channel resolve failed for ${rawThreadId}: ${summarizeDiscordError(err)}`,
     );
     return null;
   }

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.ts
@@ -238,10 +238,10 @@ export async function resolveChannelIdForBinding(params: {
   if (explicit) {
     return explicit;
   }
-  // Strip "channel:"/"user:" prefix so Discord API receives a raw snowflake.
-  const rawThreadId =
-    parseDiscordTarget(params.threadId, { defaultKind: "channel" })?.id ?? params.threadId;
   try {
+    // Strip "channel:"/"user:" prefix so Discord API receives a raw snowflake.
+    const rawThreadId =
+      parseDiscordTarget(params.threadId, { defaultKind: "channel" })?.id ?? params.threadId;
     const rest = createDiscordRestClient(
       {
         accountId: params.accountId,
@@ -271,7 +271,7 @@ export async function resolveChannelIdForBinding(params: {
     return channelId || null;
   } catch (err) {
     logVerbose(
-      `discord thread binding channel resolve failed for ${rawThreadId}: ${summarizeDiscordError(err)}`,
+      `discord thread binding channel resolve failed for ${params.threadId}: ${summarizeDiscordError(err)}`,
     );
     return null;
   }


### PR DESCRIPTION
## Summary

- **Problem:** When spawning an ACP session with `thread:true` on Discord, the session binding adapter's `bind()` passes a prefixed conversation id (e.g. `channel:1234567890`) to `resolveChannelIdForBinding`, which forwards it directly to the Discord API via `Routes.channel()`. The Discord API expects a raw snowflake id, so the call fails and `bind()` returns null, causing `thread_binding_invalid` / `Session binding adapter failed to bind target conversation`.
- **Why it matters:** ACP thread-bound sessions on Discord are completely broken — any `sessions_spawn(runtime="acp", thread=true)` or `/acp spawn --thread auto` fails.
- **What changed:** `resolveChannelIdForBinding` now strips `channel:`/`user:` prefixes via `parseDiscordTarget` before calling the Discord API, protecting all 4 call sites.
- **What did NOT change (scope boundary):** No caller-side changes. The existing lifecycle path that already handled this correctly (`thread-bindings.lifecycle.ts`) is unaffected.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Root Cause (if applicable)

- **Root cause:** `resolveChannelIdForBinding` received conversation ids in the `channel:<snowflake>` format from `resolveInboundConversation` but passed them raw to `Routes.channel()`, which only accepts bare snowflake ids. The lifecycle path (`thread-bindings.lifecycle.ts:143`) already handled this by calling `parseDiscordTarget()` before the API call, but the session binding adapter path (`thread-bindings.manager.ts:645`) did not.
- **Missing detection / guardrail:** No test covers ACP `bind()` with a prefixed Discord conversation id.
- **Contributing context:** The prefixed format (`channel:ID`) is the standard output of Discord's `resolveInboundConversation` hook. The mismatch only surfaces on the ACP thread-binding path because it's the only `bind()` caller that receives conversation ids directly from the inbound resolution layer without pre-normalization.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/discord/src/monitor/thread-bindings.discord-api.test.ts`
- Scenario the test should lock in: `resolveChannelIdForBinding` with a `channel:`-prefixed threadId should resolve the same as a bare snowflake id
- Why this is the smallest reliable guardrail: The fix is entirely within this one function
- If no new test is added, why not: The existing `resolveChannelIdForBinding` tests all use bare snowflake ids. A new test case with prefixed ids would be ideal — happy to add one if reviewers prefer.

## User-visible / Behavior Changes

ACP sessions spawned with `thread:true` on Discord now correctly create and bind to a child thread instead of failing with `thread_binding_invalid`.

## Diagram (if applicable)

```text
Before:
[sessions_spawn thread:true] -> resolveInboundConversation -> "channel:123" -> resolveChannelIdForBinding -> Routes.channel("channel:123") -> Discord API 404 -> bind() null -> thread_binding_invalid

After:
[sessions_spawn thread:true] -> resolveInboundConversation -> "channel:123" -> resolveChannelIdForBinding -> parseDiscordTarget -> "123" -> Routes.channel("123") -> Discord API OK -> thread created & bound
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same Discord API call, just with correct id format)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 26.3 (arm64)
- Runtime: Node 22.22.0
- OpenClaw: 2026.4.11 through 2026.4.15-beta.1
- Channel: Discord

### Steps

1. Configure ACP with `acp.enabled=true`, `channels.discord.threadBindings.spawnAcpSessions=true`, `session.threadBindings.enabled=true`
2. In a Discord guild channel, trigger `sessions_spawn(runtime="acp", agentId="claude", thread=true, mode="session", task="...")`
3. Observe `errorCode: thread_binding_invalid`

### Expected

A child thread is created in the Discord channel and the ACP session is bound to it.

### Actual

`Session binding adapter failed to bind target conversation` — no thread created.

## Evidence

- [x] Verified fix locally: built from source, started gateway with patched code, successfully spawned ACP thread-bound session on Discord
- [x] All 940 Discord extension tests pass
- [x] All 387 channel contract tests pass
- [x] `pnpm check` clean

## Human Verification (required)

- **Verified scenarios:** ACP `thread:true` spawn on Discord — thread created and session bound successfully with local build
- **Edge cases checked:** Bare snowflake ids still work (covered by existing tests); prefixed ids now normalized
- **What I did not verify:** Other channels (Matrix, Telegram) — their thread binding paths use different adapters

## AI/Vibe-Coded PR 🤖

- [x] AI-assisted (Claude Code)
- [x] Fully tested locally + all extension and contract tests pass
- [x] I understand what the code does — `parseDiscordTarget` strips the `channel:` prefix to extract the raw snowflake before Discord API calls

## Review Conversations

- [x] N/A (initial submission)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** `parseDiscordTarget` could return `undefined` for malformed ids
  - **Mitigation:** Falls back to `params.threadId` via `?? params.threadId`, preserving existing behavior