### PR TITLE
fix(gateway): fall back to explicit provider config for image capability when catalog misses [AI-assisted]

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1004,4 +1004,138 @@ describe("resolveGatewayModelSupportsImages", () => {
       }),
     ).resolves.toBe(true);
   });
+
+  test("falls back to explicit provider config when model is missing from catalog and config declares image input", async () => {
+    resetConfigRuntimeState();
+    try {
+      const cfg = {
+        models: {
+          providers: {
+            qwen: {
+              baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
+              models: [
+                {
+                  id: "qwen3.6-plus",
+                  name: "qwen3.6-plus",
+                  reasoning: false,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1_000_000,
+                  maxTokens: 65_536,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setRuntimeConfigSnapshot(cfg, cfg);
+
+      await expect(
+        resolveGatewayModelSupportsImages({
+          model: "qwen3.6-plus",
+          provider: "qwen",
+          loadGatewayModelCatalog: async () => [],
+        }),
+      ).resolves.toBe(true);
+    } finally {
+      resetConfigRuntimeState();
+    }
+  });
+
+  test("returns false when model is missing from catalog and explicit config declares text-only input", async () => {
+    resetConfigRuntimeState();
+    try {
+      const cfg = {
+        models: {
+          providers: {
+            qwen: {
+              baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
+              models: [
+                {
+                  id: "qwen3-coder-plus",
+                  name: "qwen3-coder-plus",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1_000_000,
+                  maxTokens: 65_536,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setRuntimeConfigSnapshot(cfg, cfg);
+
+      await expect(
+        resolveGatewayModelSupportsImages({
+          model: "qwen3-coder-plus",
+          provider: "qwen",
+          loadGatewayModelCatalog: async () => [],
+        }),
+      ).resolves.toBe(false);
+    } finally {
+      resetConfigRuntimeState();
+    }
+  });
+
+  test("returns false when model is missing from both catalog and explicit provider config", async () => {
+    resetConfigRuntimeState();
+    try {
+      const cfg = {
+        models: {},
+      } as unknown as OpenClawConfig;
+      setRuntimeConfigSnapshot(cfg, cfg);
+
+      await expect(
+        resolveGatewayModelSupportsImages({
+          model: "unknown-model",
+          provider: "unknown-provider",
+          loadGatewayModelCatalog: async () => [],
+        }),
+      ).resolves.toBe(false);
+    } finally {
+      resetConfigRuntimeState();
+    }
+  });
+
+  test("catalog hit takes precedence over explicit provider config", async () => {
+    resetConfigRuntimeState();
+    try {
+      const cfg = {
+        models: {
+          providers: {
+            qwen: {
+              baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
+              models: [
+                {
+                  id: "qwen3.6-plus",
+                  name: "qwen3.6-plus",
+                  reasoning: false,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1_000_000,
+                  maxTokens: 65_536,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setRuntimeConfigSnapshot(cfg, cfg);
+
+      await expect(
+        resolveGatewayModelSupportsImages({
+          model: "qwen3.6-plus",
+          provider: "qwen",
+          loadGatewayModelCatalog: async () => [
+            { id: "qwen3.6-plus", name: "qwen3.6-plus", provider: "qwen", input: ["text"] },
+          ],
+        }),
+      ).resolves.toBe(false);
+    } finally {
+      resetConfigRuntimeState();
+    }
+  });
 });
+

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -6,6 +6,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
+import { normalizeProviderId } from "../agents/provider-id.js";
 import { lookupContextTokens, resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
@@ -1008,10 +1009,10 @@ function resolveExplicitProviderModelSupportsImages(
     if (!providers) {
       return false;
     }
-    const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+    const normalizedProvider = normalizeProviderId(provider);
     const normalizedModel = normalizeLowercaseStringOrEmpty(model);
     for (const [providerId, providerConfig] of Object.entries(providers)) {
-      if (normalizeLowercaseStringOrEmpty(providerId) !== normalizedProvider) {
+      if (normalizeProviderId(providerId) !== normalizedProvider) {
         continue;
       }
       for (const modelDef of providerConfig.models ?? []) {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -989,6 +989,43 @@ export function resolveSessionModelRef(
   return resolved;
 }
 
+/**
+ * Check if a model has explicit image input capability declared in the user's
+ * provider configuration (openclaw.json → models.providers).  Returns true only
+ * when a matching provider+model definition explicitly lists "image" in its
+ * `input` array. Returns false for any miss or when config is unavailable.
+ */
+function resolveExplicitProviderModelSupportsImages(
+  provider: string | undefined,
+  model: string | undefined,
+): boolean {
+  if (!provider || !model) {
+    return false;
+  }
+  try {
+    const cfg = loadConfig();
+    const providers = cfg.models?.providers;
+    if (!providers) {
+      return false;
+    }
+    const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+    const normalizedModel = normalizeLowercaseStringOrEmpty(model);
+    for (const [providerId, providerConfig] of Object.entries(providers)) {
+      if (normalizeLowercaseStringOrEmpty(providerId) !== normalizedProvider) {
+        continue;
+      }
+      for (const modelDef of providerConfig.models ?? []) {
+        if (normalizeLowercaseStringOrEmpty(modelDef.id) === normalizedModel) {
+          return Array.isArray(modelDef.input) && modelDef.input.includes("image");
+        }
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 export async function resolveGatewayModelSupportsImages(params: {
   loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
   provider?: string;
@@ -1052,6 +1089,13 @@ export async function resolveGatewayModelSupportsImages(params: {
           candidate.startsWith("claude-"),
       )
     ) {
+      return true;
+    }
+    // Fallback: check user-defined provider model configs for explicit image
+    // input capability. This covers models that the built-in catalog filters
+    // out (e.g. qwen3.6-plus on coding.dashscope) but the user has explicitly
+    // configured with input: ["text", "image"] in openclaw.json.
+    if (resolveExplicitProviderModelSupportsImages(params.provider, params.model)) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary

When using Qwen models (e.g. `qwen3.6-plus`) with a `coding.dashscope` base URL, WebChat silently discards image attachments because `resolveGatewayModelSupportsImages()` returns `false` for models missing from the built-in catalog, even when the user has explicitly configured image support.

## Problem

The Qwen provider plugin filters `qwen3.6-plus` from the built-in catalog for coding plan URLs (since the coding plan doesn't support that model). `resolveGatewayModelSupportsImages()` in `src/gateway/session-utils.ts` only checks the built-in model catalog and hardcoded provider shims (Foundry, claude-cli). When a model is absent from the catalog, it returns `false` without consulting the user's explicit provider configuration (`config.models.providers`).

## Fix

Add a fallback path: when the catalog lookup misses and no hardcoded shim matches, read `loadConfig().models.providers` and check if the user has explicitly defined the model with `image` in its `input` array. Catalog hits still take full precedence.

### `src/gateway/session-utils.ts`
- Add `resolveExplicitProviderModelSupportsImages()` helper and integrate it as a fallback in `resolveGatewayModelSupportsImages()`

### `src/gateway/session-utils.test.ts`
- Add 4 regression tests covering catalog hit precedence, catalog miss + explicit image config, catalog miss + text-only config, and catalog miss + no config

## Testing

- `npx vitest run src/gateway/session-utils.test.ts` — all tests pass (including 4 new regression tests)
- Tested with `qwen3.6-plus` on `coding.dashscope` base URL; images are now correctly accepted

Fixes #67759

---
> [!NOTE]
> This contribution was made with the assistance of AI tools (GitHub Copilot, Antigravity).