### PR TITLE
fix(ui): don't block local attachments before bootstrap roots load

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -586,7 +586,7 @@ describe("handleControlUiHttpRequest", () => {
   it("serves bootstrap config JSON", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        const { res, end } = makeMockHttpResponse();
+        const { res, end, setHeader } = makeMockHttpResponse();
         const handled = await handleControlUiHttpRequest(
           { url: CONTROL_UI_BOOTSTRAP_CONFIG_PATH, method: "GET" } as IncomingMessage,
           res,
@@ -605,6 +605,10 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantAvatar).toBe("/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
         expect(Array.isArray(parsed.localMediaPreviewRoots)).toBe(true);
+        expect(setHeader).toHaveBeenCalledWith(
+          "Cache-Control",
+          "no-store, no-cache, must-revalidate",
+        );
       },
     });
   });
@@ -666,7 +670,7 @@ describe("handleControlUiHttpRequest", () => {
   it("serves bootstrap config JSON under basePath", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
-        const { res, end } = makeMockHttpResponse();
+        const { res, end, setHeader } = makeMockHttpResponse();
         const handled = await handleControlUiHttpRequest(
           { url: `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`, method: "GET" } as IncomingMessage,
           res,
@@ -686,6 +690,10 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantAvatar).toBe("/openclaw/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
         expect(Array.isArray(parsed.localMediaPreviewRoots)).toBe(true);
+        expect(setHeader).toHaveBeenCalledWith(
+          "Cache-Control",
+          "no-store, no-cache, must-revalidate",
+        );
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -169,10 +169,10 @@ function applyControlUiSecurityHeaders(res: ServerResponse) {
   res.setHeader("Referrer-Policy", "no-referrer");
 }
 
-function sendJson(res: ServerResponse, status: number, body: unknown) {
+function sendJson(res: ServerResponse, status: number, body: unknown, cacheControl = "no-cache") {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
-  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Cache-Control", cacheControl);
   res.end(JSON.stringify(body));
 }
 
@@ -784,28 +784,33 @@ export async function handleControlUiHttpRequest(
     if (req.method === "HEAD") {
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
-      res.setHeader("Cache-Control", "no-cache");
+      res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
       res.end();
       return true;
     }
-    sendJson(res, 200, {
-      basePath,
-      assistantName: identity.name,
-      assistantAvatar: avatarValue ?? identity.avatar,
-      assistantAvatarSource: avatarMeta.avatarSource,
-      assistantAvatarStatus: avatarMeta.avatarStatus,
-      assistantAvatarReason: avatarMeta.avatarReason,
-      assistantAgentId: identity.agentId,
-      serverVersion: resolveRuntimeServiceVersion(process.env),
-      localMediaPreviewRoots: [...getAgentScopedMediaLocalRoots(config ?? {}, identity.agentId)],
-      embedSandbox:
-        config?.gateway?.controlUi?.embedSandbox === "trusted"
-          ? "trusted"
-          : config?.gateway?.controlUi?.embedSandbox === "strict"
-            ? "strict"
-            : "scripts",
-      allowExternalEmbedUrls: config?.gateway?.controlUi?.allowExternalEmbedUrls === true,
-    } satisfies ControlUiBootstrapConfig);
+    sendJson(
+      res,
+      200,
+      {
+        basePath,
+        assistantName: identity.name,
+        assistantAvatar: avatarValue ?? identity.avatar,
+        assistantAvatarSource: avatarMeta.avatarSource,
+        assistantAvatarStatus: avatarMeta.avatarStatus,
+        assistantAvatarReason: avatarMeta.avatarReason,
+        assistantAgentId: identity.agentId,
+        serverVersion: resolveRuntimeServiceVersion(process.env),
+        localMediaPreviewRoots: [...getAgentScopedMediaLocalRoots(config ?? {}, identity.agentId)],
+        embedSandbox:
+          config?.gateway?.controlUi?.embedSandbox === "trusted"
+            ? "trusted"
+            : config?.gateway?.controlUi?.embedSandbox === "strict"
+              ? "strict"
+              : "scripts",
+        allowExternalEmbedUrls: config?.gateway?.controlUi?.allowExternalEmbedUrls === true,
+      } satisfies ControlUiBootstrapConfig,
+      "no-store, no-cache, must-revalidate",
+    );
     return true;
   }
 

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -950,6 +950,51 @@ describe("grouped chat rendering", () => {
     vi.unstubAllGlobals();
   });
 
+  it("checks server metadata instead of hard-denying local attachments while preview roots are empty", async () => {
+    resetAssistantAttachmentAvailabilityCacheForTest();
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("meta=1")) {
+        return {
+          ok: true,
+          json: async () => ({ available: true }),
+        };
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const container = document.createElement("div");
+    const renderMessage = () =>
+      renderAssistantMessage(
+        container,
+        {
+          id: "assistant-local-media-empty-roots",
+          role: "assistant",
+          content: "Local image\nMEDIA:/tmp/openclaw/test image.png",
+          timestamp: Date.now(),
+        },
+        {
+          showToolCalls: false,
+          basePath: "/openclaw",
+          localMediaPreviewRoots: [],
+          onRequestUpdate: renderMessage,
+        },
+      );
+
+    renderMessage();
+
+    expect(container.textContent).toContain("Checking...");
+    expect(container.textContent).not.toContain("Outside allowed folders");
+    await flushAssistantAttachmentAvailabilityChecks();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest+image.png&meta=1",
+      expect.objectContaining({ credentials: "same-origin", method: "GET" }),
+    );
+    expect(container.querySelector(".chat-message-image")).not.toBeNull();
+    expect(container.textContent).not.toContain("Outside allowed folders");
+    vi.unstubAllGlobals();
+  });
+
   it("rechecks local assistant attachment availability when the auth token changes", async () => {
     resetAssistantAttachmentAvailabilityCacheForTest();
     const fetchMock = vi.fn(async (url: string) => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -966,7 +966,13 @@ function resolveAssistantAttachmentAvailability(
   if (!isLocalAssistantAttachmentSource(source)) {
     return { status: "available" };
   }
-  if (!isLocalAttachmentPreviewAllowed(source, localMediaPreviewRoots)) {
+  if (
+    // When roots are empty, bootstrap config hasn't loaded yet; fall through to the
+    // authoritative server-side meta check rather than hard-denying. If the server
+    // genuinely has no roots configured, the meta endpoint will deny correctly.
+    localMediaPreviewRoots.length > 0 &&
+    !isLocalAttachmentPreviewAllowed(source, localMediaPreviewRoots)
+  ) {
     return { status: "unavailable", reason: "Outside allowed folders", checkedAt: Date.now() };
   }
   const normalizedAuthToken = authToken?.trim() ?? "";

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -42,7 +42,7 @@ describe("loadControlUiBootstrapConfig", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
-      expect.objectContaining({ method: "GET" }),
+      expect.objectContaining({ method: "GET", cache: "no-store" }),
     );
     expect(state.assistantName).toBe("Ops");
     expect(state.assistantAvatar).toBe("O");
@@ -212,7 +212,7 @@ describe("loadControlUiBootstrapConfig", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
-      expect.objectContaining({ method: "GET" }),
+      expect.objectContaining({ method: "GET", cache: "no-store" }),
     );
     expect(state.assistantName).toBe("Assistant");
     expect(state.embedSandboxMode).toBe("scripts");
@@ -240,7 +240,7 @@ describe("loadControlUiBootstrapConfig", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
-      expect.objectContaining({ method: "GET" }),
+      expect.objectContaining({ method: "GET", cache: "no-store" }),
     );
 
     vi.unstubAllGlobals();

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -85,7 +85,12 @@ export async function loadControlUiBootstrapConfig(
       if (candidate) {
         headers.Authorization = `Bearer ${candidate}`;
       }
-      res = await fetch(url, { method: "GET", headers, credentials: "same-origin" });
+      res = await fetch(url, {
+        method: "GET",
+        headers,
+        credentials: "same-origin",
+        cache: "no-store",
+      });
       if (res.ok) {
         break;
       }


### PR DESCRIPTION
## Summary

- Problem: Local assistant media attachments (TTS audio, images, documents via `MEDIA:` lines) render as "Unavailable — Outside allowed folders" in Control UI even when the server config and meta endpoint confirm the path is valid.
- Why it matters: Users cannot play, preview, or download assistant-generated local media in the webchat UI — the primary interactive surface.
- What changed: Skip the client-side allowed-folder gate when `localMediaPreviewRoots` is empty (not yet loaded from bootstrap), falling through to the authoritative server-side meta check. Also harden bootstrap config caching on both client and server.
- What did NOT change (scope boundary): The `isLocalAttachmentPreviewAllowed` logic itself is untouched — it still blocks paths outside configured roots once roots are populated. The `sendJson` helper's default `Cache-Control` for other endpoints (`no-cache`) is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67915
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveAssistantAttachmentAvailability()` in `ui/src/ui/chat/grouped-render.ts` calls `isLocalAttachmentPreviewAllowed(source, localMediaPreviewRoots)` as a hard gate before the server-side meta check. When `localMediaPreviewRoots` is `[]` (bootstrap config fetch not yet complete), every local path fails this check and returns `{ status: "unavailable", reason: "Outside allowed folders" }` without ever reaching the server.
- Missing detection / guardrail: No test covers the case where roots are empty (bootstrap still loading) and a valid local attachment is checked. The existing "blocked" test correctly provides non-empty roots with a path outside them.
- Contributing context (if known): The bootstrap config fetch is async and completes after first render. The allowed-folder check was designed as a client-side optimisation to avoid unnecessary server round-trips, but didn't account for the empty-roots bootstrap window.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/chat.test.ts`
- Scenario the test should lock in: A local `MEDIA:` attachment checked against an empty `localMediaPreviewRoots` array should fall through to the server meta check (status `"checking"`), not hard-deny as `"Outside allowed folders"`.
- Why this is the smallest reliable guardrail: The render-level test already exercises `resolveAssistantAttachmentAvailability` through the full render path and can assert the absence of "Outside allowed folders" when roots are empty.
- Existing test that already covers this (if any): The existing "blocks local attachments outside preview roots" test covers the populated-roots case. No existing test covers the empty-roots case.
- If no new test is added, why not: Vitest execution is blocked in the current CI-adjacent pod environment by `Error: No such built-in module: node:` (Node v24 + Vitest environment incompatibility). The test scenario is documented above for addition once the environment issue is resolved or in CI.

## User-visible / Behavior Changes

- Local assistant attachments that previously appeared as "Unavailable — Outside allowed folders" on page load will now show as "Checking..." briefly, then render correctly once the server-side meta check completes.
- No config or API changes. No new environment variables.

## Diagram (if applicable)

```text
Before:
[page load] -> [attachments render] -> [roots=[]] -> isLocalAttachmentPreviewAllowed() -> false -> "Outside allowed folders" (STUCK)

After:
[page load] -> [attachments render] -> [roots=[]] -> skip client gate -> server meta check -> "available" ✓
                                        [bootstrap loads roots] -> future checks use client gate normally
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No new calls. When roots are empty, attachments that previously hard-denied now fall through to the existing `assistant-media?meta=1` server endpoint, which performs the authoritative access check server-side. This is the same endpoint used for all other attachment availability checks.
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Debian 12 (bookworm) / Linux 6.12.0 (OpenShift pod)
- Runtime/container: Node v24.14.0, OpenClaw 2026.4.12–2026.4.16
- Model/provider: Any (bug is in UI rendering path)
- Integration/channel (if any): Control UI webchat
- Relevant config (redacted): Default config with TTS enabled producing local media under `~/.openclaw/media/outbound/`

### Steps

1. Run OpenClaw with Control UI and TTS enabled.
2. Trigger an assistant response that includes a `MEDIA:/path/to/local/file.mp3` line.
3. Observe the attachment card in webchat on initial page load.

### Expected

- Attachment renders as playable audio with player controls and download link.

### Actual

- Attachment renders as "Unavailable — Outside allowed folders" with a blocked status card, despite the server confirming `{"available": true}`.

## Evidence

- [x] Trace/log snippets

Server-side verification (all return expected results):
```
GET /__openclaw__/assistant-media?source=/home/node/.openclaw/media/outbound/8ad46428-7c81-412e-9df8-e1dbab658b57.mp3&meta=1
→ 200 {"available":true}

GET /__openclaw__/assistant-media?source=/home/node/.openclaw/media/outbound/8ad46428-7c81-412e-9df8-e1dbab658b57.mp3
→ 200 audio/mpeg

GET /__openclaw__/control-ui-config.json
→ 200 { "localMediaPreviewRoots": ["/home/node/.openclaw/media", ...] }
```

UI shows "Unavailable — Outside allowed folders" because the bootstrap config hadn't loaded when the attachment first rendered.

## Human Verification (required)

- Verified scenarios: Traced the full code path from `resolveAssistantAttachmentAvailability` through `isLocalAttachmentPreviewAllowed` with empty vs populated roots. Confirmed server-side endpoints return correct results. Confirmed the `sendJson` default for other callers is unchanged.
- Edge cases checked: (1) Empty roots skips client gate → falls through to server check. (2) Populated roots with path outside them → still blocks as before. (3) Non-local sources (URLs) → still return `available` immediately. (4) `sendJson` callers other than bootstrap (availability, avatar meta) → unchanged `no-cache` default.
- What you did **not** verify: Full Vitest test suite execution (blocked by Node v24 environment issue in pod). CI should cover this.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: During the bootstrap loading window, attachments now make server-side meta requests instead of being client-side denied. This adds a brief round-trip per local attachment on page load.
  - Mitigation: The meta endpoint is lightweight (JSON response, no file I/O beyond `stat`), the window is sub-second, and this is the same endpoint already used for all attachment checks that pass the client gate. The previous behavior (permanent false denial) is worse than a brief loading state.