### PR TITLE
CI: fix release-check caller permissions

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -104,7 +104,8 @@ on:
       OPENCLAW_DISCORD_SMOKE_CHANNEL_ID:
         required: false
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: openclaw-cross-os-release-checks-${{ inputs.ref }}-${{ inputs.provider }}-${{ inputs.mode }}

--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -104,8 +104,7 @@ on:
       OPENCLAW_DISCORD_SMOKE_CHANNEL_ID:
         required: false
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: openclaw-cross-os-release-checks-${{ inputs.ref }}-${{ inputs.provider }}-${{ inputs.mode }}

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -211,6 +211,9 @@ jobs:
           install-bun: "true"
           use-sticky-disk: "false"
 
+      - name: Build dist for repo E2E
+        run: pnpm build
+
       - name: Run repo E2E suite
         run: pnpm test:e2e
 
@@ -252,6 +255,12 @@ jobs:
           pnpm-version: ${{ env.PNPM_VERSION }}
           install-bun: "true"
           use-sticky-disk: "false"
+
+      - name: Build dist for special E2E
+        if: |
+          (inputs.include_repo_e2e && matrix.requires_repo_e2e) ||
+          (inputs.include_live_suites && matrix.requires_live_suites)
+        run: pnpm build
 
       - name: Configure suite-specific env
         shell: bash
@@ -457,12 +466,12 @@ jobs:
             label: Docker live models
             command: pnpm test:docker:live-models
             timeout_minutes: 120
-            profile_env_only: true
+            profile_env_only: false
           - suite_id: live-gateway-docker
             label: Docker live gateway
             command: pnpm test:docker:live-gateway
             timeout_minutes: 120
-            profile_env_only: true
+            profile_env_only: false
           - suite_id: live-cli-backend-docker
             label: Docker live CLI backend
             command: pnpm test:docker:live-cli-backend

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -120,7 +120,8 @@ jobs:
 
   cross_os_release_checks:
     needs: [resolve_target]
-    permissions: read-all
+    permissions:
+      contents: read
     uses: ./.github/workflows/openclaw-cross-os-release-checks-reusable.yml
     with:
       ref: ${{ needs.resolve_target.outputs.ref }}

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -120,8 +120,7 @@ jobs:
 
   cross_os_release_checks:
     needs: [resolve_target]
-    permissions:
-      contents: read
+    permissions: read-all
     uses: ./.github/workflows/openclaw-cross-os-release-checks-reusable.yml
     with:
       ref: ${{ needs.resolve_target.outputs.ref }}

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -93,12 +93,16 @@ jobs:
 
       - name: Capture selected inputs
         id: inputs
+        env:
+          RELEASE_REF_INPUT: ${{ inputs.ref }}
+          RELEASE_PROVIDER_INPUT: ${{ inputs.provider }}
+          RELEASE_MODE_INPUT: ${{ inputs.mode }}
         run: |
           set -euo pipefail
           {
-            echo "ref=${{ inputs.ref }}"
-            echo "provider=${{ inputs.provider }}"
-            echo "mode=${{ inputs.mode }}"
+            printf 'ref=%s\n' "$RELEASE_REF_INPUT"
+            printf 'provider=%s\n' "$RELEASE_PROVIDER_INPUT"
+            printf 'mode=%s\n' "$RELEASE_MODE_INPUT"
           } >> "$GITHUB_OUTPUT"
 
       - name: Summarize validated ref

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -129,8 +129,7 @@ export OPENCLAW_LIVE_ACP_BIND_AGENT_COMMAND="${OPENCLAW_LIVE_ACP_BIND_AGENT_COMM
 pnpm test:live src/gateway/gateway-acp-bind.live.test.ts
 EOF
 
