### PR TITLE
fix(control-ui): prevent chat auto-follow from overriding manual scroll

### DIFF
--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -15,12 +15,13 @@ title: "Thinking Levels"
   - low → “think hard”
   - medium → “think harder”
   - high → “ultrathink” (max budget)
-  - xhigh → “ultrathink+” (GPT-5.2 + Codex models only)
-  - adaptive → provider-managed adaptive reasoning budget (supported for Anthropic Claude 4.6 model family)
+  - xhigh → “ultrathink+” (GPT-5.2 + Codex models and Anthropic Claude Opus 4.7)
+  - adaptive → provider-managed adaptive reasoning budget (supported for Anthropic Claude 4.6 and Opus 4.7)
   - `x-high`, `x_high`, `extra-high`, `extra high`, and `extra_high` map to `xhigh`.
   - `highest`, `max` map to `high`.
 - Provider notes:
-  - Anthropic Claude 4.6 models default to `adaptive` when no explicit thinking level is set.
+  - Anthropic Claude 4.6 and Opus 4.7 models default to `adaptive` when no explicit thinking level is set.
+  - Anthropic Claude Opus 4.7 maps `/think xhigh` to `output_config.effort: "xhigh"`.
   - MiniMax (`minimax/*`) on the Anthropic-compatible streaming path defaults to `thinking: { type: "disabled" }` unless you explicitly set thinking in model params or request params. This avoids leaked `reasoning_content` deltas from MiniMax's non-native Anthropic stream format.
   - Z.AI (`zai/*`) only supports binary thinking (`on`/`off`). Any non-`off` level is treated as `on` (mapped to `low`).
   - Moonshot (`moonshot/*`) maps `/think off` to `thinking: { type: "disabled" }` and any non-`off` level to `thinking: { type: "enabled" }`. When thinking is enabled, Moonshot only accepts `tool_choice` `auto|none`; OpenClaw normalizes incompatible values to `auto`.
@@ -31,7 +32,7 @@ title: "Thinking Levels"
 2. Session override (set by sending a directive-only message).
 3. Per-agent default (`agents.list[].thinkingDefault` in config).
 4. Global default (`agents.defaults.thinkingDefault` in config).
-5. Fallback: `adaptive` for Anthropic Claude 4.6 models, `low` for other reasoning-capable models, `off` otherwise.
+5. Fallback: `adaptive` for Anthropic Claude 4.6 and Opus 4.7 models, `low` for other reasoning-capable models, `off` otherwise.
 
 ## Setting a session default
 
@@ -104,8 +105,9 @@ title: "Thinking Levels"
 
 - The web chat thinking selector mirrors the session's stored level from the inbound session store/config when the page loads.
 - Picking another level writes the session override immediately via `sessions.patch`; it does not wait for the next send and it is not a one-shot `thinkingOnce` override.
-- The first option is always `Default (<resolved level>)`, where the resolved default comes from the active session model: `adaptive` for Claude 4.6 on Anthropic/Bedrock, `low` for other reasoning-capable models, `off` otherwise.
+- The first option is always `Default (<resolved level>)`, where the resolved default comes from the active session model: `adaptive` for Claude 4.6 and Opus 4.7 on Anthropic, `low` for other reasoning-capable models, `off` otherwise.
 - The picker stays provider-aware:
   - most providers show `off | minimal | low | medium | high | adaptive`
+  - Anthropic Claude Opus 4.7 shows `off | minimal | low | medium | high | xhigh | adaptive`
   - Z.AI shows binary `off | on`
 - `/think:<level>` still works and updates the same stored session level, so chat directives and the picker stay in sync.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -15,13 +15,14 @@ title: "Thinking Levels"
   - low → “think hard”
   - medium → “think harder”
   - high → “ultrathink” (max budget)
-  - xhigh → “ultrathink+” (GPT-5.2 + Codex models and Anthropic Claude Opus 4.7)
-  - adaptive → provider-managed adaptive reasoning budget (supported for Anthropic Claude 4.6 and Opus 4.7)
+  - xhigh → “ultrathink+” (GPT-5.2 + Codex models and Anthropic Claude Opus 4.7 effort)
+  - adaptive → provider-managed adaptive thinking (supported for Anthropic Claude 4.6 and Opus 4.7)
   - `x-high`, `x_high`, `extra-high`, `extra high`, and `extra_high` map to `xhigh`.
   - `highest`, `max` map to `high`.
 - Provider notes:
-  - Anthropic Claude 4.6 and Opus 4.7 models default to `adaptive` when no explicit thinking level is set.
-  - Anthropic Claude Opus 4.7 maps `/think xhigh` to `output_config.effort: "xhigh"`.
+  - Anthropic Claude 4.6 models default to `adaptive` when no explicit thinking level is set.
+  - Anthropic Claude Opus 4.7 does not default to adaptive thinking. Its API effort default remains provider-owned unless you explicitly set a thinking level.
+  - Anthropic Claude Opus 4.7 maps `/think xhigh` to adaptive thinking plus `output_config.effort: "xhigh"`, because `/think` is a thinking directive and `xhigh` is the Opus 4.7 effort setting.
   - MiniMax (`minimax/*`) on the Anthropic-compatible streaming path defaults to `thinking: { type: "disabled" }` unless you explicitly set thinking in model params or request params. This avoids leaked `reasoning_content` deltas from MiniMax's non-native Anthropic stream format.
   - Z.AI (`zai/*`) only supports binary thinking (`on`/`off`). Any non-`off` level is treated as `on` (mapped to `low`).
   - Moonshot (`moonshot/*`) maps `/think off` to `thinking: { type: "disabled" }` and any non-`off` level to `thinking: { type: "enabled" }`. When thinking is enabled, Moonshot only accepts `tool_choice` `auto|none`; OpenClaw normalizes incompatible values to `auto`.
@@ -32,7 +33,7 @@ title: "Thinking Levels"
 2. Session override (set by sending a directive-only message).
 3. Per-agent default (`agents.list[].thinkingDefault` in config).
 4. Global default (`agents.defaults.thinkingDefault` in config).
-5. Fallback: `adaptive` for Anthropic Claude 4.6 and Opus 4.7 models, `low` for other reasoning-capable models, `off` otherwise.
+5. Fallback: `adaptive` for Anthropic Claude 4.6 models, `off` for Anthropic Claude Opus 4.7 unless explicitly configured, `low` for other reasoning-capable models, `off` otherwise.
 
 ## Setting a session default
 
@@ -105,7 +106,7 @@ title: "Thinking Levels"
 
 - The web chat thinking selector mirrors the session's stored level from the inbound session store/config when the page loads.
 - Picking another level writes the session override immediately via `sessions.patch`; it does not wait for the next send and it is not a one-shot `thinkingOnce` override.
-- The first option is always `Default (<resolved level>)`, where the resolved default comes from the active session model: `adaptive` for Claude 4.6 and Opus 4.7 on Anthropic, `low` for other reasoning-capable models, `off` otherwise.
+- The first option is always `Default (<resolved level>)`, where the resolved default comes from the active session model: `adaptive` for Claude 4.6 on Anthropic, `off` for Anthropic Claude Opus 4.7 unless configured, `low` for other reasoning-capable models, `off` otherwise.
 - The picker stays provider-aware:
   - most providers show `off | minimal | low | medium | high | adaptive`
   - Anthropic Claude Opus 4.7 shows `off | minimal | low | medium | high | xhigh | adaptive`

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -199,6 +199,12 @@ describe("anthropic provider replay hooks", () => {
         provider: "anthropic",
         modelId: "claude-opus-4-7",
       } as never),
