### PR TITLE
feat: correlate plugin approvals with executed tool calls

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1119,8 +1119,10 @@ export async function handleToolExecutionEnd(
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? (await loadHookRunnerGlobal()).getGlobalHookRunner();
   if (hookRunnerAfter?.hasHooks("after_tool_call")) {
-    const { consumeAdjustedParamsForToolCall } = await loadBeforeToolCall();
+    const { consumeAdjustedParamsForToolCall, consumeApprovalTraceForToolCall } =
+      await loadBeforeToolCall();
     const adjustedArgs = consumeAdjustedParamsForToolCall(toolCallId, runId);
+    const approval = consumeApprovalTraceForToolCall(toolCallId, runId);
     const afterToolCallArgs =
       adjustedArgs && typeof adjustedArgs === "object"
         ? (adjustedArgs as Record<string, unknown>)
@@ -1134,6 +1136,7 @@ export async function handleToolExecutionEnd(
       result: sanitizedResult,
       error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
       durationMs,
+      approval,
     };
     void hookRunnerAfter
       .runAfterToolCall(hookEvent, {

--- a/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -21,6 +21,7 @@ const hookMocks = vi.hoisted(() => ({
 
 const beforeToolCallMocks = vi.hoisted(() => ({
   consumeAdjustedParamsForToolCall: vi.fn((_: string): unknown => undefined),
+  consumeApprovalTraceForToolCall: vi.fn((_: string): unknown => undefined),
   isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
   runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
     blocked: false,
@@ -89,6 +90,7 @@ async function loadFreshAfterToolCallModulesForTest() {
   }));
   vi.doMock("./pi-tools.before-tool-call.js", () => ({
     consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,
+    consumeApprovalTraceForToolCall: beforeToolCallMocks.consumeApprovalTraceForToolCall,
     isToolWrappedWithBeforeToolCallHook: beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook,
     runBeforeToolCallHook: beforeToolCallMocks.runBeforeToolCallHook,
   }));
@@ -109,6 +111,8 @@ describe("after_tool_call fires exactly once in embedded runs", () => {
     hookMocks.runner.runBeforeToolCall.mockResolvedValue(undefined);
     beforeToolCallMocks.consumeAdjustedParamsForToolCall.mockClear();
     beforeToolCallMocks.consumeAdjustedParamsForToolCall.mockReturnValue(undefined);
+    beforeToolCallMocks.consumeApprovalTraceForToolCall.mockClear();
+    beforeToolCallMocks.consumeApprovalTraceForToolCall.mockReturnValue(undefined);
     beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook.mockClear();
     beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook.mockReturnValue(false);
     beforeToolCallMocks.runBeforeToolCallHook.mockClear();
@@ -245,6 +249,42 @@ describe("after_tool_call fires exactly once in embedded runs", () => {
     const event = (hookMocks.runner.runAfterToolCall as ReturnType<typeof vi.fn>).mock
       .calls[0]?.[0] as { params?: unknown } | undefined;
     expect(event?.params).toEqual(adjusted);
+  });
+
+  it("includes plugin approval trace in after_tool_call payload", async () => {
+    const { def, extensionContext } = resolveAdapterDefinition(createTestTool("exec"));
+
+    const toolCallId = "integration-call-approved";
+    const args = { command: "echo hi" };
+    const approval = {
+      kind: "plugin",
+      approvalId: "plugin:approval-123",
+      pluginId: "sage",
+      resolution: "allow-once",
+    };
+    const ctx = createToolHandlerCtx();
+
+    beforeToolCallMocks.consumeApprovalTraceForToolCall.mockImplementation((id: string) =>
+      id === toolCallId ? approval : undefined,
+    );
+
+    await emitToolExecutionStartEvent({ ctx, toolName: "exec", toolCallId, args });
+    await def.execute(toolCallId, args, undefined, undefined, extensionContext);
+    await emitToolExecutionEndEvent({
+      ctx,
+      toolName: "exec",
+      toolCallId,
+      isError: false,
+      result: { content: [{ type: "text", text: "ok" }] },
+    });
+
+    expect(beforeToolCallMocks.consumeApprovalTraceForToolCall).toHaveBeenCalledWith(
+      toolCallId,
+      "integration-test",
+    );
+    const event = (hookMocks.runner.runAfterToolCall as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as { approval?: unknown } | undefined;
+    expect(event?.approval).toEqual(approval);
   });
 
   it("fires after_tool_call exactly once per tool across multiple sequential tool calls", async () => {

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -13,6 +13,7 @@ import {
 import { CRITICAL_THRESHOLD, GLOBAL_CIRCUIT_BREAKER_THRESHOLD } from "./tool-loop-detection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
+import { consumeApprovalTraceForToolCall } from "./pi-tools.before-tool-call.js";
 
 vi.mock("../plugins/hook-runner-global.js", async () => {
   const actual = await vi.importActual<typeof import("../plugins/hook-runner-global.js")>(
@@ -649,6 +650,38 @@ describe("before_tool_call requireApproval handling", () => {
     });
 
     expect(onResolution).toHaveBeenCalledWith("allow-once");
+  });
+
+  it("stores plugin approval trace for later execution correlation", async () => {
+    hookRunner.runBeforeToolCall.mockResolvedValue({
+      requireApproval: {
+        title: "Trace me",
+        description: "Capture approval metadata",
+        pluginId: "sage",
+      },
+    });
+
+    mockCallGateway.mockResolvedValueOnce({ id: "plugin:trace-1", status: "accepted" });
+    mockCallGateway.mockResolvedValueOnce({ id: "plugin:trace-1", decision: "allow-once" });
+
+    const toolCallId = "trace-call-1";
+    const runId = "trace-run-1";
+
+    const result = await runBeforeToolCallHook({
+      toolName: "bash",
+      params: { command: "echo trace" },
+      toolCallId,
+      ctx: { agentId: "main", sessionKey: "main", runId },
+    });
+
+    expect(result.blocked).toBe(false);
+    expect(consumeApprovalTraceForToolCall(toolCallId, runId)).toEqual({
+      kind: "plugin",
+      approvalId: "plugin:trace-1",
+      pluginId: "sage",
+      resolution: "allow-once",
+    });
+    expect(consumeApprovalTraceForToolCall(toolCallId, runId)).toBeUndefined();
   });
 
   it("does not await onResolution before returning approval outcome", async () => {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -10,6 +10,7 @@ import { copyChannelAgentToolMeta } from "./channel-tools.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
+import type { PluginHookToolApprovalTrace } from "../plugins/types.js";
 
 export type HookContext = {
   agentId?: string;
@@ -27,6 +28,7 @@ const BEFORE_TOOL_CALL_WRAPPED = Symbol("beforeToolCallWrapped");
 const BEFORE_TOOL_CALL_HOOK_FAILURE_REASON =
   "Tool call blocked because before_tool_call hook failed";
 const adjustedParamsByToolCallId = new Map<string, unknown>();
+const approvalTraceByToolCallId = new Map<string, PluginHookToolApprovalTrace>();
 const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
 const LOOP_WARNING_BUCKET_SIZE = 10;
 const MAX_LOOP_WARNING_KEYS = 256;
@@ -41,6 +43,27 @@ function buildAdjustedParamsKey(params: { runId?: string; toolCallId: string }):
     return `${params.runId}:${params.toolCallId}`;
   }
   return params.toolCallId;
+}
+
+function trackApprovalTraceForToolCall(params: {
+  toolCallId?: string;
+  runId?: string;
+  trace: PluginHookToolApprovalTrace;
+}): void {
+  if (!params.toolCallId) {
+    return;
+  }
+  const adjustedParamsKey = buildAdjustedParamsKey({
+    runId: params.runId,
+    toolCallId: params.toolCallId,
+  });
+  approvalTraceByToolCallId.set(adjustedParamsKey, params.trace);
+  if (approvalTraceByToolCallId.size > MAX_TRACKED_ADJUSTED_PARAMS) {
+    const oldest = approvalTraceByToolCallId.keys().next().value;
+    if (oldest) {
+      approvalTraceByToolCallId.delete(oldest);
+    }
+  }
 }
 
 function mergeParamsWithApprovalOverrides(
@@ -321,6 +344,16 @@ export async function runBeforeToolCallHook(args: {
             ? decision
             : PluginApprovalResolutions.TIMEOUT;
         safeOnResolution(resolution);
+        trackApprovalTraceForToolCall({
+          toolCallId: args.toolCallId,
+          runId: args.ctx?.runId,
+          trace: {
+            kind: "plugin",
+            approvalId: id,
+            pluginId: approval.pluginId,
+            resolution,
+          },
+        });
         if (
           decision === PluginApprovalResolutions.ALLOW_ONCE ||
           decision === PluginApprovalResolutions.ALLOW_ALWAYS
@@ -453,11 +486,23 @@ export function consumeAdjustedParamsForToolCall(toolCallId: string, runId?: str
   return params;
 }
 
+export function consumeApprovalTraceForToolCall(
+  toolCallId: string,
+  runId?: string,
+): PluginHookToolApprovalTrace | undefined {
+  const adjustedParamsKey = buildAdjustedParamsKey({ runId, toolCallId });
+  const trace = approvalTraceByToolCallId.get(adjustedParamsKey);
+  approvalTraceByToolCallId.delete(adjustedParamsKey);
+  return trace;
+}
+
 export const __testing = {
   BEFORE_TOOL_CALL_WRAPPED,
   buildAdjustedParamsKey,
   adjustedParamsByToolCallId,
+  approvalTraceByToolCallId,
   runBeforeToolCallHook,
   mergeParamsWithApprovalOverrides,
   isPlainObject,
+  trackApprovalTraceForToolCall,
 };

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -306,6 +306,13 @@ export const PluginApprovalResolutions = {
 export type PluginApprovalResolution =
   (typeof PluginApprovalResolutions)[keyof typeof PluginApprovalResolutions];
 
+export type PluginHookToolApprovalTrace = {
+  kind: "plugin";
+  approvalId: string;
+  pluginId?: string;
+  resolution: PluginApprovalResolution;
+};
+
 export type PluginHookBeforeToolCallResult = {
   params?: Record<string, unknown>;
   block?: boolean;
@@ -329,6 +336,7 @@ export type PluginHookAfterToolCallEvent = {
   result?: unknown;
   error?: string;
   durationMs?: number;
+  approval?: PluginHookToolApprovalTrace;
 };
 
 export type PluginHookToolResultPersistContext = {


### PR DESCRIPTION
## Summary
- carry plugin approval correlation metadata from before_tool_call into the executed tool completion path
- expose approval trace on after_tool_call so downstream hooks can correlate approval decisions with actual execution
- add focused tests for trace capture and propagation

## Why
This creates the first narrow closed loop from approval decision to actual runtime execution, which is the concrete seam needed for OAP/OpenClaw correlation.