### PR TITLE
Doctor/config: repair misplaced channels.<id>.messages.* (fixes #67859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
+- Doctor/config: detect and repair misplaced `channels.<id>.messages.*` and `channels.<id>.accounts.<aid>.messages.*` blocks. These paths are not part of any channel schema, so the runtime was silently ignoring keys like `ackReaction`, `ackReactionScope`, `removeAckAfterReply`, and `statusReactions` when users nested them under a channel. `openclaw doctor --fix` now lifts channel-scoped `ackReaction`/`responsePrefix` to the channel/account scalar and relocates the other `MessagesConfig` keys to top-level `messages.*`. (#67859) [AI-assisted]
 
 ## 2026.4.15
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -190,6 +190,7 @@ Current migrations:
 - `browser.ssrfPolicy.allowPrivateNetwork` → `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork`
 - `browser.profiles.*.driver: "extension"` → `"existing-session"`
 - remove `browser.relayBindHost` (legacy extension relay setting)
+- `channels.<id>.messages.*` / `channels.<id>.accounts.<aid>.messages.*` → the canonical locations (per-channel `ackReaction` / `responsePrefix` stay on the channel/account; `ackReactionScope`, `removeAckAfterReply`, `statusReactions`, and the other `MessagesConfig` keys land on top-level `messages.*`). The nested `messages` block is not a valid path on any channel schema, so the runtime silently ignores it until doctor repairs it.
 
 Doctor warnings also include account-default guidance for multi-account channels:
 

--- a/src/commands/doctor/shared/legacy-config-migrations.channel-messages.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.channel-messages.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.js";
+import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
+
+function migrateLegacyConfigForTest(raw: unknown): {
+  config: OpenClawConfig | null;
+  changes: string[];
+} {
+  if (!raw || typeof raw !== "object") {
+    return { config: null, changes: [] };
+  }
+  const next = structuredClone(raw) as Record<string, unknown>;
+  const changes: string[] = [];
+  for (const migration of LEGACY_CONFIG_MIGRATIONS) {
+    migration.apply(next, changes);
+  }
+  return changes.length === 0
+    ? { config: null, changes }
+    : { config: next as OpenClawConfig, changes };
+}
+
+describe("legacy migrate channels.<id>.messages.* misplacement (issue #67859)", () => {
+  it("does nothing when no channel carries a misplaced messages block", () => {
+    const res = migrateLegacyConfigForTest({
+      messages: { ackReaction: "👀" },
+      channels: {
+        telegram: {
+          ackReaction: "👀",
+        },
+      },
+    });
+
+    expect(res.changes).toEqual([]);
+    expect(res.config).toBeNull();
+  });
+
+  it("lifts telegram reaction config from channels.telegram.messages to the correct locations", () => {
+    const res = migrateLegacyConfigForTest({
+      channels: {
+        telegram: {
+          messages: {
+            ackReaction: "👀",
+            ackReactionScope: "all",
+            removeAckAfterReply: true,
+            statusReactions: {
+              enabled: true,
+              emojis: { thinking: "🤔", done: "👍", error: "💔" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toEqual(
+      expect.arrayContaining([
+        "Moved channels.telegram.messages.ackReaction → channels.telegram.ackReaction.",
+        "Moved channels.telegram.messages.ackReactionScope → messages.ackReactionScope.",
+        "Moved channels.telegram.messages.removeAckAfterReply → messages.removeAckAfterReply.",
+        "Moved channels.telegram.messages.statusReactions → messages.statusReactions.",
+      ]),
+    );
+
+    const cfg = res.config as {
+      messages?: {
+        ackReactionScope?: string;
+        removeAckAfterReply?: boolean;
+        statusReactions?: { enabled?: boolean };
+      };
+      channels?: {
+        telegram?: {
+          ackReaction?: string;
+          messages?: unknown;
+        };
+      };
+    };
+
+    // Channel-scoped keys land on the channel scalar.
+    expect(cfg.channels?.telegram?.ackReaction).toBe("👀");
+    // Global-only keys land at the top level.
+    expect(cfg.messages?.ackReactionScope).toBe("all");
+    expect(cfg.messages?.removeAckAfterReply).toBe(true);
+    expect(cfg.messages?.statusReactions?.enabled).toBe(true);
+    // The misplaced container is removed when emptied.
+    expect(cfg.channels?.telegram?.messages).toBeUndefined();
+  });
+
+  it("lifts account-level messages blocks (channels.<id>.accounts.<aid>.messages.*)", () => {
+    const res = migrateLegacyConfigForTest({
+      channels: {
+        telegram: {
+          accounts: {
+            main: {
+              messages: {
+                ackReaction: "🦞",
+                responsePrefix: "[main]",
+                statusReactions: { enabled: true },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toEqual(
+      expect.arrayContaining([
+        "Moved channels.telegram.accounts.main.messages.ackReaction → channels.telegram.accounts.main.ackReaction.",
+        "Moved channels.telegram.accounts.main.messages.responsePrefix → channels.telegram.accounts.main.responsePrefix.",
+        "Moved channels.telegram.accounts.main.messages.statusReactions → messages.statusReactions.",
+      ]),
+    );
+
+    const cfg = res.config as {
+      messages?: { statusReactions?: { enabled?: boolean } };
+      channels?: {
+        telegram?: {
+          accounts?: Record<
+            string,
+            {
+              ackReaction?: string;
+              responsePrefix?: string;
+              messages?: unknown;
+            }
+          >;
+        };
+      };
+    };
+
+    expect(cfg.channels?.telegram?.accounts?.main?.ackReaction).toBe("🦞");
+    expect(cfg.channels?.telegram?.accounts?.main?.responsePrefix).toBe("[main]");
+    expect(cfg.channels?.telegram?.accounts?.main?.messages).toBeUndefined();
+    expect(cfg.messages?.statusReactions?.enabled).toBe(true);
+  });
+
+  it("honors existing destination values and removes the misplaced key with a note", () => {
+    const res = migrateLegacyConfigForTest({
+      messages: {
+        ackReactionScope: "group-mentions",
+      },
+      channels: {
+        telegram: {
+          ackReaction: "🦐",
+          messages: {
+            ackReaction: "👀",
+            ackReactionScope: "all",
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toEqual(
+      expect.arrayContaining([
+        "Removed channels.telegram.messages.ackReaction (channels.telegram.ackReaction already set).",
+        "Removed channels.telegram.messages.ackReactionScope (messages.ackReactionScope already set).",
+      ]),
+    );
+
+    const cfg = res.config as {
+      messages?: { ackReactionScope?: string };
+      channels?: {
+        telegram?: {
+          ackReaction?: string;
+          messages?: unknown;
+        };
+      };
+    };
+
+    expect(cfg.channels?.telegram?.ackReaction).toBe("🦐");
+    expect(cfg.messages?.ackReactionScope).toBe("group-mentions");
+    expect(cfg.channels?.telegram?.messages).toBeUndefined();
+  });
+
+  it("leaves unknown nested keys in place so third-party plugin config is not touched", () => {
+    const res = migrateLegacyConfigForTest({
+      channels: {
+        customChannel: {
+          messages: {
+            ackReaction: "👀",
+            someThirdPartyKey: { foo: "bar" },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved channels.customChannel.messages.ackReaction → channels.customChannel.ackReaction.",
+    );
+
+    const cfg = res.config as {
+      channels?: {
+        customChannel?: {
+          ackReaction?: string;
+          messages?: { someThirdPartyKey?: { foo?: string } };
+        };
+      };
+    };
+
+    expect(cfg.channels?.customChannel?.ackReaction).toBe("👀");
+    expect(cfg.channels?.customChannel?.messages?.someThirdPartyKey).toEqual({ foo: "bar" });
+  });
+
+  it("does not clobber a non-record top-level messages value", () => {
+    const res = migrateLegacyConfigForTest({
+      messages: "invalid-scalar",
+      channels: {
+        telegram: {
+          messages: {
+            ackReaction: "👀",
+            ackReactionScope: "all",
+          },
+        },
+      },
+    });
+
+    // Channel-scoped keys still lift onto the channel scalar.
+    expect(res.changes).toContain(
+      "Moved channels.telegram.messages.ackReaction → channels.telegram.ackReaction.",
+    );
+    // Global-only keys are left under the misplaced block so the operator can
+    // fix the invalid top-level `messages` first.
+    expect(res.changes).not.toContain(
+      "Moved channels.telegram.messages.ackReactionScope → messages.ackReactionScope.",
+    );
+
+    const cfg = res.config as {
+      messages?: unknown;
+      channels?: {
+        telegram?: {
+          ackReaction?: string;
+          messages?: { ackReactionScope?: string };
+        };
+      };
+    };
+
+    expect(cfg.messages).toBe("invalid-scalar");
+    expect(cfg.channels?.telegram?.ackReaction).toBe("👀");
+    expect(cfg.channels?.telegram?.messages?.ackReactionScope).toBe("all");
+  });
+
+  it("skips channels.defaults and channels.modelByChannel", () => {
+    const res = migrateLegacyConfigForTest({
+      channels: {
+        defaults: {
+          messages: { ackReaction: "👀" },
+        },
+        modelByChannel: {
+          messages: { ackReaction: "👀" },
+        },
+      },
+    });
+
+    expect(res.changes).toEqual([]);
+    expect(res.config).toBeNull();
+  });
+});

--- a/src/commands/doctor/shared/legacy-config-migrations.channel-messages.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.channel-messages.ts
@@ -1,0 +1,222 @@
+import {
+  defineLegacyConfigMigration,
+  getRecord,
+  type LegacyConfigMigrationSpec,
+  type LegacyConfigRule,
+} from "../../../config/legacy.shared.js";
+
+/**
+ * Top-level `messages.*` keys that users sometimes misplace under
+ * `channels.<id>.messages.*` or `channels.<id>.accounts.<aid>.messages.*`. Those
+ * nested paths are not part of any channel schema, so the runtime silently
+ * ignores them (see issue #67859 for the Telegram status-reaction variant).
+ *
+ * This migration moves each known key to its correct location. We do not touch
+ * unknown keys so third-party plugin config that happens to nest a `messages`
+ * block under a channel entry is preserved as-is.
+ */
+const MESSAGES_CONFIG_KEYS = [
+  "ackReaction",
+  "ackReactionScope",
+  "removeAckAfterReply",
+  "statusReactions",
+  "messagePrefix",
+  "responsePrefix",
+  "groupChat",
+  "queue",
+  "inbound",
+  "suppressToolErrors",
+  "tts",
+] as const;
+
+type MessagesConfigKey = (typeof MESSAGES_CONFIG_KEYS)[number];
+
+// Keys that have a valid per-channel equivalent. Lifting these out of a misplaced
+// `messages` block preserves the user's channel-scoping intent instead of
+// unconditionally globalizing them.
+const CHANNEL_SCOPED_KEYS = new Set<MessagesConfigKey>(["ackReaction", "responsePrefix"]);
+
+function hasMisplacedMessagesBlock(messagesValue: unknown): boolean {
+  const messages = getRecord(messagesValue);
+  if (!messages) {
+    return false;
+  }
+  return MESSAGES_CONFIG_KEYS.some((key) => Object.prototype.hasOwnProperty.call(messages, key));
+}
+
+function hasMisplacedMessagesInAnyChannel(value: unknown): boolean {
+  const channels = getRecord(value);
+  if (!channels) {
+    return false;
+  }
+  for (const [channelId, channelValue] of Object.entries(channels)) {
+    if (channelId === "defaults" || channelId === "modelByChannel") {
+      continue;
+    }
+    const channel = getRecord(channelValue);
+    if (!channel) {
+      continue;
+    }
+    if (hasMisplacedMessagesBlock(channel.messages)) {
+      return true;
+    }
+    const accounts = getRecord(channel.accounts);
+    if (!accounts) {
+      continue;
+    }
+    for (const accountValue of Object.values(accounts)) {
+      const account = getRecord(accountValue);
+      if (!account) {
+        continue;
+      }
+      if (hasMisplacedMessagesBlock(account.messages)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function ensureTopLevelMessages(raw: Record<string, unknown>): Record<string, unknown> | null {
+  const existing = getRecord(raw.messages);
+  if (existing) {
+    return existing;
+  }
+  // Refuse to clobber a non-record value already present under `messages`. The
+  // zod schema will reject it anyway; leaving it alone avoids silently erasing
+  // user data we do not own.
+  if (raw.messages !== undefined) {
+    return null;
+  }
+  const next: Record<string, unknown> = {};
+  raw.messages = next;
+  return next;
+}
+
+function migrateEntry(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  raw: Record<string, unknown>;
+  changes: string[];
+}): void {
+  const messages = getRecord(params.entry.messages);
+  if (!messages) {
+    return;
+  }
+
+  const movedKeys: string[] = [];
+  for (const key of MESSAGES_CONFIG_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(messages, key)) {
+      continue;
+    }
+    const value = messages[key];
+    const sourcePath = `${params.pathPrefix}.messages.${key}`;
+
+    if (CHANNEL_SCOPED_KEYS.has(key)) {
+      // Lift to the channel/account scalar equivalent so the user's
+      // channel-scoping intent is preserved.
+      const targetPath = `${params.pathPrefix}.${key}`;
+      if (params.entry[key] === undefined) {
+        params.entry[key] = value;
+        params.changes.push(`Moved ${sourcePath} → ${targetPath}.`);
+      } else {
+        params.changes.push(`Removed ${sourcePath} (${targetPath} already set).`);
+      }
+    } else {
+      // Global-only top-level `messages.*` key. Move to the top-level `messages`
+      // object if not already set; otherwise honor the existing top-level value.
+      const topLevelMessages = ensureTopLevelMessages(params.raw);
+      const targetPath = `messages.${key}`;
+      if (topLevelMessages === null) {
+        // Top-level `messages` holds a non-record value we will not clobber.
+        // Skip the move so the user can resolve the invalid shape manually.
+        continue;
+      }
+      if (topLevelMessages[key] === undefined) {
+        topLevelMessages[key] = value;
+        params.changes.push(`Moved ${sourcePath} → ${targetPath}.`);
+      } else {
+        params.changes.push(`Removed ${sourcePath} (${targetPath} already set).`);
+      }
+    }
+
+    delete messages[key];
+    movedKeys.push(key);
+  }
+
+  if (movedKeys.length === 0) {
+    return;
+  }
+
+  // Drop the `messages` container if it is now empty. Preserve any unknown keys
+  // the user may have added (third-party plugin config surface) so we never
+  // delete data we do not own.
+  if (Object.keys(messages).length === 0) {
+    delete params.entry.messages;
+  } else {
+    params.entry.messages = messages;
+  }
+}
+
+const CHANNEL_MESSAGES_MISPLACEMENT_RULES: LegacyConfigRule[] = [
+  {
+    path: ["channels"],
+    message:
+      'channels.<id>.messages.* and channels.<id>.accounts.<aid>.messages.* are not valid config paths. The canonical location is top-level messages.* (per-channel ackReaction/responsePrefix stay on the channel/account). Run "openclaw doctor --fix".',
+    match: (value) => hasMisplacedMessagesInAnyChannel(value),
+  },
+];
+
+export const LEGACY_CONFIG_MIGRATIONS_CHANNEL_MESSAGES: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "channels.<id>.messages->messages",
+    describe:
+      "Relocate misplaced channels.<id>.messages.* (and account-level nested messages.*) to their canonical locations",
+    legacyRules: CHANNEL_MESSAGES_MISPLACEMENT_RULES,
+    apply: (raw, changes) => {
+      const channels = getRecord(raw.channels);
+      if (!channels) {
+        return;
+      }
+
+      for (const [channelId, channelValue] of Object.entries(channels)) {
+        if (channelId === "defaults" || channelId === "modelByChannel") {
+          continue;
+        }
+        const channel = getRecord(channelValue);
+        if (!channel) {
+          continue;
+        }
+
+        migrateEntry({
+          entry: channel,
+          pathPrefix: `channels.${channelId}`,
+          raw,
+          changes,
+        });
+
+        const accounts = getRecord(channel.accounts);
+        if (accounts) {
+          for (const [accountId, accountValue] of Object.entries(accounts)) {
+            const account = getRecord(accountValue);
+            if (!account) {
+              continue;
+            }
+            migrateEntry({
+              entry: account,
+              pathPrefix: `channels.${channelId}.accounts.${accountId}`,
+              raw,
+              changes,
+            });
+            accounts[accountId] = account;
+          }
+          channel.accounts = accounts;
+        }
+
+        channels[channelId] = channel;
+      }
+
+      raw.channels = channels;
+    },
+  }),
+];

--- a/src/commands/doctor/shared/legacy-config-migrations.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.ts
@@ -1,10 +1,12 @@
 import { LEGACY_CONFIG_MIGRATIONS_AUDIO } from "./legacy-config-migrations.audio.js";
+import { LEGACY_CONFIG_MIGRATIONS_CHANNEL_MESSAGES } from "./legacy-config-migrations.channel-messages.js";
 import { LEGACY_CONFIG_MIGRATIONS_CHANNELS } from "./legacy-config-migrations.channels.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME } from "./legacy-config-migrations.runtime.js";
 import { LEGACY_CONFIG_MIGRATIONS_WEB_SEARCH } from "./legacy-config-migrations.web-search.js";
 
 const LEGACY_CONFIG_MIGRATION_SPECS = [
   ...LEGACY_CONFIG_MIGRATIONS_CHANNELS,
+  ...LEGACY_CONFIG_MIGRATIONS_CHANNEL_MESSAGES,
   ...LEGACY_CONFIG_MIGRATIONS_AUDIO,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME,
   ...LEGACY_CONFIG_MIGRATIONS_WEB_SEARCH,


### PR DESCRIPTION
## Summary

- Problem: Users who nest reaction config under `channels.<id>.messages.*` (for example the reporter's \`channels.telegram.messages.statusReactions\` / \`ackReaction\` / \`ackReactionScope\`) observe no ack reaction and no status reactions. The runtime only reads these keys from top-level \`messages.*\` (plus \`channels.<id>.ackReaction\` / \`.responsePrefix\` for the two channel-scoped variants), so the nested keys are silently dropped with no user-visible signal.
- Why it matters: There is no actionable error today — config validates (the top-level \`ChannelsSchema\` uses \`passthrough()\`) and the channel boots, the bot just never reacts. The reporter (and this is not the first time this path confuses users) has no way to self-diagnose the mismatch.
- What changed: New \`openclaw doctor --fix\` legacy-config migration \`channels.<id>.messages->messages\` that detects misplaced \`channels.<id>.messages.*\` and \`channels.<id>.accounts.<aid>.messages.*\` blocks and relocates each known \`MessagesConfig\` key to its canonical location. Channel-scoped keys (\`ackReaction\`, \`responsePrefix\`) stay on the channel/account scalar so the user's per-channel intent is preserved; the other \`MessagesConfig\` keys (\`ackReactionScope\`, \`removeAckAfterReply\`, \`statusReactions\`, \`suppressToolErrors\`, \`messagePrefix\`, \`groupChat\`, \`queue\`, \`inbound\`, \`tts\`) land at top-level \`messages.*\`. Covers both channel-level and account-level misplacement; honors existing destination values (logs a removed note instead of clobbering); never touches unknown keys (third-party plugin config is preserved).
- What did NOT change (scope boundary): No changes to the reaction pipeline itself — \`resolveAckReaction\`, \`shouldAckReactionGate\`, and \`createStatusReactionController\` still read from the same canonical locations they already did. No changes to channel/message schemas, defaults, runtime gating, or SDK surface. No config keys were retired, added, or aliased into the public contract.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67859
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: No schema rejects \`channels.<id>.messages\` (the outer \`ChannelsSchema\` is \`passthrough()\` to tolerate third-party channel configs), and no runtime code path reads from that nested location — runtime reads \`cfg.messages.ackReactionScope\`, \`cfg.messages.statusReactions\`, \`cfg.messages.removeAckAfterReply\` (see \`extensions/telegram/src/bot.ts\` and \`extensions/telegram/src/bot-message-context.ts\`) and \`resolveAckReaction\` (see \`src/agents/identity.ts\`). The result: misplaced keys are silently ignored with no repair signal.
- Missing detection / guardrail: Doctor had no migration spec for this shape, so \`openclaw doctor\` did not flag or repair it.
- Contributing context: The reporter's JSON looks intuitively \"Telegram-scoped\", but the actual contract keeps \`messages\` globally at the top level and exposes per-channel \`ackReaction\` / \`responsePrefix\` scalars at \`channels.<id>.*\` (not under a \`messages\` sub-object).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: [x] Unit test
- Target test or file: \`src/commands/doctor/shared/legacy-config-migrations.channel-messages.test.ts\`
- Scenario the test should lock in: Config with misplaced \`channels.<id>.messages.*\` (channel-level) and \`channels.<id>.accounts.<aid>.messages.*\` (account-level) is migrated to canonical locations; destination-already-set paths are honored; unknown third-party keys are preserved; non-record top-level \`messages\` is never clobbered.
- Why this is the smallest reliable guardrail: Drives the migration through the production aggregator (\`LEGACY_CONFIG_MIGRATIONS\`) with raw \`unknown\` input and asserts the exact post-migration shape plus \`changes\` strings. No mocks, no helper defaults.
- Existing test that already covers this (if any): None.

## User-visible / Behavior Changes

- \`openclaw doctor\` now warns when \`channels.<id>.messages.*\` or \`channels.<id>.accounts.<aid>.messages.*\` is present.
- \`openclaw doctor --fix\` (and \`--repair\`) now repairs those configs in place and rewrites \`~/.openclaw/openclaw.json\`:
  - Channel-scoped keys move to \`channels.<id>.<key>\` / \`channels.<id>.accounts.<aid>.<key>\` (\`ackReaction\`, \`responsePrefix\`).
  - Global-only keys move to \`messages.<key>\` (\`ackReactionScope\`, \`removeAckAfterReply\`, \`statusReactions\`, \`suppressToolErrors\`, \`messagePrefix\`, \`groupChat\`, \`queue\`, \`inbound\`, \`tts\`).
- Runtime behavior of Telegram/other channel reactions is unchanged for correctly-configured users; the fix only makes a previously silent misconfiguration self-healing.

## Diagram (if applicable)

\`\`\`text
Before (silently ignored by runtime):
channels.telegram.messages.statusReactions.enabled: true
channels.telegram.messages.ackReactionScope: \"all\"
channels.telegram.messages.ackReaction: \"👀\"

After (doctor --fix):
channels.telegram.ackReaction: \"👀\"           # channel-scoped scalar
messages.ackReactionScope: \"all\"              # global (runtime-read path)
messages.statusReactions: { enabled: true }    # global (runtime-read path)
\`\`\`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Notes: The underlying reaction gating is enforced at runtime by \`shouldAckReactionGate\` / \`resolveAckReaction\` / \`createStatusReactionController\` (not by prompt text), and those functions are unchanged. Doctor only relocates config bytes to the canonical locations those functions already read. The migration never clobbers data it does not own: unknown nested keys are preserved, non-record top-level \`messages\` is refused, and existing destination values are honored (the misplaced source is removed with a note rather than overwriting a user-set value).

## Repro + Verification

### Environment

- OS: macOS 26.3 (darwin)
- Runtime/container: Node 22, local \`pnpm\`
- Model/provider: N/A (config migration, no provider calls)
- Integration/channel (if any): Telegram (issue source), but migration covers all channels.
- Relevant config (redacted): see \"Diagram\" above.

### Steps

1. Place reaction keys under \`channels.telegram.messages.*\` (the shape from #67859).
2. Run \`openclaw doctor --fix\`.
3. Re-open \`~/.openclaw/openclaw.json\`.

### Expected

- \`channels.telegram.messages\` is gone.
- \`channels.telegram.ackReaction\` carries the prior \`ackReaction\`.
- \`messages.ackReactionScope\`, \`messages.removeAckAfterReply\`, \`messages.statusReactions\` carry the prior global-only values.
- Reactions and status reactions now fire per the documented contract.

### Actual

- Matches expected via the new unit suite (see \"Evidence\").

## Evidence

- [x] Failing test/log before + passing after: \`pnpm test src/commands/doctor/shared/legacy-config-migrations.channel-messages.test.ts\` → 7 tests pass (new file).
- [x] Adjacent regression coverage still green: \`pnpm test src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor-legacy-config.migrations.test.ts\` → 57 tests pass, \`pnpm test src/commands/doctor-config-flow.test.ts\` → 40 tests pass.
- [x] Full directory: \`pnpm test src/commands/doctor/shared\` → 45 tests pass (commands lane).
- [x] Drift checks: \`pnpm config:docs:check\` OK, \`pnpm plugin-sdk:api:check\` OK (no config schema or SDK surface change).
- [x] \`pnpm check\` (lint + tsgo + import-cycles + madge) → green.

## Human Verification (required)

- Verified scenarios: Channel-level misplaced block (reporter's shape); account-level misplaced block; destination-already-set (honored, not clobbered); unknown third-party keys under the misplaced block (preserved); non-record top-level \`messages\` (refused, channel-scoped keys still repaired); \`channels.defaults\` / \`channels.modelByChannel\` (skipped — they are not channel entries).
- Edge cases checked: Empty \`messages\` after migration is dropped; partial moves leave the container in place when unknown keys remain.
- What you did not verify: Live gateway roundtrip against the Telegram bot on the reporter's account (not possible from the PR branch without their token). The runtime paths that consume the migrated config (\`cfg.messages?.ackReactionScope\`, \`cfg.messages?.statusReactions\`, \`resolveAckReaction\` channel / global fallback) are already covered by existing extension tests (e.g. \`extensions/telegram/src/bot.create-telegram-bot.test.ts\` — \"reacts to mention-gated group messages when ackReaction is enabled\" passes at HEAD when the config lives at top-level \`messages.*\`).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes (non-breaking; existing correct configs untouched).
- Config/env changes? No schema change; doctor adds a new repair path.
- Migration needed? No manual step; \`openclaw doctor --fix\` handles affected configs.

## Risks and Mitigations

- Risk: A global-only key (for example \`statusReactions\`) placed under a specific channel now lifts to top-level \`messages\`, which applies globally to all channels. That matches the documented contract, but a user who intended it to be channel-scoped may be surprised.
  - Mitigation: The misplaced location was never wired to runtime, so prior behavior was \"no effect\" everywhere — lifting to top-level is strictly closer to the user's apparent intent and the only place the runtime reads from. Doctor emits an explicit change line for every move (\"Moved channels.X.messages.Y → messages.Y.\"), and existing destination values are honored rather than overwritten.
- Risk: Third-party plugin config nesting a \`messages\` block under a channel could look like misplacement.
  - Mitigation: The migration only touches keys in the known \`MessagesConfig\` set; unknown keys are preserved in place, and the \`messages\` container is only deleted when it is empty after migration.

---

Tested: fully tested (new unit suite + adjacent regression suites + full \`pnpm check\`). AI-assisted.

Made with [Cursor](https://cursor.com)