### PR TITLE
fix(agents): scope nested lane per target session to stop cross-agent blocking (#67502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/openai-completions: always send `stream_options.include_usage` on streaming requests, so local and custom OpenAI-compatible backends report real context usage instead of showing 0%. (#68746) Thanks @kagura-agent.
+- Agents/nested lanes: scope nested agent work per target session so a long-running nested run on one session no longer head-of-line blocks unrelated sessions across the gateway. (#67785) Thanks @stainlu.
 
 ## 2026.4.19-beta.1
 

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -25,7 +25,7 @@ import {
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
-import { AGENT_LANE_NESTED } from "../lanes.js";
+import { isNestedAgentLane } from "../lanes.js";
 import type { AgentCommandOpts } from "./types.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../pi-embedded.js"))["runEmbeddedPiAgent"]>>;
@@ -351,7 +351,7 @@ export async function deliverAgentCommandResult(params: {
     if (!output) {
       return;
     }
-    if (opts.lane === AGENT_LANE_NESTED) {
+    if (isNestedAgentLane(opts.lane)) {
       logNestedOutput(runtime, opts, output, effectiveSessionKey);
       return;
     }

--- a/src/agents/lanes.test.ts
+++ b/src/agents/lanes.test.ts
@@ -36,8 +36,6 @@ describe("resolveNestedAgentLaneForSession (#67502)", () => {
   });
 
   it("produces distinct lanes for distinct target sessions", () => {
-    // This is the reliability invariant behind #67502: a long ACP run on
-    // session A must not queue nested work for session B onto the same lane.
     const laneA = resolveNestedAgentLaneForSession("agent:ebao-next:discord:channel:1");
     const laneB = resolveNestedAgentLaneForSession("agent:ebao-vue:discord:channel:2");
     expect(laneA).not.toBe(laneB);
@@ -73,8 +71,6 @@ describe("isNestedAgentLane", () => {
   });
 
   it("returns false for lanes that merely contain 'nested' as a substring", () => {
-    // Guard against lane names that happen to include the token but are
-    // neither the unscoped lane nor a scoped nested:* lane.
     expect(isNestedAgentLane("deeply-nested-lane")).toBe(false);
     expect(isNestedAgentLane("session:nested")).toBe(false);
     expect(isNestedAgentLane("nestedfoo")).toBe(false);

--- a/src/agents/lanes.test.ts
+++ b/src/agents/lanes.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { AGENT_LANE_NESTED, resolveNestedAgentLane } from "./lanes.js";
+import {
+  AGENT_LANE_NESTED,
+  isNestedAgentLane,
+  resolveNestedAgentLane,
+  resolveNestedAgentLaneForSession,
+} from "./lanes.js";
 
 describe("resolveNestedAgentLane", () => {
   it("defaults to the nested lane when no lane is provided", () => {
@@ -14,5 +19,69 @@ describe("resolveNestedAgentLane", () => {
   it("preserves non-cron lanes", () => {
     expect(resolveNestedAgentLane("subagent")).toBe("subagent");
     expect(resolveNestedAgentLane(" custom-lane ")).toBe("custom-lane");
+  });
+});
+
+describe("resolveNestedAgentLaneForSession (#67502)", () => {
+  it("falls back to the unscoped nested lane when no session key is provided", () => {
+    expect(resolveNestedAgentLaneForSession(undefined)).toBe(AGENT_LANE_NESTED);
+    expect(resolveNestedAgentLaneForSession("")).toBe(AGENT_LANE_NESTED);
+    expect(resolveNestedAgentLaneForSession("   ")).toBe(AGENT_LANE_NESTED);
+  });
+
+  it("scopes the nested lane per target session key", () => {
+    expect(resolveNestedAgentLaneForSession("agent:ebao-next:discord:channel:1")).toBe(
+      `${AGENT_LANE_NESTED}:agent:ebao-next:discord:channel:1`,
+    );
+  });
+
+  it("produces distinct lanes for distinct target sessions", () => {
+    // This is the reliability invariant behind #67502: a long ACP run on
+    // session A must not queue nested work for session B onto the same lane.
+    const laneA = resolveNestedAgentLaneForSession("agent:ebao-next:discord:channel:1");
+    const laneB = resolveNestedAgentLaneForSession("agent:ebao-vue:discord:channel:2");
+    expect(laneA).not.toBe(laneB);
+  });
+
+  it("is deterministic for the same session key across calls", () => {
+    const key = "agent:ebao:discord:channel:1";
+    expect(resolveNestedAgentLaneForSession(key)).toBe(resolveNestedAgentLaneForSession(key));
+  });
+
+  it("trims whitespace around the session key before scoping", () => {
+    expect(resolveNestedAgentLaneForSession("   agent:ebao:main   ")).toBe(
+      `${AGENT_LANE_NESTED}:agent:ebao:main`,
+    );
+  });
+});
+
+describe("isNestedAgentLane", () => {
+  it("returns true for the unscoped nested lane", () => {
+    expect(isNestedAgentLane(AGENT_LANE_NESTED)).toBe(true);
+  });
+
+  it("returns true for per-session nested lanes", () => {
+    expect(isNestedAgentLane(resolveNestedAgentLaneForSession("agent:a:main"))).toBe(true);
+    expect(isNestedAgentLane(`${AGENT_LANE_NESTED}:agent:a:main`)).toBe(true);
+  });
+
+  it("returns false for unrelated lanes", () => {
+    expect(isNestedAgentLane("main")).toBe(false);
+    expect(isNestedAgentLane("cron")).toBe(false);
+    expect(isNestedAgentLane("subagent")).toBe(false);
+    expect(isNestedAgentLane("session:agent:a:main")).toBe(false);
+  });
+
+  it("returns false for lanes that merely contain 'nested' as a substring", () => {
+    // Guard against lane names that happen to include the token but are
+    // neither the unscoped lane nor a scoped nested:* lane.
+    expect(isNestedAgentLane("deeply-nested-lane")).toBe(false);
+    expect(isNestedAgentLane("session:nested")).toBe(false);
+    expect(isNestedAgentLane("nestedfoo")).toBe(false);
+  });
+
+  it("returns false for empty or missing lane names", () => {
+    expect(isNestedAgentLane(undefined)).toBe(false);
+    expect(isNestedAgentLane("")).toBe(false);
   });
 });

--- a/src/agents/lanes.ts
+++ b/src/agents/lanes.ts
@@ -28,6 +28,15 @@ export function resolveNestedAgentLane(lane?: string): string {
  * step follow-ups, ACP Claude Code runs) through a single global `nested`
  * queue with `maxConcurrent=1`. A single long ACP run on one session could
  * starve every other agent's nested work across the gateway (#67502).
+ *
+ * Lane lifecycle: per-session lanes follow the same pattern as the existing
+ * `session:<key>` lanes (see `src/agents/pi-embedded-runner/lanes.ts`). Lane
+ * state in `src/process/command-queue.ts` persists for the gateway process
+ * lifetime in its `Map<string, LaneState>` and is never actively reaped, so
+ * each distinct session key minted here contributes one long-lived entry
+ * (~200 bytes). This matches existing per-session lane behaviour and has
+ * not been a problem in practice; an idle-lane reaper would be a clean
+ * follow-up but is intentionally out of scope here.
  */
 export function resolveNestedAgentLaneForSession(sessionKey: string | undefined): string {
   const trimmed = sessionKey?.trim();

--- a/src/agents/lanes.ts
+++ b/src/agents/lanes.ts
@@ -1,11 +1,9 @@
 import { CommandLane } from "../process/lanes.js";
 
-// Keep exported lane identifiers as plain strings so callers can compare them
-// against arbitrary lane labels (per-session suffixes, user-supplied lanes)
-// without tripping no-unsafe-enum-comparison.
-export const AGENT_LANE_NESTED: string = CommandLane.Nested;
-export const AGENT_LANE_SUBAGENT: string = CommandLane.Subagent;
-const NESTED_LANE_SESSION_SEPARATOR = ":";
+export const AGENT_LANE_NESTED = CommandLane.Nested;
+export const AGENT_LANE_SUBAGENT = CommandLane.Subagent;
+const NESTED_LANE = "nested";
+const NESTED_LANE_PREFIX = `${NESTED_LANE}:`;
 
 export function resolveNestedAgentLane(lane?: string): string {
   const trimmed = lane?.trim();
@@ -17,47 +15,17 @@ export function resolveNestedAgentLane(lane?: string): string {
   return trimmed;
 }
 
-/**
- * Build a nested-agent lane key scoped to the target session key so that a
- * long-running nested operation against session A does not block nested
- * operations against session B. Fall back to the unscoped nested lane when
- * no session key is available so existing cron/legacy callers keep their
- * current semantics.
- *
- * Prior behaviour routed every nested run (sessions_send A2A flows, agent
- * step follow-ups, ACP Claude Code runs) through a single global `nested`
- * queue with `maxConcurrent=1`. A single long ACP run on one session could
- * starve every other agent's nested work across the gateway (#67502).
- *
- * Lane lifecycle: per-session lanes follow the same pattern as the existing
- * `session:<key>` lanes (see `src/agents/pi-embedded-runner/lanes.ts`). Lane
- * state in `src/process/command-queue.ts` persists for the gateway process
- * lifetime in its `Map<string, LaneState>` and is never actively reaped, so
- * each distinct session key minted here contributes one long-lived entry
- * (~200 bytes). This matches existing per-session lane behaviour and has
- * not been a problem in practice; an idle-lane reaper would be a clean
- * follow-up but is intentionally out of scope here.
- */
 export function resolveNestedAgentLaneForSession(sessionKey: string | undefined): string {
   const trimmed = sessionKey?.trim();
   if (!trimmed) {
     return AGENT_LANE_NESTED;
   }
-  return `${AGENT_LANE_NESTED}${NESTED_LANE_SESSION_SEPARATOR}${trimmed}`;
+  return `${NESTED_LANE_PREFIX}${trimmed}`;
 }
 
-/**
- * Return true when `lane` is the unscoped nested lane or a per-session
- * nested lane produced by `resolveNestedAgentLaneForSession`. Callers that
- * switch on lane identity (delivery logging, metrics) should treat both
- * forms the same way.
- */
 export function isNestedAgentLane(lane: string | undefined): boolean {
   if (!lane) {
     return false;
   }
-  return (
-    lane === AGENT_LANE_NESTED ||
-    lane.startsWith(`${AGENT_LANE_NESTED}${NESTED_LANE_SESSION_SEPARATOR}`)
-  );
+  return lane === NESTED_LANE || lane.startsWith(NESTED_LANE_PREFIX);
 }

--- a/src/agents/lanes.ts
+++ b/src/agents/lanes.ts
@@ -1,7 +1,11 @@
 import { CommandLane } from "../process/lanes.js";
 
-export const AGENT_LANE_NESTED = CommandLane.Nested;
-export const AGENT_LANE_SUBAGENT = CommandLane.Subagent;
+// Keep exported lane identifiers as plain strings so callers can compare them
+// against arbitrary lane labels (per-session suffixes, user-supplied lanes)
+// without tripping no-unsafe-enum-comparison.
+export const AGENT_LANE_NESTED: string = CommandLane.Nested;
+export const AGENT_LANE_SUBAGENT: string = CommandLane.Subagent;
+const NESTED_LANE_SESSION_SEPARATOR = ":";
 
 export function resolveNestedAgentLane(lane?: string): string {
   const trimmed = lane?.trim();
@@ -11,4 +15,40 @@ export function resolveNestedAgentLane(lane?: string): string {
     return AGENT_LANE_NESTED;
   }
   return trimmed;
+}
+
+/**
+ * Build a nested-agent lane key scoped to the target session key so that a
+ * long-running nested operation against session A does not block nested
+ * operations against session B. Fall back to the unscoped nested lane when
+ * no session key is available so existing cron/legacy callers keep their
+ * current semantics.
+ *
+ * Prior behaviour routed every nested run (sessions_send A2A flows, agent
+ * step follow-ups, ACP Claude Code runs) through a single global `nested`
+ * queue with `maxConcurrent=1`. A single long ACP run on one session could
+ * starve every other agent's nested work across the gateway (#67502).
+ */
+export function resolveNestedAgentLaneForSession(sessionKey: string | undefined): string {
+  const trimmed = sessionKey?.trim();
+  if (!trimmed) {
+    return AGENT_LANE_NESTED;
+  }
+  return `${AGENT_LANE_NESTED}${NESTED_LANE_SESSION_SEPARATOR}${trimmed}`;
+}
+
+/**
+ * Return true when `lane` is the unscoped nested lane or a per-session
+ * nested lane produced by `resolveNestedAgentLaneForSession`. Callers that
+ * switch on lane identity (delivery logging, metrics) should treat both
+ * forms the same way.
+ */
+export function isNestedAgentLane(lane: string | undefined): boolean {
+  if (!lane) {
+    return false;
+  }
+  return (
+    lane === AGENT_LANE_NESTED ||
+    lane.startsWith(`${AGENT_LANE_NESTED}${NESTED_LANE_SESSION_SEPARATOR}`)
+  );
 }

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -757,8 +757,6 @@ describe("sessions tools", () => {
     const historyOnlyCalls = calls.filter((call) => call.method === "chat.history");
     expect(agentCalls).toHaveLength(8);
     for (const call of agentCalls) {
-      // #67502: nested lanes are now scoped per-target-session. Accept either
-      // the unscoped `nested` lane or a scoped `nested:<sessionKey>` lane.
       expect(call.params).toMatchObject({
         lane: expect.stringMatching(/^nested(?::|$)/),
         channel: "webchat",
@@ -939,8 +937,6 @@ describe("sessions tools", () => {
     const agentCalls = calls.filter((call) => call.method === "agent");
     expect(agentCalls).toHaveLength(4);
     for (const call of agentCalls) {
-      // #67502: nested lanes are now scoped per-target-session. Accept either
-      // the unscoped `nested` lane or a scoped `nested:<sessionKey>` lane.
       expect(call.params).toMatchObject({
         lane: expect.stringMatching(/^nested(?::|$)/),
         channel: "webchat",

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -757,8 +757,10 @@ describe("sessions tools", () => {
     const historyOnlyCalls = calls.filter((call) => call.method === "chat.history");
     expect(agentCalls).toHaveLength(8);
     for (const call of agentCalls) {
+      // #67502: nested lanes are now scoped per-target-session. Accept either
+      // the unscoped `nested` lane or a scoped `nested:<sessionKey>` lane.
       expect(call.params).toMatchObject({
-        lane: "nested",
+        lane: expect.stringMatching(/^nested(?::|$)/),
         channel: "webchat",
         inputProvenance: { kind: "inter_session" },
       });
@@ -937,8 +939,10 @@ describe("sessions tools", () => {
     const agentCalls = calls.filter((call) => call.method === "agent");
     expect(agentCalls).toHaveLength(4);
     for (const call of agentCalls) {
+      // #67502: nested lanes are now scoped per-target-session. Accept either
+      // the unscoped `nested` lane or a scoped `nested:<sessionKey>` lane.
       expect(call.params).toMatchObject({
-        lane: "nested",
+        lane: expect.stringMatching(/^nested(?::|$)/),
         channel: "webchat",
         inputProvenance: { kind: "inter_session" },
       });

--- a/src/agents/tools/agent-step.ts
+++ b/src/agents/tools/agent-step.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { callGateway } from "../../gateway/call.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
-import { AGENT_LANE_NESTED } from "../lanes.js";
+import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import { waitForAgentRunAndReadUpdatedAssistantReply } from "../run-wait.js";
 
 export { readLatestAssistantReply } from "../run-wait.js";
@@ -36,7 +36,7 @@ export async function runAgentStep(params: {
       idempotencyKey: stepIdem,
       deliver: false,
       channel: params.channel ?? INTERNAL_MESSAGE_CHANNEL,
-      lane: params.lane ?? AGENT_LANE_NESTED,
+      lane: params.lane ?? resolveNestedAgentLaneForSession(params.sessionKey),
       extraSystemPrompt: params.extraSystemPrompt,
       inputProvenance: {
         kind: "inter_session",

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -3,7 +3,7 @@ import type { CallGatewayOptions } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
-import { AGENT_LANE_NESTED } from "../lanes.js";
+import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import { readLatestAssistantReply, waitForAgentRun } from "../run-wait.js";
 import { runAgentStep } from "./agent-step.js";
 import { resolveAnnounceTarget } from "./sessions-announce-target.js";
@@ -92,7 +92,7 @@ export async function runSessionsSendA2AFlow(params: {
           message: incomingMessage,
           extraSystemPrompt: replyPrompt,
           timeoutMs: params.announceTimeoutMs,
-          lane: AGENT_LANE_NESTED,
+          lane: resolveNestedAgentLaneForSession(currentSessionKey),
           sourceSessionKey: nextSessionKey,
           sourceChannel:
             nextSessionKey === params.requesterSessionKey ? params.requesterChannel : targetChannel,
@@ -123,7 +123,7 @@ export async function runSessionsSendA2AFlow(params: {
       message: "Agent-to-agent announce step.",
       extraSystemPrompt: announcePrompt,
       timeoutMs: params.announceTimeoutMs,
-      lane: AGENT_LANE_NESTED,
+      lane: resolveNestedAgentLaneForSession(params.targetSessionKey),
       sourceSessionKey: params.requesterSessionKey,
       sourceChannel: params.requesterChannel,
       sourceTool: "sessions_send",

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -10,7 +10,7 @@ import {
   type GatewayMessageChannel,
   INTERNAL_MESSAGE_CHANNEL,
 } from "../../utils/message-channel.js";
-import { AGENT_LANE_NESTED } from "../lanes.js";
+import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import {
   readLatestAssistantReplySnapshot,
   waitForAgentRunAndReadUpdatedAssistantReply,
@@ -276,7 +276,7 @@ export function createSessionsSendTool(opts?: {
         idempotencyKey,
         deliver: false,
         channel: INTERNAL_MESSAGE_CHANNEL,
-        lane: AGENT_LANE_NESTED,
+        lane: resolveNestedAgentLaneForSession(resolvedKey),
         extraSystemPrompt: agentMessageContext,
         inputProvenance: {
           kind: "inter_session",

--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -292,6 +292,32 @@ describe("deliverAgentCommandResult", () => {
     expect(line).toContain("ANNOUNCE_SKIP");
   });
 
+  it("prefixes per-session nested lanes with the same nested log context (#67502)", async () => {
+    // The reliability fix in #67502 routes nested agent runs onto per-target-session
+    // lanes (nested:<sessionKey>). Delivery logging still needs to recognise these
+    // as nested so the [agent:nested] prefix is preserved.
+    const runtime = createRuntime();
+    await runDelivery({
+      runtime,
+      resultText: "ANNOUNCE_SKIP",
+      opts: {
+        message: "hello",
+        deliver: false,
+        lane: "nested:agent:ebao-next:discord:channel:1",
+        sessionKey: "agent:ebao-next:discord:channel:1",
+        runId: "run-announce",
+        messageChannel: "webchat",
+      },
+      sessionEntry: undefined,
+    });
+
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    const line = String((runtime.log as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]);
+    expect(line).toContain("[agent:nested]");
+    expect(line).toContain("session=agent:ebao-next:discord:channel:1");
+    expect(line).toContain("ANNOUNCE_SKIP");
+  });
+
   it("preserves audioAsVoice in JSON output envelopes", async () => {
     const runtime = createRuntime();
     await runDelivery({

--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -293,9 +293,6 @@ describe("deliverAgentCommandResult", () => {
   });
 
   it("prefixes per-session nested lanes with the same nested log context (#67502)", async () => {
-    // The reliability fix in #67502 routes nested agent runs onto per-target-session
-    // lanes (nested:<sessionKey>). Delivery logging still needs to recognise these
-    // as nested so the [agent:nested] prefix is preserved.
     const runtime = createRuntime();
     await runDelivery({
       runtime,

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -150,7 +150,9 @@ describe("sessions_send gateway loopback", () => {
     const firstCall = spy.mock.calls[0]?.[0] as
       | { lane?: string; inputProvenance?: { kind?: string; sourceTool?: string } }
       | undefined;
-    expect(firstCall?.lane).toBe("nested");
+    // #67502: nested lanes are scoped per-target-session; accept either the
+    // unscoped `nested` lane or a `nested:<sessionKey>` variant.
+    expect(firstCall?.lane).toMatch(/^nested(?::|$)/);
     expect(firstCall?.inputProvenance).toMatchObject({
       kind: "inter_session",
       sourceTool: "sessions_send",

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -150,8 +150,6 @@ describe("sessions_send gateway loopback", () => {
     const firstCall = spy.mock.calls[0]?.[0] as
       | { lane?: string; inputProvenance?: { kind?: string; sourceTool?: string } }
       | undefined;
-    // #67502: nested lanes are scoped per-target-session; accept either the
-    // unscoped `nested` lane or a `nested:<sessionKey>` variant.
     expect(firstCall?.lane).toMatch(/^nested(?::|$)/);
     expect(firstCall?.inputProvenance).toMatchObject({
       kind: "inter_session",


### PR DESCRIPTION
## Summary

**Problem:** A single long-running nested agent run (e.g. an ACP Claude Code run on session A) blocks every other nested operation across the gateway, because all nested agent runs share one global queue with `maxConcurrent=1`. In the reported incident, a 7-14 minute ACP run on `ebao-next` blocked three other agent sessions (`ebao`, `ebao-vue`, and follow-up nested work) for 7-14 minutes each. Assistant responses generated during the backlog were never delivered to Discord.

**Why:** `CommandLane.Nested = "nested"` is a single lane name used by every nested operation — `sessions_send`, `runAgentStep`, ACP dispatches — regardless of which session they target. The command queue keyed off that bare string serializes everything behind a single head-of-line run.

**What changed:** Nested lanes are now scoped to the target session key. `sessions_send`, `runAgentStep`, and the A2A ping-pong flow now compute their lane as `nested:<targetSessionKey>`. A long run on session A still serializes subsequent nested work against A (concurrency invariant preserved), but nested work against B, C, D now runs in parallel on their own lanes.

**What did NOT change:**
- `CommandLane.Nested` is still exported; callers without a known target session (legacy cron paths via `resolveNestedAgentLane(lane)`) still fall back to the unscoped lane.
- `isNestedAgentLane(lane)` treats both `nested` and `nested:<key>` as nested for delivery logging, metrics, and future switchboards.
- No concurrency invariants were weakened. Each per-session lane still has `maxConcurrent=1` by default (same as before for the unscoped `nested` lane).
- Session delivery context corruption and delivery retry/DLQ (two other sub-fixes the reporter suggested) are out of scope for this PR — see \"Out of scope\" below.

## Change Type

Bug fix (reliability / data loss prevention).

## Scope

- [x] agents (src/agents)
- [ ] plugins / providers
- [ ] channels
- [ ] gateway
- [ ] cli / web-ui / apps

## Linked Issue

Closes #67502.

## Root Cause

Architecture before this PR:

1. `resolveNestedAgentLane(lane?)` in `src/agents/lanes.ts` returned the bare string `\"nested\"` for every caller that did not supply an explicit lane.
2. Every nested call site (`src/agents/tools/sessions-send-tool.ts:279`, `src/agents/tools/sessions-send-tool.a2a.ts:95,126`, `src/agents/tools/agent-step.ts:39`) passed `lane: AGENT_LANE_NESTED` directly.
3. `src/process/command-queue.ts` keys `LaneState` by lane name in a `Map<string, LaneState>` (`getLaneState(lane)`) with a default `maxConcurrent: 1`.
4. Nested lane concurrency is never reconfigured anywhere (`src/gateway/server-lanes.ts` only sets `Cron`, `Main`, `Subagent` concurrency).

Result: every nested run across every session contends on a single lane with a hard cap of 1 in-flight task. When one session's nested work takes ~10 minutes (ACP + Claude Code, long tool loops), every other session's follow-up work queues behind it and surfaces as `lane wait exceeded: lane=nested waitedMs=576497 queueAhead=1`.

## Fix

1. Added `resolveNestedAgentLaneForSession(sessionKey)` in `src/agents/lanes.ts`. Returns `nested:<sessionKey>` when a key is supplied, and falls back to the unscoped `nested` lane when it is empty (preserves cron/legacy semantics).
2. Added `isNestedAgentLane(lane)` so delivery logging (`src/agents/command/delivery.ts:302`) and any future consumer can recognise both the unscoped and scoped variants.
3. Updated every production call site that has a target session key to use `resolveNestedAgentLaneForSession`:
   - `src/agents/tools/sessions-send-tool.ts` (top-level sessions_send)
   - `src/agents/tools/sessions-send-tool.a2a.ts` (A2A ping-pong replies + announce step)
   - `src/agents/tools/agent-step.ts` (default lane when caller does not override)
4. Changed the identity comparison in `src/agents/command/delivery.ts` from `opts.lane === AGENT_LANE_NESTED` to `isNestedAgentLane(opts.lane)` so nested logging still fires on scoped lanes.
5. Downgraded the exported `AGENT_LANE_NESTED` and `AGENT_LANE_SUBAGENT` constants to plain `string` types so callers that compare against arbitrary lane labels (per-session suffixes, user-supplied lanes) do not trip `no-unsafe-enum-comparison`.

## Regression Test Plan

- **Coverage level:** Unit tests in the owning helper test file, plus updated assertions in downstream consumer tests.
- **Target tests added:**
  - `src/agents/lanes.test.ts` — new `describe` blocks `resolveNestedAgentLaneForSession (#67502)` (5 cases) and `isNestedAgentLane` (5 cases), covering: fallback to unscoped when no key, per-session scoping, distinct lanes for distinct sessions, deterministic output, whitespace trimming, substring-guard against accidental matches like `\"deeply-nested-lane\"` / `\"nestedfoo\"`.
  - `src/commands/agent.delivery.test.ts` — new case verifying `[agent:nested]` log prefix fires for scoped lanes (`nested:agent:ebao-next:discord:channel:1`), not just the unscoped lane.
- **Updated test assertions (behaviour invariant, not regression):**
  - `src/agents/openclaw-tools.sessions.test.ts` — two assertions now match `expect.stringMatching(/^nested(?::|$)/)` instead of the literal `\"nested\"`.
  - `src/gateway/server.sessions-send.test.ts` — E2E assertion matches the same regex.

## User-visible Changes

Users running multiple agents with `sessions_send(timeoutSeconds: 0)` no longer see cross-agent stalls when one agent is running a long nested tool loop (ACP, Claude Code, subagent chains). Gateway logs continue to show `[agent:nested]` prefixed output regardless of the new lane suffix.

## Diagram

```
Before                              After
-------                             -------
                                     session-A nested lane (nested:A)
                                         | [task 1] -> [task 2] -> ...
All nested runs                     session-B nested lane (nested:B)
  |                                     | [task 1] -> [task 2] -> ...
  v   one global \"nested\" lane     session-C nested lane (nested:C)
 queue: A1 A2 B1 C1 A3 B2 ...          | [task 1] -> [task 2] -> ...
 max=1 | head-of-line blocks       (each maxConcurrent=1; concurrent across sessions)
```

## Security Impact

- **Adds or changes permissions/capabilities?** No.
- **Reads, writes, or persists secrets?** No.
- **Opens new network endpoints or outbound calls?** No.
- **Changes code execution boundaries (sandbox, exec, MCP)?** No.
- **Widens data visibility or cross-user scope?** No. Per-session lane scoping strengthens isolation.

## Repro + Verification

- **Environment:** OpenClaw 2026.4.14 (323493f), Linux 6.17.0-20-generic, Node v24.14.1, Discord persistent group sessions, ACP runtime: acpx + Claude Code.
- **Steps:** Set up three persistent Discord-bound agent sessions. Have the first dispatch tasks to the other two via `sessions_send(timeoutSeconds: 0)`. The two targets each invoke a 7-14 minute ACP coding task. Meanwhile, the orchestrator agent also needs to emit a summary.
- **Expected (after fix):** Each target's ACP run executes on `nested:<its-own-sessionKey>`. The orchestrator's follow-up runs on `nested:<orchestrator-sessionKey>`. No cross-session blocking.
- **Actual (before fix):** All three contend on `nested`; the orchestrator's summary is queued behind both ACP runs and surfaces minutes late or not at all.

## Evidence

**Failing before:** targeting distinct sessions still produced a single `Map<string, LaneState>` entry `\"nested\"`; existing tests literal-matched `lane: \"nested\"` so cross-session isolation wasn't covered by the suite.

**Passing after:**
- `pnpm test src/agents/lanes.test.ts` — 13 tests green (8 new, 5 existing).
- `pnpm test src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/command/delivery.test.ts src/agents/openclaw-tools.sessions.test.ts` — 20 tests green across the touched consumers.
- `pnpm test src/gateway/server.sessions-send.test.ts src/commands/agent.delivery.test.ts` — 14 tests green with the updated pattern matcher + new per-session nested lane logging case.
- `pnpm test src/cron/isolated-agent.lane.test.ts` — 3 tests green (cron still uses the unscoped fallback path).
- Broader `pnpm test 'src/agents/**/*.test.ts'` sweep — 3841 tests green, 2 unrelated SSRF/network failures in `web-fetch.provider-fallback.test.ts` (environment-specific; pre-exist on upstream main).

## Human Verification

- **Verified:** targeted unit tests; full `pnpm test 'src/agents/**/*.test.ts'` sweep except unrelated SSRF tests; `pnpm lint` clean on touched files (unrelated pre-existing failures in `extensions/qa-lab` and `extensions/discord` not introduced by this change); `pnpm tsgo` clean on touched files (unrelated pre-existing failures in `extensions/discord/src/monitor/gateway-plugin.*` not introduced by this change).
- **Not verified:** full `pnpm build` — fails on upstream main with an unrelated `@clawdbot/lobster/core` rolldown resolution error; did not address.
- **Edge cases considered:** empty / whitespace-only session keys (falls back to unscoped), cron paths using `resolveNestedAgentLane(lane)` (unchanged; still unscoped fallback), substring guards to ensure lane names like `\"deeply-nested-lane\"` or `\"nestedfoo\"` are not misclassified.

## Review Conversations

- [ ] All Greptile findings addressed
- [ ] All ChatGPT Codex findings addressed

## Compatibility / Migration

- **Backward compatible:** Yes. `AGENT_LANE_NESTED` is still exported; callers that continue to pass it directly keep their existing (unscoped) behaviour. Cron integration (`resolveNestedAgentLane`) was intentionally left unchanged.
- **Config changes:** None.
- **Migration required:** None.

## Risks and Mitigations

- **Risk:** The lane-state `Map` grows as new session keys appear. Lane state is ~200 bytes per entry and is never GC'd today.
  - **Mitigation:** Same memory-growth story already exists for `session:*` lanes (`src/agents/pi-embedded-runner/lanes.ts`). The realistic upper bound is the number of active sessions, which is already bounded. A future \"reap idle nested lanes\" pass can be added if it becomes a concern; deliberately out of scope for this fix.

- **Risk:** A lane label collision between the scoped nested lane and a user-supplied lane named `\"nested:something\"`.
  - **Mitigation:** `resolveNestedAgentLane` still honours caller-supplied lanes verbatim (first-call-wins via `?? resolveNestedAgentLaneForSession(...)`), and the new prefix `nested:` is namespaced to mirror the existing `session:<key>` convention.

- **Risk:** Out-of-scope sub-issues from the same report (delivery-context corruption where the session's `channel` field degrades from `\"discord\"` to `\"webchat\"`, and the absence of delivery retry / DLQ) remain.
  - **Mitigation:** Those are genuinely architectural follow-ups. This PR addresses the root lane-congestion cause the reporter documented first and lists the remaining two fixes as explicit future work in #67502.

---

AI-assisted: This PR was developed with AI assistance.