### PR TITLE
fix(memory-core): emit one degraded sqlite-vec warning per manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/webhooks: enforce synchronous plugin registration with full rollback of failed plugin side effects, and cache SecretRef-backed webhook auth per route so plugin startup and inbound webhook auth stay deterministic. (#67941) Thanks @obviyus.
 - Telegram/ACP bindings: drop persisted DM bindings that still point at missing or failed ACP sessions on restart, while preserving plugin-owned bindings and uncertain store reads. (#67822) Thanks @chinar-amrutkar.
 - Telegram/streaming: keep a transient preview on the same Telegram message when auto-compaction retries an in-flight answer, so streamed replies no longer appear duplicated after compaction. (#66939) Thanks @rubencu.
+- Memory/sqlite-vec: emit the degraded sqlite-vec warning once per degraded episode instead of repeating it for every file write, while preserving the latch across safe-reindex rollback and resetting it when vector state is genuinely rebuilt. (#67898) Thanks @rubencu.
 
 ## 2026.4.15
 

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -36,6 +36,7 @@ import {
 } from "./manager-embedding-policy.js";
 import { deleteMemoryFtsRows } from "./manager-fts-state.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
+import { logMemoryVectorDegradedWrite } from "./manager-vector-warning.js";
 import { replaceMemoryVectorRow } from "./manager-vector-write.js";
 
 const VECTOR_TABLE = "chunks_vec";
@@ -568,12 +569,15 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
       }
     }
-    if (this.vector.enabled && !vectorReady && chunks.length > 0) {
-      const errDetail = this.vector.loadError ? `: ${this.vector.loadError}` : "";
-      log.warn(
-        `chunks written for ${entry.path} without vector embeddings — chunks_vec not updated (sqlite-vec unavailable${errDetail}). Vector recall degraded for this file.`,
-      );
-    }
+    this.vectorDegradedWriteWarningShown = logMemoryVectorDegradedWrite({
+      vectorEnabled: this.vector.enabled,
+      vectorReady,
+      chunkCount: chunks.length,
+      warningShown: this.vectorDegradedWriteWarningShown,
+      path: entry.path,
+      loadError: this.vector.loadError,
+      warn: (message) => log.warn(message),
+    });
     this.upsertFileRecord(entry, source);
   }
 

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -574,7 +574,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       vectorReady,
       chunkCount: chunks.length,
       warningShown: this.vectorDegradedWriteWarningShown,
-      path: entry.path,
       loadError: this.vector.loadError,
       warn: (message) => log.warn(message),
     });

--- a/extensions/memory-core/src/memory/manager-sync-control.ts
+++ b/extensions/memory-core/src/memory/manager-sync-control.ts
@@ -11,12 +11,7 @@ const log = createSubsystemLogger("memory");
 export type MemoryReadonlyRecoveryState = {
   closed: boolean;
   db: DatabaseSync;
-  vectorReady: Promise<boolean> | null;
   vector: {
-    enabled: boolean;
-    available: boolean | null;
-    extensionPath?: string;
-    loadError?: string;
     dims?: number;
   };
   readonlyRecoveryAttempts: number;
@@ -30,6 +25,7 @@ export type MemoryReadonlyRecoveryState = {
     progress?: (update: MemorySyncProgressUpdate) => void;
   }) => Promise<void>;
   openDatabase: () => DatabaseSync;
+  resetVectorState: () => void;
   ensureSchema: () => void;
   readMeta: () => { vectorDims?: number } | undefined;
 };
@@ -107,9 +103,7 @@ export async function runMemorySyncWithReadonlyRecovery(
       state.db.close();
     } catch {}
     state.db = state.openDatabase();
