### PR TITLE
fix: MS Teams OAuth on Windows and browser.cdpUrl security redaction

### DIFF
--- a/extensions/msteams/src/setup-surface.test.ts
+++ b/extensions/msteams/src/setup-surface.test.ts
@@ -67,7 +67,13 @@ describe("msteams setup surface", () => {
     child.emit("exit", 0, null);
 
     await expect(result).resolves.toBeUndefined();
-    expect(spawn).toHaveBeenCalledWith(process.platform === "darwin" ? "open" : "xdg-open", [url], {
+    const [expectedCmd, expectedArgs] =
+      process.platform === "darwin"
+        ? ["open", [url]]
+        : process.platform === "win32"
+          ? ["cmd", ["/c", "start", '""', url]]
+          : ["xdg-open", [url]];
+    expect(spawn).toHaveBeenCalledWith(expectedCmd, expectedArgs, {
       stdio: "ignore",
       shell: false,
     });

--- a/extensions/msteams/src/setup-surface.ts
+++ b/extensions/msteams/src/setup-surface.ts
@@ -31,13 +31,13 @@ const setMSTeamsGroupPolicy = createTopLevelChannelGroupPolicySetter({
 
 export function openDelegatedOAuthUrl(url: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    const cmd =
+    const [cmd, args]: [string, string[]] =
       process.platform === "darwin"
-        ? "open"
+        ? ["open", [url]]
         : process.platform === "win32"
-          ? "explorer.exe"
-          : "xdg-open";
-    const child = spawn(cmd, [url], { stdio: "ignore", shell: false });
+          ? ["cmd", ["/c", "start", '""', url]]
+          : ["xdg-open", [url]];
+    const child = spawn(cmd, args, { stdio: "ignore", shell: false });
     child.once("error", reject);
     child.once("exit", (code, signal) => {
       if (code === 0) {

--- a/extensions/msteams/src/setup-surface.ts
+++ b/extensions/msteams/src/setup-surface.ts
@@ -31,7 +31,12 @@ const setMSTeamsGroupPolicy = createTopLevelChannelGroupPolicySetter({
 
 export function openDelegatedOAuthUrl(url: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    const cmd = process.platform === "darwin" ? "open" : "xdg-open";
+    const cmd =
+      process.platform === "darwin"
+        ? "open"
+        : process.platform === "win32"
+          ? "explorer.exe"
+          : "xdg-open";
     const child = spawn(cmd, [url], { stdio: "ignore", shell: false });
     child.once("error", reject);
     child.once("exit", (code, signal) => {

--- a/src/shared/net/redact-sensitive-url.test.ts
+++ b/src/shared/net/redact-sensitive-url.test.ts
@@ -49,6 +49,8 @@ describe("sensitive URL config metadata", () => {
     expect(isSensitiveUrlConfigPath("models.providers.*.baseUrl")).toBe(true);
     expect(isSensitiveUrlConfigPath("mcp.servers.remote.url")).toBe(true);
     expect(isSensitiveUrlConfigPath("gateway.remote.url")).toBe(false);
+    expect(isSensitiveUrlConfigPath("browser.cdpUrl")).toBe(true);
+    expect(isSensitiveUrlConfigPath("browser.profiles.default.cdpUrl")).toBe(true);
   });
 
   it("uses an explicit url-secret hint tag", () => {

--- a/src/shared/net/redact-sensitive-url.ts
+++ b/src/shared/net/redact-sensitive-url.ts
@@ -28,6 +28,9 @@ export function isSensitiveUrlConfigPath(path: string): boolean {
   if (path.endsWith(".request.proxy.url")) {
     return true;
   }
+  if (path.endsWith(".cdpUrl")) {
+    return true;
+  }
   return /^mcp\.servers\.(?:\*|[^.]+)\.url$/.test(path);
 }
 


### PR DESCRIPTION
## Summary
Fixes two issues:
1. #67659 - MS Teams delegated OAuth launcher uses xdg-open on Windows instead of explorer.exe
2. #67656 - Config API redaction does not cover browser.cdpUrl paths

## Root Cause
1. For #67659: The  function only checked for Darwin (macOS) and defaulted to  for all other platforms, including Windows.
2. For #67656: The  function did not include  paths, allowing credentials in browser CDP URLs to leak in config responses.

## Fix
1. Added explicit platform check for Windows () to use  instead of 
2. Added  suffix check to  to ensure browser CDP URLs are treated as sensitive

## Test Plan
- [x] Unit tests pass for redact-sensitive-url
- [x] Schema hint tests pass
- [x] Code follows existing patterns

Closes openclaw#67659
Closes openclaw#67656