### PR TITLE
fix: guard against undefined in onboard trim calls

### DIFF
--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -216,7 +216,7 @@ async function promptPluginFields(params: {
         initialValue: currentStr,
         placeholder: hint.placeholder ?? "value1, value2",
       });
-      const trimmed = input.trim();
+      const trimmed = (input ?? "").trim();
       if (trimmed !== currentStr) {
         if (trimmed) {
           const values = trimmed
@@ -239,7 +239,7 @@ async function promptPluginFields(params: {
       initialValue: currentStr,
       placeholder: hint.placeholder,
     });
-    const trimmed = input.trim();
+    const trimmed = (input ?? "").trim();
     if (trimmed !== currentStr) {
       // Coerce numeric text input when the schema expects a JSON number or integer.
       if (schemaProp?.type === "number" || schemaProp?.type === "integer") {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -485,7 +485,7 @@ export async function runSetupWizard(
           initialValue: baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE,
         }));
 
-  const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
+  const workspaceDir = resolveUserPath((workspaceInput ?? "").trim() || onboardHelpers.DEFAULT_WORKSPACE);
 
   const { applyLocalSetupWorkspaceConfig } = await import("../commands/onboard-config.js");
   let nextConfig: OpenClawConfig = applyLocalSetupWorkspaceConfig(baseConfig, workspaceDir);


### PR DESCRIPTION
## Summary



When `prompter.text()` returns `undefined` or a config value is empty, calling `.trim()` throws `TypeError: Cannot read properties of undefined (reading 'trim')`. Add nullish coalescing (`?? ""`) to fall back to empty string before trimming.



- **Problem:** `prompter.text()` can return `undefined` when input is skipped or cancelled. Calling `.trim()` on `undefined` throws a TypeError that crashes the onboarding flow.

- **Why it matters:** Users cannot complete `openclaw onboard` in quickstart mode, when replacing existing config (e.g. Telegram token), or when skipping channel selection.

- **What changed:** Added `(input ?? "").trim()` nullish coalescing guard at 3 call sites before `.trim()` is invoked.

- **What did NOT change (scope boundary):** No logic changes beyond the null guard. Normal string inputs behave identically. No default value semantics altered.



## Change Type (select all)

- [x] Bug fix

- [ ] Feature

- [ ] Refactor required for the fix

- [ ] Docs

- [ ] Security hardening

- [ ] Chore/infra



## Scope (select all touched areas)

- [ ] Gateway / orchestration

- [ ] Skills / tool execution

- [ ] Auth / tokens

- [ ] Memory / storage

- [x] Integrations

- [ ] API / contracts

- [x] UI / DX

- [ ] CI/CD / infra



## Linked Issue/PR

- Closes #67411

- Closes #67366

- Closes #67353

- Closes #67347

- [x] This PR fixes a bug or regression



## Root Cause (if applicable)

- **Root cause:** `prompter.text()` from `@clack/prompts` returns `undefined` when the user cancels or skips a prompt. The code assumed it always returns a string, so `.trim()` was called directly without a null check.

- **Missing detection / guardrail:** No runtime type guard or TypeScript strict null check enforced on the return value of `prompter.text()` before string method calls.

- **Contributing context (if known):** The `workspaceInput` variable in `setup.ts` can also be `undefined` via the `opts.workspace ?? (flow === "quickstart" ? ... : await prompter.text(...))` expression when the ternary falls through to a prompter that returns undefined.



## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**

- [x] Unit test

- [ ] Seam / integration test

- [ ] End-to-end test

- [ ] Existing coverage already sufficient

- **Target test or file:** `src/wizard/setup.test.ts`, `src/wizard/setup.plugin-config.test.ts`

- **Scenario the test should lock in:** `prompter.text()` returning `undefined` should not throw; it should fall through to the default value (`DEFAULT_WORKSPACE` or empty string).

- **Why this is the smallest reliable guardrail:** The fix is a simple null coalescing guard — unit tests that mock `prompter.text()` to return `undefined` directly verify the guard works.

- **Existing test that already covers this (if any):** `setup.test.ts` (11/11 pass), `setup.plugin-config.test.ts` (13/13 pass) — existing tests continue to pass with the fix applied.

- **If no new test is added, why not:** The existing test suite validates the fix is backwards-compatible. Adding a dedicated `undefined` input test would be valuable but the guard itself is trivial (`?? ""`).



## User-visible / Behavior Changes

- Onboarding no longer crashes with `TypeError` when `prompter.text()` returns `undefined`.

- Otherwise no change: valid inputs produce identical results.



## Diagram (if applicable)

```text

Before:

[prompter.text() → undefined] -> [.trim() on undefined] -> [TypeError crash]



After:

[prompter.text() → undefined] -> [(undefined ?? "").trim()] -> [""] -> [falls through to default value]

Security Impact (required)
New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No
Data access scope changed? No
Repro + Verification
Environment
OS: Linux / macOS / Windows
Runtime/container: Node.js 22
Model/provider: N/A (onboarding flow, not model-specific)
Integration/channel: All channels affected during onboarding
Relevant config: Fresh install with no existing config
Steps
Run openclaw onboard --flow quickstart on a fresh environment
Skip or cancel a prompter.text() prompt (e.g. workspace directory)
Observe crash
Expected
Onboarding completes, using default values when input is skipped.
Actual
TypeError: Cannot read properties of undefined (reading 'trim') — process crashes.
Evidence
[x] Failing test/log before + passing after
Before: TypeError thrown at setup.ts:488, setup.plugin-config.ts:219,242
After: (input ?? "").trim() returns "" instead of throwing
[x] Trace/log snippets: See linked issues #67411, #67366, #67353, #67347
Human Verification (required)
Verified scenarios: TypeScript compilation (tsc --noEmit) passes; all 24 unit tests pass (11 in setup.test.ts + 13 in setup.plugin-config.test.ts).
Edge cases checked: undefined input → "" → default value used; normal string input → trimmed as before; empty string input → "" → default value used.
What I did NOT verify: Full interactive onboarding end-to-end (requires terminal UI and model provider credentials).
Review Conversations
[x] I replied to or resolved every bot review conversation I addressed in this PR.
[x] I left unresolved only the conversations that still need reviewer or maintainer judgment.
Compatibility / Migration
Backward compatible? Yes
Config/env changes? No
Migration needed? No
Risks and Mitigations
Risk: If prompter.text() is expected to return undefined only on "cancel" and some callers intentionally check for undefined to distinguish cancel vs empty input, coalescing to "" could hide the cancel signal.
Mitigation: In all 3 fixed sites, the next line already checks the trimmed value against a default or current value. An empty string from cancel and an empty string from empty input are handled identically in the existing logic. The cancel-vs-empty distinction was not used before the fix point.