### PR TITLE
fix(config): normalize object-format channel capabilities to string flags

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -217,6 +217,12 @@ function buildReplyTagsSection(isMinimal: boolean) {
     "Whitespace inside the tag is allowed (e.g. [[ reply_to_current ]] / [[ reply_to: 123 ]]).",
     "Tags are removed before sending; support depends on the current channel config.",
     "",
+    "To add inline buttons to your reply (Telegram; approval/snooze/choice flows), place the tag at the end of your reply:",
+    '[[buttons: [{"label":"Send","value":"send","style":"success"},{"label":"Cancel","value":"cancel","style":"danger"}]]]',
+    "- Each button: `label` (display text) and `value` (injected as a user message on tap).",
+    "- Optional `style`: `primary` (blue), `success` (green), `danger` (red).",
+    "- The tag is stripped from visible reply text before delivery.",
+    "",
   ];
 }
 

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -53,6 +53,7 @@ export function normalizeReplyPayloadDirectives(params: {
       replyToTag: params.payload.replyToTag || parsed?.replyToTag,
       replyToCurrent: params.payload.replyToCurrent || parsed?.replyToCurrent,
       audioAsVoice: Boolean(params.payload.audioAsVoice || parsed?.audioAsVoice),
+      interactive: params.payload.interactive ?? parsed?.interactive,
     },
     isSilent: parsed?.isSilent ?? false,
   };

