### PR TITLE
fix(pre-commit): support corepack-managed pnpm in hook tooling

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -65,6 +65,9 @@ git add -- "${files[@]}"
 # exist. Only run the repo-wide validation gate inside a real checkout.
 if [[ -f "$ROOT_DIR/package.json" ]] && [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; then
   cd "$ROOT_DIR"
+  if ! command -v pnpm >/dev/null 2>&1 && command -v corepack >/dev/null 2>&1; then
+    corepack enable >/dev/null 2>&1 || true
+  fi
   case "${FAST_COMMIT:-}" in
     1|true|TRUE|yes|YES|on|ON)
       echo "FAST_COMMIT enabled: skipping pnpm check in pre-commit hook."

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -76,7 +76,14 @@ if [[ -f "$ROOT_DIR/package.json" ]] && [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; the
       if [[ "$docs_only" == true ]]; then
         echo "Docs-only staged changes detected: skipping pnpm check in pre-commit hook."
       else
-        pnpm check
+        if command -v pnpm >/dev/null 2>&1; then
+          pnpm check
+        elif command -v corepack >/dev/null 2>&1; then
+          corepack pnpm check
+        else
+          echo "Missing package manager: pnpm required for pre-commit check (or Corepack-enabled pnpm)." >&2
+          exit 1
+        fi
       fi
       ;;
   esac

--- a/scripts/pre-commit/run-node-tool.sh
+++ b/scripts/pre-commit/run-node-tool.sh
@@ -17,7 +17,7 @@ if [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; then
   fi
   if command -v corepack >/dev/null 2>&1 && [[ -f "$ROOT_DIR/package.json" ]]; then
     package_manager="$(node -e "const p=require(process.argv[1]); process.stdout.write(typeof p.packageManager==='string' ? p.packageManager : '')" "$ROOT_DIR/package.json" 2>/dev/null || true)"
-    if [[ "$package_manager" == pnpm@* ]]; then
+    if [[ "$package_manager" == pnpm@* ]] && corepack pnpm --version >/dev/null 2>&1; then
       exec corepack pnpm exec "$tool" "$@"
     fi
   fi

--- a/scripts/pre-commit/run-node-tool.sh
+++ b/scripts/pre-commit/run-node-tool.sh
@@ -11,8 +11,16 @@ fi
 tool="$1"
 shift
 
-if [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]] && command -v pnpm >/dev/null 2>&1; then
-  exec pnpm exec "$tool" "$@"
+if [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; then
+  if command -v pnpm >/dev/null 2>&1; then
+    exec pnpm exec "$tool" "$@"
+  fi
+  if command -v corepack >/dev/null 2>&1 && [[ -f "$ROOT_DIR/package.json" ]]; then
+    package_manager="$(node -e "const p=require(process.argv[1]); process.stdout.write(typeof p.packageManager==='string' ? p.packageManager : '')" "$ROOT_DIR/package.json" 2>/dev/null || true)"
+    if [[ "$package_manager" == pnpm@* ]]; then
+      exec corepack pnpm exec "$tool" "$@"
+    fi
+  fi
 fi
 
 if { [[ -f "$ROOT_DIR/bun.lockb" ]] || [[ -f "$ROOT_DIR/bun.lock" ]]; } && command -v bun >/dev/null 2>&1; then
@@ -27,5 +35,5 @@ if command -v npx >/dev/null 2>&1; then
   exec npx "$tool" "$@"
 fi
 
-echo "Missing package manager: pnpm, bun, or npm required." >&2
+echo "Missing package manager: pnpm (or Corepack-managed pnpm), bun, or npm required." >&2
 exit 1


### PR DESCRIPTION
## Summary
- support Corepack-managed pnpm in pre-commit tooling
- restore run-node-tool Corepack support in the hook path
- preserve npm fallback behavior when pnpm is unavailable

Closes #66695.

## Testing
- existing branch validation from the original work
