### PR TITLE
fix(memory-core): show light-only dreaming state in memory status

### DIFF
--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -111,6 +111,33 @@ describe("resolveIMessageInboundDecision echo detection", () => {
     );
   });
 
+  it("drops reflected assistant metadata even when echo cache misses", () => {
+    const echoHas = vi.fn(() => false);
+    const logVerbose = vi.fn();
+    const reflectedText = [
+      "| col | val |",
+      "| --- | --- |",
+      "| a | 1 |",
+      "assistant to=final",
+    ].join("\n");
+
+    const decision = resolveDecision({
+      message: {
+        id: 43,
+        text: reflectedText,
+      },
+      messageText: reflectedText,
+      bodyText: reflectedText,
+      echoCache: { has: echoHas },
+      logVerbose,
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "reflected assistant content" });
+    expect(logVerbose).toHaveBeenCalledWith(
+      "imessage: dropping reflected assistant content (markers: assistant-role-marker)",
+    );
+  });
+
   it("drops reflected self-chat duplicates after seeing the from-me copy", () => {
     const selfChatCache = createSelfChatCache();
     const createdAt = "2026-03-02T20:58:10.649Z";

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -2,7 +2,11 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
+import {
+  resolveMemoryDeepDreamingConfig,
+  resolveMemoryLightDreamingConfig,
+  resolveMemoryRemDreamingConfig,
+} from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
@@ -211,12 +215,20 @@ async function listWorkspaceDailyFiles(workspaceDir: string, limit: number): Pro
 
 function formatDreamingSummary(cfg: OpenClawConfig): string {
   const pluginConfig = resolveMemoryPluginConfig(cfg);
-  const dreaming = resolveShortTermPromotionDreamingConfig({ pluginConfig, cfg });
-  if (!dreaming.enabled) {
+  const light = resolveMemoryLightDreamingConfig({ pluginConfig, cfg });
+  const deep = resolveMemoryDeepDreamingConfig({ pluginConfig, cfg });
+  if (!light.enabled && !deep.enabled) {
     return "off";
   }
-  const timezone = dreaming.timezone ? ` (${dreaming.timezone})` : "";
-  return `${dreaming.cron}${timezone} · limit=${dreaming.limit} · minScore=${dreaming.minScore} · minRecallCount=${dreaming.minRecallCount} · minUniqueQueries=${dreaming.minUniqueQueries} · recencyHalfLifeDays=${dreaming.recencyHalfLifeDays} · maxAgeDays=${dreaming.maxAgeDays ?? "none"}`;
+  const lightSummary = light.enabled
+    ? `light=on (cron=${light.cron} · lookbackDays=${light.lookbackDays} · limit=${light.limit})`
+    : "light=off";
+  const deepSummary = deep.enabled
+    ? `deep=on (cron=${deep.cron} · limit=${deep.limit} · minScore=${deep.minScore} · minRecallCount=${deep.minRecallCount} · minUniqueQueries=${deep.minUniqueQueries} · recencyHalfLifeDays=${deep.recencyHalfLifeDays} · maxAgeDays=${deep.maxAgeDays ?? "none"})`
+    : "deep=off";
+  const timezone = light.timezone ?? deep.timezone;
+  const timezoneSummary = timezone ? ` · timezone=${timezone}` : "";
+  return `${lightSummary} · ${deepSummary}${timezoneSummary}`;
 }
 
 function formatAuditCounts(audit: ShortTermAuditSummary): string {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -384,6 +384,44 @@ describe("memory cli", () => {
     });
   });
 
+  it("reports light-only dreaming status when deep phase is disabled", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      loadConfig.mockReturnValueOnce({
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "0 3 * * *",
+                  timezone: "America/Sao_Paulo",
+                  phases: {
+                    light: { enabled: true, lookbackDays: 7, limit: 20 },
+                    deep: { enabled: false },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        probeVectorAvailability: vi.fn(async () => true),
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(["status"]);
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("Dreaming: light=on"));
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("deep=off"));
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
   it("repairs invalid recall metadata and stale locks with status --fix", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");


### PR DESCRIPTION
## Summary
- update `memory status` dreaming summary to read both light and deep phase config
- report per-phase state instead of treating deep config as the only source of truth
- include a regression test for light-only configuration (`light=on`, `deep=off`)

## Why
`memory status` currently reports `Dreaming: off` for valid light-only setups because it only reads deep dreaming config.

Fixes #67868

## Testing
- `./node_modules/.bin/vitest extensions/memory-core/src/cli.test.ts -t "reports light-only dreaming status when deep phase is disabled"`
