### PR TITLE
Fix: Added a typeof value === 'string' guard in setup-wizard-helpers.ts before calling .trim() on the prompter.text() result. Closes #67684

### DIFF
--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -985,13 +985,13 @@ export async function promptSingleChannelToken(params: {
   keepPrompt: string;
   inputPrompt: string;
 }): Promise<{ useEnv: boolean; token: string | null }> {
-  const promptToken = async (): Promise<string> =>
-    (
-      await params.prompter.text({
-        message: params.inputPrompt,
-        validate: (value) => (value?.trim() ? undefined : "Required"),
-      })
-    ).trim();
+  const promptToken = async (): Promise<string> => {
+    const value = await params.prompter.text({
+      message: params.inputPrompt,
+      validate: (value) => (value?.trim() ? undefined : "Required"),
+    });
+    return typeof value === "string" ? value.trim() : "";
+  };
 
   if (params.canUseEnv) {
     const keepEnv = await params.prompter.confirm({

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -990,10 +990,10 @@ export async function promptSingleChannelToken(params: {
       message: params.inputPrompt,
       validate: (value) => (value?.trim() ? undefined : "Required"),
     });
-    if (value === undefined) {
-      return;
+    if (value === undefined || value === null || typeof value !== "string") {
+      throw new Error("Prompt input was cancelled or invalid");
     }
-    return typeof value === "string" ? value.trim() : "";
+    return value.trim();
   };
 
   if (params.canUseEnv) {

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -990,6 +990,9 @@ export async function promptSingleChannelToken(params: {
       message: params.inputPrompt,
       validate: (value) => (value?.trim() ? undefined : "Required"),
     });
+    if (value === undefined) {
+      return;
+    }
     return typeof value === "string" ? value.trim() : "";
   };
 


### PR DESCRIPTION
This PR fixes a TypeError crash during the OpenClaw onboard wizard.

Root cause: @clack/prompts text() can return undefined in edge cases. A prior commit removed String() wrappers around these return values, leaving direct .trim() calls vulnerable.

Fix: Added a typeof value === 'string' guard in setup-wizard-helpers.ts before calling .trim() on the prompter.text() result.

Fixes #67684