### PR TITLE
fix(ui): prevent chat messages from disappearing after send when tools are used

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -287,7 +287,12 @@ function handleTerminalChatEvent(
   // Check if tool events were seen before resetting (resetToolStream clears toolStreamOrder).
   const toolHost = host as unknown as Parameters<typeof resetToolStream>[0];
   const hadToolEvents = toolHost.toolStreamOrder.length > 0;
-  resetToolStream(toolHost);
+  // When tool events were seen, defer resetToolStream until after history loads.
+  // Resetting immediately clears chatToolMessages and chatStreamSegments, causing
+  // a visible gap where tool cards disappear and only reappear once history returns.
+  if (!hadToolEvents || state !== "final") {
+    resetToolStream(toolHost);
+  }
   void flushChatQueueForEvent(host as unknown as Parameters<typeof flushChatQueueForEvent>[0]);
   const runId = payload?.runId;
   if (runId && host.refreshSessionsAfterChat.has(runId)) {
@@ -299,9 +304,12 @@ function handleTerminalChatEvent(
     }
   }
   // Reload history when tools were used so the persisted tool results
-  // replace the now-cleared streaming state.
+  // replace the now-cleared streaming state. Reset tool stream only after
+  // history arrives so tool cards remain visible during the network round-trip.
   if (hadToolEvents && state === "final") {
-    void loadChatHistory(host as unknown as OpenClawApp);
+    void loadChatHistory(host as unknown as OpenClawApp).then(() => {
+      resetToolStream(toolHost);
+    });
     return true;
   }
   return false;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -490,6 +490,7 @@ export function renderChatMobileToggle(state: AppViewState) {
 export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   state.sessionKey = nextSessionKey;
   state.chatMessage = "";
+  state.chatMessages = [];
   state.chatStream = null;
   // P1: Clear queued chat items from the previous session
   (state as unknown as { chatQueue: unknown[] }).chatQueue = [];

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1384,6 +1384,7 @@ export function renderApp(state: AppViewState) {
                   state.chatStreamStartedAt = null;
                   state.chatRunId = null;
                   state.chatQueue = [];
+                  state.chatMessages = [];
                   state.resetToolStream();
                   state.resetChatScroll();
                   state.applySettings({

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -631,6 +631,84 @@ describe("loadChatHistory", () => {
     expect(state.lastError).toBeNull();
   });
 
+  it("does not clear chatStream when a run is still active", async () => {
+    const request = vi.fn().mockResolvedValue({
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatRunId: "run-active",
+      chatStream: "partial response so far",
+      chatStreamStartedAt: Date.now(),
+    });
+
+    await loadChatHistory(state);
+
+    // chatMessages is updated from history
+    expect(state.chatMessages).toHaveLength(1);
+    // chatStream must NOT be wiped — the in-flight message isn't in history yet
+    expect(state.chatStream).toBe("partial response so far");
+    expect(state.chatStreamStartedAt).not.toBeNull();
+  });
+
+  it("does not replace non-empty chatMessages with empty history", async () => {
+    // Simulates the case where loadChatHistory is triggered before the session file
+    // has been written to disk (SessionManager only flushes after the first assistant
+    // message). The server returns [] but we must not wipe optimistic UI messages.
+    const request = vi.fn().mockResolvedValue({ messages: [] });
+    const existingMessages = [{ role: "user", content: [{ type: "text", text: "hello" }] }];
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: existingMessages,
+      chatRunId: "run-active",
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual(existingMessages);
+  });
+
+  it("does not replace chatMessages when server history has fewer user/assistant messages (post-compaction)", async () => {
+    // After context compaction the session file is shorter (compacted) and chat.history
+    // returns fewer user/assistant messages preceded by a system compaction divider.
+    // Replacing chatMessages with this shorter list would wipe pre-compaction messages
+    // and cause the "Compaction" system message to appear unexpectedly mid-conversation.
+    const compactionMsg = {
+      role: "system",
+      content: [{ type: "text", text: "Compaction" }],
+      __openclaw: { kind: "compaction" },
+    };
+    const recentUserMsg = { role: "user", content: [{ type: "text", text: "recent q" }] };
+    const recentAssistantMsg = {
+      role: "assistant",
+      content: [{ type: "text", text: "recent a" }],
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [compactionMsg, recentUserMsg, recentAssistantMsg],
+    });
+    const existingMessages = [
+      { role: "user", content: [{ type: "text", text: "old q1" }] },
+      { role: "assistant", content: [{ type: "text", text: "old a1" }] },
+      { role: "user", content: [{ type: "text", text: "old q2" }] },
+      { role: "assistant", content: [{ type: "text", text: "old a2" }] },
+      { role: "user", content: [{ type: "text", text: "recent q" }] },
+      { role: "assistant", content: [{ type: "text", text: "recent a" }] },
+    ];
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: existingMessages,
+    });
+
+    await loadChatHistory(state);
+
+    // Server returned 2 user/assistant messages (after compaction), but current
+    // chatMessages has 6 — the existing messages must be preserved.
+    expect(state.chatMessages).toEqual(existingMessages);
+  });
+
   it("shows a targeted message when chat history is unauthorized", async () => {
     const request = vi.fn().mockRejectedValue(
       new GatewayRequestError({

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -83,13 +83,39 @@ export async function loadChatHistory(state: ChatState) {
       },
     );
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
+    const filtered = messages.filter((message) => !isAssistantSilentReply(message));
+    // Guard: don't replace chatMessages if the server returned fewer user/assistant
+    // messages than we currently have.  Two known scenarios where this matters:
+    //
+    // 1. Session not yet persisted — the Pi SessionManager only flushes to disk after
+    //    the first assistant message arrives, so an early reload returns [] and would
+    //    wipe the optimistic user message the UI just added.
+    //
+    // 2. Post-compaction reload — after context compaction, chat.history reads the
+    //    compacted (shorter) JSONL file which omits pre-compaction messages.  Replacing
+    //    chatMessages with this shorter list causes old messages to disappear and a
+    //    "Compaction" divider to appear unexpectedly mid-conversation.
+    //
+    // Strategy: count non-system messages (user + assistant) in both lists.  Only
+    // replace when the server has at least as many as the client currently holds —
+    // i.e., it is additive or equal, never subtractive.  If chatMessages is empty
+    // (initial load, session switch, clear-history flow) always replace.
+    const countNonSystem = (msgs: unknown[]) =>
+      msgs.filter((m) => (m as { role?: string }).role?.toLowerCase() !== "system").length;
+    const filteredNonSystem = countNonSystem(filtered);
+    const currentNonSystem = countNonSystem(state.chatMessages);
+    if (state.chatMessages.length === 0 || filteredNonSystem >= currentNonSystem) {
+      state.chatMessages = filtered;
+    }
     state.chatThinkingLevel = res.thinkingLevel ?? null;
-    // Clear all streaming state — history includes tool results and text
-    // inline, so keeping streaming artifacts would cause duplicates.
-    maybeResetToolStream(state);
-    state.chatStream = null;
-    state.chatStreamStartedAt = null;
+    // Clear streaming state only when no run is active. If a run is still in
+    // progress its message isn't in history yet, so wiping chatStream here
+    // would cause the streamed text to vanish and reappear on the final event.
+    if (!state.chatRunId) {
+      maybeResetToolStream(state);
+      state.chatStream = null;
+      state.chatStreamStartedAt = null;
+    }
   } catch (err) {
     if (isMissingOperatorReadScopeError(err)) {
       state.chatMessages = [];


### PR DESCRIPTION
## Summary

- **Bug**: in the dashboard chat UI, the user's sent message (and the assistant reply) disappear for several seconds after every tool-assisted exchange, then reappear.
- **Root cause**: when the assistant uses tools, `handleTerminalChatEvent` calls `loadChatHistory` after the run completes (`hadToolEvents && state === "final"`). The server returns a history snapshot that is 1–2 messages behind the UI (disk write hasn't caught up), and without a guard `state.chatMessages = filtered` overwrites the in-memory state — wiping the optimistic user message and the assistant reply that were already displayed.
- **Fix 1** (`ui/src/ui/controllers/chat.ts`): guard `loadChatHistory` so it only replaces `chatMessages` when the server returned at least as many non-system messages as the client currently holds. Covers both the tool-reload scenario and post-compaction reloads.
- **Fix 2** (`ui/src/ui/controllers/chat.ts`): don't clear `chatStream` / reset tool stream inside `loadChatHistory` while a run is still active (`chatRunId` is set), so streaming text isn't wiped before the final event arrives.
- **Fix 3** (`ui/src/ui/app-gateway.ts`): defer `resetToolStream` until after `loadChatHistory` resolves when tool events were seen, so tool cards stay visible during the network round-trip.
- **Fix 4** (`ui/src/ui/app-render.helpers.ts`, `ui/src/ui/app-render.ts`): clear `chatMessages` on session switch so the guard's `length === 0` fast path fires correctly on initial load after switching.

## Test plan

- [x] `pnpm test -- ui/src/ui/controllers/chat.test.ts` — 31 tests pass (3 new tests added)
- [x] `pnpm test -- ui/src/ui/app-gateway.sessions.node.test.ts` — passes
- [x] `pnpm check` — clean
- [x] Manually verified via browser console logging: server returned 199 non-system messages vs 201 in client → `willReplace: false` — messages no longer disappear after send

🤖 Generated with [Claude Code](https://claude.com/claude-code)