### PR TITLE
fix(discord): narrow message tool component block schema

### DIFF
--- a/extensions/discord/src/message-tool-schema.test.ts
+++ b/extensions/discord/src/message-tool-schema.test.ts
@@ -1,0 +1,39 @@
+import { Value } from "@sinclair/typebox/value";
+import { describe, expect, it } from "vitest";
+import { createDiscordMessageToolComponentsSchema } from "./message-tool-schema.js";
+
+describe("createDiscordMessageToolComponentsSchema", () => {
+  it("accepts plain text-only component payloads", () => {
+    const schema = createDiscordMessageToolComponentsSchema();
+    expect(Value.Check(schema, { text: "hello" })).toBe(true);
+  });
+
+  it("accepts action rows with buttons without requiring buttons on other block types", () => {
+    const schema = createDiscordMessageToolComponentsSchema();
+    expect(
+      Value.Check(schema, {
+        blocks: [
+          { type: "text", text: "hello" },
+          { type: "actions", buttons: [{ label: "Approve", style: "success" }] },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts select-only action rows", () => {
+    const schema = createDiscordMessageToolComponentsSchema();
+    expect(
+      Value.Check(schema, {
+        blocks: [
+          {
+            type: "actions",
+            select: {
+              type: "string",
+              options: [{ label: "One", value: "1" }],
+            },
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+});

--- a/extensions/discord/src/message-tool-schema.ts
+++ b/extensions/discord/src/message-tool-schema.ts
@@ -38,13 +38,8 @@ const discordComponentSelectSchema = Type.Object({
   options: Type.Optional(Type.Array(discordComponentOptionSchema)),
 });
 
-const discordTextBlockSchema = Type.Object({
-  type: Type.Literal("text"),
-  text: Type.String(),
-});
-
-const discordSectionBlockSchema = Type.Object({
-  type: Type.Literal("section"),
+const discordComponentBlockSchema = Type.Object({
+  type: stringEnum(["text", "section", "separator", "actions", "media-gallery", "file"]),
   text: Type.Optional(Type.String()),
   texts: Type.Optional(Type.Array(Type.String())),
   accessory: Type.Optional(
@@ -54,45 +49,22 @@ const discordSectionBlockSchema = Type.Object({
       button: Type.Optional(discordComponentButtonSchema),
     }),
   ),
-});
-
-const discordSeparatorBlockSchema = Type.Object({
-  type: Type.Literal("separator"),
   spacing: Type.Optional(stringEnum(["small", "large"])),
   divider: Type.Optional(Type.Boolean()),
-});
-
-const discordActionsBlockSchema = Type.Object({
-  type: Type.Literal("actions"),
   buttons: Type.Optional(Type.Array(discordComponentButtonSchema)),
   select: Type.Optional(discordComponentSelectSchema),
-});
-
-const discordMediaGalleryBlockSchema = Type.Object({
-  type: Type.Literal("media-gallery"),
-  items: Type.Array(
-    Type.Object({
-      url: Type.String(),
-      description: Type.Optional(Type.String()),
-      spoiler: Type.Optional(Type.Boolean()),
-    }),
+  items: Type.Optional(
+    Type.Array(
+      Type.Object({
+        url: Type.String(),
+        description: Type.Optional(Type.String()),
+        spoiler: Type.Optional(Type.Boolean()),
+      }),
+    ),
   ),
-});
-
-const discordFileBlockSchema = Type.Object({
-  type: Type.Literal("file"),
-  file: Type.String(),
+  file: Type.Optional(Type.String()),
   spoiler: Type.Optional(Type.Boolean()),
 });
-
-const discordComponentBlockSchema = Type.Union([
-  discordTextBlockSchema,
-  discordSectionBlockSchema,
-  discordSeparatorBlockSchema,
-  discordActionsBlockSchema,
-  discordMediaGalleryBlockSchema,
-  discordFileBlockSchema,
-]);
 
 const discordComponentModalFieldSchema = Type.Object({
   type: Type.String(),

--- a/extensions/discord/src/message-tool-schema.ts
+++ b/extensions/discord/src/message-tool-schema.ts
@@ -38,8 +38,13 @@ const discordComponentSelectSchema = Type.Object({
   options: Type.Optional(Type.Array(discordComponentOptionSchema)),
 });
 
-const discordComponentBlockSchema = Type.Object({
-  type: Type.String(),
+const discordTextBlockSchema = Type.Object({
+  type: Type.Literal("text"),
+  text: Type.String(),
+});
+
+const discordSectionBlockSchema = Type.Object({
+  type: Type.Literal("section"),
   text: Type.Optional(Type.String()),
   texts: Type.Optional(Type.Array(Type.String())),
   accessory: Type.Optional(
@@ -49,22 +54,45 @@ const discordComponentBlockSchema = Type.Object({
       button: Type.Optional(discordComponentButtonSchema),
     }),
   ),
+});
+
+const discordSeparatorBlockSchema = Type.Object({
+  type: Type.Literal("separator"),
   spacing: Type.Optional(stringEnum(["small", "large"])),
   divider: Type.Optional(Type.Boolean()),
+});
+
+const discordActionsBlockSchema = Type.Object({
+  type: Type.Literal("actions"),
   buttons: Type.Optional(Type.Array(discordComponentButtonSchema)),
   select: Type.Optional(discordComponentSelectSchema),
-  items: Type.Optional(
-    Type.Array(
-      Type.Object({
-        url: Type.String(),
-        description: Type.Optional(Type.String()),
-        spoiler: Type.Optional(Type.Boolean()),
-      }),
-    ),
+});
+
+const discordMediaGalleryBlockSchema = Type.Object({
+  type: Type.Literal("media-gallery"),
+  items: Type.Array(
+    Type.Object({
+      url: Type.String(),
+      description: Type.Optional(Type.String()),
+      spoiler: Type.Optional(Type.Boolean()),
+    }),
   ),
-  file: Type.Optional(Type.String()),
+});
+
+const discordFileBlockSchema = Type.Object({
+  type: Type.Literal("file"),
+  file: Type.String(),
   spoiler: Type.Optional(Type.Boolean()),
 });
+
+const discordComponentBlockSchema = Type.Union([
+  discordTextBlockSchema,
+  discordSectionBlockSchema,
+  discordSeparatorBlockSchema,
+  discordActionsBlockSchema,
+  discordMediaGalleryBlockSchema,
+  discordFileBlockSchema,
+]);
 
 const discordComponentModalFieldSchema = Type.Object({
   type: Type.String(),


### PR DESCRIPTION
## Summary
- narrow the Discord message tool component block schema into explicit block-type unions
- stop plain text and non-button blocks from tripping `buttons` validation errors
- add regression tests for text-only, button, and select component payloads

Closes #67852.

## Testing
- node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/discord/src/message-tool-schema.test.ts extensions/discord/src/send.components.test.ts
