### PR TITLE
fix(agents): dedupe repeated bootstrap truncation warnings

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../hooks/internal-hooks.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import {
+  _resetBootstrapWarningCacheForTest,
   FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
   hasCompletedBootstrapTurn,
   makeBootstrapWarn,
@@ -364,6 +365,10 @@ describe("hasCompletedBootstrapTurn", () => {
 });
 
 describe("makeBootstrapWarn", () => {
+  afterEach(() => {
+    _resetBootstrapWarningCacheForTest();
+  });
+
   it("deduplicates repeated warnings for the same session and message", () => {
     const warnings: string[] = [];
     const warn = makeBootstrapWarn({
@@ -396,6 +401,28 @@ describe("makeBootstrapWarn", () => {
     expect(warnings).toEqual([
       "workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating (sessionKey=agent:main:first-session)",
       "workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating (sessionKey=agent:main:second-session)",
+    ]);
+  });
+
+  it("keeps warnings distinct across workspaces with the same session", () => {
+    const warnings: string[] = [];
+    const first = makeBootstrapWarn({
+      sessionLabel: "agent:main:shared-session",
+      workspaceDir: "/tmp/workspace-a",
+      warn: (message) => warnings.push(message),
+    });
+    const second = makeBootstrapWarn({
+      sessionLabel: "agent:main:shared-session",
+      workspaceDir: "/tmp/workspace-b",
+      warn: (message) => warnings.push(message),
+    });
+
+    first?.("workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating");
+    second?.("workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating");
+
+    expect(warnings).toEqual([
+      "workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating (sessionKey=agent:main:shared-session)",
+      "workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating (sessionKey=agent:main:shared-session)",
     ]);
   });
 });

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -10,6 +10,7 @@ import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import {
   FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
   hasCompletedBootstrapTurn,
+  makeBootstrapWarn,
   resolveBootstrapContextForRun,
   resolveBootstrapFilesForRun,
   resolveContextInjectionMode,
@@ -359,6 +360,43 @@ describe("hasCompletedBootstrapTurn", () => {
     );
     await fs.symlink(realFile, linkFile);
     expect(await hasCompletedBootstrapTurn(linkFile)).toBe(false);
+  });
+});
+
+describe("makeBootstrapWarn", () => {
+  it("deduplicates repeated warnings for the same session and message", () => {
+    const warnings: string[] = [];
+    const warn = makeBootstrapWarn({
+      sessionLabel: "agent:main:test-session",
+      warn: (message) => warnings.push(message),
+    });
+
+    warn?.("workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating");
+    warn?.("workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating");
+
+    expect(warnings).toEqual([
+      "workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating (sessionKey=agent:main:test-session)",
+    ]);
+  });
+
+  it("keeps warnings distinct across sessions", () => {
+    const warnings: string[] = [];
+    const first = makeBootstrapWarn({
+      sessionLabel: "agent:main:first-session",
+      warn: (message) => warnings.push(message),
+    });
+    const second = makeBootstrapWarn({
+      sessionLabel: "agent:main:second-session",
+      warn: (message) => warnings.push(message),
+    });
+
+    first?.("workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating");
+    second?.("workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating");
+
+    expect(warnings).toEqual([
+      "workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating (sessionKey=agent:main:first-session)",
+      "workspace bootstrap file MEMORY.md is 36697 chars (limit 12000); truncating (sessionKey=agent:main:second-session)",
+    ]);
   });
 });
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -27,6 +27,22 @@ const CONTINUATION_SCAN_MAX_RECORDS = 500;
 export const FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE = "openclaw:bootstrap-context:full";
 const BOOTSTRAP_WARNING_DEDUPE_LIMIT = 1024;
 const seenBootstrapWarnings = new Set<string>();
+const bootstrapWarningOrder: string[] = [];
+
+function rememberBootstrapWarning(key: string): boolean {
+  if (seenBootstrapWarnings.has(key)) {
+    return false;
+  }
+  if (seenBootstrapWarnings.size >= BOOTSTRAP_WARNING_DEDUPE_LIMIT) {
+    const oldest = bootstrapWarningOrder.shift();
+    if (oldest) {
+      seenBootstrapWarnings.delete(oldest);
+    }
+  }
+  seenBootstrapWarnings.add(key);
+  bootstrapWarningOrder.push(key);
+  return true;
+}
 
 export function resolveContextInjectionMode(config?: OpenClawConfig): AgentContextInjection {
   return config?.agents?.defaults?.contextInjection ?? "always";
@@ -112,15 +128,8 @@ export function makeBootstrapWarn(params: {
   }
   return (message: string) => {
     const key = `${params.sessionLabel}\u0000${message}`;
-    if (seenBootstrapWarnings.has(key)) {
+    if (!rememberBootstrapWarning(key)) {
       return;
-    }
-    seenBootstrapWarnings.add(key);
-    if (seenBootstrapWarnings.size > BOOTSTRAP_WARNING_DEDUPE_LIMIT) {
-      const oldest = seenBootstrapWarnings.values().next().value;
-      if (typeof oldest === "string") {
-        seenBootstrapWarnings.delete(oldest);
-      }
     }
     params.warn?.(`${message} (sessionKey=${params.sessionLabel})`);
   };

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -44,6 +44,12 @@ function rememberBootstrapWarning(key: string): boolean {
   return true;
 }
 
+/** @internal Reset the bootstrap warning cache. Exported for tests only. */
+export function _resetBootstrapWarningCacheForTest(): void {
+  seenBootstrapWarnings.clear();
+  bootstrapWarningOrder.length = 0;
+}
+
 export function resolveContextInjectionMode(config?: OpenClawConfig): AgentContextInjection {
   return config?.agents?.defaults?.contextInjection ?? "always";
 }
@@ -121,13 +127,14 @@ export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<bo
 
 export function makeBootstrapWarn(params: {
   sessionLabel: string;
+  workspaceDir?: string;
   warn?: (message: string) => void;
 }): ((message: string) => void) | undefined {
   if (!params.warn) {
     return undefined;
   }
   return (message: string) => {
-    const key = `${params.sessionLabel}\u0000${message}`;
+    const key = `${params.workspaceDir ?? ""}\u0000${params.sessionLabel}\u0000${message}`;
     if (!rememberBootstrapWarning(key)) {
       return;
     }

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -44,7 +44,6 @@ function rememberBootstrapWarning(key: string): boolean {
   return true;
 }
 
-/** @internal Reset the bootstrap warning cache. Exported for tests only. */
 export function _resetBootstrapWarningCacheForTest(): void {
   seenBootstrapWarnings.clear();
   bootstrapWarningOrder.length = 0;
@@ -130,15 +129,17 @@ export function makeBootstrapWarn(params: {
   workspaceDir?: string;
   warn?: (message: string) => void;
 }): ((message: string) => void) | undefined {
-  if (!params.warn) {
+  const warn = params.warn;
+  if (!warn) {
     return undefined;
   }
+  const workspacePrefix = params.workspaceDir ?? "";
   return (message: string) => {
-    const key = `${params.workspaceDir ?? ""}\u0000${params.sessionLabel}\u0000${message}`;
+    const key = `${workspacePrefix}\u0000${params.sessionLabel}\u0000${message}`;
     if (!rememberBootstrapWarning(key)) {
       return;
     }
-    params.warn?.(`${message} (sessionKey=${params.sessionLabel})`);
+    warn(`${message} (sessionKey=${params.sessionLabel})`);
   };
 }
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -25,6 +25,8 @@ export type BootstrapContextRunKind = "default" | "heartbeat" | "cron";
 const CONTINUATION_SCAN_MAX_TAIL_BYTES = 256 * 1024;
 const CONTINUATION_SCAN_MAX_RECORDS = 500;
 export const FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE = "openclaw:bootstrap-context:full";
+const BOOTSTRAP_WARNING_DEDUPE_LIMIT = 1024;
+const seenBootstrapWarnings = new Set<string>();
 
 export function resolveContextInjectionMode(config?: OpenClawConfig): AgentContextInjection {
   return config?.agents?.defaults?.contextInjection ?? "always";
@@ -108,7 +110,20 @@ export function makeBootstrapWarn(params: {
   if (!params.warn) {
     return undefined;
   }
-  return (message: string) => params.warn?.(`${message} (sessionKey=${params.sessionLabel})`);
+  return (message: string) => {
+    const key = `${params.sessionLabel}\u0000${message}`;
+    if (seenBootstrapWarnings.has(key)) {
+      return;
+    }
+    seenBootstrapWarnings.add(key);
+    if (seenBootstrapWarnings.size > BOOTSTRAP_WARNING_DEDUPE_LIMIT) {
+      const oldest = seenBootstrapWarnings.values().next().value;
+      if (typeof oldest === "string") {
+        seenBootstrapWarnings.delete(oldest);
+      }
+    }
+    params.warn?.(`${message} (sessionKey=${params.sessionLabel})`);
+  };
 }
 
 function sanitizeBootstrapFiles(

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -91,6 +91,7 @@ export async function prepareCliRunContext(
     sessionId: params.sessionId,
     warn: prepareDeps.makeBootstrapWarn({
       sessionLabel,
+      workspaceDir,
       warn: (message) => cliBackendLog.warn(message),
     }),
   });

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -465,6 +465,7 @@ export async function compactEmbeddedPiSessionDirect(
       sessionId: params.sessionId,
       warn: makeBootstrapWarn({
         sessionLabel,
+        workspaceDir: effectiveWorkspace,
         warn: (message) => log.warn(message),
       }),
     });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -464,7 +464,11 @@ export async function runEmbeddedAttempt(
           config: params.config,
           sessionKey: params.sessionKey,
           sessionId: params.sessionId,
-          warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+          warn: makeBootstrapWarn({
+            sessionLabel,
+            workspaceDir: effectiveWorkspace,
+            warn: (message) => log.warn(message),
+          }),
           contextMode: params.bootstrapContextMode,
           runKind: params.bootstrapContextRunKind,
         }),


### PR DESCRIPTION
## Summary

- Problem: repeated embedded-agent bootstrap attempts can emit the same workspace bootstrap truncation warning over and over for the same session.
- Why it matters: retry loops can flood `gateway:watch` with identical truncation warnings, which makes real bootstrap failures and other startup events harder to spot.
- What changed: `makeBootstrapWarn` now deduplicates repeated warnings by session key plus message using a bounded cache.
- What did NOT change (scope boundary): this does not change bootstrap truncation behavior, injected content, or bootstrap file selection; it only fixes repeated warning emission.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the bootstrap warning wrapper appended the session label but did not remember which warnings had already been emitted for that session.
- Missing detection / guardrail: there was no unit test pinning the behavior for repeated truncation warnings in the same session.
- Contributing context (if known): oversized `MEMORY.md` files can trigger the same truncation path repeatedly during embedded-agent retries.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/bootstrap-files.test.ts`
- Scenario the test should lock in: identical truncation warnings only emit once per session, while different sessions still emit their own warning.
- Why this is the smallest reliable guardrail: the bug is isolated to the warning wrapper, so a focused unit test catches it without needing a full gateway startup harness.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Repeated identical bootstrap truncation warnings now emit once per session instead of spamming during retries.

## Diagram (if applicable)

```text
Before:
[bootstrap retry] -> [same file still too large] -> [same warning logged again]

After:
[bootstrap retry] -> [same file still too large] -> [duplicate warning suppressed]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: N/A
- Integration/channel (if any): embedded agent bootstrap / `gateway:watch`
- Relevant config (redacted): workspace with oversized `MEMORY.md`

### Steps

1. Start `gateway:watch` with a workspace `MEMORY.md` larger than the bootstrap injection limit.
2. Let the embedded agent retry bootstrap for the same session.
3. Watch the logs.

### Expected

- One truncation warning per session/message combination.

### Actual

- Before this fix, the same truncation warning repeated on each retry for the same session.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused unit coverage plus manual `gateway:watch` verification during repeated bootstrap attempts.
- Edge cases checked: different sessions still emit distinct warnings.
- What you did **not** verify: full end-to-end bootstrap behavior beyond warning emission.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a long-lived process could accumulate too many unique warning keys.
  - Mitigation: the dedupe cache is bounded and evicts the oldest entries.