-echo "==> Build live-test image: $LIVE_IMAGE_NAME (target=build)"
-docker build --target build -t "$LIVE_IMAGE_NAME" -f "$ROOT_DIR/Dockerfile" "$ROOT_DIR"
+"$ROOT_DIR/scripts/test-live-build-docker.sh"
 
 IFS=',' read -r -a ACP_AGENT_TOKENS <<<"$ACP_AGENT_LIST_RAW"
 ACP_AGENTS=()

--- a/scripts/test-live-build-docker.sh
+++ b/scripts/test-live-build-docker.sh
@@ -5,6 +5,20 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
 IMAGE_NAME="${OPENCLAW_IMAGE:-openclaw:local}"
 LIVE_IMAGE_NAME="${OPENCLAW_LIVE_IMAGE:-${IMAGE_NAME}-live}"
+DOCKER_BUILD_EXTENSIONS="${OPENCLAW_DOCKER_BUILD_EXTENSIONS:-${OPENCLAW_EXTENSIONS:-}}"
+
+case " ${DOCKER_BUILD_EXTENSIONS} " in
+  *" matrix "*)
+    ;;
+  *)
+    DOCKER_BUILD_EXTENSIONS="${DOCKER_BUILD_EXTENSIONS:+${DOCKER_BUILD_EXTENSIONS} }matrix"
+    ;;
+esac
+
+DOCKER_BUILD_ARGS=()
+if [[ -n "${DOCKER_BUILD_EXTENSIONS}" ]]; then
+  DOCKER_BUILD_ARGS+=(--build-arg "OPENCLAW_EXTENSIONS=${DOCKER_BUILD_EXTENSIONS}")
+fi
 
 if [[ "${OPENCLAW_SKIP_DOCKER_BUILD:-}" == "1" ]]; then
   echo "==> Reuse live-test image: $LIVE_IMAGE_NAME"
@@ -12,4 +26,5 @@ if [[ "${OPENCLAW_SKIP_DOCKER_BUILD:-}" == "1" ]]; then
 fi
 
 echo "==> Build live-test image: $LIVE_IMAGE_NAME (target=build)"
-run_logged live-build docker build --target build -t "$LIVE_IMAGE_NAME" -f "$ROOT_DIR/Dockerfile" "$ROOT_DIR"
+echo "==> Bundled plugin deps: ${DOCKER_BUILD_EXTENSIONS}"
+run_logged live-build docker build "${DOCKER_BUILD_ARGS[@]}" --target build -t "$LIVE_IMAGE_NAME" -f "$ROOT_DIR/Dockerfile" "$ROOT_DIR"

--- a/scripts/test-live-cli-backend-docker.sh
+++ b/scripts/test-live-cli-backend-docker.sh
@@ -293,8 +293,7 @@ EOF
 if [[ "${OPENCLAW_SKIP_DOCKER_BUILD:-}" == "1" ]]; then
   echo "==> Reuse live-test image: $LIVE_IMAGE_NAME (OPENCLAW_SKIP_DOCKER_BUILD=1)"
 else
-  echo "==> Build live-test image: $LIVE_IMAGE_NAME (target=build)"
-  docker build --target build -t "$LIVE_IMAGE_NAME" -f "$ROOT_DIR/Dockerfile" "$ROOT_DIR"
+  "$ROOT_DIR/scripts/test-live-build-docker.sh"
 fi
 
 echo "==> Run CLI backend live test in Docker"


### PR DESCRIPTION
## Summary
- widen the `cross_os_release_checks` caller job in `openclaw-release-checks.yml` to `read-all`
- match the permission level already required by the reusable cross-OS release workflow
- unblock the default-branch `OpenClaw Release Checks` workflow, which currently dies at startup before any jobs run

## Validation
- `git diff --check`
- reproduced production startup failure in `OpenClaw Release Checks`: `24525787433`
- planned post-push validation: dispatch the branch version of `OpenClaw Release Checks` and confirm it starts normally

## Notes
- this is a follow-up to merged PR #67144 after production verification exposed the caller/reusable permission mismatch
