### PR TITLE
feat(agents): add adaptive thinking support for Claude Opus 4.7

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -427,48 +427,67 @@ describe("anthropic transport stream", () => {
     );
   });
 
-  it("maps adaptive thinking effort for Claude 4.6 transport runs", async () => {
-    const model = attachModelProviderRequestTransport(
-      {
-        id: "claude-opus-4-6",
-        name: "Claude Opus 4.6",
-        api: "anthropic-messages",
-        provider: "anthropic",
-        baseUrl: "https://api.anthropic.com",
-        reasoning: true,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 200000,
-        maxTokens: 8192,
-      } satisfies Model<"anthropic-messages">,
-      {
-        proxy: {
-          mode: "env-proxy",
+  it.each([
+    {
+      id: "claude-opus-4-6",
+      name: "Claude Opus 4.6",
+      expectedEffort: "max",
+    },
+    {
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      expectedEffort: "max",
+    },
+    {
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      expectedEffort: "max",
+    },
+  ])(
+    "maps xhigh adaptive thinking effort for $name transport runs",
+    async ({ id, name, expectedEffort }) => {
+      const model = attachModelProviderRequestTransport(
+        {
+          id,
+          name,
+          api: "anthropic-messages",
+          provider: "anthropic",
+          baseUrl: "https://api.anthropic.com",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200000,
+          maxTokens: 8192,
+        } satisfies Model<"anthropic-messages">,
+        {
+          proxy: {
+            mode: "env-proxy",
+          },
         },
-      },
-    );
-    const streamFn = createAnthropicMessagesTransportStreamFn();
+      );
+      const streamFn = createAnthropicMessagesTransportStreamFn();
 
-    const stream = await Promise.resolve(
-      streamFn(
-        model,
-        {
-          messages: [{ role: "user", content: "Think deeply." }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "sk-ant-api",
-          reasoning: "xhigh",
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    await stream.result();
+      const stream = await Promise.resolve(
+        streamFn(
+          model,
+          {
+            messages: [{ role: "user", content: "Think deeply." }],
+          } as Parameters<typeof streamFn>[1],
+          {
+            apiKey: "sk-ant-api",
+            reasoning: "xhigh",
+          } as Parameters<typeof streamFn>[2],
+        ),
+      );
+      await stream.result();
 
-    expect(anthropicMessagesStreamMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        thinking: { type: "adaptive" },
-        output_config: { effort: "max" },
-      }),
-      undefined,
-    );
-  });
+      expect(anthropicMessagesStreamMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "adaptive" },
+          output_config: { effort: expectedEffort },
+        }),
+        undefined,
+      );
+    },
+  );
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -98,8 +98,10 @@ type MutableAssistantOutput = {
   errorMessage?: string;
 };
 
