### PR TITLE
fix(cron): add single-job get path for id-based inspection

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -25,6 +25,7 @@ openclaw cron add \
 
 # Check your jobs
 openclaw cron list
+openclaw cron get <job-id>
 
 # See run history
 openclaw cron runs --id <job-id>

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -39,6 +39,8 @@ Note: `openclaw cron run` now returns as soon as the manual run is queued for ex
 Note: `openclaw cron run <job-id>` force-runs by default. Use `--due` to keep the
 older "only run if due" behavior.
 
+Note: `openclaw cron get <job-id>` returns the full stored job definition for one job, which is the right fit for scripting or inspection when you already know the id.
+
 Note: isolated cron turns suppress stale acknowledgement-only replies. If the
 first result is just an interim status update and no descendant subagent run is
 responsible for the eventual answer, cron re-prompts once for the real result
@@ -131,6 +133,12 @@ Delivery ownership note:
   directly.
 
 ## Common admin commands
+
+Inspect a single job:
+
+```bash
+openclaw cron get <job-id>
+```
 
 Manual run:
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1672,7 +1672,7 @@ Manage scheduled jobs (Gateway RPC). See [/automation/cron-jobs](/automation/cro
 Subcommands:
 
 - `cron status [--json]`
-- `cron get <id> [--json]`
+- `cron get <id>`
 - `cron list [--all] [--json]` (table output by default; use `--json` for raw)
 - `cron add` (alias: `create`; requires `--name` and exactly one of `--at` | `--every` | `--cron`, and exactly one payload of `--system-event` | `--message`)
 - `cron edit <id>` (patch fields)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1672,6 +1672,7 @@ Manage scheduled jobs (Gateway RPC). See [/automation/cron-jobs](/automation/cro
 Subcommands:
 
 - `cron status [--json]`
+- `cron get <id> [--json]`
 - `cron list [--all] [--json]` (table output by default; use `--json` for raw)
 - `cron add` (alias: `create`; requires `--name` and exactly one of `--at` | `--every` | `--cron`, and exactly one payload of `--system-event` | `--message`)
 - `cron edit <id>` (patch fields)

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -234,7 +234,7 @@ describe("resolveEffectiveToolInventory", () => {
           name: "cron",
           label: "Cron",
           description:
-            'Manage Gateway cron jobs (status/list/add/update/remove/run/runs) and send wake events. Use this for reminders, "check back later" requests, delayed follow-ups, and recurring tasks. Do not emulate scheduling with exec sleep or process polling.\n\nACTIONS:\n- status: Check cron scheduler status\nJOB SCHEMA:\n{ ... }',
+            'Manage Gateway cron jobs (status/get/list/add/update/remove/run/runs) and send wake events. Use this for reminders, "check back later" requests, delayed follow-ups, and recurring tasks. Do not emulate scheduling with exec sleep or process polling.\n\nACTIONS:\n- status: Check cron scheduler status\nJOB SCHEMA:\n{ ... }',
         }),
       ],
     });
