### PR TITLE
fix(browser): drop redundant --disable-setuid-sandbox flag

### DIFF
--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -112,7 +112,6 @@ export function buildOpenClawChromeLaunchArgs(params: {
   }
   if (resolved.noSandbox) {
     args.push("--no-sandbox");
-    args.push("--disable-setuid-sandbox");
   }
   if (process.platform === "linux") {
     args.push("--disable-dev-shm-usage");


### PR DESCRIPTION
## Summary

- **Problem:** When `browser.noSandbox` is enabled, `buildOpenClawChromeLaunchArgs` pushes both `--no-sandbox` and `--disable-setuid-sandbox`. On modern Chrome (147+) the latter now triggers a persistent yellow banner: *"You are using an unsupported command-line flag: --disable-setuid-sandbox. Stability and security will suffer."* This is visible to users running in headed mode.
- **Why it matters:** `--no-sandbox` already disables all sandboxing, including the setuid helper layer — `--disable-setuid-sandbox` is strictly a subset. The combination is historical and no longer useful.
- **What changed:** Remove the redundant `--disable-setuid-sandbox` push in `extensions/browser/src/browser/chrome.ts`. One-line deletion.
- **What did NOT change:** `--no-sandbox` behavior, config surface, docs that mention both flags (they're accurate for older Chrome; can follow up if desired), container entrypoint (`scripts/sandbox-browser-entrypoint.sh`) which still passes both flags.

## Change Type

- [x] Bug fix
- [x] Refactor required for the fix

## Scope

- [x] Integrations (browser plugin)

## Root Cause

- Root cause: `--disable-setuid-sandbox` was pushed alongside `--no-sandbox` historically; Chrome has since marked it as unsupported and surfaces a warning banner to the user in headed mode.
- Missing detection / guardrail: no automated check against Chrome's unsupported-flags list.
- Contributing context: warning only appears on headed launches, so headless CI didn't catch it.

## Regression Test Plan

- Coverage level: N/A (one-line removal of a redundant flag; behavior under `noSandbox: true` is unchanged — `--no-sandbox` already disables the setuid sandbox). Existing browser launch tests continue to assert the `--no-sandbox` argument.

## Verified locally

Rebuilt and restarted the gateway + browser on a headed Linux install (Chrome 147.0.7680.164 → 147.0.7727.101 after rebuild). Chrome launches successfully, the warning banner is gone, and the CDP endpoint continues to serve `/json/version` with `webSocketDebuggerUrl` as before.