-function supportsAdaptiveThinking(modelId: string): boolean {
+export function supportsAdaptiveThinking(modelId: string): boolean {
   return (
+    modelId.includes("opus-4-7") ||
+    modelId.includes("opus-4.7") ||
     modelId.includes("opus-4-6") ||
     modelId.includes("opus-4.6") ||
     modelId.includes("sonnet-4-6") ||
@@ -107,7 +109,7 @@ function supportsAdaptiveThinking(modelId: string): boolean {
   );
 }
 
-function mapThinkingLevelToEffort(
+export function mapAdaptiveThinkingLevelToEffort(
   level: ThinkingLevel,
   modelId: string,
 ): NonNullable<AnthropicOptions["effort"]> {
@@ -117,8 +119,24 @@ function mapThinkingLevelToEffort(
       return "low";
     case "medium":
       return "medium";
+    case "high":
+      return "high";
     case "xhigh":
-      return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
+      // Anthropic introduced a separate `xhigh` effort on Opus 4.7 (extended exploration),
+      // but their docs order `max > xhigh`. Openclaw's `xhigh` ThinkingLevel means
+      // "top of scale", so we always map it to `max` where supported to give users the
+      // highest effort consistently across 4.6 and 4.7 models.
+      if (
+        modelId.includes("opus-4-7") ||
+        modelId.includes("opus-4.7") ||
+        modelId.includes("opus-4-6") ||
+        modelId.includes("opus-4.6") ||
+        modelId.includes("sonnet-4-6") ||
+        modelId.includes("sonnet-4.6")
+      ) {
+        return "max";
+      }
+      return "high";
     default:
       return "high";
   }
@@ -616,7 +634,7 @@ function resolveAnthropicTransportOptions(
   }
   if (supportsAdaptiveThinking(model.id)) {
     resolved.thinkingEnabled = true;
-    resolved.effort = mapThinkingLevelToEffort(options.reasoning, model.id);
+    resolved.effort = mapAdaptiveThinkingLevelToEffort(options.reasoning, model.id);
     return resolved;
   }
   const adjusted = adjustMaxTokensForThinking({

--- a/src/agents/anthropic-vertex-stream.test.ts
+++ b/src/agents/anthropic-vertex-stream.test.ts
@@ -130,7 +130,7 @@ describe("createAnthropicVertexStreamFn", () => {
     );
   });
 
-  it("maps xhigh reasoning to max effort for adaptive Opus models", () => {
+  it("plumbs adaptive-thinking effort from the shared mapper into vertex stream options", () => {
     const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5");
     const model = makeModel({ id: "claude-opus-4-6", maxTokens: 64000 });
 

--- a/src/agents/anthropic-vertex-stream.ts
+++ b/src/agents/anthropic-vertex-stream.ts
@@ -9,8 +9,10 @@ import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
-
-type AnthropicVertexEffort = NonNullable<AnthropicOptions["effort"]>;
+import {
+  mapAdaptiveThinkingLevelToEffort,
+  supportsAdaptiveThinking,
+} from "./anthropic-transport-stream.js";
 
 function resolveAnthropicVertexMaxTokens(params: {
   modelMaxTokens: number | undefined;
@@ -110,22 +112,11 @@ export function createAnthropicVertexStreamFn(
     };
 
     if (options?.reasoning) {
-      const isAdaptive =
-        model.id.includes("opus-4-6") ||
-        model.id.includes("opus-4.6") ||
-        model.id.includes("sonnet-4-6") ||
-        model.id.includes("sonnet-4.6");
+      const isAdaptive = supportsAdaptiveThinking(model.id);
 
       if (isAdaptive) {
         opts.thinkingEnabled = true;
-        const effortMap: Record<string, AnthropicVertexEffort> = {
-          minimal: "low",
-          low: "low",
-          medium: "medium",
-          high: "high",
-          xhigh: model.id.includes("opus-4-6") || model.id.includes("opus-4.6") ? "max" : "high",
-        };
-        opts.effort = effortMap[options.reasoning] ?? "high";
+        opts.effort = mapAdaptiveThinkingLevelToEffort(options.reasoning, model.id);
       } else {
         opts.thinkingEnabled = true;
         const budgets = options.thinkingBudgets;


### PR DESCRIPTION
## Summary

- Add Opus 4.7 to `supportsAdaptiveThinking` 
- Export `supportsAdaptiveThinking` and `mapAdaptiveThinkingLevelToEffort` from `anthropic-transport-stream.ts` and reuse them from `anthropic-vertex-stream.ts` instead of duplicating inline.
- On `xhigh` input, map Opus 4.7 to `max` (matching 4.6). Anthropic docs order `max > xhigh`; openclaw's `xhigh` means "top of scale", so we always send the highest supported effort. Comment in-code.

Relevant docs: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking

<img width="884" height="390" alt="Screenshot 2026-04-16 at 3 45 44 PM" src="https://github.com/user-attachments/assets/f66f6da3-8719-4ef4-843a-32ca31c8c0b6" />