### PR TITLE
fix(agents): preserve session totalTokens when provider omits usage data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/openai-completions: always send `stream_options.include_usage` on streaming requests, so local and custom OpenAI-compatible backends report real context usage instead of showing 0%. (#68746) Thanks @kagura-agent.
 - Agents/nested lanes: scope nested agent work per target session so a long-running nested run on one session no longer head-of-line blocks unrelated sessions across the gateway. (#67785) Thanks @stainlu.
+- Agents/status: preserve carried-forward session token totals for providers that omit usage metadata, so `/status` and `openclaw sessions` keep showing the last known context usage instead of dropping back to unknown/0%. (#67695) Thanks @stainlu.
 
 ## 2026.4.19-beta.1
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -277,7 +277,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
       const sessionKey = "agent:main:explicit:test-no-usage";
       const sessionId = "test-session";
 
-      // Session already has totalTokens from a prior run or compaction.
       const sessionStore: Record<string, SessionEntry> = {
         [sessionKey]: {
           sessionId,
@@ -288,7 +287,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
       };
       await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
 
-      // Provider returns no usage data (e.g., MiniMax Anthropic endpoint).
       const result: EmbeddedPiRunResult = {
         meta: {
           durationMs: 500,
@@ -311,9 +309,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
         result,
       });
 
-      // totalTokens should be preserved (not reset to undefined).
       expect(sessionStore[sessionKey]?.totalTokens).toBe(21225);
-      // Marked stale since it's from a prior run, not this one.
       expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(false);
 
       const persisted = loadSessionStore(storePath);

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -272,51 +272,53 @@ describe("updateSessionStoreAfterAgentRun", () => {
   });
 
   it("preserves previous totalTokens when provider returns no usage data (#67667)", async () => {
-    const cfg = {} as OpenClawConfig;
-    const sessionKey = "agent:main:explicit:test-no-usage";
-    const sessionId = "test-session";
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-no-usage";
+      const sessionId = "test-session";
 
-    // Session already has totalTokens from a prior run or compaction.
-    const sessionStore: Record<string, SessionEntry> = {
-      [sessionKey]: {
-        sessionId,
-        updatedAt: 1,
-        totalTokens: 21225,
-        totalTokensFresh: true,
-      },
-    };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
-
-    // Provider returns no usage data (e.g., MiniMax Anthropic endpoint).
-    const result: EmbeddedPiRunResult = {
-      meta: {
-        durationMs: 500,
-        agentMeta: {
+      // Session already has totalTokens from a prior run or compaction.
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
           sessionId,
-          provider: "minimax",
-          model: "MiniMax-M2.7",
+          updatedAt: 1,
+          totalTokens: 21225,
+          totalTokensFresh: true,
         },
-      },
-    };
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
 
-    await updateSessionStoreAfterAgentRun({
-      cfg,
-      sessionId,
-      sessionKey,
-      storePath,
-      sessionStore,
-      defaultProvider: "minimax",
-      defaultModel: "MiniMax-M2.7",
-      result,
+      // Provider returns no usage data (e.g., MiniMax Anthropic endpoint).
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 500,
+          agentMeta: {
+            sessionId,
+            provider: "minimax",
+            model: "MiniMax-M2.7",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "minimax",
+        defaultModel: "MiniMax-M2.7",
+        result,
+      });
+
+      // totalTokens should be preserved (not reset to undefined).
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(21225);
+      // Marked stale since it's from a prior run, not this one.
+      expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(false);
+
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.totalTokens).toBe(21225);
+      expect(persisted[sessionKey]?.totalTokensFresh).toBe(false);
     });
-
-    // totalTokens should be preserved (not reset to undefined).
-    expect(sessionStore[sessionKey]?.totalTokens).toBe(21225);
-    // Marked stale since it's from a prior run, not this one.
-    expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(false);
-
-    const persisted = loadSessionStore(storePath);
-    expect(persisted[sessionKey]?.totalTokens).toBe(21225);
-    expect(persisted[sessionKey]?.totalTokensFresh).toBe(false);
   });
 });

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -270,4 +270,53 @@ describe("updateSessionStoreAfterAgentRun", () => {
       });
     });
   });