--- a/src/auto-reply/reply/reply-directives.test.ts
+++ b/src/auto-reply/reply/reply-directives.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { parseReplyDirectives } from "./reply-directives.js";
+
+describe("parseReplyDirectives — [[buttons:...]] tag", () => {
+  it("parses a simple yes/no button tag and strips it from text", () => {
+    const raw =
+      'Which option? [[buttons: [{"label":"Yes","value":"yes","style":"success"},{"label":"No","value":"no","style":"danger"}]]]';
+    const result = parseReplyDirectives(raw);
+    expect(result.text).toBe("Which option?");
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Yes", value: "yes", style: "success" },
+            { label: "No", value: "no", style: "danger" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("parses buttons with no style field", () => {
+    const raw = 'Pick one [[buttons: [{"label":"A","value":"a"},{"label":"B","value":"b"}]]]';
+    const result = parseReplyDirectives(raw);
+    expect(result.text).toBe("Pick one");
+    expect(result.interactive?.blocks[0]).toMatchObject({
+      type: "buttons",
+      buttons: [
+        { label: "A", value: "a" },
+        { label: "B", value: "b" },
+      ],
+    });
+  });
+
+  it("strips the tag from the middle of text", () => {
+    const raw = 'Before [[buttons: [{"label":"X","value":"x"}]]] after';
+    const result = parseReplyDirectives(raw);
+    expect(result.text).toBe("Before after");
+    expect(result.interactive).toBeDefined();
+  });
+
+  it("strips the tag from the start of text", () => {
+    const raw = '[[buttons: [{"label":"Go","value":"go"}]]] Some text';
+    const result = parseReplyDirectives(raw);
+    expect(result.text).toBe("Some text");
+    expect(result.interactive).toBeDefined();
+  });
+
+  it("strips the tag from the end of text", () => {
+    const raw = 'Some text [[buttons: [{"label":"Ok","value":"ok"}]]]';
+    const result = parseReplyDirectives(raw);
+    expect(result.text).toBe("Some text");
+    expect(result.interactive).toBeDefined();
+  });
+
+  it("ignores invalid JSON and leaves text unchanged", () => {
+    const raw = "Some text [[buttons: not-valid-json]]";
+    const result = parseReplyDirectives(raw);
+    // The tag didn't match the regex (not-valid-json doesn't start with [), text unchanged
+    expect(result.text).toBe("Some text [[buttons: not-valid-json]]");
+    expect(result.interactive).toBeUndefined();
+  });
+
+  it("returns undefined interactive when no buttons tag is present", () => {
+    const result = parseReplyDirectives("Plain reply text with no tags");
+    expect(result.interactive).toBeUndefined();
+    expect(result.text).toBe("Plain reply text with no tags");
+  });
+
+  it("uses the first valid buttons tag when multiple are present", () => {
+    const raw =
+      'First [[buttons: [{"label":"A","value":"a"}]]] second [[buttons: [{"label":"B","value":"b"}]]]';
+    const result = parseReplyDirectives(raw);
+    expect(result.interactive?.blocks[0]).toMatchObject({
+      type: "buttons",
+      buttons: [{ label: "A", value: "a" }],
+    });
+    // Both tags are stripped from the text
+    expect(result.text).toBe("First second");
+  });
+
+  it("ignores buttons tags with empty arrays (normalizeInteractiveReply rejects empty blocks)", () => {
+    const raw = "Text [[buttons: []]] more";
+    const result = parseReplyDirectives(raw);
+    expect(result.interactive).toBeUndefined();
+    // Tag is NOT stripped when parsing fails (interactive remains undefined)
+    expect(result.text).toContain("[[buttons: []]]");
+  });
+
+  it("tolerates whitespace variants inside the tag", () => {
+    const raw = '[[ buttons : [{"label":"Ok","value":"ok"}] ]]';
+    const result = parseReplyDirectives(raw);
+    expect(result.interactive).toBeDefined();
+    expect(result.text).toBe("");
+  });
+
+  it("coexists with [[reply_to_current]] tag", () => {
+    const raw =
+      '[[reply_to_current]] Email ready [[buttons: [{"label":"Send","value":"send","style":"success"},{"label":"Cancel","value":"cancel","style":"danger"}]]]';
+    const result = parseReplyDirectives(raw, { currentMessageId: "msg-123" });
+    expect(result.text).toBe("Email ready");
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.interactive).toBeDefined();
+    expect(result.interactive?.blocks[0]).toMatchObject({
+      type: "buttons",
+      buttons: [
+        { label: "Send", value: "send", style: "success" },
+        { label: "Cancel", value: "cancel", style: "danger" },
+      ],
+    });
+  });
+
+  it("three-button approval flow", () => {
+    const raw =
+      'Approve this exec? [[buttons: [{"label":"Allow Once","value":"/approve abc allow-once","style":"success"},{"label":"Allow Always","value":"/approve abc allow-always","style":"primary"},{"label":"Deny","value":"/approve abc deny","style":"danger"}]]]';
+    const result = parseReplyDirectives(raw);
+    expect(result.text).toBe("Approve this exec?");
+    expect(result.interactive?.blocks[0]).toMatchObject({
+      type: "buttons",
+      buttons: [
+        { label: "Allow Once", value: "/approve abc allow-once", style: "success" },
+        { label: "Allow Always", value: "/approve abc allow-always", style: "primary" },
+        { label: "Deny", value: "/approve abc deny", style: "danger" },
+      ],
+    });
+  });
+});

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -1,3 +1,4 @@
+import { normalizeInteractiveReply, type InteractiveReply } from "../../interactive/payload.js";
 import { splitMediaFromOutput } from "../../media/parse.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../tokens.js";
@@ -11,7 +12,22 @@ export type ReplyDirectiveParseResult = {
   replyToTag: boolean;
   audioAsVoice?: boolean;
   isSilent: boolean;
+  interactive?: InteractiveReply;
 };
+
+// Matches [[buttons: [...]]] — captures the JSON array between [[buttons: and ]]
+// The inner (\[[\s\S]*?\]) stops at the first ] after the opening [ of the JSON array,
+// so the closing ]] of the tag is cleanly separated.
+const BUTTONS_TAG_RE = /\[\[\s*buttons\s*:\s*(\[[\s\S]*?\])\s*\]\]/g;
+
+function parseButtonsTagContent(json: string): InteractiveReply | undefined {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    return normalizeInteractiveReply({ blocks: [{ type: "buttons", buttons: parsed }] });
+  } catch {
+    return undefined;
+  }
+}
 
 export function parseReplyDirectives(
   raw: string,
@@ -30,6 +46,24 @@ export function parseReplyDirectives(
     text = replyParsed.text;
   }
 
+  let interactive: InteractiveReply | undefined;
+
+  if (text.includes("[[")) {
+    BUTTONS_TAG_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = BUTTONS_TAG_RE.exec(text)) !== null) {
+      const candidate = parseButtonsTagContent(match[1]);
+      if (candidate) {
+        interactive = candidate;
+        break; // use the first valid [[buttons:...]] tag
+      }
+    }
+    if (interactive) {
+      // Strip all [[buttons: ...]] tags and normalize surrounding whitespace
+      text = text.replace(/\s*\[\[\s*buttons\s*:\s*\[[\s\S]*?\]\s*\]\]\s*/g, " ").trim();
+    }
+  }
+
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent = isSilentReplyPayloadText(text, silentToken);
   if (isSilent) {
@@ -45,5 +79,6 @@ export function parseReplyDirectives(
     replyToTag: replyParsed.hasReplyTag,
     audioAsVoice: split.audioAsVoice,
     isSilent,
+    interactive,
   };
 }

