### PR TITLE
fix(agents): rename auto_compaction_start/end to compaction_start/end [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engines: keep loop-hook and final `afterTurn` prompt-cache touch metadata aligned with the current assistant turn so cache-aware context engines retain accurate cache TTL state during tool loops. (#67767) thanks @jalehman.
 - Memory/dreaming: strip AI-facing inbound metadata envelopes from session-corpus user turns before normalization so REM topic extraction sees the user's actual message text, including array-shaped split envelopes. (#66548) Thanks @zqchris.
 - Agents/errors: detect standalone Cloudflare/CDN HTML challenge pages before transport DNS classification so provider block pages no longer appear as local DNS lookup failures. (#67704) Thanks @chris-yyau.
+- Agents/compaction: rename embedded Pi compaction lifecycle events to `compaction_start` / `compaction_end` so OpenClaw stays aligned with `pi-coding-agent` 0.66.1 event naming. (#67713) Thanks @mpz4life.
 - Security/approvals: redact secrets in exec approval prompts so inline approval review can no longer leak credential material in rendered prompt content. (#61077, #64790)
 - CLI/configure: re-read the persisted config hash after writes so config updates stop failing with stale-hash races. (#64188, #66528)
 - CLI/update: prune stale packaged `dist` chunks after npm upgrades and keep downgrade/verify inventory checks compat-safe so global upgrades stop failing on stale chunk imports. (#66959) Thanks @obviyus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
+- Agents/compaction: rename embedded Pi compaction lifecycle events to `compaction_start` / `compaction_end` so OpenClaw stays aligned with `pi-coding-agent` 0.66.1 event naming. (#67713) Thanks @mpz4life.
 
 ## 2026.4.19-beta.2
 
@@ -212,7 +213,6 @@ Docs: https://docs.openclaw.ai
 - Agents/context engines: keep loop-hook and final `afterTurn` prompt-cache touch metadata aligned with the current assistant turn so cache-aware context engines retain accurate cache TTL state during tool loops. (#67767) thanks @jalehman.
 - Memory/dreaming: strip AI-facing inbound metadata envelopes from session-corpus user turns before normalization so REM topic extraction sees the user's actual message text, including array-shaped split envelopes. (#66548) Thanks @zqchris.
 - Agents/errors: detect standalone Cloudflare/CDN HTML challenge pages before transport DNS classification so provider block pages no longer appear as local DNS lookup failures. (#67704) Thanks @chris-yyau.
-- Agents/compaction: rename embedded Pi compaction lifecycle events to `compaction_start` / `compaction_end` so OpenClaw stays aligned with `pi-coding-agent` 0.66.1 event naming. (#67713) Thanks @mpz4life.
 - Security/approvals: redact secrets in exec approval prompts so inline approval review can no longer leak credential material in rendered prompt content. (#61077, #64790)
 - CLI/configure: re-read the persisted config hash after writes so config updates stop failing with stale-hash races. (#64188, #66528)
 - CLI/update: prune stale packaged `dist` chunks after npm upgrades and keep downgrade/verify inventory checks compat-safe so global upgrades stop failing on stale chunk imports. (#66959) Thanks @obviyus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/install: repair active and default-enabled bundled plugin runtime dependencies before import in packaged installs, so bundled Discord, WhatsApp, Slack, Telegram, and provider plugins work without putting their dependency trees in core.
 - BlueBubbles: raise the outbound `/api/v1/message/text` send timeout default from 10s to 30s, and add a configurable `channels.bluebubbles.sendTimeoutMs` (also per-account) so macOS 26 setups where Private API iMessage sends stall for 60+ seconds no longer silently lose messages at the 10s abort. Probes, chat lookups, and health checks keep the shorter 10s default. Fixes #67486. (#69193) Thanks @omarshahine.
 - Context engine/plugins: stop rejecting third-party context engines whose `info.id` differs from the registered plugin slot id. The strict-match contract added in 2026.4.14 broke `lossless-claw` and other plugins whose internal engine id does not equal the slot id they are registered under, producing repeated `info.id must match registered id` lane failures on every turn. Fixes #66601. (#66678) Thanks @GodsBoy.
+- Agents/compaction: rename embedded Pi compaction lifecycle events to `compaction_start` / `compaction_end` so OpenClaw stays aligned with `pi-coding-agent` 0.66.1 event naming. (#67713) Thanks @mpz4life.
 
 ## 2026.4.20
 
@@ -57,7 +58,6 @@ Docs: https://docs.openclaw.ai
 - Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
-- Agents/compaction: rename embedded Pi compaction lifecycle events to `compaction_start` / `compaction_end` so OpenClaw stays aligned with `pi-coding-agent` 0.66.1 event naming. (#67713) Thanks @mpz4life.
 
 ## 2026.4.19-beta.2
 

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -225,7 +225,7 @@ Events handled include:
 - `tool_execution_start` / `tool_execution_update` / `tool_execution_end`
 - `turn_start` / `turn_end`
 - `agent_start` / `agent_end`
-- `auto_compaction_start` / `auto_compaction_end`
+- `compaction_start` / `compaction_end`
 
 ### 4. Prompting
 

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
@@ -13,7 +13,7 @@ import {
   waitForCompactionCount,
 } from "./pi-embedded-subscribe.compaction-test-helpers.js";
 import {
-  handleAutoCompactionEnd,
+  handleCompactionEnd,
   reconcileSessionStoreCompactionCountAfterSuccess,
 } from "./pi-embedded-subscribe.handlers.compaction.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
@@ -112,7 +112,7 @@ describe("reconcileSessionStoreCompactionCountAfterSuccess", () => {
   });
 });
 
-describe("handleAutoCompactionEnd", () => {
+describe("handleCompactionEnd", () => {
   it("reconciles the session store after a successful compaction end event", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-handler-"));
     const storePath = path.join(tmp, "sessions.json");
@@ -129,8 +129,8 @@ describe("handleAutoCompactionEnd", () => {
       initialCount: 1,
     });
 
-    handleAutoCompactionEnd(ctx, {
-      type: "auto_compaction_end",
+    handleCompactionEnd(ctx, {
+      type: "compaction_end",
       result: { kept: 12 },
       willRetry: false,
       aborted: false,

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -4,7 +4,7 @@ import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
-export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
+export function handleCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.state.compactionInFlight = true;
   ctx.state.livenessState = "paused";
   ctx.ensureCompactionPromise();
@@ -39,7 +39,7 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   }
 }
 
-export function handleAutoCompactionEnd(
+export function handleCompactionEnd(
   ctx: EmbeddedPiSubscribeContext,
   evt: AgentEvent & { willRetry?: unknown; result?: unknown; aborted?: unknown },
 ) {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -16,8 +16,8 @@ import { isPromiseLike } from "./pi-embedded-subscribe.promise.js";
 import { isAssistantMessage } from "./pi-embedded-utils.js";
 
 export {
-  handleAutoCompactionEnd,
-  handleAutoCompactionStart,
+  handleCompactionEnd,
+  handleCompactionStart,
 } from "./pi-embedded-subscribe.handlers.compaction.js";
 
 export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -1,8 +1,8 @@
 import {
   handleAgentEnd,
   handleAgentStart,
-  handleAutoCompactionEnd,
-  handleAutoCompactionStart,
+  handleCompactionEnd,
+  handleCompactionStart,
 } from "./pi-embedded-subscribe.handlers.lifecycle.js";
 import {
   handleMessageEnd,
@@ -113,14 +113,14 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
           handleAgentStart(ctx);
         });
         return;
-      case "auto_compaction_start":
+      case "compaction_start":
         scheduleEvent(evt, () => {
-          handleAutoCompactionStart(ctx);
+          handleCompactionStart(ctx);
         });
         return;
-      case "auto_compaction_end":
+      case "compaction_end":
         scheduleEvent(evt, () => {
-          handleAutoCompactionEnd(ctx, evt as never);
+          handleCompactionEnd(ctx, evt as never);
         });
         return;
       case "agent_end":

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts
@@ -58,7 +58,7 @@ describe("subscribeEmbeddedPiSession", () => {
 
     for (const listener of listeners) {
       listener({
-        type: "auto_compaction_end",
+        type: "compaction_end",
         willRetry: true,
       });
     }
@@ -96,7 +96,7 @@ describe("subscribeEmbeddedPiSession", () => {
     });
 
     for (const listener of listeners) {
-      listener({ type: "auto_compaction_start" });
+      listener({ type: "compaction_start" });
     }
 
     expect(subscription.isCompacting()).toBe(true);
@@ -110,7 +110,7 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(resolved).toBe(false);
 
     for (const listener of listeners) {
-      listener({ type: "auto_compaction_end", willRetry: false });
+      listener({ type: "compaction_end", willRetry: false });
     }
 
     await waitPromise;
@@ -147,7 +147,7 @@ describe("subscribeEmbeddedPiSession", () => {
     });
 
     for (const listener of listeners) {
-      listener({ type: "auto_compaction_end", willRetry: false });
+      listener({ type: "compaction_end", willRetry: false });
     }
 
     const usage = (session.messages?.[0] as { usage?: unknown } | undefined)?.usage;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -602,7 +602,7 @@ describe("subscribeEmbeddedPiSession", () => {
       isError: false,
       result: { ok: true },
     });
-    emit({ type: "auto_compaction_end", willRetry: true, result: { summary: "compacted" } });
+    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
     emit({ type: "agent_end" });
 
     expect(subscription.getReplayState()).toEqual({
@@ -638,7 +638,7 @@ describe("subscribeEmbeddedPiSession", () => {
       isError: false,
       result: { details: { status: "ok" } },
     });
-    emit({ type: "auto_compaction_end", willRetry: true, result: { summary: "compacted" } });
+    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
     emit({ type: "agent_end" });
 
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts
@@ -8,8 +8,8 @@ describe("subscribeEmbeddedPiSession", () => {
       runId: "run-3",
     });
 
-    emit({ type: "auto_compaction_end", willRetry: true });
-    emit({ type: "auto_compaction_end", willRetry: true });
+    emit({ type: "compaction_end", willRetry: true });
+    emit({ type: "compaction_end", willRetry: true });
 
     let resolved = false;
     const waitPromise = subscription.waitForCompactionRetry().then(() => {
@@ -35,15 +35,15 @@ describe("subscribeEmbeddedPiSession", () => {
       runId: "run-compaction-count",
     });
 
-    emit({ type: "auto_compaction_start" });
+    emit({ type: "compaction_start" });
     expect(subscription.getCompactionCount()).toBe(0);
 
     // willRetry with result — counter IS incremented (overflow compaction succeeded)
-    emit({ type: "auto_compaction_end", willRetry: true, result: { summary: "s" } });
+    emit({ type: "compaction_end", willRetry: true, result: { summary: "s" } });
     expect(subscription.getCompactionCount()).toBe(1);
 
     // willRetry=false with result — counter incremented again
-    emit({ type: "auto_compaction_end", willRetry: false, result: { summary: "s2" } });
+    emit({ type: "compaction_end", willRetry: false, result: { summary: "s2" } });
     expect(subscription.getCompactionCount()).toBe(2);
   });
 
@@ -53,10 +53,10 @@ describe("subscribeEmbeddedPiSession", () => {
     });
 
     // No result (e.g. aborted or cancelled) — counter stays at 0
-    emit({ type: "auto_compaction_end", willRetry: false, result: undefined });
+    emit({ type: "compaction_end", willRetry: false, result: undefined });
     expect(subscription.getCompactionCount()).toBe(0);
 
-    emit({ type: "auto_compaction_end", willRetry: false, aborted: true });
+    emit({ type: "compaction_end", willRetry: false, aborted: true });
     expect(subscription.getCompactionCount()).toBe(0);
   });
 
@@ -79,9 +79,9 @@ describe("subscribeEmbeddedPiSession", () => {
       });
     });
 
-    emit({ type: "auto_compaction_start" });
-    emit({ type: "auto_compaction_end", willRetry: true });
-    emit({ type: "auto_compaction_end", willRetry: false });
+    emit({ type: "compaction_start" });
+    emit({ type: "compaction_end", willRetry: true });
+    emit({ type: "compaction_end", willRetry: false });
 
     stop();
 
@@ -99,7 +99,7 @@ describe("subscribeEmbeddedPiSession", () => {
       sessionExtras: { isCompacting: true, abortCompaction },
     });
 
-    emit({ type: "auto_compaction_start" });
+    emit({ type: "compaction_start" });
 
     const waitPromise = subscription.waitForCompactionRetry();
     subscription.unsubscribe();

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -22,8 +22,8 @@ vi.mock("../infra/agent-events.js", () => ({
 }));
 
 import {
-  handleAutoCompactionEnd,
-  handleAutoCompactionStart,
+  handleCompactionEnd,
+  handleCompactionStart,
 } from "../agents/pi-embedded-subscribe.handlers.compaction.js";
 
 describe("compaction hook wiring", () => {
@@ -111,16 +111,16 @@ describe("compaction hook wiring", () => {
       aborted?: boolean;
     },
   ) {
-    handleAutoCompactionEnd(
+    handleCompactionEnd(
       ctx as never,
       {
-        type: "auto_compaction_end",
+        type: "compaction_end",
         ...event,
       } as never,
     );
   }
 
-  it("calls runBeforeCompaction in handleAutoCompactionStart", () => {
+  it("calls runBeforeCompaction in handleCompactionStart", () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
 
     const ctx = {
@@ -136,7 +136,7 @@ describe("compaction hook wiring", () => {
       ensureCompactionPromise: vi.fn(),
     };
 
-    handleAutoCompactionStart(ctx as never);
+    handleCompactionStart(ctx as never);
 
     expect(hookMocks.runner.runBeforeCompaction).toHaveBeenCalledTimes(1);
     expectCompactionEvent({


### PR DESCRIPTION
## Summary

- Problem: `pi-coding-agent` 0.66.1 renamed `auto_compaction_start`/`auto_compaction_end` events to `compaction_start`/`compaction_end`. OpenClaw handlers and tests were still using the old event names, which would silently break compaction lifecycle handling.
- Why it matters: Without this change, compaction start/end events from the embedded Pi runner are ignored, breaking liveness state, compaction counting, and plugin hooks.
- What changed: Renamed all occurrences of `auto_compaction_start` → `compaction_start` and `auto_compaction_end` → `compaction_end` across handlers, tests, and docs. Also renamed handler functions `handleAutoCompactionStart` → `handleCompactionStart` and `handleAutoCompactionEnd` → `handleCompactionEnd` for consistency.
- What did NOT change (scope boundary): No behavioral changes to compaction logic itself; this is a pure event-name alignment.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Upstream `pi-coding-agent` SDK changed its event names in 0.66.1. OpenClaw was not updated to match.
- Missing detection / guardrail: Type-only `AgentEvent` union does not include compaction events (they are emitted via the SDK session), so TypeScript did not surface the mismatch.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts`
- Scenario the test should lock in: Compaction start/end events are routed correctly and update subscription state.
- Why this is the smallest reliable guardrail: It directly exercises the event handler switch cases that would otherwise miss the renamed events.
- Existing test that already covers this (if any): Multiple compaction-related tests already cover the logic; they were updated to use the new event names.
- If no new test is added, why not: Existing tests were updated to reflect the new names and continue to guard the behavior.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22

### Steps

1. Run `pnpm test src/agents/pi-embedded-subscribe.handlers.compaction.test.ts`
2. Run `pnpm test src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts`
3. Run `pnpm test src/plugins/wired-hooks-compaction.test.ts`

### Expected

- All compaction-related tests pass.

### Actual

- 49 tests passed (5 test files in agents + 1 in plugins).

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios:
  - `pnpm test` on all affected compaction test files passes.
  - Grepped the repo to confirm no remaining `auto_compaction_start`/`auto_compaction_end` references outside `CHANGELOG.md`.
- Edge cases checked:
  - Both `willRetry: true` and `willRetry: false` compaction end events are handled.
  - Hook wiring (`before_compaction` / `after_compaction`) remains intact.
- What I did **not** verify:
  - Live integration against a running LLM (not needed for a pure event rename).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

None.
