### PR TITLE
fix(discord): normalize ACP child thread binding targets

### DIFF
--- a/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
@@ -85,6 +85,40 @@ describe("resolveChannelIdForBinding", () => {
     expect(resolved).toBe("channel-parent");
   });
 
+  it("strips channel prefix before resolving route", async () => {
+    restGet.mockResolvedValueOnce({
+      id: "123456789",
+      type: ChannelType.GuildText,
+    });
+
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "channel:123456789",
+    });
+
+    expect(resolved).toBe("123456789");
+    const route = JSON.stringify(restGet.mock.calls[0]?.[0] ?? null);
+    expect(route).toContain("123456789");
+    expect(route).not.toContain("channel:");
+  });
+
+  it("strips user prefix before resolving route", async () => {
+    restGet.mockResolvedValueOnce({
+      id: "987654321",
+      type: ChannelType.DM,
+    });
+
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "user:987654321",
+    });
+
+    expect(resolved).toBe("987654321");
+    const route = JSON.stringify(restGet.mock.calls[0]?.[0] ?? null);
+    expect(route).toContain("987654321");
+    expect(route).not.toContain("user:");
+  });
+
   it("forwards cfg when resolving channel id through Discord client", async () => {
     const cfg = {
       channels: { discord: { token: "tok" } },

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.ts
@@ -237,6 +237,11 @@ export async function resolveChannelIdForBinding(params: {
   if (explicit) {
     return explicit;
   }
+  const normalizedThreadId =
+    normalizeOptionalString(params.threadId)?.replace(/^(?:channel:|user:)/i, "") ?? "";
+  if (!normalizedThreadId) {
+    return null;
+  }
   try {
     const rest = createDiscordRestClient(
       {
@@ -245,7 +250,7 @@ export async function resolveChannelIdForBinding(params: {
       },
       params.cfg,
     ).rest;
-    const channel = (await rest.get(Routes.channel(params.threadId))) as {
+    const channel = (await rest.get(Routes.channel(normalizedThreadId))) as {
       id?: string;
       type?: number;
       parent_id?: string;

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -15,6 +15,7 @@ import {
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { createDiscordRestClient } from "../client.js";
+import { normalizeDiscordMessagingTarget } from "../normalize.js";
 import {
   createThreadForBinding,
   createWebhookForChannel,
@@ -630,11 +631,17 @@ export function createThreadBindingManager(
           ? normalizeOptionalString(metadata.agentId)
           : undefined;
       let threadId: string | undefined;
-      let channelId = normalizeOptionalString(input.conversation.parentConversationId);
+      let channelId =
+        normalizeDiscordMessagingTarget(
+          normalizeOptionalString(input.conversation.parentConversationId) ?? "",
+        ) ?? undefined;
       let createThread = false;
 
       if (placement === "child") {
         createThread = true;
+        if (channelId) {
+          channelId = normalizeOptionalString(channelId)?.replace(/^channel:/i, "") ?? undefined;
+        }
         if (!channelId && conversationId) {
           const cfg = resolveCurrentCfg();
           channelId =


### PR DESCRIPTION
## Summary

Fix Discord ACP child-thread binding failures caused by unnormalized conversation targets during bind resolution.

This patch does two things:

- strips `channel:` / `user:` prefixes before `resolveChannelIdForBinding(...)` calls the Discord channel route
- normalizes `parentConversationId` for Discord child ACP thread binds before falling back to channel resolution

Together these fix a real repro where persistent Discord-bound ACP sessions failed with:

- `Session binding adapter failed to bind target conversation`

## Problem

In the failing Discord ACP `mode="session", thread=true` path, bind prep could succeed but the Discord child binding still returned `null`.

The remaining issue was in target normalization inside the Discord binding layer:

1. `resolveChannelIdForBinding(...)` could receive prefixed ids like `channel:...` or `user:...` and pass them straight into `Routes.channel(...)`
2. child placement handling only lightly trimmed `parentConversationId`, instead of normalizing it as a Discord messaging target before using it as the parent channel for thread creation/binding

That made valid Discord conversation refs fail to resolve cleanly in the child-thread bind path.

## Changes

### 1. Normalize prefixed ids in `resolveChannelIdForBinding(...)`
File:
- `extensions/discord/src/monitor/thread-bindings.discord-api.ts`

Before calling `Routes.channel(...)`, normalize `threadId` by stripping:
- `channel:`
- `user:`

If the normalized id is empty, return `null`.

### 2. Normalize child binding parent conversation target
File:
- `extensions/discord/src/monitor/thread-bindings.manager.ts`

For `placement === "child"`:
- normalize `input.conversation.parentConversationId` with `normalizeDiscordMessagingTarget(...)`
- strip the `channel:` prefix before using it as `channelId`
- if no normalized parent channel is available, keep the existing fallback through `resolveChannelIdForBinding(...)`

This preserves the existing fallback behavior while making explicit parent refs resolve correctly.

## Tests

Added regression coverage in:
- `extensions/discord/src/monitor/thread-bindings.discord-api.test.ts`

New cases cover:
- `channel:` prefixed thread ids
- `user:` prefixed thread ids

Targeted validation run:
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-channels.config.ts extensions/discord/src/monitor/thread-bindings.discord-api.test.ts`

Result:
- passed

## Real-world repro validated locally

This fix came from debugging a live Discord ACP persistent-session failure where:
- Discord thread creation itself worked
- bot permissions/channel type were valid
- Codex auth was valid
- `channels.discord.threadBindings.spawnAcpSessions=true` was already enabled

But persistent ACP thread binding still failed until the child-binding normalization path was fixed.

## Notes

The full repo-wide pre-commit check is currently failing on unrelated existing lint/test issues elsewhere in the tree, so this patch was validated with targeted tests for the affected Discord binding area.