+
+  it("preserves previous totalTokens when provider returns no usage data (#67667)", async () => {
+    const cfg = {} as OpenClawConfig;
+    const sessionKey = "agent:main:explicit:test-no-usage";
+    const sessionId = "test-session";
+
+    // Session already has totalTokens from a prior run or compaction.
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 1,
+        totalTokens: 21225,
+        totalTokensFresh: true,
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+    // Provider returns no usage data (e.g., MiniMax Anthropic endpoint).
+    const result: EmbeddedPiRunResult = {
+      meta: {
+        durationMs: 500,
+        agentMeta: {
+          sessionId,
+          provider: "minimax",
+          model: "MiniMax-M2.7",
+        },
+      },
+    };
+
+    await updateSessionStoreAfterAgentRun({
+      cfg,
+      sessionId,
+      sessionKey,
+      storePath,
+      sessionStore,
+      defaultProvider: "minimax",
+      defaultModel: "MiniMax-M2.7",
+      result,
+    });
+
+    // totalTokens should be preserved (not reset to undefined).
+    expect(sessionStore[sessionKey]?.totalTokens).toBe(21225);
+    // Marked stale since it's from a prior run, not this one.
+    expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(false);
+
+    const persisted = loadSessionStore(storePath);
+    expect(persisted[sessionKey]?.totalTokens).toBe(21225);
+    expect(persisted[sessionKey]?.totalTokensFresh).toBe(false);
+  });
 });

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -139,9 +139,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
     Number.isFinite(entry.totalTokens) &&
     entry.totalTokens > 0
   ) {
-    // Provider did not return usage data for this run. Preserve the last
-    // known totalTokens (from a prior run or compaction) so /status doesn't
-    // reset to 0%. Mark as stale so display layers know it's not from this turn.
     next.totalTokens = entry.totalTokens;
     next.totalTokensFresh = false;
   }

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -134,6 +134,16 @@ export async function updateSessionStoreAfterAgentRun(params: {
       next.estimatedCostUsd =
         (resolveNonNegativeNumber(entry.estimatedCostUsd) ?? 0) + runEstimatedCostUsd;
     }
+  } else if (
+    typeof entry.totalTokens === "number" &&
+    Number.isFinite(entry.totalTokens) &&
+    entry.totalTokens > 0
+  ) {
+    // Provider did not return usage data for this run. Preserve the last
+    // known totalTokens (from a prior run or compaction) so /status doesn't
+    // reset to 0%. Mark as stale so display layers know it's not from this turn.
+    next.totalTokens = entry.totalTokens;
+    next.totalTokensFresh = false;
   }
   if (compactionsThisRun > 0) {
     next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -106,6 +106,29 @@ describe("sessionsCommand", () => {
     expect(group?.totalTokensFresh).toBe(false);
   });
 
+  it("shows preserved stale totals in JSON output", async () => {
+    const store = writeStore({
+      main: {
+        sessionId: "abc123",
+        updatedAt: Date.now() - 10 * 60_000,
+        totalTokens: 2000,
+        totalTokensFresh: false,
+        model: "pi:opus",
+      },
+    });
+
+    const payload = await runSessionsJson<{
+      sessions?: Array<{
+        key: string;
+        totalTokens: number | null;
+        totalTokensFresh: boolean;
+      }>;
+    }>(sessionsCommand, store);
+    const main = payload.sessions?.find((row) => row.key === "main");
+    expect(main?.totalTokens).toBe(2000);
+    expect(main?.totalTokensFresh).toBe(false);
+  });
+
   it("applies --active filtering in JSON output", async () => {
     const store = writeStore(
       {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { loadConfig } from "../config/config.js";
-import { loadSessionStore, resolveFreshSessionTotalTokens } from "../config/sessions.js";
+import { loadSessionStore, resolveSessionTotalTokens } from "../config/sessions.js";
 import { info } from "../globals.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
@@ -183,7 +183,7 @@ export async function sessionsCommand(
           const model = resolveSessionDisplayModel(cfg, r);
           return {
             ...r,
-            totalTokens: resolveFreshSessionTotalTokens(r) ?? null,
+            totalTokens: resolveSessionTotalTokens(r) ?? null,
             totalTokensFresh:
               typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
             contextTokens:
@@ -237,7 +237,7 @@ export async function sessionsCommand(
       configuredContextTokens ??
       (await lookupContextTokensForDisplay(model)) ??
       configContextTokens;
-    const total = resolveFreshSessionTotalTokens(row);
+    const total = resolveSessionTotalTokens(row);
 
     const line = [
       ...(showAgentColumn

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -3,7 +3,7 @@ import { hasPotentialConfiguredChannels } from "../channels/config-presence.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { readSessionStoreReadOnly } from "../config/sessions/store-read.js";
-import { resolveFreshSessionTotalTokens, type SessionEntry } from "../config/sessions/types.js";
+import { resolveSessionTotalTokens, type SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
@@ -197,7 +197,7 @@ export async function getStatusSummary(
             fallbackContextTokens: configContextTokens ?? undefined,
             allowAsyncLoad: false,
           }) ?? null;
-        const total = resolveFreshSessionTotalTokens(entry);
+        const total = resolveSessionTotalTokens(entry);
         const totalTokensFresh =
           typeof entry?.totalTokens === "number" ? entry?.totalTokensFresh !== false : false;
         const remaining =

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -202,10 +202,7 @@ function createSessionStatusRows() {
     >;
     const recent = Object.entries(store).map(([key, entry]) => {
       const contextTokens = typeof entry.contextTokens === "number" ? entry.contextTokens : null;
-      const freshTotal =
-        typeof entry.totalTokens === "number" && (entry.totalTokensFresh ?? true)
-          ? entry.totalTokens
-          : null;
+      const total = typeof entry.totalTokens === "number" ? entry.totalTokens : null;
       return {
         agentId: agent.id,
         key,
@@ -217,18 +214,14 @@ function createSessionStatusRows() {
         verboseLevel: entry.verboseLevel,
         inputTokens: entry.inputTokens,
         outputTokens: entry.outputTokens,
-        totalTokens: freshTotal,
-        totalTokensFresh: freshTotal !== null,
+        totalTokens: total,
+        totalTokensFresh: typeof entry.totalTokens === "number" ? entry.totalTokensFresh : false,
         cacheRead: entry.cacheRead,
         cacheWrite: entry.cacheWrite,
         remainingTokens:
-          freshTotal !== null && contextTokens !== null
-            ? Math.max(0, contextTokens - freshTotal)
-            : null,
+          total !== null && contextTokens !== null ? Math.max(0, contextTokens - total) : null,
         percentUsed:
-          freshTotal !== null && contextTokens
-            ? Math.round((freshTotal / contextTokens) * 100)
-            : null,
+          total !== null && contextTokens ? Math.round((total / contextTokens) * 100) : null,
         model: typeof entry.model === "string" ? entry.model : null,
         contextTokens,
         flags: [
@@ -530,6 +523,9 @@ vi.mock("../config/sessions/store-read.js", () => ({
   readSessionStoreReadOnly: mocks.loadSessionStore,
 }));
 vi.mock("../config/sessions/types.js", () => ({
+  resolveSessionTotalTokens: vi.fn((entry?: { totalTokens?: number }) =>
+    typeof entry?.totalTokens === "number" ? entry.totalTokens : undefined,
+  ),
   resolveFreshSessionTotalTokens: vi.fn(
     (entry?: { totalTokens?: number; totalTokensFresh?: boolean }) =>
       typeof entry?.totalTokens === "number" && entry?.totalTokensFresh !== false
@@ -1018,6 +1014,25 @@ describe("statusCommand", () => {
       expect(payload.sessions.recent[0].percentUsed).toBeNull();
       expect(payload.sessions.recent[0].remainingTokens).toBeNull();
     });
+  });
+
+  it("surfaces stale usage when totalTokens is preserved but not fresh", async () => {
+    mocks.loadSessionStore.mockReturnValue({
+      "+1000": {
+        updatedAt: Date.now() - 60_000,
+        totalTokens: 5_000,
+        totalTokensFresh: false,
+        contextTokens: 10_000,
+        model: "pi:opus",
+      },
+    });
+    runtimeLogMock.mockClear();
+    await statusCommand({ json: true }, runtime as never);
+    const payload = JSON.parse(String(runtimeLogMock.mock.calls.at(-1)?.[0]));
+    expect(payload.sessions.recent[0].totalTokens).toBe(5000);
+    expect(payload.sessions.recent[0].totalTokensFresh).toBe(false);
+    expect(payload.sessions.recent[0].percentUsed).toBe(50);
+    expect(payload.sessions.recent[0].remainingTokens).toBe(5000);
   });
 
   it("prints formatted lines with verbose cache details", async () => {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -409,11 +409,21 @@ export function mergeSessionEntryPreserveActivity(
   });
 }
 
-export function resolveFreshSessionTotalTokens(
+export function resolveSessionTotalTokens(
   entry?: Pick<SessionEntry, "totalTokens" | "totalTokensFresh"> | null,
 ): number | undefined {
   const total = entry?.totalTokens;
   if (typeof total !== "number" || !Number.isFinite(total) || total < 0) {
+    return undefined;
+  }
+  return total;
+}
+
+export function resolveFreshSessionTotalTokens(
+  entry?: Pick<SessionEntry, "totalTokens" | "totalTokensFresh"> | null,
+): number | undefined {
+  const total = resolveSessionTotalTokens(entry);
+  if (total === undefined) {
     return undefined;
   }
   if (entry?.totalTokensFresh === false) {


### PR DESCRIPTION
## Summary

- **Problem:** `/status` shows `Context: 0/264k (0%)` even after thousands of messages and compaction, because `totalTokens` in the session entry is never set.
- **Root cause:** When a provider (e.g. MiniMax via its Anthropic-compatible endpoint) does not include usage data (`input_tokens`, `output_tokens`) in its API response, `hasNonzeroUsage()` returns false and the entire `totalTokens` update block in `persistSessionAfterRun` (`src/agents/command/session-store.ts`) is skipped. The session entry keeps `totalTokens: undefined`, and `/status` reads this as 0%.
- **Fix:** When the current run has no usage data but the session entry already has a `totalTokens` value (from a prior run or compaction), preserve it instead of letting it reset to undefined. The preserved value is marked `totalTokensFresh: false` so display layers know it is stale. This is strictly better than null — the user sees the last known context usage instead of 0%.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #67667