### PR TITLE
fix(ui): stop unsupported wiki RPC probes during startup

### DIFF
--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -22,6 +22,7 @@ function createState(): { state: DreamingState; request: ReturnType<typeof vi.fn
       request,
     } as unknown as DreamingState["client"],
     connected: true,
+    hello: null,
     configSnapshot: { hash: "hash-1" },
     applySessionKey: "main",
     dreamingStatusLoading: false,
@@ -227,6 +228,11 @@ describe("dreaming controller", () => {
 
   it("loads and normalizes wiki import insights", async () => {
     const { state, request } = createState();
+    state.hello = {
+      type: "hello-ok",
+      protocol: 3,
+      features: { methods: ["wiki.importInsights"] },
+    };
     state.configSnapshot = {
       hash: "hash-1",
       config: {
@@ -321,8 +327,48 @@ describe("dreaming controller", () => {
     expect(state.wikiImportInsightsLoading).toBe(false);
   });
 
+  it("skips wiki import insights when the gateway does not advertise the method", async () => {
+    const { state, request } = createState();
+    state.hello = {
+      type: "hello-ok",
+      protocol: 3,
+      features: { methods: ["doctor.memory.status"] },
+    };
+    state.configSnapshot = {
+      hash: "hash-1",
+      config: {
+        plugins: {
+          entries: {
+            "memory-wiki": {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+    state.wikiImportInsights = {
+      sourceType: "chatgpt",
+      totalItems: 1,
+      totalClusters: 1,
+      clusters: [],
+    };
+    state.wikiImportInsightsError = "unknown method: wiki.importInsights";
+
+    await loadWikiImportInsights(state);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(state.wikiImportInsights).toBeNull();
+    expect(state.wikiImportInsightsError).toBeNull();
+    expect(state.wikiImportInsightsLoading).toBe(false);
+  });
+
   it("loads and normalizes the wiki memory palace", async () => {
     const { state, request } = createState();
+    state.hello = {
+      type: "hello-ok",
+      protocol: 3,
+      features: { methods: ["wiki.palace"] },
+    };
     state.configSnapshot = {
       hash: "hash-1",
       config: {
@@ -397,6 +443,42 @@ describe("dreaming controller", () => {
       hash: "hash-1",
       config: {
         plugins: {},
+      },
+    };
+    state.wikiMemoryPalace = {
+      totalItems: 1,
+      totalClaims: 1,
+      totalQuestions: 0,
+      totalContradictions: 0,
+      clusters: [],
+    };
+    state.wikiMemoryPalaceError = "unknown method: wiki.palace";
+
+    await loadWikiMemoryPalace(state);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(state.wikiMemoryPalace).toBeNull();
+    expect(state.wikiMemoryPalaceError).toBeNull();
+    expect(state.wikiMemoryPalaceLoading).toBe(false);
+  });
+
+  it("skips wiki memory palace when the gateway does not advertise the method", async () => {
+    const { state, request } = createState();
+    state.hello = {
+      type: "hello-ok",
+      protocol: 3,
+      features: { methods: ["doctor.memory.status"] },
+    };
+    state.configSnapshot = {
+      hash: "hash-1",
+      config: {
+        plugins: {
+          entries: {
+            "memory-wiki": {
+              enabled: true,
+            },
+          },
+        },
       },
     };
     state.wikiMemoryPalace = {

--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -303,6 +303,40 @@ describe("dreaming controller", () => {
     expect(state.wikiImportInsightsLoading).toBe(false);
   });
 
+  it("falls back to config gating for wiki import insights when methods are not advertised", async () => {
+    const { state, request } = createState();
+    state.configSnapshot = {
+      hash: "hash-1",
+      config: {
+        plugins: {
+          entries: {
+            "memory-wiki": {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+    request.mockResolvedValue({
+      sourceType: "chatgpt",
+      totalItems: 1,
+      totalClusters: 1,
+      clusters: [],
+    });
+
+    await loadWikiImportInsights(state);
+
+    expect(request).toHaveBeenCalledWith("wiki.importInsights", {});
+    expect(state.wikiImportInsights).toEqual(
+      expect.objectContaining({
+        totalItems: 1,
+        totalClusters: 1,
+      }),
+    );
+    expect(state.wikiImportInsightsError).toBeNull();
+    expect(state.wikiImportInsightsLoading).toBe(false);
+  });
+
   it("skips wiki import insights when memory-wiki is not enabled", async () => {
     const { state, request } = createState();
     state.configSnapshot = {
@@ -431,6 +465,41 @@ describe("dreaming controller", () => {
             ],
           }),
         ],
+      }),
+    );
+    expect(state.wikiMemoryPalaceError).toBeNull();
+    expect(state.wikiMemoryPalaceLoading).toBe(false);
+  });
+
+  it("falls back to config gating for wiki memory palace when methods are not advertised", async () => {
+    const { state, request } = createState();
+    state.configSnapshot = {
+      hash: "hash-1",
+      config: {
+        plugins: {
+          entries: {
+            "memory-wiki": {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+    request.mockResolvedValue({
+      totalItems: 1,
+      totalClaims: 2,
+      totalQuestions: 0,
+      totalContradictions: 0,
+      clusters: [],
+    });
+
+    await loadWikiMemoryPalace(state);
+
+    expect(request).toHaveBeenCalledWith("wiki.palace", {});
+    expect(state.wikiMemoryPalace).toEqual(
+      expect.objectContaining({
+        totalItems: 1,
+        totalClaims: 2,
       }),
     );
     expect(state.wikiMemoryPalaceError).toBeNull();

--- a/ui/src/ui/controllers/dreaming.ts
+++ b/ui/src/ui/controllers/dreaming.ts
@@ -1,4 +1,4 @@
-import type { GatewayBrowserClient } from "../gateway.ts";
+import type { GatewayBrowserClient, GatewayHelloOk } from "../gateway.ts";
 import { isPluginEnabledInConfigSnapshot } from "../plugin-activation.ts";
 import type { ConfigSnapshot } from "../types.ts";
 
@@ -201,6 +201,7 @@ type WikiMemoryPalacePayload = {
 export type DreamingState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
+  hello: GatewayHelloOk | null;
   configSnapshot: ConfigSnapshot | null;
   applySessionKey: string;
   dreamingStatusLoading: boolean;
@@ -234,6 +235,22 @@ function isMemoryWikiEnabled(state: DreamingState): boolean {
   return isPluginEnabledInConfigSnapshot(state.configSnapshot, MEMORY_WIKI_PLUGIN_ID, {
     enabledByDefault: false,
   });
+}
+
+function hasGatewayMethod(state: DreamingState, method: string): boolean | null {
+  const methods = state.hello?.features?.methods;
+  if (!Array.isArray(methods)) {
+    return null;
+  }
+  return methods.includes(method);
+}
+
+function canCallMemoryWikiMethod(state: DreamingState, method: string): boolean {
+  const available = hasGatewayMethod(state, method);
+  if (available !== null) {
+    return available;
+  }
+  return isMemoryWikiEnabled(state);
 }
 
 function buildDreamDiaryActionSuccessMessage(
@@ -748,7 +765,7 @@ export async function loadWikiImportInsights(state: DreamingState): Promise<void
   if (!state.client || !state.connected || state.wikiImportInsightsLoading) {
     return;
   }
-  if (!isMemoryWikiEnabled(state)) {
+  if (!canCallMemoryWikiMethod(state, "wiki.importInsights")) {
     state.wikiImportInsights = null;
     state.wikiImportInsightsError = null;
     return;
@@ -772,7 +789,7 @@ export async function loadWikiMemoryPalace(state: DreamingState): Promise<void> 
   if (!state.client || !state.connected || state.wikiMemoryPalaceLoading) {
     return;
   }
-  if (!isMemoryWikiEnabled(state)) {
+  if (!canCallMemoryWikiMethod(state, "wiki.palace")) {
     state.wikiMemoryPalace = null;
     state.wikiMemoryPalaceError = null;
     return;


### PR DESCRIPTION
## Summary

- Problem: the Control UI can probe `wiki.importInsights` and `wiki.palace` even when the connected gateway does not advertise those methods.
- Why it matters: healthy gateway startups produce avoidable `INVALID_REQUEST unknown method` errors in `gateway:watch`, especially in mixed-version UI/gateway combinations.
- What changed: the dreaming controller now prefers `hello.features.methods` to decide whether the wiki RPCs are callable, while preserving config-based fallback behavior for older gateways that do not advertise method lists yet.
- What did NOT change (scope boundary): this does not add wiki methods to older gateways or change wiki feature behavior when the methods are genuinely supported.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the controller inferred wiki availability from config/plugin state without first confirming that the gateway actually advertised the RPC methods.
- Missing detection / guardrail: there was no controller test for the case where config suggested wiki support but `hello.features.methods` omitted the wiki RPCs.
- Contributing context (if known): mixed-version Control UI and gateway combinations make method-advertisement checks important during startup.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/controllers/dreaming.test.ts`
- Scenario the test should lock in: when the gateway does not advertise the wiki RPCs, the controller does not call them; when methods are not advertised at all, the legacy config fallback still works.
- Why this is the smallest reliable guardrail: the bug is local to controller request gating, and the tests can assert the exact RPCs invoked.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Control UI startup no longer emits unsupported `wiki.importInsights` / `wiki.palace` RPC errors against gateways that do not support those methods.

## Diagram (if applicable)

```text
Before:
[UI startup] -> [config says memory-wiki enabled] -> [call wiki RPCs] -> [gateway returns INVALID_REQUEST]

After:
[UI startup] -> [check advertised methods] -> [skip unsupported wiki RPCs] -> [clean startup]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: N/A
- Integration/channel (if any): Control UI + gateway websocket startup
- Relevant config (redacted): gateway without advertised wiki methods

### Steps

1. Start a gateway that does not advertise `wiki.importInsights` or `wiki.palace` in `hello.features.methods`.
2. Open Control UI.
3. Watch gateway startup logs.

### Expected

- The UI skips unsupported wiki probes.

### Actual

- Before this fix, the UI issued both RPCs and the gateway responded with `INVALID_REQUEST unknown method`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: controller tests for advertised-method gating and legacy fallback, plus manual gateway restarts showing the `wiki.* unknown method` startup errors disappear.
- Edge cases checked: gateways without method-advertisement lists still use the config fallback path.
- What you did **not** verify: full browser-level UI interaction beyond startup probing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a gateway that supports the wiki RPCs but fails to advertise them could skip probes under the advertised-method path.
  - Mitigation: the controller preserves config-based fallback behavior when method advertisements are absent.
