### PR TITLE
fix(image): respect configured timeout on MiniMax VLM fallback path

### DIFF
--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -111,6 +111,33 @@ describe("resolveIMessageInboundDecision echo detection", () => {
     );
   });
 
+  it("drops reflected assistant metadata even when echo cache misses", () => {
+    const echoHas = vi.fn(() => false);
+    const logVerbose = vi.fn();
+    const reflectedText = [
+      "| col | val |",
+      "| --- | --- |",
+      "| a | 1 |",
+      "assistant to=final",
+    ].join("\n");
+
+    const decision = resolveDecision({
+      message: {
+        id: 43,
+        text: reflectedText,
+      },
+      messageText: reflectedText,
+      bodyText: reflectedText,
+      echoCache: { has: echoHas },
+      logVerbose,
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "reflected assistant content" });
+    expect(logVerbose).toHaveBeenCalledWith(
+      "imessage: dropping reflected assistant content (markers: assistant-role-marker)",
+    );
+  });
+
   it("drops reflected self-chat duplicates after seeing the from-me copy", () => {
     const selfChatCache = createSelfChatCache();
     const createdAt = "2026-03-02T20:58:10.649Z";

--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -50,6 +50,30 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
   it("drops non-Latin1 characters from apiKey before sending Authorization header", async () => {
     await runNormalizationCase("minimax-\u0417\u2502test-key");
   });
+
+  it("uses caller-provided timeout when set", async () => {
+    const timeoutSignal = new AbortController().signal;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.signal).toBe(timeoutSignal);
+      return new Response(apiResponse, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    await minimaxUnderstandImage({
+      apiKey: "minimax-test-key",
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+      timeoutMs: 180_000,
+    });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(180_000);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
 });
 
 describe("isMinimaxVlmModel", () => {

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -51,6 +51,7 @@ export async function minimaxUnderstandImage(params: {
   imageDataUrl: string;
   apiHost?: string;
   modelBaseUrl?: string;
+  timeoutMs?: number;
 }): Promise<string> {
   const apiKey = normalizeSecretInput(params.apiKey);
   if (!apiKey) {
@@ -73,6 +74,12 @@ export async function minimaxUnderstandImage(params: {
     modelBaseUrl: params.modelBaseUrl,
   });
   const url = new URL("/v1/coding_plan/vlm", host).toString();
+  const timeoutMs =
+    typeof params.timeoutMs === "number" &&
+    Number.isFinite(params.timeoutMs) &&
+    params.timeoutMs > 0
+      ? Math.floor(params.timeoutMs)
+      : 60_000;
 
   // Ensure env-based proxy dispatcher is active before the outbound fetch call.
   // Without this, HTTP_PROXY/HTTPS_PROXY env vars are silently ignored (#51619).
@@ -85,7 +92,7 @@ export async function minimaxUnderstandImage(params: {
       "Content-Type": "application/json",
       "MM-API-Source": "OpenClaw",
     },
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(timeoutMs),
     body: JSON.stringify({
       prompt,
       image_url: imageDataUrl,

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -94,6 +94,7 @@ async function describeImagesWithMinimax(params: {
   modelBaseUrl?: string;
   prompt: string;
   images: Array<{ buffer: Buffer; mime?: string }>;
+  timeoutMs?: number;
 }): Promise<ImagesDescriptionResult> {
   const responses: string[] = [];
   for (const [index, image] of params.images.entries()) {
@@ -106,6 +107,7 @@ async function describeImagesWithMinimax(params: {
       prompt,
       imageDataUrl: `data:${image.mime ?? "image/jpeg"};base64,${image.buffer.toString("base64")}`,
       modelBaseUrl: params.modelBaseUrl,
+      timeoutMs: params.timeoutMs,
     });
     responses.push(params.images.length > 1 ? `Image ${index + 1}:\n${text.trim()}` : text.trim());
   }
@@ -172,6 +174,7 @@ export async function describeImagesWithModel(
       modelBaseUrl: fallback.modelBaseUrl,
       prompt,
       images: params.images,
+      timeoutMs: params.timeoutMs,
     });
   }
 
@@ -182,6 +185,7 @@ export async function describeImagesWithModel(
       modelBaseUrl: model.baseUrl,
       prompt,
       images: params.images,
+      timeoutMs: params.timeoutMs,
     });
   }
 


### PR DESCRIPTION
## Summary
- add optional `timeoutMs` to `minimaxUnderstandImage`
- use configured timeout (with 60s default fallback) instead of always forcing 60s
- pass image-tool timeout through MiniMax VLM fallback path
- add regression test for custom timeout propagation

## Why
The image understanding tool currently ignores configured `tools.media.image.timeoutSeconds` on the MiniMax VLM path due to a hardcoded `AbortSignal.timeout(60_000)`.

Fixes #67889

## Testing
- `./node_modules/.bin/vitest src/agents/minimax-vlm.normalizes-api-key.test.ts src/media-understanding/image.test.ts`
