### PR TITLE
fix(errors): stop treating Codex HTML challenge pages as DNS failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI Responses: add `models.providers.*.models.*.compat.supportsPromptCacheKey` so OpenAI-compatible proxies that forward `prompt_cache_key` can keep prompt caching enabled while incompatible endpoints can still force stripping. (#67427) Thanks @damselem.
 - Agents/context engines: keep loop-hook and final `afterTurn` prompt-cache touch metadata aligned with the current assistant turn so cache-aware context engines retain accurate cache TTL state during tool loops. (#67767) thanks @jalehman.
 - Memory/dreaming: strip AI-facing inbound metadata envelopes from session-corpus user turns before normalization so REM topic extraction sees the user's actual message text, including array-shaped split envelopes. (#66548) Thanks @zqchris.
+- Agents/errors: detect standalone Cloudflare/CDN HTML challenge pages before transport DNS classification so provider block pages no longer appear as local DNS lookup failures. (#67704) Thanks @chris-yyau.
 
 ## 2026.4.15-beta.1
 

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -185,6 +185,23 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("does not misdiagnose standalone Cloudflare challenge HTML as DNS", () => {
+    const msg = makeAssistantError(`<!DOCTYPE html>
+<html>
+  <head>
+    <title>Just a moment...</title>
+    <link rel="dns-prefetch" href="//chatgpt.com">
+  </head>
+  <body>
+    <span id="challenge-error-text">Enable JavaScript and cookies to continue</span>
+    <script src="/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1"></script>
+  </body>
+</html>`);
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The provider returned an HTML error page instead of an API response. This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. Retry in a moment or check provider status.",
+    );
+  });
+
   it("returns a friendly message for empty stream chunk errors", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
@@ -337,6 +354,21 @@ describe("formatRawAssistantErrorForUi", () => {
 
     expect(formatRawAssistantErrorForUi(htmlError)).toBe(
       "The AI service is temporarily unavailable (HTTP 521). Please try again in a moment.",
+    );
+  });
+
+  it("formats standalone Cloudflare challenge HTML into a clean provider error", () => {
+    const htmlError = `<!DOCTYPE html>
+<html lang="en-US">
+  <head><title>Just a moment...</title></head>
+  <body>
+    <span id="challenge-error-text">Enable JavaScript and cookies to continue</span>
+    <script src="/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1"></script>
+  </body>
+</html>`;
+
+    expect(formatRawAssistantErrorForUi(htmlError)).toBe(
+      "The provider returned an HTML error page instead of an API response. This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. Retry in a moment or check provider status.",
     );
   });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -266,6 +266,18 @@ describe("isCloudflareOrHtmlErrorPage", () => {
     expect(isCloudflareOrHtmlErrorPage(htmlError)).toBe(true);
   });
 
+  it("detects standalone Cloudflare challenge HTML pages", () => {
+    const htmlError = `<!DOCTYPE html>
+<html lang="en-US">
+  <head><title>Just a moment...</title></head>
+  <body>
+    <span id="challenge-error-text">Enable JavaScript and cookies to continue</span>
+    <script src="/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1"></script>
+  </body>
+</html>`;
+    expect(isCloudflareOrHtmlErrorPage(htmlError)).toBe(true);
+  });
+
   it("does not flag non-HTML status lines", () => {
     expect(isCloudflareOrHtmlErrorPage("500 Internal Server Error")).toBe(false);
     expect(isCloudflareOrHtmlErrorPage("429 Too Many Requests")).toBe(false);

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -102,6 +102,11 @@ export function formatTransportErrorCopy(raw: string): string | undefined {
   if (!raw) {
     return undefined;
   }
+
+  if (isCloudflareOrHtmlErrorPage(raw)) {
+    return undefined;
+  }
+
   const lower = normalizeLowercaseStringOrEmpty(raw);
 
   if (

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -10,7 +10,10 @@ const HTTP_STATUS_CODE_PREFIX_RE = new RegExp(
   "i",
 );
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
+const HTML_CLOSE_RE = /<\/html>/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
+const STANDALONE_HTML_ERROR_HINT_RE =
+  /\bcloudflare\b|cdn-cgi\/challenge-platform|challenge-error-text|enable javascript and cookies to continue|access denied|forbidden|service unavailable|bad gateway|web server is down|captcha|attention required/i;
 
 type ErrorPayload = Record<string, unknown>;
 
@@ -94,6 +97,14 @@ export function isCloudflareOrHtmlErrorPage(raw: string): boolean {
     return false;
   }
 
+  if (
+    HTML_ERROR_PREFIX_RE.test(trimmed) &&
+    HTML_CLOSE_RE.test(trimmed) &&
+    STANDALONE_HTML_ERROR_HINT_RE.test(trimmed)
+  ) {
+    return true;
+  }
+
   const status = extractLeadingHttpStatus(trimmed);
   if (!status || status.code < 500) {
     return false;
@@ -104,7 +115,7 @@ export function isCloudflareOrHtmlErrorPage(raw: string): boolean {
   }
 
   return (
-    status.code < 600 && HTML_ERROR_PREFIX_RE.test(status.rest) && /<\/html>/i.test(status.rest)
+    status.code < 600 && HTML_ERROR_PREFIX_RE.test(status.rest) && HTML_CLOSE_RE.test(status.rest)
   );
 }
 
@@ -173,6 +184,14 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
   const leadingStatus = extractLeadingHttpStatus(trimmed);
   if (leadingStatus && isCloudflareOrHtmlErrorPage(trimmed)) {
     return `The AI service is temporarily unavailable (HTTP ${leadingStatus.code}). Please try again in a moment.`;
+  }
+
+  if (isCloudflareOrHtmlErrorPage(trimmed)) {
+    return (
+      "The provider returned an HTML error page instead of an API response. " +
+      "This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. " +
+      "Retry in a moment or check provider status."
+    );
   }
 
   const httpMatch = trimmed.match(HTTP_STATUS_PREFIX_RE);

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -182,11 +182,12 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
   }
 
   const leadingStatus = extractLeadingHttpStatus(trimmed);
-  if (leadingStatus && isCloudflareOrHtmlErrorPage(trimmed)) {
+  const isHtmlChallenge = isCloudflareOrHtmlErrorPage(trimmed);
+  if (leadingStatus && isHtmlChallenge) {
     return `The AI service is temporarily unavailable (HTTP ${leadingStatus.code}). Please try again in a moment.`;
   }
 
-  if (isCloudflareOrHtmlErrorPage(trimmed)) {
+  if (isHtmlChallenge) {
     return (
       "The provider returned an HTML error page instead of an API response. " +
       "This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. " +


### PR DESCRIPTION
## Summary

- detect standalone Cloudflare/CDN HTML challenge pages even when the provider response has no leading HTTP status line
- stop transport error copy from classifying those HTML documents as DNS failures just because the page contains generic `dns` substrings
- format standalone HTML challenge pages with the existing CDN/HTML block message instead of leaking truncated raw markup
- add regression coverage for standalone challenge HTML in the shared formatter and assistant error formatting tests

## Why

Codex OAuth requests can fail with a raw HTML challenge page from `chatgpt.com/backend-api` (for example, `Enable JavaScript and cookies to continue`). Today those pages can be mislabeled as `LLM request failed: DNS lookup for the provider endpoint failed.`

That makes the failure mode look like a local network problem even though the real issue is an upstream HTML/CDN block page.

## Verification

- `oxfmt --check src/shared/assistant-error-format.ts src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `node scripts/test-projects.mjs src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- targeted `node --import tsx` verification for:
  - standalone Cloudflare challenge HTML -> upstream HTML/CDN block message
  - real ENOTFOUND lookup string -> DNS lookup failure message remains unchanged
