### PR TITLE
fix: guard .trim() on undefined prompter values in WhatsApp personal phone setup

### DIFF
--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -234,6 +234,55 @@ describe("whatsapp setup wizard", () => {
     expectWhatsAppLoginFollowup(harness);
   });
 
+  it("handles undefined phone number input without crashing (#67837)", async () => {
+    hoisted.pathExists.mockResolvedValue(true);
+    const harness = createQueuedWizardPrompter({
+      confirmValues: [false],
+      selectValues: ["personal"],
+      textValues: ["+15555550199"],
+    });
+
+    // Capture the validate callback to test it directly
+    let capturedValidate: ((value: string) => string | undefined) | undefined;
+    const originalText = harness.prompter.text;
+    let callCount = 0;
+    harness.prompter.text = async (opts) => {
+      callCount++;
+      if (callCount === 1 && opts.validate) {
+        capturedValidate = opts.validate;
+      }
+      return originalText.call(harness.prompter, opts);
+    };
+
+    const result = await runConfigureWithHarness({ harness });
+    expect(result.cfg).toBeDefined();
+    // The validate callback must not throw on undefined — this was the #67837 crash
+    expect(capturedValidate).toBeDefined();
+    expect(capturedValidate!(undefined as unknown as string)).toBe("Required");
+  });
+
+  it("handles undefined allowFrom text input without crashing (#67837)", async () => {
+    hoisted.pathExists.mockResolvedValue(true);
+
+    let capturedValidate: ((value: string) => string | undefined) | undefined;
+    const harness = createSeparatePhoneHarness({
+      selectValues: ["separate", "allowlist", "list"],
+      textValues: ["+15555550123"],
+    });
+    const originalText = harness.prompter.text;
+    harness.prompter.text = async (opts) => {
+      if (opts.validate && !capturedValidate) {
+        capturedValidate = opts.validate;
+      }
+      return originalText.call(harness.prompter, opts);
+    };
+
+    const result = await runConfigureWithHarness({ harness });
+    expect(result.cfg).toBeDefined();
+    expect(capturedValidate).toBeDefined();
+    expect(capturedValidate!(undefined as unknown as string)).toBe("Required");
+  });
+
   it("heartbeat readiness uses configured defaultAccount for active listener checks", async () => {
     const result = await checkWhatsAppHeartbeatReady({
       cfg: {

--- a/extensions/whatsapp/src/setup-finalize.ts
+++ b/extensions/whatsapp/src/setup-finalize.ts
@@ -124,7 +124,7 @@ async function promptWhatsAppOwnerAllowFrom(params: {
     placeholder: "+15555550123",
     initialValue: existingAllowFrom[0],
     validate: (value) => {
-      const raw = value.trim();
+      const raw = (value ?? "").trim();
       if (!raw) {
         return "Required";
       }
@@ -136,7 +136,7 @@ async function promptWhatsAppOwnerAllowFrom(params: {
     },
   });
 
-  const normalized = normalizeE164(entry.trim());
+  const normalized = normalizeE164((entry ?? "").trim());
   if (!normalized) {
     throw new Error("Invalid WhatsApp owner number (expected E.164 after validation).");
   }
@@ -311,7 +311,7 @@ async function promptWhatsAppDmAccess(params: {
     message: "Allowed sender numbers (comma-separated, E.164)",
     placeholder: "+15555550123, +447700900123",
     validate: (value) => {
-      const raw = value.trim();
+      const raw = (value ?? "").trim();
       if (!raw) {
         return "Required";
       }
@@ -326,7 +326,7 @@ async function promptWhatsAppDmAccess(params: {
     },
   });
 
-  const parsed = parseWhatsAppAllowFromEntries(allowRaw);
+  const parsed = parseWhatsAppAllowFromEntries(allowRaw ?? "");
   return setWhatsAppAllowFrom(next, accountId, parsed.entries);
 }
 


### PR DESCRIPTION
Fixes #67837

**Problem:** WhatsApp personal phone setup crashes with `TypeError: Cannot read properties of undefined (reading 'trim')` after entering a valid phone number. The prompter can return `undefined` for optional fields, but `.trim()` was called without null guards.

**Fix:** Added null/undefined guards before `.trim()` calls in `setup-finalize.ts`, similar to the fixes in #67489 and #67525.

**Tests:** Added test coverage for the case where prompter returns undefined values.