### PR TITLE
fix(onboard): preserve existing gateway auth token during re-onboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
+
 ## 2026.4.15
 
 ### Changes

--- a/src/commands/onboard-non-interactive.gateway-health-auth.test.ts
+++ b/src/commands/onboard-non-interactive.gateway-health-auth.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveGatewayHealthProbeToken } from "./onboard-non-interactive/local.js";
+
+async function withTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-health-auth-"));
+  try {
+    return await run(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function writeSecureFile(filePath: string, content: string): Promise<void> {
+  await fs.writeFile(filePath, content, { mode: 0o600 });
+  await fs.chmod(filePath, 0o600);
+}
+
+describe("resolveGatewayHealthProbeToken", () => {
+  const originalGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+
+  afterEach(() => {
+    if (originalGatewayToken === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = originalGatewayToken;
+    }
+  });
+
+  it("resolves file SecretRefs for the local onboarding health probe without persisting plaintext", async () => {
+    await withTempDir(async (dir) => {
+      const tokenPath = path.join(dir, "gateway-token.txt");
+      await writeSecureFile(tokenPath, "file-secret-token\n");
+      process.env.OPENCLAW_GATEWAY_TOKEN = "stale-env-token";
+
+      const resolved = await resolveGatewayHealthProbeToken({
+        gateway: {
+          auth: {
+            mode: "token",
+            token: {
+              source: "file",
+              provider: "gateway-token-file",
+              id: "value",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            "gateway-token-file": {
+              source: "file",
+              path: tokenPath,
+              mode: "singleValue",
+            },
+          },
+        },
+      } as OpenClawConfig);
+
+      expect(resolved).toEqual({ token: "file-secret-token" });
+    });
+  });
+
+  it("does not fall back to stale OPENCLAW_GATEWAY_TOKEN when a SecretRef is unresolved", async () => {
+    await withTempDir(async (dir) => {
+      process.env.OPENCLAW_GATEWAY_TOKEN = "stale-env-token";
+
+      const resolved = await resolveGatewayHealthProbeToken({
+        gateway: {
+          auth: {
+            mode: "token",
+            token: {
+              source: "file",
+              provider: "gateway-token-file",
+              id: "value",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            "gateway-token-file": {
+              source: "file",
+              path: path.join(dir, "missing-token.txt"),
+              mode: "singleValue",
+            },
+          },
+        },
+      } as OpenClawConfig);
+
+      expect(resolved.token).toBeUndefined();
+      expect(resolved.unresolvedRefReason).toContain("gateway.auth.token SecretRef is unresolved");
+    });
+  });
+});

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -101,10 +101,22 @@ export async function resolveGatewayHealthProbeToken(
     envFallback: "no-secret-ref",
     unresolvedReasonStyle: "detailed",
   });
-  return {
-    ...(resolved.token ? { token: resolved.token } : {}),
-    ...(resolved.unresolvedRefReason ? { unresolvedRefReason: resolved.unresolvedRefReason } : {}),
-  };
+  const probeAuth: { token?: string; unresolvedRefReason?: string } = {};
+  if (resolved.token) {
+    probeAuth.token = resolved.token;
+  }
+  if (resolved.unresolvedRefReason) {
+    probeAuth.unresolvedRefReason = resolved.unresolvedRefReason;
+  }
+  return probeAuth;
+}
+
+function formatGatewayHealthFailureDetail(params: {
+  probeDetail?: string;
+  unresolvedRefReason?: string;
+}): string | undefined {
+  const detail = [params.probeDetail, params.unresolvedRefReason].filter(Boolean).join("\n");
+  return detail || undefined;
 }
 
 export async function runNonInteractiveLocalSetup(params: {
@@ -258,8 +270,10 @@ export async function runNonInteractiveLocalSetup(params: {
         : undefined,
     });
     if (!probe.ok) {
-      const detail =
-        [probe.detail, probeAuth.unresolvedRefReason].filter(Boolean).join("\n") || undefined;
+      const detail = formatGatewayHealthFailureDetail({
+        probeDetail: probe.detail,
+        unresolvedRefReason: probeAuth.unresolvedRefReason,
+      });
       const diagnostics = opts.installDaemon
         ? await collectGatewayHealthFailureDiagnostics()
         : undefined;

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -2,6 +2,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import { replaceConfigFile, resolveGatewayPort } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveGatewayAuthToken } from "../../gateway/auth-token-resolution.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../daemon-runtime.js";
 import { applyLocalSetupWorkspaceConfig } from "../onboard-config.js";
@@ -89,6 +90,21 @@ async function collectGatewayHealthFailureDiagnostics(): Promise<
   return diagnostics.service || diagnostics.lastGatewayError || diagnostics.inspectError
     ? diagnostics
     : undefined;
+}
+
+export async function resolveGatewayHealthProbeToken(
+  nextConfig: OpenClawConfig,
+): Promise<{ token?: string; unresolvedRefReason?: string }> {
+  const resolved = await resolveGatewayAuthToken({
+    cfg: nextConfig,
+    env: process.env,
+    envFallback: "no-secret-ref",
+    unresolvedReasonStyle: "detailed",
+  });
+  return {
+    ...(resolved.token ? { token: resolved.token } : {}),
+    ...(resolved.unresolvedRefReason ? { unresolvedRefReason: resolved.unresolvedRefReason } : {}),
+  };
 }
 
 export async function runNonInteractiveLocalSetup(params: {
@@ -230,9 +246,10 @@ export async function runNonInteractiveLocalSetup(params: {
       basePath: undefined,
     });
     const installDaemonGatewayHealthTiming = resolveInstallDaemonGatewayHealthTiming();
+    const probeAuth = await resolveGatewayHealthProbeToken(nextConfig);
     const probe = await waitForGatewayReachable({
       url: links.wsUrl,
-      token: gatewayResult.gatewayToken,
+      token: probeAuth.token,
       deadlineMs: opts.installDaemon
         ? installDaemonGatewayHealthTiming.deadlineMs
         : ATTACH_EXISTING_GATEWAY_HEALTH_DEADLINE_MS,
@@ -241,6 +258,8 @@ export async function runNonInteractiveLocalSetup(params: {
         : undefined,
     });
     if (!probe.ok) {
+      const detail =
+        [probe.detail, probeAuth.unresolvedRefReason].filter(Boolean).join("\n") || undefined;
       const diagnostics = opts.installDaemon
         ? await collectGatewayHealthFailureDiagnostics()
         : undefined;
@@ -250,7 +269,7 @@ export async function runNonInteractiveLocalSetup(params: {
         mode,
         phase: "gateway-health",
         message: `Gateway did not become reachable at ${links.wsUrl}.`,
-        detail: probe.detail,
+        detail,
         gateway: {
           wsUrl: links.wsUrl,
           httpUrl: links.httpUrl,

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { OnboardOptions } from "../onboard-types.js";
+import { applyNonInteractiveGatewayConfig } from "./gateway-config.js";
+
+// Narrow mock: reproduce normalize semantics (typeof-string + trim, reject
+// "undefined"/"null" literals) and stub randomToken so we can assert when a
+// fresh token is generated vs. reused from the resolution chain.
+const randomToken = vi.hoisted(() => vi.fn(() => "generated-random-token"));
+vi.mock("../../onboard-helpers.js", () => ({
+  normalizeGatewayTokenInput: (value: unknown): string => {
+    if (typeof value !== "string") return "";
+    const trimmed = value.trim();
+    if (trimmed === "undefined" || trimmed === "null") return "";
+    return trimmed;
+  },
+  randomToken,
+}));
+
+function createRuntime() {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+}
+
+const baseOpts = {} as OnboardOptions;
+
+describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
+  const originalEnvToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalEnvToken === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = originalEnvToken;
+    }
+  });
+
+  it("preserves existing gateway.auth.token when no flag or env override is provided", () => {
+    const nextConfig = {
+      gateway: { auth: { mode: "token", token: "existing-user-token" } },
+    } as OpenClawConfig;
+
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig,
+      opts: baseOpts,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(result?.gatewayToken).toBe("existing-user-token");
+    expect(result?.nextConfig.gateway?.auth?.token).toBe("existing-user-token");
+    expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it("prefers --gateway-token flag over existing config token", () => {
+    const nextConfig = {
+      gateway: { auth: { mode: "token", token: "existing-user-token" } },
+    } as OpenClawConfig;
+
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig,
+      opts: { gatewayToken: "flag-token" } as OnboardOptions,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(result?.gatewayToken).toBe("flag-token");
+    expect(result?.nextConfig.gateway?.auth?.token).toBe("flag-token");
+    expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it("prefers OPENCLAW_GATEWAY_TOKEN env var over existing config token", () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    const nextConfig = {
+      gateway: { auth: { mode: "token", token: "existing-user-token" } },
+    } as OpenClawConfig;
+
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig,
+      opts: baseOpts,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(result?.gatewayToken).toBe("env-token");
+    expect(result?.nextConfig.gateway?.auth?.token).toBe("env-token");
+    expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it("generates a random token only when flag, env, and existing config are all empty", () => {
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig: {} as OpenClawConfig,
+      opts: baseOpts,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(randomToken).toHaveBeenCalledOnce();
+    expect(result?.gatewayToken).toBe("generated-random-token");
+    expect(result?.nextConfig.gateway?.auth?.token).toBe("generated-random-token");
+  });
+});

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -9,9 +9,13 @@ import { applyNonInteractiveGatewayConfig } from "./gateway-config.js";
 const randomToken = vi.hoisted(() => vi.fn(() => "generated-random-token"));
 vi.mock("../../onboard-helpers.js", () => ({
   normalizeGatewayTokenInput: (value: unknown): string => {
-    if (typeof value !== "string") return "";
+    if (typeof value !== "string") {
+      return "";
+    }
     const trimmed = value.trim();
-    if (trimmed === "undefined" || trimmed === "null") return "";
+    if (trimmed === "undefined" || trimmed === "null") {
+      return "";
+    }
     return trimmed;
   },
   randomToken,

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -23,12 +23,20 @@ function createRuntime() {
 
 const baseOpts = {} as OnboardOptions;
 
+const SAMPLE_SECRET_REF = {
+  source: "env" as const,
+  provider: "default",
+  id: "OPENCLAW_GATEWAY_TOKEN_REF",
+};
+
 describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
   const originalEnvToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+  const originalRefValue = process.env[SAMPLE_SECRET_REF.id];
 
   beforeEach(() => {
     vi.clearAllMocks();
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env[SAMPLE_SECRET_REF.id];
   });
 
   afterEach(() => {
@@ -37,9 +45,16 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
     } else {
       process.env.OPENCLAW_GATEWAY_TOKEN = originalEnvToken;
     }
+    if (originalRefValue === undefined) {
+      delete process.env[SAMPLE_SECRET_REF.id];
+    } else {
+      process.env[SAMPLE_SECRET_REF.id] = originalRefValue;
+    }
   });
 
-  it("preserves existing gateway.auth.token when no flag or env override is provided", () => {
+  // --- Plaintext preservation (the original regression) ---
+
+  it("preserves existing plaintext gateway.auth.token when no flag or env override is provided", () => {
     const nextConfig = {
       gateway: { auth: { mode: "token", token: "existing-user-token" } },
     } as OpenClawConfig;
@@ -56,7 +71,27 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
     expect(randomToken).not.toHaveBeenCalled();
   });
 
-  it("prefers --gateway-token flag over existing config token", () => {
+  it("prefers existing plaintext token over ambient OPENCLAW_GATEWAY_TOKEN on re-onboard", () => {
+    // A stale shell/launchd OPENCLAW_GATEWAY_TOKEN must not rotate a
+    // persisted token — that would break already-paired clients.
+    process.env.OPENCLAW_GATEWAY_TOKEN = "stale-env-token";
+    const nextConfig = {
+      gateway: { auth: { mode: "token", token: "existing-user-token" } },
+    } as OpenClawConfig;
+
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig,
+      opts: baseOpts,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(result?.gatewayToken).toBe("existing-user-token");
+    expect(result?.nextConfig.gateway?.auth?.token).toBe("existing-user-token");
+    expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it("prefers --gateway-token flag over existing plaintext token", () => {
     const nextConfig = {
       gateway: { auth: { mode: "token", token: "existing-user-token" } },
     } as OpenClawConfig;
@@ -73,14 +108,11 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
     expect(randomToken).not.toHaveBeenCalled();
   });
 
-  it("prefers OPENCLAW_GATEWAY_TOKEN env var over existing config token", () => {
+  it("uses OPENCLAW_GATEWAY_TOKEN to fill an empty config on first-run", () => {
     process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
-    const nextConfig = {
-      gateway: { auth: { mode: "token", token: "existing-user-token" } },
-    } as OpenClawConfig;
 
     const result = applyNonInteractiveGatewayConfig({
-      nextConfig,
+      nextConfig: {} as OpenClawConfig,
       opts: baseOpts,
       runtime: createRuntime() as never,
       defaultPort: 18789,
@@ -102,5 +134,118 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
     expect(randomToken).toHaveBeenCalledOnce();
     expect(result?.gatewayToken).toBe("generated-random-token");
     expect(result?.nextConfig.gateway?.auth?.token).toBe("generated-random-token");
+  });
+
+  // --- SecretRef preservation ---
+
+  it("preserves an existing SecretRef when no flag or env override is provided", () => {
+    const nextConfig = {
+      gateway: { auth: { mode: "token", token: SAMPLE_SECRET_REF } },
+    } as unknown as OpenClawConfig;
+
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig,
+      opts: baseOpts,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(result?.nextConfig.gateway?.auth?.token).toEqual(SAMPLE_SECRET_REF);
+    expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it("preserves an existing SecretRef even when ambient OPENCLAW_GATEWAY_TOKEN is set", () => {
+    // A stale ambient env must not declassify a configured SecretRef.
+    process.env.OPENCLAW_GATEWAY_TOKEN = "stale-env-token";
+    const nextConfig = {
+      gateway: { auth: { mode: "token", token: SAMPLE_SECRET_REF } },
+    } as unknown as OpenClawConfig;
+
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig,
+      opts: baseOpts,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(result?.nextConfig.gateway?.auth?.token).toEqual(SAMPLE_SECRET_REF);
+    expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it("resolves an env-source SecretRef for the health probe without persisting plaintext", () => {
+    // For probe/runtime use only: resolve process.env[ref.id] and return it
+    // as gatewayToken, while leaving the SecretRef intact in config.
+    process.env[SAMPLE_SECRET_REF.id] = "resolved-secret-value";
+    const nextConfig = {
+      gateway: { auth: { mode: "token", token: SAMPLE_SECRET_REF } },
+    } as unknown as OpenClawConfig;
+
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig,
+      opts: baseOpts,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(result?.gatewayToken).toBe("resolved-secret-value");
+    expect(result?.nextConfig.gateway?.auth?.token).toEqual(SAMPLE_SECRET_REF);
+  });
+
+  it("leaves gatewayToken undefined when an env-source SecretRef is unresolved", () => {
+    const nextConfig = {
+      gateway: { auth: { mode: "token", token: SAMPLE_SECRET_REF } },
+    } as unknown as OpenClawConfig;
+
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig,
+      opts: baseOpts,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(result?.gatewayToken).toBeUndefined();
+    expect(result?.nextConfig.gateway?.auth?.token).toEqual(SAMPLE_SECRET_REF);
+  });
+
+  it("overrides an existing SecretRef when --gateway-token flag is provided", () => {
+    const nextConfig = {
+      gateway: { auth: { mode: "token", token: SAMPLE_SECRET_REF } },
+    } as unknown as OpenClawConfig;
+
+    const result = applyNonInteractiveGatewayConfig({
+      nextConfig,
+      opts: { gatewayToken: "flag-token" } as OnboardOptions,
+      runtime: createRuntime() as never,
+      defaultPort: 18789,
+    });
+
+    expect(result?.gatewayToken).toBe("flag-token");
+    expect(result?.nextConfig.gateway?.auth?.token).toBe("flag-token");
+    expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it("overrides an existing SecretRef when --gateway-token-ref-env is provided", () => {
+    const newRefId = "OPENCLAW_GATEWAY_TOKEN_NEW_REF";
+    process.env[newRefId] = "resolved-new-ref-value";
+    try {
+      const nextConfig = {
+        gateway: { auth: { mode: "token", token: SAMPLE_SECRET_REF } },
+      } as unknown as OpenClawConfig;
+
+      const result = applyNonInteractiveGatewayConfig({
+        nextConfig,
+        opts: { gatewayTokenRefEnv: newRefId } as OnboardOptions,
+        runtime: createRuntime() as never,
+        defaultPort: 18789,
+      });
+
+      expect(result?.gatewayToken).toBe("resolved-new-ref-value");
+      const newToken = result?.nextConfig.gateway?.auth?.token;
+      expect(newToken).toMatchObject({ source: "env", id: newRefId });
+      expect(newToken).not.toEqual(SAMPLE_SECRET_REF);
+      expect(randomToken).not.toHaveBeenCalled();
+    } finally {
+      delete process.env[newRefId];
+    }
   });
 });

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -70,7 +70,6 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
       defaultPort: 18789,
     });
 
-    expect(result?.gatewayToken).toBe("existing-user-token");
     expect(result?.nextConfig.gateway?.auth?.token).toBe("existing-user-token");
     expect(randomToken).not.toHaveBeenCalled();
   });
@@ -90,7 +89,6 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
       defaultPort: 18789,
     });
 
-    expect(result?.gatewayToken).toBe("existing-user-token");
     expect(result?.nextConfig.gateway?.auth?.token).toBe("existing-user-token");
     expect(randomToken).not.toHaveBeenCalled();
   });
@@ -107,7 +105,6 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
       defaultPort: 18789,
     });
 
-    expect(result?.gatewayToken).toBe("flag-token");
     expect(result?.nextConfig.gateway?.auth?.token).toBe("flag-token");
     expect(randomToken).not.toHaveBeenCalled();
   });
@@ -122,7 +119,6 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
       defaultPort: 18789,
     });
 
-    expect(result?.gatewayToken).toBe("env-token");
     expect(result?.nextConfig.gateway?.auth?.token).toBe("env-token");
     expect(randomToken).not.toHaveBeenCalled();
   });
@@ -136,7 +132,6 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
     });
 
     expect(randomToken).toHaveBeenCalledOnce();
-    expect(result?.gatewayToken).toBe("generated-random-token");
     expect(result?.nextConfig.gateway?.auth?.token).toBe("generated-random-token");
   });
 
@@ -176,9 +171,7 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
     expect(randomToken).not.toHaveBeenCalled();
   });
 
-  it("resolves an env-source SecretRef for the health probe without persisting plaintext", () => {
-    // For probe/runtime use only: resolve process.env[ref.id] and return it
-    // as gatewayToken, while leaving the SecretRef intact in config.
+  it("leaves env-source SecretRef resolution to the health probe path", () => {
     process.env[SAMPLE_SECRET_REF.id] = "resolved-secret-value";
     const nextConfig = {
       gateway: { auth: { mode: "token", token: SAMPLE_SECRET_REF } },
@@ -191,24 +184,8 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
       defaultPort: 18789,
     });
 
-    expect(result?.gatewayToken).toBe("resolved-secret-value");
     expect(result?.nextConfig.gateway?.auth?.token).toEqual(SAMPLE_SECRET_REF);
-  });
-
-  it("leaves gatewayToken undefined when an env-source SecretRef is unresolved", () => {
-    const nextConfig = {
-      gateway: { auth: { mode: "token", token: SAMPLE_SECRET_REF } },
-    } as unknown as OpenClawConfig;
-
-    const result = applyNonInteractiveGatewayConfig({
-      nextConfig,
-      opts: baseOpts,
-      runtime: createRuntime() as never,
-      defaultPort: 18789,
-    });
-
-    expect(result?.gatewayToken).toBeUndefined();
-    expect(result?.nextConfig.gateway?.auth?.token).toEqual(SAMPLE_SECRET_REF);
+    expect(randomToken).not.toHaveBeenCalled();
   });
 
   it("overrides an existing SecretRef when --gateway-token flag is provided", () => {
@@ -223,7 +200,6 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
       defaultPort: 18789,
     });
 
-    expect(result?.gatewayToken).toBe("flag-token");
     expect(result?.nextConfig.gateway?.auth?.token).toBe("flag-token");
     expect(randomToken).not.toHaveBeenCalled();
   });
@@ -243,7 +219,6 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
         defaultPort: 18789,
       });
 
-      expect(result?.gatewayToken).toBe("resolved-new-ref-value");
       const newToken = result?.nextConfig.gateway?.auth?.token;
       expect(newToken).toMatchObject({ source: "env", id: newRefId });
       expect(newToken).not.toEqual(SAMPLE_SECRET_REF);

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import type { OnboardOptions } from "../onboard-types.js";
+import type { OnboardOptions } from "../../onboard-types.js";
 import { applyNonInteractiveGatewayConfig } from "./gateway-config.js";
 
 // Narrow mock: reproduce normalize semantics (typeof-string + trim, reject

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -18,7 +18,6 @@ export function applyNonInteractiveGatewayConfig(params: {
   authMode: string;
   tailscaleMode: string;
   tailscaleResetOnExit: boolean;
-  gatewayToken?: string;
 } | null {
   const { opts, runtime } = params;
 
@@ -121,16 +120,6 @@ export function applyNonInteractiveGatewayConfig(params: {
           },
         },
       };
-      // Resolve env-source refs inline for the health probe only — do not
-      // persist any plaintext here. Other ref sources (file/exec) defer to
-      // the gateway's own resolver; the health probe may then fail unless
-      // --skip-health is set.
-      if (existingTokenRef.source === "env") {
-        const resolved = process.env[existingTokenRef.id]?.trim();
-        gatewayToken = resolved || undefined;
-      } else {
-        gatewayToken = undefined;
-      }
     } else {
       if (!gatewayToken) {
         gatewayToken = randomToken();
@@ -190,6 +179,5 @@ export function applyNonInteractiveGatewayConfig(params: {
     authMode,
     tailscaleMode,
     tailscaleResetOnExit,
-    gatewayToken,
   };
 }

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -54,7 +54,8 @@ export function applyNonInteractiveGatewayConfig(params: {
   let nextConfig = params.nextConfig;
   const explicitGatewayToken = normalizeGatewayTokenInput(opts.gatewayToken);
   const envGatewayToken = normalizeGatewayTokenInput(process.env.OPENCLAW_GATEWAY_TOKEN);
-  let gatewayToken = explicitGatewayToken || envGatewayToken || undefined;
+  const existingToken = normalizeGatewayTokenInput(nextConfig?.gateway?.auth?.token);
+  let gatewayToken = explicitGatewayToken || envGatewayToken || existingToken || undefined;
   const gatewayTokenRefEnv = normalizeOptionalString(opts.gatewayTokenRefEnv ?? "") ?? "";
 
   if (authMode === "token") {

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { isValidEnvSecretRefId } from "../../../config/types.secrets.js";
+import { isValidEnvSecretRefId, resolveSecretInputRef } from "../../../config/types.secrets.js";
 import type { RuntimeEnv } from "../../../runtime.js";
 import { resolveDefaultSecretProviderAlias } from "../../../secrets/ref-contract.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
@@ -54,8 +54,18 @@ export function applyNonInteractiveGatewayConfig(params: {
   let nextConfig = params.nextConfig;
   const explicitGatewayToken = normalizeGatewayTokenInput(opts.gatewayToken);
   const envGatewayToken = normalizeGatewayTokenInput(process.env.OPENCLAW_GATEWAY_TOKEN);
-  const existingToken = normalizeGatewayTokenInput(nextConfig?.gateway?.auth?.token);
-  let gatewayToken = explicitGatewayToken || envGatewayToken || existingToken || undefined;
+  const existingTokenInput = nextConfig.gateway?.auth?.token;
+  const existingTokenRef = resolveSecretInputRef({
+    value: existingTokenInput,
+    defaults: nextConfig.secrets?.defaults,
+  }).ref;
+  const existingPlaintextToken = normalizeGatewayTokenInput(existingTokenInput);
+  // Resolution order on re-onboard: explicit --gateway-token > persisted
+  // plaintext > ambient OPENCLAW_GATEWAY_TOKEN > randomToken(). Ambient env
+  // must not rotate a token already written to disk — a stale shell or
+  // launchd env var otherwise breaks already-paired clients.
+  let gatewayToken =
+    explicitGatewayToken || existingPlaintextToken || envGatewayToken || undefined;
   const gatewayTokenRefEnv = normalizeOptionalString(opts.gatewayTokenRefEnv ?? "") ?? "";
 
   if (authMode === "token") {
@@ -96,6 +106,32 @@ export function applyNonInteractiveGatewayConfig(params: {
           },
         },
       };
+    } else if (!explicitGatewayToken && existingTokenRef) {
+      // Preserve an already-configured SecretRef on re-onboard. Without this
+      // branch, an ambient OPENCLAW_GATEWAY_TOKEN (or randomToken() fallback)
+      // would silently overwrite {source, provider, id} with a plaintext
+      // literal, de-secretref-ing the gateway.
+      nextConfig = {
+        ...nextConfig,
+        gateway: {
+          ...nextConfig.gateway,
+          auth: {
+            ...nextConfig.gateway?.auth,
+            mode: "token",
+            // token field intentionally preserved as the existing SecretRef.
+          },
+        },
+      };
+      // Resolve env-source refs inline for the health probe only — do not
+      // persist any plaintext here. Other ref sources (file/exec) defer to
+      // the gateway's own resolver; the health probe may then fail unless
+      // --skip-health is set.
+      if (existingTokenRef.source === "env") {
+        const resolved = process.env[existingTokenRef.id]?.trim();
+        gatewayToken = resolved || undefined;
+      } else {
+        gatewayToken = undefined;
+      }
     } else {
       if (!gatewayToken) {
         gatewayToken = randomToken();

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -64,8 +64,7 @@ export function applyNonInteractiveGatewayConfig(params: {
   // plaintext > ambient OPENCLAW_GATEWAY_TOKEN > randomToken(). Ambient env
   // must not rotate a token already written to disk — a stale shell or
   // launchd env var otherwise breaks already-paired clients.
-  let gatewayToken =
-    explicitGatewayToken || existingPlaintextToken || envGatewayToken || undefined;
+  let gatewayToken = explicitGatewayToken || existingPlaintextToken || envGatewayToken || undefined;
   const gatewayTokenRefEnv = normalizeOptionalString(opts.gatewayTokenRefEnv ?? "") ?? "";
 
   if (authMode === "token") {


### PR DESCRIPTION
## Summary
- Problem: `openclaw onboard --non-interactive` unconditionally generates a new `gateway.auth.token`, even when one already exists in the config. This immediately breaks all live gateway connections with `4001: gateway auth changed` / `1008: token mismatch`, killing all sessions, subagents, CLI commands, and channel connections.
- Why it matters: Any re-onboard (e.g., adding a new provider, re-auth, Spark setup) causes a full outage requiring `gateway install` to regenerate the LaunchAgent plist. Hit twice in production in one week.
- What changed: Added the existing config's `gateway.auth.token` to the token resolution fallback chain, between env var and `randomToken()`. One line added: `const existingToken = normalizeGatewayTokenInput(nextConfig.gateway?.auth?.token)`. Token is now only generated fresh on first install when no token exists anywhere.
- What did NOT change (scope boundary): Interactive onboard wizard not touched. `--gateway-token` flag and `OPENCLAW_GATEWAY_TOKEN` env var still take priority. SecretRef token objects correctly ignored (normalizeGatewayTokenInput returns `""` for non-strings). No changes to gateway auth validation, daemon lifecycle, or config schema.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: `applyNonInteractiveGatewayConfig()` resolves the token from flag and env var only. If neither is set, it calls `randomToken()` without checking if the config already has a valid token. The existing token in `nextConfig.gateway.auth.token` is never read.
- Missing detection / guardrail: No check for "is a gateway currently running with this token" before overwriting.
- Contributing context (if known): Re-onboarding is a common operation when adding providers or re-authing. Users don't expect it to rotate the gateway token.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/onboard-non-interactive/local/gateway-config.test.ts`
- Scenario the test should lock in: When `nextConfig.gateway.auth.token` is already set and no flag/env override is provided, the existing token is preserved in the output config.
- Why this is the smallest reliable guardrail: Unit test on the token resolution logic catches the exact gap without needing a running gateway.
- Existing test that already covers this (if any): None — token generation is untested.
- If no new test is added, why not: Happy to add one if maintainers prefer. The fix is a single line in the fallback chain.

## User-visible / Behavior Changes
`openclaw onboard --non-interactive` no longer rotates the gateway auth token when re-onboarding. Existing gateway connections remain valid. Token is only generated on first install or when explicitly overridden via `--gateway-token` or `OPENCLAW_GATEWAY_TOKEN`.

## Diagram (if applicable)
```text
Before:
[re-onboard without --gateway-token] -> [randomToken() called] -> [config written with new token] -> [gateway rejects all connections: 4001]

After:
[re-onboard without --gateway-token] -> [existing token preserved from config] -> [config written with same token] -> [gateway connections unaffected]
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: The change preserves an existing token instead of generating a new one. This is strictly less disruptive — the token value doesn't change, no new token is introduced. If a user needs to rotate their token, `--gateway-token` flag still works. No reduction in security posture.

## Repro + Verification
### Environment
- OS: macOS 15.4
- Runtime/container: Node 22 / npm global
- Model/provider: N/A — affects gateway auth, not model calls
- Integration/channel (if any): All channels (Discord, WhatsApp, etc.)
- Relevant config (redacted): `gateway.auth.token` set in `openclaw.json`

### Steps
1. Start gateway with a valid config and active sessions
2. Run `openclaw onboard --non-interactive --accept-risk --skip-health --custom-base-url "http://..." --custom-model-id "..."`
3. Observe gateway behavior

### Expected
- Existing gateway connections remain valid, token unchanged

### Actual
- All connections killed with `4001: gateway auth changed`, requires `gateway install` to recover

## Evidence
- [x] Trace/log snippets

Two production incidents in one week. Gateway logs show `4001: gateway auth changed` / `1008: token mismatch` immediately after re-onboard. Recovery required `openclaw gateway install` to regenerate the LaunchAgent plist with the new token.

## Human Verification (required)
- Verified scenarios: Confirmed `applyNonInteractiveGatewayConfig()` is the sole writer in the onboard path. Confirmed it reads flag and env but never reads existing config token. Confirmed `normalizeGatewayTokenInput` returns `""` for non-strings (SecretRef safe). Confirmed `nextConfig` carries the existing token at the point of resolution.
- Edge cases checked: SecretRef token objects fall through correctly. `--gateway-token` flag still takes priority. Fresh install with no existing token still generates via `randomToken()`.
- What you did **not** verify: Interactive onboard wizard (separate code path). Could not run test suite locally.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Users who intentionally want token rotation on re-onboard lose that implicit behavior.
  - Mitigation: `--gateway-token <new-token>` flag explicitly rotates the token. The implicit rotation was undocumented and destructive — no user relies on it intentionally.