### PR TITLE
fix: redact credentials in browser.cdpUrl config paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ Docs: https://docs.openclaw.ai
 - Gateway/assistant media: require `operator.read` scope for assistant-media file and metadata requests on identity-bearing HTTP auth paths so callers without a read scope can no longer access assistant media. (#68175) Thanks @eleqtrizit.
 - Exec approvals/display: escape raw control characters (including newline and carriage return) in the shared and macOS approval-prompt command sanitizers, so trailing command payloads no longer render on hidden extra lines in the approval UI. (#68198)
 - OpenAI Codex/OAuth + Pi: keep imported Codex CLI OAuth bootstrap, Pi auth export, and runtime overlay handling aligned so Codex sessions survive refresh and health checks without leaking transient CLI state into saved auth files. Thanks @vincentkoc.
-- Agents/TTS: report failed speech synthesis as a real tool error so unconfigured providers no longer feed successful TTS failure output back into agent loops. (#67980) Thanks @lawrence3699.
 - Config/redact: add `browser.cdpUrl` and `browser.profiles.*.cdpUrl` to sensitive URL config paths so embedded credentials (query tokens and HTTP Basic auth) are properly redacted in `config.get` API responses and availability error messages. (#67679) Thanks @Ziy1-Tan.
+- Agents/TTS: report failed speech synthesis as a real tool error so unconfigured providers no longer feed successful TTS failure output back into agent loops. (#67980) Thanks @lawrence3699.
 
 ## 2026.4.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config/redact: add `browser.cdpUrl` and `browser.profiles.*.cdpUrl` to sensitive URL config paths so embedded credentials (query tokens and HTTP Basic auth) are properly redacted in `config.get` API responses and availability error messages. (#67656) Thanks @Ziy1-Tan.
+
 - Agents/bootstrap: resolve bootstrap from workspace truth instead of stale session transcript markers, keep embedded bootstrap instructions on a hidden user-context prelude, suppress normal `/new` and `/reset` greetings while `BOOTSTRAP.md` is still pending, and make the embedded runner read the bootstrap ritual before replying normally.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
 - Gateway/hello-ok: always report negotiated auth metadata for successful shared-auth handshakes, including control-ui bypass coverage when no device token is issued. (#67810) Thanks @BunsDev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Config/redact: add `browser.cdpUrl` and `browser.profiles.*.cdpUrl` to sensitive URL config paths so embedded credentials (query tokens and HTTP Basic auth) are properly redacted in `config.get` API responses and availability error messages. (#67656) Thanks @Ziy1-Tan.
+- Config/redact: add `browser.cdpUrl` and `browser.profiles.*.cdpUrl` to sensitive URL config paths so embedded credentials (query tokens and HTTP Basic auth) are properly redacted in `config.get` API responses and availability error messages. (#67679) Thanks @Ziy1-Tan.
 
 - Agents/bootstrap: resolve bootstrap from workspace truth instead of stale session transcript markers, keep embedded bootstrap instructions on a hidden user-context prelude, suppress normal `/new` and `/reset` greetings while `BOOTSTRAP.md` is still pending, and make the embedded runner read the bootstrap ritual before replying normally.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - macOS/gateway: add `screen.snapshot` support for macOS app nodes, including runtime plumbing, default macOS allowlisting, and docs for monitor preview flows. (#67954) Thanks @BunsDev.
+- fix: redact credentials in browser.cdpUrl config paths (#67679). Thanks @Ziy1-Tan
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Config/redact: add `browser.cdpUrl` and `browser.profiles.*.cdpUrl` to sensitive URL config paths so embedded credentials (query tokens and HTTP Basic auth) are properly redacted in `config.get` API responses and availability error messages. (#67679) Thanks @Ziy1-Tan.
-
 - Agents/bootstrap: resolve bootstrap from workspace truth instead of stale session transcript markers, keep embedded bootstrap instructions on a hidden user-context prelude, suppress normal `/new` and `/reset` greetings while `BOOTSTRAP.md` is still pending, and make the embedded runner read the bootstrap ritual before replying normally.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
 - Gateway/hello-ok: always report negotiated auth metadata for successful shared-auth handshakes, including control-ui bypass coverage when no device token is issued. (#67810) Thanks @BunsDev.
@@ -46,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals/display: escape raw control characters (including newline and carriage return) in the shared and macOS approval-prompt command sanitizers, so trailing command payloads no longer render on hidden extra lines in the approval UI. (#68198)
 - OpenAI Codex/OAuth + Pi: keep imported Codex CLI OAuth bootstrap, Pi auth export, and runtime overlay handling aligned so Codex sessions survive refresh and health checks without leaking transient CLI state into saved auth files. Thanks @vincentkoc.
 - Agents/TTS: report failed speech synthesis as a real tool error so unconfigured providers no longer feed successful TTS failure output back into agent loops. (#67980) Thanks @lawrence3699.
+- Config/redact: add `browser.cdpUrl` and `browser.profiles.*.cdpUrl` to sensitive URL config paths so embedded credentials (query tokens and HTTP Basic auth) are properly redacted in `config.get` API responses and availability error messages. (#67679) Thanks @Ziy1-Tan.
 
 ## 2026.4.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Config/redaction: redact credentials embedded in `browser.cdpUrl` and `browser.profiles.*.cdpUrl` config paths so query tokens and HTTP Basic auth userinfo are no longer returned in plaintext by `config.get` responses. (#67656) Thanks @Ziy1-Tan.
 - Gateway/tools: anchor trusted local `MEDIA:` tool-result passthrough on the exact raw name of this run's registered built-in tools, and reject client tool definitions whose names normalize-collide with a built-in or with another client tool in the same request (`400 invalid_request_error` on both JSON and SSE paths), so a client-supplied tool named like a built-in can no longer inherit its local-media trust. (#67303)
 - Agents/replay recovery: classify the provider wording `401 input item ID does not belong to this connection` as replay-invalid, so users get the existing `/new` session reset guidance instead of a raw 401-style failure. (#66475) Thanks @dallylee.
 - Gateway/webchat: enforce localRoots containment on webchat audio embedding path [AI-assisted]. (#67298) Thanks @pgondhi987.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config/redaction: redact credentials embedded in `browser.cdpUrl` and `browser.profiles.*.cdpUrl` config paths so query tokens and HTTP Basic auth userinfo are no longer returned in plaintext by `config.get` responses. (#67656) Thanks @Ziy1-Tan.
 - Gateway/tools: anchor trusted local `MEDIA:` tool-result passthrough on the exact raw name of this run's registered built-in tools, and reject client tool definitions whose names normalize-collide with a built-in or with another client tool in the same request (`400 invalid_request_error` on both JSON and SSE paths), so a client-supplied tool named like a built-in can no longer inherit its local-media trust. (#67303)
 - Agents/replay recovery: classify the provider wording `401 input item ID does not belong to this connection` as replay-invalid, so users get the existing `/new` session reset guidance instead of a raw 401-style failure. (#66475) Thanks @dallylee.
 - Gateway/webchat: enforce localRoots containment on webchat audio embedding path [AI-assisted]. (#67298) Thanks @pgondhi987.

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -7,6 +7,7 @@ import {
   PROFILE_POST_RESTART_WS_TIMEOUT_MS,
   resolveCdpReachabilityTimeouts,
 } from "./cdp-timeouts.js";
+import { redactCdpUrl } from "./cdp.helpers.js";
 import {
   closeChromeMcpSession,
   ensureChromeMcpAvailable,
@@ -59,6 +60,7 @@ export function createProfileAvailability({
   getProfileState,
   setProfileRunning,
 }: AvailabilityDeps): AvailabilityOps {
+  const redactedProfileCdpUrl = redactCdpUrl(profile.cdpUrl) ?? profile.cdpUrl;
   const capabilities = getBrowserProfileCapabilities(profile);
   const resolveTimeouts = (timeoutMs: number | undefined) =>
     resolveCdpReachabilityTimeouts({
@@ -210,7 +212,7 @@ export function createProfileAvailability({
       if (attachOnly || remoteCdp) {
         throw new BrowserProfileUnavailableError(
           remoteCdp
-            ? `Remote CDP for profile "${profile.name}" is not reachable at ${profile.cdpUrl}.`
+            ? `Remote CDP for profile "${profile.name}" is not reachable at ${redactedProfileCdpUrl}.`
             : `Browser attachOnly is enabled and profile "${profile.name}" is not running.`,
         );
       }

--- a/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -5,6 +5,7 @@ import {
   PROFILE_HTTP_REACHABILITY_TIMEOUT_MS,
 } from "./cdp-timeouts.js";
 import * as chromeModule from "./chrome.js";
+import { BrowserProfileUnavailableError } from "./errors.js";
 import { createBrowserRouteContext } from "./server-context.js";
 import { makeBrowserServerState, mockLaunchedChrome } from "./server-context.test-harness.js";
 
@@ -172,6 +173,41 @@ describe("browser server-context ensureBrowserAvailable", () => {
       state.resolved.remoteCdpHandshakeTimeoutMs,
       undefined,
     );
+    expect(launchOpenClawChrome).not.toHaveBeenCalled();
+    expect(stopOpenClawChrome).not.toHaveBeenCalled();
+  });
+
+  it("redacts credentials in remote CDP availability errors", async () => {
+    const { launchOpenClawChrome, stopOpenClawChrome } = setupEnsureBrowserAvailableHarness();
+    const isChromeReachable = vi.mocked(chromeModule.isChromeReachable);
+
+    const state = makeBrowserServerState({
+      profile: {
+        name: "remote",
+        cdpUrl: "https://user:pass@browserless.example.com?token=supersecret123",
+        cdpHost: "browserless.example.com",
+        cdpIsLoopback: false,
+        cdpPort: 443,
+        color: "#00AA00",
+        driver: "openclaw",
+        attachOnly: false,
+      },
+      resolvedOverrides: {
+        defaultProfile: "remote",
+        ssrfPolicy: {},
+      },
+    });
+    const ctx = createBrowserRouteContext({ getState: () => state });
+    const profile = ctx.forProfile("remote");
+
+    isChromeReachable.mockResolvedValue(false);
+
+    const promise = profile.ensureBrowserAvailable();
+    await expect(promise).rejects.toThrow(BrowserProfileUnavailableError);
+    await expect(promise).rejects.toThrow(
+      'Remote CDP for profile "remote" is not reachable at https://browserless.example.com/?token=***.',
+    );
+
     expect(launchOpenClawChrome).not.toHaveBeenCalled();
     expect(stopOpenClawChrome).not.toHaveBeenCalled();
   });

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -1162,4 +1162,96 @@ describe("redactConfigSnapshot", () => {
     expect(channels.slack.accounts[0].botToken).toBe(REDACTED_SENTINEL);
     expect(channels.slack.accounts[1].botToken).toBe(REDACTED_SENTINEL);
   });
+
+  it("redacts credentials embedded in browser.cdpUrl (query token and userinfo)", () => {
+    const hints = buildConfigSchema().uiHints;
+    const raw = `{
+  browser: {
+    cdpUrl: "https://user:pass@chrome.browserless.io?token=supersecret123",
+  },
+}`;
+    const snapshot = makeSnapshot(
+      {
+        browser: {
+          cdpUrl: "https://user:pass@chrome.browserless.io?token=supersecret123",
+        },
+      },
+      raw,
+    );
+
+    const result = redactConfigSnapshot(snapshot, hints);
+    const cfg = result.config as typeof snapshot.config;
+    expect(cfg.browser.cdpUrl).toBe(REDACTED_SENTINEL);
+    expect(result.raw).toContain(REDACTED_SENTINEL);
+    expect(result.raw).not.toContain("user:pass@");
+    expect(result.raw).not.toContain("supersecret123");
+
+    const restored = restoreRedactedValues(result.config, snapshot.config, hints);
+    expect(restored.browser.cdpUrl).toBe(
+      "https://user:pass@chrome.browserless.io?token=supersecret123",
+    );
+  });
+
+  it("redacts credentials embedded in browser.profiles.*.cdpUrl", () => {
+    const hints = buildConfigSchema().uiHints;
+    const raw = `{
+  browser: {
+    profiles: {
+      staging: {
+        cdpUrl: "https://chrome.staging.example.com?token=staging-secret",
+      },
+      prod: {
+        cdpUrl: "https://alice:secret@chrome.prod.example.com",
+      },
+    },
+  },
+}`;
+    const snapshot = makeSnapshot(
+      {
+        browser: {
+          profiles: {
+            staging: {
+              cdpUrl: "https://chrome.staging.example.com?token=staging-secret",
+            },
+            prod: {
+              cdpUrl: "https://alice:secret@chrome.prod.example.com",
+            },
+          },
+        },
+      },
+      raw,
+    );
+
+    const result = redactConfigSnapshot(snapshot, hints);
+    const cfg = result.config as typeof snapshot.config;
+    expect(cfg.browser.profiles.staging.cdpUrl).toBe(REDACTED_SENTINEL);
+    expect(cfg.browser.profiles.prod.cdpUrl).toBe(REDACTED_SENTINEL);
+    expect(result.raw).not.toContain("staging-secret");
+    expect(result.raw).not.toContain("alice:secret@");
+
+    const restored = restoreRedactedValues(result.config, snapshot.config, hints);
+    expect(restored.browser.profiles.staging.cdpUrl).toBe(
+      "https://chrome.staging.example.com?token=staging-secret",
+    );
+    expect(restored.browser.profiles.prod.cdpUrl).toBe(
+      "https://alice:secret@chrome.prod.example.com",
+    );
+  });
+
+  it("does not redact bare cdpUrl addresses without credentials", () => {
+    const hints = buildConfigSchema().uiHints;
+    const snapshot = makeSnapshot({
+      browser: {
+        cdpUrl: "http://10.0.0.42:9222",
+        profiles: {
+          local: { cdpUrl: "ws://localhost:9222" },
+        },
+      },
+    });
+
+    const result = redactConfigSnapshot(snapshot, hints);
+    const cfg = result.config as typeof snapshot.config;
+    expect(cfg.browser.cdpUrl).toBe("http://10.0.0.42:9222");
+    expect(cfg.browser.profiles.local.cdpUrl).toBe("ws://localhost:9222");
+  });
 });

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -1163,45 +1163,20 @@ describe("redactConfigSnapshot", () => {
     expect(channels.slack.accounts[1].botToken).toBe(REDACTED_SENTINEL);
   });
 
-  it("redacts credentials embedded in browser.cdpUrl (query token and userinfo)", () => {
+  it("redacts browser cdpUrl secrets while preserving bare endpoints", () => {
     const hints = buildConfigSchema().uiHints;
     const raw = `{
   browser: {
     cdpUrl: "https://user:pass@chrome.browserless.io?token=supersecret123",
-  },
-}`;
-    const snapshot = makeSnapshot(
-      {
-        browser: {
-          cdpUrl: "https://user:pass@chrome.browserless.io?token=supersecret123",
-        },
-      },
-      raw,
-    );
-
-    const result = redactConfigSnapshot(snapshot, hints);
-    const cfg = result.config as typeof snapshot.config;
-    expect(cfg.browser.cdpUrl).toBe(REDACTED_SENTINEL);
-    expect(result.raw).toContain(REDACTED_SENTINEL);
-    expect(result.raw).not.toContain("user:pass@");
-    expect(result.raw).not.toContain("supersecret123");
-
-    const restored = restoreRedactedValues(result.config, snapshot.config, hints);
-    expect(restored.browser.cdpUrl).toBe(
-      "https://user:pass@chrome.browserless.io?token=supersecret123",
-    );
-  });
-
-  it("redacts credentials embedded in browser.profiles.*.cdpUrl", () => {
-    const hints = buildConfigSchema().uiHints;
-    const raw = `{
-  browser: {
     profiles: {
-      staging: {
+      remote: {
         cdpUrl: "https://chrome.staging.example.com?token=staging-secret",
       },
       prod: {
         cdpUrl: "https://alice:secret@chrome.prod.example.com",
+      },
+      local: {
+        cdpUrl: "ws://localhost:9222",
       },
     },
   },
@@ -1209,12 +1184,16 @@ describe("redactConfigSnapshot", () => {
     const snapshot = makeSnapshot(
       {
         browser: {
+          cdpUrl: "https://user:pass@chrome.browserless.io?token=supersecret123",
           profiles: {
-            staging: {
+            remote: {
               cdpUrl: "https://chrome.staging.example.com?token=staging-secret",
             },
             prod: {
               cdpUrl: "https://alice:secret@chrome.prod.example.com",
+            },
+            local: {
+              cdpUrl: "ws://localhost:9222",
             },
           },
         },
@@ -1224,34 +1203,26 @@ describe("redactConfigSnapshot", () => {
 
     const result = redactConfigSnapshot(snapshot, hints);
     const cfg = result.config as typeof snapshot.config;
-    expect(cfg.browser.profiles.staging.cdpUrl).toBe(REDACTED_SENTINEL);
+    expect(cfg.browser.cdpUrl).toBe(REDACTED_SENTINEL);
+    expect(cfg.browser.profiles.remote.cdpUrl).toBe(REDACTED_SENTINEL);
     expect(cfg.browser.profiles.prod.cdpUrl).toBe(REDACTED_SENTINEL);
+    expect(cfg.browser.profiles.local.cdpUrl).toBe("ws://localhost:9222");
+    expect(result.raw).toContain(REDACTED_SENTINEL);
+    expect(result.raw).not.toContain("user:pass@");
+    expect(result.raw).not.toContain("supersecret123");
     expect(result.raw).not.toContain("staging-secret");
     expect(result.raw).not.toContain("alice:secret@");
 
     const restored = restoreRedactedValues(result.config, snapshot.config, hints);
-    expect(restored.browser.profiles.staging.cdpUrl).toBe(
+    expect(restored.browser.cdpUrl).toBe(
+      "https://user:pass@chrome.browserless.io?token=supersecret123",
+    );
+    expect(restored.browser.profiles.remote.cdpUrl).toBe(
       "https://chrome.staging.example.com?token=staging-secret",
     );
     expect(restored.browser.profiles.prod.cdpUrl).toBe(
       "https://alice:secret@chrome.prod.example.com",
     );
-  });
-
-  it("does not redact bare cdpUrl addresses without credentials", () => {
-    const hints = buildConfigSchema().uiHints;
-    const snapshot = makeSnapshot({
-      browser: {
-        cdpUrl: "http://10.0.0.42:9222",
-        profiles: {
-          local: { cdpUrl: "ws://localhost:9222" },
-        },
-      },
-    });
-
-    const result = redactConfigSnapshot(snapshot, hints);
-    const cfg = result.config as typeof snapshot.config;
-    expect(cfg.browser.cdpUrl).toBe("http://10.0.0.42:9222");
-    expect(cfg.browser.profiles.local.cdpUrl).toBe("ws://localhost:9222");
+    expect(restored.browser.profiles.local.cdpUrl).toBe("ws://localhost:9222");
   });
 });

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -23522,7 +23522,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "browser.cdpUrl": {
       label: "Browser CDP URL",
       help: "Remote CDP websocket URL used to attach to an externally managed browser instance. Use this for centralized browser hosts and keep URL access restricted to trusted network paths.",
-      tags: ["advanced"],
+      tags: ["advanced", "url-secret"],
     },
     "browser.color": {
       label: "Browser Accent Color",
@@ -23572,7 +23572,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "browser.profiles.*.cdpUrl": {
       label: "Browser Profile CDP URL",
       help: "Per-profile CDP websocket URL used for explicit remote browser routing by profile name. Use this when profile connections terminate on remote hosts or tunnels.",
-      tags: ["storage"],
+      tags: ["storage", "url-secret"],
     },
     "browser.profiles.*.userDataDir": {
       label: "Browser Profile User Data Dir",

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -157,6 +157,62 @@ describe("gateway config methods", () => {
     expect(res.payload?.config).toBeTruthy();
   });
 
+  it("redacts browser cdpUrl credentials from config.get responses", async () => {
+    const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");
+    const configPath = createConfigIO().configPath;
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    try {
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            browser: {
+              cdpUrl: "https://user:pass@chrome.browserless.io?token=supersecret123",
+              profiles: {
+                remote: {
+                  cdpUrl: "https://alice:secret@chrome.remote.example.com?token=profile-secret",
+                },
+                local: {
+                  cdpUrl: "ws://127.0.0.1:9222",
+                },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+      resetConfigRuntimeState();
+
+      const after = await rpcReq<{
+        raw?: string | null;
+        config?: {
+          browser?: {
+            cdpUrl?: string;
+            profiles?: Record<string, { cdpUrl?: string }>;
+          };
+        };
+      }>(requireWs(), "config.get", {});
+      expect(after.ok).toBe(true);
+      expect(after.payload?.config?.browser?.cdpUrl).toBe("__OPENCLAW_REDACTED__");
+      expect(after.payload?.config?.browser?.profiles?.remote?.cdpUrl).toBe(
+        "__OPENCLAW_REDACTED__",
+      );
+      expect(after.payload?.config?.browser?.profiles?.local?.cdpUrl).toBe("ws://127.0.0.1:9222");
+      if (typeof after.payload?.raw === "string") {
+        expect(after.payload.raw).toContain("__OPENCLAW_REDACTED__");
+        expect(after.payload.raw).not.toContain("supersecret123");
+        expect(after.payload.raw).not.toContain("user:pass@");
+        expect(after.payload.raw).not.toContain("profile-secret");
+        expect(after.payload.raw).not.toContain("alice:secret@");
+      }
+    } finally {
+      await fs.rm(configPath, { force: true });
+      resetConfigRuntimeState();
+    }
+  });
+
   it("does not reject config.set for unresolved auth-profile refs outside submitted config", async () => {
     const missingEnvVar = `OPENCLAW_MISSING_AUTH_PROFILE_REF_${Date.now()}`;
     await writeUnresolvedAuthProfileTokenRef(missingEnvVar);

--- a/src/shared/net/redact-sensitive-url.test.ts
+++ b/src/shared/net/redact-sensitive-url.test.ts
@@ -51,6 +51,12 @@ describe("sensitive URL config metadata", () => {
     expect(isSensitiveUrlConfigPath("gateway.remote.url")).toBe(false);
   });
 
+  it("recognizes cdpUrl config paths as sensitive (browser CDP URLs can embed credentials)", () => {
+    expect(isSensitiveUrlConfigPath("browser.cdpUrl")).toBe(true);
+    expect(isSensitiveUrlConfigPath("browser.profiles.remote.cdpUrl")).toBe(true);
+    expect(isSensitiveUrlConfigPath("browser.profiles.staging.cdpUrl")).toBe(true);
+  });
+
   it("uses an explicit url-secret hint tag", () => {
     expect(SENSITIVE_URL_HINT_TAG).toBe("url-secret");
     expect(hasSensitiveUrlHintTag({ tags: [SENSITIVE_URL_HINT_TAG] })).toBe(true);

--- a/src/shared/net/redact-sensitive-url.ts
+++ b/src/shared/net/redact-sensitive-url.ts
@@ -25,6 +25,9 @@ export function isSensitiveUrlConfigPath(path: string): boolean {
   if (path.endsWith(".baseUrl") || path.endsWith(".httpUrl")) {
     return true;
   }
+  if (path.endsWith(".cdpUrl")) {
+    return true;
+  }
   if (path.endsWith(".request.proxy.url")) {
     return true;
   }


### PR DESCRIPTION
## What

Add `browser.cdpUrl` and `browser.profiles.*.cdpUrl` to the set of config paths recognized as sensitive URLs, so embedded credentials (query tokens like `?token=xxx` and HTTP Basic auth `user:pass@host`) are properly redacted in `config.get` API responses.

Also regenerate the base schema artifact so shipped `uiHints` stay aligned with the updated sensitive-URL matcher and continue to expose the correct `url-secret` metadata for the new `cdpUrl` paths.

## Why

Browser CDP URLs can embed authentication credentials in two documented formats:
- Query token: `https://chrome.browserless.io?token=<secret>`
- HTTP Basic auth: `https://user:pass@chrome.example.com`

These paths bypassed all three redaction gates:
1. Schema `.register(sensitive)` — not registered
2. Path-name pattern match (`/token$/i`, `/api.?key$/i`, …) — `cdpUrl` does not match
3. URL-path match (`.baseUrl`, `.httpUrl`, `mcp.servers.*.url`) — `.cdpUrl` was not listed

Fixes #67656.

## Changes

- **`src/shared/net/redact-sensitive-url.ts`** — Add `.cdpUrl` suffix check to `isSensitiveUrlConfigPath()` (3 lines)
- **`src/shared/net/redact-sensitive-url.test.ts`** — Unit tests for `isSensitiveUrlConfigPath()` with cdpUrl paths
- **`src/config/redact-snapshot.test.ts`** — Snapshot redact/restore round-trip tests covering:
  - `browser.cdpUrl` with query token + HTTP Basic auth
  - `browser.profiles.*.cdpUrl` with per-profile credentials
  - Bare cdpUrl addresses without credentials remain unchanged
- **`src/config/schema.base.generated.ts`** — Regenerated the base schema artifact so shipped `uiHints` include `url-secret` metadata for `browser.cdpUrl` and `browser.profiles.*.cdpUrl`

## Testing

- `pnpm build` ✅
- `pnpm check` ✅
- `node --import tsx scripts/generate-base-config-schema.ts --check` ✅
- All 49 related tests pass (8 unit + 41 snapshot)
- Tested: `fully tested`

| Test Case | Expected | Actual | PASS |
| --- | --- | --- | --- |
| `isSensitiveUrlConfigPath()` recognizes `.cdpUrl` | Both cdpUrl paths treated as sensitive | Unit test passes | ✅ |
| Redact `browser.cdpUrl` credentials | Secrets stripped, safe parts kept | Snapshot passes (token + Basic auth) | ✅ |
| Redact `browser.profiles.*.cdpUrl` credentials | Profile secrets stripped, round-trip safe | Snapshot passes | ✅ |
| Regenerated base schema artifact | `url-secret` tag on both cdpUrl paths | `--check` passes after regeneration | ✅ |

## AI Disclosure

This PR was AI-assisted (CodeBuddy / Claude). All code has been reviewed and understood by the author. Tests were written in TDD style (failing test first, then minimal implementation).