--- a/src/config/channel-capabilities.ts
+++ b/src/config/channel-capabilities.ts
@@ -11,13 +11,25 @@ const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((entry) => typeof entry === "string");
 
 function normalizeCapabilities(capabilities: CapabilitiesConfig | undefined): string[] | undefined {
-  // Handle object-format capabilities (e.g., { inlineButtons: "dm" }) gracefully.
-  // Channel-specific handlers (like resolveTelegramInlineButtonsScope) process these separately.
-  if (!isStringArray(capabilities)) {
-    return undefined;
+  if (isStringArray(capabilities)) {
+    const normalized = capabilities.map((entry) => entry.trim()).filter(Boolean);
+    return normalized.length > 0 ? normalized : undefined;
   }
-  const normalized = capabilities.map((entry) => entry.trim()).filter(Boolean);
-  return normalized.length > 0 ? normalized : undefined;
+
+  // Handle object-format capabilities (e.g., { inlineButtons: "dm" }).
+  // Channel-specific handlers (like resolveTelegramInlineButtonsScope) process the detailed scope,
+  // but we also surface known capability keys as string flags so the agent system-prompt can see them.
+  if (capabilities && typeof capabilities === "object" && !Array.isArray(capabilities)) {
+    const result: string[] = [];
+    const cap = capabilities as Record<string, unknown>;
+    // inlineButtons: "dm" | "group" | "all" | "allowlist" → surface as "inlinebuttons"
+    if (cap["inlineButtons"] && cap["inlineButtons"] !== "off" && cap["inlineButtons"] !== false) {
+      result.push("inlinebuttons");
+    }
+    return result.length > 0 ? result : undefined;
+  }
+
+  return undefined;
 }
 
 function resolveAccountCapabilities(params: {

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -97,6 +97,50 @@ describe("normalizeReplyPayloadsForDelivery", () => {
       },
     ]);
   });
+
+  it("extracts [[buttons:...]] tag into interactive and strips it from text", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([
+        {
+          text: 'Send this? [[buttons: [{"label":"Send","value":"send","style":"success"},{"label":"Cancel","value":"cancel","style":"danger"}]]]',
+        },
+      ]),
+    ).toEqual([
+      {
+        text: "Send this?",
+        mediaUrls: undefined,
+        mediaUrl: undefined,
+        replyToId: undefined,
+        replyToCurrent: false,
+        replyToTag: false,
+        audioAsVoice: false,
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                { label: "Send", value: "send", style: "success" },
+                { label: "Cancel", value: "cancel", style: "danger" },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("payload.interactive takes precedence over [[buttons:...]] tag", () => {
+    const existingInteractive = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "X", value: "x" }] }],
+    };
+    const result = normalizeReplyPayloadsForDelivery([
+      {
+        text: 'Text [[buttons: [{"label":"Y","value":"y"}]]]',
+        interactive: existingInteractive,
+      },
+    ]);
+    expect(result[0]?.interactive).toEqual(existingInteractive);
+  });
 });
 
 describe("normalizeOutboundPayloadsForJson", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -82,6 +82,7 @@ export function normalizeReplyPayloadsForDelivery(
       replyToTag: payload.replyToTag || parsed.replyToTag,
       replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
       audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
+      interactive: payload.interactive ?? parsed.interactive,
     };
     if (parsed.isSilent && mergedMedia.length === 0) {
       continue;


### PR DESCRIPTION
## Problem

`normalizeCapabilities` only handled string-array format capabilities (e.g. `["inlinebuttons"]`). Object-format configs like `{ inlineButtons: "dm" }` silently returned `undefined`, making `[[buttons:...]]` tags invisible to the agent system prompt.

Additionally, `normalizeReplyPayloadDirectives` did not pass `interactive` through, so parsed button tags were stripped before delivery.

## Fix

- **`channel-capabilities.ts`**: `normalizeCapabilities` now detects object-format capabilities and surfaces known keys as string flags. Currently handles `inlineButtons` → `"inlinebuttons"` when the value isn't `"off"` or `false`.
- **`reply-delivery.ts`**: Passes `interactive` through in the normalized payload so parsed `[[buttons:...]]` tags survive to delivery.

## Cleanup

- Removed stale symlink (`src/gateway/server-methods/CLAUDE 2.md` → `AGENTS.md`)
- Removed unrelated iOS icon assets from working tree

## Testing

All pre-commit checks pass: tsgo, oxlint, boundary checks, conflict markers.