### PR TITLE
fix(plugins): explain missing bundled runtime deps [AI-assisted]

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3731,6 +3731,102 @@ module.exports = {
     expect(diagnostic!.message).toContain("failed to load setup entry");
   });
 
+  it("adds actionable guidance when a bundled plugin load fails due to a missing runtime dependency", () => {
+    const missingDep = "definitely-missing-pkg-openclaw";
+    const { bundledDir } = writeBundledPlugin({
+      id: "telegram",
+      filename: "index.cjs",
+      body: `require(${JSON.stringify(missingDep)});
+module.exports = { id: "telegram", register() {} };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: bundledDir,
+      onlyPluginIds: ["telegram"],
+      config: {
+        plugins: {
+          entries: {
+            telegram: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    const diagnostic = registry.diagnostics.find(
+      (entry) => entry.pluginId === "telegram" && entry.level === "error",
+    );
+    expect(diagnostic).toBeDefined();
+    expect(diagnostic?.message).toContain("failed to load plugin:");
+    expect(diagnostic?.message).toContain(
+      `bundled plugin runtime dependency "${missingDep}" appears to be missing; if this is a packaged install run "openclaw doctor --fix", and if this is a Docker source build rebuild with OPENCLAW_EXTENSIONS including "telegram"`,
+    );
+    expect(diagnostic?.message).toContain(`Cannot find module '${missingDep}'`);
+  });
+
+  it("does not add bundled-runtime guidance for missing relative files inside bundled plugins", () => {
+    const missingFile = "./missing-local-file.cjs";
+    const { bundledDir } = writeBundledPlugin({
+      id: "telegram",
+      filename: "index.cjs",
+      body: `require(${JSON.stringify(missingFile)});
+module.exports = { id: "telegram", register() {} };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: bundledDir,
+      onlyPluginIds: ["telegram"],
+      config: {
+        plugins: {
+          entries: {
+            telegram: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    const diagnostic = registry.diagnostics.find(
+      (entry) => entry.pluginId === "telegram" && entry.level === "error",
+    );
+    expect(diagnostic).toBeDefined();
+    expect(diagnostic?.message).toContain(`Cannot find module '${missingFile}'`);
+    expect(diagnostic?.message).not.toContain(
+      "bundled plugin runtime dependency appears to be missing",
+    );
+  });
+
+  it("does not add bundled-runtime guidance for non-bundled plugin load failures", () => {
+    useNoBundledPlugins();
+    const missingDep = "definitely-missing-pkg-openclaw";
+    const plugin = writePlugin({
+      id: "missing-dep-local",
+      filename: "missing-dep-local.cjs",
+      body: `require(${JSON.stringify(missingDep)});
+module.exports = { id: "missing-dep-local", register() {} };`,
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["missing-dep-local"],
+      },
+    });
+
+    const diagnostic = registry.diagnostics.find(
+      (entry) => entry.pluginId === "missing-dep-local" && entry.level === "error",
+    );
+    expect(diagnostic).toBeDefined();
+    expect(diagnostic?.message).toContain(`Cannot find module '${missingDep}'`);
+    expect(diagnostic?.message).not.toContain(
+      "bundled plugin runtime dependency appears to be missing",
+    );
+  });
+
   it("keeps healthy sibling channel plugins loadable when a setup entry throws", () => {
     useNoBundledPlugins();
     const brokenDir = makeTempDir();

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -933,11 +933,34 @@ function recordPluginError(params: {
     typeof params.error.stack === "string"
       ? params.error.stack
       : String(params.error);
+  const missingModuleSpecifier = (() => {
+    const moduleMatch = errorText.match(/Cannot find module '([^']+)'/);
+    if (moduleMatch?.[1]) {
+      return moduleMatch[1];
+    }
+    const packageMatch = errorText.match(/Cannot find package '([^']+)'/);
+    return packageMatch?.[1] ?? null;
+  })();
+  const missingBarePackageSpecifier =
+    missingModuleSpecifier &&
+    !missingModuleSpecifier.startsWith(".") &&
+    !missingModuleSpecifier.startsWith("/") &&
+    !missingModuleSpecifier.startsWith("file:") &&
+    !missingModuleSpecifier.startsWith("node:") &&
+    !/^[A-Za-z]:[\\/]/.test(missingModuleSpecifier) &&
+    !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(missingModuleSpecifier)
+      ? missingModuleSpecifier
+      : null;
+  const missingBundledDependencyHint =
+    params.record.origin === "bundled" && missingBarePackageSpecifier
+      ? `bundled plugin runtime dependency "${missingBarePackageSpecifier}" appears to be missing; if this is a packaged install run "openclaw doctor --fix", and if this is a Docker source build rebuild with OPENCLAW_EXTENSIONS including "${params.record.id}"`
+      : null;
   const deprecatedApiHint =
     errorText.includes("api.registerHttpHandler") && errorText.includes("is not a function")
       ? "deprecated api.registerHttpHandler(...) was removed; use api.registerHttpRoute(...) for plugin-owned routes or registerPluginHttpRoute(...) for dynamic lifecycle routes"
       : null;
-  const displayError = deprecatedApiHint ? `${deprecatedApiHint} (${errorText})` : errorText;
+  const hint = deprecatedApiHint ?? missingBundledDependencyHint;
+  const displayError = hint ? `${hint} (${errorText})` : errorText;
   params.logger.error(`${params.logPrefix}${displayError}`);
   params.record.status = "error";
   params.record.error = displayError;


### PR DESCRIPTION
## Summary

- Problem: bundled plugin load failures caused by missing bare package deps only surfaced raw `Cannot find module` / `Cannot find package` errors.
- Why it matters: operators following the Docker/source setup path in #52328 can still end up with a configured Telegram plugin that fails to load without actionable recovery guidance.
- What changed: `src/plugins/loader.ts` now adds a targeted hint for bundled plugin load errors caused by missing bare package specifiers, pointing packaged installs to `openclaw doctor --fix` and Docker source builds to `OPENCLAW_EXTENSIONS`.
- What did NOT change (scope boundary): no plugin loading logic, dependency installation behavior, discovery rules, or docs flow changed.

AI-assisted: yes (Codex CLI).
Testing: fully tested for the touched surface.
Session log / prompt history: local Codex session used for issue triage, reproduction, patching, and verification.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52328
- Related #57219
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `recordPluginError` in `src/plugins/loader.ts` special-cased one deprecated API migration, but otherwise forwarded plugin load exceptions verbatim. Bundled plugin `MODULE_NOT_FOUND` / `ERR_MODULE_NOT_FOUND` failures therefore surfaced only raw module-resolution text.
- Missing detection / guardrail: there was no bundled-plugin-specific hint for missing runtime package dependencies, even though doctor already has a bundled runtime dependency repair path and Docker builds rely on `OPENCLAW_EXTENSIONS` to preinstall extension deps.
- Contributing context (if known): Docker/source installs can configure Telegram successfully but still miss image-baked runtime deps when `OPENCLAW_EXTENSIONS=telegram` is omitted.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/loader.test.ts`
- Scenario the test should lock in: bundled plugin load failures caused by missing bare package specifiers emit an actionable hint; relative-file misses and non-bundled plugin misses do not.
- Why this is the smallest reliable guardrail: the bug is in loader error formatting, so a focused loader test exercises the exact branch without needing a full Docker build.
- Existing test that already covers this (if any): existing tests covered deprecated `registerHttpHandler` hinting but not missing bundled deps.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Bundled plugin load errors caused by missing bare package deps now explain the two relevant recovery paths:
  - packaged install: run `openclaw doctor --fix`
  - Docker source build: rebuild with `OPENCLAW_EXTENSIONS` including the plugin id
- The original module-not-found error text is still preserved after the hint.

## Diagram (if applicable)

```text
Before:
[bundled plugin load] -> [missing bare package dep] -> [raw Cannot find module error]

After:
[bundled plugin load] -> [missing bare package dep] -> [actionable repair hint + raw error text]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 / Darwin arm64
- Runtime/container: local source checkout, Node 24.14.0 via `nvm`
- Model/provider: N/A
- Integration/channel (if any): synthetic bundled Telegram plugin fixture
- Relevant config (redacted): `plugins.entries.telegram.enabled=true`

### Steps

1. Create a bundled plugin fixture whose entrypoint requires a missing bare package specifier.
2. Load that plugin through `loadOpenClawPlugins`.
3. Inspect the emitted plugin diagnostic.

### Expected

- Diagnostic explains that a bundled runtime dependency is missing and points to the correct repair path.
- Relative bundled file misses and non-bundled plugin misses remain raw module-resolution errors.

### Actual

- Before this patch, the diagnostic only showed raw `Cannot find module ...` text.
- After this patch, bundled bare-package misses include the repair hint and preserve the raw error.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - targeted failing test first on `main` for missing bundled runtime dependency guidance
  - bundled bare-package miss now emits the hint
  - bundled relative-file miss does not emit the hint
  - non-bundled plugin miss does not emit the hint
- Edge cases checked:
  - relative-path `Cannot find module './missing-local-file.cjs'`
  - existing deprecated `registerHttpHandler` guidance still passes
- What you did **not** verify:
  - full Docker image rebuild path end to end
  - packaged `npm -g openclaw` install end to end

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the loader could misclassify missing relative files inside bundled plugins as missing runtime package deps.
  - Mitigation: the hint is limited to missing bare package specifiers only; a dedicated negative test covers relative-file misses.
- Risk: operators might assume the hint changes repair behavior.
  - Mitigation: the raw underlying module-not-found error is preserved, and the patch changes only displayed guidance.
