### PR TITLE
feat(browser): Add enhanced snapshot with script-based element detection

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -429,9 +429,38 @@ OpenClaw supports two “snapshot” styles:
   - Internally, the ref is resolved via `getByRole(...)` (plus `nth()` for duplicates).
   - Add `--labels` to include a viewport screenshot with overlayed `e12` labels.
 
+- **Enhanced snapshot (script-based)**: agent/browser tool `snapshotFormat: "enhanced"`, or HTTP `GET /snapshot-enhanced` on the browser control service.
+  - Injects `page-script-enhanced.js`: standard selectors, ARIA roles, **cursor-based** detection for custom controls, topmost hit-testing, and precomputed rects.
+  - Response includes role-style `refs`, `viewport`, **visible viewport text**, and **page metadata** (JSON-LD blocks, microdata, meta tags).
+
+- **Hybrid snapshot (recommended)**: `snapshotFormat: "hybrid"`, or `GET /snapshot-hybrid`.
+  - Uses Playwright `ariaSnapshot()` as the primary tree, then merges interactive elements found only by the enhanced script.
+  - Same extras as enhanced: `viewport`, visible text, and page metadata.
+
 Ref behavior:
 - Refs are **not stable across navigations**; if something fails, re-run `snapshot` and use a fresh ref.
 - If the role snapshot was taken with `--frame`, role refs are scoped to that iframe until the next role snapshot.
+
+### Agent tool
+
+```ts
+// Enhanced detection only
+browser({ action: "snapshot", snapshotFormat: "enhanced" });
+
+// Hybrid (Playwright + enhanced merge)
+browser({ action: "snapshot", snapshotFormat: "hybrid" });
+```
+
+For enhanced and hybrid, the text shown to the model includes the snapshot, then optional **Visible text** and **Page metadata** sections (subject to the same `maxChars` budget as AI snapshots when set).
+
+### HTTP API (browser control service)
+
+Query params match other snapshot routes (`targetId`, `profile`, `interactive`, `compact`, `depth`, `selector`, `frame`).
+
+```http
+GET /snapshot-enhanced?targetId=<tab-target-id>
+GET /snapshot-hybrid?targetId=<tab-target-id>
+```
 
 ## Wait power-ups
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "docs:bin": "node scripts/build-docs-list.mjs",
     "docs:dev": "cd docs && mint dev",
     "docs:build": "cd docs && pnpm dlx --reporter append-only mint broken-links",
