### PR TITLE
CI: fix live docker vite temp overlay

### DIFF
--- a/scripts/test-live-gateway-models-docker.sh
+++ b/scripts/test-live-gateway-models-docker.sh
@@ -129,6 +129,10 @@ cleanup() {
 trap cleanup EXIT
 source /src/scripts/lib/live-docker-stage.sh
 openclaw_live_stage_source_tree "$tmp_dir"
+mkdir -p "$tmp_dir/node_modules"
+cp -aRs /app/node_modules/. "$tmp_dir/node_modules"
+rm -rf "$tmp_dir/node_modules/.vite-temp"
+mkdir -p "$tmp_dir/node_modules/.vite-temp"
 openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config

--- a/scripts/test-live-models-docker.sh
+++ b/scripts/test-live-models-docker.sh
@@ -159,6 +159,10 @@ cleanup() {
 trap cleanup EXIT
 source /src/scripts/lib/live-docker-stage.sh
 openclaw_live_stage_source_tree "$tmp_dir"
+mkdir -p "$tmp_dir/node_modules"
+cp -aRs /app/node_modules/. "$tmp_dir/node_modules"
+rm -rf "$tmp_dir/node_modules/.vite-temp"
+mkdir -p "$tmp_dir/node_modules/.vite-temp"
 openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config


### PR DESCRIPTION
## Summary
- add the writable staged node_modules overlay to the live-models Docker lane
- add the same writable staged node_modules overlay to the live-gateway Docker lane
- align these profile-based lanes with the already-fixed ACP, CLI backend, and Codex harness Docker flows

## Testing
- bash -n scripts/test-live-models-docker.sh scripts/test-live-gateway-models-docker.sh
- git diff --check
- TMPDIR=$(mktemp -d) CI=true OPENCLAW_DOCKER_PROFILE_ENV_ONLY=1 OPENCLAW_LIVE_MODELS=openai-codex/gpt-5.4 OPENCLAW_LIVE_MAX_MODELS=1 scripts/test-live-models-docker.sh
- TMPDIR=$(mktemp -d) HOME=$(mktemp -d) CI=true OPENCLAW_LIVE_GATEWAY_PROVIDERS=openai-codex OPENCLAW_LIVE_GATEWAY_MODELS=openai-codex/gpt-5.4 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=1 scripts/test-live-gateway-models-docker.sh  # local machine failed later during Docker build env setup, but not on the old .vite-temp write path