-    state.vectorReady = null;
-    state.vector.available = null;
-    state.vector.loadError = undefined;
+    state.resetVectorState();
     state.ensureSchema();
     const meta = state.readMeta();
     state.vector.dims = meta?.vectorDims;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -166,6 +166,7 @@ export abstract class MemoryManagerSyncOps {
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
   >();
+  protected vectorDegradedWriteWarningShown = false;
   private lastMetaSerialized: string | null = null;
 
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1131,6 +1131,7 @@ export abstract class MemoryManagerSyncOps {
       vectorAvailable: this.vector.available,
       vectorLoadError: this.vector.loadError,
       vectorDims: this.vector.dims,
+      vectorDegradedWriteWarningShown: this.vectorDegradedWriteWarningShown,
       vectorReady: this.vectorReady,
     };
 
@@ -1145,6 +1146,7 @@ export abstract class MemoryManagerSyncOps {
       this.vector.available = originalDbClosed ? null : originalState.vectorAvailable;
       this.vector.loadError = originalState.vectorLoadError;
       this.vector.dims = originalState.vectorDims;
+      this.vectorDegradedWriteWarningShown = originalState.vectorDegradedWriteWarningShown;
       this.vectorReady = originalDbClosed ? null : originalState.vectorReady;
     };
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -191,6 +191,14 @@ export abstract class MemoryManagerSyncOps {
     options: { source: MemorySource; content?: string },
   ): Promise<void>;
 
+  protected resetVectorState(): void {
+    this.vectorReady = null;
+    this.vector.available = null;
+    this.vector.loadError = undefined;
+    this.vector.dims = undefined;
+    this.vectorDegradedWriteWarningShown = false;
+  }
+
   protected async ensureVectorReady(dimensions?: number): Promise<boolean> {
     if (!this.vector.enabled) {
       return false;
@@ -1141,10 +1149,7 @@ export abstract class MemoryManagerSyncOps {
     };
 
     this.db = tempDb;
-    this.vectorReady = null;
-    this.vector.available = null;
-    this.vector.loadError = undefined;
-    this.vector.dims = undefined;
+    this.resetVectorState();
     this.fts.available = false;
     this.fts.loadError = undefined;
     this.ensureSchema();
@@ -1212,9 +1217,7 @@ export abstract class MemoryManagerSyncOps {
       });
 
       this.db = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
-      this.vectorReady = null;
-      this.vector.available = null;
-      this.vector.loadError = undefined;
+      this.resetVectorState();
       this.ensureSchema();
       this.vector.dims = nextMeta?.vectorDims;
     } catch (err) {

--- a/extensions/memory-core/src/memory/manager-vector-warning.test.ts
+++ b/extensions/memory-core/src/memory/manager-vector-warning.test.ts
@@ -10,7 +10,6 @@ describe("memory vector degradation warnings", () => {
       vectorReady: false,
       chunkCount: 3,
       warningShown: false,
-      path: "MEMORY.md",
       loadError: "load failed",
       warn,
     });
@@ -19,7 +18,6 @@ describe("memory vector degradation warnings", () => {
       vectorReady: false,
       chunkCount: 2,
       warningShown: first,
-      path: "memory/2026-04-16.md",
       loadError: "load failed",
       warn,
     });
@@ -28,7 +26,7 @@ describe("memory vector degradation warnings", () => {
     expect(second).toBe(true);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
-      "chunks written for MEMORY.md without vector embeddings — chunks_vec not updated (sqlite-vec unavailable: load failed). Vector recall degraded; suppressing duplicate per-file warnings for this manager.",
+      "chunks_vec not updated — sqlite-vec unavailable: load failed. Vector recall degraded. Further duplicate warnings suppressed.",
     );
   });
 

--- a/extensions/memory-core/src/memory/manager-vector-warning.test.ts
+++ b/extensions/memory-core/src/memory/manager-vector-warning.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { logMemoryVectorDegradedWrite } from "./manager-vector-warning.js";
+
+describe("memory vector degradation warnings", () => {
+  it("emits the degraded warning only once for a manager", () => {
+    const warn = vi.fn();
+
+    const first = logMemoryVectorDegradedWrite({
+      vectorEnabled: true,
+      vectorReady: false,
+      chunkCount: 3,
+      warningShown: false,
+      path: "MEMORY.md",
+      loadError: "load failed",
+      warn,
+    });
+    const second = logMemoryVectorDegradedWrite({
+      vectorEnabled: true,
+      vectorReady: false,
+      chunkCount: 2,
+      warningShown: first,
+      path: "memory/2026-04-16.md",
+      loadError: "load failed",
+      warn,
+    });
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "chunks written for MEMORY.md without vector embeddings — chunks_vec not updated (sqlite-vec unavailable: load failed). Vector recall degraded; suppressing duplicate per-file warnings for this manager.",
+    );
+  });
+
+  it("skips the warning when vector writes are available", () => {
+    const warn = vi.fn();
+
+    const shown = logMemoryVectorDegradedWrite({
+      vectorEnabled: true,
+      vectorReady: true,
+      chunkCount: 1,
+      warningShown: false,
+      path: "MEMORY.md",
+      warn,
+    });
+
+    expect(shown).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/memory-core/src/memory/manager-vector-warning.test.ts
+++ b/extensions/memory-core/src/memory/manager-vector-warning.test.ts
@@ -38,7 +38,6 @@ describe("memory vector degradation warnings", () => {
       vectorReady: true,
       chunkCount: 1,
       warningShown: false,
-      path: "MEMORY.md",
       warn,
     });
 

--- a/extensions/memory-core/src/memory/manager-vector-warning.ts
+++ b/extensions/memory-core/src/memory/manager-vector-warning.ts
@@ -1,0 +1,23 @@
+export function logMemoryVectorDegradedWrite(params: {
+  vectorEnabled: boolean;
+  vectorReady: boolean;
+  chunkCount: number;
+  warningShown: boolean;
+  path: string;
+  loadError?: string;
+  warn: (message: string) => void;
+}): boolean {
+  if (
+    !params.vectorEnabled ||
+    params.vectorReady ||
+    params.chunkCount <= 0 ||
+    params.warningShown
+  ) {
+    return params.warningShown;
+  }
+  const errDetail = params.loadError ? `: ${params.loadError}` : "";
+  params.warn(
+    `chunks written for ${params.path} without vector embeddings — chunks_vec not updated (sqlite-vec unavailable${errDetail}). Vector recall degraded; suppressing duplicate per-file warnings for this manager.`,
+  );
+  return true;
+}

--- a/extensions/memory-core/src/memory/manager-vector-warning.ts
+++ b/extensions/memory-core/src/memory/manager-vector-warning.ts
@@ -3,7 +3,6 @@ export function logMemoryVectorDegradedWrite(params: {
   vectorReady: boolean;
   chunkCount: number;
   warningShown: boolean;
-  path: string;
   loadError?: string;
   warn: (message: string) => void;
 }): boolean {
@@ -17,7 +16,7 @@ export function logMemoryVectorDegradedWrite(params: {
   }
   const errDetail = params.loadError ? `: ${params.loadError}` : "";
   params.warn(
-    `chunks written for ${params.path} without vector embeddings — chunks_vec not updated (sqlite-vec unavailable${errDetail}). Vector recall degraded; suppressing duplicate per-file warnings for this manager.`,
+    `chunks_vec not updated — sqlite-vec unavailable${errDetail}. Vector recall degraded. Further duplicate warnings suppressed.`,
   );
   return true;
 }

--- a/extensions/memory-core/src/memory/manager.readonly-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.readonly-recovery.test.ts
@@ -16,10 +16,12 @@ type ReadonlyRecoveryHarness = MemoryReadonlyRecoveryState & {
   syncing: Promise<void> | null;
   queuedSessionFiles: Set<string>;
   queuedSessionSync: Promise<void> | null;
+  vectorDegradedWriteWarningShown: boolean;
   ensureProviderInitialized: ReturnType<typeof vi.fn>;
   enqueueTargetedSessionSync: ReturnType<typeof vi.fn>;
   runSync: ReturnType<typeof vi.fn>;
   openDatabase: ReturnType<typeof vi.fn>;
+  resetVectorState: ReturnType<typeof vi.fn>;
   ensureSchema: ReturnType<typeof vi.fn>;
   readMeta: ReturnType<typeof vi.fn>;
 };
@@ -66,13 +68,10 @@ describe("memory manager readonly recovery", () => {
       queuedSessionFiles: new Set<string>(),
       queuedSessionSync: null,
       db: initialDb,
-      vectorReady: null,
       vector: {
-        enabled: false,
-        available: null,
-        loadError: "stale",
         dims: 123,
       },
+      vectorDegradedWriteWarningShown: true,
       readonlyRecoveryAttempts: 0,
       readonlyRecoverySuccesses: 0,
       readonlyRecoveryFailures: 0,
@@ -81,6 +80,10 @@ describe("memory manager readonly recovery", () => {
       enqueueTargetedSessionSync: vi.fn(async () => {}),
       runSync: vi.fn(async (_params) => undefined) as ReadonlyRecoveryHarness["runSync"],
       openDatabase: vi.fn(() => reopenedDb),
+      resetVectorState: vi.fn(function (this: ReadonlyRecoveryHarness) {
+        this.vector.dims = undefined;
+        this.vectorDegradedWriteWarningShown = false;
+      }) as ReadonlyRecoveryHarness["resetVectorState"],
       ensureSchema: vi.fn(() => undefined) as ReadonlyRecoveryHarness["ensureSchema"],
       readMeta: vi.fn(() => undefined),
     };
@@ -132,6 +135,7 @@ describe("memory manager readonly recovery", () => {
 
     expect(harness.runSync).toHaveBeenCalledTimes(2);
     expect(harness.openDatabase).toHaveBeenCalledTimes(1);
+    expect(harness.resetVectorState).toHaveBeenCalledTimes(1);
     expect(initialClose).toHaveBeenCalledTimes(1);
     expectReadonlyRecoveryStatus(harness, params.expectedLastError);
   }
@@ -173,7 +177,21 @@ describe("memory manager readonly recovery", () => {
     ).rejects.toThrow("embedding timeout");
     expect(harness.runSync).toHaveBeenCalledTimes(1);
     expect(harness.openDatabase).not.toHaveBeenCalled();
+    expect(harness.resetVectorState).not.toHaveBeenCalled();
     expect(initialClose).not.toHaveBeenCalled();
+  });
+
+  it("clears the degraded warning latch before retrying", async () => {
+    const { harness } = createReadonlyRecoveryHarness();
+    harness.runSync.mockRejectedValueOnce(new Error("attempt to write a readonly database"));
+
+    await expect(
+      runSyncWithReadonlyRecovery(harness, {
+        reason: "test",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(harness.vectorDegradedWriteWarningShown).toBe(false);
   });
 
   it("sets busy_timeout on memory sqlite connections", async () => {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -615,10 +615,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     const setDb = (value: DatabaseSync) => {
       this.db = value;
     };
-    const getVectorReady = () => this.vectorReady;
-    const setVectorReady = (value: Promise<boolean> | null) => {
-      this.vectorReady = value;
-    };
     const getReadonlyRecoveryAttempts = () => this.readonlyRecoveryAttempts;
     const setReadonlyRecoveryAttempts = (value: number) => {
       this.readonlyRecoveryAttempts = value;
@@ -644,12 +640,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       },
       set db(value) {
         setDb(value);
-      },
-      get vectorReady() {
-        return getVectorReady();
-      },
-      set vectorReady(value) {
-        setVectorReady(value);
       },
       vector: this.vector,
       get readonlyRecoveryAttempts() {
@@ -678,6 +668,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       },
       runSync: (nextParams) => this.runSync(nextParams),
       openDatabase: () => this.openDatabase(),
+      resetVectorState: () => this.resetVectorState(),
       ensureSchema: () => this.ensureSchema(),
       readMeta: () => this.readMeta() ?? undefined,
     };


### PR DESCRIPTION
## Summary

- Problem: when `sqlite-vec` is unavailable, memory indexing can emit the same degraded-state warning repeatedly across many file writes in the same manager lifecycle.
- Why it matters: `gateway:watch` gets flooded with duplicate degraded-memory warnings, which makes it harder to spot the first failure and any unrelated follow-on errors.
- What changed: memory-core now emits a single manager-level degraded warning and suppresses duplicate repeats for the same manager instance.
- What did NOT change (scope boundary): this does not restore vector indexing or change fallback behavior when `sqlite-vec` is missing; it only fixes repeated warning emission.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the degraded-vector warning was emitted from the per-write path, so one unavailable vector backend could produce many identical warnings during a single sync pass.
- Missing detection / guardrail: there was no focused test pinning the warning-emission contract for the degraded sqlite-vec path.
- Contributing context (if known): large memory corpora make the duplicate warning volume much worse because one degraded pass can touch many files.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/memory/manager-vector-warning.test.ts`
- Scenario the test should lock in: once sqlite-vec is known unavailable for a manager, repeated writes do not re-emit the same degraded-state warning.
- Why this is the smallest reliable guardrail: the bug is in warning emission policy, so a focused unit test is the narrowest stable place to catch it.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

When vector indexing is degraded because `sqlite-vec` is unavailable, the gateway now logs that degraded state once per manager instead of repeating it for every file write.

## Diagram (if applicable)

```text
Before:
[sqlite-vec unavailable] -> [many file writes] -> [same degraded warning repeated]

After:
[sqlite-vec unavailable] -> [first degraded write] -> [one warning]
                                     -> [later writes] -> [duplicates suppressed]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: N/A
- Integration/channel (if any): memory-core indexing / `gateway:watch`
- Relevant config (redacted): vector recall enabled with `sqlite-vec` unavailable

### Steps

1. Start the gateway with memory indexing enabled and `sqlite-vec` unavailable.
2. Trigger memory sync for multiple files.
3. Watch the logs.

### Expected

- One degraded vector warning for the manager.

### Actual

- Before this fix, the same degraded warning repeated across many file writes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused unit coverage plus manual `gateway:watch` verification with the same degraded sqlite-vec condition.
- Edge cases checked: the first degraded warning still emits; only duplicate repeats are suppressed.
- What you did **not** verify: restoration of vector recall itself when sqlite-vec becomes available again.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: operators see fewer repeated reminders about the same degraded state.
  - Mitigation: the first warning remains explicit and unchanged in meaning; only duplicate repeats are suppressed.
