### PR TITLE
fix(openai): align auth picker labels for API key vs Codex OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/OpenAI: lock the auth picker wording for OpenAI API key, Codex browser login, and Codex device pairing so the setup choices no longer imply a mixed Codex/API-key auth path. (#67848) Thanks @tmlxrd.
 - Agents/BTW: route `/btw` side questions through provider stream registration with the session workspace, so Ollama provider URL construction and workspace-scoped hooks apply correctly. Fixes #68336. (#70413) Thanks @suboss87.
 - Memory search: use sqlite-vec KNN for vector recall while preserving full post-filter result limits in multi-model indexes. Fixes #69666. (#69680) Thanks @aalekh-sarvam.
 - Providers/OpenAI Codex: stop stale per-agent `openai-codex:default` OAuth profiles from shadowing a newer main-agent identity-scoped profile, and let `openclaw doctor` offer the matching cleanup. (#70393) Thanks @pashpashpash.

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -110,6 +110,21 @@ describe("openai codex provider", () => {
     });
   });
 
+  it("exposes grouped model/auth picker labels for Codex auth methods", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+    const oauth = provider.auth?.find((method) => method.id === "oauth");
+    const deviceCode = provider.auth?.find((method) => method.id === "device-code");
+
+    expect(oauth?.wizard).toMatchObject({
+      choiceLabel: "OpenAI Codex Browser Login",
+      groupHint: "API key + Codex auth",
+    });
+    expect(deviceCode?.wizard).toMatchObject({
+      choiceLabel: "OpenAI Codex Device Pairing",
+      groupHint: "API key + Codex auth",
+    });
+  });
+
   it("returns deprecated-profile doctor guidance for legacy Codex CLI ids", () => {
     const provider = buildOpenAICodexProviderPlugin();
 

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -49,6 +49,16 @@ function runWrappedPayloadCase(params: {
 }
 
 describe("buildOpenAIProvider", () => {
+  it("exposes grouped model/auth picker labels for API key setup", () => {
+    const provider = buildOpenAIProvider();
+    const apiKey = provider.auth.find((method) => method.id === "api-key");
+
+    expect(apiKey?.wizard).toMatchObject({
+      choiceLabel: "OpenAI API Key",
+      groupHint: "API key + Codex auth",
+    });
+  });
+
   it("resolves gpt-5.4 mini and nano from GPT-5 small-model templates", () => {
     const provider = buildOpenAIProvider();
     const registry = {

--- a/extensions/openai/openclaw.plugin.test.ts
+++ b/extensions/openai/openclaw.plugin.test.ts
@@ -5,8 +5,13 @@ const manifest = JSON.parse(
   readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf8"),
 ) as {
   providerAuthChoices?: Array<{
+    provider?: string;
+    method?: string;
+    choiceLabel?: string;
+    choiceHint?: string;
     choiceId?: string;
     deprecatedChoiceIds?: string[];
+    groupHint?: string;
   }>;
 };
 
@@ -17,5 +22,35 @@ describe("OpenAI plugin manifest", () => {
     );
 
     expect(codexBrowserLogin?.deprecatedChoiceIds).toContain("openai-codex-import");
+  });
+
+  it("labels OpenAI API key and Codex auth choices without stale mixed OAuth wording", () => {
+    const choices = manifest.providerAuthChoices ?? [];
+    const codexBrowserLogin = choices.find((choice) => choice.choiceId === "openai-codex");
+    const codexDeviceCode = choices.find(
+      (choice) => choice.choiceId === "openai-codex-device-code",
+    );
+    const apiKey = choices.find(
+      (choice) => choice.provider === "openai" && choice.method === "api-key",
+    );
+
+    expect(codexBrowserLogin).toMatchObject({
+      choiceLabel: "OpenAI Codex Browser Login",
+      choiceHint: "Sign in with OpenAI in your browser",
+      groupHint: "API key + Codex auth",
+    });
+    expect(codexDeviceCode).toMatchObject({
+      choiceLabel: "OpenAI Codex Device Pairing",
+      choiceHint: "Pair in browser with a device code",
+      groupHint: "API key + Codex auth",
+    });
+    expect(apiKey).toMatchObject({
+      choiceLabel: "OpenAI API Key",
+      groupHint: "API key + Codex auth",
+    });
+    expect(choices.map((choice) => choice.choiceLabel)).not.toContain(
+      "OpenAI Codex (ChatGPT OAuth)",
+    );
+    expect(choices.map((choice) => choice.groupHint)).not.toContain("Codex OAuth + API key");
   });
 });


### PR DESCRIPTION
## Summary

- Problem: The auth picker showed misleading OpenAI labeling by combining API key and Codex OAuth hints, and the OpenAI Codex row did not show a matching auth hint.
- Why it matters: This can confuse users during provider setup and makes the OpenAI and OpenAI Codex auth paths look inconsistent.
- What changed: Split the OpenAI hints so API key and Codex OAuth are labeled separately, updated the Codex choice label wording, and added regression tests.
- What did NOT change (scope boundary): No auth behavior, provider IDs, token handling, or network logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: OpenAI auth-choice metadata used misleading shared hints across distinct auth paths, and the Codex row did not expose matching grouped-picker hint metadata.
- Missing detection / guardrail: No regression coverage for bundled OpenAI auth-choice labeling in the manifest/provider setup metadata.
- Contributing context (if known): The grouped picker and provider setup metadata were not aligned for OpenAI API key vs OpenAI Codex OAuth wording.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/commands/auth-choice-options.test.ts`
  - `extensions/openai/openai-codex-provider.test.ts`
- Scenario the test should lock in: OpenAI auth choices are labeled distinctly as API key vs Codex OAuth in bundled manifest/provider metadata.
- Why this is the smallest reliable guardrail: The bug is in auth-choice metadata and provider setup labels, so targeted unit coverage is enough.
- Existing test that already covers this (if any): None specific to this labeling.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- The auth picker now shows `OpenAI (API key)` and `OpenAI Codex (Codex OAuth)` instead of ambiguous/misaligned wording.

## Diagram (if applicable)

```text
Before:
[user opens auth picker] -> [OpenAI label implies mixed auth methods / Codex row lacks matching hint]

After:
[user opens auth picker] -> [OpenAI (API key) and OpenAI Codex (Codex OAuth)] -> [clearer provider setup choices]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm
- Model/provider: OpenAI / OpenAI Codex auth picker
- Integration/channel (if any): CLI configure flow
- Relevant config (redacted): N/A

### Steps

1. Open the auth/model provider configure flow before the fix.
2. Observe the OpenAI and OpenAI Codex entries in the picker.
3. Apply the patch and rerun configure flow.

### Expected

- Distinct, accurate labels for API key vs Codex OAuth.

### Actual

- Before the fix, the wording was misleading/inconsistent.
- After the fix, the labels are explicit and aligned.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- Before: auth picker showed `OpenAI (Codex OAuth + API key)` and `OpenAI Codex`
<img width="323" height="176" alt="image" src="https://github.com/user-attachments/assets/2d6f3721-90f5-4485-8d7d-94b1252be8e8" />
<img width="355" height="129" alt="image" src="https://github.com/user-attachments/assets/0ddcc01d-b82b-4919-a92d-94a43de1abe8" />

- After: auth picker shows `OpenAI (API key)` and `OpenAI Codex (Codex OAuth)`
<img width="249" height="104" alt="image" src="https://github.com/user-attachments/assets/75263920-9f3e-403a-a4d7-a206b68aee55" />
<img width="275" height="113" alt="image" src="https://github.com/user-attachments/assets/c5c5b491-cf97-4b62-8dbf-dba828a329e5" />

- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Confirmed the picker shows `OpenAI (API key)` and `OpenAI Codex (Codex OAuth)`.
- Edge cases checked: Verified bundled manifest/provider metadata and related tests/build pass.
- What you did **not** verify: Did not verify unrelated auth providers or broader onboarding flows beyond this label fix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Wording expectations may differ from maintainer preference.
  - Mitigation: Change is small, scoped, and covered by targeted tests.