-    "build": "pnpm canvas:a2ui:bundle && tsc -p tsconfig.json && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts",
+    "build": "pnpm canvas:a2ui:bundle && tsc -p tsconfig.json && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-browser-page-script.ts && node --import tsx scripts/write-build-info.ts",
     "plugins:sync": "node --import tsx scripts/sync-plugin-versions.ts",
     "release:check": "node --import tsx scripts/release-check.ts",
     "ui:install": "node scripts/ui.js install",

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -142,7 +142,7 @@ describe("createOpenClawCodingTools", () => {
       | undefined;
     expect(snapshotFormat?.type).toBe("string");
     expect(snapshotFormat?.anyOf).toBeUndefined();
-    expect(snapshotFormat?.enum).toEqual(["aria", "ai"]);
+    expect(snapshotFormat?.enum).toEqual(["aria", "ai", "enhanced", "hybrid"]);
   });
   it("inlines local $ref before removing unsupported keywords", () => {
     const cleaned = __testing.cleanToolSchemaForGemini({

--- a/src/agents/tools/browser-tool.schema.ts
+++ b/src/agents/tools/browser-tool.schema.ts
@@ -37,7 +37,7 @@ const BROWSER_TOOL_ACTIONS = [
 
 const BROWSER_TARGETS = ["sandbox", "host", "node"] as const;
 
-const BROWSER_SNAPSHOT_FORMATS = ["aria", "ai"] as const;
+const BROWSER_SNAPSHOT_FORMATS = ["aria", "ai", "enhanced", "hybrid"] as const;
 const BROWSER_SNAPSHOT_MODES = ["efficient"] as const;
 const BROWSER_SNAPSHOT_REFS = ["role", "aria"] as const;
 

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -8,6 +8,7 @@ import {
   browserStatus,
   browserStop,
   browserTabs,
+  type BrowserPageMetadata,
 } from "../../browser/client.js";
 import {
   browserAct,
@@ -24,10 +25,35 @@ import { resolveBrowserConfig } from "../../browser/config.js";
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "../../browser/constants.js";
 import { loadConfig } from "../../config/config.js";
 import { saveMediaBuffer } from "../../media/store.js";
+import { wrapExternalContent } from "../../security/external-content.js";
 import { listNodes, resolveNodeIdFromList, type NodeListNode } from "./nodes-utils.js";
 import { BrowserToolSchema } from "./browser-tool.schema.js";
 import { type AnyAgentTool, imageResultFromFile, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool } from "./gateway.js";
+
+function appendEnhancedHybridSnapshotSections(
+  snapshot: {
+    visibleText?: string;
+    pageMetadata?: BrowserPageMetadata;
+  },
+  snapshotText: string,
+): string {
+  const parts = [snapshotText];
+  const visible = snapshot.visibleText?.trim();
+  if (visible) {
+    parts.push("\n\n## Visible text (viewport)\n\n" + visible);
+  }
+  const pm = snapshot.pageMetadata;
+  if (
+    pm &&
+    ((Array.isArray(pm.jsonLd) && pm.jsonLd.length > 0) ||
+      (Array.isArray(pm.microdata) && pm.microdata.length > 0) ||
+      (pm.metaTags && Object.keys(pm.metaTags).length > 0))
+  ) {
+    parts.push("\n\n## Page metadata\n\n" + JSON.stringify(pm, null, 2));
+  }
+  return parts.join("");
+}
 
 type BrowserProxyFile = {
   path: string;
@@ -413,8 +439,11 @@ export function createBrowserTool(opts?: {
         case "snapshot": {
           const snapshotDefaults = loadConfig().browser?.snapshotDefaults;
           const format =
-            params.snapshotFormat === "ai" || params.snapshotFormat === "aria"
-              ? (params.snapshotFormat as "ai" | "aria")
+            params.snapshotFormat === "ai" ||
+            params.snapshotFormat === "aria" ||
+            params.snapshotFormat === "enhanced" ||
+            params.snapshotFormat === "hybrid"
+              ? (params.snapshotFormat as "ai" | "aria" | "enhanced" | "hybrid")
               : "ai";
           const mode =
             params.mode === "efficient"
@@ -443,7 +472,13 @@ export function createBrowserTool(opts?: {
                 : mode === "efficient"
                   ? undefined
                   : DEFAULT_AI_SNAPSHOT_MAX_CHARS
-              : undefined;
+              : format === "enhanced" || format === "hybrid"
+                ? hasMaxChars
+                  ? maxChars
+                  : mode === "efficient"
+                    ? undefined
+                    : DEFAULT_AI_SNAPSHOT_MAX_CHARS
+                : undefined;
           const interactive =
             typeof params.interactive === "boolean" ? params.interactive : undefined;
           const compact = typeof params.compact === "boolean" ? params.compact : undefined;
@@ -453,25 +488,43 @@ export function createBrowserTool(opts?: {
               : undefined;
           const selector = typeof params.selector === "string" ? params.selector.trim() : undefined;
           const frame = typeof params.frame === "string" ? params.frame.trim() : undefined;
+          const snapshotPath =
+            format === "enhanced"
+              ? "/snapshot-enhanced"
+              : format === "hybrid"
+                ? "/snapshot-hybrid"
+                : "/snapshot";
           const snapshot = proxyRequest
             ? ((await proxyRequest({
                 method: "GET",
-                path: "/snapshot",
+                path: snapshotPath,
                 profile,
-                query: {
-                  format,
-                  targetId,
-                  limit,
-                  ...(typeof resolvedMaxChars === "number" ? { maxChars: resolvedMaxChars } : {}),
-                  refs,
-                  interactive,
-                  compact,
-                  depth,
-                  selector,
-                  frame,
-                  labels,
-                  mode,
-                },
+                query:
+                  format === "enhanced" || format === "hybrid"
+                    ? {
+                        targetId,
+                        ...(typeof interactive === "boolean" ? { interactive } : {}),
+                        ...(typeof compact === "boolean" ? { compact } : {}),
+                        ...(typeof depth === "number" ? { depth } : {}),
+                        ...(selector ? { selector } : {}),
+                        ...(frame ? { frame } : {}),
+                      }
+                    : {
+                        format,
+                        targetId,
+                        limit,
+                        ...(typeof resolvedMaxChars === "number"
+                          ? { maxChars: resolvedMaxChars }
+                          : {}),
+                        refs,
+                        interactive,
+                        compact,
+                        depth,
+                        selector,
+                        frame,
+                        labels,
+                        mode,
+                      },
               })) as Awaited<ReturnType<typeof browserSnapshot>>)
             : await browserSnapshot(baseUrl, {
                 format,
@@ -488,6 +541,40 @@ export function createBrowserTool(opts?: {
                 mode,
                 profile,
               });
+          if (snapshot.format === "enhanced" || snapshot.format === "hybrid") {
+            let body = snapshot.snapshot ?? "";
+            body = appendEnhancedHybridSnapshotSections(snapshot, body);
+            if (
+              typeof resolvedMaxChars === "number" &&
+              resolvedMaxChars > 0 &&
+              body.length > resolvedMaxChars
+            ) {
+              body = `${body.slice(0, resolvedMaxChars)}\n\n… [truncated]`;
+            }
+            const text = wrapExternalContent(body, {
+              source: "api",
+              includeWarning: true,
+            });
+            const safeDetails = {
+              ok: true,
+              format: snapshot.format,
+              targetId: snapshot.targetId,
+              url: snapshot.url,
+              stats: snapshot.stats,
+              refs: snapshot.refs ? Object.keys(snapshot.refs).length : undefined,
+              externalContent: {
+                untrusted: true,
+                source: "browser",
+                kind: "snapshot",
+                format: snapshot.format,
+                wrapped: true,
+              },
+            };
+            return {
+              content: [{ type: "text", text }],
+              details: safeDetails,
+            };
+          }
           if (snapshot.format === "ai") {
             if (labels && snapshot.imagePath) {
               return await imageResultFromFile({

--- a/src/browser/ENHANCED_SNAPSHOT_README.md
+++ b/src/browser/ENHANCED_SNAPSHOT_README.md
@@ -1,0 +1,95 @@
+# Enhanced Snapshot Module
+
+This module provides an alternative snapshot implementation using script-based interactive element detection.
+
+## Overview
+
+The enhanced snapshot module (`pw-tools-core-enhanced-snapshot.ts`) uses injected JavaScript to detect interactive elements with multiple heuristics:
+
+- **Cursor-based detection**: Finds elements with non-default cursors (catches custom interactive elements)
+- **Bounding boxes stored upfront**: Faster access for screenshot labeling
+- **Topmost visibility checking**: Ensures elements are actually visible (not covered)
+- **Multiple detection heuristics**: Better coverage of modern web apps
+
+## Usage
+
+### Via Browser Tool
+
+Use the `snapshotFormat` parameter:
+
+```typescript
+// Enhanced detection only
+browser({ action: "snapshot", snapshotFormat: "enhanced" });
+
+// Hybrid: Playwright + Enhanced (recommended)
+browser({ action: "snapshot", snapshotFormat: "hybrid" });
+```
+
+### Via API
+
+**Enhanced Snapshot**:
+
+```
+GET /snapshot-enhanced?targetId=<id>&interactive=true
+```
+
+**Hybrid Snapshot** (combines Playwright + Enhanced):
+
+```
+GET /snapshot-hybrid?targetId=<id>&interactive=true
+```
+
+## Features
+
+### Enhanced Snapshot (`format="enhanced"`)
+
+- Uses script-based detection only
+- Returns:
+  - `snapshot`: Role-based snapshot text
+  - `refs`: Role reference map
+  - `stats`: Snapshot statistics
+  - `interactiveRegions`: Full interactive region data with bounding boxes
+  - `viewport`: Viewport information
+  - `visibleText`: Visible text from viewport
+  - `pageMetadata`: JSON-LD (per script tag), microdata, and meta tags when present
+
+### Hybrid Snapshot (`format="hybrid"`)
+
+- Combines Playwright's `ariaSnapshot()` (primary) with enhanced detection (fallback)
+- Merges results to include elements from both methods
+- Same extras as enhanced: `viewport`, `visibleText`, `pageMetadata`
+
+## Benefits
+
+1. **Better Coverage**: Catches custom interactive elements that Playwright might miss
+2. **Faster Bounding Boxes**: Stored upfront, no on-demand calculation
+3. **More Accurate**: Topmost visibility checking reduces false positives
+4. **Better for Modern Apps**: Handles SPAs and custom UI components well
+
+## Implementation Details
+
+- Script is injected via `page.addInitScript()` for persistence
+- Uses `__openclaw_elementId` attributes for stable in-page labeling during a snapshot pass
+- Compatible with existing ref-based interaction system
+- Can be used alongside standard Playwright snapshots
+
+## When to Use
+
+**Use Enhanced** when:
+
+- Standard Playwright snapshot misses elements
+- Working with custom UI components
+- Need bounding boxes upfront for labeling
+- Better visibility checking is important
+
+**Use Hybrid** when:
+
+- Want best of both worlds
+- Need structured Playwright data + custom element detection
+- Working with diverse websites
+
+**Use Standard** (ai/aria) when:
+
+- Standard detection is sufficient
+- Don't need custom element detection
+- Performance is critical (standard is slightly faster)

--- a/src/browser/client.ts
+++ b/src/browser/client.ts
@@ -47,6 +47,13 @@ export type BrowserTab = {
   type?: string;
 };
 
+/** JSON-LD, microdata, and meta tags from enhanced snapshot script (in-page extraction). */
+export type BrowserPageMetadata = {
+  jsonLd?: unknown[];
+  microdata?: Array<Record<string, unknown>>;
+  metaTags?: Record<string, string>;
+};
+
 export type SnapshotAriaNode = {
   ref: string;
   role: string;
@@ -84,6 +91,66 @@ export type SnapshotResult =
       labelsSkipped?: number;
       imagePath?: string;
       imageType?: "png" | "jpeg";
+    }
+  | {
+      ok: true;
+      format: "enhanced";
+      targetId: string;
+      url: string;
+      snapshot: string;
+      refs: Record<string, { role: string; name?: string; nth?: number }>;
+      stats: {
+        lines: number;
+        chars: number;
+        refs: number;
+        interactive: number;
+      };
+      viewport: {
+        height: number;
+        width: number;
+        offsetLeft: number;
+        offsetTop: number;
+        pageLeft: number;
+        pageTop: number;
+        scale: number;
+        clientWidth: number;
+        clientHeight: number;
+        scrollWidth: number;
+        scrollHeight: number;
+      };
+      visibleText: string;
+      pageMetadata: BrowserPageMetadata;
+      interactiveRegionsCount: number;
+    }
+  | {
+      ok: true;
+      format: "hybrid";
+      targetId: string;
+      url: string;
+      snapshot: string;
+      refs: Record<string, { role: string; name?: string; nth?: number }>;
+      stats: {
+        lines: number;
+        chars: number;
+        refs: number;
+        interactive: number;
+      };
+      viewport: {
+        height: number;
+        width: number;
+        offsetLeft: number;
+        offsetTop: number;
+        pageLeft: number;
+        pageTop: number;
+        scale: number;
+        clientWidth: number;
+        clientHeight: number;
+        scrollWidth: number;
+        scrollHeight: number;
+      };
+      visibleText: string;
+      pageMetadata: BrowserPageMetadata;
+      enhancedRegionsCount: number;
     };
 
 function buildProfileQuery(profile?: string): string {
@@ -274,7 +341,7 @@ export async function browserTabAction(
 export async function browserSnapshot(
   baseUrl: string | undefined,
   opts: {
-    format: "aria" | "ai";
+    format: "aria" | "ai" | "enhanced" | "hybrid";
     targetId?: string;
     limit?: number;
     maxChars?: number;
@@ -289,6 +356,24 @@ export async function browserSnapshot(
     profile?: string;
   },
 ): Promise<SnapshotResult> {
+  if (opts.format === "enhanced" || opts.format === "hybrid") {
+    const endpoint = opts.format === "enhanced" ? "/snapshot-enhanced" : "/snapshot-hybrid";
+    const q = new URLSearchParams();
+    if (opts.targetId) q.set("targetId", opts.targetId);
+    if (typeof opts.interactive === "boolean") q.set("interactive", String(opts.interactive));
+    if (typeof opts.compact === "boolean") q.set("compact", String(opts.compact));
+    if (typeof opts.depth === "number") q.set("depth", String(opts.depth));
+    if (opts.selector?.trim()) q.set("selector", opts.selector.trim());
+    if (opts.frame?.trim()) q.set("frame", opts.frame.trim());
+    if (opts.profile) q.set("profile", opts.profile);
+    return await fetchBrowserJson<SnapshotResult>(
+      withBaseUrl(baseUrl, `${endpoint}?${q.toString()}`),
+      {
+        timeoutMs: 20000,
+      },
+    );
+  }
+
   const q = new URLSearchParams();
   q.set("format", opts.format);
   if (opts.targetId) q.set("targetId", opts.targetId);

--- a/src/browser/page-script-enhanced.js
+++ b/src/browser/page-script-enhanced.js
@@ -1,0 +1,491 @@
+// Enhanced page script for interactive element detection (interactive rects, viewport,
+// visible text, structured page metadata). Exposed globally as OpenClawEnhancedDetection.
+var OpenClawEnhancedDetection =
+  OpenClawEnhancedDetection ||
+  (function () {
+    let nextLabel = 10;
+
+    let roleMapping = {
+      a: "link",
+      area: "link",
+      button: "button",
+      "input, type=button": "button",
+      "input, type=checkbox": "checkbox",
+      "input, type=email": "textbox",
+      "input, type=number": "spinbutton",
+      "input, type=radio": "radio",
+      "input, type=range": "slider",
+      "input, type=reset": "button",
+      "input, type=search": "searchbox",
+      "input, type=submit": "button",
+      "input, type=tel": "textbox",
+      "input, type=text": "textbox",
+      "input, type=url": "textbox",
+      search: "search",
+      select: "combobox",
+      option: "option",
+      textarea: "textbox",
+    };
+
+    let getCursor = function (elm) {
+      return window.getComputedStyle(elm)["cursor"];
+    };
+
+    let getInteractiveElements = function (root) {
+      root = root || document;
+      let results = [];
+      let roles = [
+        "scrollbar",
+        "searchbox",
+        "slider",
+        "spinbutton",
+        "switch",
+        "tab",
+        "treeitem",
+        "button",
+        "checkbox",
+        "gridcell",
+        "link",
+        "menuitem",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "option",
+        "progressbar",
+        "radio",
+        "textbox",
+        "combobox",
+        "menu",
+        "tree",
+        "treegrid",
+        "grid",
+        "listbox",
+        "radiogroup",
+        "widget",
+      ];
+      let inertCursors = [
+        "auto",
+        "default",
+        "none",
+        "text",
+        "vertical-text",
+        "not-allowed",
+        "no-drop",
+      ];
+
+      // Get the main interactive elements
+      let nodeList = root.querySelectorAll(
+        "input, select, textarea, button, [href], [onclick], [contenteditable], [tabindex]:not([tabindex='-1'])",
+      );
+      for (let i = 0; i < nodeList.length; i++) {
+        results.push(nodeList[i]);
+      }
+
+      // Anything not already included that has a suitable role
+      nodeList = root.querySelectorAll("[role]");
+      for (let i = 0; i < nodeList.length; i++) {
+        if (results.indexOf(nodeList[i]) == -1) {
+          let role = nodeList[i].getAttribute("role");
+          if (roles.indexOf(role) > -1) {
+            results.push(nodeList[i]);
+          }
+        }
+      }
+
+      // Any element that changes the cursor to something implying interactivity
+      nodeList = root.querySelectorAll("*");
+      for (let i = 0; i < nodeList.length; i++) {
+        let node = nodeList[i];
+
+        // Cursor is default, or does not suggest interactivity
+        let cursor = getCursor(node);
+        if (inertCursors.indexOf(cursor) >= 0) {
+          continue;
+        }
+
+        // Move up to the first instance of this cursor change
+        let parent = node.parentNode;
+        while (parent && getCursor(parent) == cursor) {
+          node = parent;
+          parent = node.parentNode;
+        }
+
+        // Add the node if it is new
+        if (results.indexOf(node) == -1) {
+          results.push(node);
+        }
+      }
+
+      return results;
+    };
+
+    let labelElements = function (elements) {
+      for (let i = 0; i < elements.length; i++) {
+        if (!elements[i].hasAttribute("__openclaw_elementId")) {
+          elements[i].setAttribute("__openclaw_elementId", "" + nextLabel++);
+        }
+      }
+    };
+
+    let isTopmost = function (element, x, y) {
+      let hit = document.elementFromPoint(x, y);
+
+      // Hack to handle elements outside the viewport
+      if (hit === null) {
+        return true;
+      }
+
+      while (hit) {
+        if (hit == element) {
+          return true;
+        }
+        hit = hit.parentNode;
+      }
+      return false;
+    };
+
+    let getFocusedElementId = function () {
+      let elm = document.activeElement;
+      while (elm) {
+        if (elm.hasAttribute && elm.hasAttribute("__openclaw_elementId")) {
+          return elm.getAttribute("__openclaw_elementId");
+        }
+        elm = elm.parentNode;
+      }
+      return null;
+    };
+
+    let trimmedInnerText = function (element) {
+      if (!element) {
+        return "";
+      }
+      let text = element.innerText;
+      if (!text) {
+        return "";
+      }
+      return text.trim();
+    };
+
+    let getApproximateAriaName = function (element) {
+      // Check for aria labels
+      if (element.hasAttribute("aria-labelledby")) {
+        let buffer = "";
+        let ids = element.getAttribute("aria-labelledby").split(" ");
+        for (let i = 0; i < ids.length; i++) {
+          let label = document.getElementById(ids[i]);
+          if (label) {
+            buffer = buffer + " " + trimmedInnerText(label);
+          }
+        }
+        return buffer.trim();
+      }
+
+      if (element.hasAttribute("aria-label")) {
+        return element.getAttribute("aria-label");
+      }
+
+      // Check for labels
+      if (element.hasAttribute("id")) {
+        let label_id = element.getAttribute("id");
+        let label = "";
+        let labels = document.querySelectorAll("label[for='" + label_id + "']");
+        for (let j = 0; j < labels.length; j++) {
+          label += labels[j].innerText + " ";
+        }
+        label = label.trim();
+        if (label != "") {
+          return label;
+        }
+      }
+
+      if (element.parentElement && element.parentElement.tagName == "LABEL") {
+        return element.parentElement.innerText;
+      }
+
+      // Check for alt text or titles
+      if (element.hasAttribute("alt")) {
+        return element.getAttribute("alt");
+      }
+
+      if (element.hasAttribute("title")) {
+        return element.getAttribute("title");
+      }
+
+      return trimmedInnerText(element);
+    };
+
+    let getApproximateAriaRole = function (element) {
+      let tag = element.tagName.toLowerCase();
+      if (tag == "input" && element.hasAttribute("type")) {
+        tag = tag + ", type=" + element.getAttribute("type");
+      }
+
+      if (element.hasAttribute("role")) {
+        return [element.getAttribute("role"), tag];
+      } else if (tag in roleMapping) {
+        return [roleMapping[tag], tag];
+      } else {
+        return ["", tag];
+      }
+    };
+
+    let getInteractiveRects = function (root) {
+      root = root || document;
+      labelElements(getInteractiveElements(root));
+      let elements = root.querySelectorAll("[__openclaw_elementId]");
+      let results = {};
+      for (let i = 0; i < elements.length; i++) {
+        let key = elements[i].getAttribute("__openclaw_elementId");
+        let rects = elements[i].getClientRects();
+        let ariaRole = getApproximateAriaRole(elements[i]);
+        let ariaName = getApproximateAriaName(elements[i]);
+        let vScrollable = elements[i].scrollHeight - elements[i].clientHeight >= 1;
+
+        let record = {
+          tag_name: ariaRole[1],
+          role: ariaRole[0],
+          aria_name: ariaName,
+          v_scrollable: vScrollable,
+          rects: [],
+        };
+
+        for (const rect of rects) {
+          let x = rect.left + rect.width / 2;
+          let y = rect.top + rect.height / 2;
+          if (isTopmost(elements[i], x, y)) {
+            record["rects"].push({
+              x: rect.left,
+              y: rect.top,
+              width: rect.width,
+              height: rect.height,
+              top: rect.top,
+              right: rect.right,
+              bottom: rect.bottom,
+              left: rect.left,
+            });
+          }
+        }
+
+        if (record["rects"].length > 0) {
+          results[key] = record;
+        }
+      }
+      return results;
+    };
+
+    let getVisualViewport = function () {
+      let vv = window.visualViewport;
+      let de = document.documentElement;
+      return {
+        height: vv ? vv.height : 0,
+        width: vv ? vv.width : 0,
+        offsetLeft: vv ? vv.offsetLeft : 0,
+        offsetTop: vv ? vv.offsetTop : 0,
+        pageLeft: vv ? vv.pageLeft : 0,
+        pageTop: vv ? vv.pageTop : 0,
+        scale: vv ? vv.scale : 0,
+        clientWidth: de ? de.clientWidth : 0,
+        clientHeight: de ? de.clientHeight : 0,
+        scrollWidth: de ? de.scrollWidth : 0,
+        scrollHeight: de ? de.scrollHeight : 0,
+      };
+    };
+
+    let _getMetaTags = function () {
+      let meta = document.querySelectorAll("meta");
+      let results = {};
+      for (let i = 0; i < meta.length; i++) {
+        let key = null;
+        if (meta[i].hasAttribute("name")) {
+          key = meta[i].getAttribute("name");
+        } else if (meta[i].hasAttribute("property")) {
+          key = meta[i].getAttribute("property");
+        } else {
+          continue;
+        }
+        if (meta[i].hasAttribute("content")) {
+          results[key] = meta[i].getAttribute("content");
+        }
+      }
+      return results;
+    };
+
+    let _getJsonLdRaw = function () {
+      let out = [];
+      let scripts = document.querySelectorAll('script[type="application/ld+json"]');
+      for (let i = 0; i < scripts.length; i++) {
+        out.push(scripts[i].innerHTML.trim());
+      }
+      return out;
+    };
+
+    // From: https://www.stevefenton.co.uk/blog/2022/12/parse-microdata-with-javascript/
+    let _getMicrodata = function () {
+      function sanitize(input) {
+        return input.replace(/\s/gi, " ").trim();
+      }
+
+      function addValue(information, name, value) {
+        if (information[name]) {
+          if (Array.isArray(information[name])) {
+            information[name].push(value);
+          } else {
+            const arr = [];
+            arr.push(information[name]);
+            arr.push(value);
+            information[name] = arr;
+          }
+        } else {
+          information[name] = value;
+        }
+      }
+
+      function traverseItem(item, information) {
+        const children = item.children;
+
+        for (let i = 0; i < children.length; i++) {
+          const child = children[i];
+
+          if (child.hasAttribute("itemscope")) {
+            if (child.hasAttribute("itemprop")) {
+              const itemProp = child.getAttribute("itemprop");
+              const itemType = child.getAttribute("itemtype");
+
+              const childInfo = {
+                itemType: itemType,
+              };
+
+              traverseItem(child, childInfo);
+
+              itemProp.split(" ").forEach((propName) => {
+                addValue(information, propName, childInfo);
+              });
+            }
+          } else if (child.hasAttribute("itemprop")) {
+            const itemProp = child.getAttribute("itemprop");
+            itemProp.split(" ").forEach((propName) => {
+              if (propName === "url") {
+                addValue(information, propName, child.href);
+              } else {
+                addValue(
+                  information,
+                  propName,
+                  sanitize(
+                    child.getAttribute("content") ||
+                      child.content ||
+                      child.textContent ||
+                      child.src ||
+                      "",
+                  ),
+                );
+              }
+            });
+            traverseItem(child, information);
+          } else {
+            traverseItem(child, information);
+          }
+        }
+      }
+
+      const microdata = [];
+
+      document.querySelectorAll("[itemscope]").forEach(function (elem) {
+        const itemType = elem.getAttribute("itemtype");
+        const information = {
+          itemType: itemType,
+        };
+        traverseItem(elem, information);
+        microdata.push(information);
+      });
+
+      return microdata;
+    };
+
+    let getPageMetadata = function () {
+      let jsonldRaw = _getJsonLdRaw();
+      let metaTags = _getMetaTags();
+      let microdata = _getMicrodata();
+      let results = {};
+
+      if (jsonldRaw.length > 0) {
+        let parsed = [];
+        for (let i = 0; i < jsonldRaw.length; i++) {
+          let raw = jsonldRaw[i];
+          if (!raw) {
+            continue;
+          }
+          try {
+            parsed.push(JSON.parse(raw));
+          } catch {
+            parsed.push(raw);
+          }
+        }
+        if (parsed.length > 0) {
+          results.jsonLd = parsed;
+        }
+      }
+      if (microdata.length > 0) {
+        results.microdata = microdata;
+      }
+      if (Object.keys(metaTags).length > 0) {
+        results.metaTags = metaTags;
+      }
+      return results;
+    };
+
+    let getVisibleText = function () {
+      // Get the window's current viewport boundaries
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+      const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+
+      let textInView = "";
+      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false);
+
+      while (walker.nextNode()) {
+        const textNode = walker.currentNode;
+        // Create a range to retrieve bounding rectangles of the current text node
+        const range = document.createRange();
+        range.selectNodeContents(textNode);
+
+        const rects = range.getClientRects();
+
+        // Check if any rect is inside (or partially inside) the viewport
+        for (const rect of rects) {
+          const isVisible =
+            rect.width > 0 &&
+            rect.height > 0 &&
+            rect.bottom >= 0 &&
+            rect.right >= 0 &&
+            rect.top <= viewportHeight &&
+            rect.left <= viewportWidth;
+
+          if (isVisible) {
+            textInView += textNode.nodeValue.replace(/\s+/g, " ");
+            // Is the parent a block element?
+            if (textNode.parentNode) {
+              const parent = textNode.parentNode;
+              const style = window.getComputedStyle(parent);
+              if (["inline", "hidden", "none"].indexOf(style.display) === -1) {
+                textInView += "\n";
+              }
+            }
+            break; // No need to check other rects once found visible
+          }
+        }
+      }
+
+      // Remove blank lines from textInView
+      textInView = textInView
+        .replace(/^\s*\n/gm, "")
+        .trim()
+        .replace(/\n+/g, "\n");
+      return textInView;
+    };
+
+    return {
+      getInteractiveRects: getInteractiveRects,
+      getVisualViewport: getVisualViewport,
+      getFocusedElementId: getFocusedElementId,
+      getPageMetadata: getPageMetadata,
+      getVisibleText: getVisibleText,
+    };
+  })();

--- a/src/browser/pw-ai.ts
+++ b/src/browser/pw-ai.ts
@@ -58,3 +58,18 @@ export {
   waitForDownloadViaPlaywright,
   waitForViaPlaywright,
 } from "./pw-tools-core.js";
+
+export {
+  getFocusedElementIdViaScript,
+  getInteractiveRegionsViaScript,
+  getPageMetadataViaScript,
+  getVisibleTextViaScript,
+  getVisualViewportViaScript,
+  snapshotEnhancedViaPlaywright,
+  snapshotHybridViaPlaywright,
+  type DOMRectangle,
+  type EnhancedSnapshotResult,
+  type InteractiveRegion,
+  type PageMetadata,
+  type VisualViewport,
+} from "./pw-tools-core-enhanced-snapshot.js";

--- a/src/browser/pw-tools-core-enhanced-snapshot.ts
+++ b/src/browser/pw-tools-core-enhanced-snapshot.ts
@@ -1,0 +1,588 @@
+/**
+ * Enhanced snapshot module using script-based interactive element detection.
+ *
+ * Uses injected JavaScript alongside Playwright with:
+ * - Cursor-based detection (custom interactive surfaces)
+ * - Bounding boxes captured up front
+ * - Topmost visibility checks
+ * - Multiple heuristics (selectors, ARIA roles, cursor styling)
+ */
+
+import type { Page, Locator } from "playwright-core";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildRoleSnapshotFromAriaSnapshot,
+  getRoleSnapshotStats,
+  type RoleRefMap,
+  type RoleSnapshotOptions,
+} from "./pw-role-snapshot.js";
+import { ensurePageState, getPageForTargetId, storeRoleRefsForTarget } from "./pw-session.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Load the page script
+let pageScriptContent: string | null = null;
+function getPageScript(): string {
+  if (pageScriptContent === null) {
+    const scriptPath = join(__dirname, "page-script-enhanced.js");
+    pageScriptContent = readFileSync(scriptPath, "utf-8");
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  return pageScriptContent!;
+}
+
+/**
+ * Type definitions for enhanced detection results
+ */
+export type DOMRectangle = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
+export type InteractiveRegion = {
+  tag_name: string;
+  role: string;
+  aria_name: string;
+  v_scrollable: boolean;
+  rects: DOMRectangle[];
+};
+
+export type VisualViewport = {
+  height: number;
+  width: number;
+  offsetLeft: number;
+  offsetTop: number;
+  pageLeft: number;
+  pageTop: number;
+  scale: number;
+  clientWidth: number;
+  clientHeight: number;
+  scrollWidth: number;
+  scrollHeight: number;
+};
+
+/** JSON-LD, microdata, and meta tags extracted in-page. */
+export type PageMetadata = {
+  jsonLd?: unknown[];
+  microdata?: Array<Record<string, unknown>>;
+  metaTags?: Record<string, string>;
+};
+
+export type EnhancedSnapshotResult = {
+  snapshot: string;
+  refs: RoleRefMap;
+  stats: { lines: number; chars: number; refs: number; interactive: number };
+  interactiveRegions: Record<string, InteractiveRegion>;
+  viewport: VisualViewport;
+  visibleText: string;
+  pageMetadata: PageMetadata;
+};
+
+// Track which pages have had the script injected
+const pagesWithScript = new WeakSet<Page>();
+
+/**
+ * Ensure the enhanced detection script is injected into the page.
+ * Uses addInitScript for persistence across navigations.
+ * @throws Error if script injection fails after all attempts
+ */
+async function ensureScriptInjected(page: Page): Promise<void> {
+  if (pagesWithScript.has(page)) {
+    // Script already injected, just verify it's available
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      const isAvailable = (await page.evaluate(
+        "typeof OpenClawEnhancedDetection !== 'undefined'",
+      )) as boolean;
+      if (isAvailable) {
+        return;
+      }
+      // Script not available, re-inject
+      pagesWithScript.delete(page);
+    } catch {
+      // Evaluation failed, re-inject
+      pagesWithScript.delete(page);
+    }
+  }
+
+  const script = getPageScript();
+  let lastError: unknown;
+
+  try {
+    // Add as init script so it persists across navigations
+    await page.addInitScript(script);
+    // Also evaluate immediately to make it available now
+    await page.evaluate(script);
+    // Verify it's available
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    const isAvailable = (await page.evaluate(
+      "typeof OpenClawEnhancedDetection !== 'undefined'",
+    )) as boolean;
+    if (isAvailable) {
+      pagesWithScript.add(page);
+      return;
+    }
+    lastError = new Error("OpenClawEnhancedDetection not available after injection");
+  } catch (err) {
+    lastError = err;
+  }
+
+  // If addInitScript fails, try direct evaluation
+  try {
+    await page.evaluate(script);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    const isAvailable = (await page.evaluate(
+      "typeof OpenClawEnhancedDetection !== 'undefined'",
+    )) as boolean;
+    if (isAvailable) {
+      pagesWithScript.add(page);
+      return;
+    }
+    lastError = new Error("OpenClawEnhancedDetection not available after direct evaluation");
+  } catch (err) {
+    lastError = err;
+  }
+
+  // All injection attempts failed - throw clear error
+  throw new Error(
+    `Failed to inject enhanced detection script: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+    { cause: lastError },
+  );
+}
+
+/**
+ * Get interactive regions using the enhanced script-based detection.
+ */
+export async function getInteractiveRegionsViaScript(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  locator?: Locator;
+}): Promise<Record<string, InteractiveRegion>> {
+  const page = await getPageForTargetId(opts);
+  ensurePageState(page);
+  await ensureScriptInjected(page);
+
+  // Evaluate script within locator context if provided, otherwise use document
+  const result = opts.locator
+    ? ((await opts.locator.evaluate((el: Element) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (window as any).OpenClawEnhancedDetection.getInteractiveRects(el);
+      })) as Record<string, unknown>)
+    : ((await page.evaluate(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (window as any).OpenClawEnhancedDetection.getInteractiveRects(document);
+      })) as Record<string, unknown>);
+
+  const regions: Record<string, InteractiveRegion> = {};
+  for (const [key, value] of Object.entries(result)) {
+    const v = value as {
+      tag_name?: string;
+      role?: string;
+      aria_name?: string;
+      v_scrollable?: boolean;
+      rects?: Array<{
+        x?: number;
+        y?: number;
+        width?: number;
+        height?: number;
+        top?: number;
+        right?: number;
+        bottom?: number;
+        left?: number;
+      }>;
+    };
+
+    if (v.tag_name && v.role !== undefined && v.aria_name !== undefined) {
+      const rects: DOMRectangle[] = [];
+      for (const rect of v.rects ?? []) {
+        if (
+          typeof rect.x === "number" &&
+          typeof rect.y === "number" &&
+          typeof rect.width === "number" &&
+          typeof rect.height === "number"
+        ) {
+          rects.push({
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+            top: rect.top ?? rect.y,
+            right: rect.right ?? rect.x + rect.width,
+            bottom: rect.bottom ?? rect.y + rect.height,
+            left: rect.left ?? rect.x,
+          });
+        }
+      }
+
+      regions[key] = {
+        tag_name: v.tag_name,
+        role: v.role,
+        aria_name: v.aria_name,
+        v_scrollable: Boolean(v.v_scrollable),
+        rects,
+      };
+    }
+  }
+
+  return regions;
+}
+
+/**
+ * Get visual viewport information.
+ */
+export async function getVisualViewportViaScript(opts: {
+  cdpUrl: string;
+  targetId?: string;
+}): Promise<VisualViewport> {
+  const page = await getPageForTargetId(opts);
+  ensurePageState(page);
+  await ensureScriptInjected(page);
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const result = (await page.evaluate("OpenClawEnhancedDetection.getVisualViewport();")) as Record<
+    string,
+    number
+  >;
+
+  return {
+    height: result.height ?? 0,
+    width: result.width ?? 0,
+    offsetLeft: result.offsetLeft ?? 0,
+    offsetTop: result.offsetTop ?? 0,
+    pageLeft: result.pageLeft ?? 0,
+    pageTop: result.pageTop ?? 0,
+    scale: result.scale ?? 0,
+    clientWidth: result.clientWidth ?? 0,
+    clientHeight: result.clientHeight ?? 0,
+    scrollWidth: result.scrollWidth ?? 0,
+    scrollHeight: result.scrollHeight ?? 0,
+  };
+}
+
+/**
+ * Get visible text from viewport.
+ */
+export async function getVisibleTextViaScript(opts: {
+  cdpUrl: string;
+  targetId?: string;
+}): Promise<string> {
+  const page = await getPageForTargetId(opts);
+  ensurePageState(page);
+  await ensureScriptInjected(page);
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const result = (await page.evaluate("OpenClawEnhancedDetection.getVisibleText();")) as string;
+
+  return String(result ?? "");
+}
+
+/**
+ * Structured page metadata (JSON-LD, microdata, meta tags).
+ */
+export async function getPageMetadataViaScript(opts: {
+  cdpUrl: string;
+  targetId?: string;
+}): Promise<PageMetadata> {
+  const page = await getPageForTargetId(opts);
+  ensurePageState(page);
+  await ensureScriptInjected(page);
+
+  const result = (await page.evaluate("OpenClawEnhancedDetection.getPageMetadata();")) as Record<
+    string,
+    unknown
+  >;
+
+  const meta: PageMetadata = {};
+  if (Array.isArray(result.jsonLd) && result.jsonLd.length > 0) {
+    meta.jsonLd = result.jsonLd;
+  }
+  if (Array.isArray(result.microdata) && result.microdata.length > 0) {
+    meta.microdata = result.microdata as Array<Record<string, unknown>>;
+  }
+  if (result.metaTags && typeof result.metaTags === "object" && result.metaTags !== null) {
+    meta.metaTags = result.metaTags as Record<string, string>;
+  }
+  return meta;
+}
+
+/**
+ * Get focused element ID.
+ */
+export async function getFocusedElementIdViaScript(opts: {
+  cdpUrl: string;
+  targetId?: string;
+}): Promise<string | null> {
+  const page = await getPageForTargetId(opts);
+  ensurePageState(page);
+  await ensureScriptInjected(page);
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const result = (await page.evaluate("OpenClawEnhancedDetection.getFocusedElementId();")) as
+    | string
+    | null;
+
+  return result;
+}
+
+/**
+ * Create a role-based snapshot from enhanced interactive regions.
+ * Converts the script-detected regions into OpenClaw's role snapshot format.
+ */
+function buildRoleSnapshotFromInteractiveRegions(
+  regions: Record<string, InteractiveRegion>,
+  options: RoleSnapshotOptions = {},
+): { snapshot: string; refs: RoleRefMap } {
+  const refs: RoleRefMap = {};
+  const lines: string[] = [];
+  const INTERACTIVE_ROLES = new Set([
+    "button",
+    "link",
+    "textbox",
+    "checkbox",
+    "radio",
+    "combobox",
+    "listbox",
+    "menuitem",
+    "menuitemcheckbox",
+    "menuitemradio",
+    "option",
+    "searchbox",
+    "slider",
+    "spinbutton",
+    "switch",
+    "tab",
+    "treeitem",
+  ]);
+
+  let refCounter = 0;
+  const nextRef = () => {
+    refCounter += 1;
+    return `e${refCounter}`;
+  };
+
+  for (const [_elementId, region] of Object.entries(regions)) {
+    const role = region.role.toLowerCase();
+    const name = region.aria_name.trim();
+
+    // Filter by interactive if requested
+    if (options.interactive && !INTERACTIVE_ROLES.has(role)) {
+      continue;
+    }
+
+    const ref = nextRef();
+    refs[ref] = {
+      role,
+      ...(name ? { name } : {}),
+    };
+
+    const roleDisplay = role || "element";
+    const nameDisplay = name ? ` "${name}"` : "";
+    const tagDisplay = region.tag_name ? ` (${region.tag_name})` : "";
+    const scrollableDisplay = region.v_scrollable ? " [scrollable]" : "";
+    const rectsDisplay =
+      region.rects.length > 0
+        ? ` [${region.rects.length} rect${region.rects.length > 1 ? "s" : ""}]`
+        : "";
+
+    lines.push(
+      `- ${roleDisplay}${nameDisplay}${tagDisplay} [ref=${ref}]${scrollableDisplay}${rectsDisplay}`,
+    );
+  }
+
+  const snapshot = lines.length > 0 ? lines.join("\n") : "(no interactive elements)";
+  return { snapshot, refs };
+}
+
+/**
+ * Enhanced snapshot using script-based detection (alternative to role/AI-only snapshots).
+ */
+export async function snapshotEnhancedViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  selector?: string;
+  frameSelector?: string;
+  options?: RoleSnapshotOptions;
+}): Promise<EnhancedSnapshotResult> {
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+  });
+  ensurePageState(page);
+  await ensureScriptInjected(page);
+
+  // Build locator for scoping (same pattern as snapshotRoleViaPlaywright)
+  const frameSelector = opts.frameSelector?.trim() || "";
+  const selector = opts.selector?.trim() || "";
+  const locator = frameSelector
+    ? selector
+      ? page.frameLocator(frameSelector).locator(selector)
+      : page.frameLocator(frameSelector).locator(":root")
+    : selector
+      ? page.locator(selector)
+      : page.locator(":root");
+
+  // Get interactive regions via script, scoped to locator
+  const interactiveRegions = await getInteractiveRegionsViaScript({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    locator,
+  });
+
+  const [viewport, visibleText, pageMetadata] = await Promise.all([
+    getVisualViewportViaScript({ cdpUrl: opts.cdpUrl, targetId: opts.targetId }),
+    getVisibleTextViaScript({ cdpUrl: opts.cdpUrl, targetId: opts.targetId }),
+    getPageMetadataViaScript({ cdpUrl: opts.cdpUrl, targetId: opts.targetId }),
+  ]);
+
+  // Build role snapshot from regions
+  const { snapshot, refs } = buildRoleSnapshotFromInteractiveRegions(
+    interactiveRegions,
+    opts.options,
+  );
+
+  // Store refs for later use
+  storeRoleRefsForTarget({
+    page,
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    refs,
+    frameSelector: opts.frameSelector?.trim() || undefined,
+    mode: "role",
+  });
+
+  const stats = getRoleSnapshotStats(snapshot, refs);
+
+  return {
+    snapshot,
+    refs,
+    stats,
+    interactiveRegions,
+    viewport,
+    visibleText,
+    pageMetadata,
+  };
+}
+
+/**
+ * Hybrid snapshot: combines Playwright's ariaSnapshot with enhanced script detection.
+ * Uses Playwright as primary, enhances with script-based detection for custom elements.
+ */
+export async function snapshotHybridViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  selector?: string;
+  frameSelector?: string;
+  options?: RoleSnapshotOptions;
+}): Promise<{
+  snapshot: string;
+  refs: RoleRefMap;
+  stats: { lines: number; chars: number; refs: number; interactive: number };
+  enhancedRegions?: Record<string, InteractiveRegion>;
+  viewport: VisualViewport;
+  visibleText: string;
+  pageMetadata: PageMetadata;
+}> {
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+  });
+  ensurePageState(page);
+
+  // Get Playwright's aria snapshot (primary method)
+  const frameSelector = opts.frameSelector?.trim() || "";
+  const selector = opts.selector?.trim() || "";
+  const locator = frameSelector
+    ? selector
+      ? page.frameLocator(frameSelector).locator(selector)
+      : page.frameLocator(frameSelector).locator(":root")
+    : selector
+      ? page.locator(selector)
+      : page.locator(":root");
+
+  const ariaSnapshot = await locator.ariaSnapshot();
+  const built = buildRoleSnapshotFromAriaSnapshot(String(ariaSnapshot ?? ""), opts.options);
+
+  // Get enhanced regions for additional elements (scoped to same locator)
+  await ensureScriptInjected(page);
+  const enhancedRegions = await getInteractiveRegionsViaScript({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    locator,
+  });
+
+  const [viewport, visibleText, pageMetadata] = await Promise.all([
+    getVisualViewportViaScript({ cdpUrl: opts.cdpUrl, targetId: opts.targetId }),
+    getVisibleTextViaScript({ cdpUrl: opts.cdpUrl, targetId: opts.targetId }),
+    getPageMetadataViaScript({ cdpUrl: opts.cdpUrl, targetId: opts.targetId }),
+  ]);
+
+  // Merge: use Playwright's refs as primary, add any missing from enhanced detection
+  const mergedRefs = { ...built.refs };
+  let mergedLines = built.snapshot.split("\n");
+
+  let nextRefNum =
+    Object.keys(mergedRefs)
+      .map((ref) => {
+        const match = ref.match(/^e(\d+)$/);
+        return match ? Number.parseInt(match[1], 10) : 0;
+      })
+      .reduce((max, n) => Math.max(max, n), 0) + 1;
+  const findNextRef = (): string => `e${nextRefNum++}`;
+
+  // Find elements in enhanced regions that aren't in Playwright's snapshot
+  const existingRefs = new Set(Object.keys(built.refs));
+  for (const [_elementId, region] of Object.entries(enhancedRegions)) {
+    const role = region.role.toLowerCase();
+    const name = region.aria_name.trim();
+
+    // Check if this element is already in the snapshot
+    const alreadyExists = Array.from(existingRefs).some((ref) => {
+      const refData = built.refs[ref];
+      return refData?.role === role && (refData?.name ?? "") === name;
+    });
+
+    if (!alreadyExists && region.rects.length > 0) {
+      // Add missing element with collision-safe ref
+      const ref = findNextRef();
+      mergedRefs[ref] = {
+        role,
+        ...(name ? { name } : {}),
+      };
+
+      const roleDisplay = role || "element";
+      const nameDisplay = name ? ` "${name}"` : "";
+      mergedLines.push(`- ${roleDisplay}${nameDisplay} [ref=${ref}] [enhanced]`);
+    }
+  }
+
+  const mergedSnapshot = mergedLines.join("\n");
+  const stats = getRoleSnapshotStats(mergedSnapshot, mergedRefs);
+
+  storeRoleRefsForTarget({
+    page,
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    refs: mergedRefs,
+    frameSelector: frameSelector || undefined,
+    mode: "role",
+  });
+
+  return {
+    snapshot: mergedSnapshot,
+    refs: mergedRefs,
+    stats,
+    enhancedRegions,
+    viewport,
+    visibleText,
+    pageMetadata,
+  };
+}

--- a/src/browser/pw-tools-core.ts
+++ b/src/browser/pw-tools-core.ts
@@ -3,6 +3,7 @@ export * from "./pw-tools-core.downloads.js";
 export * from "./pw-tools-core.interactions.js";
 export * from "./pw-tools-core.responses.js";
 export * from "./pw-tools-core.snapshot.js";
+export * from "./pw-tools-core-enhanced-snapshot.js";
 export * from "./pw-tools-core.state.js";
 export * from "./pw-tools-core.storage.js";
 export * from "./pw-tools-core.trace.js";

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -305,4 +305,96 @@ export function registerBrowserAgentSnapshotRoutes(
       handleRouteError(ctx, res, err);
     }
   });
+
+  // Enhanced snapshot endpoint using script-based detection
+  app.get("/snapshot-enhanced", async (req, res) => {
+    const profileCtx = resolveProfileContext(req, res, ctx);
+    if (!profileCtx) return;
+    const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
+    const interactiveRaw = toBoolean(req.query.interactive);
+    const compactRaw = toBoolean(req.query.compact);
+    const depthRaw = toNumber(req.query.depth);
+    const selector = toStringOrEmpty(req.query.selector);
+    const frameSelector = toStringOrEmpty(req.query.frame);
+
+    try {
+      const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
+      const pw = await requirePwAi(res, "enhanced snapshot");
+      if (!pw) return;
+
+      const snap = await pw.snapshotEnhancedViaPlaywright({
+        cdpUrl: profileCtx.profile.cdpUrl,
+        targetId: tab.targetId,
+        selector: selector.trim() || undefined,
+        frameSelector: frameSelector.trim() || undefined,
+        options: {
+          interactive: interactiveRaw ?? undefined,
+          compact: compactRaw ?? undefined,
+          maxDepth: depthRaw ?? undefined,
+        },
+      });
+
+      return res.json({
+        ok: true,
+        format: "enhanced",
+        targetId: tab.targetId,
+        url: tab.url,
+        snapshot: snap.snapshot,
+        refs: snap.refs,
+        stats: snap.stats,
+        viewport: snap.viewport,
+        visibleText: snap.visibleText,
+        pageMetadata: snap.pageMetadata,
+        interactiveRegionsCount: Object.keys(snap.interactiveRegions).length,
+      });
+    } catch (err) {
+      handleRouteError(ctx, res, err);
+    }
+  });
+
+  // Hybrid snapshot endpoint: combines Playwright + enhanced detection
+  app.get("/snapshot-hybrid", async (req, res) => {
+    const profileCtx = resolveProfileContext(req, res, ctx);
+    if (!profileCtx) return;
+    const targetId = typeof req.query.targetId === "string" ? req.query.targetId.trim() : "";
+    const interactiveRaw = toBoolean(req.query.interactive);
+    const compactRaw = toBoolean(req.query.compact);
+    const depthRaw = toNumber(req.query.depth);
+    const selector = toStringOrEmpty(req.query.selector);
+    const frameSelector = toStringOrEmpty(req.query.frame);
+
+    try {
+      const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
+      const pw = await requirePwAi(res, "hybrid snapshot");
+      if (!pw) return;
+
+      const snap = await pw.snapshotHybridViaPlaywright({
+        cdpUrl: profileCtx.profile.cdpUrl,
+        targetId: tab.targetId,
+        selector: selector.trim() || undefined,
+        frameSelector: frameSelector.trim() || undefined,
+        options: {
+          interactive: interactiveRaw ?? undefined,
+          compact: compactRaw ?? undefined,
+          maxDepth: depthRaw ?? undefined,
+        },
+      });
+
+      return res.json({
+        ok: true,
+        format: "hybrid",
+        targetId: tab.targetId,
+        url: tab.url,
+        snapshot: snap.snapshot,
+        refs: snap.refs,
+        stats: snap.stats,
+        viewport: snap.viewport,
+        visibleText: snap.visibleText,
+        pageMetadata: snap.pageMetadata,
+        enhancedRegionsCount: snap.enhancedRegions ? Object.keys(snap.enhancedRegions).length : 0,
+      });
+    } catch (err) {
+      handleRouteError(ctx, res, err);
+    }
+  });
 }


### PR DESCRIPTION
## Summary

Adds optional **enhanced** and **hybrid** snapshot modes that inject a small page script for richer interactive-element detection, plus structured **page metadata** and **viewport-visible text** on those paths. Existing `ai` / `aria` snapshots and defaults are unchanged.

## Changes

- **New module**: `src/browser/pw-tools-core-enhanced-snapshot.ts` — Playwright integration, snapshot building, hybrid merge
- **New page script**: `src/browser/page-script-enhanced.js` — in-page detection and metadata extraction
- **Re-export**: `src/browser/pw-tools-core.ts` and `src/browser/pw-ai.ts` expose enhanced snapshot APIs
- **HTTP**: `GET /snapshot-enhanced` and `GET /snapshot-hybrid` (same query knobs as other snapshot routes where applicable: `targetId`, `profile`, `interactive`, `compact`, `depth`, `selector`, `frame`)
- **Client**: `browserSnapshot()` routes `format: "enhanced" | "hybrid"` to those endpoints; `SnapshotResult` extended with `BrowserPageMetadata` and related fields
- **Agent tool**: `snapshotFormat: "enhanced" | "hybrid"` in schema; node proxy uses `/snapshot-enhanced` / `/snapshot-hybrid` when needed; model text includes snapshot + optional visible text + page metadata (with `maxChars` truncation when configured)
- **Docs**: `docs/tools/browser.md` and `src/browser/ENHANCED_SNAPSHOT_README.md`

## Features

### Enhanced snapshot (`snapshotFormat: "enhanced"`)

- Injected script finds interactive targets using:
  - Common selectors (`input`, `button`, `[href]`, `[onclick]`, `[contenteditable]`, focusable `tabindex`, etc.)
  - Interactive `role` values
  - **Cursor styling** (non-default cursors, hoisted to a sensible ancestor)
- **Bounding boxes** computed up front; **topmost** checks reduce covered/hidden noise
- Response includes **viewport**, **visible viewport text**, and **page metadata** (JSON-LD per script tag, microdata, meta tags when present)

### Hybrid snapshot (`snapshotFormat: "hybrid"`) — recommended when you want Playwright’s tree first

- Primary: Playwright **`ariaSnapshot()`**-based role snapshot
- Merge: adds elements seen only by the enhanced script (tagged in the merged listing)
- Same extras as enhanced: **viewport**, **visible text**, **page metadata**

## Benefits

1. **Coverage** — Better on custom controls, cursor-only affordances, and pages weak on ARIA
2. **Context** — Visible text + metadata helps grounding without an extra round trip
3. **Optional** — New formats only; default `ai` / `aria` behavior preserved

## Usage

### Browser tool

Enhanced only:

```ts
browser({ action: "snapshot", snapshotFormat: "enhanced" })
```

Hybrid (Playwright tree + enhanced fill-in):

```ts
browser({ action: "snapshot", snapshotFormat: "hybrid" })
```

Optional: `maxChars`, `targetId`, `selector`, `frame`, `interactive`, `compact`, `depth`, `profile`, etc., same as other snapshot actions where supported.

### HTTP (browser control service)

Query parameters align with existing snapshot routes (`targetId`, `profile`, `interactive`, `compact`, `depth`, `selector`, `frame`).

```http
GET /snapshot-enhanced?targetId=<tab-target-id>
GET /snapshot-hybrid?targetId=<tab-target-id>
```

