### PR TITLE
fix(agents): classify raw HTML error responses even without leading HTTP status prefix

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -290,6 +290,23 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("returns the upstream-HTML message for openai-codex HTML pages without a leading HTTP status (#67712)", () => {
+    // Cloudflare challenge bodies often mention DNS in body copy. Before the fix,
+    // isHtmlErrorResponse required an inferrable status and bailed to
+    // isDnsTransportErrorMessage, producing "DNS lookup for the provider endpoint failed".
+    const rawHtml =
+      "<!doctype html><html><head><title>Just a moment...</title></head>" +
+      "<body><h1>Checking your browser...</h1>" +
+      "<p>The owner of this website has configured DNS routing that requires verification.</p>" +
+      "</body></html>";
+    const msg = makeAssistantError(rawHtml);
+    expect(formatAssistantErrorText(msg, { provider: "openai-codex" })).toBe(
+      "The provider returned an HTML error page instead of an API response. " +
+        "This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. " +
+        "Retry in a moment or check provider status.",
+    );
+  });
+
   it("returns a proxy-specific message for proxy misroutes", () => {
     const msg = makeAssistantError("407 Proxy Authentication Required");
     expect(formatAssistantErrorText(msg)).toBe(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -341,16 +341,25 @@ function isHtmlErrorResponse(raw: string, status?: number): boolean {
   if (!trimmed) {
     return false;
   }
-  const candidate = extractLeadingHttpStatus(trimmed) ? trimmed : stripErrorPrefix(trimmed);
+  const leading = extractLeadingHttpStatus(trimmed);
+  const candidate = leading ? trimmed : stripErrorPrefix(trimmed);
+  const body = leading ? leading.rest : (extractLeadingHttpStatus(candidate)?.rest ?? candidate);
+  if (!HTML_BODY_RE.test(body) || !HTML_CLOSE_RE.test(body)) {
+    return false;
+  }
+  // When a status is available, keep the existing >= 400 guard so a sub-400
+  // status-prefixed payload is not flagged. When no status can be inferred,
+  // trust the strong HTML markers: upstream CDNs sometimes surface raw HTML
+  // without a leading status prefix, and falling through would misclassify
+  // them as DNS/transport failures downstream.
   const inferred =
     typeof status === "number" && Number.isFinite(status)
       ? status
-      : extractLeadingHttpStatus(candidate)?.code;
-  if (typeof inferred !== "number" || inferred < 400) {
+      : (leading?.code ?? extractLeadingHttpStatus(candidate)?.code);
+  if (typeof inferred === "number" && inferred < 400) {
     return false;
   }
-  const rest = extractLeadingHttpStatus(candidate)?.rest ?? candidate;
-  return HTML_BODY_RE.test(rest) && HTML_CLOSE_RE.test(rest);
+  return true;
 }
 
 function isTransportHtmlErrorStatus(status: number | undefined): boolean {

--- a/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
+++ b/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
@@ -230,3 +230,46 @@ describe("Cloudflare / CDN HTML error page classification (#67517)", () => {
     expect(classifyFailoverReason(jsonRateLimit)).toBe("rate_limit");
   });
 });
+
+describe("Raw HTML error pages without a leading HTTP status (#67712)", () => {
+  const rawHtmlChallenge =
+    "<!doctype html><html><head><title>Just a moment...</title></head>" +
+    "<body><h1>Checking your browser...</h1>" +
+    "<p>The owner of this website has configured DNS routing that requires verification.</p>" +
+    "</body></html>";
+  const rawHtmlServerError =
+    "<html><head><title>Bad Gateway</title></head>" +
+    "<body><h1>502 Bad Gateway</h1><p>cloudflare</p></body></html>";
+  const errorPrefixedRawHtml = `Error: ${rawHtmlServerError}`;
+
+  it("classifies raw Cloudflare challenge HTML as upstream_html without a status prefix", () => {
+    expect(classifyProviderRuntimeFailureKind({ message: rawHtmlChallenge })).toBe("upstream_html");
+  });
+
+  it("prefers upstream_html over dns even when HTML body mentions DNS", () => {
+    // Regression: openai-codex/Cloudflare HTML challenge pages frequently reference DNS.
+    // Previously this fell through isHtmlErrorResponse (status-less) into isDnsTransportErrorMessage
+    // (substring match on 'dns') and produced "DNS lookup failed" user copy.
+    expect(classifyProviderRuntimeFailureKind({ message: rawHtmlChallenge })).not.toBe("dns");
+  });
+
+  it("classifies raw HTML as upstream_html even when stripped of the Error: prefix", () => {
+    expect(classifyProviderRuntimeFailureKind({ message: errorPrefixedRawHtml })).toBe(
+      "upstream_html",
+    );
+  });
+
+  it("does not misclassify plain DNS transport errors as HTML", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({
+        message: "dial tcp: lookup api.openai.com: no such host (ENOTFOUND)",
+      }),
+    ).toBe("dns");
+  });
+
+  it("still rejects HTML-looking bodies when an explicit sub-400 status is provided", () => {
+    expect(
+      classifyProviderRuntimeFailureKind({ status: 200, message: rawHtmlServerError }),
+    ).not.toBe("upstream_html");
+  });
+});


### PR DESCRIPTION
## Summary

**Problem:** openai-codex runs whose upstream returns a raw HTML Cloudflare/CDN error page (without a leading HTTP status prefix) are surfaced to the user as:

> LLM request failed: DNS lookup for the provider endpoint failed.

Even though host DNS is healthy, short live probes succeed, and the gateway logs clearly show ``rawError=<html>...``. The message is misleading, and a user seeing it has no reason to suspect a CDN/gateway issue upstream.

**Why:** Follow-up to merged #67642 (Cloudflare HTML misclassification). That PR taught `classifyProviderRuntimeFailureKind` to return `upstream_html` for HTML bodies — but only when an HTTP status >= 400 could be inferred. When providers forward a raw `<html>...</html>` body without a leading status prefix and callers don't pass an explicit status, the classifier silently fails over to `isDnsTransportErrorMessage` (which substring-matches `dns` anywhere in the body) and produces a DNS-lookup message.

**What changed:** Relaxed `isHtmlErrorResponse` in `src/agents/pi-embedded-helpers/errors.ts` to trust strong HTML markers (``<!doctype html>``/``<html>`` start + ``</html>`` close) even when no status can be inferred. The pre-existing `< 400` guard still fires whenever a status IS inferred — so status-prefixed payloads keep their current semantics.

**What did NOT change:**
- `classifyFailoverSignal` (failover/timeout gate at 408/499/5xx) — intentionally left as is.
- `formatTransportErrorCopy` substring ``dns`` match — the HTML branch now runs first so the fall-through isn't reachable for HTML bodies; tightening the DNS regex would be a separate cleanup.
- `src/shared/assistant-error-format.ts:isCloudflareOrHtmlErrorPage` — similar gap but broader blast radius, out of scope.

## Change Type

Bug fix.

## Scope

- [x] agents (src/agents)
- [ ] plugins / providers
- [ ] channels
- [ ] gateway
- [ ] cli / web-ui / apps

## Linked Issue

Closes #67712. Follow-up to #67642 (same classification pipeline, same reviewer surface).

## Root Cause

`isHtmlErrorResponse` at `src/agents/pi-embedded-helpers/errors.ts:339-354` required an inferrable HTTP status code >= 400 to classify raw HTML as an HTML error.

Classification chain for an openai-codex HTML response without a leading status prefix:

1. `extractLeadingHttpStatus("<html>...")` returns `null` (no 3-digit prefix).
2. `inferred` is `undefined`.
3. `if (typeof inferred !== "number" || inferred < 400) return false;` — bails early.
4. `classifyProviderRuntimeFailureKind` at line 820 does not return `"upstream_html"`.
5. Falls through to `isDnsTransportErrorMessage(message)` (line 831). That uses `DNS_ERROR_RE` with `\bdns\b`, which matches Cloudflare challenge bodies that reference DNS in their body copy.
6. Returns kind `"dns"`.
7. `formatAssistantErrorText` has no explicit `"dns"` branch, falls through to `formatTransportErrorCopy(raw)` at line 971, matches `lower.includes("dns")`, returns `"LLM request failed: DNS lookup for the provider endpoint failed."`

The status-gate was reasonable for status-prefixed payloads (e.g. `200 {"...":"..."}`) where we don't want sub-400 responses to be flagged as HTML errors. It was overly strict for raw HTML bodies where the HTML markers themselves are strong enough evidence that the upstream is misbehaving.

## Regression Test Plan

- **Coverage level:** Unit tests in the owning helper test file, plus end-to-end user-message test in `formatassistanterrortext.test.ts`.
- **Target tests added:**
  - `provider-error-patterns.test.ts` — new `describe` block `"Raw HTML error pages without a leading HTTP status (#67712)"` with 5 cases:
    1. Raw Cloudflare challenge HTML classifies as `upstream_html`.
    2. HTML body that mentions DNS does NOT classify as `dns` (the reported regression).
    3. `Error:`-prefixed raw HTML still classifies as `upstream_html`.
    4. Plain DNS transport errors (`ENOTFOUND`) still classify as `dns` (negative guard).
    5. Explicit sub-400 status still vetoes HTML classification (preserves status-gate semantics when the status is known).
  - `pi-embedded-helpers.formatassistanterrortext.test.ts` — end-to-end: raw HTML body containing the substring "DNS" returns the upstream-HTML user copy, not the DNS copy.
- **Existing coverage preserved:** All #67517 (Cloudflare HTML with status) and existing DNS/transport tests keep passing.

## User-visible Changes

openai-codex runs that receive a raw HTML Cloudflare/CDN response now surface the upstream-HTML message:

> The provider returned an HTML error page instead of an API response. This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. Retry in a moment or check provider status.

Instead of the misleading:

> LLM request failed: DNS lookup for the provider endpoint failed.

## Diagram

N/A.

## Security Impact

- **Adds or changes permissions/capabilities?** No.
- **Reads, writes, or persists secrets?** No.
- **Opens new network endpoints or outbound calls?** No.
- **Changes code execution boundaries (sandbox, exec, MCP)?** No.
- **Widens data visibility or cross-user scope?** No.

## Repro + Verification

- **Environment:** OpenClaw 2026.4.14 (323493f), macOS 15.6.1 arm64, Node 24.12.0.
- **Steps:**
  1. Configure `openai-codex/gpt-5.2` as primary model.
  2. Trigger a run while the upstream returns an HTML Cloudflare/CDN error body (raw, no status prefix).
  3. Observe user-facing message and gateway logs.
- **Expected (after fix):** User sees the upstream-HTML message; logs still show `rawError=<html>...`.
- **Actual (before fix):** User sees `"LLM request failed: DNS lookup for the provider endpoint failed."` even though DNS is healthy.

## Evidence

Failing before:
- `classifyProviderRuntimeFailureKind({message: "<html>...</html>"})` returned `"dns"` (when body mentioned DNS) or `"unknown"` otherwise.
- `formatAssistantErrorText(raw)` returned the DNS copy.

Passing after:
- `pnpm test src/agents/pi-embedded-helpers/provider-error-patterns.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts` → all green (47 + 43 tests).
- `pnpm test src/agents/pi-embedded-helpers/ src/agents/pi-embedded-helpers.*.test.ts` broader sweep → all green (128 tests for the sanitize/format surface).

## Human Verification

- **Verified:** targeted tests for `provider-error-patterns.test.ts`, `formatassistanterrortext.test.ts`, and `sanitizeuserfacingtext.test.ts`; no touched-file changes show up in `pnpm tsgo` or `pnpm lint` output.
- **Not verified:** full `pnpm tsgo` / `pnpm lint` / `pnpm build` are clean on upstream main — local runs surface pre-existing failures in `extensions/discord/src/monitor/gateway-plugin.*`, `extensions/qa-lab/src/scenario-runtime-api.test.ts`, and a `@clawdbot/lobster/core` rolldown resolution error, all unrelated to this change.
- **Edge cases considered:** status-prefixed HTML (preserved), sub-400 statuses (preserved veto), `Error:`-prefixed HTML, plain DNS messages (still classify as dns).

## Review Conversations

- [ ] All Greptile findings addressed
- [ ] All ChatGPT Codex findings addressed

## Compatibility / Migration

- **Backward compatible:** Yes. All previously-classified HTML+status cases still classify identically; only previously-unclassified raw-HTML-without-status cases change.
- **Config changes:** None.
- **Migration required:** None.

## Risks and Mitigations

- **Risk:** A non-error payload that legitimately starts with `<html>` and closes with `</html>` could now be classified as `upstream_html` when previously it would fall through.
  - **Mitigation:** The `< 400` status veto still fires whenever a status can be inferred, so explicit `200 <html>...` responses remain unclassified. Status-less raw HTML arriving through error-paths inside the agent runtime is already an exceptional signal — treating it as upstream HTML is accurate.
- **Risk:** Downstream consumers of `"dns"` classification may have relied on HTML bodies to reach them for retry logic.
  - **Mitigation:** Our #67642 already diverted status-prefixed HTML to `upstream_html`; this PR simply extends that to the status-less case. No new semantic class is introduced.

---

AI-assisted: This PR was developed with AI assistance.