### PR TITLE
fix(memory-wiki): skip bridge prune when capability unavailable but sources intact [AI-assisted]

### DIFF
--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -300,6 +300,95 @@ describe("syncMemoryWikiBridgeSources", () => {
     });
   });
 
+  it("does not prune bridge pages when capability is lost but source files still exist (#67658)", async () => {
+    const workspaceDir = await createBridgeWorkspace("capability-lost-workspace");
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("capability-lost-vault"),
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: true,
+        },
+      },
+    });
+
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Durable Memory\n", "utf8");
+    registerBridgeArtifacts([
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+        absolutePath: path.join(workspaceDir, "MEMORY.md"),
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+    const appConfig: OpenClawConfig = {
+      agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
+    };
+
+    const first = await syncMemoryWikiBridgeSources({ config, appConfig });
+    const firstPagePath = first.pagePaths[0] ?? "";
+    expect(first.importedCount).toBe(1);
+    await expect(fs.stat(path.join(vaultDir, firstPagePath))).resolves.toBeTruthy();
+
+    // Simulate capability becoming temporarily unavailable (plugin unregistered).
+    // Source file is still on disk.
+    clearMemoryPluginState();
+    const second = await syncMemoryWikiBridgeSources({ config, appConfig });
+
+    expect(second.artifactCount).toBe(0);
+    expect(second.removedCount).toBe(0);
+    await expect(fs.stat(path.join(vaultDir, firstPagePath))).resolves.toBeTruthy();
+  });
+
+  it("still prunes bridge pages when capability is lost and source files are also deleted (#67658)", async () => {
+    const workspaceDir = await createBridgeWorkspace("capability-and-file-lost-workspace");
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("capability-and-file-lost-vault"),
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: true,
+        },
+      },
+    });
+
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Durable Memory\n", "utf8");
+    registerBridgeArtifacts([
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+        absolutePath: path.join(workspaceDir, "MEMORY.md"),
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+    const appConfig: OpenClawConfig = {
+      agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
+    };
+
+    const first = await syncMemoryWikiBridgeSources({ config, appConfig });
+    const firstPagePath = first.pagePaths[0] ?? "";
+    expect(first.importedCount).toBe(1);
+
+    // Both capability and source file are gone — prune should proceed normally.
+    await fs.rm(path.join(workspaceDir, "MEMORY.md"));
+    clearMemoryPluginState();
+    const second = await syncMemoryWikiBridgeSources({ config, appConfig });
+
+    expect(second.artifactCount).toBe(0);
+    expect(second.removedCount).toBe(1);
+    await expect(fs.stat(path.join(vaultDir, firstPagePath))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
   it("caps composed bridge source filenames to the filesystem component limit", async () => {
     const workspaceDir = await createBridgeWorkspace(`${"漢".repeat(50)}-workspace`);
     const { rootDir: vaultDir, config } = await createVault({

--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -389,6 +389,62 @@ describe("syncMemoryWikiBridgeSources", () => {
     });
   });
 
+  it("prunes bridge pages when config filters out all artifact kinds but capability is healthy", async () => {
+    const workspaceDir = await createBridgeWorkspace("config-filter-workspace");
+    const { rootDir: vaultDir, config: firstConfig } = await createVault({
+      rootDir: nextCaseRoot("config-filter-vault"),
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: true,
+        },
+      },
+    });
+
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Durable Memory\n", "utf8");
+    registerBridgeArtifacts([
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+        absolutePath: path.join(workspaceDir, "MEMORY.md"),
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+    const appConfig: OpenClawConfig = {
+      agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
+    };
+
+    const first = await syncMemoryWikiBridgeSources({ config: firstConfig, appConfig });
+    expect(first.importedCount).toBe(1);
+    const firstPagePath = first.pagePaths[0] ?? "";
+    await expect(fs.stat(path.join(vaultDir, firstPagePath))).resolves.toBeTruthy();
+
+    // Now disable indexMemoryRoot — capability still returns artifacts, but
+    // config filters them all out. This is NOT an outage; prune should proceed.
+    const { config: secondConfig } = await createVault({
+      rootDir: vaultDir,
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: false,
+        },
+      },
+    });
+    const second = await syncMemoryWikiBridgeSources({ config: secondConfig, appConfig });
+
+    expect(second.artifactCount).toBe(0);
+    expect(second.removedCount).toBe(1);
+    await expect(fs.stat(path.join(vaultDir, firstPagePath))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
   it("caps composed bridge source filenames to the filesystem component limit", async () => {
     const workspaceDir = await createBridgeWorkspace(`${"漢".repeat(50)}-workspace`);
     const { rootDir: vaultDir, config } = await createVault({

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -248,12 +248,31 @@ export async function syncMemoryWikiBridgeSources(params: {
   }
   const workspaceCount = new Set(publicArtifacts.map((artifact) => artifact.workspaceDir)).size;
 
-  const removedCount = await pruneImportedSourceEntries({
-    vaultRoot: params.config.vault.path,
-    group: "bridge",
-    activeKeys,
-    state,
-  });
+  // Guard: when no artifacts were found but existing bridge entries still have
+  // source files on disk, the memory capability is likely temporarily unavailable
+  // rather than all sources being genuinely deleted. Skip pruning in that case to
+  // avoid wiping all bridge pages on a transient capability outage. (#67658)
+  const existingBridgeSourcePaths = Object.values(state.entries)
+    .filter((entry) => entry.group === "bridge")
+    .map((entry) => entry.sourcePath);
+
+  const shouldSkipPrune =
+    artifacts.length === 0 &&
+    existingBridgeSourcePaths.length > 0 &&
+    (await Promise.any(
+      existingBridgeSourcePaths.map((sourcePath) =>
+        fs.access(sourcePath).then(() => true),
+      ),
+    ).catch(() => false));
+
+  const removedCount = shouldSkipPrune
+    ? 0
+    : await pruneImportedSourceEntries({
+        vaultRoot: params.config.vault.path,
+        group: "bridge",
+        activeKeys,
+        state,
+      });
   await writeMemoryWikiSourceSyncState(params.config.vault.path, state);
   const importedCount = results.filter((result) => result.changed && result.created).length;
   const updatedCount = results.filter((result) => result.changed && !result.created).length;

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -252,6 +252,12 @@ export async function syncMemoryWikiBridgeSources(params: {
   // source files on disk, the memory capability is likely temporarily unavailable
   // rather than all sources being genuinely deleted. Skip pruning in that case to
   // avoid wiping all bridge pages on a transient capability outage. (#67658)
+  //
+  // Known limitation: this heuristic cannot distinguish a transient outage from
+  // a legitimate "all workspaces removed" scenario where source files still linger
+  // on disk. In that edge case stale bridge pages will persist until the next sync
+  // cycle where the capability is available and returns a definitive empty result.
+  // This is an acceptable tradeoff: stale pages are benign, data loss is not.
   const existingBridgeSourcePaths = Object.values(state.entries)
     .filter((entry) => entry.group === "bridge")
     .map((entry) => entry.sourcePath);

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -248,22 +248,19 @@ export async function syncMemoryWikiBridgeSources(params: {
   }
   const workspaceCount = new Set(publicArtifacts.map((artifact) => artifact.workspaceDir)).size;
 
-  // Guard: when no artifacts were found but existing bridge entries still have
-  // source files on disk, the memory capability is likely temporarily unavailable
-  // rather than all sources being genuinely deleted. Skip pruning in that case to
-  // avoid wiping all bridge pages on a transient capability outage. (#67658)
-  //
-  // Known limitation: this heuristic cannot distinguish a transient outage from
-  // a legitimate "all workspaces removed" scenario where source files still linger
-  // on disk. In that edge case stale bridge pages will persist until the next sync
-  // cycle where the capability is available and returns a definitive empty result.
-  // This is an acceptable tradeoff: stale pages are benign, data loss is not.
+  // Guard: when the capability returned zero artifacts (unfiltered) but existing
+  // bridge entries still have source files on disk, the memory capability is likely
+  // temporarily unavailable rather than all sources being genuinely deleted. Skip
+  // pruning in that case to avoid wiping all bridge pages on a transient outage.
+  // Note: we check publicArtifacts (pre-filter), not artifacts (post-filter), so
+  // config-driven filtering (e.g. disabling all bridge index flags) correctly
+  // triggers pruning rather than being misread as an outage. (#67658)
   const existingBridgeSourcePaths = Object.values(state.entries)
     .filter((entry) => entry.group === "bridge")
     .map((entry) => entry.sourcePath);
 
   const shouldSkipPrune =
-    artifacts.length === 0 &&
+    publicArtifacts.length === 0 &&
     existingBridgeSourcePaths.length > 0 &&
     (await Promise.any(
       existingBridgeSourcePaths.map((sourcePath) =>


### PR DESCRIPTION
AI-assisted: yes (Antigravity / Gemini).

## Summary

Fixes #67658.

When syncMemoryWikiBridgeSources runs and listActiveMemoryPublicArtifacts returns an empty array (because the memory plugin capability is temporarily unregistered or unavailable), ctiveKeys ends up as an empty Set. The subsequent call to pruneImportedSourceEntries then marks every existing group=bridge state entry as stale and deletes the corresponding wiki pages — even though the underlying source files are still on disk.

## Root cause

ridge.ts conflates two distinct situations:
1. **Transient capability outage** — plugin not loaded this cycle, source files still exist
2. **Genuine source deletion** — artifact removed, source files also gone

Both produce an empty rtifacts list, but only case 2 should trigger pruning.

## Fix

Before calling pruneImportedSourceEntries, check whether the empty artifacts list coincides with existing bridge entries whose source files are still accessible on disk. If at least one source file is reachable via s.access, skip the prune entirely (emovedCount = 0). When all source files are also gone, pruning proceeds as before.

`	s
// Guard: skip pruning when capability is temporarily unavailable but
// source files still exist on disk. (#67658)
const existingBridgeSourcePaths = Object.values(state.entries)
  .filter((entry) => entry.group === 'bridge')
  .map((entry) => entry.sourcePath);

const shouldSkipPrune =
  artifacts.length === 0 &&
  existingBridgeSourcePaths.length > 0 &&
  (await Promise.any(
    existingBridgeSourcePaths.map((p) => fs.access(p).then(() => true)),
  ).catch(() => false));
`

## Tests

Two new regression tests added to ridge.test.ts:

| Scenario | emovedCount | Pages on disk |
|---|---|---|
| Capability lost, source files **still exist** | 