### PR TITLE
fix(openai-codex): unify responses API store capability detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
+- OpenAI Codex/Responses: unify native Responses API capability detection so Codex OAuth requests emit the required `store: false` field on the native Responses path. (#67918) Thanks @obviyus.
 
 ## 2026.4.15
 

--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -106,4 +106,21 @@ describe("openai responses payload policy", () => {
 
     expect(payload).not.toHaveProperty("reasoning");
   });
+
+  it("emits store false for native OpenAI Codex responses disable mode", () => {
+    expect(
+      resolveOpenAIResponsesPayloadPolicy(
+        {
+          api: "openai-codex-responses",
+          provider: "openai-codex",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+        },
+        { storeMode: "disable" },
+      ),
+    ).toMatchObject({
+      explicitStore: false,
+      allowsServiceTier: true,
+      shouldStripStore: false,
+    });
+  });
 });

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -1,4 +1,5 @@
 import { readStringValue } from "../shared/string-coerce.js";
+import { isOpenAIResponsesApi } from "./provider-attribution.js";
 import { resolveProviderRequestPolicyConfig } from "./provider-request-config.js";
 
 type OpenAIResponsesPayloadModel = {
@@ -25,12 +26,6 @@ export type OpenAIResponsesPayloadPolicy = {
   shouldStripStore: boolean;
   useServerCompaction: boolean;
 };
-
-const OPENAI_RESPONSES_APIS = new Set([
-  "openai-responses",
-  "azure-openai-responses",
-  "openai-codex-responses",
-]);
 
 function parsePositiveInteger(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value) && value > 0) {
@@ -112,7 +107,7 @@ export function resolveOpenAIResponsesPayloadPolicy(
         : capabilities.allowsResponsesStore
           ? true
           : undefined;
-  const isResponsesApi = typeof model.api === "string" && OPENAI_RESPONSES_APIS.has(model.api);
+  const isResponsesApi = isOpenAIResponsesApi(readStringValue(model.api));
 
   return {
     allowsServiceTier: capabilities.allowsOpenAIServiceTier,

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -957,6 +957,28 @@ describe("provider attribution", () => {
           supportsNativeStreamingUsageCompat: false,
         },
       },
+      {
+        name: "native OpenAI Codex responses",
+        input: {
+          provider: "openai-codex",
+          api: "openai-codex-responses",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          capability: "llm" as const,
+          transport: "stream" as const,
+        },
+        expected: {
+          knownProviderFamily: "openai-family",
+          endpointClass: "openai-codex",
+          isKnownNativeEndpoint: true,
+          allowsOpenAIServiceTier: true,
+          supportsOpenAIReasoningCompatPayload: true,
+          allowsResponsesStore: false,
+          supportsResponsesStoreField: true,
+          shouldStripResponsesPromptCache: false,
+          allowsAnthropicServiceTier: false,
+          supportsNativeStreamingUsageCompat: false,
+        },
+      },
     ];
 
     for (const testCase of cases) {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -124,7 +124,11 @@ const MODELSTUDIO_NATIVE_BASE_URLS = new Set([
   "https://dashscope.aliyuncs.com/compatible-mode/v1",
   "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
 ]);
-const OPENAI_RESPONSES_APIS = new Set(["openai-responses", "azure-openai-responses"]);
+const OPENAI_RESPONSES_APIS = new Set([
+  "openai-responses",
+  "azure-openai-responses",
+  "openai-codex-responses",
+]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
 const MOONSHOT_COMPAT_PROVIDERS = new Set(["moonshot", "kimi"]);
 
@@ -315,6 +319,11 @@ function resolveKnownProviderFamily(provider: string | undefined): string {
     default:
       return provider || "unknown";
   }
+}
+
+export function isOpenAIResponsesApi(api: string | null | undefined): boolean {
+  const normalizedApi = normalizeOptionalLowercaseString(api);
+  return normalizedApi !== undefined && OPENAI_RESPONSES_APIS.has(normalizedApi);
 }
 
 export function resolveProviderAttributionIdentity(
@@ -573,7 +582,7 @@ export function resolveProviderRequestCapabilities(
     compatibilityFamily = "moonshot";
   }
 
-  const isResponsesApi = api !== undefined && OPENAI_RESPONSES_APIS.has(api);
+  const isResponsesApi = isOpenAIResponsesApi(api);
   const promptCacheKeySupport = input.compat?.supportsPromptCacheKey;
   // Default strip behavior (proxy-like endpoints with responses APIs) is
   // preserved as a safety net for providers that reject prompt_cache_key,


### PR DESCRIPTION
Fixes #67740.

Supersedes #67757 and #67762.

This fixes the still-live Codex Responses store-capability regression on `main`.

Root cause: we had two different definitions of what counts as a Responses API. `provider-attribution.ts` excluded `openai-codex-responses`, while `openai-responses-payload-policy.ts` included it. That left native Codex OAuth requests without `supportsResponsesStoreField`, so disable mode omitted the required `store: false`.

This PR unifies that check behind one shared helper and adds the missing regressions:
- native `openai-codex-responses` resolves `supportsResponsesStoreField: true`
- disable mode emits `explicitStore: false`

Verified with:
- `pnpm test src/agents/provider-attribution.test.ts src/agents/openai-responses-payload-policy.test.ts src/agents/pi-embedded-helpers/provider-error-patterns.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`

Not changed:
- no new HTML/DNS error-path logic; the user-facing HTML path is already fixed on `main`
- `pnpm tsgo` is still red on pre-existing unrelated `extensions/qa-lab/src/providers/aimock/server.ts` failures