@@ -243,7 +243,7 @@ describe("resolveEffectiveToolInventory", () => {
 
     const description = result.groups[0]?.tools[0]?.description ?? "";
     expect(description).toContain(
-      "Manage Gateway cron jobs (status/list/add/update/remove/run/runs) and send wake events.",
+      "Manage Gateway cron jobs (status/get/list/add/update/remove/run/runs) and send wake events.",
     );
     expect(description).toContain("Use this for reminders");
     expect(description.endsWith("...")).toBe(true);

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -21,7 +21,17 @@ import { resolveInternalSessionKey, resolveMainSessionAlias } from "./sessions-h
 // We spell out job/patch properties so that LLMs know what fields to send.
 // Nested unions are avoided; runtime validation happens in normalizeCronJob*.
 
-const CRON_ACTIONS = ["status", "list", "add", "update", "remove", "run", "runs", "wake"] as const;
+const CRON_ACTIONS = [
+  "status",
+  "get",
+  "list",
+  "add",
+  "update",
+  "remove",
+  "run",
+  "runs",
+  "wake",
+] as const;
 
 const CRON_SCHEDULE_KINDS = ["at", "every", "cron"] as const;
 const CRON_WAKE_MODES = ["now", "next-heartbeat"] as const;
@@ -390,12 +400,13 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
     name: "cron",
     ownerOnly: isOpenClawOwnerOnlyCoreToolName("cron"),
     displaySummary: CRON_TOOL_DISPLAY_SUMMARY,
-    description: `Manage Gateway cron jobs (status/list/add/update/remove/run/runs) and send wake events. Use this for reminders, "check back later" requests, delayed follow-ups, and recurring tasks. Do not emulate scheduling with exec sleep or process polling.
+    description: `Manage Gateway cron jobs (status/get/list/add/update/remove/run/runs) and send wake events. Use this for reminders, "check back later" requests, delayed follow-ups, and recurring tasks. Do not emulate scheduling with exec sleep or process polling.
 
 Main-session cron jobs enqueue system events for heartbeat handling. Isolated cron jobs create background task runs that appear in \`openclaw tasks\`.
 
 ACTIONS:
 - status: Check cron scheduler status
+- get: Fetch a single job by id/jobId
 - list: List jobs (use includeDisabled:true to include disabled)
 - add: Create job (requires job object, see schema below)
 - update: Modify job (requires jobId + patch object)
@@ -474,6 +485,13 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
       switch (action) {
         case "status":
           return jsonResult(await callGateway("cron.status", gatewayOpts, {}));
+        case "get": {
+          const id = readStringParam(params, "jobId") ?? readStringParam(params, "id");
+          if (!id) {
+            throw new Error("jobId required (id accepted for backward compatibility)");
+          }
+          return jsonResult(await callGateway("cron.get", gatewayOpts, { id }));
+        }
         case "list":
           return jsonResult(
             await callGateway("cron.list", gatewayOpts, {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -129,6 +129,12 @@ async function runCronSimpleAndGetUpdatePatch(
   };
 }
 
+async function runCronGetAndCaptureParams(args: string[] = ["cron", "get", "job-1"]) {
+  await runCronCommand(args);
+  const getCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.get");
+  return (getCall?.[2] ?? {}) as { id?: string };
+}
+
 function mockCronEditJobLookup(schedule: unknown): void {
   callGatewayFromCli.mockImplementation(
     async (method: string, _opts: unknown, params?: unknown) => {
@@ -216,6 +222,10 @@ async function runCronRunAndCaptureExit(params: {
 }
 
 describe("cron cli", () => {
+  it("routes cron get to cron.get with the provided id", async () => {
+    await expect(runCronGetAndCaptureParams()).resolves.toEqual({ id: "job-1" });
+  });
+
   it.each([
     {
       name: "exits 0 for cron run when job executes successfully",

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -35,7 +35,6 @@ export function registerCronSimpleCommands(cron: Command) {
       .command("get")
       .description("Show a cron job by id")
       .argument("<id>", "Job id")
-      .option("--json", "Output JSON", false)
       .action(async (id, opts) => {
         try {
           const res = await callGatewayFromCli("cron.get", opts, { id });
@@ -53,7 +52,6 @@ export function registerCronSimpleCommands(cron: Command) {
       .alias("delete")
       .description("Remove a cron job")
       .argument("<id>", "Job id")
-      .option("--json", "Output JSON", false)
       .action(async (id, opts) => {
         try {
           const res = await callGatewayFromCli("cron.remove", opts, { id });

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -52,6 +52,7 @@ export function registerCronSimpleCommands(cron: Command) {
       .alias("delete")
       .description("Remove a cron job")
       .argument("<id>", "Job id")
+      .option("--json", "Output JSON", false)
       .action(async (id, opts) => {
         try {
           const res = await callGatewayFromCli("cron.remove", opts, { id });

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -32,6 +32,22 @@ function registerCronToggleCommand(params: {
 export function registerCronSimpleCommands(cron: Command) {
   addGatewayClientOptions(
     cron
+      .command("get")
+      .description("Show a cron job by id")
+      .argument("<id>", "Job id")
+      .option("--json", "Output JSON", false)
+      .action(async (id, opts) => {
+        try {
+          const res = await callGatewayFromCli("cron.get", opts, { id });
+          printCronJson(res);
+        } catch (err) {
+          handleCronCliError(err);
+        }
+      }),
+  );
+
+  addGatewayClientOptions(
+    cron
       .command("rm")
       .alias("remove")
       .alias("delete")

--- a/src/cron/service-contract.ts
+++ b/src/cron/service-contract.ts
@@ -45,6 +45,7 @@ export interface CronServiceContract {
   status(): Promise<CronStatusSummary>;
   list(opts?: { includeDisabled?: boolean }): Promise<CronListResult>;
   listPage(opts?: CronListPageOptions): Promise<CronListPageResult>;
+  get(id: string): Promise<CronJob | undefined>;
   add(input: CronAddInput): Promise<CronAddResult>;
   update(id: string, patch: CronUpdateInput): Promise<CronUpdateResult>;
   remove(id: string): Promise<CronRemoveResult>;

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -42,6 +42,10 @@ export class CronService implements CronServiceContract {
     return await ops.listPage(this.state, opts);
   }
 
+  async get(id: string) {
+    return await ops.get(this.state, id);
+  }
+
   async add(input: CronJobCreate) {
     return await ops.add(this.state, input);
   }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -260,6 +260,13 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
   });
 }
 
+export async function get(state: CronServiceState, id: string) {
+  return await locked(state, async () => {
+    await ensureLoadedForRead(state);
+    return state.store?.jobs.find((job) => job.id === id);
+  });
+}
+
 export async function add(state: CronServiceState, input: CronJobCreate) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -100,6 +100,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "sessions.usage",
     "sessions.usage.timeseries",
     "sessions.usage.logs",
+    "cron.get",
     "cron.list",
     "cron.status",
     "cron.runs",

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   validateCronAddParams,
+  validateCronGetParams,
   validateCronListParams,
   validateCronRemoveParams,
   validateCronRunParams,
@@ -57,6 +58,11 @@ describe("cron protocol validators", () => {
   it("accepts remove params for id and jobId selectors", () => {
     expect(validateCronRemoveParams({ id: "job-1" })).toBe(true);
     expect(validateCronRemoveParams({ jobId: "job-2" })).toBe(true);
+  });
+
+  it("accepts get params for id and jobId selectors", () => {
+    expect(validateCronGetParams({ id: "job-1" })).toBe(true);
+    expect(validateCronGetParams({ jobId: "job-2" })).toBe(true);
   });
 
   it("accepts run params mode for id and jobId selectors", () => {

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -779,6 +779,7 @@ export type {
   SessionsCompactParams,
   SessionsUsageParams,
   CronJob,
+  CronGetParams,
   CronListParams,
   CronStatusParams,
   CronAddParams,

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -93,6 +93,8 @@ import {
   CronAddParamsSchema,
   type CronJob,
   CronJobSchema,
+  type CronGetParams,
+  CronGetParamsSchema,
   type CronListParams,
   CronListParamsSchema,
   type CronRemoveParams,
@@ -448,6 +450,7 @@ export const validateSkillsSearchParams = ajv.compile<SkillsSearchParams>(Skills
 export const validateSkillsDetailParams = ajv.compile<SkillsDetailParams>(SkillsDetailParamsSchema);
 export const validateCronListParams = ajv.compile<CronListParams>(CronListParamsSchema);
 export const validateCronStatusParams = ajv.compile<CronStatusParams>(CronStatusParamsSchema);
+export const validateCronGetParams = ajv.compile<CronGetParams>(CronGetParamsSchema);
 export const validateCronAddParams = ajv.compile<CronAddParams>(CronAddParamsSchema);
 export const validateCronUpdateParams = ajv.compile<CronUpdateParams>(CronUpdateParamsSchema);
 export const validateCronRemoveParams = ajv.compile<CronRemoveParams>(CronRemoveParamsSchema);
@@ -650,6 +653,7 @@ export {
   CronJobSchema,
   CronListParamsSchema,
   CronStatusParamsSchema,
+  CronGetParamsSchema,
   CronAddParamsSchema,
   CronUpdateParamsSchema,
   CronRemoveParamsSchema,

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -284,6 +284,8 @@ export const CronListParamsSchema = Type.Object(
 
 export const CronStatusParamsSchema = Type.Object({}, { additionalProperties: false });
 
+export const CronGetParamsSchema = cronIdOrJobIdParams({});
+
 export const CronAddParamsSchema = Type.Object(
   {
     name: NonEmptyString,

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -79,6 +79,7 @@ import {
 } from "./config.js";
 import {
   CronAddParamsSchema,
+  CronGetParamsSchema,
   CronJobSchema,
   CronListParamsSchema,
   CronRemoveParamsSchema,
@@ -328,6 +329,7 @@ export const ProtocolSchemas = {
   CronJob: CronJobSchema,
   CronListParams: CronListParamsSchema,
   CronStatusParams: CronStatusParamsSchema,
+  CronGetParams: CronGetParamsSchema,
   CronAddParams: CronAddParamsSchema,
   CronUpdateParams: CronUpdateParamsSchema,
   CronRemoveParams: CronRemoveParamsSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -130,6 +130,7 @@ export type SkillsUpdateParams = SchemaType<"SkillsUpdateParams">;
 export type CronJob = SchemaType<"CronJob">;
 export type CronListParams = SchemaType<"CronListParams">;
 export type CronStatusParams = SchemaType<"CronStatusParams">;
+export type CronGetParams = SchemaType<"CronGetParams">;
 export type CronAddParams = SchemaType<"CronAddParams">;
 export type CronUpdateParams = SchemaType<"CronUpdateParams">;
 export type CronRemoveParams = SchemaType<"CronRemoveParams">;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -113,6 +113,7 @@ const BASE_METHODS = [
   "node.invoke.result",
   "node.event",
   "node.canvas.capability.refresh",
+  "cron.get",
   "cron.list",
   "cron.status",
   "cron.add",

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -13,6 +13,7 @@ import {
   errorShape,
   formatValidationErrors,
   validateCronAddParams,
+  validateCronGetParams,
   validateCronListParams,
   validateCronRemoveParams,
   validateCronRunParams,
@@ -89,6 +90,39 @@ export const cronHandlers: GatewayRequestHandlers = {
     }
     const status = await context.cron.status();
     respond(true, status, undefined);
+  },
+  "cron.get": async ({ params, respond, context }) => {
+    if (!validateCronGetParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid cron.get params: ${formatValidationErrors(validateCronGetParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params as { id?: string; jobId?: string };
+    const jobId = p.id ?? p.jobId;
+    if (!jobId) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "invalid cron.get params: missing id"),
+      );
+      return;
+    }
+    const job = await context.cron.get(jobId);
+    if (!job) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `cron job not found: ${jobId}`),
+      );
+      return;
+    }
+    respond(true, job, undefined);
   },
   "cron.add": async ({ params, respond, context }) => {
     const sessionKey =

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -289,6 +289,12 @@ describe("gateway server cron", () => {
         ((jobs as Array<{ delivery?: { mode?: unknown } }>)[0]?.delivery?.mode as string) ?? "",
       ).toBe("webhook");
 
+      const firstJobId = ((jobs as Array<{ id?: unknown }>)[0]?.id as string) ?? "";
+      const getRes = await rpcReq(ws, "cron.get", { id: firstJobId });
+      expect(getRes.ok).toBe(true);
+      expect((getRes.payload as { id?: unknown; name?: unknown } | null)?.id).toBe(firstJobId);
+      expect((getRes.payload as { name?: unknown } | null)?.name).toBe("daily");
+
       const routeAtMs = Date.now() - 1;
       const routeRes = await rpcReq(ws, "cron.add", {
         name: "route test",
@@ -716,6 +722,25 @@ describe("gateway server cron", () => {
         status: "ok",
         summary: "background finished",
       });
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  });
+
+  test("returns an error for cron.get when the job is missing", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-get-missing-",
+      cronEnabled: true,
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      const response = await rpcReq(ws, "cron.get", { id: "missing-job-id" });
+      expect(response.ok).toBe(false);
+      expect(response.error?.code).toBe("INVALID_REQUEST");
+      expect(response.error?.message).toContain("cron job not found");
     } finally {
       await cleanupCronTestRun({ ws, server, prevSkipCron });
     }


### PR DESCRIPTION
## Summary

- Problem: `openclaw cron` only supports full-job inspection via `cron list --json`, so consumers must fetch and filter the entire job set even when they already know the target job id.
- Why it matters: this is inconsistent with existing id-based cron operations and wastes payload/token budget for agent-driven, scripted, and debugging workflows.
- What changed: added `cron.get` plus `openclaw cron get <id>` for single-job inspection.
- What did NOT change (scope boundary): no scheduling, execution, delivery, or existing `cron list` behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67671
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: cron jobs are already modeled as id-addressable resources for mutate operations (`edit`, `run`, `rm`), but the CLI/RPC surface did not expose a matching single-job read path.
- Missing detection / guardrail: there was no test coverage asserting parity between id-based cron mutation and id-based cron inspection.
- Contributing context (if known): callers that already knew a job id still had to fetch the full job list and filter client-side.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/cli/cron-cli.test.ts`
  - `src/gateway/protocol/cron-validators.test.ts`
  - `src/gateway/server.cron.test.ts`
- Scenario the test should lock in: a caller can fetch one cron job by id through both CLI and gateway RPC, and missing ids fail cleanly.
- Why this is the smallest reliable guardrail: the change is a CLI/protocol/server seam addition, so those seams are the narrowest place to lock the behavior.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Added `openclaw cron get <id>` for single-job inspection.
- Added gateway RPC `cron.get`.
- Added the same single-job inspection path to the cron agent tool.

## Diagram (if applicable)

```text
Before:
[caller knows job id] -> [cron list --json] -> [filter full job set client-side]

After:
[caller knows job id] -> [cron get <id>] -> [single job payload]
