### PR TITLE
fix(anthropic): add Sonnet 4.7 forward-compat resolution [AI-assisted]

### DIFF
--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -220,6 +220,103 @@ describe("anthropic provider replay hooks", () => {
     ).toBe(false);
   });
 
+  describe("resolves Anthropic 4.7 forward-compat models (#67710)", () => {
+    const runtimeModels = [
+      {
+        id: "claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 32_000,
+      } as ProviderRuntimeModel,
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 32_000,
+      } as ProviderRuntimeModel,
+    ];
+
+    it.each([
+      "claude-opus-4-7",
+      "claude-opus-4.7",
+      "claude-opus-4-7-20260901",
+      "claude-sonnet-4-7",
+      "claude-sonnet-4.7",
+      "claude-sonnet-4-7-20260901",
+    ])("resolves %s from the 4.6 template family", async (modelId) => {
+      const provider = await registerSingleProviderPlugin(anthropicPlugin);
+      const resolved = provider.resolveDynamicModel?.({
+        provider: "anthropic",
+        modelId,
+        modelRegistry: createModelRegistry(runtimeModels),
+      } as ProviderResolveDynamicModelContext);
+
+      expect(resolved).toMatchObject({
+        provider: "anthropic",
+        id: modelId,
+        api: "anthropic-messages",
+        reasoning: true,
+      });
+    });
+
+    it.each(["claude-opus-4-7", "claude-sonnet-4-7"])(
+      "marks %s as a modern model",
+      async (modelId) => {
+        const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+        expect(
+          provider.isModernModelRef?.({
+            provider: "anthropic",
+            modelId,
+          } as never),
+        ).toBe(true);
+      },
+    );
+
+    it("uses off thinking for opus-4-7 (xhigh-capable)", async () => {
+      const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+      expect(
+        provider.resolveDefaultThinkingLevel?.({
+          provider: "anthropic",
+          modelId: "claude-opus-4-7",
+        } as never),
+      ).toBe("off");
+    });
+
+    it("uses adaptive thinking for sonnet-4-7", async () => {
+      const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+      expect(
+        provider.resolveDefaultThinkingLevel?.({
+          provider: "anthropic",
+          modelId: "claude-sonnet-4-7",
+        } as never),
+      ).toBe("adaptive");
+    });
+
+    it("does not resolve unrecognized model variants", async () => {
+      const provider = await registerSingleProviderPlugin(anthropicPlugin);
+      const resolved = provider.resolveDynamicModel?.({
+        provider: "anthropic",
+        modelId: "claude-opus-4-99",
+        modelRegistry: createModelRegistry(runtimeModels),
+      } as ProviderResolveDynamicModelContext);
+
+      expect(resolved).toBeUndefined();
+    });
+  });
+
   it("resolves claude-cli synthetic oauth auth", async () => {
     readClaudeCliCredentialsForRuntimeMock.mockReset();
     readClaudeCliCredentialsForRuntimeMock.mockReturnValue({

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -269,7 +269,12 @@ describe("anthropic provider replay hooks", () => {
       });
     });
 
-    it.each(["claude-opus-4-7", "claude-sonnet-4-7"])(
+    it.each([
+      "claude-opus-4-7",
+      "claude-opus-4.7",
+      "claude-sonnet-4-7",
+      "claude-sonnet-4.7",
+    ])(
       "marks %s as a modern model",
       async (modelId) => {
         const provider = await registerSingleProviderPlugin(anthropicPlugin);
@@ -303,6 +308,44 @@ describe("anthropic provider replay hooks", () => {
           modelId: "claude-sonnet-4-7",
         } as never),
       ).toBe("adaptive");
+    });
+
+    it("uses adaptive thinking for dot-form claude-sonnet-4.7", async () => {
+      const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+      expect(
+        provider.resolveDefaultThinkingLevel?.({
+          provider: "anthropic",
+          modelId: "claude-sonnet-4.7",
+        } as never),
+      ).toBe("adaptive");
+    });
+
+    it("resolves sonnet-4-7 from 4.5 template when only 4.5 is available", async () => {
+      const provider = await registerSingleProviderPlugin(anthropicPlugin);
+      const resolved = provider.resolveDynamicModel?.({
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-7",
+        modelRegistry: createModelRegistry([
+          {
+            id: "claude-sonnet-4-5",
+            name: "Claude Sonnet 4.5",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            reasoning: true,
+            input: ["text", "image"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 200_000,
+            maxTokens: 32_000,
+          } as ProviderRuntimeModel,
+        ]),
+      } as ProviderResolveDynamicModelContext);
+
+      expect(resolved).toMatchObject({
+        provider: "anthropic",
+        id: "claude-sonnet-4-7",
+        api: "anthropic-messages",
+      });
     });
 
     it("does not resolve unrecognized model variants", async () => {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -57,7 +57,9 @@ const ANTHROPIC_SONNET_47_DOT_MODEL_ID = "claude-sonnet-4.7";
 const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet-4.5"] as const;
 const ANTHROPIC_MODERN_MODEL_PREFIXES = [
   "claude-opus-4-7",
+  "claude-opus-4.7",
   "claude-sonnet-4-7",
+  "claude-sonnet-4.7",
   "claude-opus-4-6",
   "claude-sonnet-4-6",
   "claude-opus-4-5",
@@ -247,7 +249,11 @@ function resolveAnthropicForwardCompatModel(
       dotModelId: ANTHROPIC_SONNET_47_DOT_MODEL_ID,
       dashTemplateId: ANTHROPIC_SONNET_46_MODEL_ID,
       dotTemplateId: ANTHROPIC_SONNET_46_DOT_MODEL_ID,
-      fallbackTemplateIds: [ANTHROPIC_SONNET_46_MODEL_ID, ANTHROPIC_SONNET_46_DOT_MODEL_ID],
+      fallbackTemplateIds: [
+        ANTHROPIC_SONNET_46_MODEL_ID,
+        ANTHROPIC_SONNET_46_DOT_MODEL_ID,
+        ...ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS,
+      ],
     }) ??
     resolveAnthropic46ForwardCompatModel({
       ctx,

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -52,9 +52,12 @@ const ANTHROPIC_OPUS_47_TEMPLATE_MODEL_IDS = [
 const ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS = ["claude-opus-4-5", "claude-opus-4.5"] as const;
 const ANTHROPIC_SONNET_46_MODEL_ID = "claude-sonnet-4-6";
 const ANTHROPIC_SONNET_46_DOT_MODEL_ID = "claude-sonnet-4.6";
+const ANTHROPIC_SONNET_47_MODEL_ID = "claude-sonnet-4-7";
+const ANTHROPIC_SONNET_47_DOT_MODEL_ID = "claude-sonnet-4.7";
 const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet-4.5"] as const;
 const ANTHROPIC_MODERN_MODEL_PREFIXES = [
   "claude-opus-4-7",
+  "claude-sonnet-4-7",
   "claude-opus-4-6",
   "claude-sonnet-4-6",
   "claude-opus-4-5",
@@ -240,6 +243,14 @@ function resolveAnthropicForwardCompatModel(
     }) ??
     resolveAnthropic46ForwardCompatModel({
       ctx,
+      dashModelId: ANTHROPIC_SONNET_47_MODEL_ID,
+      dotModelId: ANTHROPIC_SONNET_47_DOT_MODEL_ID,
+      dashTemplateId: ANTHROPIC_SONNET_46_MODEL_ID,
+      dotTemplateId: ANTHROPIC_SONNET_46_DOT_MODEL_ID,
+      fallbackTemplateIds: [ANTHROPIC_SONNET_46_MODEL_ID, ANTHROPIC_SONNET_46_DOT_MODEL_ID],
+    }) ??
+    resolveAnthropic46ForwardCompatModel({
+      ctx,
       dashModelId: ANTHROPIC_OPUS_46_MODEL_ID,
       dotModelId: ANTHROPIC_OPUS_46_DOT_MODEL_ID,
       dashTemplateId: "claude-opus-4-5",
@@ -260,6 +271,8 @@ function resolveAnthropicForwardCompatModel(
 function shouldUseAnthropicAdaptiveThinkingDefault(modelId: string): boolean {
   const lowerModelId = normalizeLowercaseStringOrEmpty(modelId);
   return (
+    lowerModelId.startsWith(ANTHROPIC_SONNET_47_MODEL_ID) ||
+    lowerModelId.startsWith(ANTHROPIC_SONNET_47_DOT_MODEL_ID) ||
     lowerModelId.startsWith(ANTHROPIC_OPUS_46_MODEL_ID) ||
     lowerModelId.startsWith(ANTHROPIC_OPUS_46_DOT_MODEL_ID) ||
     lowerModelId.startsWith(ANTHROPIC_SONNET_46_MODEL_ID) ||


### PR DESCRIPTION
AI-assisted: yes (Antigravity / Gemini). Testing level: fully tested.

## Summary

Fixes #67710.

Adds **Sonnet 4.7** forward-compat support to the Anthropic provider. Opus 4.7 support already landed on main via 628b454eff / c73a6d2f68 / 2753e2d9f; this PR complements it with the missing Sonnet 4.7 path.

### Root cause

esolveAnthropicForwardCompatModel has no branch for claude-sonnet-4-7 (dash or dot notation). A user running openclaw models set anthropic/claude-sonnet-4-7 gets configured+missing because the dynamic resolver returns undefined.

### Changes (runtime)

1. **New constants** — ANTHROPIC_SONNET_47_MODEL_ID, ANTHROPIC_SONNET_47_DOT_MODEL_ID
2. **esolveAnthropicForwardCompatModel** — new branch mapping Sonnet 4.7 dash/dot/date-suffixed variants to the 4.6 Sonnet template
3. **ANTHROPIC_MODERN_MODEL_PREFIXES** — add claude-sonnet-4-7 so isModernModelRef returns true
4. **shouldUseAnthropicAdaptiveThinkingDefault** — add Sonnet 4.7 dash/dot prefixes (Opus 4.7 intentionally excluded — it uses \off\ thinking via the separate \isAnthropicOpus47Model\ path on main)

### Regression tests

| Scenario | Result |
|---|---|
| claude-sonnet-4-7 (dash) | resolves via 4.6 template ✅ |
| claude-sonnet-4.7 (dot) | resolves via 4.6 template ✅ |
| claude-sonnet-4-7-20260901 (date-suffixed) | resolves via 4.6 template ✅ |
| claude-opus-4-7 / dot / date-suffixed | resolves (existing + new coverage) ✅ |
| isModernModelRef for opus-4-7 and sonnet-4-7 | true ✅ |
| resolveDefaultThinkingLevel for opus-4-7 | off ✅ (xhigh-capable) |
| resolveDefaultThinkingLevel for sonnet-4-7 | adaptive ✅ |
| claude-opus-4-99 (unrecognized) | undefined ✅ |

### Rebase note

Rebased onto latest main (includes 2753e2d9f which separated Opus 4.7 effort from adaptive thinking). Tests adapted: Opus 4.7 correctly returns \off\ thinking level instead of \daptive\.

## Verification

- \
px vitest run extensions/anthropic/index.test.ts\ — 21 tests pass
