### PR TITLE
extensions(moonshot): publish real per-token prices in the catalog

### DIFF
--- a/extensions/moonshot/provider-catalog.ts
+++ b/extensions/moonshot/provider-catalog.ts
@@ -9,11 +9,35 @@ export const MOONSHOT_CN_BASE_URL = "https://api.moonshot.cn/v1";
 export const MOONSHOT_DEFAULT_MODEL_ID = "kimi-k2.5";
 const MOONSHOT_DEFAULT_CONTEXT_WINDOW = 262144;
 const MOONSHOT_DEFAULT_MAX_TOKENS = 262144;
-const MOONSHOT_DEFAULT_COST = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
+
+// Per-model costs (USD per token). Sourced from Moonshot's public pricing
+// pages at platform.kimi.ai/docs/pricing/chat-k25 and chat-k2 (retrieved
+// 2026-04-17). `input` is the cache-miss rate (charged when a cached
+// prefix does not exist), `cacheRead` is the cache-hit input rate, and
+// `cacheWrite` is charged at the same rate as `input` (cache writes
+// happen only on the first occurrence of a prefix, so pay the normal
+// input price once, then cache reads at the lower rate thereafter).
+// Moonshot's pricing is quoted per 1M tokens; divide by 1_000_000 to
+// convert to the per-token shape Pi's provider catalog expects.
+const MOONSHOT_K25_COST = {
+  input: 0.6e-6,
+  output: 3.0e-6,
+  cacheRead: 0.1e-6,
+  cacheWrite: 0.6e-6,
+};
+
+const MOONSHOT_K2_THINKING_COST = {
+  input: 0.6e-6,
+  output: 2.5e-6,
+  cacheRead: 0.15e-6,
+  cacheWrite: 0.6e-6,
+};
+
+const MOONSHOT_K2_TURBO_COST = {
+  input: 1.15e-6,
+  output: 8.0e-6,
+  cacheRead: 0.15e-6,
+  cacheWrite: 1.15e-6,
 };
 
 const MOONSHOT_MODEL_CATALOG = [
@@ -22,7 +46,7 @@ const MOONSHOT_MODEL_CATALOG = [
     name: "Kimi K2.5",
     reasoning: false,
     input: ["text", "image"],
-    cost: MOONSHOT_DEFAULT_COST,
+    cost: MOONSHOT_K25_COST,
     contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
     maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
   },
@@ -31,7 +55,7 @@ const MOONSHOT_MODEL_CATALOG = [
     name: "Kimi K2 Thinking",
     reasoning: true,
     input: ["text"],
-    cost: MOONSHOT_DEFAULT_COST,
+    cost: MOONSHOT_K2_THINKING_COST,
     contextWindow: 262144,
     maxTokens: 262144,
   },
@@ -40,7 +64,7 @@ const MOONSHOT_MODEL_CATALOG = [
     name: "Kimi K2 Thinking Turbo",
     reasoning: true,
     input: ["text"],
-    cost: MOONSHOT_DEFAULT_COST,
+    cost: MOONSHOT_K2_TURBO_COST,
     contextWindow: 262144,
     maxTokens: 262144,
   },
@@ -49,7 +73,7 @@ const MOONSHOT_MODEL_CATALOG = [
     name: "Kimi K2 Turbo",
     reasoning: false,
     input: ["text"],
-    cost: MOONSHOT_DEFAULT_COST,
+    cost: MOONSHOT_K2_TURBO_COST,
     contextWindow: 256000,
     maxTokens: 16384,
   },


### PR DESCRIPTION
## What

Replace the zero-default `MOONSHOT_DEFAULT_COST` placeholder in `extensions/moonshot/provider-catalog.ts` with three per-model cost records sourced from Moonshot's public pricing pages ([platform.kimi.ai/docs/pricing/chat-k25](https://platform.kimi.ai/docs/pricing/chat-k25) and [chat-k2](https://platform.kimi.ai/docs/pricing/chat-k2), retrieved 2026-04-17), converted from per-M to per-token:

| Model                  | input (miss) | output   | cacheRead (hit) | cacheWrite |
| ---------------------- | ------------ | -------- | --------------- | ---------- |
| kimi-k2.5              | $0.60/M      | $3.00/M  | $0.10/M         | $0.60/M    |
| kimi-k2-thinking       | $0.60/M      | $2.50/M  | $0.15/M         | $0.60/M    |
| kimi-k2-thinking-turbo | $1.15/M      | $8.00/M  | $0.15/M         | $1.15/M    |
| kimi-k2-turbo          | $1.15/M      | $8.00/M  | $0.15/M         | $1.15/M    |

`cacheWrite` is set to the input (miss) rate since writes pay full price once and subsequent hits bill at `cacheRead`. Moonshot's pricing pages do not explicitly list a cacheWrite value, so this is the conservative default.

## Why

The existing zeros mean any downstream consumer that reads `message.usage.cost.total` from the session log gets `0` on every Moonshot run — same for the OpenAI-compat `usage.cost_usd` response, and for billing layers that sit on top of Pi's per-turn cost. Real numbers flow straight through the existing cost-aggregation plumbing with no API change.

Category A providers (anthropic, openai, google, xai, mistral, openrouter, amazon-bedrock) already publish real catalog prices; this brings Moonshot to parity.

## What changes

- Three named constants (`MOONSHOT_K25_COST`, `MOONSHOT_K2_THINKING_COST`, `MOONSHOT_K2_TURBO_COST`) replace the single zero-default. kimi-k2.5 gets its own record because its output rate ($3.00/M) differs from the k2 family.
- Pinning source + date in a doc comment so the next person to update prices knows where to verify.

## What does NOT change

- No plugin SDK surface.
- No new exports, no schema changes.
- Any consumer that does not read `usage.cost.total` is unaffected.
- Tests in `extensions/moonshot/provider-catalog.test.ts` still pass unchanged.

## Test plan

- [x] `pnpm test extensions/moonshot/provider-catalog.test.ts` — 2/2 passing locally with the new constants.
- [ ] CI `pnpm check` / `pnpm tsgo` / `pnpm test` — please let CI run.

## Provenance

Prices retrieved by fetching the public pricing pages on 2026-04-17 (see file comment block). Moonshot's pricing has been stable since Kimi K2's April 2026 launch but is subject to change; this PR captures a point-in-time snapshot with the source URL inline so future updates are a clean find-and-replace.