### PR TITLE
fix(memory-core): report active dreaming phases in memory status

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -2,7 +2,11 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
+import {
+  resolveMemoryDreamingConfig,
+  resolveMemoryLightDreamingConfig,
+  resolveMemoryRemDreamingConfig,
+} from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
@@ -211,12 +215,31 @@ async function listWorkspaceDailyFiles(workspaceDir: string, limit: number): Pro
 
 function formatDreamingSummary(cfg: OpenClawConfig): string {
   const pluginConfig = resolveMemoryPluginConfig(cfg);
-  const dreaming = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
-  if (!dreaming.enabled) {
+  const dreaming = resolveMemoryDreamingConfig({ pluginConfig, cfg });
+  const light = resolveMemoryLightDreamingConfig({ pluginConfig, cfg });
+  const rem = resolveMemoryRemDreamingConfig({ pluginConfig, cfg });
+  const deep = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
+  if (!light.enabled && !rem.enabled && !deep.enabled) {
     return "off";
   }
   const timezone = dreaming.timezone ? ` (${dreaming.timezone})` : "";
-  return `${dreaming.cron}${timezone} · limit=${dreaming.limit} · minScore=${dreaming.minScore} · minRecallCount=${dreaming.minRecallCount} · minUniqueQueries=${dreaming.minUniqueQueries} · recencyHalfLifeDays=${dreaming.recencyHalfLifeDays} · maxAgeDays=${dreaming.maxAgeDays ?? "none"}`;
+  const details = [`cron=${dreaming.frequency}${timezone}`];
+  if (deep.enabled) {
+    details.push(
+      `limit=${deep.limit}`,
+      `minScore=${deep.minScore}`,
+      `minRecallCount=${deep.minRecallCount}`,
+      `minUniqueQueries=${deep.minUniqueQueries}`,
+      `recencyHalfLifeDays=${deep.recencyHalfLifeDays}`,
+      `maxAgeDays=${deep.maxAgeDays ?? "none"}`,
+    );
+  }
+  return [
+    `light=${light.enabled ? "on" : "off"}`,
+    `REM=${rem.enabled ? "on" : "off"}`,
+    `deep=${deep.enabled ? "on" : "off"}`,
+    ...details,
+  ].join(" · ");
 }
 
 function formatAuditCounts(audit: ShortTermAuditSummary): string {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -384,6 +384,50 @@ describe("memory cli", () => {
     });
   });
 
+  it("reports light-only dreaming status during status", async () => {
+    const close = vi.fn(async () => {});
+    loadConfig.mockReturnValue({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: "0 3 * * *",
+                timezone: "America/Sao_Paulo",
+                phases: {
+                  light: {
+                    enabled: true,
+                    lookbackDays: 7,
+                    limit: 20,
+                  },
+                  deep: {
+                    enabled: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus({ files: 1, chunks: 1 }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status"]);
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Dreaming: light=on"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("REM=on"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("deep=off"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("cron=0 3 * * *"));
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Dreaming: off"));
+    expect(close).toHaveBeenCalled();
+  });
+
   it("repairs invalid recall metadata and stale locks with status --fix", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");


### PR DESCRIPTION
## Summary

AI-assisted: Yes (Codex)
Testing: targeted regression + `memory-core` extension lane + repo build
Session log: not attached

- Problem: `openclaw memory status` reported `Dreaming: off` when deep dreaming was disabled even if other dreaming phases were active.
- Why it matters: operators use `memory status` to verify that dreaming is enabled, so light/REM-capable setups looked fully disabled.
- What changed: the status summary now derives its state from the overall dreaming config plus per-phase light/REM/deep enablement, and a regression test covers the light-enabled/deep-disabled case.
- What did NOT change (scope boundary): no dreaming execution logic, cron reconciliation, or `/dreaming status` behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67868
- Related #67836
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/memory-core/src/cli.runtime.ts` built the `Dreaming:` line from `resolveShortTermPromotionDreamingConfig()`, which only reflects the deep phase.
- Missing detection / guardrail: there was no CLI regression covering a config where dreaming was active outside the deep phase.
- Contributing context (if known): `resolveMemoryDreamingConfig()` defaults light and REM phases on when global dreaming is enabled, so the old summary could incorrectly collapse active configs to `off`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/cli.test.ts`
- Scenario the test should lock in: a light-enabled / deep-disabled dreaming config should not print `Dreaming: off` in `openclaw memory status`.
- Why this is the smallest reliable guardrail: it exercises the actual CLI render path and config resolution without needing a live gateway or cron runtime.
- Existing test that already covers this (if any): `prints recall-store audit details during status` still covers the fully-off/default case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw memory status` now reports active dreaming phases (`light`, `REM`, `deep`) and the configured sweep cron instead of incorrectly collapsing valid non-deep setups to `off`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[memory status] -> [deep phase disabled] -> [Dreaming: off]

After:
[memory status] -> [light/REM/deep phase summary] -> [accurate active/off state]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 24.14.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `plugins.entries.memory-core.config.dreaming.enabled=true` with `phases.light.enabled=true` and `phases.deep.enabled=false`

### Steps

1. Configure `memory-core` dreaming with global dreaming enabled and deep disabled while keeping light dreaming enabled.
2. Run `openclaw memory status`.
3. Inspect the `Dreaming:` line.

### Expected

- `memory status` reports active dreaming phases instead of saying dreaming is fully off.

### Actual

- Before this change, `memory status` printed `Dreaming: off` because it only consulted the deep-phase helper.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added a focused regression in `extensions/memory-core/src/cli.test.ts` and confirmed it failed before the code change.
  - Re-ran that targeted test after the fix and confirmed it passed.
  - Ran the full `memory-core` extension lane.
  - Ran `pnpm build` successfully.
- Edge cases checked:
  - Default/off behavior still has existing coverage.
  - The light-enabled / deep-disabled config no longer renders `Dreaming: off`.
  - REM default enablement is surfaced explicitly in the status line.
- What you did **not** verify:
  - No live gateway/manual CLI run outside the test harness.
  - No `/dreaming status` output changes; that command was intentionally left untouched.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: any external tooling that matched the exact active `Dreaming:` string may need to tolerate a phase breakdown instead of a deep-only summary.
  - Mitigation: `off` behavior is preserved when no phase is active, and the new output is a more accurate reflection of the configured dreaming phases.
