### PR TITLE
fix(telegram): clean up thread bindings to stale/failed ACP sessions on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Models/config: preserve an existing `models.json` provider `baseUrl` during merge-mode regeneration so custom endpoints do not get reset on restart. (#67893) Thanks @lawrence3699.
 - Plugins/discovery: reuse bundled and global plugin discovery results across workspace cache misses so Windows multi-workspace startup stops redoing the shared synchronous scan. (#67940) Thanks @obviyus.
 - Plugins/webhooks: enforce synchronous plugin registration with full rollback of failed plugin side effects, and cache SecretRef-backed webhook auth per route so plugin startup and inbound webhook auth stay deterministic. (#67941) Thanks @obviyus.
+- Telegram/ACP bindings: drop persisted DM bindings that still point at missing or failed ACP sessions on restart, while preserving plugin-owned bindings and uncertain store reads. (#67822) Thanks @chinar-amrutkar.
 - Telegram/streaming: keep a transient preview on the same Telegram message when auto-compaction retries an in-flight answer, so streamed replies no longer appear duplicated after compaction. (#66939) Thanks @rubencu.
 
 ## 2026.4.15

--- a/extensions/telegram/src/thread-bindings.test.ts
+++ b/extensions/telegram/src/thread-bindings.test.ts
@@ -7,6 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { importFreshModule } from "../../../test/helpers/import-fresh.js";
 
 const writeJsonFileAtomicallyMock = vi.hoisted(() => vi.fn());
+const readAcpSessionEntryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/acp-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/acp-runtime")>(
+    "openclaw/plugin-sdk/acp-runtime",
+  );
+  readAcpSessionEntryMock.mockImplementation(actual.readAcpSessionEntry);
+  return {
+    ...actual,
+    readAcpSessionEntry: readAcpSessionEntryMock,
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/json-store", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/json-store")>(
@@ -36,6 +48,11 @@ describe("telegram thread bindings", () => {
 
   beforeEach(async () => {
     writeJsonFileAtomicallyMock.mockClear();
+    readAcpSessionEntryMock.mockReset();
+    const acpRuntime = await vi.importActual<typeof import("openclaw/plugin-sdk/acp-runtime")>(
+      "openclaw/plugin-sdk/acp-runtime",
+    );
+    readAcpSessionEntryMock.mockImplementation(acpRuntime.readAcpSessionEntry);
     await __testing.resetTelegramThreadBindingsForTests();
   });
 
@@ -291,6 +308,136 @@ describe("telegram thread bindings", () => {
     });
 
     expect(reloaded.getByConversationId("8460800771")).toBeUndefined();
+  });
+
+  it("cleans up stale ACP bindings before restart routing can reuse them", async () => {
+    stateDirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-bindings-"));
+    process.env.OPENCLAW_STATE_DIR = stateDirOverride;
+
+    createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: true,
+      enableSweeper: false,
+    });
+
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:acp:stale-1",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "cleanup-me",
+      },
+    });
+
+    await __testing.resetTelegramThreadBindingsForTests();
+    readAcpSessionEntryMock.mockReturnValue({
+      cfg: {} as never,
+      storePath: "/tmp/acp-store.json",
+      sessionKey: "agent:main:acp:stale-1",
+      storeSessionKey: "agent:main:acp:stale-1",
+      entry: undefined,
+      acp: undefined,
+      storeReadFailed: false,
+    });
+
+    const reloaded = createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: true,
+      enableSweeper: false,
+    });
+
+    expect(reloaded.getByConversationId("cleanup-me")).toBeUndefined();
+    await __testing.resetTelegramThreadBindingsForTests();
+    const persisted = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          resolveStateDir(process.env, os.homedir),
+          "telegram",
+          "thread-bindings-default.json",
+        ),
+        "utf8",
+      ),
+    ) as { bindings?: Array<{ conversationId?: string }> };
+    expect(persisted.bindings?.map((binding) => binding.conversationId)).not.toContain(
+      "cleanup-me",
+    );
+  });
+
+  it("keeps plugin-owned bindings when ACP cleanup runs on startup", async () => {
+    stateDirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-bindings-"));
+    process.env.OPENCLAW_STATE_DIR = stateDirOverride;
+
+    createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: true,
+      enableSweeper: false,
+    });
+
+    await getSessionBindingService().bind({
+      targetSessionKey: "plugin-binding:openclaw-codex-app-server:still-valid",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "plugin-binding-convo",
+      },
+    });
+
+    await __testing.resetTelegramThreadBindingsForTests();
+
+    const reloaded = createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: true,
+      enableSweeper: false,
+    });
+
+    expect(reloaded.getByConversationId("plugin-binding-convo")?.targetSessionKey).toBe(
+      "plugin-binding:openclaw-codex-app-server:still-valid",
+    );
+    expect(readAcpSessionEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps ACP bindings when the session store cannot be read during startup cleanup", async () => {
+    stateDirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-bindings-"));
+    process.env.OPENCLAW_STATE_DIR = stateDirOverride;
+
+    createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: true,
+      enableSweeper: false,
+    });
+
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:acp:read-failed",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "keep-on-read-failure",
+      },
+    });
+
+    await __testing.resetTelegramThreadBindingsForTests();
+    readAcpSessionEntryMock.mockReturnValue({
+      cfg: {} as never,
+      storePath: "/tmp/acp-store.json",
+      sessionKey: "agent:main:acp:read-failed",
+      storeSessionKey: "agent:main:acp:read-failed",
+      entry: undefined,
+      acp: undefined,
+      storeReadFailed: true,
+    });
+
+    const reloaded = createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: true,
+      enableSweeper: false,
+    });
+
+    expect(reloaded.getByConversationId("keep-on-read-failure")?.targetSessionKey).toBe(
+      "agent:main:acp:read-failed",
+    );
   });
 
   it("flushes pending lifecycle update persists before test reset", async () => {

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -15,8 +15,7 @@ import {
 import { readAcpSessionEntry } from "openclaw/plugin-sdk/acp-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
-import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
-import { isAcpSessionKey } from "../../sessions/session-key-utils.js";
+import { normalizeAccountId, isAcpSessionKey } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -15,7 +15,8 @@ import {
 import { readAcpSessionEntry } from "openclaw/plugin-sdk/acp-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
-import { isAcpSessionKey, normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { isAcpSessionKey } from "openclaw/sessions/session-key-utils";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -442,12 +442,23 @@ export function createTelegramThreadBindingManager(
   }
 
   // Clean up bindings to stale/failed ACP sessions on startup
-  const staleSessionKeys = new Set<string>();
+  // Group bindings by targetSessionKey to avoid redundant session store reads
+  const bindingsByTargetSession = new Map<string, TelegramThreadBindingRecord[]>();
   for (const binding of getThreadBindingsState().bindingsByAccountConversation.values()) {
     if (binding.targetKind !== "acp") {
       continue;
     }
-    const sessionEntry = readAcpSessionEntry({ sessionKey: binding.targetSessionKey });
+    const existing = bindingsByTargetSession.get(binding.targetSessionKey);
+    if (existing) {
+      existing.push(binding);
+    } else {
+      bindingsByTargetSession.set(binding.targetSessionKey, [binding]);
+    }
+  }
+
+  const staleSessionKeys = new Set<string>();
+  for (const [targetSessionKey, bindings] of bindingsByTargetSession) {
+    const sessionEntry = readAcpSessionEntry({ sessionKey: targetSessionKey });
     if (!sessionEntry || sessionEntry.storeReadFailed) {
       continue;
     }
@@ -458,7 +469,7 @@ export function createTelegramThreadBindingManager(
       sessionEntry.entry.status === "timeout" ||
       sessionEntry.entry.acp?.state === "error";
     if (isStale) {
-      staleSessionKeys.add(binding.targetSessionKey);
+      staleSessionKeys.add(targetSessionKey);
     }
   }
 

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -15,7 +15,7 @@ import {
 import { readAcpSessionEntry } from "openclaw/plugin-sdk/acp-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
-import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { isAcpSessionKey, normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
@@ -443,9 +443,14 @@ export function createTelegramThreadBindingManager(
 
   // Clean up bindings to stale/failed ACP sessions on startup
   // Group bindings by targetSessionKey to avoid redundant session store reads
+  // Only process ACP runtime sessions (skip plugin-bound sessions like "plugin-binding:*")
   const bindingsByTargetSession = new Map<string, TelegramThreadBindingRecord[]>();
   for (const binding of getThreadBindingsState().bindingsByAccountConversation.values()) {
     if (binding.targetKind !== "acp") {
+      continue;
+    }
+    // Skip plugin-bound sessions — they use "plugin-binding:*" keys, not ACP session keys
+    if (!isAcpSessionKey(binding.targetSessionKey)) {
       continue;
     }
     const existing = bindingsByTargetSession.get(binding.targetSessionKey);

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -16,7 +16,7 @@ import { readAcpSessionEntry } from "openclaw/plugin-sdk/acp-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
-import { isAcpSessionKey } from "openclaw/sessions/session-key-utils";
+import { isAcpSessionKey } from "../../sessions/session-key-utils.js";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
@@ -463,7 +463,7 @@ export function createTelegramThreadBindingManager(
   }
 
   const staleSessionKeys = new Set<string>();
-  for (const [targetSessionKey, bindings] of bindingsByTargetSession) {
+  for (const targetSessionKey of bindingsByTargetSession.keys()) {
     const sessionEntry = readAcpSessionEntry({ sessionKey: targetSessionKey });
     if (!sessionEntry || sessionEntry.storeReadFailed) {
       continue;

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -12,6 +12,7 @@ import {
   type SessionBindingAdapter,
   type SessionBindingRecord,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import { readAcpSessionEntry } from "openclaw/plugin-sdk/acp-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
@@ -437,6 +438,49 @@ export function createTelegramThreadBindingManager(
     getThreadBindingsState().bindingsByAccountConversation.set(key, {
       ...entry,
       accountId,
+    });
+  }
+
+  // Clean up bindings to stale/failed ACP sessions on startup
+  const staleSessionKeys = new Set<string>();
+  for (const binding of getThreadBindingsState().bindingsByAccountConversation.values()) {
+    if (binding.targetKind !== "acp") {
+      continue;
+    }
+    const sessionEntry = readAcpSessionEntry({ sessionKey: binding.targetSessionKey });
+    const isStale =
+      !sessionEntry.entry ||
+      sessionEntry.entry?.status === "failed" ||
+      sessionEntry.entry?.status === "killed" ||
+      sessionEntry.entry?.status === "timeout" ||
+      sessionEntry.entry?.acp?.state === "error";
+    if (isStale) {
+      staleSessionKeys.add(binding.targetSessionKey);
+    }
+  }
+
+  let needsPersist = false;
+  for (const sessionKey of staleSessionKeys) {
+    const bindingsToRemove = listBindingsForAccount(accountId).filter(
+      (b) => b.targetSessionKey === sessionKey,
+    );
+    for (const binding of bindingsToRemove) {
+      getThreadBindingsState().bindingsByAccountConversation.delete(
+        resolveBindingKey({ accountId, conversationId: binding.conversationId }),
+      );
+    }
+    needsPersist = true;
+    logVerbose(
+      `telegram thread binding: cleaned up ${bindingsToRemove.length} stale binding(s) for session ${sessionKey}`,
+    );
+  }
+
+  if (needsPersist && persist) {
+    persistBindingsSafely({
+      accountId,
+      persist: true,
+      bindings: listBindingsForAccount(accountId),
+      reason: "cleanup-stale",
     });
   }
 

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -448,12 +448,15 @@ export function createTelegramThreadBindingManager(
       continue;
     }
     const sessionEntry = readAcpSessionEntry({ sessionKey: binding.targetSessionKey });
+    if (!sessionEntry || sessionEntry.storeReadFailed) {
+      continue;
+    }
     const isStale =
       !sessionEntry.entry ||
-      sessionEntry.entry?.status === "failed" ||
-      sessionEntry.entry?.status === "killed" ||
-      sessionEntry.entry?.status === "timeout" ||
-      sessionEntry.entry?.acp?.state === "error";
+      sessionEntry.entry.status === "failed" ||
+      sessionEntry.entry.status === "killed" ||
+      sessionEntry.entry.status === "timeout" ||
+      sessionEntry.entry.acp?.state === "error";
     if (isStale) {
       staleSessionKeys.add(binding.targetSessionKey);
     }
@@ -469,10 +472,12 @@ export function createTelegramThreadBindingManager(
         resolveBindingKey({ accountId, conversationId: binding.conversationId }),
       );
     }
-    needsPersist = true;
-    logVerbose(
-      `telegram thread binding: cleaned up ${bindingsToRemove.length} stale binding(s) for session ${sessionKey}`,
-    );
+    if (bindingsToRemove.length > 0) {
+      needsPersist = true;
+      logVerbose(
+        `telegram thread binding: cleaned up ${bindingsToRemove.length} stale binding(s) for session ${sessionKey}`,
+      );
+    }
   }
 
   if (needsPersist && persist) {

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { readAcpSessionEntry } from "openclaw/plugin-sdk/acp-runtime";
 import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
   formatThreadBindingDurationLabel,
@@ -12,7 +13,6 @@ import {
   type SessionBindingAdapter,
   type SessionBindingRecord,
 } from "openclaw/plugin-sdk/conversation-runtime";
-import { readAcpSessionEntry } from "openclaw/plugin-sdk/acp-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
 import { normalizeAccountId, isAcpSessionKey } from "openclaw/plugin-sdk/routing";
@@ -441,28 +441,16 @@ export function createTelegramThreadBindingManager(
     });
   }
 
-  // Clean up bindings to stale/failed ACP sessions on startup
-  // Group bindings by targetSessionKey to avoid redundant session store reads
-  // Only process ACP runtime sessions (skip plugin-bound sessions like "plugin-binding:*")
-  const bindingsByTargetSession = new Map<string, TelegramThreadBindingRecord[]>();
+  const acpSessionKeys = new Set<string>();
   for (const binding of getThreadBindingsState().bindingsByAccountConversation.values()) {
-    if (binding.targetKind !== "acp") {
+    if (binding.targetKind !== "acp" || !isAcpSessionKey(binding.targetSessionKey)) {
       continue;
     }
-    // Skip plugin-bound sessions — they use "plugin-binding:*" keys, not ACP session keys
-    if (!isAcpSessionKey(binding.targetSessionKey)) {
-      continue;
-    }
-    const existing = bindingsByTargetSession.get(binding.targetSessionKey);
-    if (existing) {
-      existing.push(binding);
-    } else {
-      bindingsByTargetSession.set(binding.targetSessionKey, [binding]);
-    }
+    acpSessionKeys.add(binding.targetSessionKey);
   }
 
   const staleSessionKeys = new Set<string>();
-  for (const targetSessionKey of bindingsByTargetSession.keys()) {
+  for (const targetSessionKey of acpSessionKeys) {
     const sessionEntry = readAcpSessionEntry({ sessionKey: targetSessionKey });
     if (!sessionEntry || sessionEntry.storeReadFailed) {
       continue;

--- a/src/plugin-sdk/routing.ts
+++ b/src/plugin-sdk/routing.ts
@@ -13,6 +13,7 @@ export {
   DEFAULT_MAIN_KEY,
   buildGroupHistoryKey,
   isCronSessionKey,
+  isAcpSessionKey,
   isSubagentSessionKey,
   normalizeAccountId,
   normalizeAgentId,


### PR DESCRIPTION
## Summary

When a Telegram DM is bound to an ACP session and that session becomes stale/failed, the binding persisted across OpenClaw restarts, causing DMs to continue routing to the dead session instead of the main agent.

## Root Cause

Bindings are persisted to `~/.openclaw/telegram/thread-bindings-{accountId}.json` and loaded on manager startup. No validation was performed to check whether the target ACP session still existed or was valid.

## Fix

When `createTelegramThreadBindingManager` initializes, it now validates each ACP binding against the session store and removes bindings where:
- Session entry doesn't exist (deleted externally)
- Session status is `failed`/`killed`/`timeout`
- ACP runtime state is `error`

## Changes

- `extensions/telegram/src/thread-bindings.ts`: Added stale session cleanup logic on manager creation
- Uses `readAcpSessionEntry()` from `openclaw/plugin-sdk/acp-runtime` to check session validity

## Testing

1. Bind Telegram DM to ACP session
2. Kill/fail the ACP session externally
3. Restart OpenClaw
4. Send new DM. This should route to main agent, not stale session

## Related Issue

Fixes #60102
