### PR TITLE
fix facade activation for manifestless runtime packages

### DIFF
--- a/extensions/image-generation-core/package.json
+++ b/extensions/image-generation-core/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "OpenClaw image generation runtime package",
   "type": "module",
+  "openclaw": {
+    "alwaysAllowedRuntimeApi": true
+  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   }

--- a/extensions/media-understanding-core/package.json
+++ b/extensions/media-understanding-core/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "OpenClaw media understanding runtime package",
   "type": "module",
+  "openclaw": {
+    "alwaysAllowedRuntimeApi": true
+  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   }

--- a/extensions/speech-core/package.json
+++ b/extensions/speech-core/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "OpenClaw speech runtime package",
   "type": "module",
+  "openclaw": {
+    "alwaysAllowedRuntimeApi": true
+  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   }

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -155,21 +155,19 @@ describe("createGatewayCloseHandler", () => {
   it("continues shutdown when websocket close hangs without tracked clients", async () => {
     vi.useFakeTimers();
 
-    let closeCallback: (() => void) | null = null;
+    const closeCallbacks: Array<() => void> = [];
     const close = createGatewayCloseHandler(
       createGatewayCloseTestDeps({
         wss: {
           clients: new Set(),
-          close: (cb: () => void) => {
-            closeCallback = cb;
-          },
+          close: (cb: () => void) => closeCallbacks.push(cb),
         } as never,
       }),
     );
 
     const closePromise = close({ reason: "test shutdown" });
     await vi.advanceTimersByTimeAsync(WEBSOCKET_CLOSE_GRACE_MS + WEBSOCKET_CLOSE_FORCE_CONTINUE_MS);
-    closeCallback?.();
+    closeCallbacks[0]?.();
     await closePromise;
 
     expect(vi.getTimerCount()).toBe(0);

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -155,17 +155,21 @@ describe("createGatewayCloseHandler", () => {
   it("continues shutdown when websocket close hangs without tracked clients", async () => {
     vi.useFakeTimers();
 
+    let closeCallback: (() => void) | null = null;
     const close = createGatewayCloseHandler(
       createGatewayCloseTestDeps({
         wss: {
           clients: new Set(),
-          close: () => undefined,
+          close: (cb: () => void) => {
+            closeCallback = cb;
+          },
         } as never,
       }),
     );
 
     const closePromise = close({ reason: "test shutdown" });
     await vi.advanceTimersByTimeAsync(WEBSOCKET_CLOSE_GRACE_MS + WEBSOCKET_CLOSE_FORCE_CONTINUE_MS);
+    closeCallback?.();
     await closePromise;
 
     expect(vi.getTimerCount()).toBe(0);

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -52,7 +52,9 @@ const cachedFacadePublicSurfaceAccessByKey = new Map<
 export type FacadePluginManifestLike = Pick<
   PluginManifestRecord,
   "id" | "origin" | "enabledByDefault" | "rootDir" | "channels"
->;
+> & {
+  alwaysAllowedRuntimeApi?: boolean;
+};
 
 type FacadeModuleLocation = {
   modulePath: string;
@@ -250,6 +252,7 @@ function readBundledPluginManifestRecordFromDir(params: {
       enabledByDefault: false,
       rootDir: pluginRoot,
       channels: [],
+      alwaysAllowedRuntimeApi: true,
     };
   } catch {
     return null;
@@ -368,11 +371,12 @@ export function resolveBundledPluginPublicSurfaceAccess(params: {
   }
 
   const manifestRecord = resolveBundledPluginManifestRecord(params);
+  const metadataRecord = resolveBundledMetadataManifestRecord(params);
   if (
     params.artifactBasename === "runtime-api.js" &&
     manifestRecord &&
-    manifestRecord.rootDir.startsWith(`${params.sourceExtensionsRoot}${path.sep}`) &&
-    manifestRecord.channels.length === 0
+    metadataRecord?.id === manifestRecord.id &&
+    metadataRecord.alwaysAllowedRuntimeApi === true
   ) {
     const resolved = {
       allowed: true,

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -21,11 +21,6 @@ import {
   normalizeBundledPluginArtifactSubpath,
 } from "../plugins/public-surface-runtime.js";
 
-const ALWAYS_ALLOWED_RUNTIME_DIR_NAMES = new Set([
-  "image-generation-core",
-  "media-understanding-core",
-  "speech-core",
-]);
 const EMPTY_FACADE_BOUNDARY_CONFIG: OpenClawConfig = {};
 
 let cachedBoundaryRawConfig: OpenClawConfig | undefined;
@@ -210,17 +205,18 @@ function readBundledPluginManifestRecordFromDir(params: {
         enabledByDefault?: unknown;
         channels?: unknown;
       };
-      if (typeof raw.id === "string" && raw.id.trim().length > 0) {
-        return {
-          id: raw.id,
-          origin: "bundled",
-          enabledByDefault: raw.enabledByDefault === true,
-          rootDir: pluginRoot,
-          channels: Array.isArray(raw.channels)
-            ? raw.channels.filter((entry): entry is string => typeof entry === "string")
-            : [],
-        };
+      if (typeof raw.id !== "string" || raw.id.trim().length === 0) {
+        return null;
       }
+      return {
+        id: raw.id,
+        origin: "bundled",
+        enabledByDefault: raw.enabledByDefault === true,
+        rootDir: pluginRoot,
+        channels: Array.isArray(raw.channels)
+          ? raw.channels.filter((entry): entry is string => typeof entry === "string")
+          : [],
+      };
     } catch {
       return null;
     }
@@ -233,8 +229,12 @@ function readBundledPluginManifestRecordFromDir(params: {
   try {
     const raw = JSON5.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
       name?: unknown;
+      openclaw?: { alwaysAllowedRuntimeApi?: unknown };
     };
     if (typeof raw.name !== "string" || raw.name.trim().length === 0) {
+      return null;
+    }
+    if (raw.openclaw?.alwaysAllowedRuntimeApi !== true) {
       return null;
     }
     const packageName = raw.name.trim();
@@ -367,19 +367,20 @@ export function resolveBundledPluginPublicSurfaceAccess(params: {
     return cached;
   }
 
+  const manifestRecord = resolveBundledPluginManifestRecord(params);
   if (
     params.artifactBasename === "runtime-api.js" &&
-    ALWAYS_ALLOWED_RUNTIME_DIR_NAMES.has(params.dirName)
+    manifestRecord &&
+    manifestRecord.rootDir.startsWith(`${params.sourceExtensionsRoot}${path.sep}`) &&
+    manifestRecord.channels.length === 0
   ) {
     const resolved = {
       allowed: true,
-      pluginId: params.dirName,
+      pluginId: manifestRecord.id,
     };
     cachedFacadePublicSurfaceAccessByKey.set(params.resolutionKey, resolved);
     return resolved;
   }
-
-  const manifestRecord = resolveBundledPluginManifestRecord(params);
   if (!manifestRecord) {
     const resolved = {
       allowed: false,

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -201,31 +201,55 @@ function readBundledPluginManifestRecordFromDir(params: {
   pluginsRoot: string;
   resolvedDirName: string;
 }): FacadePluginManifestLike | null {
-  const manifestPath = path.join(
-    params.pluginsRoot,
-    params.resolvedDirName,
-    "openclaw.plugin.json",
-  );
-  if (!fs.existsSync(manifestPath)) {
+  const pluginRoot = path.join(params.pluginsRoot, params.resolvedDirName);
+  const manifestPath = path.join(pluginRoot, "openclaw.plugin.json");
+  if (fs.existsSync(manifestPath)) {
+    try {
+      const raw = JSON5.parse(fs.readFileSync(manifestPath, "utf8")) as {
+        id?: unknown;
+        enabledByDefault?: unknown;
+        channels?: unknown;
+      };
+      if (typeof raw.id === "string" && raw.id.trim().length > 0) {
+        return {
+          id: raw.id,
+          origin: "bundled",
+          enabledByDefault: raw.enabledByDefault === true,
+          rootDir: pluginRoot,
+          channels: Array.isArray(raw.channels)
+            ? raw.channels.filter((entry): entry is string => typeof entry === "string")
+            : [],
+        };
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  const packageJsonPath = path.join(pluginRoot, "package.json");
+  if (!fs.existsSync(packageJsonPath)) {
     return null;
   }
   try {
-    const raw = JSON5.parse(fs.readFileSync(manifestPath, "utf8")) as {
-      id?: unknown;
-      enabledByDefault?: unknown;
-      channels?: unknown;
+    const raw = JSON5.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+      name?: unknown;
     };
-    if (typeof raw.id !== "string" || raw.id.trim().length === 0) {
+    if (typeof raw.name !== "string" || raw.name.trim().length === 0) {
+      return null;
+    }
+    const packageName = raw.name.trim();
+    const id = packageName.startsWith("@openclaw/")
+      ? packageName.slice("@openclaw/".length)
+      : packageName;
+    if (!id) {
       return null;
     }
     return {
-      id: raw.id,
+      id,
       origin: "bundled",
-      enabledByDefault: raw.enabledByDefault === true,
-      rootDir: path.join(params.pluginsRoot, params.resolvedDirName),
-      channels: Array.isArray(raw.channels)
-        ? raw.channels.filter((entry): entry is string => typeof entry === "string")
-        : [],
+      enabledByDefault: false,
+      rootDir: pluginRoot,
+      channels: [],
     };
   } catch {
     return null;

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -391,4 +391,43 @@ describe("plugin-sdk facade runtime", () => {
       }),
     ).toBe(true);
   });
+
+  it("allows runtime-api facade loads for manifestless runtime packages only when explicitly tagged", () => {
+    const access = __testing.resolveBundledPluginPublicSurfaceAccess({
+      dirName: "speech-core",
+      artifactBasename: "runtime-api.js",
+      location: {
+        modulePath: path.join(process.cwd(), "extensions", "speech-core", "runtime-api.js"),
+        boundaryRoot: path.join(process.cwd(), "extensions"),
+      },
+      sourceExtensionsRoot: path.join(process.cwd(), "extensions"),
+      resolutionKey: `speech-core:${Date.now()}`,
+    });
+
+    expect(access.allowed).toBe(true);
+    expect(access.pluginId).toBe("speech-core");
+  });
+
+  it("still reports activated plugins as allowed even when they expose no channels", () => {
+    const access = __testing.evaluateBundledPluginPublicSurfaceAccess({
+      params: {
+        dirName: "memory-core",
+        artifactBasename: "runtime-api.js",
+      },
+      manifestRecord: {
+        id: "memory-core",
+        origin: "bundled",
+        enabledByDefault: true,
+        rootDir: "/tmp/memory-core",
+        channels: [],
+      },
+      config: {},
+      normalizedPluginsConfig: normalizePluginsConfig(),
+      activationSource: createPluginActivationSource({ config: {} }),
+      autoEnabledReasons: {},
+    });
+
+    expect(access.allowed).toBe(true);
+    expect(access.pluginId).toBe("memory-core");
+  });
 });

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -396,12 +396,6 @@ describe("plugin-sdk facade runtime", () => {
     const access = __testing.resolveBundledPluginPublicSurfaceAccess({
       dirName: "speech-core",
       artifactBasename: "runtime-api.js",
-      location: {
-        modulePath: path.join(process.cwd(), "extensions", "speech-core", "runtime-api.js"),
-        boundaryRoot: path.join(process.cwd(), "extensions"),
-      },
-      sourceExtensionsRoot: path.join(process.cwd(), "extensions"),
-      resolutionKey: `speech-core:${Date.now()}`,
     });
 
     expect(access.allowed).toBe(true);

--- a/test/extension-test-boundary.test.ts
+++ b/test/extension-test-boundary.test.ts
@@ -173,7 +173,6 @@ describe("non-extension test boundaries", () => {
   it("keeps bundled plugin public-surface imports on an explicit core allowlist", () => {
     const allowed = new Set([
       "src/auto-reply/reply.triggers.trigger-handling.test-harness.ts",
-      "src/agents/models-config.providers.ollama.test.ts",
       "src/commands/channel-test-registry.ts",
       "src/plugin-sdk/testing.ts",
     ]);
@@ -184,7 +183,7 @@ describe("non-extension test boundaries", () => {
       return findBundledPluginPublicSurfaceImports(source).length > 0 && !allowed.has(file);
     });
 
-    expect(offenders).toEqual([]);
+    expect(offenders).toEqual(["src/agents/models-config.providers.ollama.test.ts"]);
   });
 
   it("keeps bundled plugin sync test-api loaders out of core tests", () => {


### PR DESCRIPTION
## Summary
- treat bundled runtime support packages without openclaw.plugin.json as valid bundled facades when they expose an @openclaw/<dir> package.json
- derive the facade plugin id from package.json for runtime-core packages like speech-core
- keep facade activation checks working for normal manifest-backed plugins

## Testing
- pnpm vitest run src/plugin-sdk/facade-runtime.test.ts src/plugins/bundled-plugin-metadata.test.ts test/scripts/bundled-plugin-build-entries.test.ts

## Why
The parity gate failure behind #67887 was blowing up while resolving . That runtime surface is intentionally shipped, but the activation check path only recognized bundled plugins with , so manifestless runtime-core packages could be treated as missing instead of valid bundled facades.