### PR TITLE
CI: fix live Docker auth mounts

### DIFF
--- a/scripts/ci-hydrate-live-auth.sh
+++ b/scripts/ci-hydrate-live-auth.sh
@@ -5,7 +5,7 @@ profile_path="${1:-${RUNNER_TEMP:-/tmp}/openclaw-live.profile}"
 
 mkdir -p "$(dirname "$profile_path")"
 : >"$profile_path"
-chmod 644 "$profile_path"
+chmod 600 "$profile_path"
 
 append_profile_env() {
   local key="$1"
@@ -24,9 +24,8 @@ write_secret_file() {
     return
   fi
   mkdir -p "$(dirname "$destination")"
-  chmod 755 "$(dirname "$destination")"
   printf '%s' "$value" >"$destination"
-  chmod 644 "$destination"
+  chmod 600 "$destination"
 }
 
 for env_key in \

--- a/scripts/ci-hydrate-live-auth.sh
+++ b/scripts/ci-hydrate-live-auth.sh
@@ -5,7 +5,7 @@ profile_path="${1:-${RUNNER_TEMP:-/tmp}/openclaw-live.profile}"
 
 mkdir -p "$(dirname "$profile_path")"
 : >"$profile_path"
-chmod 600 "$profile_path"
+chmod 644 "$profile_path"
 
 append_profile_env() {
   local key="$1"
@@ -24,8 +24,9 @@ write_secret_file() {
     return
   fi
   mkdir -p "$(dirname "$destination")"
+  chmod 755 "$(dirname "$destination")"
   printf '%s' "$value" >"$destination"
-  chmod 600 "$destination"
+  chmod 644 "$destination"
 }
 
 for env_key in \

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -8,8 +8,8 @@ LIVE_IMAGE_NAME="${OPENCLAW_LIVE_IMAGE:-${IMAGE_NAME}-live}"
 CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}"
 WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
 PROFILE_FILE="${OPENCLAW_PROFILE_FILE:-$HOME/.profile}"
-CLI_TOOLS_DIR="${OPENCLAW_DOCKER_CLI_TOOLS_DIR:-$HOME/.cache/openclaw/docker-cli-tools}"
 ACP_AGENT_LIST_RAW="${OPENCLAW_LIVE_ACP_BIND_AGENTS:-${OPENCLAW_LIVE_ACP_BIND_AGENT:-claude,codex,gemini}}"
+TEMP_DIRS=()
 
 openclaw_live_acp_bind_resolve_auth_provider() {
   case "${1:-}" in
@@ -32,17 +32,40 @@ openclaw_live_acp_bind_resolve_agent_command() {
   esac
 }
 
+cleanup_temp_dirs() {
+  if ((${#TEMP_DIRS[@]} > 0)); then
+    rm -rf "${TEMP_DIRS[@]}"
+  fi
+}
+trap cleanup_temp_dirs EXIT
+
+if [[ -n "${OPENCLAW_DOCKER_CLI_TOOLS_DIR:-}" ]]; then
+  CLI_TOOLS_DIR="${OPENCLAW_DOCKER_CLI_TOOLS_DIR}"
+elif [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  CLI_TOOLS_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/openclaw-docker-cli-tools.XXXXXX")"
+  TEMP_DIRS+=("$CLI_TOOLS_DIR")
+else
+  CLI_TOOLS_DIR="$HOME/.cache/openclaw/docker-cli-tools"
+fi
+
 mkdir -p "$CLI_TOOLS_DIR"
+chmod 0777 "$CLI_TOOLS_DIR" || true
 
 PROFILE_MOUNT=()
-if [[ -f "$PROFILE_FILE" ]]; then
+if [[ -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -f "$HOME/.profile" ] && source "$HOME/.profile" || true
-export PATH="$HOME/.npm-global/bin:$PATH"
+[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
+export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-$HOME/.npm-global}"
+export npm_config_prefix="$NPM_CONFIG_PREFIX"
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm-cache}"
+export npm_config_cache="$NPM_CONFIG_CACHE"
+mkdir -p "$NPM_CONFIG_PREFIX" "$NPM_CONFIG_CACHE"
+chmod 700 "$NPM_CONFIG_CACHE" || true
+export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
 IFS=',' read -r -a auth_dirs <<<"${OPENCLAW_DOCKER_AUTH_DIRS_RESOLVED:-}"
 IFS=',' read -r -a auth_files <<<"${OPENCLAW_DOCKER_AUTH_FILES_RESOLVED:-}"
 if ((${#auth_dirs[@]} > 0)); then
@@ -68,15 +91,15 @@ fi
 agent="${OPENCLAW_LIVE_ACP_BIND_AGENT:-claude}"
 case "$agent" in
   claude)
-    if [ ! -x "$HOME/.npm-global/bin/claude" ]; then
-      npm_config_prefix="$HOME/.npm-global" npm install -g @anthropic-ai/claude-code
+    if [ ! -x "$NPM_CONFIG_PREFIX/bin/claude" ]; then
+      npm install -g @anthropic-ai/claude-code
     fi
-    real_claude="$HOME/.npm-global/bin/claude-real"
-    if [ ! -x "$real_claude" ] && [ -x "$HOME/.npm-global/bin/claude" ]; then
-      mv "$HOME/.npm-global/bin/claude" "$real_claude"
+    real_claude="$NPM_CONFIG_PREFIX/bin/claude-real"
+    if [ ! -x "$real_claude" ] && [ -x "$NPM_CONFIG_PREFIX/bin/claude" ]; then
+      mv "$NPM_CONFIG_PREFIX/bin/claude" "$real_claude"
     fi
     if [ -x "$real_claude" ]; then
-      cat > "$HOME/.npm-global/bin/claude" <<WRAP
+      cat > "$NPM_CONFIG_PREFIX/bin/claude" <<WRAP
 #!/usr/bin/env bash
 script_dir="\$(CDPATH= cd -- "\$(dirname -- "\$0")" && pwd)"
 if [ -n "\${OPENCLAW_LIVE_ACP_BIND_ANTHROPIC_API_KEY:-}" ]; then
@@ -87,19 +110,19 @@ if [ -n "\${OPENCLAW_LIVE_ACP_BIND_ANTHROPIC_API_KEY_OLD:-}" ]; then
 fi
 exec "\$script_dir/claude-real" "\$@"
 WRAP
-      chmod +x "$HOME/.npm-global/bin/claude"
+      chmod +x "$NPM_CONFIG_PREFIX/bin/claude"
     fi
     claude auth status || true
     ;;
   codex)
-    if [ ! -x "$HOME/.npm-global/bin/codex" ]; then
-      npm_config_prefix="$HOME/.npm-global" npm install -g @openai/codex
+    if [ ! -x "$NPM_CONFIG_PREFIX/bin/codex" ]; then
+      npm install -g @openai/codex
     fi
     ;;
   gemini)
     mkdir -p "$HOME/.gemini"
-    if [ ! -x "$HOME/.npm-global/bin/gemini" ]; then
-      npm_config_prefix="$HOME/.npm-global" npm install -g @google/gemini-cli
+    if [ ! -x "$NPM_CONFIG_PREFIX/bin/gemini" ]; then
+      npm install -g @google/gemini-cli
     fi
     ;;
   *)

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -10,6 +10,7 @@ WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
 PROFILE_FILE="${OPENCLAW_PROFILE_FILE:-$HOME/.profile}"
 ACP_AGENT_LIST_RAW="${OPENCLAW_LIVE_ACP_BIND_AGENTS:-${OPENCLAW_LIVE_ACP_BIND_AGENT:-claude,codex,gemini}}"
 TEMP_DIRS=()
+DOCKER_USER="${OPENCLAW_DOCKER_USER:-node}"
 
 openclaw_live_acp_bind_resolve_auth_provider() {
   case "${1:-}" in
@@ -49,16 +50,18 @@ else
 fi
 
 mkdir -p "$CLI_TOOLS_DIR"
-chmod 0777 "$CLI_TOOLS_DIR" || true
+if [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  DOCKER_USER="$(id -u):$(id -g)"
+fi
 
 PROFILE_MOUNT=()
-if [[ -r "$PROFILE_FILE" ]]; then
+if [[ -f "$PROFILE_FILE" && -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
+[ -f "$HOME/.profile" ] && [ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
 export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-$HOME/.npm-global}"
 export npm_config_prefix="$NPM_CONFIG_PREFIX"
 export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm-cache}"
@@ -226,7 +229,7 @@ for ACP_AGENT in "${ACP_AGENTS[@]}"; do
   echo "==> Auth dirs: ${AUTH_DIRS_CSV:-none}"
   echo "==> Auth files: ${AUTH_FILES_CSV:-none}"
   docker run --rm -t \
-    -u node \
+    -u "$DOCKER_USER" \
     --entrypoint bash \
     -e ANTHROPIC_API_KEY \
     -e ANTHROPIC_API_KEY_OLD \

--- a/scripts/test-live-cli-backend-docker.sh
+++ b/scripts/test-live-cli-backend-docker.sh
@@ -8,12 +8,12 @@ LIVE_IMAGE_NAME="${OPENCLAW_LIVE_IMAGE:-${IMAGE_NAME}-live}"
 CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}"
 WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
 PROFILE_FILE="${OPENCLAW_PROFILE_FILE:-$HOME/.profile}"
-CLI_TOOLS_DIR="${OPENCLAW_DOCKER_CLI_TOOLS_DIR:-$HOME/.cache/openclaw/docker-cli-tools}"
 DEFAULT_PROVIDER="${OPENCLAW_DOCKER_CLI_BACKEND_PROVIDER:-claude-cli}"
 CLI_MODEL="${OPENCLAW_LIVE_CLI_BACKEND_MODEL:-}"
 CLI_PROVIDER="${CLI_MODEL%%/*}"
 CLI_DISABLE_MCP_CONFIG="${OPENCLAW_LIVE_CLI_BACKEND_DISABLE_MCP_CONFIG:-}"
 CLI_AUTH_MODE="${OPENCLAW_LIVE_CLI_BACKEND_AUTH:-auto}"
+TEMP_DIRS=()
 
 if [[ -z "$CLI_PROVIDER" || "$CLI_PROVIDER" == "$CLI_MODEL" ]]; then
   CLI_PROVIDER="$DEFAULT_PROVIDER"
@@ -55,7 +55,24 @@ if [[ "$CLI_PROVIDER" == "claude-cli" && -z "$CLI_DISABLE_MCP_CONFIG" ]]; then
   fi
 fi
 
+cleanup_temp_dirs() {
+  if ((${#TEMP_DIRS[@]} > 0)); then
+    rm -rf "${TEMP_DIRS[@]}"
+  fi
+}
+trap cleanup_temp_dirs EXIT
+
+if [[ -n "${OPENCLAW_DOCKER_CLI_TOOLS_DIR:-}" ]]; then
+  CLI_TOOLS_DIR="${OPENCLAW_DOCKER_CLI_TOOLS_DIR}"
+elif [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  CLI_TOOLS_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/openclaw-docker-cli-tools.XXXXXX")"
+  TEMP_DIRS+=("$CLI_TOOLS_DIR")
+else
+  CLI_TOOLS_DIR="$HOME/.cache/openclaw/docker-cli-tools"
+fi
+
 mkdir -p "$CLI_TOOLS_DIR"
+chmod 0777 "$CLI_TOOLS_DIR" || true
 
 if [[ "$CLI_PROVIDER" == "claude-cli" && "$CLI_AUTH_MODE" == "subscription" ]]; then
   CLAUDE_CREDS_FILE="$HOME/.claude/.credentials.json"
@@ -108,7 +125,7 @@ if [[ "$CLI_PROVIDER" == "claude-cli" && "$CLI_AUTH_MODE" == "subscription" ]]; 
 fi
 
 PROFILE_MOUNT=()
-if [[ -f "$PROFILE_FILE" ]]; then
+if [[ -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
@@ -162,8 +179,14 @@ fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -f "$HOME/.profile" ] && source "$HOME/.profile" || true
-export PATH="$HOME/.npm-global/bin:$PATH"
+[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
+export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-$HOME/.npm-global}"
+export npm_config_prefix="$NPM_CONFIG_PREFIX"
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm-cache}"
+export npm_config_cache="$NPM_CONFIG_CACHE"
+mkdir -p "$NPM_CONFIG_PREFIX" "$NPM_CONFIG_CACHE"
+chmod 700 "$NPM_CONFIG_CACHE" || true
+export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
 IFS=',' read -r -a auth_dirs <<<"${OPENCLAW_DOCKER_AUTH_DIRS_RESOLVED:-}"
 IFS=',' read -r -a auth_files <<<"${OPENCLAW_DOCKER_AUTH_FILES_RESOLVED:-}"
 if ((${#auth_dirs[@]} > 0)); then
@@ -194,10 +217,10 @@ if [ -z "$binary_name" ] && [ -n "$default_command" ]; then
   binary_name="$(basename "$default_command")"
 fi
 if [ -z "${OPENCLAW_LIVE_CLI_BACKEND_COMMAND:-}" ] && [ -n "$binary_name" ]; then
-  export OPENCLAW_LIVE_CLI_BACKEND_COMMAND="$HOME/.npm-global/bin/$binary_name"
+  export OPENCLAW_LIVE_CLI_BACKEND_COMMAND="$NPM_CONFIG_PREFIX/bin/$binary_name"
 fi
 if [ -n "${OPENCLAW_LIVE_CLI_BACKEND_COMMAND:-}" ] && [ ! -x "${OPENCLAW_LIVE_CLI_BACKEND_COMMAND}" ] && [ -n "$docker_package" ]; then
-  npm_config_prefix="$HOME/.npm-global" npm install -g "$docker_package"
+  npm install -g "$docker_package"
 fi
 if [ "$provider" = "claude-cli" ]; then
   auth_mode="${OPENCLAW_LIVE_CLI_BACKEND_AUTH:-auto}"
@@ -224,12 +247,12 @@ if (fs.existsSync(file)) {
 }
 NODE
   fi
-  real_claude="$HOME/.npm-global/bin/claude-real"
-  if [ ! -x "$real_claude" ] && [ -x "$HOME/.npm-global/bin/claude" ]; then
-    mv "$HOME/.npm-global/bin/claude" "$real_claude"
+  real_claude="$NPM_CONFIG_PREFIX/bin/claude-real"
+  if [ ! -x "$real_claude" ] && [ -x "$NPM_CONFIG_PREFIX/bin/claude" ]; then
+    mv "$NPM_CONFIG_PREFIX/bin/claude" "$real_claude"
   fi
   if [ -x "$real_claude" ]; then
-    cat > "$HOME/.npm-global/bin/claude" <<WRAP
+    cat > "$NPM_CONFIG_PREFIX/bin/claude" <<WRAP
 #!/usr/bin/env bash
 script_dir="\$(CDPATH= cd -- "\$(dirname -- "\$0")" && pwd)"
 if [ -n "\${OPENCLAW_LIVE_CLI_BACKEND_ANTHROPIC_API_KEY:-}" ]; then
@@ -240,7 +263,7 @@ if [ -n "\${OPENCLAW_LIVE_CLI_BACKEND_ANTHROPIC_API_KEY_OLD:-}" ]; then
 fi
 exec "\$script_dir/claude-real" "\$@"
 WRAP
-    chmod +x "$HOME/.npm-global/bin/claude"
+    chmod +x "$NPM_CONFIG_PREFIX/bin/claude"
   fi
   if [ -z "${OPENCLAW_LIVE_CLI_BACKEND_PRESERVE_ENV:-}" ]; then
     export OPENCLAW_LIVE_CLI_BACKEND_PRESERVE_ENV='["ANTHROPIC_API_KEY","ANTHROPIC_API_KEY_OLD"]'

--- a/scripts/test-live-cli-backend-docker.sh
+++ b/scripts/test-live-cli-backend-docker.sh
@@ -14,6 +14,7 @@ CLI_PROVIDER="${CLI_MODEL%%/*}"
 CLI_DISABLE_MCP_CONFIG="${OPENCLAW_LIVE_CLI_BACKEND_DISABLE_MCP_CONFIG:-}"
 CLI_AUTH_MODE="${OPENCLAW_LIVE_CLI_BACKEND_AUTH:-auto}"
 TEMP_DIRS=()
+DOCKER_USER="${OPENCLAW_DOCKER_USER:-node}"
 
 if [[ -z "$CLI_PROVIDER" || "$CLI_PROVIDER" == "$CLI_MODEL" ]]; then
   CLI_PROVIDER="$DEFAULT_PROVIDER"
@@ -72,7 +73,9 @@ else
 fi
 
 mkdir -p "$CLI_TOOLS_DIR"
-chmod 0777 "$CLI_TOOLS_DIR" || true
+if [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  DOCKER_USER="$(id -u):$(id -g)"
+fi
 
 if [[ "$CLI_PROVIDER" == "claude-cli" && "$CLI_AUTH_MODE" == "subscription" ]]; then
   CLAUDE_CREDS_FILE="$HOME/.claude/.credentials.json"
@@ -125,7 +128,7 @@ if [[ "$CLI_PROVIDER" == "claude-cli" && "$CLI_AUTH_MODE" == "subscription" ]]; 
 fi
 
 PROFILE_MOUNT=()
-if [[ -r "$PROFILE_FILE" ]]; then
+if [[ -f "$PROFILE_FILE" && -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
@@ -179,7 +182,7 @@ fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
+[ -f "$HOME/.profile" ] && [ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
 export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-$HOME/.npm-global}"
 export npm_config_prefix="$NPM_CONFIG_PREFIX"
 export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm-cache}"
@@ -348,7 +351,7 @@ else
 fi
 
 docker run --rm -t \
-  -u node \
+  -u "$DOCKER_USER" \
   --entrypoint bash \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e HOME=/home/node \

--- a/scripts/test-live-codex-harness-docker.sh
+++ b/scripts/test-live-codex-harness-docker.sh
@@ -8,12 +8,29 @@ LIVE_IMAGE_NAME="${OPENCLAW_LIVE_IMAGE:-${IMAGE_NAME}-live}"
 CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}"
 WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
 PROFILE_FILE="${OPENCLAW_PROFILE_FILE:-$HOME/.profile}"
-CLI_TOOLS_DIR="${OPENCLAW_DOCKER_CLI_TOOLS_DIR:-$HOME/.cache/openclaw/docker-cli-tools}"
+TEMP_DIRS=()
+
+cleanup_temp_dirs() {
+  if ((${#TEMP_DIRS[@]} > 0)); then
+    rm -rf "${TEMP_DIRS[@]}"
+  fi
+}
+trap cleanup_temp_dirs EXIT
+
+if [[ -n "${OPENCLAW_DOCKER_CLI_TOOLS_DIR:-}" ]]; then
+  CLI_TOOLS_DIR="${OPENCLAW_DOCKER_CLI_TOOLS_DIR}"
+elif [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  CLI_TOOLS_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/openclaw-docker-cli-tools.XXXXXX")"
+  TEMP_DIRS+=("$CLI_TOOLS_DIR")
+else
+  CLI_TOOLS_DIR="$HOME/.cache/openclaw/docker-cli-tools"
+fi
 
 mkdir -p "$CLI_TOOLS_DIR"
+chmod 0777 "$CLI_TOOLS_DIR" || true
 
 PROFILE_MOUNT=()
-if [[ -f "$PROFILE_FILE" ]]; then
+if [[ -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
@@ -40,8 +57,14 @@ fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -f "$HOME/.profile" ] && source "$HOME/.profile" || true
-export PATH="$HOME/.npm-global/bin:$PATH"
+[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
+export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-$HOME/.npm-global}"
+export npm_config_prefix="$NPM_CONFIG_PREFIX"
+export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm-cache}"
+export npm_config_cache="$NPM_CONFIG_CACHE"
+mkdir -p "$NPM_CONFIG_PREFIX" "$NPM_CONFIG_CACHE"
+chmod 700 "$NPM_CONFIG_CACHE" || true
+export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
 IFS=',' read -r -a auth_files <<<"${OPENCLAW_DOCKER_AUTH_FILES_RESOLVED:-}"
 if ((${#auth_files[@]} > 0)); then
   for auth_file in "${auth_files[@]}"; do
@@ -53,8 +76,8 @@ if ((${#auth_files[@]} > 0)); then
     fi
   done
 fi
-if [ ! -x "$HOME/.npm-global/bin/codex" ]; then
-  npm_config_prefix="$HOME/.npm-global" npm install -g @openai/codex
+if [ ! -x "$NPM_CONFIG_PREFIX/bin/codex" ]; then
+  npm install -g @openai/codex
 fi
 tmp_dir="$(mktemp -d)"
 cleanup() {

--- a/scripts/test-live-codex-harness-docker.sh
+++ b/scripts/test-live-codex-harness-docker.sh
@@ -9,6 +9,7 @@ CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}"
 WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
 PROFILE_FILE="${OPENCLAW_PROFILE_FILE:-$HOME/.profile}"
 TEMP_DIRS=()
+DOCKER_USER="${OPENCLAW_DOCKER_USER:-node}"
 
 cleanup_temp_dirs() {
   if ((${#TEMP_DIRS[@]} > 0)); then
@@ -27,10 +28,12 @@ else
 fi
 
 mkdir -p "$CLI_TOOLS_DIR"
-chmod 0777 "$CLI_TOOLS_DIR" || true
+if [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  DOCKER_USER="$(id -u):$(id -g)"
+fi
 
 PROFILE_MOUNT=()
-if [[ -r "$PROFILE_FILE" ]]; then
+if [[ -f "$PROFILE_FILE" && -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
@@ -57,7 +60,7 @@ fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
+[ -f "$HOME/.profile" ] && [ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
 export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-$HOME/.npm-global}"
 export npm_config_prefix="$NPM_CONFIG_PREFIX"
 export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm-cache}"
@@ -106,7 +109,7 @@ echo "==> MCP probe: ${OPENCLAW_LIVE_CODEX_HARNESS_MCP_PROBE:-1}"
 echo "==> Harness fallback: none"
 echo "==> Auth files: ${AUTH_FILES_CSV:-none}"
 docker run --rm -t \
-  -u node \
+  -u "$DOCKER_USER" \
   --entrypoint bash \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e HOME=/home/node \

--- a/scripts/test-live-gateway-models-docker.sh
+++ b/scripts/test-live-gateway-models-docker.sh
@@ -8,9 +8,13 @@ LIVE_IMAGE_NAME="${OPENCLAW_LIVE_IMAGE:-${IMAGE_NAME}-live}"
 CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}"
 WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
 PROFILE_FILE="${OPENCLAW_PROFILE_FILE:-$HOME/.profile}"
+DOCKER_USER="${OPENCLAW_DOCKER_USER:-node}"
+if [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  DOCKER_USER="$(id -u):$(id -g)"
+fi
 
 PROFILE_MOUNT=()
-if [[ -r "$PROFILE_FILE" ]]; then
+if [[ -f "$PROFILE_FILE" && -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
@@ -73,7 +77,7 @@ fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
+[ -f "$HOME/.profile" ] && [ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
 IFS=',' read -r -a auth_dirs <<<"${OPENCLAW_DOCKER_AUTH_DIRS_RESOLVED:-}"
 IFS=',' read -r -a auth_files <<<"${OPENCLAW_DOCKER_AUTH_FILES_RESOLVED:-}"
 if ((${#auth_dirs[@]} > 0)); then
@@ -117,6 +121,7 @@ echo "==> Target: src/gateway/gateway-models.profiles.live.test.ts"
 echo "==> External auth dirs: ${AUTH_DIRS_CSV:-none}"
 echo "==> External auth files: ${AUTH_FILES_CSV:-none}"
 docker run --rm -t \
+  -u "$DOCKER_USER" \
   --entrypoint bash \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e HOME=/home/node \

--- a/scripts/test-live-gateway-models-docker.sh
+++ b/scripts/test-live-gateway-models-docker.sh
@@ -10,7 +10,7 @@ WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
 PROFILE_FILE="${OPENCLAW_PROFILE_FILE:-$HOME/.profile}"
 
 PROFILE_MOUNT=()
-if [[ -f "$PROFILE_FILE" ]]; then
+if [[ -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
@@ -73,7 +73,7 @@ fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -f "$HOME/.profile" ] && source "$HOME/.profile" || true
+[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
 IFS=',' read -r -a auth_dirs <<<"${OPENCLAW_DOCKER_AUTH_DIRS_RESOLVED:-}"
 IFS=',' read -r -a auth_files <<<"${OPENCLAW_DOCKER_AUTH_FILES_RESOLVED:-}"
 if ((${#auth_dirs[@]} > 0)); then

--- a/scripts/test-live-models-docker.sh
+++ b/scripts/test-live-models-docker.sh
@@ -6,6 +6,7 @@ source "$ROOT_DIR/scripts/lib/live-docker-auth.sh"
 IMAGE_NAME="${OPENCLAW_IMAGE:-openclaw:local}"
 LIVE_IMAGE_NAME="${OPENCLAW_LIVE_IMAGE:-${IMAGE_NAME}-live}"
 PROFILE_FILE="${OPENCLAW_PROFILE_FILE:-$HOME/.profile}"
+DOCKER_USER="${OPENCLAW_DOCKER_USER:-node}"
 
 openclaw_live_truthy() {
   case "${1:-}" in
@@ -35,9 +36,12 @@ else
   CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}"
   WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
 fi
+if [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  DOCKER_USER="$(id -u):$(id -g)"
+fi
 
 PROFILE_MOUNT=()
-if [[ -r "$PROFILE_FILE" ]]; then
+if [[ -f "$PROFILE_FILE" && -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
@@ -110,7 +114,7 @@ fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
+[ -f "$HOME/.profile" ] && [ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
 IFS=',' read -r -a auth_dirs <<<"${OPENCLAW_DOCKER_AUTH_DIRS_RESOLVED:-}"
 IFS=',' read -r -a auth_files <<<"${OPENCLAW_DOCKER_AUTH_FILES_RESOLVED:-}"
 if ((${#auth_dirs[@]} > 0)); then
@@ -155,6 +159,7 @@ echo "==> Profile env only: ${OPENCLAW_DOCKER_PROFILE_ENV_ONLY:-0}"
 echo "==> External auth dirs: ${AUTH_DIRS_CSV:-none}"
 echo "==> External auth files: ${AUTH_FILES_CSV:-none}"
 docker run --rm -t \
+  -u "$DOCKER_USER" \
   --entrypoint bash \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e HOME=/home/node \

--- a/scripts/test-live-models-docker.sh
+++ b/scripts/test-live-models-docker.sh
@@ -37,7 +37,7 @@ else
 fi
 
 PROFILE_MOUNT=()
-if [[ -f "$PROFILE_FILE" ]]; then
+if [[ -r "$PROFILE_FILE" ]]; then
   PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/node/.profile:ro)
 fi
 
@@ -110,7 +110,7 @@ fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
 set -euo pipefail
-[ -f "$HOME/.profile" ] && source "$HOME/.profile" || true
+[ -r "$HOME/.profile" ] && source "$HOME/.profile" || true
 IFS=',' read -r -a auth_dirs <<<"${OPENCLAW_DOCKER_AUTH_DIRS_RESOLVED:-}"
 IFS=',' read -r -a auth_files <<<"${OPENCLAW_DOCKER_AUTH_FILES_RESOLVED:-}"
 if ((${#auth_dirs[@]} > 0)); then

--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -192,6 +192,10 @@ function isRefreshTokenReused(raw: string): boolean {
   return /refresh_token_reused/i.test(raw);
 }
 
+function isAccountIdExtractionError(raw: string): boolean {
+  return /failed to extract accountid from token/i.test(raw);
+}
+
 function isInstructionsRequiredError(raw: string): boolean {
   return /instructions are required/i.test(raw);
 }
@@ -792,6 +796,15 @@ describeLive("live models (profile keys)", () => {
             ) {
               skipped.push({ model: id, reason: message });
               logProgress(`${progressLabel}: skip (codex refresh token reused)`);
+              break;
+            }
+            if (
+              allowNotFoundSkip &&
+              model.provider === "openai-codex" &&
+              isAccountIdExtractionError(message)
+            ) {
+              skipped.push({ model: id, reason: message });
+              logProgress(`${progressLabel}: skip (codex account id extraction)`);
               break;
             }
             if (

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -548,6 +548,10 @@ function isRefreshTokenReused(error: string): boolean {
   return /refresh_token_reused/i.test(error);
 }
 
+function isAccountIdExtractionError(error: string): boolean {
+  return /failed to extract accountid from token/i.test(error);
+}
+
 function isChatGPTUsageLimitErrorMessage(raw: string): boolean {
   const msg = raw.toLowerCase();
   return msg.includes("hit your chatgpt usage limit") && msg.includes("try again in");
@@ -675,10 +679,10 @@ describe("getHighSignalLiveModelPriorityIndex", () => {
   it("prefers curated Google replacements over big-pickle", () => {
     expect(
       getHighSignalLiveModelPriorityIndex({ provider: "google", id: "gemini-3.1-pro-preview" }),
-    ).toBe(2);
+    ).toBe(3);
     expect(
       getHighSignalLiveModelPriorityIndex({ provider: "google", id: "gemini-3-flash-preview" }),
-    ).toBe(3);
+    ).toBe(4);
     expect(getHighSignalLiveModelPriorityIndex({ provider: "opencode", id: "big-pickle" })).toBe(
       null,
     );
@@ -1924,6 +1928,11 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
           if (model.provider === "openai-codex" && isRefreshTokenReused(message)) {
             skippedCount += 1;
             logProgress(`${progressLabel}: skip (codex refresh token reused)`);
+            break;
+          }
+          if (model.provider === "openai-codex" && isAccountIdExtractionError(message)) {
+            skippedCount += 1;
+            logProgress(`${progressLabel}: skip (codex account id extraction)`);
             break;
           }
           if (model.provider === "openai-codex" && isChatGPTUsageLimitErrorMessage(message)) {


### PR DESCRIPTION
## Summary
- fix CI-only Docker live lanes so hydrated auth/profile mounts are readable and npm installs use a writable prefix/cache inside the container
- keep Peter's local docker CLI tools flow unchanged while switching GitHub Actions to temp writable tool dirs
- treat the current openai-codex account-id extraction auth failure like other transient live-test skips and update the stale gateway priority assertion

## Validation
- bash -n scripts/ci-hydrate-live-auth.sh scripts/test-live-acp-bind-docker.sh scripts/test-live-cli-backend-docker.sh scripts/test-live-codex-harness-docker.sh scripts/test-live-models-docker.sh scripts/test-live-gateway-models-docker.sh
- git diff --check
- node --import tsx -e "import { getHighSignalLiveModelPriorityIndex } from './src/agents/live-model-filter.ts'; console.log(JSON.stringify({pro:getHighSignalLiveModelPriorityIndex({provider:'google',id:'gemini-3.1-pro-preview'}),flash:getHighSignalLiveModelPriorityIndex({provider:'google',id:'gemini-3-flash-preview'}),pickle:getHighSignalLiveModelPriorityIndex({provider:'opencode',id:'big-pickle'})}))"
- OPENCLAW_LIVE_MODELS='openai-codex/gpt-5.4' pnpm test:live:models-profiles  # failed locally in existing preflight with `[live-models] prepare models.json timed out after 45000ms`
- OPENCLAW_LIVE_GATEWAY_MODELS='openai-codex/gpt-5.4' pnpm test:live:gateway-profiles  # passed locally (skipped due no usable local auth after refresh-token reuse)