### PR TITLE
fix(exec): tolerate  inside Python/JS string literals during preflight

### DIFF
--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -78,6 +78,55 @@ describeNonWin("exec script preflight", () => {
     });
   });
 
+  it("does not block python scripts where $VAR appears only inside string literals", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      const pyPath = path.join(tmp, "good.py");
+
+      await fs.writeFile(
+        pyPath,
+        [
+          "def main():",
+          "    '''sim: Execute on Simmer LMSR with $SIM (paper trading)'''",
+          "    cost = 42.50",
+          '    print(f"Total: ${cost:.2f}")',
+          "    help_text = \"Trading venue: 'sim' for $SIM paper trading\"",
+          "main()",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+
+      const result = await tool.execute("call-string-literal", {
+        command: "python good.py",
+        workdir: tmp,
+      });
+      const text = result.content.find((block) => block.type === "text")?.text ?? "";
+      expect(text).not.toMatch(/exec preflight:/);
+    });
+  });
+
+  it("does not block node scripts where $VAR appears only inside string literals", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      const jsPath = path.join(tmp, "good.js");
+
+      await fs.writeFile(
+        jsPath,
+        ['const msg = "Price: $USD";', "console.log(msg);"].join("\n"),
+        "utf-8",
+      );
+
+      const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+
+      const result = await tool.execute("call-js-string-literal", {
+        command: "node good.js",
+        workdir: tmp,
+      });
+      const text = result.content.find((block) => block.type === "text")?.text ?? "";
+      expect(text).not.toMatch(/exec preflight:/);
+    });
+  });
+
   it("blocks obvious shell-as-js output before node execution", async () => {
     await withTempDir("openclaw-exec-preflight-", async (tmp) => {
       const jsPath = path.join(tmp, "bad.js");

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -920,6 +920,67 @@ function shouldFailClosedInterpreterPreflight(command: string): {
   };
 }
 
+function isInsideStringLiteral(content: string, index: number): boolean {
+  let inSingle = false;
+  let inDouble = false;
+  let inTripleSingle = false;
+  let inTripleDouble = false;
+  let i = 0;
+  while (i < index) {
+    const c = content[i];
+    const c2 = content[i + 1] ?? "";
+    const c3 = content[i + 2] ?? "";
+
+    if (inTripleDouble) {
+      if (c === '"' && c2 === '"' && c3 === '"') {
+        inTripleDouble = false;
+        i += 3;
+        continue;
+      }
+    } else if (inTripleSingle) {
+      if (c === "'" && c2 === "'" && c3 === "'") {
+        inTripleSingle = false;
+        i += 3;
+        continue;
+      }
+    } else if (inDouble) {
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === '"') {
+        inDouble = false;
+      }
+    } else if (inSingle) {
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === "'") {
+        inSingle = false;
+      }
+    } else {
+      if (c === "#") {
+        // Skip to end of line (Python/JS-style comment outside strings)
+        const nl = content.indexOf("\n", i);
+        i = nl === -1 ? content.length : nl;
+      } else if (c === '"' && c2 === '"' && c3 === '"') {
+        inTripleDouble = true;
+        i += 2;
+      } else if (c === "'" && c2 === "'" && c3 === "'") {
+        inTripleSingle = true;
+        i += 2;
+      } else if (c === '"') {
+        inDouble = true;
+      } else if (c === "'") {
+        inSingle = true;
+      }
+    }
+    i++;
+  }
+  return inSingle || inDouble || inTripleSingle || inTripleDouble;
+}
+
 async function validateScriptFileForShellBleed(params: {
   command: string;
   workdir: string;
@@ -988,13 +1049,17 @@ async function validateScriptFileForShellBleed(params: {
 
     // Common failure mode: shell env var syntax leaking into Python/JS.
     // We deliberately match all-caps/underscore vars to avoid false positives with `$` as a JS identifier.
-    const envVarRegex = /\$[A-Z_][A-Z0-9_]{1,}/g;
-    const first = envVarRegex.exec(content);
-    if (first) {
-      const idx = first.index;
+    // Skip `$` followed by `{` (f-strings / template literals) and matches inside string literals.
+    const envVarRegex = /\$[A-Z_][A-Z0-9_]{1,}(?!\{)/g;
+    let match: RegExpExecArray | null;
+    while ((match = envVarRegex.exec(content)) !== null) {
+      if (isInsideStringLiteral(content, match.index)) {
+        continue;
+      }
+      const idx = match.index;
       const before = content.slice(0, idx);
       const line = before.split("\n").length;
-      const token = first[0];
+      const token = match[0];
       throw new Error(
         [
           `exec preflight: detected likely shell variable injection (${token}) in ${target.kind} script: ${path.basename(


### PR DESCRIPTION
## Summary

The exec preflight scanner (`security=full`) was incorrectly flagging `$VAR` patterns inside Python and Node.js string literals as shell variable injection. This change adds a string-literal awareness helper so matches that occur inside single, double, or triple quoted strings are ignored, while still catching actual shell variable injection outside of string literals.

## Changes

- Added `isInsideStringLiteral()` helper in `src/agents/bash-tools.exec.ts` that tracks whether a given index falls inside a string literal (handles single quotes, double quotes, triple quotes, and escape sequences).
- Updated the preflight scanner to skip `$VAR` matches that are inside string literals.
- Added regression tests for both Python and Node.js scripts containing `$VAR` in docstrings, f-strings, and regular string literals.

## Test plan

- [x] `pnpm test src/agents/bash-tools.exec.script-preflight.test.ts` passes (55 tests)
- [x] `pnpm tsgo` passes
- [x] `pnpm oxlint` on changed files passes

## Related issue

Fixes #67621
