### PR TITLE
Agents/image tool: honor tools.media.image.timeoutSeconds (#67889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
+- Agents/image tool: honor `tools.media.image.timeoutSeconds` when the agent invokes the `image` tool (and plumb it through to the MiniMax VLM path), instead of silently capping every call at a hardcoded 30s. Brings the agent-tool path in line with the auto-attachment image-understanding path and lets slower local/self-hosted vision models finish. (#67889) Thanks @neeravmakwana.
 
 ## 2026.4.15
 

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -45,12 +45,21 @@ function pickString(rec: Record<string, unknown>, key: string): string {
   return typeof v === "string" ? v : "";
 }
 
+/**
+ * Default abort timeout applied to the MiniMax VLM HTTP call when the caller
+ * does not supply a timeout. Kept aligned with the media-understanding image
+ * default (see `DEFAULT_TIMEOUT_SECONDS.image`) so callers that forward the
+ * user-configured `tools.media.image.timeoutSeconds` can override this.
+ */
+const MINIMAX_VLM_DEFAULT_TIMEOUT_MS = 60_000;
+
 export async function minimaxUnderstandImage(params: {
   apiKey: string;
   prompt: string;
   imageDataUrl: string;
   apiHost?: string;
   modelBaseUrl?: string;
+  timeoutMs?: number;
 }): Promise<string> {
   const apiKey = normalizeSecretInput(params.apiKey);
   if (!apiKey) {
@@ -78,6 +87,13 @@ export async function minimaxUnderstandImage(params: {
   // Without this, HTTP_PROXY/HTTPS_PROXY env vars are silently ignored (#51619).
   ensureGlobalUndiciEnvProxyDispatcher();
 
+  const timeoutMs =
+    typeof params.timeoutMs === "number" &&
+    Number.isFinite(params.timeoutMs) &&
+    params.timeoutMs > 0
+      ? params.timeoutMs
+      : MINIMAX_VLM_DEFAULT_TIMEOUT_MS;
+
   const res = await fetch(url, {
     method: "POST",
     headers: {
@@ -85,7 +101,7 @@ export async function minimaxUnderstandImage(params: {
       "Content-Type": "application/json",
       "MM-API-Source": "OpenClaw",
     },
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(timeoutMs),
     body: JSON.stringify({
       prompt,
       image_url: imageDataUrl,

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1440,3 +1440,179 @@ describe("image tool response validation", () => {
     expect(text).toBe("hello");
   });
 });
+
+// Regression guard for #67889: the `image` tool previously hardcoded a 30s
+// timeout for describeImage/describeImages, which silently overrode the user's
+// `tools.media.image.timeoutSeconds` configuration and starved local/self-hosted
+// vision models. These tests lock in that the configured capability-level
+// timeout (and the 60s default, aligned with DEFAULT_TIMEOUT_SECONDS.image) is
+// plumbed through to the underlying describe calls.
+describe("image tool timeout configuration (#67889)", () => {
+  const priorFetch = global.fetch;
+  registerImageToolEnvReset(priorFetch, ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]);
+
+  let capturedTimeouts: number[];
+
+  function installCapturingProviderStubs(): void {
+    capturedTimeouts = [];
+    const defaultImageModels = new Map<string, string>([
+      ["anthropic", "claude-opus-4-6"],
+      ["openai", "gpt-5.4-mini"],
+    ]);
+    imageProviderHarness.setProviders([]);
+    __testing.setProviderDepsForTest({
+      buildProviderRegistry: () => new Map(),
+      getMediaUnderstandingProvider: () => undefined,
+      describeImageWithModel: async (params: ImageDescriptionRequest) => {
+        capturedTimeouts.push(params.timeoutMs);
+        return { text: "ok", model: params.model };
+      },
+      describeImagesWithModel: async (params: ImagesDescriptionRequest) => {
+        capturedTimeouts.push(params.timeoutMs);
+        return { text: "ok", model: params.model };
+      },
+      resolveAutoMediaKeyProviders: ({ capability }) =>
+        capability === "image" ? ["openai", "anthropic"] : [],
+      resolveDefaultMediaModel: ({ providerId, capability }) =>
+        capability === "image" ? defaultImageModels.get(providerId.toLowerCase()) : undefined,
+    });
+  }
+
+  beforeEach(() => {
+    installCapturingProviderStubs();
+    vi.stubEnv("OPENAI_API_KEY", "openai-test");
+  });
+
+  afterEach(() => {
+    imageProviderHarness.reset();
+    __testing.setProviderDepsForTest();
+  });
+
+  function createConfigWith(timeoutSeconds?: number): OpenClawConfig {
+    return {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4-mini" },
+          imageModel: { primary: "openai/gpt-5.4-mini" },
+        },
+      },
+      ...(typeof timeoutSeconds === "number"
+        ? {
+            tools: {
+              media: {
+                image: {
+                  timeoutSeconds,
+                },
+              },
+            },
+          }
+        : {}),
+    };
+  }
+
+  it("defaults to DEFAULT_TIMEOUT_SECONDS.image (60s) when no config is set", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const tool = createRequiredImageTool({ config: createConfigWith(), agentDir });
+      await tool.execute("t1", {
+        prompt: "Describe.",
+        image: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      });
+      expect(capturedTimeouts).toEqual([60_000]);
+    });
+  });
+
+  it("honors tools.media.image.timeoutSeconds for single-image requests", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const tool = createRequiredImageTool({ config: createConfigWith(180), agentDir });
+      await tool.execute("t1", {
+        prompt: "Describe.",
+        image: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      });
+      expect(capturedTimeouts).toEqual([180_000]);
+    });
+  });
+
+  it("honors tools.media.image.timeoutSeconds for multi-image requests", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const tool = createRequiredImageTool({ config: createConfigWith(300), agentDir });
+      await tool.execute("t1", {
+        prompt: "Compare.",
+        images: [
+          `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+          `data:image/jpeg;base64,${ONE_PIXEL_JPEG_B64}`,
+        ],
+      });
+      expect(capturedTimeouts).toEqual([300_000]);
+    });
+  });
+
+  it("clamps sub-second timeoutSeconds to the resolveTimeoutMs 1000ms floor", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const tool = createRequiredImageTool({ config: createConfigWith(0.2), agentDir });
+      await tool.execute("t1", {
+        prompt: "Describe.",
+        image: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      });
+      expect(capturedTimeouts).toEqual([1_000]);
+    });
+  });
+});
+
+// Regression guard for #67889: the MiniMax VLM HTTP call previously used a
+// hardcoded `AbortSignal.timeout(60_000)` regardless of caller-supplied
+// timeouts. The helper now accepts and honors an explicit `timeoutMs`.
+describe("minimaxUnderstandImage timeout plumbing (#67889)", () => {
+  const priorFetch = global.fetch;
+  const priorAbortTimeout = AbortSignal.timeout;
+  let capturedTimeouts: number[];
+
+  beforeEach(() => {
+    capturedTimeouts = [];
+    vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
+    AbortSignal.timeout = ((ms: number) => {
+      capturedTimeouts.push(ms);
+      return priorAbortTimeout.call(AbortSignal, ms);
+    }) as typeof AbortSignal.timeout;
+  });
+
+  afterEach(() => {
+    AbortSignal.timeout = priorAbortTimeout;
+    vi.unstubAllEnvs();
+    global.fetch = priorFetch;
+  });
+
+  async function invoke(timeoutMs?: number): Promise<void> {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(),
+      json: async () => ({ content: "ok", base_resp: { status_code: 0, status_msg: "" } }),
+    });
+    global.fetch = withFetchPreconnect(fetch);
+    await minimaxUnderstandImage({
+      apiKey: "minimax-test",
+      prompt: "Describe.",
+      imageDataUrl: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      ...(typeof timeoutMs === "number" ? { timeoutMs } : {}),
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  }
+
+  it("uses the caller-supplied timeoutMs when provided", async () => {
+    await invoke(200_000);
+    expect(capturedTimeouts).toEqual([200_000]);
+  });
+
+  it("falls back to 60s when no timeoutMs is supplied", async () => {
+    await invoke();
+    expect(capturedTimeouts).toEqual([60_000]);
+  });
+
+  it("falls back to 60s when timeoutMs is non-finite or non-positive", async () => {
+    await invoke(0);
+    await invoke(Number.NaN);
+    await invoke(-1_000);
+    expect(capturedTimeouts).toEqual([60_000, 60_000, 60_000]);
+  });
+});

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -2,10 +2,12 @@ import { resolve, isAbsolute } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  DEFAULT_TIMEOUT_SECONDS,
   resolveAutoMediaKeyProviders,
   resolveDefaultMediaModel,
 } from "../../media-understanding/defaults.js";
 import { getMediaUnderstandingProvider } from "../../media-understanding/provider-registry.js";
+import { resolveTimeoutMs } from "../../media-understanding/resolve.js";
 import { buildProviderRegistry } from "../../media-understanding/runner.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import {
@@ -91,6 +93,21 @@ function resolveImageToolMaxTokens(modelMaxTokens: number | undefined, requested
     return requestedMaxTokens;
   }
   return Math.min(requestedMaxTokens, modelMaxTokens);
+}
+
+/**
+ * Resolve the effective per-call timeout (ms) for the `image` tool.
+ *
+ * Order of precedence, matching the auto-attachment image-understanding path
+ * in `media-understanding/runner.entries.ts`:
+ *   1. `cfg.tools.media.image.timeoutSeconds`
+ *   2. `DEFAULT_TIMEOUT_SECONDS.image` (60s)
+ *
+ * Previously hardcoded to 30_000, which silently overrode any user timeout
+ * configuration and starved local/self-hosted vision models (#67889).
+ */
+function resolveImageToolTimeoutMs(cfg: OpenClawConfig | undefined): number {
+  return resolveTimeoutMs(cfg?.tools?.media?.image?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS.image);
 }
 
 /**
@@ -191,6 +208,7 @@ async function runImagePrompt(params: {
   const effectiveCfg = applyImageModelConfigDefaults(params.cfg, params.imageModelConfig);
   const providerCfg: OpenClawConfig = effectiveCfg ?? {};
   const providerRegistry = imageToolProviderDeps.buildProviderRegistry(undefined, providerCfg);
+  const timeoutMs = resolveImageToolTimeoutMs(effectiveCfg);
 
   const result = await runWithImageModelFallback({
     cfg: effectiveCfg,
@@ -216,7 +234,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -234,7 +252,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -251,7 +269,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: `${params.prompt}\n\nDescribe image ${index + 1} of ${params.images.length}.`,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -94,6 +94,7 @@ async function describeImagesWithMinimax(params: {
   modelBaseUrl?: string;
   prompt: string;
   images: Array<{ buffer: Buffer; mime?: string }>;
+  timeoutMs?: number;
 }): Promise<ImagesDescriptionResult> {
   const responses: string[] = [];
   for (const [index, image] of params.images.entries()) {
@@ -106,6 +107,7 @@ async function describeImagesWithMinimax(params: {
       prompt,
       imageDataUrl: `data:${image.mime ?? "image/jpeg"};base64,${image.buffer.toString("base64")}`,
       modelBaseUrl: params.modelBaseUrl,
+      timeoutMs: params.timeoutMs,
     });
     responses.push(params.images.length > 1 ? `Image ${index + 1}:\n${text.trim()}` : text.trim());
   }
@@ -172,6 +174,7 @@ export async function describeImagesWithModel(
       modelBaseUrl: fallback.modelBaseUrl,
       prompt,
       images: params.images,
+      timeoutMs: params.timeoutMs,
     });
   }
 
@@ -182,6 +185,7 @@ export async function describeImagesWithModel(
       modelBaseUrl: model.baseUrl,
       prompt,
       images: params.images,
+      timeoutMs: params.timeoutMs,
     });
   }
 


### PR DESCRIPTION
## Summary

- Problem: the agent-facing \`image\` tool hardcoded a 30s abort timeout for every \`describeImage\`/\`describeImages\` call, silently overriding the documented \`tools.media.image.timeoutSeconds\` config. Self-hosted / local vision models (Ollama, etc.) that need longer than 30s got aborted even when operators explicitly set a larger value. Separately, \`minimaxUnderstandImage\` used a hardcoded \`AbortSignal.timeout(60_000)\` regardless of caller-supplied timeouts, so the MiniMax VLM path could not pick up the operator's configured value either.
- Why it matters: users following the public docs (\"Timeout in seconds for each image understanding request before it is aborted. Increase for high-resolution analysis...\") would see their configured timeout ignored by the \`image\` tool, reproducing #67889.
- What changed:
  - \`src/agents/tools/image-tool.ts\`: resolve the effective timeout from \`cfg.tools.media.image.timeoutSeconds\` (falling back to \`DEFAULT_TIMEOUT_SECONDS.image\` = 60s, via the existing \`resolveTimeoutMs\` helper) and pass it to every \`describeImage\` / \`describeImages\` call instead of the hardcoded \`30_000\`.
  - \`src/media-understanding/image.ts\`: forward \`params.timeoutMs\` into the MiniMax branch (\`describeImagesWithMinimax\`).
  - \`src/agents/minimax-vlm.ts\`: accept an optional \`timeoutMs\` parameter and use it for \`AbortSignal.timeout(...)\` instead of the hardcoded \`60_000\` (falls back to 60s when not supplied, preserving existing behavior for any callers that do not plumb a timeout).
- What did NOT change (scope boundary):
  - No config schema, default value, help text, or label changes. \`tools.media.image.timeoutSeconds\` already existed with a documented 60s default; this PR makes the tool honor what was already documented.
  - No public Plugin SDK surface changes.
  - No network, fs, sandbox, permission, or model-selection behavior changes.
  - The auto-attachment image-understanding path (\`src/media-understanding/runner.entries.ts\`) already honored this config — unchanged here.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #67889
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: \`src/agents/tools/image-tool.ts\` threaded a hardcoded \`timeoutMs: 30_000\` into all three \`describeImage\`/\`describeImages\` call sites, completely bypassing \`cfg.tools.media.image.timeoutSeconds\`. Additionally, \`src/agents/minimax-vlm.ts\` used \`AbortSignal.timeout(60_000)\` regardless of caller input, so even if a caller had wanted to override the MiniMax branch's timeout it had nowhere to flow.
- Missing detection / guardrail: no test asserted that \`tools.media.image.timeoutSeconds\` flowed through to the tool's underlying \`describeImage\`/\`describeImages\` calls. The existing image-tool tests covered model selection, sandbox, workspace policy, and MiniMax routing, but not timeout plumbing.
- Contributing context: the auto-attachment path (\`runner.entries.ts\`) did honor the config correctly via \`resolveTimeoutMs\`, which hid the tool-side divergence from casual inspection.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: \`src/agents/tools/image-tool.test.ts\`
- Scenario the test should lock in: the effective \`timeoutMs\` passed into the mocked \`describeImageWithModel\`/\`describeImagesWithModel\` (and into \`AbortSignal.timeout\` on the MiniMax path) matches \`cfg.tools.media.image.timeoutSeconds\` (with the 60s default when unset, and the 1000ms floor from \`resolveTimeoutMs\`).
- Why this is the smallest reliable guardrail: captures timeout at the exact seam where the bug lived (tool → describe call site, and minimax helper → \`AbortSignal.timeout\`). No network, no vision model, no fake timers.

Added tests:

- \`describe(\"image tool timeout configuration (#67889)\")\` — 4 cases:
  - default (no config) → 60,000 ms (aligned with \`DEFAULT_TIMEOUT_SECONDS.image\`)
  - \`tools.media.image.timeoutSeconds: 180\` single-image → 180,000 ms
  - \`tools.media.image.timeoutSeconds: 300\` multi-image → 300,000 ms
  - sub-second value (\`0.2\`) clamps to the \`resolveTimeoutMs\` 1000 ms floor
- \`describe(\"minimaxUnderstandImage timeout plumbing (#67889)\")\` — 3 cases:
  - explicit \`timeoutMs\` → used verbatim on \`AbortSignal.timeout\`
  - no \`timeoutMs\` → 60,000 ms default
  - non-finite / non-positive \`timeoutMs\` → 60,000 ms default

## User-visible / Behavior Changes

- Operators who set \`tools.media.image.timeoutSeconds\` now see that value respected by the \`image\` tool (including the MiniMax VLM branch), matching the existing docs and the already-correct auto-attachment path.
- Default timeout for the \`image\` tool changes from the previously-hardcoded 30s to \`DEFAULT_TIMEOUT_SECONDS.image\` (60s), aligning with the image-understanding default used elsewhere in the system. Admins who want a tighter cap can set \`tools.media.image.timeoutSeconds\` to the desired number of seconds (minimum 1s floor).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same outbound calls, only the wall-clock timeout before they abort changes)
- Command/tool execution surface changed? No (same tool surface, same fs/sandbox/workspace policy)
- Data access scope changed? No
- Security/runtime controls unchanged by this PR:
  - Trusted local \`MEDIA:\` tool-result passthrough and built-in tool name collision enforcement (unchanged).
  - Image tool sandbox, workspace, and \`tools.fs.workspaceOnly\` policy (unchanged — existing image-tool tests covering these still pass).
  - Remote URL blocking in sandboxed image tool (unchanged).
  - Auth / model selection / provider registry (unchanged).
  - Timeout enforcement itself remains runtime-enforced via \`resolveTimeoutMs\` → \`setTimeout\` / \`AbortSignal.timeout\`, never derived from prompt text; the admin-controlled config value is the source of truth.

## Repro + Verification

### Environment

- OS: macOS (any); also applies to Linux/Windows
- Runtime/container: Node 22+, \`pnpm\`
- Model/provider: any vision model (issue reported with a local Ollama model; also affects MiniMax VLM)
- Integration/channel (if any): N/A (reproduces directly through the \`image\` agent tool)
- Relevant config (redacted): \`tools.media.image.timeoutSeconds: <any value > 30>\`, e.g. \`180\`

### Steps

1. Configure \`tools.media.image.timeoutSeconds: 180\`.
2. Have the agent invoke the \`image\` tool against a model whose first-byte latency exceeds 30s (e.g. a large local vision model).

### Expected

- The request is aborted only after the configured 180s timeout.

### Actual (before this PR)

- The request is aborted after ~30s regardless of the configured value.

## Evidence

- [x] Failing test/log before + passing after — added regression tests fail against the old hardcoded timeouts and pass against the new implementation (\`pnpm test src/agents/tools/image-tool.test.ts -t \"#67889\"\`: 7 passed).

## Human Verification (required)

- Verified scenarios:
  - \`pnpm test src/agents/tools/image-tool.test.ts\` — 42 passed, 0 failed.
  - \`pnpm test src/media-understanding/image.test.ts\` — 5 passed, 0 failed.
  - \`pnpm lint\` on touched files — clean (remaining lint errors are in unrelated \`extensions/qa-lab/src/providers/aimock/server.ts\`, pre-existing on \`origin/main\`).
  - \`pnpm tsgo\` on touched files — clean (same pre-existing \`aimock\` errors on \`origin/main\`, unrelated).
  - \`pnpm format\` — clean on touched files.
- Edge cases checked:
  - Unset config → 60s default.
  - \`timeoutSeconds: 0.2\` → clamped to 1000ms floor by \`resolveTimeoutMs\`.
  - MiniMax branch with no \`timeoutMs\` supplied → still 60s default (existing behavior preserved for any other callers).
  - MiniMax branch with non-finite / non-positive \`timeoutMs\` → falls back to 60s default (hardening).
- What I did not verify:
  - Full \`pnpm test\` suite (long runtime; CI covers it).
  - Full \`pnpm check\` (blocked by pre-existing unrelated failures on main).
  - Live end-to-end run against a real slow local vision model (the regression tests directly capture the timeout value at the seam that failed, which is the exact source of the bug).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — configs without \`tools.media.image.timeoutSeconds\` now get the documented 60s default (previously the tool silently capped at 30s).
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: users who implicitly depended on the old 30s cap see image-tool calls run up to 60s by default.
  - Mitigation: the 60s default matches the already-documented capability default used everywhere else in media understanding; admins who want a stricter cap can set \`tools.media.image.timeoutSeconds\` explicitly (with a 1s floor).


Made with [Cursor](https://cursor.com)