### PR TITLE
feat(memory-core): persist session trigger, exclude cron/heartbeat from dreaming

### DIFF
--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -48,6 +48,20 @@
               }
             }
           },
+          "sessionIngestion": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Controls which sessions are ingested into the dreaming corpus.",
+            "properties": {
+              "excludeTriggers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Session triggers to exclude from corpus ingestion (default: [\"cron\", \"heartbeat\"]). Set to [] to ingest all sessions."
+              }
+            }
+          },
           "phases": {
             "type": "object",
             "additionalProperties": false,

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -7,6 +7,7 @@ import {
   buildSessionEntry,
   listSessionFilesForAgent,
   loadDreamingNarrativeTranscriptPathSetForAgent,
+  loadTriggerExcludedTranscriptPathSetForAgent,
   normalizeSessionTranscriptPathForComparison,
   parseUsageCountedSessionIdFromFileName,
   sessionPathForFile,
@@ -14,6 +15,7 @@ import {
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
   formatMemoryDreamingDay,
+  resolveMemoryDreamingConfig,
   resolveMemoryDreamingWorkspaces,
   resolveMemoryLightDreamingConfig,
   resolveMemoryRemDreamingConfig,
@@ -40,6 +42,7 @@ type RunPhaseIfTriggeredParams = {
   trigger?: string;
   workspaceDir?: string;
   cfg?: OpenClawConfig;
+  excludeTriggers?: readonly string[];
   logger: Logger;
   subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
   eventText: string;
@@ -672,6 +675,7 @@ async function collectSessionIngestionBatches(params: {
   lookbackDays: number;
   nowMs: number;
   timezone?: string;
+  excludeTriggers?: readonly string[];
   state: SessionIngestionState;
 }): Promise<SessionIngestionCollectionResult> {
   if (!params.cfg) {
@@ -690,6 +694,11 @@ async function collectSessionIngestionBatches(params: {
   const nextSeenMessages: Record<string, string[]> = { ...params.state.seenMessages };
   let changed = false;
 
+  const excludeTriggersSet =
+    params.excludeTriggers && params.excludeTriggers.length > 0
+      ? new Set(params.excludeTriggers)
+      : undefined;
+
   const sessionFiles: Array<{
     agentId: string;
     absolutePath: string;
@@ -702,13 +711,19 @@ async function collectSessionIngestionBatches(params: {
       files.length > 0
         ? loadDreamingNarrativeTranscriptPathSetForAgent(agentId)
         : new Set<string>();
+    const triggerExcludedPaths =
+      files.length > 0 && excludeTriggersSet
+        ? loadTriggerExcludedTranscriptPathSetForAgent(agentId, excludeTriggersSet)
+        : new Set<string>();
     for (const absolutePath of files) {
+      const normalizedPath = normalizeSessionTranscriptPathForComparison(absolutePath);
+      if (triggerExcludedPaths.has(normalizedPath)) {
+        continue;
+      }
       sessionFiles.push({
         agentId,
         absolutePath,
-        generatedByDreamingNarrative: dreamingTranscriptPaths.has(
-          normalizeSessionTranscriptPathForComparison(absolutePath),
-        ),
+        generatedByDreamingNarrative: dreamingTranscriptPaths.has(normalizedPath),
         sessionPath: sessionPathForFile(absolutePath),
       });
     }
@@ -960,6 +975,7 @@ async function ingestSessionTranscriptSignals(params: {
   lookbackDays: number;
   nowMs: number;
   timezone?: string;
+  excludeTriggers?: readonly string[];
 }): Promise<void> {
   const state = await readSessionIngestionState(params.workspaceDir);
   const collected = await collectSessionIngestionBatches({
@@ -968,6 +984,7 @@ async function ingestSessionTranscriptSignals(params: {
     lookbackDays: params.lookbackDays,
     nowMs: params.nowMs,
     timezone: params.timezone,
+    excludeTriggers: params.excludeTriggers,
     state,
   });
   const ingestionDayBucket = formatMemoryDreamingDay(params.nowMs, params.timezone);
@@ -1478,6 +1495,7 @@ async function runLightDreaming(params: {
     timezone?: string;
     storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
   };
+  excludeTriggers?: readonly string[];
   logger: Logger;
   subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
   nowMs?: number;
@@ -1497,6 +1515,7 @@ async function runLightDreaming(params: {
     lookbackDays: params.config.lookbackDays,
     nowMs,
     timezone: params.config.timezone,
+    excludeTriggers: params.excludeTriggers,
   });
   const entries = dedupeEntries(
     (await readShortTermRecallEntries({ workspaceDir: params.workspaceDir, nowMs }))
@@ -1558,6 +1577,7 @@ async function runRemDreaming(params: {
     timezone?: string;
     storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
   };
+  excludeTriggers?: readonly string[];
   logger: Logger;
   subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
   nowMs?: number;
@@ -1577,6 +1597,7 @@ async function runRemDreaming(params: {
     lookbackDays: params.config.lookbackDays,
     nowMs,
     timezone: params.config.timezone,
+    excludeTriggers: params.excludeTriggers,
   });
   const entries = (
     await readShortTermRecallEntries({ workspaceDir: params.workspaceDir, nowMs })
@@ -1641,6 +1662,12 @@ export async function runDreamingSweepPhases(params: {
   subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
   nowMs?: number;
 }): Promise<void> {
+  const dreamingConfig = resolveMemoryDreamingConfig({
+    pluginConfig: params.pluginConfig,
+    cfg: params.cfg,
+  });
+  const { excludeTriggers } = dreamingConfig.sessionIngestion;
+
   const light = resolveMemoryLightDreamingConfig({
     pluginConfig: params.pluginConfig,
     cfg: params.cfg,
@@ -1650,6 +1677,7 @@ export async function runDreamingSweepPhases(params: {
       workspaceDir: params.workspaceDir,
       cfg: params.cfg,
       config: light,
+      excludeTriggers,
       logger: params.logger,
       subagent: params.subagent,
       nowMs: params.nowMs,
@@ -1665,6 +1693,7 @@ export async function runDreamingSweepPhases(params: {
       workspaceDir: params.workspaceDir,
       cfg: params.cfg,
       config: rem,
+      excludeTriggers,
       logger: params.logger,
       subagent: params.subagent,
       nowMs: params.nowMs,
@@ -1703,6 +1732,7 @@ async function runPhaseIfTriggered(
           workspaceDir,
           cfg: params.cfg,
           config: params.config,
+          excludeTriggers: params.excludeTriggers,
           logger: params.logger,
           subagent: params.subagent,
         });
@@ -1711,6 +1741,7 @@ async function runPhaseIfTriggered(
           workspaceDir,
           cfg: params.cfg,
           config: params.config,
+          excludeTriggers: params.excludeTriggers,
           logger: params.logger,
           subagent: params.subagent,
         });

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -124,6 +124,13 @@ export type SessionEntry = {
   heartbeatIsolatedBaseSessionKey?: string;
   /** Heartbeat task state (task name -> last run timestamp ms). */
   heartbeatTaskState?: Record<string, number>;
+  /**
+   * What initiated this session: "user", "cron", "heartbeat", "memory",
+   * "overflow", or "manual". Persisted so downstream consumers (dreaming
+   * ingestion, analytics) can distinguish automated sessions from
+   * interactive ones.
+   */
+  trigger?: "cron" | "heartbeat" | "manual" | "memory" | "overflow" | "user";
   sessionId: string;
   updatedAt: number;
   sessionFile?: string;

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -71,6 +71,7 @@ export function resolveCronSession(params: {
     sessionId,
     updatedAt: params.nowMs,
     systemSent,
+    trigger: "cron",
     // When starting a fresh session (forceNew / isolated), clear delivery routing
     // state inherited from prior sessions. Without this, lastThreadId leaks into
     // the new session and causes announce-mode cron deliveries to post as thread

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -264,7 +264,7 @@ function normalizeStringArrayLoose(value: unknown, fallback: readonly string[]):
   }
   const normalized: string[] = [];
   for (const entry of value) {
-    const trimmed = normalizeTrimmedString(entry);
+    const trimmed = normalizeOptionalLowercaseString(entry);
     if (trimmed && !normalized.includes(trimmed)) {
       normalized.push(trimmed);
     }

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -115,6 +115,15 @@ export type MemoryRemDreamingConfig = {
 
 export type MemoryDreamingPhaseName = "light" | "deep" | "rem";
 
+export type MemoryDreamingSessionIngestionConfig = {
+  /**
+   * Session triggers whose transcripts are excluded from dreaming corpus
+   * ingestion. Defaults to `["cron", "heartbeat"]` so automated sessions
+   * do not pollute the recall store with repetitive noise.
+   */
+  excludeTriggers: readonly string[];
+};
+
 export type MemoryDreamingConfig = {
   enabled: boolean;
   frequency: string;
@@ -124,6 +133,7 @@ export type MemoryDreamingConfig = {
   execution: {
     defaults: MemoryDreamingExecutionConfig;
   };
+  sessionIngestion: MemoryDreamingSessionIngestionConfig;
   phases: {
     light: MemoryLightDreamingConfig;
     deep: MemoryDeepDreamingConfig;
@@ -136,6 +146,7 @@ export type MemoryDreamingWorkspace = {
   agentIds: string[];
 };
 
+const DEFAULT_MEMORY_SESSION_INGESTION_EXCLUDE_TRIGGERS: readonly string[] = ["cron", "heartbeat"];
 const DEFAULT_MEMORY_LIGHT_DREAMING_SOURCES: MemoryLightDreamingSource[] = [
   "daily",
   "sessions",
@@ -245,6 +256,20 @@ function normalizeStringArray<T extends string>(
     }
   }
   return normalized.length > 0 ? normalized : [...fallback];
+}
+
+function normalizeStringArrayLoose(value: unknown, fallback: readonly string[]): readonly string[] {
+  if (!Array.isArray(value)) {
+    return fallback;
+  }
+  const normalized: string[] = [];
+  for (const entry of value) {
+    const trimmed = normalizeTrimmedString(entry);
+    if (trimmed && !normalized.includes(trimmed)) {
+      normalized.push(trimmed);
+    }
+  }
+  return normalized;
 }
 
 function normalizeStorageMode(value: unknown): MemoryDreamingStorageMode {
@@ -358,6 +383,7 @@ export function resolveMemoryDreamingConfig(params: {
     DEFAULT_MEMORY_DREAMING_TIMEZONE;
   const storage = asNullableRecord(dreaming?.storage);
   const execution = asNullableRecord(dreaming?.execution);
+  const sessionIngestionRaw = asNullableRecord(dreaming?.sessionIngestion);
   const phases = asNullableRecord(dreaming?.phases);
 
   const defaultExecution = resolveExecutionConfig(execution?.defaults, {
@@ -389,6 +415,12 @@ export function resolveMemoryDreamingConfig(params: {
     },
     execution: {
       defaults: defaultExecution,
+    },
+    sessionIngestion: {
+      excludeTriggers: normalizeStringArrayLoose(
+        sessionIngestionRaw?.excludeTriggers,
+        DEFAULT_MEMORY_SESSION_INGESTION_EXCLUDE_TRIGGERS,
+      ),
     },
     phases: {
       light: {

--- a/src/memory-host-sdk/engine-qmd.ts
+++ b/src/memory-host-sdk/engine-qmd.ts
@@ -5,6 +5,7 @@ export {
   buildSessionEntry,
   listSessionFilesForAgent,
   loadDreamingNarrativeTranscriptPathSetForAgent,
+  loadTriggerExcludedTranscriptPathSetForAgent,
   normalizeSessionTranscriptPathForComparison,
   sessionPathForFile,
   type BuildSessionEntryOptions,

--- a/src/memory-host-sdk/host/session-files.ts
+++ b/src/memory-host-sdk/host/session-files.ts
@@ -150,6 +150,42 @@ export function loadDreamingNarrativeTranscriptPathSetForAgent(
   );
 }
 
+/**
+ * Returns the set of absolute transcript paths whose session entry has a
+ * `trigger` value in the given exclusion list. Used by the dreaming ingestion
+ * pipeline to skip automated session transcripts (e.g. cron, heartbeat).
+ */
+export function loadTriggerExcludedTranscriptPathSetForSessionsDir(
+  sessionsDir: string,
+  excludeTriggers: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (excludeTriggers.size === 0) {
+    return new Set();
+  }
+  const storePath = path.join(sessionsDir, "sessions.json");
+  const store = loadSessionStore(storePath);
+  const excludedPaths = new Set<string>();
+  for (const entry of Object.values(store)) {
+    if (entry.trigger && excludeTriggers.has(entry.trigger)) {
+      const transcriptPath = resolveSessionStoreTranscriptPath(sessionsDir, entry);
+      if (transcriptPath) {
+        excludedPaths.add(transcriptPath);
+      }
+    }
+  }
+  return excludedPaths;
+}
+
+export function loadTriggerExcludedTranscriptPathSetForAgent(
+  agentId: string,
+  excludeTriggers: ReadonlySet<string>,
+): ReadonlySet<string> {
+  return loadTriggerExcludedTranscriptPathSetForSessionsDir(
+    resolveSessionTranscriptsDirForAgent(agentId),
+    excludeTriggers,
+  );
+}
+
 function isDreamingNarrativeTranscriptFromSessionStore(absPath: string): boolean {
   const sessionsDir = path.dirname(absPath);
   const normalizedAbsPath = normalizeComparablePath(absPath);


### PR DESCRIPTION
## Summary

Automated sessions (cron jobs, heartbeat checks) pollute the dreaming recall store with repetitive noise. In real-world usage on a gateway running hourly email-watch cron + heartbeat, **61% of recall entries** were `HEARTBEAT_OK` messages. The dreaming system was literally dreaming about server pings instead of consolidating meaningful memories.

This PR:

- **Persists `trigger` on `SessionEntry`** — the runtime already knows `trigger: "cron"` but discarded it before session persistence. Now it's stored so downstream consumers can filter by it.
- **Sets `trigger: "cron"` in `resolveCronSession()`** — all cron-created sessions carry the metadata forward.
- **Adds `loadTriggerExcludedTranscriptPathSetForAgent()`** — reads the session store and returns transcript paths matching excluded triggers, following the exact same pattern as the existing dreaming-narrative exclusion.
- **Adds `dreaming.sessionIngestion.excludeTriggers` config** — defaults to `["cron", "heartbeat"]`. Set to `[]` to ingest all sessions.
- **Filters in `collectSessionIngestionBatches()`** — excluded-trigger sessions are skipped before corpus ingestion, same codepath as dreaming-narrative transcript skipping.

## Motivation

With a gateway running:
- Hourly email-watch cron (24 sessions/day)
- Heartbeat checks (variable frequency)
- Occasional real Discord conversations

The session corpus was dominated by cron prompts and `HEARTBEAT_OK` responses. REM reflections surfaced themes like `heartbeat-ok` (109 mentions) and `user`/`assistant` role tokens (93/79 mentions). The dream diary contained poetic riffs about server pings. Zero recall entries were promoted to long-term memory because meaningful signal was drowned out.

## Design Decisions

1. **Follows existing patterns** — the trigger exclusion mirrors `generatedByDreamingNarrative` filtering: load a set of excluded paths from the session store, skip matching files in the ingestion loop.
2. **Configurable with sensible defaults** — `["cron", "heartbeat"]` excludes automated sessions out of the box. Users who want cron sessions in their dreams can set `excludeTriggers: []`.
3. **Minimal surface** — only 7 files changed, no new dependencies. The `trigger` field on `SessionEntry` is optional and backward-compatible (existing sessions without it are treated as `undefined`/unfiltered).
4. **Forward-compatible** — when other trigger types (`"memory"`, `"overflow"`) are set by their respective subsystems, they'll automatically be filterable through the same config.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm check` — 0 warnings, 0 errors
- [x] `pnpm test:extension memory-core` — 47 files, 482 passed, 3 skipped
- [x] `pnpm test:contracts` — 121 files, 749 passed
- [ ] Manual: deploy to personal gateway, verify cron sessions get `trigger: "cron"` in session store
- [ ] Manual: run dreaming sweep, verify cron sessions are excluded from corpus

Closes #67272

---

🤖 AI-assisted (Claude Opus 4.6). I understand what every line does — this was a real-world bug I hit on my own gateway with 61% recall store pollution. The pattern follows the existing dreaming-narrative exclusion exactly.