### PR TITLE
[AI-assisted] fix(models-config): preserve existing models.json baseUrls on regen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
 - OpenAI Codex/Responses: unify native Responses API capability detection so Codex OAuth requests emit the required `store: false` field on the native Responses path. (#67918) Thanks @obviyus.
 - WhatsApp/setup: guard personal-phone and allowlist prompt values so setup fails with clear validation errors instead of crashing on undefined prompt text. (#67895) Thanks @lawrence3699.
+- Models/config: preserve an existing `models.json` provider `baseUrl` during merge-mode regeneration so custom endpoints do not get reset on restart. (#67893) Thanks @lawrence3699.
 
 ## 2026.4.15
 

--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -134,14 +134,13 @@ describe("models-config merge helpers", () => {
         } as ExistingProviderConfig,
       },
       secretRefManagedProviders: new Set<string>(),
-      explicitBaseUrlProviders: new Set<string>(["custom-proxy"]),
     });
 
     expect(merged.existing?.baseUrl).toBe("http://localhost:1234/v1");
     expect(merged["custom-proxy"]?.baseUrl).toBe("http://localhost:4000/v1");
   });
 
-  it("preserves non-empty existing apiKey while explicit baseUrl wins", async () => {
+  it("preserves non-empty existing apiKey and baseUrl from models.json", async () => {
     const merged = mergeWithExistingProviderSecrets({
       nextProviders: {
         custom: createConfigProvider(),
@@ -150,14 +149,13 @@ describe("models-config merge helpers", () => {
         custom: createExistingProvider(),
       },
       secretRefManagedProviders: new Set<string>(),
-      explicitBaseUrlProviders: new Set<string>(["custom"]),
     });
 
     expect(merged.custom?.apiKey).toBe(preservedApiKey);
-    expect(merged.custom?.baseUrl).toBe("https://config.example/v1");
+    expect(merged.custom?.baseUrl).toBe("https://agent.example/v1");
   });
 
-  it("preserves existing apiKey after explicit provider key normalization", async () => {
+  it("preserves existing baseUrl after explicit provider key normalization", async () => {
     const normalized = mergeProviders({
       explicit: {
         " custom ": createConfigProvider(),
@@ -169,11 +167,10 @@ describe("models-config merge helpers", () => {
         custom: createExistingProvider(),
       },
       secretRefManagedProviders: new Set<string>(),
-      explicitBaseUrlProviders: new Set<string>(["custom"]),
     });
 
     expect(merged.custom?.apiKey).toBe(preservedApiKey);
-    expect(merged.custom?.baseUrl).toBe("https://config.example/v1");
+    expect(merged.custom?.baseUrl).toBe("https://agent.example/v1");
   });
 
   it("preserves implicit provider headers when explicit config adds extra headers", async () => {
@@ -228,7 +225,6 @@ describe("models-config merge helpers", () => {
         } as ExistingProviderConfig,
       },
       secretRefManagedProviders: new Set<string>(),
-      explicitBaseUrlProviders: new Set<string>(),
     });
 
     expect(merged.custom).toEqual(
@@ -255,7 +251,6 @@ describe("models-config merge helpers", () => {
         custom: existingProvider,
       },
       secretRefManagedProviders: new Set<string>(),
-      explicitBaseUrlProviders: new Set<string>(["custom"]),
     });
 
     expect(merged.custom?.apiKey).toBe(preservedApiKey);
@@ -277,7 +272,6 @@ describe("models-config merge helpers", () => {
         } as ExistingProviderConfig,
       },
       secretRefManagedProviders: new Set<string>(),
-      explicitBaseUrlProviders: new Set<string>(),
     });
 
     expect(merged.custom?.apiKey).toBe("GOOGLE_API_KEY"); // pragma: allowlist secret
@@ -294,11 +288,10 @@ describe("models-config merge helpers", () => {
         }),
       },
       secretRefManagedProviders: new Set<string>(),
-      explicitBaseUrlProviders: new Set<string>(["custom"]),
     });
 
     expect(merged.custom?.apiKey).toBe("ALLCAPS_SAMPLE"); // pragma: allowlist secret
-    expect(merged.custom?.baseUrl).toBe("https://config.example/v1");
+    expect(merged.custom?.baseUrl).toBe("https://agent.example/v1");
   });
 
   it("uses config apiKey/baseUrl when existing values are empty", async () => {
@@ -313,7 +306,6 @@ describe("models-config merge helpers", () => {
         }),
       },
       secretRefManagedProviders: new Set<string>(),
-      explicitBaseUrlProviders: new Set<string>(["custom"]),
     });
 
     expect(merged.custom?.apiKey).toBe(configApiKey);

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -196,17 +196,11 @@ function shouldPreserveExistingApiKey(params: {
 }
 
 function shouldPreserveExistingBaseUrl(params: {
-  providerKey: string;
   existing: ExistingProviderConfig;
   nextEntry: ProviderConfig;
-  explicitBaseUrlProviders: ReadonlySet<string>;
 }): boolean {
-  const { providerKey, existing, nextEntry, explicitBaseUrlProviders } = params;
-  if (
-    explicitBaseUrlProviders.has(providerKey) ||
-    typeof existing.baseUrl !== "string" ||
-    existing.baseUrl.length === 0
-  ) {
+  const { existing, nextEntry } = params;
+  if (typeof existing.baseUrl !== "string" || existing.baseUrl.length === 0) {
     return false;
   }
 
@@ -219,10 +213,8 @@ export function mergeWithExistingProviderSecrets(params: {
   nextProviders: Record<string, ProviderConfig>;
   existingProviders: Record<string, ExistingProviderConfig>;
   secretRefManagedProviders: ReadonlySet<string>;
-  explicitBaseUrlProviders: ReadonlySet<string>;
 }): Record<string, ProviderConfig> {
-  const { nextProviders, existingProviders, secretRefManagedProviders, explicitBaseUrlProviders } =
-    params;
+  const { nextProviders, existingProviders, secretRefManagedProviders } = params;
   const mergedProviders: Record<string, ProviderConfig> = {};
   for (const [key, entry] of Object.entries(existingProviders)) {
     mergedProviders[key] = entry;
@@ -246,10 +238,8 @@ export function mergeWithExistingProviderSecrets(params: {
     }
     if (
       shouldPreserveExistingBaseUrl({
-        providerKey: key,
         existing,
         nextEntry: newEntry,
-        explicitBaseUrlProviders,
       })
     ) {
       preserved.baseUrl = existing.baseUrl;

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -58,26 +58,11 @@ export async function resolveProvidersForModelsJsonWithDeps(
   });
 }
 
-function resolveExplicitBaseUrlProviders(
-  providers: OpenClawConfig["models"] | undefined,
-): ReadonlySet<string> {
-  return new Set(
-    Object.entries(providers?.providers ?? {})
-      .map(([key, provider]) => [key.trim(), provider] as const)
-      .filter(
-        ([key, provider]) =>
-          Boolean(key) && typeof provider?.baseUrl === "string" && provider.baseUrl.trim(),
-      )
-      .map(([key]) => key),
-  );
-}
-
 function resolveProvidersForMode(params: {
   mode: NonNullable<ModelsConfig["mode"]>;
   existingParsed: unknown;
   providers: Record<string, ProviderConfig>;
   secretRefManagedProviders: ReadonlySet<string>;
-  explicitBaseUrlProviders: ReadonlySet<string>;
 }): Record<string, ProviderConfig> {
   if (params.mode !== "merge") {
     return params.providers;
@@ -94,7 +79,6 @@ function resolveProvidersForMode(params: {
     nextProviders: params.providers,
     existingProviders: existingProviders as Record<string, ExistingProviderConfig>,
     secretRefManagedProviders: params.secretRefManagedProviders,
-    explicitBaseUrlProviders: params.explicitBaseUrlProviders,
   });
 }
 
@@ -135,7 +119,6 @@ export async function planOpenClawModelsJsonWithDeps(
     existingParsed: params.existingParsed,
     providers: normalizedProviders,
     secretRefManagedProviders,
-    explicitBaseUrlProviders: resolveExplicitBaseUrlProviders(cfg.models),
   });
   const secretEnforcedProviders =
     enforceSourceManagedProviderSecrets({

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -279,6 +279,9 @@ describe("models-config runtime source snapshot", () => {
               openai: {
                 ...runtimeConfig.models!.providers!.openai,
                 baseUrl: "https://api.openai.com/v1",
+                headers: {
+                  "X-OpenClaw-Test": "one",
+                },
               },
             },
           },
@@ -290,6 +293,9 @@ describe("models-config runtime source snapshot", () => {
               openai: {
                 ...runtimeConfig.models!.providers!.openai,
                 baseUrl: "https://mirror.example/v1",
+                headers: {
+                  "X-OpenClaw-Test": "two",
+                },
               },
             },
           },
@@ -299,17 +305,25 @@ describe("models-config runtime source snapshot", () => {
           setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
           await ensureOpenClawModelsJson(firstCandidate);
           let parsed = await readGeneratedModelsJson<{
-            providers: Record<string, { baseUrl?: string; apiKey?: string }>;
+            providers: Record<
+              string,
+              { baseUrl?: string; apiKey?: string; headers?: Record<string, string> }
+            >;
           }>();
           expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
           expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+          expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("one");
 
           await ensureOpenClawModelsJson(secondCandidate);
           parsed = await readGeneratedModelsJson<{
-            providers: Record<string, { baseUrl?: string; apiKey?: string }>;
+            providers: Record<
+              string,
+              { baseUrl?: string; apiKey?: string; headers?: Record<string, string> }
+            >;
           }>();
-          expect(parsed.providers.openai?.baseUrl).toBe("https://mirror.example/v1");
+          expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
           expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+          expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("two");
         } finally {
           clearRuntimeConfigSnapshot();
           clearConfigCache();

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -314,6 +314,7 @@ describe("models-config runtime source snapshot", () => {
           expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
           expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("one");
 
+          // Header changes still rewrite models.json, but merge mode preserves the existing baseUrl.
           await ensureOpenClawModelsJson(secondCandidate);
           parsed = await readGeneratedModelsJson<{
             providers: Record<

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -125,6 +125,11 @@ describe("models-config", () => {
   });
 
   it("keeps a non-empty existing models.json baseUrl when merge mode regenerates the provider", async () => {
+    const kilocodeProvider = {
+      baseUrl: "https://api.kilo.ai/api/gateway/v1",
+      api: "openai-completions" as const,
+      models: [],
+    };
     const existingContents = `${JSON.stringify(
       {
         providers: {
@@ -144,29 +149,21 @@ describe("models-config", () => {
         cfg: {
           models: {
             providers: {
-              kilocode: {
-                baseUrl: "https://api.kilo.ai/api/gateway/v1",
-                api: "openai-completions",
-                models: [],
-              },
+              kilocode: kilocodeProvider,
             },
           },
         },
         sourceConfigForSecrets: {
           models: {
             providers: {
-              kilocode: {
-                baseUrl: "https://api.kilo.ai/api/gateway/v1",
-                api: "openai-completions",
-                models: [],
-              },
+              kilocode: kilocodeProvider,
             },
           },
         },
         agentDir: "/tmp/openclaw-agent",
         env: {} as NodeJS.ProcessEnv,
         existingRaw: existingContents,
-        existingParsed: JSON.parse(existingContents) as unknown,
+        existingParsed: JSON.parse(existingContents),
       },
       {
         resolveImplicitProviders: async () => ({}),

--- a/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
+++ b/src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts
@@ -124,6 +124,58 @@ describe("models-config", () => {
     });
   });
 
+  it("keeps a non-empty existing models.json baseUrl when merge mode regenerates the provider", async () => {
+    const existingContents = `${JSON.stringify(
+      {
+        providers: {
+          kilocode: {
+            baseUrl: "https://api.kilo.ai/api/gateway",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`;
+
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {
+              kilocode: {
+                baseUrl: "https://api.kilo.ai/api/gateway/v1",
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+        },
+        sourceConfigForSecrets: {
+          models: {
+            providers: {
+              kilocode: {
+                baseUrl: "https://api.kilo.ai/api/gateway/v1",
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-agent",
+        env: {} as NodeJS.ProcessEnv,
+        existingRaw: existingContents,
+        existingParsed: JSON.parse(existingContents) as unknown,
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan).toEqual({ action: "noop" });
+  });
+
   it("uses tokenRef env var when github-copilot profile omits plaintext token", () => {
     const auth = createProviderAuthResolver(
       {


### PR DESCRIPTION
## Summary

- Problem: restarting the gateway rewrites a non-empty agent `models.json` `baseUrl` back to the config/provider value, so custom endpoints like `https://api.kilo.ai/api/gateway` get forced back to `/v1`.
- Why it matters: merge mode is documented to preserve an existing agent `models.json` `baseUrl`, and users editing custom provider endpoints lose those changes on restart.
- What changed: removed the merge special-case that let explicit config `baseUrl` values override non-empty agent `models.json` `baseUrl` values; added regression tests at the merge, plan, and runtime-snapshot layers.
- What did NOT change (scope boundary): `models.mode: "replace"` behavior is unchanged, and stale `baseUrl` values still refresh when the provider API surface changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67875
- Related #67875
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the recent `models.json` merge refactor added an `explicitBaseUrlProviders` override in `src/agents/models-config.merge.ts`, which forced config `models.providers.*.baseUrl` to win even in merge mode.
- Missing detection / guardrail: merge tests encoded the wrong precedence, and there was no plan-level regression test covering a restart rewrite from an existing `models.json` file.
- Contributing context (if known): the documented merge semantics in `docs/concepts/models.md` and `docs/gateway/configuration-reference.md` already say that a non-empty agent `models.json` `baseUrl` should win.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/models-config.uses-first-github-copilot-profile-env-tokens.test.ts`
  - `src/agents/models-config.merge.test.ts`
  - `src/agents/models-config.runtime-source-snapshot.test.ts`
- Scenario the test should lock in: when merge mode regenerates `models.json`, an existing non-empty agent `baseUrl` survives restart/regeneration unless the provider API surface changed.
- Why this is the smallest reliable guardrail: the bug is in the merge/planning path, so these tests exercise the exact persistence behavior without requiring a full gateway boot.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- In merge mode, custom provider `baseUrl` values already present in `~/.openclaw/agents/<agentId>/agent/models.json` now survive gateway regeneration/restart again.

## Diagram (if applicable)

```text
Before:
[user edits models.json baseUrl] -> [gateway restart] -> [config baseUrl overwrites existing value]

After:
[user edits models.json baseUrl] -> [gateway restart] -> [existing models.json baseUrl preserved] -> [custom endpoint remains usable]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.x
- Runtime/container: Node 24.14.0 via `nvm`
- Model/provider: custom OpenAI-compatible provider config (`kilocode` repro)
- Integration/channel (if any): none
- Relevant config (redacted): `models.mode: "merge"`, `models.providers.kilocode.baseUrl: "https://api.kilo.ai/api/gateway/v1"`

### Steps

1. Start with merge mode and a configured custom provider whose config `baseUrl` ends in `/v1`.
2. Write an existing agent `models.json` entry for the same provider with a non-empty `baseUrl` that omits `/v1`.
3. Regenerate `models.json` via the normal planning path (or restart the gateway).

### Expected

- The existing agent `models.json` `baseUrl` stays unchanged in merge mode.

### Actual

- Before this fix, regeneration rewrote the agent `baseUrl` back to the config value with `/v1`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the rewrite locally with `mergeWithExistingProviderSecrets` and `planOpenClawModelsJsonWithDeps`, then verified the updated tests and commit hook preserve the existing `baseUrl` while still refreshing other fields.
- Edge cases checked: stale `baseUrl` values still refresh when the provider API surface changes; runtime-source-snapshot regeneration still updates refreshable headers under the same snapshot.
- What you did **not** verify: I did not run an actual Android/Termux gateway restart or Kilo Code end-to-end integration.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: users who relied on merge mode to force config `baseUrl` updates into an existing agent `models.json` will now keep the existing value instead.
  - Mitigation: this restores the documented merge precedence; `models.mode: "replace"` and API-surface mismatch handling still provide the explicit overwrite paths.

## AI Assistance

- AI-assisted: Codex
- Testing note: fully tested for the touched surface (`build`, targeted `test`, full pre-commit `check`)
- Prompt/session summary: fix the regression where merge mode rewrites a non-empty agent `models.json` `baseUrl` back to the config value on restart, with concrete repro, minimal scope, and regression coverage.
