### PR TITLE
fix(doctor): stop optional bundled runtime deps from triggering broken repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - Cron/delivery: clean up isolated sessions after direct deliveries when `deleteAfterRun` is enabled, covering structured and threaded branches that previously bypassed cleanup. (#67807) Thanks @MonkeyLeeT.
 - Gateway/hello-ok: always report negotiated auth metadata and preserve scopes for reused device tokens on successful shared-auth handshakes, including control-ui bypass coverage when no device token is issued. (#67810, #68039) Thanks @BunsDev.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
+- Doctor/bundled plugin runtime deps: stop `openclaw doctor` and `openclaw doctor --fix` from treating optional bundled runtime deps as required repair targets, so optional Discord `@discordjs/opus` no longer triggers a broken ARM64 repair path while required deps like `opusscript` are still detected and repairable. (#64070, #66476)
 - OpenAI Codex/Responses: unify native Responses API capability detection so Codex OAuth requests emit the required `store: false` field on the native Responses path. (#67918) Thanks @obviyus.
 - WhatsApp/setup: guard personal-phone and allowlist prompt values so setup fails with clear validation errors instead of crashing on undefined prompt text. (#67895) Thanks @lawrence3699.
 - Models/config: preserve an existing `models.json` provider `baseUrl` during merge-mode regeneration so custom endpoints do not get reset on restart. (#67893) Thanks @lawrence3699.
@@ -205,7 +206,6 @@ Docs: https://docs.openclaw.ai
 - OpenRouter/streaming: treat `reasoning_details.response.output_text` and `reasoning_details.response.text` as visible assistant output on OpenRouter-compatible completions streams, while keeping `reasoning.text` hidden and refusing to surface ambiguous bare `text` items by default so visible replies, thinking blocks, and tool calls can coexist in the same chunk. (#67410) Thanks @neeravmakwana.
 - Models/OpenRouter aliases: resolve `openrouter:auto` to the canonical `openrouter/auto` model and map `openrouter:free` to the first configured concrete `openrouter/...:free` model instead of mis-resolving these compatibility aliases under the default provider. (#57066) Thanks @sumiisiaran.
 - OpenRouter/Arcee: canonicalize stale OpenRouter `https://openrouter.ai/v1` base URLs during provider config normalization and runtime model/transport resolution, so fresh `models.json` writes and previously discovered rows self-heal back to `https://openrouter.ai/api/v1` instead of breaking OpenRouter-routed requests. (#67295) Thanks @achalkov.
-- Doctor/bundled plugin runtime deps: honor root `pnpm.ignoredBuiltDependencies` when classifying missing mirrored plugin runtime deps, so optional native packages like Discord `@discordjs/opus` no longer trigger a broken `openclaw doctor --fix` repair path when JS fallbacks are available.
 
 ## 2026.4.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,7 @@ Docs: https://docs.openclaw.ai
 - OpenRouter/streaming: treat `reasoning_details.response.output_text` and `reasoning_details.response.text` as visible assistant output on OpenRouter-compatible completions streams, while keeping `reasoning.text` hidden and refusing to surface ambiguous bare `text` items by default so visible replies, thinking blocks, and tool calls can coexist in the same chunk. (#67410) Thanks @neeravmakwana.
 - Models/OpenRouter aliases: resolve `openrouter:auto` to the canonical `openrouter/auto` model and map `openrouter:free` to the first configured concrete `openrouter/...:free` model instead of mis-resolving these compatibility aliases under the default provider. (#57066) Thanks @sumiisiaran.
 - OpenRouter/Arcee: canonicalize stale OpenRouter `https://openrouter.ai/v1` base URLs during provider config normalization and runtime model/transport resolution, so fresh `models.json` writes and previously discovered rows self-heal back to `https://openrouter.ai/api/v1` instead of breaking OpenRouter-routed requests. (#67295) Thanks @achalkov.
+- Doctor/bundled plugin runtime deps: honor root `pnpm.ignoredBuiltDependencies` when classifying missing mirrored plugin runtime deps, so optional native packages like Discord `@discordjs/opus` no longer trigger a broken `openclaw doctor --fix` repair path when JS fallbacks are available.
 
 ## 2026.4.14
 

--- a/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
+++ b/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
@@ -36,6 +36,7 @@ function createPrompter(overrides: Partial<DoctorPrompter> = {}): DoctorPrompter
       nonInteractive: false,
       shouldForce: false,
       shouldRepair: false,
+      updateInProgress: false,
     },
     ...overrides,
   } as unknown as DoctorPrompter;
@@ -91,20 +92,15 @@ describe("doctor bundled plugin runtime deps", () => {
     const result = scanBundledPluginRuntimeDeps({ packageRoot: root });
     const missing = result.missing.map((dep) => `${dep.name}@${dep.version}`);
 
-    expect(missing).toEqual(["@scope/dep-two@2.0.0", "dep-opt@3.0.0"]);
+    expect(missing).toEqual(["@scope/dep-two@2.0.0"]);
     expect(result.conflicts).toHaveLength(1);
     expect(result.conflicts[0]?.name).toBe("dep-conflict");
     expect(result.conflicts[0]?.versions).toEqual(["1.0.0", "2.0.0"]);
   });
 
-  it("ignores deps listed in pnpm.ignoredBuiltDependencies", () => {
+  it("ignores optional deps when scanning bundled runtime deps", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
-    writeJson(path.join(root, "package.json"), {
-      name: "openclaw",
-      pnpm: {
-        ignoredBuiltDependencies: ["@discordjs/opus"],
-      },
-    });
+    writeJson(path.join(root, "package.json"), { name: "openclaw" });
 
     writeJson(path.join(root, "dist", "extensions", "discord", "package.json"), {
       dependencies: {
@@ -122,39 +118,58 @@ describe("doctor bundled plugin runtime deps", () => {
 
     const result = scanBundledPluginRuntimeDeps({ packageRoot: root });
     expect(result.missing).toEqual([]);
+    expect(result.conflicts).toEqual([]);
   });
 
-  it("still reports required deps when ignored deps are filtered", () => {
+  it("ignores required deps listed in pnpm.ignoredBuiltDependencies", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
     writeJson(path.join(root, "package.json"), {
       name: "openclaw",
       pnpm: {
-        ignoredBuiltDependencies: ["dep-optional-native"],
+        ignoredBuiltDependencies: ["dep-ignored-native"],
       },
     });
 
-    writeJson(path.join(root, "dist", "extensions", "discord", "package.json"), {
+    writeJson(path.join(root, "dist", "extensions", "alpha", "package.json"), {
       dependencies: {
-        opusscript: "0.1.1",
-      },
-      optionalDependencies: {
-        "dep-optional-native": "2.0.0",
+        "dep-ignored-native": "1.0.0",
+        "dep-required": "2.0.0",
       },
     });
 
     const result = scanBundledPluginRuntimeDeps({ packageRoot: root });
     const missing = result.missing.map((dep) => `${dep.name}@${dep.version}`);
-    expect(missing).toEqual(["opusscript@0.1.1"]);
+
+    expect(missing).toEqual(["dep-required@2.0.0"]);
   });
 
-  it("does not install ignored deps during doctor repair", async () => {
+  it("hides ignored built dependency conflicts", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
     writeJson(path.join(root, "package.json"), {
       name: "openclaw",
       pnpm: {
-        ignoredBuiltDependencies: ["@discordjs/opus"],
+        ignoredBuiltDependencies: ["dep-ignored-native"],
       },
     });
+
+    writeJson(path.join(root, "dist", "extensions", "alpha", "package.json"), {
+      dependencies: {
+        "dep-ignored-native": "1.0.0",
+      },
+    });
+    writeJson(path.join(root, "dist", "extensions", "beta", "package.json"), {
+      dependencies: {
+        "dep-ignored-native": "2.0.0",
+      },
+    });
+
+    const result = scanBundledPluginRuntimeDeps({ packageRoot: root });
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("repairs only required deps for the Discord opus fallback case", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
+    writeJson(path.join(root, "package.json"), { name: "openclaw" });
 
     writeJson(path.join(root, "dist", "extensions", "discord", "package.json"), {
       dependencies: {
@@ -167,6 +182,7 @@ describe("doctor bundled plugin runtime deps", () => {
 
     const confirmAutoFix = vi.fn().mockResolvedValue(true);
     const installDeps = vi.fn();
+
     await maybeRepairBundledPluginRuntimeDeps({
       installDeps,
       packageRoot: root,
@@ -185,14 +201,9 @@ describe("doctor bundled plugin runtime deps", () => {
     });
   });
 
-  it("skips doctor repair when only ignored deps are missing", async () => {
+  it("skips repair when only optional deps are absent", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
-    writeJson(path.join(root, "package.json"), {
-      name: "openclaw",
-      pnpm: {
-        ignoredBuiltDependencies: ["@discordjs/opus"],
-      },
-    });
+    writeJson(path.join(root, "package.json"), { name: "openclaw" });
 
     writeJson(path.join(root, "dist", "extensions", "discord", "package.json"), {
       dependencies: {
@@ -210,6 +221,7 @@ describe("doctor bundled plugin runtime deps", () => {
 
     const confirmAutoFix = vi.fn().mockResolvedValue(true);
     const installDeps = vi.fn();
+
     await maybeRepairBundledPluginRuntimeDeps({
       installDeps,
       packageRoot: root,

--- a/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
+++ b/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
@@ -1,12 +1,44 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
-import { scanBundledPluginRuntimeDeps } from "./doctor-bundled-plugin-runtime-deps.js";
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  maybeRepairBundledPluginRuntimeDeps,
+  scanBundledPluginRuntimeDeps,
+} from "./doctor-bundled-plugin-runtime-deps.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
 
 function writeJson(filePath: string, value: unknown) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function createRuntime(): RuntimeEnv {
+  return {
+    error: vi.fn(),
+    exit: vi.fn(),
+    log: vi.fn(),
+  };
+}
+
+function createPrompter(overrides: Partial<DoctorPrompter> = {}): DoctorPrompter {
+  return {
+    confirm: vi.fn(),
+    confirmAggressiveAutoFix: vi.fn(),
+    confirmAutoFix: vi.fn().mockResolvedValue(true),
+    confirmRuntimeRepair: vi.fn(),
+    select: vi.fn(async (_params, fallback) => fallback),
+    shouldRepair: false,
+    shouldForce: false,
+    repairMode: {
+      canPrompt: true,
+      nonInteractive: false,
+      shouldForce: false,
+      shouldRepair: false,
+    },
+    ...overrides,
+  } as unknown as DoctorPrompter;
 }
 
 describe("doctor bundled plugin runtime deps", () => {
@@ -63,5 +95,131 @@ describe("doctor bundled plugin runtime deps", () => {
     expect(result.conflicts).toHaveLength(1);
     expect(result.conflicts[0]?.name).toBe("dep-conflict");
     expect(result.conflicts[0]?.versions).toEqual(["1.0.0", "2.0.0"]);
+  });
+
+  it("ignores deps listed in pnpm.ignoredBuiltDependencies", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
+    writeJson(path.join(root, "package.json"), {
+      name: "openclaw",
+      pnpm: {
+        ignoredBuiltDependencies: ["@discordjs/opus"],
+      },
+    });
+
+    writeJson(path.join(root, "dist", "extensions", "discord", "package.json"), {
+      dependencies: {
+        opusscript: "0.1.1",
+      },
+      optionalDependencies: {
+        "@discordjs/opus": "^0.10.0",
+      },
+    });
+
+    writeJson(path.join(root, "node_modules", "opusscript", "package.json"), {
+      name: "opusscript",
+      version: "0.1.1",
+    });
+
+    const result = scanBundledPluginRuntimeDeps({ packageRoot: root });
+    expect(result.missing).toEqual([]);
+  });
+
+  it("still reports required deps when ignored deps are filtered", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
+    writeJson(path.join(root, "package.json"), {
+      name: "openclaw",
+      pnpm: {
+        ignoredBuiltDependencies: ["dep-optional-native"],
+      },
+    });
+
+    writeJson(path.join(root, "dist", "extensions", "discord", "package.json"), {
+      dependencies: {
+        opusscript: "0.1.1",
+      },
+      optionalDependencies: {
+        "dep-optional-native": "2.0.0",
+      },
+    });
+
+    const result = scanBundledPluginRuntimeDeps({ packageRoot: root });
+    const missing = result.missing.map((dep) => `${dep.name}@${dep.version}`);
+    expect(missing).toEqual(["opusscript@0.1.1"]);
+  });
+
+  it("does not install ignored deps during doctor repair", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
+    writeJson(path.join(root, "package.json"), {
+      name: "openclaw",
+      pnpm: {
+        ignoredBuiltDependencies: ["@discordjs/opus"],
+      },
+    });
+
+    writeJson(path.join(root, "dist", "extensions", "discord", "package.json"), {
+      dependencies: {
+        opusscript: "0.1.1",
+      },
+      optionalDependencies: {
+        "@discordjs/opus": "^0.10.0",
+      },
+    });
+
+    const confirmAutoFix = vi.fn().mockResolvedValue(true);
+    const installDeps = vi.fn();
+    await maybeRepairBundledPluginRuntimeDeps({
+      installDeps,
+      packageRoot: root,
+      prompter: createPrompter({
+        confirmAutoFix,
+        shouldRepair: true,
+      }),
+      runtime: createRuntime(),
+    });
+
+    expect(confirmAutoFix).not.toHaveBeenCalled();
+    expect(installDeps).toHaveBeenCalledTimes(1);
+    expect(installDeps).toHaveBeenCalledWith({
+      packageRoot: root,
+      missingSpecs: ["opusscript@0.1.1"],
+    });
+  });
+
+  it("skips doctor repair when only ignored deps are missing", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
+    writeJson(path.join(root, "package.json"), {
+      name: "openclaw",
+      pnpm: {
+        ignoredBuiltDependencies: ["@discordjs/opus"],
+      },
+    });
+
+    writeJson(path.join(root, "dist", "extensions", "discord", "package.json"), {
+      dependencies: {
+        opusscript: "0.1.1",
+      },
+      optionalDependencies: {
+        "@discordjs/opus": "^0.10.0",
+      },
+    });
+
+    writeJson(path.join(root, "node_modules", "opusscript", "package.json"), {
+      name: "opusscript",
+      version: "0.1.1",
+    });
+
+    const confirmAutoFix = vi.fn().mockResolvedValue(true);
+    const installDeps = vi.fn();
+    await maybeRepairBundledPluginRuntimeDeps({
+      installDeps,
+      packageRoot: root,
+      prompter: createPrompter({
+        confirmAutoFix,
+      }),
+      runtime: createRuntime(),
+    });
+
+    expect(confirmAutoFix).not.toHaveBeenCalled();
+    expect(installDeps).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/doctor-bundled-plugin-runtime-deps.ts
+++ b/src/commands/doctor-bundled-plugin-runtime-deps.ts
@@ -31,10 +31,9 @@ function dependencySentinelPath(depName: string): string {
   return path.join("node_modules", ...depName.split("/"), "package.json");
 }
 
-function collectRuntimeDeps(packageJson: Record<string, unknown>): Record<string, unknown> {
+function collectRequiredRuntimeDeps(packageJson: Record<string, unknown>): Record<string, unknown> {
   return {
     ...(packageJson.dependencies as Record<string, unknown> | undefined),
-    ...(packageJson.optionalDependencies as Record<string, unknown> | undefined),
   };
 }
 
@@ -84,7 +83,7 @@ function collectBundledPluginRuntimeDeps(params: { extensionsDir: string }): {
         string,
         unknown
       >;
-      for (const [name, rawVersion] of Object.entries(collectRuntimeDeps(packageJson))) {
+      for (const [name, rawVersion] of Object.entries(collectRequiredRuntimeDeps(packageJson))) {
         if (typeof rawVersion !== "string" || rawVersion.trim() === "") {
           continue;
         }
@@ -155,10 +154,10 @@ export function scanBundledPluginRuntimeDeps(params: { packageRoot: string }): {
       !ignoredBuiltDependencies.has(dep.name) &&
       !fs.existsSync(path.join(params.packageRoot, dependencySentinelPath(dep.name))),
   );
-  const visibleConflicts = conflicts.filter(
-    (conflict) => !ignoredBuiltDependencies.has(conflict.name),
-  );
-  return { missing, conflicts: visibleConflicts };
+  return {
+    missing,
+    conflicts: conflicts.filter((conflict) => !ignoredBuiltDependencies.has(conflict.name)),
+  };
 }
 
 function createNestedNpmInstallEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/src/commands/doctor-bundled-plugin-runtime-deps.ts
+++ b/src/commands/doctor-bundled-plugin-runtime-deps.ts
@@ -38,6 +38,32 @@ function collectRuntimeDeps(packageJson: Record<string, unknown>): Record<string
   };
 }
 
+function collectIgnoredBuiltDependencies(params: { packageRoot: string }): Set<string> {
+  const packageJsonPath = path.join(params.packageRoot, "package.json");
+  if (!fs.existsSync(packageJsonPath)) {
+    return new Set<string>();
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+      pnpm?: {
+        ignoredBuiltDependencies?: unknown;
+      };
+    };
+    const ignoredBuiltDependencies = packageJson.pnpm?.ignoredBuiltDependencies;
+    if (!Array.isArray(ignoredBuiltDependencies)) {
+      return new Set<string>();
+    }
+    return new Set(
+      ignoredBuiltDependencies
+        .map((name) => (typeof name === "string" ? name.trim() : ""))
+        .filter((name) => name.length > 0),
+    );
+  } catch {
+    return new Set<string>();
+  }
+}
+
 function collectBundledPluginRuntimeDeps(params: { extensionsDir: string }): {
   deps: RuntimeDepEntry[];
   conflicts: RuntimeDepConflict[];
@@ -120,11 +146,19 @@ export function scanBundledPluginRuntimeDeps(params: { packageRoot: string }): {
   if (!fs.existsSync(extensionsDir)) {
     return { missing: [], conflicts: [] };
   }
+  const ignoredBuiltDependencies = collectIgnoredBuiltDependencies({
+    packageRoot: params.packageRoot,
+  });
   const { deps, conflicts } = collectBundledPluginRuntimeDeps({ extensionsDir });
   const missing = deps.filter(
-    (dep) => !fs.existsSync(path.join(params.packageRoot, dependencySentinelPath(dep.name))),
+    (dep) =>
+      !ignoredBuiltDependencies.has(dep.name) &&
+      !fs.existsSync(path.join(params.packageRoot, dependencySentinelPath(dep.name))),
   );
-  return { missing, conflicts };
+  const visibleConflicts = conflicts.filter(
+    (conflict) => !ignoredBuiltDependencies.has(conflict.name),
+  );
+  return { missing, conflicts: visibleConflicts };
 }
 
 function createNestedNpmInstallEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` treated bundled plugin `optionalDependencies` as required runtime mirrors and reported them as missing.
- Why it matters: on ARM64 Linux, Discord optional native opus (`@discordjs/opus`) often cannot build, so doctor suggested a broken `doctor --fix` recovery path.
- What changed: bundled runtime-dep scanning now ignores optional plugin deps for missing/repair detection and still honors root `pnpm.ignoredBuiltDependencies` filtering.
- What did NOT change (scope boundary): required dependency scanning and repair behavior remain intact for true required deps (for example `opusscript`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64070
- Related #66476
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: bundled runtime dependency collection merged `dependencies` + `optionalDependencies`, so optional native packages were treated as required missing mirrors.
- Missing detection / guardrail: doctor had no optional-vs-required boundary when building repair targets.
- Contributing context (if known): Discord declares `@discordjs/opus` as optional while supporting JS fallback via `opusscript`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor-bundled-plugin-runtime-deps.test.ts`
- Scenario the test should lock in:
  - optional deps are excluded from missing/repair set
  - required deps are still reported/repairable
  - Discord fallback case only repairs required `opusscript`
- Why this is the smallest reliable guardrail: failure is isolated to local dependency classification logic in doctor scan/repair path.
- Existing test that already covers this (if any): existing file already covered baseline missing/conflict behavior; this PR extends it for optional deps + filtered repair.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw doctor` no longer reports optional native bundled deps (notably Discord `@discordjs/opus`) as missing repair targets.
- `openclaw doctor --fix` no longer attempts to install those optional deps.
- Required deps still surface and repair normally.

## Diagram (if applicable)

```text
Before:
plugin deps (required + optional) -> doctor missing set -> doctor --fix tries native optional install

After:
plugin required deps (+ ignoredBuiltDependencies filter) -> doctor missing set -> doctor --fix repairs only required deps
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (Raspberry Pi, ARM64)
- Runtime/container: global npm install + packaged test install
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord enabled; production service pinned at `2026.4.5`

### Steps

1. Run doctor on packaged install where Discord optional opus native build is unavailable on ARM64.
2. Observe doctor classification and `doctor --fix` behavior.
3. Re-run after patch.

### Expected

- Optional `@discordjs/opus` is not surfaced as a required missing mirror.
- Repair targets only include required deps.

### Actual

- Matches expected in local tests and remote Pi validation.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local command:

- `corepack pnpm test src/commands/doctor-bundled-plugin-runtime-deps.test.ts`

Result:

- `1 passed`, `7 passed`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - remote Pi packaged-install doctor path no longer pushes `@discordjs/opus`
  - repair path still targets required `opusscript`
  - production setup remained untouched (`/usr/local` binary and service env/version unchanged)
- Edge cases checked:
  - optional-only absence does not trigger repair
  - required deps still detected/repairable
- What you did **not** verify:
  - full repo test suite on Pi (ran targeted doctor tests)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: optional dependency classification could hide a dependency that should have been required.
  - Mitigation: repair and missing checks still run on required deps, and tests lock required-vs-optional behavior explicitly.