+    ).toBe("off");
+    expect(
+      provider.resolveDefaultThinkingLevel?.({
+        provider: "anthropic",
+        modelId: "claude-opus-4-6",
+      } as never),
     ).toBe("adaptive");
     expect(
       provider.supportsXHighThinking?.({

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -200,6 +200,18 @@ describe("anthropic provider replay hooks", () => {
         modelId: "claude-opus-4-7",
       } as never),
     ).toBe("adaptive");
+    expect(
+      provider.supportsXHighThinking?.({
+        provider: "anthropic",
+        modelId: "claude-opus-4-7",
+      } as never),
+    ).toBe(true);
+    expect(
+      provider.supportsXHighThinking?.({
+        provider: "anthropic",
+        modelId: "claude-opus-4-6",
+      } as never),
+    ).toBe(false);
   });
 
   it("resolves claude-cli synthetic oauth auth", async () => {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -260,7 +260,6 @@ function resolveAnthropicForwardCompatModel(
 function shouldUseAnthropicAdaptiveThinkingDefault(modelId: string): boolean {
   const lowerModelId = normalizeLowercaseStringOrEmpty(modelId);
   return (
-    isAnthropicOpus47Model(lowerModelId) ||
     lowerModelId.startsWith(ANTHROPIC_OPUS_46_MODEL_ID) ||
     lowerModelId.startsWith(ANTHROPIC_OPUS_46_DOT_MODEL_ID) ||
     lowerModelId.startsWith(ANTHROPIC_SONNET_46_MODEL_ID) ||
@@ -491,9 +490,11 @@ export function registerAnthropicPlugin(api: OpenClawPluginApi): void {
     supportsXHighThinking: ({ modelId }) => isAnthropicOpus47Model(modelId),
     wrapStreamFn: wrapAnthropicProviderStream,
     resolveDefaultThinkingLevel: ({ modelId }) =>
-      matchesAnthropicModernModel(modelId) && shouldUseAnthropicAdaptiveThinkingDefault(modelId)
-        ? "adaptive"
-        : undefined,
+      isAnthropicOpus47Model(modelId)
+        ? "off"
+        : matchesAnthropicModernModel(modelId) && shouldUseAnthropicAdaptiveThinkingDefault(modelId)
+          ? "adaptive"
+          : undefined,
     resolveUsageAuth: async (ctx) => await ctx.resolveOAuthToken(),
     fetchUsageSnapshot: async (ctx) =>
       await fetchClaudeUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn),

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -260,12 +260,19 @@ function resolveAnthropicForwardCompatModel(
 function shouldUseAnthropicAdaptiveThinkingDefault(modelId: string): boolean {
   const lowerModelId = normalizeLowercaseStringOrEmpty(modelId);
   return (
-    lowerModelId.startsWith(ANTHROPIC_OPUS_47_MODEL_ID) ||
-    lowerModelId.startsWith(ANTHROPIC_OPUS_47_DOT_MODEL_ID) ||
+    isAnthropicOpus47Model(lowerModelId) ||
     lowerModelId.startsWith(ANTHROPIC_OPUS_46_MODEL_ID) ||
     lowerModelId.startsWith(ANTHROPIC_OPUS_46_DOT_MODEL_ID) ||
     lowerModelId.startsWith(ANTHROPIC_SONNET_46_MODEL_ID) ||
     lowerModelId.startsWith(ANTHROPIC_SONNET_46_DOT_MODEL_ID)
+  );
+}
+
+function isAnthropicOpus47Model(modelId: string): boolean {
+  const lowerModelId = normalizeLowercaseStringOrEmpty(modelId);
+  return (
+    lowerModelId.startsWith(ANTHROPIC_OPUS_47_MODEL_ID) ||
+    lowerModelId.startsWith(ANTHROPIC_OPUS_47_DOT_MODEL_ID)
   );
 }
 
@@ -481,6 +488,7 @@ export function registerAnthropicPlugin(api: OpenClawPluginApi): void {
     buildReplayPolicy: buildAnthropicReplayPolicy,
     isModernModelRef: ({ modelId }) => matchesAnthropicModernModel(modelId),
     resolveReasoningOutputMode: () => "native",
+    supportsXHighThinking: ({ modelId }) => isAnthropicOpus47Model(modelId),
     wrapStreamFn: wrapAnthropicProviderStream,
     resolveDefaultThinkingLevel: ({ modelId }) =>
       matchesAnthropicModernModel(modelId) && shouldUseAnthropicAdaptiveThinkingDefault(modelId)

--- a/packages/memory-host-sdk/src/host/embeddings-gemini.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-gemini.test.ts
@@ -20,10 +20,20 @@ vi.mock("../../../../src/infra/net/fetch-guard.js", () => ({
   },
 }));
 
-vi.mock("../../../../src/agents/model-auth.js", async () => {
-  const { createModelAuthMockModule } =
-    await import("../../../../src/test-utils/model-auth-mock.js");
-  return createModelAuthMockModule();
+const { resolveApiKeyForProviderMock } = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(),
+}));
+
+vi.mock("../../../../src/agents/model-auth.js", () => {
+  return {
+    resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+    requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
+      if (auth.apiKey) {
+        return auth.apiKey;
+      }
+      throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth.mode}).`);
+    },
+  };
 });
 
 const createGeminiFetchMock = (embeddingValues = [1, 2, 3]) =>

--- a/packages/memory-host-sdk/src/host/embeddings-gemini.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-gemini.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as authModule from "../../../../src/agents/model-auth.js";
-import { mockPublicPinnedHostname } from "./test-helpers/ssrf.js";
 
 vi.mock("../../../../src/infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: async (params: {
@@ -101,7 +100,6 @@ async function createProviderWithFetch(
   options: Partial<Parameters<typeof createGeminiEmbeddingProvider>[0]> & { model: string },
 ) {
   installFetchMock(fetchMock as unknown as typeof globalThis.fetch);
-  mockPublicPinnedHostname();
   mockResolvedProviderKey();
   const { provider } = await createGeminiEmbeddingProvider({
     config: {} as never,

--- a/packages/memory-host-sdk/src/host/embeddings-voyage.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-voyage.test.ts
@@ -22,10 +22,20 @@ vi.mock("../../../../src/infra/net/fetch-guard.js", () => ({
   },
 }));
 
-vi.mock("../../../../src/agents/model-auth.js", async () => {
-  const { createModelAuthMockModule } =
-    await import("../../../../src/test-utils/model-auth-mock.js");
-  return createModelAuthMockModule();
+const { resolveApiKeyForProviderMock } = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(),
+}));
+
+vi.mock("../../../../src/agents/model-auth.js", () => {
+  return {
+    resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+    requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
+      if (auth.apiKey) {
+        return auth.apiKey;
+      }
+      throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth.mode}).`);
+    },
+  };
 });
 
 const createFetchMock = () => {

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -4,10 +4,20 @@ import { createEmbeddingProvider, DEFAULT_LOCAL_MODEL } from "./embeddings.js";
 import * as nodeLlamaModule from "./node-llama.js";
 import { mockPublicPinnedHostname } from "./test-helpers/ssrf.js";
 
-vi.mock("../../../../src/agents/model-auth.js", async () => {
-  const { createModelAuthMockModule } =
-    await import("../../../../src/test-utils/model-auth-mock.js");
-  return createModelAuthMockModule();
+const { resolveApiKeyForProviderMock } = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(),
+}));
+
+vi.mock("../../../../src/agents/model-auth.js", () => {
+  return {
+    resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+    requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
+      if (auth.apiKey) {
+        return auth.apiKey;
+      }
+      throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth.mode}).`);
+    },
+  };
 });
 
 vi.mock("../../../../src/infra/net/fetch-guard.js", () => ({

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -3,6 +3,24 @@ import path from "node:path";
 import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+
+vi.mock("../secrets/provider-env-vars.js", () => ({
+  listKnownProviderAuthEnvVarNames: () => ["OPENAI_API_KEY", "GITHUB_TOKEN", "HF_TOKEN"],
+  omitEnvKeysCaseInsensitive: (
+    baseEnv: NodeJS.ProcessEnv,
+    keys: Iterable<string>,
+  ): NodeJS.ProcessEnv => {
+    const denied = new Set([...keys].map((key) => key.trim().toUpperCase()).filter(Boolean));
+    const env = { ...baseEnv };
+    for (const key of Object.keys(env)) {
+      if (denied.has(key.toUpperCase())) {
+        delete env[key];
+      }
+    }
+    return env;
+  },
+}));
+
 import {
   buildAcpClientStripKeys,
   resolveAcpClientSpawnEnv,

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -471,4 +471,49 @@ describe("anthropic transport stream", () => {
       undefined,
     );
   });
+
+  it("maps xhigh thinking effort for Claude Opus 4.7 transport runs", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-opus-4-7",
+        name: "Claude Opus 4.7",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Think extra hard." }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+          reasoning: "xhigh",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(anthropicMessagesStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thinking: { type: "adaptive" },
+        output_config: { effort: "xhigh" },
+      }),
+      undefined,
+    );
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -59,6 +59,7 @@ type AnthropicTransportModel = Model<"anthropic-messages"> & {
 
 type AnthropicTransportOptions = AnthropicOptions &
   Pick<SimpleStreamOptions, "reasoning" | "thinkingBudgets">;
+type AnthropicAdaptiveEffort = NonNullable<AnthropicOptions["effort"]> | "xhigh";
 
 type TransportContentBlock =
   | { type: "text"; text: string; index?: number }
@@ -98,19 +99,24 @@ type MutableAssistantOutput = {
   errorMessage?: string;
 };
 
+function isClaudeOpus47Model(modelId: string): boolean {
+  return modelId.includes("opus-4-7") || modelId.includes("opus-4.7");
+}
+
+function isClaudeOpus46Model(modelId: string): boolean {
+  return modelId.includes("opus-4-6") || modelId.includes("opus-4.6");
+}
+
 function supportsAdaptiveThinking(modelId: string): boolean {
   return (
-    modelId.includes("opus-4-6") ||
-    modelId.includes("opus-4.6") ||
+    isClaudeOpus47Model(modelId) ||
+    isClaudeOpus46Model(modelId) ||
     modelId.includes("sonnet-4-6") ||
     modelId.includes("sonnet-4.6")
   );
 }
 
-function mapThinkingLevelToEffort(
-  level: ThinkingLevel,
-  modelId: string,
-): NonNullable<AnthropicOptions["effort"]> {
+function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): AnthropicAdaptiveEffort {
   switch (level) {
     case "minimal":
     case "low":
@@ -118,7 +124,10 @@ function mapThinkingLevelToEffort(
     case "medium":
       return "medium";
     case "xhigh":
-      return modelId.includes("opus-4-6") || modelId.includes("opus-4.6") ? "max" : "high";
+      if (isClaudeOpus47Model(modelId)) {
+        return "xhigh";
+      }
+      return isClaudeOpus46Model(modelId) ? "max" : "high";
     default:
       return "high";
   }
@@ -616,7 +625,9 @@ function resolveAnthropicTransportOptions(
   }
   if (supportsAdaptiveThinking(model.id)) {
     resolved.thinkingEnabled = true;
-    resolved.effort = mapThinkingLevelToEffort(options.reasoning, model.id);
+    resolved.effort = mapThinkingLevelToEffort(options.reasoning, model.id) as NonNullable<
+      AnthropicOptions["effort"]
+    >;
     return resolved;
   }
   const adjusted = adjustMaxTokensForThinking({

--- a/src/agents/anthropic-vertex-stream.test.ts
+++ b/src/agents/anthropic-vertex-stream.test.ts
@@ -146,6 +146,22 @@ describe("createAnthropicVertexStreamFn", () => {
     );
   });
 
+  it("maps xhigh reasoning to xhigh effort for Opus 4.7", () => {
+    const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5");
+    const model = makeModel({ id: "claude-opus-4-7", maxTokens: 64000 });
+
+    void streamFn(model, { messages: [] }, { reasoning: "xhigh" });
+
+    expect(hoisted.streamAnthropicMock).toHaveBeenCalledWith(
+      model,
+      { messages: [] },
+      expect.objectContaining({
+        thinkingEnabled: true,
+        effort: "xhigh",
+      }),
+    );
+  });
+
   it("applies Anthropic cache-boundary shaping before forwarding payload hooks", async () => {
     const streamFn = createAnthropicVertexStreamFn("vertex-project", "us-east5");
     const model = makeModel({ id: "claude-sonnet-4-6", maxTokens: 64000 });

--- a/src/agents/anthropic-vertex-stream.ts
+++ b/src/agents/anthropic-vertex-stream.ts
@@ -11,6 +11,38 @@ import {
 } from "./anthropic-payload-policy.js";
 
 type AnthropicVertexEffort = NonNullable<AnthropicOptions["effort"]>;
+type AnthropicVertexAdaptiveEffort = AnthropicVertexEffort | "xhigh";
+
+function isClaudeOpus47Model(modelId: string): boolean {
+  return modelId.includes("opus-4-7") || modelId.includes("opus-4.7");
+}
+
+function isClaudeOpus46Model(modelId: string): boolean {
+  return modelId.includes("opus-4-6") || modelId.includes("opus-4.6");
+}
+
+function supportsAdaptiveThinking(modelId: string): boolean {
+  return (
+    isClaudeOpus47Model(modelId) ||
+    isClaudeOpus46Model(modelId) ||
+    modelId.includes("sonnet-4-6") ||
+    modelId.includes("sonnet-4.6")
+  );
+}
+
+function mapAnthropicAdaptiveEffort(
+  reasoning: string,
+  modelId: string,
+): AnthropicVertexAdaptiveEffort {
+  const effortMap: Record<string, AnthropicVertexAdaptiveEffort> = {
+    minimal: "low",
+    low: "low",
+    medium: "medium",
+    high: "high",
+    xhigh: isClaudeOpus47Model(modelId) ? "xhigh" : isClaudeOpus46Model(modelId) ? "max" : "high",
+  };
+  return effortMap[reasoning] ?? "high";
+}
 
 function resolveAnthropicVertexMaxTokens(params: {
   modelMaxTokens: number | undefined;
@@ -110,22 +142,12 @@ export function createAnthropicVertexStreamFn(
     };
 
     if (options?.reasoning) {
-      const isAdaptive =
-        model.id.includes("opus-4-6") ||
-        model.id.includes("opus-4.6") ||
-        model.id.includes("sonnet-4-6") ||
-        model.id.includes("sonnet-4.6");
-
-      if (isAdaptive) {
+      if (supportsAdaptiveThinking(model.id)) {
         opts.thinkingEnabled = true;
-        const effortMap: Record<string, AnthropicVertexEffort> = {
-          minimal: "low",
-          low: "low",
-          medium: "medium",
-          high: "high",
-          xhigh: model.id.includes("opus-4-6") || model.id.includes("opus-4.6") ? "max" : "high",
-        };
-        opts.effort = effortMap[options.reasoning] ?? "high";
+        opts.effort = mapAnthropicAdaptiveEffort(
+          options.reasoning,
+          model.id,
+        ) as AnthropicVertexEffort;
       } else {
         opts.thinkingEnabled = true;
         const budgets = options.thinkingBudgets;

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -48,12 +48,30 @@ const ANTHROPIC_OPUS_CATALOG = [
   },
 ];
 
+const ANTHROPIC_OPUS_47_CATALOG = [
+  {
+    provider: "anthropic",
+    id: "claude-opus-4-7",
+    name: "Claude Opus 4.7",
+    reasoning: true,
+  },
+];
+
 function resolveAnthropicOpusThinking(cfg: OpenClawConfig) {
   return resolveThinkingDefault({
     cfg,
     provider: "anthropic",
     model: "claude-opus-4-6",
     catalog: ANTHROPIC_OPUS_CATALOG,
+  });
+}
+
+function resolveAnthropicOpus47Thinking(cfg: OpenClawConfig) {
+  return resolveThinkingDefault({
+    cfg,
+    provider: "anthropic",
+    model: "claude-opus-4-7",
+    catalog: ANTHROPIC_OPUS_47_CATALOG,
   });
 }
 
@@ -1156,6 +1174,18 @@ describe("model-selection", () => {
       } as OpenClawConfig;
 
       expect(resolveAnthropicOpusThinking(cfg)).toBe("adaptive");
+    });
+
+    it("uses adaptive fallback for explicitly configured Anthropic Opus 4.7", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-7" },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(resolveAnthropicOpus47Thinking(cfg)).toBe("adaptive");
     });
 
     it("falls back to low when no provider thinking hook is active", () => {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1176,7 +1176,7 @@ describe("model-selection", () => {
       expect(resolveAnthropicOpusThinking(cfg)).toBe("adaptive");
     });
 
-    it("uses adaptive fallback for explicitly configured Anthropic Opus 4.7", () => {
+    it("keeps thinking off by default for explicitly configured Anthropic Opus 4.7", () => {
       const cfg = {
         agents: {
           defaults: {
@@ -1185,7 +1185,7 @@ describe("model-selection", () => {
         },
       } as OpenClawConfig;
 
-      expect(resolveAnthropicOpus47Thinking(cfg)).toBe("adaptive");
+      expect(resolveAnthropicOpus47Thinking(cfg)).toBe("off");
     });
 
     it("falls back to low when no provider thinking hook is active", () => {

--- a/src/agents/model-thinking-default.ts
+++ b/src/agents/model-thinking-default.ts
@@ -56,11 +56,16 @@ export function resolveThinkingDefault(params: {
   }
   if (
     normalizedProvider === "anthropic" &&
+    (normalizedModel.startsWith("claude-opus-4-7") || normalizedModel.startsWith("claude-opus-4.7"))
+  ) {
+    return "off";
+  }
+  if (
+    normalizedProvider === "anthropic" &&
     explicitModelConfigured &&
     typeof catalogCandidate?.name === "string" &&
-    /4\.[67]\b/.test(catalogCandidate.name) &&
-    (normalizedModel.startsWith("claude-opus-4-7") ||
-      normalizedModel.startsWith("claude-opus-4-6") ||
+    /4\.6\b/.test(catalogCandidate.name) &&
+    (normalizedModel.startsWith("claude-opus-4-6") ||
       normalizedModel.startsWith("claude-sonnet-4-6"))
   ) {
     return "adaptive";

--- a/src/agents/model-thinking-default.ts
+++ b/src/agents/model-thinking-default.ts
@@ -58,8 +58,9 @@ export function resolveThinkingDefault(params: {
     normalizedProvider === "anthropic" &&
     explicitModelConfigured &&
     typeof catalogCandidate?.name === "string" &&
-    /4\.6\b/.test(catalogCandidate.name) &&
-    (normalizedModel.startsWith("claude-opus-4-6") ||
+    /4\.[67]\b/.test(catalogCandidate.name) &&
+    (normalizedModel.startsWith("claude-opus-4-7") ||
+      normalizedModel.startsWith("claude-opus-4-6") ||
       normalizedModel.startsWith("claude-sonnet-4-6"))
   ) {
     return "adaptive";

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -81,6 +81,12 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("demo", "demo-model")).toContain("xhigh");
   });
 
+  it("uses provider runtime hooks for xhigh labels", () => {
+    providerRuntimeMocks.resolveProviderXHighThinking.mockReturnValue(true);
+
+    expect(listThinkingLevelLabels("demo", "demo-model")).toContain("xhigh");
+  });
+
   it("includes xhigh for provider-advertised models", () => {
     providerRuntimeMocks.resolveProviderXHighThinking.mockImplementation(({ provider, context }) =>
       (provider === "openai" && ["gpt-5.4", "gpt-5.4", "gpt-5.4-pro"].includes(context.modelId)) ||

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -94,6 +94,9 @@ export function listThinkingLevelLabels(provider?: string | null, model?: string
   if (isBinaryThinkingProvider(provider, model)) {
     return ["off", "on"];
   }
+  if (supportsXHighThinking(provider, model)) {
+    return listThinkingLevels(provider, model);
+  }
   return listThinkingLevelLabelsFallback(provider, model);
 }
 

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -4,9 +4,8 @@ const resolveAgentWorkspaceDir = vi.hoisted(() =>
   vi.fn((_cfg?: unknown, _agentId?: unknown) => "/tmp/openclaw-workspace"),
 );
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn((_cfg?: unknown) => "default"));
-const listChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((_opts?: unknown): unknown[] => []));
-const getChannelPluginCatalogEntry = vi.hoisted(() =>
-  vi.fn((_id?: unknown, _opts?: unknown) => undefined),
+const listTrustedChannelPluginCatalogEntries = vi.hoisted(() =>
+  vi.fn((_params?: unknown): unknown[] => []),
 );
 const getChannelSetupPlugin = vi.hoisted(() => vi.fn((_channel?: unknown) => undefined));
 const listChannelSetupPlugins = vi.hoisted(() => vi.fn((): unknown[] => []));
@@ -28,12 +27,6 @@ vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentWorkspaceDir: (cfg?: unknown, agentId?: unknown) =>
     resolveAgentWorkspaceDir(cfg, agentId),
   resolveDefaultAgentId: (cfg?: unknown) => resolveDefaultAgentId(cfg),
-}));
-
-vi.mock("../channels/plugins/catalog.js", () => ({
-  listChannelPluginCatalogEntries: (opts?: unknown) => listChannelPluginCatalogEntries(opts),
-  getChannelPluginCatalogEntry: (id?: unknown, opts?: unknown) =>
-    getChannelPluginCatalogEntry(id, opts),
 }));
 
 vi.mock("../channels/plugins/setup-registry.js", () => ({
@@ -63,6 +56,11 @@ vi.mock("../commands/channel-setup/registry.js", () => ({
   resolveChannelSetupWizardAdapterForPlugin: () => undefined,
 }));
 
+vi.mock("../commands/channel-setup/trusted-catalog.js", () => ({
+  listTrustedChannelPluginCatalogEntries: (params?: unknown) =>
+    listTrustedChannelPluginCatalogEntries(params),
+}));
+
 vi.mock("../config/channel-configured.js", () => ({
   isChannelConfigured: (cfg?: unknown, channel?: unknown) => isChannelConfigured(cfg, channel),
 }));
@@ -90,10 +88,11 @@ describe("setupChannels workspace shadow exclusion", () => {
     vi.clearAllMocks();
     resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-workspace");
     resolveDefaultAgentId.mockReturnValue("default");
-    listChannelPluginCatalogEntries.mockReturnValue([
+    listTrustedChannelPluginCatalogEntries.mockReturnValue([
       {
         id: "telegram",
         pluginId: "@openclaw/telegram-plugin",
+        origin: "bundled",
       },
     ]);
     getChannelSetupPlugin.mockReturnValue(undefined);
@@ -112,13 +111,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     isChannelConfigured.mockReturnValue(true);
   });
 
-  it("preloads configured external plugins from the bundled fallback for untrusted shadows", async () => {
-    listChannelPluginCatalogEntries.mockImplementation((opts?: unknown) =>
-      (opts as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
-        ? [{ id: "telegram", pluginId: "@openclaw/telegram-plugin", origin: "bundled" }]
-        : [{ id: "telegram", pluginId: "evil-telegram-shadow", origin: "workspace" }],
-    );
-
+  it("preloads configured external plugins from the trusted catalog boundary", async () => {
     await setupChannels(
       {} as never,
       {} as never,
@@ -128,10 +121,12 @@ describe("setupChannels workspace shadow exclusion", () => {
       } as never,
     );
 
-    const fallbackCall = listChannelPluginCatalogEntries.mock.calls.find(
-      ([opts]) => (opts as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace === true,
+    expect(listTrustedChannelPluginCatalogEntries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: {},
+        workspaceDir: "/tmp/openclaw-workspace",
+      }),
     );
-    expect(fallbackCall).toBeTruthy();
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "telegram",
@@ -142,7 +137,7 @@ describe("setupChannels workspace shadow exclusion", () => {
   });
 
   it("keeps trusted workspace overrides eligible during preload", async () => {
-    listChannelPluginCatalogEntries.mockReturnValue([
+    listTrustedChannelPluginCatalogEntries.mockReturnValue([
       { id: "telegram", pluginId: "trusted-telegram-shadow", origin: "workspace" },
     ]);
 

--- a/src/image-generation/provider-registry.test.ts
+++ b/src/image-generation/provider-registry.test.ts
@@ -1,18 +1,32 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
 
-const { resolveRuntimePluginRegistryMock } = vi.hoisted(() => ({
-  resolveRuntimePluginRegistryMock: vi.fn<
-    (params?: unknown) => ReturnType<typeof createEmptyPluginRegistry> | undefined
-  >(() => undefined),
+const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
+  resolvePluginCapabilityProvidersMock: vi.fn<() => ImageGenerationProviderPlugin[]>(() => []),
 }));
 
-vi.mock("../plugins/loader.js", () => ({
-  resolveRuntimePluginRegistry: resolveRuntimePluginRegistryMock,
+vi.mock("../plugins/capability-provider-runtime.js", () => ({
+  resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
 }));
 
 let getImageGenerationProvider: typeof import("./provider-registry.js").getImageGenerationProvider;
 let listImageGenerationProviders: typeof import("./provider-registry.js").listImageGenerationProviders;
+
+function createProvider(
+  params: Pick<ImageGenerationProviderPlugin, "id"> & Partial<ImageGenerationProviderPlugin>,
+): ImageGenerationProviderPlugin {
+  return {
+    label: params.id,
+    capabilities: {
+      generate: {},
+      edit: { enabled: false },
+    },
+    generateImage: async () => ({
+      images: [{ buffer: Buffer.from("image"), mimeType: "image/png" }],
+    }),
+    ...params,
+  };
+}
 
 describe("image-generation provider registry", () => {
   beforeAll(async () => {
@@ -21,78 +35,35 @@ describe("image-generation provider registry", () => {
   });
 
   beforeEach(() => {
-    resolveRuntimePluginRegistryMock.mockReset();
-    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
+    resolvePluginCapabilityProvidersMock.mockReset();
+    resolvePluginCapabilityProvidersMock.mockReturnValue([]);
   });
 
-  it("does not load plugins when listing without config", () => {
+  it("delegates provider resolution to the capability provider boundary", () => {
     expect(listImageGenerationProviders()).toEqual([]);
-    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith();
+    expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
+      key: "imageGenerationProviders",
+      cfg: undefined,
+    });
   });
 
   it("uses active plugin providers without loading from disk", () => {
-    const registry = createEmptyPluginRegistry();
-    registry.imageGenerationProviders.push({
-      pluginId: "custom-image",
-      pluginName: "Custom Image",
-      source: "test",
-      provider: {
-        id: "custom-image",
-        label: "Custom Image",
-        capabilities: {
-          generate: {},
-          edit: { enabled: false },
-        },
-        generateImage: async () => ({
-          images: [{ buffer: Buffer.from("image"), mimeType: "image/png" }],
-        }),
-      },
-    });
-    resolveRuntimePluginRegistryMock.mockReturnValue(registry);
+    resolvePluginCapabilityProvidersMock.mockReturnValue([createProvider({ id: "custom-image" })]);
 
     const provider = getImageGenerationProvider("custom-image");
 
     expect(provider?.id).toBe("custom-image");
-    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith();
+    expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
+      key: "imageGenerationProviders",
+      cfg: undefined,
+    });
   });
 
   it("ignores prototype-like provider ids and aliases", () => {
-    const registry = createEmptyPluginRegistry();
-    registry.imageGenerationProviders.push(
-      {
-        pluginId: "blocked-image",
-        pluginName: "Blocked Image",
-        source: "test",
-        provider: {
-          id: "__proto__",
-          aliases: ["constructor", "prototype"],
-          capabilities: {
-            generate: {},
-            edit: { enabled: false },
-          },
-          generateImage: async () => ({
-            images: [{ buffer: Buffer.from("image"), mimeType: "image/png" }],
-          }),
-        },
-      },
-      {
-        pluginId: "safe-image",
-        pluginName: "Safe Image",
-        source: "test",
-        provider: {
-          id: "safe-image",
-          aliases: ["safe-alias", "constructor"],
-          capabilities: {
-            generate: {},
-            edit: { enabled: false },
-          },
-          generateImage: async () => ({
-            images: [{ buffer: Buffer.from("image"), mimeType: "image/png" }],
-          }),
-        },
-      },
-    );
-    resolveRuntimePluginRegistryMock.mockReturnValue(registry);
+    resolvePluginCapabilityProvidersMock.mockReturnValue([
+      createProvider({ id: "__proto__", aliases: ["constructor", "prototype"] }),
+      createProvider({ id: "safe-image", aliases: ["safe-alias", "constructor"] }),
+    ]);
 
     expect(listImageGenerationProviders().map((provider) => provider.id)).toEqual(["safe-image"]);
     expect(getImageGenerationProvider("__proto__")).toBeUndefined();

--- a/src/image-generation/runtime.test.ts
+++ b/src/image-generation/runtime.test.ts
@@ -353,13 +353,10 @@ describe("image-generation runtime", () => {
       return [];
     });
 
-    const promise = generateImage({ cfg: {} as OpenClawConfig, prompt: "draw a cat" });
-
-    await expect(promise).rejects.toThrow("No image-generation model configured.");
-    await expect(promise).rejects.toThrow(
-      'Set agents.defaults.imageGenerationModel.primary to a provider/model like "vision-one/paint-v1".',
+    await expect(
+      generateImage({ cfg: {} as OpenClawConfig, prompt: "draw a cat" }),
+    ).rejects.toThrow(
+      'No image-generation model configured. Set agents.defaults.imageGenerationModel.primary to a provider/model like "vision-one/paint-v1". If you want a specific provider, also configure that provider\'s auth/API key first (vision-one: VISION_ONE_API_KEY; vision-two: VISION_TWO_API_KEY).',
     );
-    await expect(promise).rejects.toThrow("vision-one: VISION_ONE_API_KEY");
-    await expect(promise).rejects.toThrow("vision-two: VISION_TWO_API_KEY");
   });
 });

--- a/src/memory-host-sdk/host/embeddings-gemini.test.ts
+++ b/src/memory-host-sdk/host/embeddings-gemini.test.ts
@@ -20,9 +20,20 @@ import {
   type JsonFetchMock,
 } from "./embeddings-provider.test-support.js";
 
-vi.mock("../../agents/model-auth.js", async () => {
-  const { createModelAuthMockModule } = await import("../../test-utils/model-auth-mock.js");
-  return createModelAuthMockModule();
+const { resolveApiKeyForProviderMock } = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(),
+}));
+
+vi.mock("../../agents/model-auth.js", () => {
+  return {
+    resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+    requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
+      if (auth.apiKey) {
+        return auth.apiKey;
+      }
+      throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth.mode}).`);
+    },
+  };
 });
 
 beforeEach(() => {

--- a/src/memory-host-sdk/host/embeddings-gemini.test.ts
+++ b/src/memory-host-sdk/host/embeddings-gemini.test.ts
@@ -12,14 +12,13 @@ import {
 } from "./embeddings-gemini.js";
 import {
   createGeminiBatchFetchMock,
-  createGeminiFetchMock,
+  createJsonResponseFetchMock,
   installFetchMock,
   mockResolvedProviderKey,
   parseFetchBody,
   readFirstFetchRequest,
   type JsonFetchMock,
 } from "./embeddings-provider.test-support.js";
-import { mockPublicPinnedHostname } from "./test-helpers/ssrf.js";
 
 vi.mock("../../agents/model-auth.js", async () => {
   const { createModelAuthMockModule } = await import("../../test-utils/model-auth-mock.js");
@@ -42,7 +41,6 @@ async function createProviderWithFetch(
   options: Partial<Parameters<typeof createGeminiEmbeddingProvider>[0]> & { model: string },
 ) {
   installFetchMock(fetchMock as unknown as typeof globalThis.fetch);
-  mockPublicPinnedHostname();
   mockResolvedProviderKey(authModule.resolveApiKeyForProvider);
   const { provider } = await createGeminiEmbeddingProvider({
     config: {} as never,
@@ -169,55 +167,26 @@ describe("gemini embedding provider", () => {
     expect(parseFetchBody(legacyFetch, 0)).not.toHaveProperty("outputDimensionality");
     expect(parseFetchBody(legacyFetch, 1)).not.toHaveProperty("outputDimensionality");
 
-    const v2QueryFetch = createGeminiFetchMock([3, 4, Number.NaN]);
-    const v2QueryProvider = await createProviderWithFetch(v2QueryFetch, {
-      model: "gemini-embedding-2-preview",
+    const v2Fetch = createJsonResponseFetchMock((input) => {
+      const url = input instanceof URL ? input.href : typeof input === "string" ? input : input.url;
+      return url.endsWith(":batchEmbedContents")
+        ? {
+            embeddings: Array.from({ length: 2 }, () => ({
+              values: [0, Number.POSITIVE_INFINITY, 5],
+            })),
+          }
+        : { embedding: { values: [3, 4, Number.NaN] } };
     });
-    await expect(v2QueryProvider.embedQuery("   ")).resolves.toEqual([]);
-    await expect(v2QueryProvider.embedBatch([])).resolves.toEqual([]);
-    await expect(v2QueryProvider.embedQuery("test query")).resolves.toEqual([0.6, 0.8, 0]);
-
-    const v2BatchFetch = createGeminiBatchFetchMock(2, [0, Number.POSITIVE_INFINITY, 5]);
-    const v2BatchProvider = await createProviderWithFetch(v2BatchFetch, {
-      model: "gemini-embedding-2-preview",
-    });
-    const batch = await v2BatchProvider.embedBatch(["text1", "text2"]);
-    expect(batch).toEqual([
-      [0, 0, 1],
-      [0, 0, 1],
-    ]);
-
-    expect(parseFetchBody(v2QueryFetch)).toMatchObject({
-      outputDimensionality: 3072,
-      taskType: "RETRIEVAL_QUERY",
-      content: { parts: [{ text: "test query" }] },
-    });
-    expect(parseFetchBody(v2BatchFetch).requests).toEqual([
-      {
-        model: "models/gemini-embedding-2-preview",
-        content: { parts: [{ text: "text1" }] },
-        taskType: "RETRIEVAL_DOCUMENT",
-        outputDimensionality: 3072,
-      },
-      {
-        model: "models/gemini-embedding-2-preview",
-        content: { parts: [{ text: "text2" }] },
-        taskType: "RETRIEVAL_DOCUMENT",
-        outputDimensionality: 3072,
-      },
-    ]);
-  });
-
-  it("supports custom dimensions, task type, multimodal inputs, and endpoint URL", async () => {
-    const fetchMock = createGeminiBatchFetchMock(2);
-    const provider = await createProviderWithFetch(fetchMock, {
+    const v2Provider = await createProviderWithFetch(v2Fetch, {
       model: "gemini-embedding-2-preview",
       outputDimensionality: 768,
       taskType: "SEMANTIC_SIMILARITY",
     });
+    await expect(v2Provider.embedQuery("   ")).resolves.toEqual([]);
+    await expect(v2Provider.embedBatch([])).resolves.toEqual([]);
+    await expect(v2Provider.embedQuery("test query")).resolves.toEqual([0.6, 0.8, 0]);
 
-    await provider.embedQuery("test");
-    const structuredBatch = await provider.embedBatchInputs?.([
+    const structuredBatch = await v2Provider.embedBatchInputs?.([
       {
         text: "Image file: diagram.png",
         parts: [
@@ -234,19 +203,20 @@ describe("gemini embedding provider", () => {
       },
     ]);
     expect(structuredBatch).toEqual([
-      [0.2672612419124244, 0.5345224838248488, 0.8017837257372732],
-      [0.2672612419124244, 0.5345224838248488, 0.8017837257372732],
+      [0, 0, 1],
+      [0, 0, 1],
     ]);
 
-    const { url } = readFirstFetchRequest(fetchMock);
+    const { url } = readFirstFetchRequest(v2Fetch);
     expect(url).toBe(
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
     );
-    expect(parseFetchBody(fetchMock, 0)).toMatchObject({
+    expect(parseFetchBody(v2Fetch, 0)).toMatchObject({
       outputDimensionality: 768,
       taskType: "SEMANTIC_SIMILARITY",
+      content: { parts: [{ text: "test query" }] },
     });
-    expect(parseFetchBody(fetchMock, 1).requests).toEqual([
+    expect(parseFetchBody(v2Fetch, 1).requests).toEqual([
       {
         model: "models/gemini-embedding-2-preview",
         content: {

--- a/src/memory-host-sdk/host/embeddings-voyage.test.ts
+++ b/src/memory-host-sdk/host/embeddings-voyage.test.ts
@@ -9,9 +9,20 @@ import {
 } from "./embeddings-provider.test-support.js";
 import { mockPublicPinnedHostname } from "./test-helpers/ssrf.js";
 
-vi.mock("../../agents/model-auth.js", async () => {
-  const { createModelAuthMockModule } = await import("../../test-utils/model-auth-mock.js");
-  return createModelAuthMockModule();
+const { resolveApiKeyForProviderMock } = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(),
+}));
+
+vi.mock("../../agents/model-auth.js", () => {
+  return {
+    resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+    requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
+      if (auth.apiKey) {
+        return auth.apiKey;
+      }
+      throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth.mode}).`);
+    },
+  };
 });
 
 let createVoyageEmbeddingProvider: typeof import("./embeddings-voyage.js").createVoyageEmbeddingProvider;

--- a/src/memory-host-sdk/host/embeddings.test.ts
+++ b/src/memory-host-sdk/host/embeddings.test.ts
@@ -17,6 +17,7 @@ const {
   bedrockSendMock,
   createOllamaEmbeddingProviderMock,
   defaultProviderMock,
+  resolveApiKeyForProviderMock,
   resolveCredentialsMock,
 } = vi.hoisted(() => ({
   bedrockSendMock: vi.fn(),
@@ -25,11 +26,19 @@ const {
   }),
   defaultProviderMock: vi.fn(),
   resolveCredentialsMock: vi.fn(),
+  resolveApiKeyForProviderMock: vi.fn(),
 }));
 
-vi.mock("../../agents/model-auth.js", async () => {
-  const { createModelAuthMockModule } = await import("../../test-utils/model-auth-mock.js");
-  return createModelAuthMockModule();
+vi.mock("../../agents/model-auth.js", () => {
+  return {
+    resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+    requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
+      if (auth.apiKey) {
+        return auth.apiKey;
+      }
+      throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth.mode}).`);
+    },
+  };
 });
 
 vi.mock("./embeddings-ollama.js", () => ({

--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -7,6 +7,48 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import { resolveOAuthDir } from "../config/paths.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import { withEnvAsync } from "../test-utils/env.js";
+
+vi.mock("../channels/plugins/pairing.js", () => ({
+  getPairingAdapter: () => null,
+}));
+
+vi.mock("../infra/file-lock.js", () => ({
+  withFileLock: async (_path: string, _options: unknown, fn: () => unknown) => await fn(),
+}));
+
+vi.mock("../plugin-sdk/json-store.js", async () => {
+  const fs = await import("node:fs/promises");
+  const path = await import("node:path");
+
+  return {
+    readJsonFileWithFallback: async <T>(filePath: string, fallback: T) => {
+      let raw: string;
+      try {
+        raw = await fs.readFile(filePath, "utf8");
+      } catch (err) {
+        if ((err as { code?: string }).code === "ENOENT") {
+          return { value: fallback, exists: false };
+        }
+        return { value: fallback, exists: false };
+      }
+      try {
+        const parsed = JSON.parse(raw) as T;
+        return {
+          value: parsed ?? fallback,
+          exists: true,
+        };
+      } catch {
+        return { value: fallback, exists: true };
+      }
+    },
+    writeJsonFileAtomically: async (filePath: string, value: unknown) => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+    },
+  };
+});
+
+import * as jsonStore from "../plugin-sdk/json-store.js";
 import {
   addChannelAllowFromStoreEntry,
   clearPairingAllowFromReadCacheForTest,
@@ -552,7 +594,7 @@ describe("pairing store", () => {
     await withTempStateDir(async (stateDir) => {
       for (const variant of [
         {
-          createReadSpy: () => vi.spyOn(fs, "readFile"),
+          createReadSpy: () => vi.spyOn(jsonStore, "readJsonFileWithFallback"),
           readAllowFrom: () => readChannelAllowFromStore("telegram", process.env, "yy"),
         },
         {

--- a/src/video-generation/provider-registry.test.ts
+++ b/src/video-generation/provider-registry.test.ts
@@ -1,18 +1,29 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import type { VideoGenerationProviderPlugin } from "../plugins/types.js";
 
-const { resolveRuntimePluginRegistryMock } = vi.hoisted(() => ({
-  resolveRuntimePluginRegistryMock: vi.fn<
-    (params?: unknown) => ReturnType<typeof createEmptyPluginRegistry> | undefined
-  >(() => undefined),
+const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
+  resolvePluginCapabilityProvidersMock: vi.fn<() => VideoGenerationProviderPlugin[]>(() => []),
 }));
 
-vi.mock("../plugins/loader.js", () => ({
-  resolveRuntimePluginRegistry: resolveRuntimePluginRegistryMock,
+vi.mock("../plugins/capability-provider-runtime.js", () => ({
+  resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
 }));
 
 let getVideoGenerationProvider: typeof import("./provider-registry.js").getVideoGenerationProvider;
 let listVideoGenerationProviders: typeof import("./provider-registry.js").listVideoGenerationProviders;
+
+function createProvider(
+  params: Pick<VideoGenerationProviderPlugin, "id"> & Partial<VideoGenerationProviderPlugin>,
+): VideoGenerationProviderPlugin {
+  return {
+    label: params.id,
+    capabilities: {},
+    generateVideo: async () => ({
+      videos: [{ buffer: Buffer.from("video"), mimeType: "video/mp4" }],
+    }),
+    ...params,
+  };
+}
 
 describe("video-generation provider registry", () => {
   beforeAll(async () => {
@@ -21,69 +32,35 @@ describe("video-generation provider registry", () => {
   });
 
   beforeEach(() => {
-    resolveRuntimePluginRegistryMock.mockReset();
-    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
+    resolvePluginCapabilityProvidersMock.mockReset();
+    resolvePluginCapabilityProvidersMock.mockReturnValue([]);
   });
 
-  it("does not load plugins when listing without config", () => {
+  it("delegates provider resolution to the capability provider boundary", () => {
     expect(listVideoGenerationProviders()).toEqual([]);
-    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith();
+    expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
+      key: "videoGenerationProviders",
+      cfg: undefined,
+    });
   });
 
   it("uses active plugin providers without loading from disk", () => {
-    const registry = createEmptyPluginRegistry();
-    registry.videoGenerationProviders.push({
-      pluginId: "custom-video",
-      pluginName: "Custom Video",
-      source: "test",
-      provider: {
-        id: "custom-video",
-        label: "Custom Video",
-        capabilities: {},
-        generateVideo: async () => ({
-          videos: [{ buffer: Buffer.from("video"), mimeType: "video/mp4" }],
-        }),
-      },
-    });
-    resolveRuntimePluginRegistryMock.mockReturnValue(registry);
+    resolvePluginCapabilityProvidersMock.mockReturnValue([createProvider({ id: "custom-video" })]);
 
     const provider = getVideoGenerationProvider("custom-video");
 
     expect(provider?.id).toBe("custom-video");
-    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith();
+    expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
+      key: "videoGenerationProviders",
+      cfg: undefined,
+    });
   });
 
   it("ignores prototype-like provider ids and aliases", () => {
-    const registry = createEmptyPluginRegistry();
-    registry.videoGenerationProviders.push(
-      {
-        pluginId: "blocked-video",
-        pluginName: "Blocked Video",
-        source: "test",
-        provider: {
-          id: "__proto__",
-          aliases: ["constructor", "prototype"],
-          capabilities: {},
-          generateVideo: async () => ({
-            videos: [{ buffer: Buffer.from("video"), mimeType: "video/mp4" }],
-          }),
-        },
-      },
-      {
-        pluginId: "safe-video",
-        pluginName: "Safe Video",
-        source: "test",
-        provider: {
-          id: "safe-video",
-          aliases: ["safe-alias", "constructor"],
-          capabilities: {},
-          generateVideo: async () => ({
-            videos: [{ buffer: Buffer.from("video"), mimeType: "video/mp4" }],
-          }),
-        },
-      },
-    );
-    resolveRuntimePluginRegistryMock.mockReturnValue(registry);
+    resolvePluginCapabilityProvidersMock.mockReturnValue([
+      createProvider({ id: "__proto__", aliases: ["constructor", "prototype"] }),
+      createProvider({ id: "safe-video", aliases: ["safe-alias", "constructor"] }),
+    ]);
 
     expect(listVideoGenerationProviders().map((provider) => provider.id)).toEqual(["safe-video"]);
     expect(getVideoGenerationProvider("__proto__")).toBeUndefined();

--- a/src/video-generation/runtime.test.ts
+++ b/src/video-generation/runtime.test.ts
@@ -757,12 +757,10 @@ describe("video-generation runtime", () => {
     ]);
     mocks.getProviderEnvVars.mockReturnValue(["MOTION_ONE_API_KEY"]);
 
-    const promise = generateVideo({ cfg: {} as OpenClawConfig, prompt: "animate a cat" });
-
-    await expect(promise).rejects.toThrow("No video-generation model configured.");
-    await expect(promise).rejects.toThrow(
-      'Set agents.defaults.videoGenerationModel.primary to a provider/model like "motion-one/animate-v1".',
+    await expect(
+      generateVideo({ cfg: {} as OpenClawConfig, prompt: "animate a cat" }),
+    ).rejects.toThrow(
+      'No video-generation model configured. Set agents.defaults.videoGenerationModel.primary to a provider/model like "motion-one/animate-v1". If you want a specific provider, also configure that provider\'s auth/API key first (motion-one: MOTION_ONE_API_KEY).',
     );
-    await expect(promise).rejects.toThrow("motion-one: MOTION_ONE_API_KEY");
   });
 });

--- a/test/helpers/media-generation/runtime-module-mocks.ts
+++ b/test/helpers/media-generation/runtime-module-mocks.ts
@@ -72,14 +72,10 @@ vi.mock("../../../src/config/model-input.js", () => ({
 vi.mock("../../../src/logging/subsystem.js", () => ({
   createSubsystemLogger: mediaRuntimeMocks.createSubsystemLogger,
 }));
-vi.mock("../../../src/secrets/provider-env-vars.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../src/secrets/provider-env-vars.js")>();
-  return {
-    ...actual,
-    getProviderEnvVars: mediaRuntimeMocks.getProviderEnvVars,
-    resolveProviderAuthEnvVarCandidates: mediaRuntimeMocks.resolveProviderAuthEnvVarCandidates,
-  };
-});
+vi.mock("../../../src/secrets/provider-env-vars.js", () => ({
+  getProviderEnvVars: mediaRuntimeMocks.getProviderEnvVars,
+  resolveProviderAuthEnvVarCandidates: mediaRuntimeMocks.resolveProviderAuthEnvVarCandidates,
+}));
 
 vi.mock("../../../src/image-generation/model-ref.js", () => ({
   parseImageGenerationModelRef: mediaRuntimeMocks.parseImageGenerationModelRef,

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1875,6 +1875,7 @@ export function renderApp(state: AppViewState) {
                 });
               },
               onChatScroll: (event) => state.handleChatScroll(event),
+              onChatWheelIntent: (event) => state.handleChatWheelIntent(event),
               getDraft: () => state.chatMessage,
               onDraftChange: (next) => (state.chatMessage = next),
               onRequestUpdate: requestHostUpdate,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -320,6 +320,22 @@ describe("scheduleChatScroll", () => {
     expect(host.chatFollowLocked).toBe(true);
   });
 
+  it("preserves the wheel-intent lock for small upward deltas that still land within the bottom threshold", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatWheelIntent(host, createWheelEvent(-5, 2000, 400));
+    handleChatScroll(host, createScrollEvent(2000, 1592, 400));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+
   it("re-enables follow once the user actually returns to the bottom", () => {
     const { host } = createScrollHost({
       scrollHeight: 2000,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -1,9 +1,11 @@
+/* @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleChatScroll, scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
-
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                            */
-/* ------------------------------------------------------------------ */
+import {
+  handleChatScroll,
+  handleChatWheelIntent,
+  resetChatScroll,
+  scheduleChatScroll,
+} from "./app-scroll.ts";
 
 /** Minimal ScrollHost stub for unit tests. */
 function createScrollHost(
@@ -28,7 +30,6 @@ function createScrollHost(
     style: { overflowY } as unknown as CSSStyleDeclaration,
   };
 
-  // Make getComputedStyle return the overflowY value
   vi.spyOn(window, "getComputedStyle").mockReturnValue({
     overflowY,
   } as unknown as CSSStyleDeclaration);
@@ -41,6 +42,9 @@ function createScrollHost(
     chatScrollTimeout: null as number | null,
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
+    chatFollowLocked: false,
+    chatSmoothAutoScrolling: false,
+    chatLastScrollTop: scrollTop,
     chatNewMessagesBelow: false,
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
@@ -56,56 +60,141 @@ function createScrollEvent(scrollHeight: number, scrollTop: number, clientHeight
   } as unknown as Event;
 }
 
-/* ------------------------------------------------------------------ */
-/*  handleChatScroll – threshold tests                                 */
-/* ------------------------------------------------------------------ */
+function createWheelEvent(deltaY: number, scrollHeight: number, clientHeight: number) {
+  return {
+    deltaY,
+    currentTarget: { scrollHeight, clientHeight },
+  } as unknown as WheelEvent;
+}
 
 describe("handleChatScroll", () => {
   it("sets chatUserNearBottom=true when within the 450px threshold", () => {
     const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 1600 - 400 = 0 → clearly near bottom
-    const event = createScrollEvent(2000, 1600, 400);
-    handleChatScroll(host, event);
+    host.chatUserNearBottom = false;
+    host.chatLastScrollTop = 0;
+
+    handleChatScroll(host, createScrollEvent(2000, 1600, 400));
+
     expect(host.chatUserNearBottom).toBe(true);
   });
 
   it("sets chatUserNearBottom=true when distance is just under threshold", () => {
     const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 1151 - 400 = 449 → just under threshold
-    const event = createScrollEvent(2000, 1151, 400);
-    handleChatScroll(host, event);
+    host.chatUserNearBottom = false;
+    host.chatLastScrollTop = 0;
+
+    handleChatScroll(host, createScrollEvent(2000, 1151, 400));
+
     expect(host.chatUserNearBottom).toBe(true);
   });
 
   it("sets chatUserNearBottom=false when distance is exactly at threshold", () => {
     const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 1150 - 400 = 450 → at threshold (uses strict <)
-    const event = createScrollEvent(2000, 1150, 400);
-    handleChatScroll(host, event);
+
+    handleChatScroll(host, createScrollEvent(2000, 1150, 400));
+
     expect(host.chatUserNearBottom).toBe(false);
   });
 
   it("sets chatUserNearBottom=false when scrolled well above threshold", () => {
     const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 500 - 400 = 1100 → way above threshold
-    const event = createScrollEvent(2000, 500, 400);
-    handleChatScroll(host, event);
+
+    handleChatScroll(host, createScrollEvent(2000, 500, 400));
+
     expect(host.chatUserNearBottom).toBe(false);
   });
 
-  it("sets chatUserNearBottom=false when user scrolled up past one long message (>200px <450px)", () => {
-    const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 1250 - 400 = 350 → old threshold would say "near", new says "near"
-    // distanceFromBottom = 2000 - 1100 - 400 = 500 → old threshold would say "not near", new also "not near"
-    const event = createScrollEvent(2000, 1100, 400);
-    handleChatScroll(host, event);
+  it("releases auto-follow immediately when the user scrolls upward away from bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1600,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
+
     expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
   });
 });
 
-/* ------------------------------------------------------------------ */
-/*  scheduleChatScroll – respects user scroll position                 */
-/* ------------------------------------------------------------------ */
+describe("handleChatWheelIntent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("cancels pending auto-follow when the user wheels upward", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+    host.chatScrollFrame = 99;
+    host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 500));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatScrollFrame).toBeNull();
+    expect(host.chatScrollTimeout).toBeNull();
+  });
+
+  it("does not cancel auto-follow when wheeling downward", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, createWheelEvent(120, 2000, 500));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("does not disengage follow when the chat cannot actually scroll", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 400,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 400, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("does not disengage follow for bubbled wheel events from nested scrollables", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatScrollFrame = 99;
+    host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
+
+    const container = document.createElement("div");
+    const nestedScrollable = document.createElement("div");
+    container.appendChild(nestedScrollable);
+    Object.defineProperty(nestedScrollable, "scrollHeight", { value: 600, configurable: true });
+    Object.defineProperty(nestedScrollable, "clientHeight", { value: 300, configurable: true });
+
+    handleChatWheelIntent(host, {
+      deltaY: -120,
+      currentTarget: container,
+      target: nestedScrollable,
+    } as unknown as WheelEvent);
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatScrollFrame).toBe(99);
+    expect(host.chatScrollTimeout).not.toBeNull();
+  });
+});
 
 describe("scheduleChatScroll", () => {
   beforeEach(() => {
@@ -127,7 +216,6 @@ describe("scheduleChatScroll", () => {
       scrollTop: 1600,
       clientHeight: 400,
     });
-    // distanceFromBottom = 2000 - 1600 - 400 = 0 → near bottom
     host.chatUserNearBottom = true;
 
     scheduleChatScroll(host);
@@ -142,7 +230,6 @@ describe("scheduleChatScroll", () => {
       scrollTop: 500,
       clientHeight: 400,
     });
-    // distanceFromBottom = 2000 - 500 - 400 = 1100 → not near bottom
     host.chatUserNearBottom = false;
     const originalScrollTop = container.scrollTop;
 
@@ -158,31 +245,28 @@ describe("scheduleChatScroll", () => {
       scrollTop: 500,
       clientHeight: 400,
     });
-    // User has scrolled up — chatUserNearBottom is false
     host.chatUserNearBottom = false;
-    host.chatHasAutoScrolled = true; // Already past initial load
+    host.chatHasAutoScrolled = true;
     const originalScrollTop = container.scrollTop;
 
     scheduleChatScroll(host, true);
     await host.updateComplete;
 
-    // force=true should still NOT override explicit user scroll-up after initial load
     expect(container.scrollTop).toBe(originalScrollTop);
   });
 
-  it("DOES scroll with force=true on initial load (chatHasAutoScrolled=false)", async () => {
+  it("DOES scroll with force=true on initial load", async () => {
     const { host, container } = createScrollHost({
       scrollHeight: 2000,
       scrollTop: 500,
       clientHeight: 400,
     });
     host.chatUserNearBottom = false;
-    host.chatHasAutoScrolled = false; // Initial load
+    host.chatHasAutoScrolled = false;
 
     scheduleChatScroll(host, true);
     await host.updateComplete;
 
-    // On initial load, force should work regardless
     expect(container.scrollTop).toBe(container.scrollHeight);
   });
 
@@ -201,11 +285,92 @@ describe("scheduleChatScroll", () => {
 
     expect(host.chatNewMessagesBelow).toBe(true);
   });
-});
 
-/* ------------------------------------------------------------------ */
-/*  Streaming: rapid chatStream changes should not reset scroll        */
-/* ------------------------------------------------------------------ */
+  it("does NOT snap back when the user manually scrolls up but is still within the old near-bottom threshold", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1540,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatHasAutoScrolled = true;
+    host.chatLastScrollTop = 1540;
+    const originalScrollTop = container.scrollTop;
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(originalScrollTop);
+    expect(host.chatNewMessagesBelow).toBe(true);
+  });
+
+  it("does NOT re-enable follow just because a post-wheel scroll event is still near bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatLastScrollTop = 2000;
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 400));
+    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+
+  it("re-enables follow once the user actually returns to the bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1576,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatLastScrollTop = 1540;
+    host.chatNewMessagesBelow = true;
+
+    handleChatScroll(host, createScrollEvent(2000, 1576, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("does not treat smooth auto-scroll progress as upward manual scroll intent", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1200,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1200;
+
+    handleChatScroll(host, createScrollEvent(2000, 1300, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("releases follow when the user scrolls upward during smooth auto-scroll", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1200,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1100, 400));
+
+    expect(host.chatSmoothAutoScrolling).toBe(false);
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+});
 
 describe("streaming scroll behavior", () => {
   beforeEach(() => {
@@ -231,7 +396,6 @@ describe("streaming scroll behavior", () => {
     host.chatHasAutoScrolled = true;
     const originalScrollTop = container.scrollTop;
 
-    // Simulate rapid streaming token updates
     scheduleChatScroll(host);
     scheduleChatScroll(host);
     scheduleChatScroll(host);
@@ -249,7 +413,6 @@ describe("streaming scroll behavior", () => {
     host.chatUserNearBottom = true;
     host.chatHasAutoScrolled = true;
 
-    // Simulate streaming
     scheduleChatScroll(host);
     await host.updateComplete;
 
@@ -257,19 +420,19 @@ describe("streaming scroll behavior", () => {
   });
 });
 
-/* ------------------------------------------------------------------ */
-/*  resetChatScroll                                                    */
-/* ------------------------------------------------------------------ */
-
 describe("resetChatScroll", () => {
   it("resets state for new chat session", () => {
     const { host } = createScrollHost({});
     host.chatHasAutoScrolled = true;
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatLastScrollTop = 1234;
 
     resetChatScroll(host);
 
     expect(host.chatHasAutoScrolled).toBe(false);
     expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatLastScrollTop).toBe(0);
   });
 });

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -118,6 +118,73 @@ describe("handleChatScroll", () => {
     expect(host.chatUserNearBottom).toBe(false);
     expect(host.chatFollowLocked).toBe(true);
   });
+
+  it("does NOT re-enable follow just because a post-wheel scroll event is still near bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatLastScrollTop = 2000;
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 400));
+    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+
+  it("re-enables follow once the user actually returns to the bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1576,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatLastScrollTop = 1540;
+    host.chatNewMessagesBelow = true;
+
+    handleChatScroll(host, createScrollEvent(2000, 1576, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("does not treat smooth auto-scroll progress as upward manual scroll intent", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1200,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1200;
+
+    handleChatScroll(host, createScrollEvent(2000, 1300, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("releases follow when the user scrolls upward during smooth auto-scroll", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1200,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1100, 400));
+
+    expect(host.chatSmoothAutoScrolling).toBe(false);
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
 });
 
 describe("handleChatWheelIntent", () => {
@@ -304,22 +371,6 @@ describe("scheduleChatScroll", () => {
     expect(host.chatNewMessagesBelow).toBe(true);
   });
 
-  it("does NOT re-enable follow just because a post-wheel scroll event is still near bottom", () => {
-    const { host } = createScrollHost({
-      scrollHeight: 2000,
-      scrollTop: 2000,
-      clientHeight: 400,
-    });
-    host.chatUserNearBottom = true;
-    host.chatLastScrollTop = 2000;
-
-    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 400));
-    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
-
-    expect(host.chatUserNearBottom).toBe(false);
-    expect(host.chatFollowLocked).toBe(true);
-  });
-
   it("preserves the wheel-intent lock for small upward deltas that still land within the bottom threshold", () => {
     const { host } = createScrollHost({
       scrollHeight: 2000,
@@ -332,57 +383,6 @@ describe("scheduleChatScroll", () => {
     handleChatWheelIntent(host, createWheelEvent(-5, 2000, 400));
     handleChatScroll(host, createScrollEvent(2000, 1592, 400));
 
-    expect(host.chatUserNearBottom).toBe(false);
-    expect(host.chatFollowLocked).toBe(true);
-  });
-
-  it("re-enables follow once the user actually returns to the bottom", () => {
-    const { host } = createScrollHost({
-      scrollHeight: 2000,
-      scrollTop: 1576,
-      clientHeight: 400,
-    });
-    host.chatUserNearBottom = false;
-    host.chatFollowLocked = true;
-    host.chatLastScrollTop = 1540;
-    host.chatNewMessagesBelow = true;
-
-    handleChatScroll(host, createScrollEvent(2000, 1576, 400));
-
-    expect(host.chatUserNearBottom).toBe(true);
-    expect(host.chatFollowLocked).toBe(false);
-    expect(host.chatNewMessagesBelow).toBe(false);
-  });
-
-  it("does not treat smooth auto-scroll progress as upward manual scroll intent", () => {
-    const { host } = createScrollHost({
-      scrollHeight: 2000,
-      scrollTop: 1200,
-      clientHeight: 400,
-    });
-    host.chatUserNearBottom = true;
-    host.chatSmoothAutoScrolling = true;
-    host.chatLastScrollTop = 1200;
-
-    handleChatScroll(host, createScrollEvent(2000, 1300, 400));
-
-    expect(host.chatUserNearBottom).toBe(true);
-    expect(host.chatFollowLocked).toBe(false);
-  });
-
-  it("releases follow when the user scrolls upward during smooth auto-scroll", () => {
-    const { host } = createScrollHost({
-      scrollHeight: 2000,
-      scrollTop: 1200,
-      clientHeight: 400,
-    });
-    host.chatUserNearBottom = true;
-    host.chatSmoothAutoScrolling = true;
-    host.chatLastScrollTop = 1600;
-
-    handleChatScroll(host, createScrollEvent(2000, 1100, 400));
-
-    expect(host.chatSmoothAutoScrolling).toBe(false);
     expect(host.chatUserNearBottom).toBe(false);
     expect(host.chatFollowLocked).toBe(true);
   });

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -169,7 +169,7 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   ) {
     host.chatUserNearBottom = false;
     host.chatFollowLocked = true;
-  } else if (backAtBottom) {
+  } else if (backAtBottom && (!host.chatFollowLocked || !scrollingUp)) {
     host.chatUserNearBottom = true;
     host.chatFollowLocked = false;
   } else if (!host.chatFollowLocked && nearBottom) {

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -1,5 +1,9 @@
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
+/** Small upward movement should stop auto-follow before the user fully leaves the old threshold. */
+const MANUAL_SCROLL_RELEASE_THRESHOLD = 24;
+/** Re-enable follow only once the user is effectively back at the bottom. */
+const FOLLOW_REACQUIRE_THRESHOLD = 24;
 
 type ScrollHost = {
   updateComplete: Promise<unknown>;
@@ -9,26 +13,41 @@ type ScrollHost = {
   chatScrollTimeout: number | null;
   chatHasAutoScrolled: boolean;
   chatUserNearBottom: boolean;
+  chatFollowLocked: boolean;
+  chatSmoothAutoScrolling: boolean;
+  chatLastScrollTop: number;
   chatNewMessagesBelow: boolean;
   logsScrollFrame: number | null;
   logsAtBottom: boolean;
   topbarObserver: ResizeObserver | null;
 };
 
-function queryHost(host: Partial<ScrollHost>, selectors: string): Element | null {
-  return typeof host.querySelector === "function" ? host.querySelector(selectors) : null;
-}
-
-export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
+function cancelPendingChatScroll(host: ScrollHost) {
   if (host.chatScrollFrame) {
     cancelAnimationFrame(host.chatScrollFrame);
+    host.chatScrollFrame = null;
   }
   if (host.chatScrollTimeout != null) {
     clearTimeout(host.chatScrollTimeout);
     host.chatScrollTimeout = null;
   }
+}
+
+function hasNestedScrollableAncestor(target: EventTarget | null, container: HTMLElement) {
+  let node = target instanceof HTMLElement ? target : null;
+  while (node && node !== container) {
+    if (node.scrollHeight - node.clientHeight > 1) {
+      return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
+
+export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
+  cancelPendingChatScroll(host);
   const pickScrollTarget = () => {
-    const container = queryHost(host, ".chat-thread") as HTMLElement | null;
+    const container = host.querySelector(".chat-thread") as HTMLElement | null;
     if (container) {
       const overflowY = getComputedStyle(container).overflowY;
       const canScroll =
@@ -49,13 +68,10 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
       if (!target) {
         return;
       }
-      const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
-
       // force=true only overrides when we haven't auto-scrolled yet (initial load).
       // After initial load, respect the user's scroll position.
       const effectiveForce = force && !host.chatHasAutoScrolled;
-      const shouldStick =
-        effectiveForce || host.chatUserNearBottom || distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+      const shouldStick = effectiveForce || (host.chatUserNearBottom && !host.chatFollowLocked);
 
       if (!shouldStick) {
         // User is scrolled up — flag that new content arrived below.
@@ -77,6 +93,11 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         target.scrollTop = scrollTop;
       }
       host.chatUserNearBottom = true;
+      host.chatFollowLocked = false;
+      host.chatSmoothAutoScrolling = smoothEnabled;
+      host.chatLastScrollTop = smoothEnabled
+        ? Math.max(target.scrollTop, 0)
+        : Math.max(0, target.scrollHeight - target.clientHeight);
       host.chatNewMessagesBelow = false;
       const retryDelay = effectiveForce ? 150 : 120;
       host.chatScrollTimeout = window.setTimeout(() => {
@@ -85,17 +106,16 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         if (!latest) {
           return;
         }
-        const latestDistanceFromBottom =
-          latest.scrollHeight - latest.scrollTop - latest.clientHeight;
         const shouldStickRetry =
-          effectiveForce ||
-          host.chatUserNearBottom ||
-          latestDistanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+          effectiveForce || (host.chatUserNearBottom && !host.chatFollowLocked);
         if (!shouldStickRetry) {
           return;
         }
         latest.scrollTop = latest.scrollHeight;
         host.chatUserNearBottom = true;
+        host.chatFollowLocked = false;
+        host.chatSmoothAutoScrolling = false;
+        host.chatLastScrollTop = Math.max(0, latest.scrollHeight - latest.clientHeight);
       }, retryDelay);
     });
   });
@@ -108,7 +128,7 @@ export function scheduleLogsScroll(host: ScrollHost, force = false) {
   void host.updateComplete.then(() => {
     host.logsScrollFrame = requestAnimationFrame(() => {
       host.logsScrollFrame = null;
-      const container = queryHost(host, ".log-stream") as HTMLElement | null;
+      const container = host.querySelector(".log-stream") as HTMLElement | null;
       if (!container) {
         return;
       }
@@ -128,12 +148,59 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   if (!container) {
     return;
   }
+  const currentScrollTop = container.scrollTop;
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-  host.chatUserNearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  const nearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  const scrollingUp = currentScrollTop < host.chatLastScrollTop;
+  const backAtBottom = distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD;
+
+  if (host.chatSmoothAutoScrolling) {
+    if (scrollingUp && distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD) {
+      host.chatSmoothAutoScrolling = false;
+      host.chatUserNearBottom = false;
+      host.chatFollowLocked = true;
+    } else if (backAtBottom || !scrollingUp) {
+      host.chatSmoothAutoScrolling = false;
+    }
+  } else if (
+    host.chatUserNearBottom &&
+    scrollingUp &&
+    distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD
+  ) {
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+  } else if (backAtBottom) {
+    host.chatUserNearBottom = true;
+    host.chatFollowLocked = false;
+  } else if (!host.chatFollowLocked && nearBottom) {
+    host.chatUserNearBottom = true;
+  }
+
+  host.chatLastScrollTop = Math.max(currentScrollTop, 0);
   // Clear the "new messages below" indicator when user scrolls back to bottom.
-  if (host.chatUserNearBottom) {
+  if (host.chatUserNearBottom && !host.chatFollowLocked) {
     host.chatNewMessagesBelow = false;
   }
+}
+
+export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
+  if (event.deltaY >= 0) {
+    return;
+  }
+  const container = event.currentTarget as HTMLElement | null;
+  if (!container || container.scrollHeight - container.clientHeight <= 1) {
+    return;
+  }
+  if (hasNestedScrollableAncestor(event.target, container)) {
+    return;
+  }
+  if (!host.chatUserNearBottom && host.chatFollowLocked) {
+    return;
+  }
+  cancelPendingChatScroll(host);
+  host.chatSmoothAutoScrolling = false;
+  host.chatUserNearBottom = false;
+  host.chatFollowLocked = true;
 }
 
 export function handleLogsScroll(host: ScrollHost, event: Event) {
@@ -148,6 +215,9 @@ export function handleLogsScroll(host: ScrollHost, event: Event) {
 export function resetChatScroll(host: ScrollHost) {
   host.chatHasAutoScrolled = false;
   host.chatUserNearBottom = true;
+  host.chatFollowLocked = false;
+  host.chatSmoothAutoScrolling = false;
+  host.chatLastScrollTop = 0;
   host.chatNewMessagesBelow = false;
 }
 
@@ -169,7 +239,7 @@ export function observeTopbar(host: ScrollHost) {
   if (typeof ResizeObserver === "undefined") {
     return;
   }
-  const topbar = queryHost(host, ".topbar");
+  const topbar = host.querySelector(".topbar");
   if (!topbar) {
     return;
   }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -421,6 +421,7 @@ export type AppViewState = {
     handleAbortChat: () => Promise<void>;
     removeQueuedMessage: (id: string) => void;
     handleChatScroll: (event: Event) => void;
+    handleChatWheelIntent: (event: WheelEvent) => void;
     resetToolStream: () => void;
     resetChatScroll: () => void;
     exportLogs: (lines: string[], label: string) => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -33,6 +33,7 @@ import { renderApp } from "./app-render.ts";
 import {
   exportLogs as exportLogsInternal,
   handleChatScroll as handleChatScrollInternal,
+  handleChatWheelIntent as handleChatWheelIntentInternal,
   handleLogsScroll as handleLogsScrollInternal,
   resetChatScroll as resetChatScrollInternal,
   scheduleChatScroll as scheduleChatScrollInternal,
@@ -502,6 +503,9 @@ export class OpenClawApp extends LitElement {
   private chatScrollTimeout: number | null = null;
   private chatHasAutoScrolled = false;
   private chatUserNearBottom = true;
+  private chatFollowLocked = false;
+  private chatSmoothAutoScrolling = false;
+  private chatLastScrollTop = 0;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;
   private logsPollInterval: number | null = null;
@@ -590,6 +594,13 @@ export class OpenClawApp extends LitElement {
   handleChatScroll(event: Event) {
     handleChatScrollInternal(
       this as unknown as Parameters<typeof handleChatScrollInternal>[0],
+      event,
+    );
+  }
+
+  handleChatWheelIntent(event: WheelEvent) {
+    handleChatWheelIntentInternal(
+      this as unknown as Parameters<typeof handleChatWheelIntentInternal>[0],
       event,
     );
   }

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2,7 +2,6 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import { i18n } from "../../i18n/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import { renderChatSessionSelect } from "../app-render.helpers.ts";
 import type { AppViewState } from "../app-view-state.ts";
@@ -18,7 +17,6 @@ import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ModelCatalogEntry } from "../types.ts";
 import type { SessionsListResult } from "../types.ts";
 import { renderChat, type ChatProps } from "./chat.ts";
-import { renderOverview, type OverviewProps } from "./overview.ts";
 
 function createSessions(): SessionsListResult {
   return {
@@ -193,60 +191,6 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     agentsList: null,
     currentAgentId: "",
     onAgentChange: () => undefined,
-    ...overrides,
-  };
-}
-
-function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewProps {
-  return {
-    warnQueryToken: false,
-    connected: false,
-    hello: null,
-    settings: {
-      gatewayUrl: "",
-      token: "",
-      sessionKey: "main",
-      lastActiveSessionKey: "main",
-      theme: "claw",
-      themeMode: "system",
-      chatFocusMode: false,
-      chatShowThinking: true,
-      chatShowToolCalls: true,
-      splitRatio: 0.6,
-      navCollapsed: false,
-      navWidth: 220,
-      navGroupsCollapsed: {},
-      borderRadius: 50,
-      locale: "en",
-    },
-    password: "",
-    lastError: null,
-    lastErrorCode: null,
-    presenceCount: 0,
-    sessionsCount: null,
-    cronEnabled: null,
-    cronNext: null,
-    lastChannelsRefresh: null,
-    modelAuthStatus: null,
-    usageResult: null,
-    sessionsResult: null,
-    skillsReport: null,
-    cronJobs: [],
-    cronStatus: null,
-    attentionItems: [],
-    eventLog: [],
-    overviewLogLines: [],
-    showGatewayToken: false,
-    showGatewayPassword: false,
-    onSettingsChange: () => undefined,
-    onPasswordChange: () => undefined,
-    onSessionKeyChange: () => undefined,
-    onToggleGatewayTokenVisibility: () => undefined,
-    onToggleGatewayPasswordVisibility: () => undefined,
-    onConnect: () => undefined,
-    onRefresh: () => undefined,
-    onNavigate: () => undefined,
-    onRefreshLogs: () => undefined,
     ...overrides,
   };
 }
@@ -541,37 +485,6 @@ describe("chat view", () => {
     );
     expect(groupedLogo).not.toBeNull();
     expect(groupedLogo?.getAttribute("src")).toBe("/openclaw/favicon.svg");
-  });
-
-  it("keeps the persisted overview locale selected before i18n hydration finishes", async () => {
-    const container = document.createElement("div");
-    const props = createOverviewProps({
-      settings: {
-        ...createOverviewProps().settings,
-        locale: "zh-CN",
-      },
-    });
-
-    getSafeLocalStorage()?.clear();
-    await i18n.setLocale("en");
-
-    render(renderOverview(props), container);
-    await Promise.resolve();
-
-    let select = container.querySelector<HTMLSelectElement>("select");
-    expect(i18n.getLocale()).toBe("en");
-    expect(select?.value).toBe("zh-CN");
-    expect(select?.selectedOptions[0]?.textContent?.trim()).toBe("简体中文 (Simplified Chinese)");
-
-    await i18n.setLocale("zh-CN");
-    render(renderOverview(props), container);
-    await Promise.resolve();
-
-    select = container.querySelector<HTMLSelectElement>("select");
-    expect(select?.value).toBe("zh-CN");
-    expect(select?.selectedOptions[0]?.textContent?.trim()).toBe("简体中文 (简体中文)");
-
-    await i18n.setLocale("en");
   });
 
   it("renders compacting indicator as a badge", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1183,7 +1183,7 @@ export function renderChat(props: ChatProps) {
       role="log"
       aria-live="polite"
       @scroll=${props.onChatScroll}
-      @wheel=${(event: WheelEvent) => props.onChatWheelIntent?.(event)}
+      @wheel=${props.onChatWheelIntent}
       @click=${handleCodeBlockCopy}
     >
       <div class="chat-thread-inner">

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -112,6 +112,7 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  onChatWheelIntent?: (event: WheelEvent) => void;
   basePath?: string;
 };
 
@@ -1182,6 +1183,7 @@ export function renderChat(props: ChatProps) {
       role="log"
       aria-live="polite"
       @scroll=${props.onChatScroll}
+      @wheel=${(event: WheelEvent) => props.onChatWheelIntent?.(event)}
       @click=${handleCodeBlockCopy}
     >
       <div class="chat-thread-inner">

--- a/ui/src/ui/views/overview.render.test.ts
+++ b/ui/src/ui/views/overview.render.test.ts
@@ -1,0 +1,94 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { i18n } from "../../i18n/index.ts";
+import { getSafeLocalStorage } from "../../local-storage.ts";
+import { renderOverview, type OverviewProps } from "./overview.ts";
+
+function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewProps {
+  return {
+    warnQueryToken: false,
+    connected: false,
+    hello: null,
+    settings: {
+      gatewayUrl: "",
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "claw",
+      themeMode: "system",
+      chatFocusMode: false,
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navWidth: 220,
+      navGroupsCollapsed: {},
+      borderRadius: 50,
+      locale: "en",
+    },
+    password: "",
+    lastError: null,
+    lastErrorCode: null,
+    presenceCount: 0,
+    sessionsCount: null,
+    cronEnabled: null,
+    cronNext: null,
+    lastChannelsRefresh: null,
+    modelAuthStatus: null,
+    usageResult: null,
+    sessionsResult: null,
+    skillsReport: null,
+    cronJobs: [],
+    cronStatus: null,
+    attentionItems: [],
+    eventLog: [],
+    overviewLogLines: [],
+    showGatewayToken: false,
+    showGatewayPassword: false,
+    onSettingsChange: () => undefined,
+    onPasswordChange: () => undefined,
+    onSessionKeyChange: () => undefined,
+    onToggleGatewayTokenVisibility: () => undefined,
+    onToggleGatewayPasswordVisibility: () => undefined,
+    onConnect: () => undefined,
+    onRefresh: () => undefined,
+    onNavigate: () => undefined,
+    onRefreshLogs: () => undefined,
+    ...overrides,
+  };
+}
+
+describe("overview view rendering", () => {
+  it("keeps the persisted overview locale selected before i18n hydration finishes", async () => {
+    const container = document.createElement("div");
+    const props = createOverviewProps({
+      settings: {
+        ...createOverviewProps().settings,
+        locale: "zh-CN",
+      },
+    });
+
+    getSafeLocalStorage()?.clear();
+    await i18n.setLocale("en");
+
+    render(renderOverview(props), container);
+    await Promise.resolve();
+
+    let select = container.querySelector<HTMLSelectElement>("select");
+    expect(i18n.getLocale()).toBe("en");
+    expect(select?.value).toBe("zh-CN");
+    expect(select?.selectedOptions[0]?.textContent?.trim()).toBe("简体中文 (Simplified Chinese)");
+
+    await i18n.setLocale("zh-CN");
+    render(renderOverview(props), container);
+    await Promise.resolve();
+
+    select = container.querySelector<HTMLSelectElement>("select");
+    expect(select?.value).toBe("zh-CN");
+    expect(select?.selectedOptions[0]?.textContent?.trim()).toBe("简体中文 (简体中文)");
+
+    await i18n.setLocale("en");
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Chat auto-follow in the Control UI could re-engage too aggressively when the user manually scrolled slightly upward during streaming, because the logic only used a broad "near bottom" threshold.
- Why it matters: Users trying to read slightly older messages could get pulled back to the bottom, which makes streaming chats feel jumpy and hard to control.
- What changed: Added an explicit manual-scroll release lock, only reacquire follow when the user is truly back at the bottom, ignore upward wheel intent from nested scrollables, cover smooth auto-scroll edge cases, and keep the handler-focused tests grouped under `ui/src/ui/app-scroll.test.ts` where they are easier to review.
- What did NOT change (scope boundary): No session-management refactors, no tool-call visibility changes, no settings/auth/token behavior changes, and no unrelated UI restructuring.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37500
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The chat scroll state treated "near bottom" as equivalent to "should still auto-follow", so a small upward manual scroll could still satisfy follow conditions and snap the user back down on subsequent updates.
- Missing detection / guardrail: There was no explicit "user took over scrolling" lock and no test coverage for slight upward manual scrolling during streaming.
- Contributing context (if known): Smooth auto-scroll progress and user-driven upward scroll were both funneled through the same scroll-state path, which made intent ambiguous.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/app-scroll.test.ts`
- Scenario the test should lock in: When the user wheels or scrolls slightly upward from the bottom during chat streaming, auto-follow disengages immediately and does not re-enable until the user actually returns to the bottom.
- Why this is the smallest reliable guardrail: The behavior is contained in the chat scroll state machine and can be deterministically exercised with direct scroll/wheel events.
- Existing test that already covers this (if any): Existing tests covered broad near-bottom behavior, but not manual release/reacquire intent or the smooth auto-scroll edge cases.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

- Chat no longer snaps back to the bottom as easily when the user manually scrolls slightly upward during streaming.
- Auto-follow resumes only when the user truly returns to the bottom.
- Wheel events coming from nested scrollable content inside the chat do not incorrectly disable or fight chat scroll state.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user scrolls slightly up] -> [still "near bottom"] -> [next stream update] -> [auto-follow re-engages]

After:
[user scrolls slightly up] -> [follow locked off] -> [next stream update] -> [stays in place]
[user returns to bottom] -> [follow unlocked] -> [next stream update] -> [auto-follow resumes]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Vite dev setup
- Model/provider: N/A
- Integration/channel (if any): Control UI chat
- Relevant config (redacted): local gateway on `ws://127.0.0.1:18789`

### Steps

1. Open the Control UI chat while a response is streaming.
2. Scroll slightly upward from the bottom or wheel upward during streaming.
3. Continue streaming, then return fully to the bottom.

### Expected

- Slight upward manual scrolling disengages auto-follow.
- Streaming updates do not snap the view back down.
- Auto-follow resumes only after returning to the bottom.

### Actual

- Before fix: chat could snap back down while the user was still trying to read upward.
- After fix: chat stays released until the bottom is reached again.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `pnpm test ui/src/ui/app-scroll.test.ts` and confirmed the targeted chat scroll regression coverage passes after the latest test regrouping.
- Edge cases checked: Slight upward scroll near bottom, re-enable only at the bottom, nested scrollable wheel intent, post-wheel near-bottom lock behavior, and smooth auto-scroll transition handling.
- What you did **not** verify: Manual browser repro in this pass, full end-to-end multi-browser/device matrix, full UI suite, and non-chat surfaces.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The new release/reacquire thresholds could feel slightly different than before for some users near the bottom of the thread.
  - Mitigation: Thresholds are small and targeted, and focused unit tests lock in the intended behavior.
- Risk: Wheel-based intent handling could interfere with nested scrollable UI inside messages.
  - Mitigation: Nested scrollable ancestors are explicitly ignored and covered by tests.
