### PR TITLE
fix(compaction): stop retaining credential-like values

### DIFF
--- a/src/agents/anthropic-payload-log.test.ts
+++ b/src/agents/anthropic-payload-log.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { createAnthropicPayloadLogger } from "./anthropic-payload-log.js";
 
 describe("createAnthropicPayloadLogger", () => {
-  it("redacts image base64 payload data before writing logs", async () => {
+  it("sanitizes credential fields and image base64 payload data before writing logs", async () => {
     const lines: string[] = [];
     const logger = createAnthropicPayloadLogger({
       env: { OPENCLAW_ANTHROPIC_PAYLOAD_LOG: "1" },
@@ -19,6 +19,7 @@ describe("createAnthropicPayloadLogger", () => {
       messages: [
         {
           role: "user",
+          authorization: "Bearer sk-secret", // pragma: allowlist secret
           content: [
             {
               type: "image",
@@ -27,6 +28,11 @@ describe("createAnthropicPayloadLogger", () => {
           ],
         },
       ],
+      metadata: {
+        api_key: "sk-test", // pragma: allowlist secret
+        nestedToken: "shh", // pragma: allowlist secret
+        tokenBudget: 1024,
+      },
     };
     const streamFn: StreamFn = ((model, __, options) => {
       options?.onPayload?.(payload, model);
@@ -37,10 +43,17 @@ describe("createAnthropicPayloadLogger", () => {
     await wrapped?.({ api: "anthropic-messages" } as never, { messages: [] } as never, {});
 
     const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
-    const message = ((event.payload as { messages?: unknown[] } | undefined)?.messages ??
-      []) as Array<Record<string, unknown>>;
+    const sanitizedPayload = (event.payload ?? {}) as Record<string, unknown>;
+    const message = ((sanitizedPayload.messages as unknown[] | undefined) ?? []) as Array<
+      Record<string, unknown>
+    >;
     const source = (((message[0]?.content as Array<Record<string, unknown>> | undefined) ?? [])[0]
       ?.source ?? {}) as Record<string, unknown>;
+    const metadata = (sanitizedPayload.metadata ?? {}) as Record<string, unknown>;
+    expect(message[0]).not.toHaveProperty("authorization");
+    expect(metadata).not.toHaveProperty("api_key");
+    expect(metadata).not.toHaveProperty("nestedToken");
+    expect(metadata.tokenBudget).toBe(1024);
     expect(source.data).toBe("<redacted>");
     expect(source.bytes).toBe(4);
     expect(source.sha256).toBe(crypto.createHash("sha256").update("QUJDRA==").digest("hex"));

--- a/src/agents/anthropic-payload-log.ts
+++ b/src/agents/anthropic-payload-log.ts
@@ -7,7 +7,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
 import { parseBooleanValue } from "../utils/boolean.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
-import { redactImageDataForDiagnostics } from "./payload-redaction.js";
+import { sanitizeDiagnosticPayload } from "./payload-redaction.js";
 import { getQueuedFileWriter, type QueuedFileWriter } from "./queued-file-writer.js";
 
 type PayloadLogStage = "request" | "usage";
@@ -137,7 +137,7 @@ export function createAnthropicPayloadLogger(params: {
         return streamFn(model, context, options);
       }
       const nextOnPayload = (payload: unknown) => {
-        const redactedPayload = redactImageDataForDiagnostics(payload);
+        const redactedPayload = sanitizeDiagnosticPayload(payload);
         record({
           ...base,
           ts: new Date().toISOString(),

--- a/src/agents/compaction.identifier-policy.test.ts
+++ b/src/agents/compaction.identifier-policy.test.ts
@@ -6,6 +6,8 @@ describe("compaction identifier policy", () => {
     const built = buildCompactionSummarizationInstructions();
     expect(built).toContain("Preserve all opaque identifiers exactly as written");
     expect(built).toContain("UUIDs");
+    expect(built).not.toContain("tokens");
+    expect(built).not.toContain("API keys");
   });
 
   it("can disable identifier preservation with off policy", () => {

--- a/src/agents/compaction.identifier-preservation.test.ts
+++ b/src/agents/compaction.identifier-preservation.test.ts
@@ -71,6 +71,8 @@ describe("compaction identifier-preservation instructions", () => {
     expect(firstSummaryInstructions()).toContain("UUIDs");
     expect(firstSummaryInstructions()).toContain("IPs");
     expect(firstSummaryInstructions()).toContain("ports");
+    expect(firstSummaryInstructions()).not.toContain("tokens");
+    expect(firstSummaryInstructions()).not.toContain("API keys");
   });
 
   it("keeps identifier-preservation guidance when custom instructions are provided", async () => {
@@ -139,6 +141,8 @@ describe("buildCompactionSummarizationInstructions", () => {
     const result = buildCompactionSummarizationInstructions();
     expect(result).toContain("Preserve all opaque identifiers exactly as written");
     expect(result).not.toContain("Additional focus:");
+    expect(result).not.toContain("tokens");
+    expect(result).not.toContain("API keys");
   });
 
   it("appends custom instructions in a stable format", () => {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -37,7 +37,7 @@ const MERGE_SUMMARIES_INSTRUCTIONS = [
 ].join("\n");
 const IDENTIFIER_PRESERVATION_INSTRUCTIONS =
   "Preserve all opaque identifiers exactly as written (no shortening or reconstruction), " +
-  "including UUIDs, hashes, IDs, tokens, API keys, hostnames, IPs, ports, URLs, and file names.";
+  "including UUIDs, hashes, IDs, hostnames, IPs, ports, URLs, and file names.";
 
 export type CompactionSummarizationInstructions = {
   identifierPolicy?: AgentCompactionIdentifierPolicy;


### PR DESCRIPTION
# fix(compaction): stop retaining credential-like values

## Summary

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: default compaction instructions explicitly told the summarizer to preserve `tokens` and `API keys`, and the Anthropic payload logger only redacted image data before persisting request payloads.
- Why it matters: both paths could retain credential-like values longer than intended in local OpenClaw state.
- What changed: removed credential wording from the default compaction identifier-preservation text, switched Anthropic payload logging to `sanitizeDiagnosticPayload(...)`, and tightened focused tests around both behaviors.
- What did NOT change (scope boundary): custom compaction instructions still remain an explicit override, and Anthropic payload logging is still opt-in with the same file/output path behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `src/agents/compaction.ts` treated credentials as opaque identifiers that should survive compaction, and `src/agents/anthropic-payload-log.ts` persisted request payloads with image-only redaction instead of the existing credential-aware sanitizer.
- Missing detection / guardrail: the compaction tests only asserted that identifier-preservation guidance existed, not that it excluded credential wording, and the payload logger test only covered image redaction.
- Contributing context (if known): adjacent diagnostic code in `src/agents/cache-trace.ts` already used `sanitizeDiagnosticPayload(...)`, so the payload logger had drifted from the stricter local-persistence standard already present in the repo.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/compaction.identifier-policy.test.ts`, `src/agents/compaction.identifier-preservation.test.ts`, `src/agents/anthropic-payload-log.test.ts`
- Scenario the test should lock in: default compaction guidance preserves technical identifiers without mentioning credentials, and Anthropic payload logging omits credential-like fields while still redacting image/base64 data.
- Why this is the smallest reliable guardrail: both behaviors are pure runtime-policy decisions in local helper code and can be validated deterministically without live model/provider traffic.
- Existing test that already covers this (if any): `src/agents/anthropic-payload-log.test.ts` already covered image redaction; this change extends it to credential-shaped fields.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Compaction no longer tells the summarization model to preserve `tokens` or `API keys` verbatim in the default identifier-preservation path.
- When `OPENCLAW_ANTHROPIC_PAYLOAD_LOG=1` is enabled, credential-like fields are omitted from persisted request payloads while image payload redaction remains in place.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: This change narrows how credential-like values are retained in local compaction and diagnostic persistence. The main compatibility risk is over-redacting benign token-shaped field names; the existing `NON_CREDENTIAL_FIELD_NAMES` allowlist and the updated `tokenBudget` assertion in `anthropic-payload-log.test.ts` keep the logger from stripping known non-secret counters.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-107-generic x86_64
- Runtime/container: task workspace container
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `OPENCLAW_ANTHROPIC_PAYLOAD_LOG=1` in targeted unit coverage

### Steps

1. Inspect `src/agents/compaction.ts` on `main` and note that `IDENTIFIER_PRESERVATION_INSTRUCTIONS` included `tokens, API keys`.
2. Inspect `src/agents/anthropic-payload-log.ts` on `main` and note that request payload persistence used `redactImageDataForDiagnostics(...)`.
3. Apply this change and run `XDG_DATA_HOME=/tmp/openclaw-xdg PNPM_HOME=/tmp/openclaw-pnpm-home node scripts/test-projects.mjs src/agents/compaction.identifier-policy.test.ts src/agents/compaction.identifier-preservation.test.ts src/agents/anthropic-payload-log.test.ts`.

### Expected

- Default compaction guidance preserves operational identifiers without instructing the summarizer to retain credential wording.
- Anthropic payload logs omit credential-like fields and still redact image/base64 payload data.

### Actual

- Matched expected behavior.
- Targeted tests passed after implementation and again after rebasing onto the latest remote `main`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation command run:

`XDG_DATA_HOME=/tmp/openclaw-xdg PNPM_HOME=/tmp/openclaw-pnpm-home node scripts/test-projects.mjs src/agents/compaction.identifier-policy.test.ts src/agents/compaction.identifier-preservation.test.ts src/agents/anthropic-payload-log.test.ts`

Pass summary:

- `vitest.unit-fast.config.ts`: 2 files passed, 6 tests passed
- `vitest.agents.config.ts`: 1 file passed, 6 tests passed

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the final diff, confirmed the branch is rebased onto the latest remote `main`, and ran the focused test slice covering compaction guidance and Anthropic payload sanitization.
- Edge cases checked: the logger still preserves `tokenBudget` while removing `authorization`, `api_key`, and `nestedToken`, and the default compaction guidance still preserves `UUIDs`, `IPs`, and `ports` while dropping credential wording.
- What you did **not** verify: a live end-to-end compaction run writing a session transcript and a live Anthropic request producing a payload log entry.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - The default compaction policy no longer treats credentials as identifiers to preserve, so summaries may omit raw secret strings that some debugging workflows previously expected to stay verbatim.
- Mitigation:
  - This is the intended hardening change; custom identifier instructions remain available for explicit operator-controlled overrides.
- Risk:
  - Credential-field matching in `sanitizeDiagnosticPayload(...)` could remove benign token-shaped diagnostic keys.
- Mitigation:
  - The existing `NON_CREDENTIAL_FIELD_NAMES` allowlist remains in place, and the updated logger test locks in that `tokenBudget` is preserved.

## Branch

`fix-credential-redaction` on `drobison00/openclaw`. Head: `942f146b833b533fe10cfd818e24e0d8e709ce2b`.
