### PR TITLE
fix(openai-codex): resolve OAuth store/stream mismatch and HTML→DNS error misclassification [AI-assisted]

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1219,4 +1219,16 @@ describe("classifyProviderRuntimeFailureKind", () => {
       ),
     ).not.toBe("proxy");
   });
+
+  it("classifies Cloudflare HTML without a leading status code as upstream_html, not dns", () => {
+    const cloudflareNoStatus =
+      '<!DOCTYPE html><html><head><title>Just a moment...</title></head><body>Cloudflare DDoS protection</body></html>';
+    expect(classifyProviderRuntimeFailureKind(cloudflareNoStatus)).toBe("upstream_html");
+  });
+
+  it("classifies HTML with <title> error indicator and no status code as upstream_html", () => {
+    const htmlTitleError =
+      '<!DOCTYPE html><html><head><title>503 Service Temporarily Unavailable - Error</title></head><body>Please try again later</body></html>';
+    expect(classifyProviderRuntimeFailureKind(htmlTitleError)).toBe("upstream_html");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -346,11 +346,31 @@ function isHtmlErrorResponse(raw: string, status?: number): boolean {
     typeof status === "number" && Number.isFinite(status)
       ? status
       : extractLeadingHttpStatus(candidate)?.code;
-  if (typeof inferred !== "number" || inferred < 400) {
+  const rest = extractLeadingHttpStatus(candidate)?.rest ?? candidate;
+  const hasHtmlStructure = HTML_BODY_RE.test(rest) && HTML_CLOSE_RE.test(rest);
+  if (!hasHtmlStructure) {
     return false;
   }
-  const rest = extractLeadingHttpStatus(candidate)?.rest ?? candidate;
-  return HTML_BODY_RE.test(rest) && HTML_CLOSE_RE.test(rest);
+  // Status code present and >= 400: clearly an error page.
+  if (typeof inferred === "number" && inferred >= 400) {
+    return true;
+  }
+  // No parseable status code: accept as HTML error when CDN/proxy indicators
+  // are present, so Cloudflare pages are not misclassified as DNS errors.
+  if (typeof inferred !== "number") {
+    const lowerRest = rest.toLowerCase();
+    return (
+      lowerRest.includes("cloudflare") ||
+      lowerRest.includes("nginx") ||
+      lowerRest.includes("error") ||
+      lowerRest.includes("denied") ||
+      lowerRest.includes("forbidden") ||
+      lowerRest.includes("not found") ||
+      lowerRest.includes("bad gateway") ||
+      lowerRest.includes("service unavailable")
+    );
+  }
+  return false;
 }
 
 function isTransportHtmlErrorStatus(status: number | undefined): boolean {

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -957,6 +957,28 @@ describe("provider attribution", () => {
           supportsNativeStreamingUsageCompat: false,
         },
       },
+      {
+        name: "native OpenAI Codex responses (store field enabled, store disallowed)",
+        input: {
+          provider: "openai-codex",
+          api: "openai-codex-responses",
+          baseUrl: "https://chatgpt.com/backend-api",
+          capability: "llm" as const,
+          transport: "stream" as const,
+        },
+        expected: {
+          knownProviderFamily: "openai-family",
+          endpointClass: "openai-codex",
+          isKnownNativeEndpoint: true,
+          allowsOpenAIServiceTier: true,
+          supportsOpenAIReasoningCompatPayload: true,
+          allowsResponsesStore: false,
+          supportsResponsesStoreField: true,
+          shouldStripResponsesPromptCache: false,
+          allowsAnthropicServiceTier: false,
+          supportsNativeStreamingUsageCompat: false,
+        },
+      },
     ];
 
     for (const testCase of cases) {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -124,7 +124,7 @@ const MODELSTUDIO_NATIVE_BASE_URLS = new Set([
   "https://dashscope.aliyuncs.com/compatible-mode/v1",
   "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
 ]);
-const OPENAI_RESPONSES_APIS = new Set(["openai-responses", "azure-openai-responses"]);
+const OPENAI_RESPONSES_APIS = new Set(["openai-responses", "azure-openai-responses", "openai-codex-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
 const MOONSHOT_COMPAT_PROVIDERS = new Set(["moonshot", "kimi"]);
 


### PR DESCRIPTION


## Summary

Fixes #67740.

Two interacting bugs cause Codex OAuth requests to fail with a misleading 'DNS lookup failed' error.

### Root cause 1: Codex store field not emitted


esolveProviderRequestCapabilities in provider-attribution.ts gates supportsResponsesStoreField on the OPENAI_RESPONSES_APIS set, which did not include openai-codex-responses. This meant the payload policy resolved explicitStore to undefined instead of alse, so the HTTP and WebSocket request builders never set store: false on Codex payloads. The Codex backend (/backend-api/codex/responses) requires store: false — without it, requests are rejected.

### Root cause 2: HTML error pages misclassified as DNS

When the Codex backend returns a Cloudflare HTML error page without a parseable HTTP status code in the message body, isHtmlErrorResponse returned alse (it required status >= 400). The error then fell through to isDnsTransportErrorMessage, whose regex matched keywords like 'dns' or 'failed' commonly found in Cloudflare HTML, producing the misleading 'DNS lookup failed' user message.

### Changes

#### src/agents/provider-attribution.ts
Add openai-codex-responses to OPENAI_RESPONSES_APIS so supportsResponsesStoreField returns 	rue for Codex. This flows through the existing payload policy to emit store: false on both HTTP and WebSocket paths — no changes needed in the transport builders.

#### src/agents/pi-embedded-helpers/errors.ts
Relax isHtmlErrorResponse to detect HTML error pages even without a parseable status code: when the response has DOCTYPE/html structure plus common CDN/proxy indicators (cloudflare, nginx, error, denied, etc.), classify it as an HTML error page instead of letting it fall through to the DNS matcher.

## Verification

- \
px vitest run src/agents/provider-attribution.test.ts src/agents/openai-responses-payload-policy.test.ts\ — 30 tests pass
- \
px vitest run src/agents/pi-embedded-helpers/provider-error-patterns.test.ts\ — 38 tests pass