### PR TITLE
fix(plugins): enforce synchronous registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/setup: guard personal-phone and allowlist prompt values so setup fails with clear validation errors instead of crashing on undefined prompt text. (#67895) Thanks @lawrence3699.
 - Models/config: preserve an existing `models.json` provider `baseUrl` during merge-mode regeneration so custom endpoints do not get reset on restart. (#67893) Thanks @lawrence3699.
 - Plugins/discovery: reuse bundled and global plugin discovery results across workspace cache misses so Windows multi-workspace startup stops redoing the shared synchronous scan. (#67940) Thanks @obviyus.
+- Plugins/webhooks: enforce synchronous plugin registration with full rollback of failed plugin side effects, and cache SecretRef-backed webhook auth per route so plugin startup and inbound webhook auth stay deterministic. (#67941) Thanks @obviyus.
 
 ## 2026.4.15
 

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -119,7 +119,7 @@ describe("active-memory plugin", () => {
     runEmbeddedPiAgent.mockResolvedValue({
       payloads: [{ text: "- lemon pepper wings\n- blue cheese" }],
     });
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
   });
 
   afterEach(async () => {
@@ -425,7 +425,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       allowedChatTypes: ["direct", "group"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what wings should we order?", messages: [] },
@@ -513,7 +513,7 @@ describe("active-memory plugin", () => {
         searchMode: "inherit",
       },
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -602,7 +602,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       queryMode: "message",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -630,7 +630,7 @@ describe("active-memory plugin", () => {
       queryMode: "message",
       promptStyle: "preference-only",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -675,7 +675,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       thinking: "medium",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -701,7 +701,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       promptAppend: "Prefer stable long-term preferences over one-off events.",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -730,7 +730,7 @@ describe("active-memory plugin", () => {
       promptOverride: "Custom memory prompt. Return NONE or one user fact.",
       promptAppend: "Extra custom instruction.",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -802,7 +802,7 @@ describe("active-memory plugin", () => {
     api.pluginConfig = {
       agents: ["main"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       { prompt: "what wings should i order? temp transcript", messages: [] },
@@ -828,7 +828,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       modelFallbackPolicy: "resolved-only",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what wings should i order? no fallback", messages: [] },
@@ -851,7 +851,7 @@ describe("active-memory plugin", () => {
       modelFallback: "google/gemini-3-flash",
       modelFallbackPolicy: "default-remote",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       { prompt: "what wings should i order? custom fallback", messages: [] },
@@ -878,7 +878,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       modelFallbackPolicy: "default-remote",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what wings should i order? built-in fallback", messages: [] },
@@ -1027,7 +1027,7 @@ describe("active-memory plugin", () => {
       timeoutMs: 250,
       logging: true,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
     let lastAbortSignal: AbortSignal | undefined;
     runEmbeddedPiAgent.mockImplementation(async (params: { abortSignal?: AbortSignal }) => {
       lastAbortSignal = params.abortSignal;
@@ -1073,7 +1073,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       logging: true,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       { prompt: "what wings should i order? session id cache", messages: [] },
@@ -1107,7 +1107,7 @@ describe("active-memory plugin", () => {
       timeoutMs: 250,
       logging: true,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
     runEmbeddedPiAgent.mockImplementationOnce(async (params: { timeoutMs?: number }) => {
       await new Promise((resolve) => setTimeout(resolve, (params.timeoutMs ?? 0) + 25));
       return {
@@ -1145,7 +1145,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       logging: true,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       { prompt: "what wings should i order? log sanitization", messages: [] },
@@ -1179,7 +1179,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       logging: true,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
     const hugeSession = `agent:main:${"x".repeat(500)}`;
 
     await hooks.before_prompt_build(
@@ -1423,7 +1423,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       queryMode: "message",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -1451,7 +1451,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       queryMode: "full",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -1482,7 +1482,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       queryMode: "recent",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -1536,7 +1536,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       queryMode: "recent",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -1578,7 +1578,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       queryMode: "recent",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -1611,7 +1611,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       queryMode: "recent",
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       {
@@ -1619,8 +1619,7 @@ describe("active-memory plugin", () => {
         messages: [
           {
             role: "user",
-            content:
-              "Active Memory: I really do want you to remember that I prefer aisle seats.",
+            content: "Active Memory: I really do want you to remember that I prefer aisle seats.",
           },
           {
             role: "user",
@@ -1674,7 +1673,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       maxSummaryChars: 40,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
     runEmbeddedPiAgent.mockResolvedValueOnce({
       payloads: [
         {
@@ -1708,7 +1707,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       maxSummaryChars: 90,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     await hooks.before_prompt_build(
       { prompt: "what wings should i order? prompt-count-check", messages: [] },
@@ -1758,7 +1757,7 @@ describe("active-memory plugin", () => {
       transcriptDir: "active-memory-subagents",
       logging: true,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
     const mkdirSpy = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
     const mkdtempSpy = vi.spyOn(fs, "mkdtemp");
     const rmSpy = vi.spyOn(fs, "rm").mockResolvedValue(undefined);
@@ -1802,7 +1801,7 @@ describe("active-memory plugin", () => {
       transcriptDir: "C:/temp/escape",
       logging: true,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
     const mkdirSpy = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
 
     await hooks.before_prompt_build(
@@ -1839,7 +1838,7 @@ describe("active-memory plugin", () => {
       transcriptDir: "active-memory-subagents",
       logging: true,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
     const mkdirSpy = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
 
     await hooks.before_prompt_build(
@@ -1906,7 +1905,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       logging: true,
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     for (let index = 0; index <= 1000; index += 1) {
       await hooks.before_prompt_build(

--- a/extensions/comfy/comfy.live.test.ts
+++ b/extensions/comfy/comfy.live.test.ts
@@ -42,7 +42,7 @@ describeLive("comfy live", () => {
   beforeAll(async () => {
     cfg = withPluginsEnabled(loadConfig());
     agentDir = resolveOpenClawAgentDir();
-    await plugin.register(
+    plugin.register(
       createTestPluginApi({
         config: cfg as never,
         registerImageGenerationProvider(provider) {

--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -92,7 +92,7 @@ function registerPairCommand(params?: {
   pluginConfig?: Record<string, unknown>;
 }): OpenClawPluginCommandDefinition {
   let command: OpenClawPluginCommandDefinition | undefined;
-  void registerDevicePair.register(
+  registerDevicePair.register(
     createApi({
       ...params,
       registerCommand: (nextCommand) => {

--- a/extensions/memory-wiki/cli-metadata.test.ts
+++ b/extensions/memory-wiki/cli-metadata.test.ts
@@ -51,7 +51,7 @@ describe("memory-wiki cli metadata entry", () => {
     const resolvedConfig = { vaultMode: "bridge", vault: { path: "/vault" } };
     mocks.resolveMemoryWikiConfig.mockReturnValue(resolvedConfig);
 
-    await plugin.register(api);
+    plugin.register(api);
 
     const register = registerCli.mock.calls[0]?.[0];
 

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -15,7 +15,7 @@ describe("memory-wiki plugin", () => {
       registerTool,
     } = createPluginApi();
 
-    await plugin.register(api);
+    plugin.register(api);
 
     expect(registerMemoryCorpusSupplement).toHaveBeenCalledTimes(1);
     expect(registerMemoryPromptSupplement).toHaveBeenCalledTimes(1);

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -54,7 +54,7 @@ const _registerOpenAIPlugin = async () =>
 async function registerOpenAIPluginWithHook(params?: { pluginConfig?: Record<string, unknown> }) {
   const on = vi.fn();
   const providers: ProviderPlugin[] = [];
-  await plugin.register(
+  plugin.register(
     createTestPluginApi({
       id: "openai",
       name: "OpenAI Provider",

--- a/extensions/phone-control/index.test.ts
+++ b/extensions/phone-control/index.test.ts
@@ -80,7 +80,7 @@ async function withRegisteredPhoneControl(
     });
 
     let command: OpenClawPluginCommandDefinition | undefined;
-    void registerPhoneControl.register(
+    registerPhoneControl.register(
       createApi({
         stateDir,
         getConfig: () => config,

--- a/extensions/talk-voice/index.test.ts
+++ b/extensions/talk-voice/index.test.ts
@@ -20,7 +20,7 @@ function createHarness(config: Record<string, unknown>) {
       command = definition;
     }),
   };
-  void register.register(api as never);
+  register.register(api as never);
   if (!command) {
     throw new Error("talk-voice command not registered");
   }

--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -40,8 +40,8 @@ describe("thread-ownership plugin", () => {
   });
 
   describe("message_sending", () => {
-    beforeEach(async () => {
-      await register.register(api as unknown as OpenClawPluginApi);
+    beforeEach(() => {
+      register.register(api as unknown as OpenClawPluginApi);
     });
 
     async function sendSlackThreadMessage() {
@@ -112,8 +112,8 @@ describe("thread-ownership plugin", () => {
   });
 
   describe("message_received @-mention tracking", () => {
-    beforeEach(async () => {
-      await register.register(api as unknown as OpenClawPluginApi);
+    beforeEach(() => {
+      register.register(api as unknown as OpenClawPluginApi);
     });
 
     it("tracks @-mentions and skips ownership check for mentioned threads", async () => {

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -37,7 +37,7 @@ type Registered = {
   methods: Map<string, unknown>;
   tools: unknown[];
 };
-type RegisterVoiceCall = (api: Record<string, unknown>) => void | Promise<void>;
+type RegisterVoiceCall = (api: Record<string, unknown>) => void;
 type RegisterCliContext = {
   program: Command;
   config: Record<string, unknown>;
@@ -83,7 +83,7 @@ async function registerVoiceCallCli(program: Command) {
   const { register } = plugin as unknown as {
     register: RegisterVoiceCall;
   };
-  await register({
+  register({
     id: "voice-call",
     name: "Voice Call",
     description: "test",

--- a/extensions/webhooks/index.test.ts
+++ b/extensions/webhooks/index.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
+import type { OpenClawPluginApi } from "./api.js";
+import plugin from "./index.js";
+
+function createApi(params?: {
+  pluginConfig?: OpenClawPluginApi["pluginConfig"];
+  registerHttpRoute?: OpenClawPluginApi["registerHttpRoute"];
+  logger?: OpenClawPluginApi["logger"];
+}): OpenClawPluginApi {
+  return createTestPluginApi({
+    id: "webhooks",
+    name: "Webhooks",
+    source: "test",
+    pluginConfig: params?.pluginConfig ?? {},
+    runtime: {
+      taskFlow: {
+        bindSession: vi.fn(({ sessionKey }: { sessionKey: string }) => ({ sessionKey })),
+      },
+    } as unknown as OpenClawPluginApi["runtime"],
+    registerHttpRoute: params?.registerHttpRoute ?? vi.fn(),
+    logger:
+      params?.logger ??
+      ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      } as OpenClawPluginApi["logger"]),
+  });
+}
+
+describe("webhooks plugin registration", () => {
+  it("registers SecretRef-backed routes synchronously", () => {
+    const registerHttpRoute = vi.fn();
+
+    const result = plugin.register(
+      createApi({
+        pluginConfig: {
+          routes: {
+            zapier: {
+              sessionKey: "agent:main:main",
+              secret: {
+                source: "env",
+                provider: "default",
+                id: "OPENCLAW_WEBHOOK_SECRET",
+              },
+            },
+          },
+        },
+        registerHttpRoute,
+      }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(registerHttpRoute).toHaveBeenCalledTimes(1);
+    expect(registerHttpRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/plugins/webhooks/zapier",
+        auth: "plugin",
+        match: "exact",
+        replaceExisting: true,
+      }),
+    );
+  });
+});

--- a/extensions/webhooks/index.ts
+++ b/extensions/webhooks/index.ts
@@ -2,50 +2,52 @@ import { definePluginEntry, type OpenClawPluginApi } from "./api.js";
 import { resolveWebhooksPluginConfig } from "./src/config.js";
 import { createTaskFlowWebhookRequestHandler, type TaskFlowWebhookTarget } from "./src/http.js";
 
+function registerWebhookRoutes(api: OpenClawPluginApi): void {
+  const routes = resolveWebhooksPluginConfig({
+    pluginConfig: api.pluginConfig,
+  });
+  if (routes.length === 0) {
+    return;
+  }
+
+  const targetsByPath = new Map<string, TaskFlowWebhookTarget[]>();
+  const handler = createTaskFlowWebhookRequestHandler({
+    cfg: api.config,
+    targetsByPath,
+  });
+
+  for (const route of routes) {
+    const taskFlow = api.runtime.taskFlow.bindSession({
+      sessionKey: route.sessionKey,
+    });
+    const target: TaskFlowWebhookTarget = {
+      routeId: route.routeId,
+      path: route.path,
+      secretInput: route.secret,
+      secretConfigPath: `plugins.entries.webhooks.routes.${route.routeId}.secret`,
+      defaultControllerId: route.controllerId,
+      taskFlow,
+    };
+    targetsByPath.set(target.path, [...(targetsByPath.get(target.path) ?? []), target]);
+    api.registerHttpRoute({
+      path: target.path,
+      auth: "plugin",
+      match: "exact",
+      replaceExisting: true,
+      handler,
+    });
+    api.logger.info?.(
+      `[webhooks] registered route ${route.routeId} on ${route.path} for session ${route.sessionKey}`,
+    );
+  }
+}
+
 export default definePluginEntry({
   id: "webhooks",
   name: "Webhooks",
   description:
     "Authenticated inbound webhooks that bind external automation to OpenClaw TaskFlows.",
-  async register(api: OpenClawPluginApi) {
-    const routes = await resolveWebhooksPluginConfig({
-      pluginConfig: api.pluginConfig,
-      cfg: api.config,
-      env: process.env,
-      logger: api.logger,
-    });
-    if (routes.length === 0) {
-      return;
-    }
-
-    const targetsByPath = new Map<string, TaskFlowWebhookTarget[]>();
-    const handler = createTaskFlowWebhookRequestHandler({
-      cfg: api.config,
-      targetsByPath,
-    });
-
-    for (const route of routes) {
-      const taskFlow = api.runtime.taskFlow.bindSession({
-        sessionKey: route.sessionKey,
-      });
-      const target: TaskFlowWebhookTarget = {
-        routeId: route.routeId,
-        path: route.path,
-        secret: route.secret,
-        defaultControllerId: route.controllerId,
-        taskFlow,
-      };
-      targetsByPath.set(target.path, [...(targetsByPath.get(target.path) ?? []), target]);
-      api.registerHttpRoute({
-        path: target.path,
-        auth: "plugin",
-        match: "exact",
-        replaceExisting: true,
-        handler,
-      });
-      api.logger.info?.(
-        `[webhooks] registered route ${route.routeId} on ${route.path} for session ${route.sessionKey}`,
-      );
-    }
+  register(api: OpenClawPluginApi) {
+    registerWebhookRoutes(api);
   },
 });

--- a/extensions/webhooks/runtime-api.ts
+++ b/extensions/webhooks/runtime-api.ts
@@ -4,6 +4,7 @@ export {
   normalizeWebhookPath,
   readJsonWebhookBodyOrReject,
   resolveRequestClientIp,
+  resolveWebhookTargetWithAuthOrReject,
   resolveWebhookTargetWithAuthOrRejectSync,
   withResolvedWebhookRequestPipeline,
   WEBHOOK_IN_FLIGHT_DEFAULTS,

--- a/extensions/webhooks/src/config.test.ts
+++ b/extensions/webhooks/src/config.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../runtime-api.js";
+import { describe, expect, it } from "vitest";
 import { resolveWebhooksPluginConfig } from "./config.js";
 
 describe("resolveWebhooksPluginConfig", () => {
-  it("resolves default paths and SecretRef-backed secrets", async () => {
-    const routes = await resolveWebhooksPluginConfig({
+  it("keeps SecretRef-backed secrets on the route config", () => {
+    const routes = resolveWebhooksPluginConfig({
       pluginConfig: {
         routes: {
           zapier: {
@@ -17,10 +16,6 @@ describe("resolveWebhooksPluginConfig", () => {
           },
         },
       },
-      cfg: {} as OpenClawConfig,
-      env: {
-        OPENCLAW_WEBHOOK_SECRET: "shared-secret",
-      },
     });
 
     expect(routes).toEqual([
@@ -28,16 +23,18 @@ describe("resolveWebhooksPluginConfig", () => {
         routeId: "zapier",
         path: "/plugins/webhooks/zapier",
         sessionKey: "agent:main:main",
-        secret: "shared-secret",
+        secret: {
+          source: "env",
+          provider: "default",
+          id: "OPENCLAW_WEBHOOK_SECRET",
+        },
         controllerId: "webhooks/zapier",
       },
     ]);
   });
 
-  it("skips routes whose secret cannot be resolved", async () => {
-    const warn = vi.fn();
-
-    const routes = await resolveWebhooksPluginConfig({
+  it("keeps routes whose secret needs runtime resolution", () => {
+    const routes = resolveWebhooksPluginConfig({
       pluginConfig: {
         routes: {
           missing: {
@@ -50,19 +47,25 @@ describe("resolveWebhooksPluginConfig", () => {
           },
         },
       },
-      cfg: {} as OpenClawConfig,
-      env: {},
-      logger: { warn } as never,
     });
 
-    expect(routes).toEqual([]);
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("[webhooks] skipping route missing:"),
-    );
+    expect(routes).toEqual([
+      {
+        routeId: "missing",
+        path: "/plugins/webhooks/missing",
+        sessionKey: "agent:main:main",
+        secret: {
+          source: "env",
+          provider: "default",
+          id: "MISSING_SECRET",
+        },
+        controllerId: "webhooks/missing",
+      },
+    ]);
   });
 
-  it("rejects duplicate normalized paths", async () => {
-    await expect(
+  it("rejects duplicate normalized paths", () => {
+    expect(() =>
       resolveWebhooksPluginConfig({
         pluginConfig: {
           routes: {
@@ -78,9 +81,7 @@ describe("resolveWebhooksPluginConfig", () => {
             },
           },
         },
-        cfg: {} as OpenClawConfig,
-        env: {},
       }),
-    ).rejects.toThrow(/conflicts with routes\.first\.path/i);
+    ).toThrow(/conflicts with routes\.first\.path/i);
   });
 });

--- a/extensions/webhooks/src/config.ts
+++ b/extensions/webhooks/src/config.ts
@@ -1,10 +1,5 @@
 import { z } from "zod";
-import type { PluginLogger } from "../api.js";
-import {
-  normalizeWebhookPath,
-  resolveConfiguredSecretInputString,
-  type OpenClawConfig,
-} from "../runtime-api.js";
+import { normalizeWebhookPath } from "../runtime-api.js";
 
 const secretRefSchema = z
   .object({
@@ -33,23 +28,22 @@ const webhooksPluginConfigSchema = z
   })
   .strict();
 
-export type ResolvedWebhookRouteConfig = {
+export type WebhookSecretInput = z.infer<typeof secretInputSchema>;
+
+export type ConfiguredWebhookRouteConfig = {
   routeId: string;
   path: string;
   sessionKey: string;
-  secret: string;
+  secret: WebhookSecretInput;
   controllerId: string;
   description?: string;
 };
 
-export async function resolveWebhooksPluginConfig(params: {
+export function resolveWebhooksPluginConfig(params: {
   pluginConfig: unknown;
-  cfg: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  logger?: PluginLogger;
-}): Promise<ResolvedWebhookRouteConfig[]> {
+}): ConfiguredWebhookRouteConfig[] {
   const parsed = webhooksPluginConfigSchema.parse(params.pluginConfig ?? {});
-  const resolvedRoutes: ResolvedWebhookRouteConfig[] = [];
+  const configuredRoutes: ConfiguredWebhookRouteConfig[] = [];
   const seenPaths = new Map<string, string>();
 
   for (const [routeId, route] of Object.entries(parsed.routes)) {
@@ -64,32 +58,16 @@ export async function resolveWebhooksPluginConfig(params: {
       );
     }
 
-    const secretResolution = await resolveConfiguredSecretInputString({
-      config: params.cfg,
-      env: params.env,
-      value: route.secret,
-      path: `plugins.entries.webhooks.routes.${routeId}.secret`,
-    });
-    const secret = secretResolution.value?.trim();
-    if (!secret) {
-      params.logger?.warn?.(
-        `[webhooks] skipping route ${routeId}: ${
-          secretResolution.unresolvedRefReason ?? "secret is empty or unresolved"
-        }`,
-      );
-      continue;
-    }
-
     seenPaths.set(path, routeId);
-    resolvedRoutes.push({
+    configuredRoutes.push({
       routeId,
       path,
       sessionKey: route.sessionKey,
-      secret,
+      secret: route.secret,
       controllerId: route.controllerId ?? `webhooks/${routeId}`,
       ...(route.description ? { description: route.description } : {}),
     });
   }
 
-  return resolvedRoutes;
+  return configuredRoutes;
 }

--- a/extensions/webhooks/src/http.test.ts
+++ b/extensions/webhooks/src/http.test.ts
@@ -10,10 +10,12 @@ const hoisted = vi.hoisted(() => {
   const sendMessageMock = vi.fn();
   const cancelSessionMock = vi.fn();
   const killSubagentRunAdminMock = vi.fn();
+  const resolveConfiguredSecretInputStringMock = vi.fn();
   return {
     sendMessageMock,
     cancelSessionMock,
     killSubagentRunAdminMock,
+    resolveConfiguredSecretInputStringMock,
   };
 });
 
@@ -30,6 +32,17 @@ vi.mock("../../../src/acp/control-plane/manager.js", () => ({
 vi.mock("../../../src/agents/subagent-control.js", () => ({
   killSubagentRunAdmin: (params: unknown) => hoisted.killSubagentRunAdminMock(params),
 }));
+
+vi.mock("../runtime-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../runtime-api.js")>();
+  hoisted.resolveConfiguredSecretInputStringMock.mockImplementation(
+    actual.resolveConfiguredSecretInputString,
+  );
+  return {
+    ...actual,
+    resolveConfiguredSecretInputString: hoisted.resolveConfiguredSecretInputStringMock,
+  };
+});
 
 type MockIncomingMessage = IncomingMessage & {
   destroyed?: boolean;
@@ -58,7 +71,7 @@ function createJsonRequest(params: {
     return req;
   }) as MockIncomingMessage["destroy"];
 
-  void Promise.resolve().then(() => {
+  setImmediate(() => {
     req.emit("data", Buffer.from(JSON.stringify(params.body), "utf8"));
     req.emit("end");
   });
@@ -93,6 +106,17 @@ function createHandler(): {
     target,
     secret,
   };
+}
+
+function createHandlerWithTarget(
+  target: TaskFlowWebhookTarget,
+  cfg: OpenClawConfig = {} as OpenClawConfig,
+): ReturnType<typeof createTaskFlowWebhookRequestHandler> {
+  const targetsByPath = new Map<string, TaskFlowWebhookTarget[]>([[target.path, [target]]]);
+  return createTaskFlowWebhookRequestHandler({
+    cfg,
+    targetsByPath,
+  });
 }
 
 async function dispatchJsonRequest(params: {
@@ -134,6 +158,47 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     expect(res.statusCode).toBe(401);
     expect(res.body).toBe("unauthorized");
     expect(target.taskFlow.list()).toEqual([]);
+  });
+
+  it("caches SecretRef resolution across requests for the same route", async () => {
+    const runtime = createRuntimeTaskFlow();
+    const target: TaskFlowWebhookTarget = {
+      routeId: "cached",
+      path: "/plugins/webhooks/cached",
+      secretInput: {
+        source: "env",
+        provider: "default",
+        id: "OPENCLAW_WEBHOOK_SECRET",
+      },
+      secretConfigPath: "plugins.entries.webhooks.routes.cached.secret",
+      defaultControllerId: "webhooks/cached",
+      taskFlow: runtime.bindSession({
+        sessionKey: "agent:main:webhook-cached",
+      }),
+    };
+    hoisted.resolveConfiguredSecretInputStringMock.mockResolvedValue({ value: "shared-secret" });
+    const handler = createHandlerWithTarget(target);
+
+    const first = await dispatchJsonRequest({
+      handler,
+      path: target.path,
+      secret: "shared-secret",
+      body: {
+        action: "list_flows",
+      },
+    });
+    const second = await dispatchJsonRequest({
+      handler,
+      path: target.path,
+      secret: "shared-secret",
+      body: {
+        action: "list_flows",
+      },
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(hoisted.resolveConfiguredSecretInputStringMock).toHaveBeenCalledTimes(1);
   });
 
   it("creates flows through the bound session and scrubs owner metadata from responses", async () => {

--- a/extensions/webhooks/src/http.test.ts
+++ b/extensions/webhooks/src/http.test.ts
@@ -69,13 +69,16 @@ function createJsonRequest(params: {
 function createHandler(): {
   handler: ReturnType<typeof createTaskFlowWebhookRequestHandler>;
   target: TaskFlowWebhookTarget;
+  secret: string;
 } {
   const runtime = createRuntimeTaskFlow();
   nextSessionId += 1;
+  const secret = "shared-secret";
   const target: TaskFlowWebhookTarget = {
     routeId: "zapier",
     path: "/plugins/webhooks/zapier",
-    secret: "shared-secret",
+    secretInput: secret,
+    secretConfigPath: "plugins.entries.webhooks.routes.zapier.secret",
     defaultControllerId: "webhooks/zapier",
     taskFlow: runtime.bindSession({
       sessionKey: `agent:main:webhook-test-${String(nextSessionId)}`,
@@ -88,6 +91,7 @@ function createHandler(): {
       targetsByPath,
     }),
     target,
+    secret,
   };
 }
 
@@ -133,11 +137,11 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("creates flows through the bound session and scrubs owner metadata from responses", async () => {
-    const { handler, target } = createHandler();
+    const { handler, target, secret } = createHandler();
     const res = await dispatchJsonRequest({
       handler,
       path: target.path,
-      secret: target.secret,
+      secret,
       body: {
         action: "create_flow",
         goal: "Review inbound queue",
@@ -158,7 +162,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("runs child tasks and scrubs task ownership fields from responses", async () => {
-    const { handler, target } = createHandler();
+    const { handler, target, secret } = createHandler();
     const flow = target.taskFlow.createManaged({
       controllerId: "webhooks/zapier",
       goal: "Triage inbox",
@@ -166,7 +170,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     const res = await dispatchJsonRequest({
       handler,
       path: target.path,
-      secret: target.secret,
+      secret,
       body: {
         action: "run_task",
         flowId: flow.flowId,
@@ -193,11 +197,11 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("returns 404 for missing flow mutations", async () => {
-    const { handler, target } = createHandler();
+    const { handler, target, secret } = createHandler();
     const res = await dispatchJsonRequest({
       handler,
       path: target.path,
-      secret: target.secret,
+      secret,
       body: {
         action: "set_waiting",
         flowId: "flow-missing",
@@ -219,7 +223,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("returns 409 for revision conflicts", async () => {
-    const { handler, target } = createHandler();
+    const { handler, target, secret } = createHandler();
     const flow = target.taskFlow.createManaged({
       controllerId: "webhooks/zapier",
       goal: "Review inbox",
@@ -227,7 +231,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     const res = await dispatchJsonRequest({
       handler,
       path: target.path,
-      secret: target.secret,
+      secret,
       body: {
         action: "set_waiting",
         flowId: flow.flowId,
@@ -252,7 +256,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("rejects internal runtimes and running-only metadata from external callers", async () => {
-    const { handler, target } = createHandler();
+    const { handler, target, secret } = createHandler();
     const flow = target.taskFlow.createManaged({
       controllerId: "webhooks/zapier",
       goal: "Review inbox",
@@ -261,7 +265,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     const runtimeRes = await dispatchJsonRequest({
       handler,
       path: target.path,
-      secret: target.secret,
+      secret,
       body: {
         action: "run_task",
         flowId: flow.flowId,
@@ -278,7 +282,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     const queuedMetadataRes = await dispatchJsonRequest({
       handler,
       path: target.path,
-      secret: target.secret,
+      secret,
       body: {
         action: "run_task",
         flowId: flow.flowId,
@@ -297,7 +301,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("reuses the same task record when retried with the same runId", async () => {
-    const { handler, target } = createHandler();
+    const { handler, target, secret } = createHandler();
     const flow = target.taskFlow.createManaged({
       controllerId: "webhooks/zapier",
       goal: "Triage inbox",
@@ -306,7 +310,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     const first = await dispatchJsonRequest({
       handler,
       path: target.path,
-      secret: target.secret,
+      secret,
       body: {
         action: "run_task",
         flowId: flow.flowId,
@@ -319,7 +323,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     const second = await dispatchJsonRequest({
       handler,
       path: target.path,
-      secret: target.secret,
+      secret,
       body: {
         action: "run_task",
         flowId: flow.flowId,
@@ -339,7 +343,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
   });
 
   it("returns 409 when cancellation targets a terminal flow", async () => {
-    const { handler, target } = createHandler();
+    const { handler, target, secret } = createHandler();
     const flow = target.taskFlow.createManaged({
       controllerId: "webhooks/zapier",
       goal: "Review inbox",
@@ -353,7 +357,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     const res = await dispatchJsonRequest({
       handler,
       path: target.path,
-      secret: target.secret,
+      secret,
       body: {
         action: "cancel_flow",
         flowId: flow.flowId,

--- a/extensions/webhooks/src/http.ts
+++ b/extensions/webhooks/src/http.ts
@@ -8,13 +8,15 @@ import {
   createWebhookInFlightLimiter,
   readJsonWebhookBodyOrReject,
   resolveRequestClientIp,
-  resolveWebhookTargetWithAuthOrRejectSync,
+  resolveConfiguredSecretInputString,
+  resolveWebhookTargetWithAuthOrReject,
   withResolvedWebhookRequestPipeline,
   WEBHOOK_IN_FLIGHT_DEFAULTS,
   WEBHOOK_RATE_LIMIT_DEFAULTS,
   type OpenClawConfig,
   type WebhookInFlightLimiter,
 } from "../runtime-api.js";
+import type { WebhookSecretInput } from "./config.js";
 
 type BoundTaskFlowRuntime = ReturnType<PluginRuntime["taskFlow"]["bindSession"]>;
 
@@ -174,7 +176,8 @@ type WebhookAction = z.infer<typeof webhookActionSchema>;
 export type TaskFlowWebhookTarget = {
   routeId: string;
   path: string;
-  secret: string;
+  secretInput: WebhookSecretInput;
+  secretConfigPath: string;
   defaultControllerId: string;
   taskFlow: BoundTaskFlowRuntime;
 };
@@ -698,11 +701,23 @@ export function createTaskFlowWebhookRequestHandler(params: {
       inFlightLimiter,
       handle: async ({ targets }) => {
         const presentedSecret = extractSharedSecret(req);
-        const target = resolveWebhookTargetWithAuthOrRejectSync({
+        const target = await resolveWebhookTargetWithAuthOrReject({
           targets,
           res,
-          isMatch: (candidate) =>
-            presentedSecret.length > 0 && timingSafeEquals(candidate.secret, presentedSecret),
+          isMatch: async (candidate) => {
+            if (presentedSecret.length === 0) {
+              return false;
+            }
+            const resolvedSecret = await resolveConfiguredSecretInputString({
+              config: params.cfg,
+              env: process.env,
+              value: candidate.secretInput,
+              path: candidate.secretConfigPath,
+            });
+            return Boolean(
+              resolvedSecret.value && timingSafeEquals(resolvedSecret.value, presentedSecret),
+            );
+          },
         });
         if (!target) {
           return true;

--- a/extensions/webhooks/src/http.ts
+++ b/extensions/webhooks/src/http.ts
@@ -667,6 +667,7 @@ export function createTaskFlowWebhookRequestHandler(params: {
   targetsByPath: Map<string, TaskFlowWebhookTarget[]>;
   inFlightLimiter?: WebhookInFlightLimiter;
 }): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
+  const secretByTarget = new WeakMap<TaskFlowWebhookTarget, Promise<string | undefined>>();
   const rateLimiter = createFixedWindowRateLimiter({
     windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
     maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
@@ -678,6 +679,20 @@ export function createTaskFlowWebhookRequestHandler(params: {
       maxInFlightPerKey: WEBHOOK_IN_FLIGHT_DEFAULTS.maxInFlightPerKey,
       maxTrackedKeys: WEBHOOK_IN_FLIGHT_DEFAULTS.maxTrackedKeys,
     });
+  const resolveTargetSecret = (target: TaskFlowWebhookTarget): Promise<string | undefined> => {
+    const cached = secretByTarget.get(target);
+    if (cached) {
+      return cached;
+    }
+    const pending = resolveConfiguredSecretInputString({
+      config: params.cfg,
+      env: process.env,
+      value: target.secretInput,
+      path: target.secretConfigPath,
+    }).then((resolved) => resolved.value);
+    secretByTarget.set(target, pending);
+    return pending;
+  };
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
     return await withResolvedWebhookRequestPipeline({
@@ -708,14 +723,9 @@ export function createTaskFlowWebhookRequestHandler(params: {
             if (presentedSecret.length === 0) {
               return false;
             }
-            const resolvedSecret = await resolveConfiguredSecretInputString({
-              config: params.cfg,
-              env: process.env,
-              value: candidate.secretInput,
-              path: candidate.secretConfigPath,
-            });
+            const resolvedSecret = await resolveTargetSecret(candidate);
             return Boolean(
-              resolvedSecret.value && timingSafeEquals(resolvedSecret.value, presentedSecret),
+              resolvedSecret && timingSafeEquals(resolvedSecret, presentedSecret),
             );
           },
         });

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -396,6 +396,16 @@ export function listContextEngineIds(): string[] {
   return [...getContextEngineRegistryState().engines.keys()];
 }
 
+export function clearContextEnginesForOwner(owner: string): void {
+  const normalizedOwner = requireContextEngineOwner(owner);
+  const registry = getContextEngineRegistryState().engines;
+  for (const [id, entry] of registry.entries()) {
+    if (entry.owner === normalizedOwner) {
+      registry.delete(id);
+    }
+  }
+}
+
 function describeResolvedContextEngineContractError(
   engineId: string,
   engine: unknown,

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -297,7 +297,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
 
     try {
       const captured = createCapturedPluginRegistration();
-      void register(captured.api);
+      register(captured.api);
       record.cliBackendIds.push(...captured.cliBackends.map((entry) => entry.id));
       record.providerIds.push(...captured.providers.map((entry) => entry.id));
       record.speechProviderIds.push(...captured.speechProviders.map((entry) => entry.id));

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -47,28 +47,6 @@ function resolvePluginCliLogger(logger?: PluginLogger): PluginLogger {
   return logger ?? createPluginCliLogger();
 }
 
-function hasIgnoredAsyncPluginRegistration(registry: PluginRegistry): boolean {
-  return (registry.diagnostics ?? []).some(
-    (entry) =>
-      entry.message === "plugin register returned a promise; async registration is ignored",
-  );
-}
-
-function mergeCliRegistrars(params: {
-  runtimeRegistry: PluginRegistry;
-  metadataRegistry: PluginRegistry;
-}): PluginRegistry["cliRegistrars"] {
-  const runtimeCommands = new Set(
-    params.runtimeRegistry.cliRegistrars.flatMap((entry) => entry.commands),
-  );
-  return [
-    ...params.runtimeRegistry.cliRegistrars,
-    ...params.metadataRegistry.cliRegistrars.filter(
-      (entry) => !entry.commands.some((command) => runtimeCommands.has(command)),
-    ),
-  ];
-}
-
 function buildPluginCliLoaderParams(
   context: PluginCliLoadContext,
   params?: { primaryCommand?: string },
@@ -129,48 +107,17 @@ export async function loadPluginCliCommandRegistryWithContext(params: {
   context: PluginCliLoadContext;
   primaryCommand?: string;
   loaderOptions?: PluginCliLoaderOptions;
-  onMetadataFallbackError: (error: unknown) => void;
 }): Promise<PluginCliRegistryLoadResult> {
-  const runtimeRegistry = loadOpenClawPlugins(
-    buildPluginCliLoaderParams(
-      params.context,
-      { primaryCommand: params.primaryCommand },
-      params.loaderOptions,
-    ),
-  );
-
-  if (!hasIgnoredAsyncPluginRegistration(runtimeRegistry)) {
-    return {
-      ...params.context,
-      registry: runtimeRegistry,
-    };
-  }
-
-  try {
-    const metadataRegistry = await loadOpenClawPluginCliRegistry(
+  return {
+    ...params.context,
+    registry: loadOpenClawPlugins(
       buildPluginCliLoaderParams(
         params.context,
         { primaryCommand: params.primaryCommand },
         params.loaderOptions,
       ),
-    );
-    return {
-      ...params.context,
-      registry: {
-        ...runtimeRegistry,
-        cliRegistrars: mergeCliRegistrars({
-          runtimeRegistry,
-          metadataRegistry,
-        }),
-      },
-    };
-  } catch (error) {
-    params.onMetadataFallbackError(error);
-    return {
-      ...params.context,
-      registry: runtimeRegistry,
-    };
-  }
+    ),
+  };
 }
 
 function buildPluginCliCommandGroupEntries(params: {
@@ -192,10 +139,6 @@ function buildPluginCliCommandGroupEntries(params: {
       });
     },
   }));
-}
-
-function logPluginCliMetadataFallbackError(logger: PluginLogger, error: unknown) {
-  logger.warn(`plugin CLI metadata fallback failed: ${String(error)}`);
 }
 
 export async function loadPluginCliDescriptors(
@@ -227,7 +170,6 @@ export async function loadPluginCliRegistrationEntries(params: {
   loaderOptions?: PluginCliLoaderOptions;
   logger?: PluginLogger;
   primaryCommand?: string;
-  onMetadataFallbackError: (error: unknown) => void;
 }): Promise<PluginCliCommandGroupEntry[]> {
   const resolvedLogger = resolvePluginCliLogger(params.logger);
   const context = resolvePluginCliLoadContext({
@@ -239,7 +181,6 @@ export async function loadPluginCliRegistrationEntries(params: {
     context,
     primaryCommand: params.primaryCommand,
     loaderOptions: params.loaderOptions,
-    onMetadataFallbackError: params.onMetadataFallbackError,
   });
   return buildPluginCliCommandGroupEntries({
     registry,
@@ -256,8 +197,5 @@ export async function loadPluginCliRegistrationEntriesWithDefaults(
   return loadPluginCliRegistrationEntries({
     ...params,
     logger,
-    onMetadataFallbackError: (error) => {
-      logPluginCliMetadataFallbackError(logger, error);
-    },
   });
 }

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -81,13 +81,6 @@ function createCliRegistry(params?: {
   };
 }
 
-function createEmptyCliRegistry(params?: { diagnostics?: Array<{ message: string }> }) {
-  return {
-    cliRegistrars: [],
-    diagnostics: params?.diagnostics ?? [],
-  };
-}
-
 function createAutoEnabledCliFixture() {
   const rawConfig = {
     plugins: {},
@@ -308,51 +301,6 @@ describe("registerPluginCliCommands", () => {
       }),
     );
     expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
-  });
-
-  it("falls back to awaited CLI metadata collection when runtime loading ignored async registration", async () => {
-    const asyncRegistrar = vi.fn(async ({ program }: { program: Command }) => {
-      const asyncCommand = program.command("async-cli").description("Async CLI");
-      asyncCommand.command("run").action(mocks.memoryListAction);
-    });
-    mocks.loadOpenClawPlugins.mockReturnValue(
-      createEmptyCliRegistry({
-        diagnostics: [
-          {
-            message: "plugin register returned a promise; async registration is ignored",
-          },
-        ],
-      }),
-    );
-    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue({
-      cliRegistrars: [
-        {
-          pluginId: "async-plugin",
-          register: asyncRegistrar,
-          commands: ["async-cli"],
-          descriptors: [
-            {
-              name: "async-cli",
-              description: "Async CLI",
-              hasSubcommands: true,
-            },
-          ],
-          source: "bundled",
-        },
-      ],
-      diagnostics: [],
-    });
-    const program = createProgram();
-    program.exitOverride();
-
-    await registerPluginCliCommands(program, {} as OpenClawConfig, undefined, undefined, {
-      mode: "lazy",
-    });
-
-    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledTimes(1);
-    await program.parseAsync(["async-cli", "run"], { from: "user" });
-    expect(asyncRegistrar).toHaveBeenCalledTimes(1);
-    expect(mocks.memoryListAction).toHaveBeenCalledTimes(1);
   });
 
   it("lazy-registers descriptor-backed plugin commands on first invocation", async () => {

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -549,7 +549,7 @@ module.exports = {
     );
   });
 
-  it("awaits async plugin registration when collecting CLI metadata", async () => {
+  it("rejects async plugin registration when collecting CLI metadata", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "async-cli",
@@ -580,10 +580,11 @@ module.exports = {
       },
     });
 
-    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain("async-cli");
-    expect(
-      registry.diagnostics.some((entry) => entry.message.includes("async registration is ignored")),
-    ).toBe(false);
+    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).not.toContain("async-cli");
+    const loaded = registry.plugins.find((entry) => entry.id === "async-cli");
+    expect(loaded?.status).toBe("error");
+    expect(loaded?.failurePhase).toBe("register");
+    expect(loaded?.error).toContain("plugin register must be synchronous");
   });
 
   it("applies memory slot gating to non-bundled CLI metadata loads", async () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { listAgentHarnessIds } from "../agents/harness/registry.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import { getContextEngineFactory, listContextEngineIds } from "../context-engine/registry.js";
 import {
   clearInternalHooks,
   createInternalHookEvent,
@@ -14,6 +15,10 @@ import { withEnv } from "../test-utils/env.js";
 import { clearPluginCommands, getPluginCommandSpecs } from "./command-registry-state.js";
 import { getGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
 import { createHookRunner } from "./hooks.js";
+import {
+  clearPluginInteractiveHandlers,
+  resolvePluginInteractiveNamespaceMatch,
+} from "./interactive-registry.js";
 import {
   __testing,
   clearPluginLoaderCache,
@@ -1770,7 +1775,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
     clearInternalHooks();
   });
 
-  it("rolls back global hook and command side effects when registration fails", async () => {
+  it("rolls back global side effects when registration fails", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "failing-side-effects",
@@ -1790,6 +1795,16 @@ module.exports = { id: "throws-after-import", register() {} };`,
             description: "Fail me",
             handler: async () => ({ text: "nope" }),
           });
+          api.registerInteractiveHandler({
+            channel: "slack",
+            namespace: "failme",
+            handle: async () => ({ handled: true }),
+          });
+          api.registerContextEngine("failme-context", () => ({
+            info: { id: "failme-context", name: "Failme Context" },
+            ingest: async () => {},
+            assemble: async () => ({ messages: [] }),
+          }));
           throw new Error("boom");
         },
       };`,
@@ -1797,6 +1812,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
 
     clearInternalHooks();
     clearPluginCommands();
+    clearPluginInteractiveHandlers();
 
     const registry = loadOpenClawPlugins({
       cache: false,
@@ -1815,6 +1831,9 @@ module.exports = { id: "throws-after-import", register() {} };`,
     );
     expect(getRegisteredEventKeys()).toEqual([]);
     expect(getPluginCommandSpecs()).toEqual([]);
+    expect(resolvePluginInteractiveNamespaceMatch("slack", "failme:payload")).toBeNull();
+    expect(getContextEngineFactory("failme-context")).toBeUndefined();
+    expect(listContextEngineIds()).not.toContain("failme-context");
 
     const event = createInternalHookEvent("gateway", "startup", "gateway:startup");
     await triggerInternalHook(event);
@@ -1822,6 +1841,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
 
     clearInternalHooks();
     clearPluginCommands();
+    clearPluginInteractiveHandlers();
   });
 
   it("can scope bundled provider loads to deepseek without hanging", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1770,6 +1770,60 @@ module.exports = { id: "throws-after-import", register() {} };`,
     clearInternalHooks();
   });
 
+  it("rolls back global hook and command side effects when registration fails", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "failing-side-effects",
+      filename: "failing-side-effects.cjs",
+      body: `module.exports = {
+        id: "failing-side-effects",
+        register(api) {
+          api.registerHook(
+            "gateway:startup",
+            (event) => {
+              event.messages.push("should-not-run");
+            },
+            { name: "failing-side-effects-hook" },
+          );
+          api.registerCommand({
+            name: "failme",
+            description: "Fail me",
+            handler: async () => ({ text: "nope" }),
+          });
+          throw new Error("boom");
+        },
+      };`,
+    });
+
+    clearInternalHooks();
+    clearPluginCommands();
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["failing-side-effects"],
+        },
+      },
+      onlyPluginIds: ["failing-side-effects"],
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "failing-side-effects")?.status).toBe(
+      "error",
+    );
+    expect(getRegisteredEventKeys()).toEqual([]);
+    expect(getPluginCommandSpecs()).toEqual([]);
+
+    const event = createInternalHookEvent("gateway", "startup", "gateway:startup");
+    await triggerInternalHook(event);
+    expect(event.messages).toEqual([]);
+
+    clearInternalHooks();
+    clearPluginCommands();
+  });
+
   it("can scope bundled provider loads to deepseek without hanging", () => {
     const scoped = loadOpenClawPlugins({
       cache: false,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1160,6 +1160,39 @@ describe("loadOpenClawPlugins", () => {
       },
     },
     {
+      label: "rejects async register functions instead of silently loading them",
+      run: () => {
+        useNoBundledPlugins();
+        const plugin = writePlugin({
+          id: "async-register",
+          filename: "async-register.cjs",
+          body: `module.exports = {
+  id: "async-register",
+  async register(api) {
+    await Promise.resolve();
+    api.registerGatewayMethod("async-register.ping", ({ respond }) => respond(true, { ok: true }));
+  },
+};`,
+        });
+
+        const registry = loadOpenClawPlugins({
+          cache: false,
+          config: {
+            plugins: {
+              load: { paths: [plugin.file] },
+              allow: ["async-register"],
+            },
+          },
+        });
+
+        const loaded = registry.plugins.find((entry) => entry.id === "async-register");
+        expect(loaded?.status).toBe("error");
+        expect(loaded?.failurePhase).toBe("register");
+        expect(loaded?.error).toContain("plugin register must be synchronous");
+        expect(Object.keys(registry.gatewayHandlers)).not.toContain("async-register.ping");
+      },
+    },
+    {
       label: "limits imports to the requested plugin ids",
       run: () => {
         useNoBundledPlugins();

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1795,6 +1795,18 @@ module.exports = { id: "throws-after-import", register() {} };`,
             description: "Fail me",
             handler: async () => ({ text: "nope" }),
           });
+          api.registerReload({
+            onConfigReload: async () => {},
+          });
+          api.registerNodeHostCommand({
+            command: "failme",
+            description: "failme",
+            run: async () => ({ ok: true }),
+          });
+          api.registerSecurityAuditCollector({
+            id: "failme",
+            collect: async () => [],
+          });
           api.registerInteractiveHandler({
             channel: "slack",
             namespace: "failme",
@@ -1831,6 +1843,9 @@ module.exports = { id: "throws-after-import", register() {} };`,
     );
     expect(getRegisteredEventKeys()).toEqual([]);
     expect(getPluginCommandSpecs()).toEqual([]);
+    expect(registry.reloads).toEqual([]);
+    expect(registry.nodeHostCommands).toEqual([]);
+    expect(registry.securityAuditCollectors).toEqual([]);
     expect(resolvePluginInteractiveNamespaceMatch("slack", "failme:payload")).toBeNull();
     expect(getContextEngineFactory("failme-context")).toBeUndefined();
     expect(listContextEngineIds()).not.toContain("failme-context");

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -98,7 +98,12 @@ import {
   shouldPreferNativeJiti,
 } from "./sdk-alias.js";
 import { hasKind, kindsEqual } from "./slots.js";
-import type { OpenClawPluginDefinition, OpenClawPluginModule, PluginLogger } from "./types.js";
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginDefinition,
+  OpenClawPluginModule,
+  PluginLogger,
+} from "./types.js";
 
 export type PluginLoadResult = PluginRegistry;
 
@@ -247,6 +252,162 @@ function profilePluginLoaderSync<T>(params: {
     console.error(
       `[plugin-load-profile] phase=${params.phase} plugin=${params.pluginId ?? "(core)"} elapsedMs=${elapsedMs.toFixed(1)} source=${params.source}`,
     );
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
+type PluginRegistrySnapshot = {
+  arrays: {
+    tools: PluginRegistry["tools"];
+    hooks: PluginRegistry["hooks"];
+    typedHooks: PluginRegistry["typedHooks"];
+    channels: PluginRegistry["channels"];
+    channelSetups: PluginRegistry["channelSetups"];
+    providers: PluginRegistry["providers"];
+    cliBackends: NonNullable<PluginRegistry["cliBackends"]>;
+    textTransforms: PluginRegistry["textTransforms"];
+    speechProviders: PluginRegistry["speechProviders"];
+    realtimeTranscriptionProviders: PluginRegistry["realtimeTranscriptionProviders"];
+    realtimeVoiceProviders: PluginRegistry["realtimeVoiceProviders"];
+    mediaUnderstandingProviders: PluginRegistry["mediaUnderstandingProviders"];
+    imageGenerationProviders: PluginRegistry["imageGenerationProviders"];
+    videoGenerationProviders: PluginRegistry["videoGenerationProviders"];
+    musicGenerationProviders: PluginRegistry["musicGenerationProviders"];
+    webFetchProviders: PluginRegistry["webFetchProviders"];
+    webSearchProviders: PluginRegistry["webSearchProviders"];
+    memoryEmbeddingProviders: PluginRegistry["memoryEmbeddingProviders"];
+    agentHarnesses: PluginRegistry["agentHarnesses"];
+    httpRoutes: PluginRegistry["httpRoutes"];
+    cliRegistrars: PluginRegistry["cliRegistrars"];
+    reloads: NonNullable<PluginRegistry["reloads"]>;
+    nodeHostCommands: NonNullable<PluginRegistry["nodeHostCommands"]>;
+    securityAuditCollectors: NonNullable<PluginRegistry["securityAuditCollectors"]>;
+    services: PluginRegistry["services"];
+    commands: PluginRegistry["commands"];
+    conversationBindingResolvedHandlers: PluginRegistry["conversationBindingResolvedHandlers"];
+    diagnostics: PluginRegistry["diagnostics"];
+  };
+  gatewayHandlers: PluginRegistry["gatewayHandlers"];
+  gatewayMethodScopes: NonNullable<PluginRegistry["gatewayMethodScopes"]>;
+};
+
+function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistrySnapshot {
+  return {
+    arrays: {
+      tools: [...registry.tools],
+      hooks: [...registry.hooks],
+      typedHooks: [...registry.typedHooks],
+      channels: [...registry.channels],
+      channelSetups: [...registry.channelSetups],
+      providers: [...registry.providers],
+      cliBackends: [...(registry.cliBackends ?? [])],
+      textTransforms: [...registry.textTransforms],
+      speechProviders: [...registry.speechProviders],
+      realtimeTranscriptionProviders: [...registry.realtimeTranscriptionProviders],
+      realtimeVoiceProviders: [...registry.realtimeVoiceProviders],
+      mediaUnderstandingProviders: [...registry.mediaUnderstandingProviders],
+      imageGenerationProviders: [...registry.imageGenerationProviders],
+      videoGenerationProviders: [...registry.videoGenerationProviders],
+      musicGenerationProviders: [...registry.musicGenerationProviders],
+      webFetchProviders: [...registry.webFetchProviders],
+      webSearchProviders: [...registry.webSearchProviders],
+      memoryEmbeddingProviders: [...registry.memoryEmbeddingProviders],
+      agentHarnesses: [...registry.agentHarnesses],
+      httpRoutes: [...registry.httpRoutes],
+      cliRegistrars: [...registry.cliRegistrars],
+      reloads: [...(registry.reloads ?? [])],
+      nodeHostCommands: [...(registry.nodeHostCommands ?? [])],
+      securityAuditCollectors: [...(registry.securityAuditCollectors ?? [])],
+      services: [...registry.services],
+      commands: [...registry.commands],
+      conversationBindingResolvedHandlers: [...registry.conversationBindingResolvedHandlers],
+      diagnostics: [...registry.diagnostics],
+    },
+    gatewayHandlers: { ...registry.gatewayHandlers },
+    gatewayMethodScopes: { ...registry.gatewayMethodScopes },
+  };
+}
+
+function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistrySnapshot): void {
+  registry.tools = snapshot.arrays.tools;
+  registry.hooks = snapshot.arrays.hooks;
+  registry.typedHooks = snapshot.arrays.typedHooks;
+  registry.channels = snapshot.arrays.channels;
+  registry.channelSetups = snapshot.arrays.channelSetups;
+  registry.providers = snapshot.arrays.providers;
+  registry.cliBackends = snapshot.arrays.cliBackends;
+  registry.textTransforms = snapshot.arrays.textTransforms;
+  registry.speechProviders = snapshot.arrays.speechProviders;
+  registry.realtimeTranscriptionProviders = snapshot.arrays.realtimeTranscriptionProviders;
+  registry.realtimeVoiceProviders = snapshot.arrays.realtimeVoiceProviders;
+  registry.mediaUnderstandingProviders = snapshot.arrays.mediaUnderstandingProviders;
+  registry.imageGenerationProviders = snapshot.arrays.imageGenerationProviders;
+  registry.videoGenerationProviders = snapshot.arrays.videoGenerationProviders;
+  registry.musicGenerationProviders = snapshot.arrays.musicGenerationProviders;
+  registry.webFetchProviders = snapshot.arrays.webFetchProviders;
+  registry.webSearchProviders = snapshot.arrays.webSearchProviders;
+  registry.memoryEmbeddingProviders = snapshot.arrays.memoryEmbeddingProviders;
+  registry.agentHarnesses = snapshot.arrays.agentHarnesses;
+  registry.httpRoutes = snapshot.arrays.httpRoutes;
+  registry.cliRegistrars = snapshot.arrays.cliRegistrars;
+  registry.reloads = snapshot.arrays.reloads;
+  registry.nodeHostCommands = snapshot.arrays.nodeHostCommands;
+  registry.securityAuditCollectors = snapshot.arrays.securityAuditCollectors;
+  registry.services = snapshot.arrays.services;
+  registry.commands = snapshot.arrays.commands;
+  registry.conversationBindingResolvedHandlers =
+    snapshot.arrays.conversationBindingResolvedHandlers;
+  registry.diagnostics = snapshot.arrays.diagnostics;
+  registry.gatewayHandlers = snapshot.gatewayHandlers;
+  registry.gatewayMethodScopes = snapshot.gatewayMethodScopes;
+}
+
+function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {
+  api: OpenClawPluginApi;
+  close: () => void;
+} {
+  let closed = false;
+  return {
+    api: new Proxy(api, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        if (typeof value !== "function") {
+          return value;
+        }
+        return (...args: unknown[]) => {
+          if (closed) {
+            return undefined;
+          }
+          return Reflect.apply(value, target, args);
+        };
+      },
+    }),
+    close: () => {
+      closed = true;
+    },
+  };
+}
+
+function runPluginRegisterSync(
+  register: NonNullable<OpenClawPluginDefinition["register"]>,
+  api: Parameters<NonNullable<OpenClawPluginDefinition["register"]>>[0],
+): void {
+  const guarded = createGuardedPluginRegistrationApi(api);
+  try {
+    const result = register(guarded.api);
+    if (isPromiseLike(result)) {
+      void Promise.resolve(result).catch(() => {});
+      throw new Error("plugin register must be synchronous");
+    }
+  } finally {
+    guarded.close();
   }
 }
 
@@ -2055,17 +2216,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
       const previousMemoryRuntime = getMemoryRuntime();
+      const registrySnapshot = snapshotPluginRegistry(registry);
 
       try {
-        const result = register(api);
-        if (result && typeof result.then === "function") {
-          registry.diagnostics.push({
-            level: "warn",
-            pluginId: record.id,
-            source: record.source,
-            message: "plugin register returned a promise; async registration is ignored",
-          });
-        }
+        runPluginRegisterSync(register, api);
         // Snapshot loads should not replace process-global runtime prompt state.
         if (!shouldActivate) {
           restoreRegisteredAgentHarnesses(previousAgentHarnesses);
@@ -2082,6 +2236,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         registry.plugins.push(record);
         seenIds.set(pluginId, candidate.origin);
       } catch (err) {
+        restorePluginRegistry(registry, registrySnapshot);
         restoreRegisteredAgentHarnesses(previousAgentHarnesses);
         restoreRegisteredCompactionProviders(previousCompactionProviders);
         restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
@@ -2477,11 +2632,13 @@ export async function loadOpenClawPluginCliRegistry(
       },
     });
 
+    const registrySnapshot = snapshotPluginRegistry(registry);
     try {
-      await register(api);
+      runPluginRegisterSync(register, api);
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);
     } catch (err) {
+      restorePluginRegistry(registry, registrySnapshot);
       recordPluginError({
         logger,
         registry,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1562,6 +1562,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     const {
       registry,
       createApi,
+      rollbackPluginGlobalSideEffects,
       registerReload,
       registerNodeHostCommand,
       registerSecurityAuditCollector,
@@ -2236,6 +2237,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         registry.plugins.push(record);
         seenIds.set(pluginId, candidate.origin);
       } catch (err) {
+        rollbackPluginGlobalSideEffects(record.id);
         restorePluginRegistry(registry, registrySnapshot);
         restoreRegisteredAgentHarnesses(previousAgentHarnesses);
         restoreRegisteredCompactionProviders(previousCompactionProviders);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2209,6 +2209,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         hookPolicy: entry?.hooks,
         registrationMode,
       });
+      const registrySnapshot = snapshotPluginRegistry(registry);
       const previousAgentHarnesses = listRegisteredAgentHarnesses();
       const previousCompactionProviders = listRegisteredCompactionProviders();
       const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
@@ -2217,7 +2218,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
       const previousMemoryRuntime = getMemoryRuntime();
-      const registrySnapshot = snapshotPluginRegistry(registry);
 
       try {
         runPluginRegisterSync(register, api);

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -23,6 +23,7 @@ import { resolveUserPath } from "../utils.js";
 import { buildPluginApi } from "./api-builder.js";
 import { normalizeRegisteredChannelPlugin } from "./channel-validation.js";
 import { registerPluginCommand, validatePluginCommandDefinition } from "./command-registration.js";
+import { clearPluginCommandsForPlugin } from "./command-registry-state.js";
 import {
   getRegisteredCompactionProvider,
   registerCompactionProvider,
@@ -173,9 +174,13 @@ const activePluginHookRegistrations = resolveGlobalSingleton<
   Map<string, Array<{ event: string; handler: Parameters<typeof registerInternalHook>[1] }>>
 >(ACTIVE_PLUGIN_HOOK_REGISTRATIONS_KEY, () => new Map());
 
+type HookRegistration = { event: string; handler: Parameters<typeof registerInternalHook>[1] };
+type HookRollbackEntry = { name: string; previousRegistrations: HookRegistration[] };
+
 export function createPluginRegistry(registryParams: PluginRegistryParams) {
   const registry = createEmptyPluginRegistry();
   const coreGatewayMethods = new Set(Object.keys(registryParams.coreGatewayHandlers ?? {}));
+  const pluginHookRollback = new Map<string, HookRollbackEntry[]>();
 
   const pushDiagnostic = (diag: PluginDiagnostic) => {
     registry.diagnostics.push(diag);
@@ -303,6 +308,12 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       nextRegistrations.push({ event, handler });
     }
     activePluginHookRegistrations.set(name, nextRegistrations);
+    const rollbackEntries = pluginHookRollback.get(record.id) ?? [];
+    rollbackEntries.push({
+      name,
+      previousRegistrations: [...previousRegistrations],
+    });
+    pluginHookRollback.set(record.id, rollbackEntries);
   };
 
   const registerGatewayMethod = (
@@ -1413,9 +1424,37 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
+  const rollbackPluginGlobalSideEffects = (pluginId: string) => {
+    if (registryParams.activateGlobalSideEffects === false) {
+      return;
+    }
+
+    clearPluginCommandsForPlugin(pluginId);
+
+    const hookRollbackEntries = pluginHookRollback.get(pluginId) ?? [];
+    for (const entry of hookRollbackEntries.toReversed()) {
+      const activeRegistrations = activePluginHookRegistrations.get(entry.name) ?? [];
+      for (const registration of activeRegistrations) {
+        unregisterInternalHook(registration.event, registration.handler);
+      }
+
+      if (entry.previousRegistrations.length === 0) {
+        activePluginHookRegistrations.delete(entry.name);
+        continue;
+      }
+
+      for (const registration of entry.previousRegistrations) {
+        registerInternalHook(registration.event, registration.handler);
+      }
+      activePluginHookRegistrations.set(entry.name, [...entry.previousRegistrations]);
+    }
+    pluginHookRollback.delete(pluginId);
+  };
+
   return {
     registry,
     createApi,
+    rollbackPluginGlobalSideEffects,
     pushDiagnostic,
     registerTool,
     registerChannel,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -6,7 +6,10 @@ import {
 import type { AgentHarness } from "../agents/harness/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
-import { registerContextEngineForOwner } from "../context-engine/registry.js";
+import {
+  clearContextEnginesForOwner,
+  registerContextEngineForOwner,
+} from "../context-engine/registry.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { registerInternalHook, unregisterInternalHook } from "../hooks/internal-hooks.js";
@@ -30,7 +33,10 @@ import {
 } from "./compaction-provider.js";
 import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
-import { registerPluginInteractiveHandler } from "./interactive-registry.js";
+import {
+  clearPluginInteractiveHandlersForPlugin,
+  registerPluginInteractiveHandler,
+} from "./interactive-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import {
   getRegisteredMemoryEmbeddingProvider,
@@ -1430,6 +1436,8 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
 
     clearPluginCommandsForPlugin(pluginId);
+    clearPluginInteractiveHandlersForPlugin(pluginId);
+    clearContextEnginesForOwner(`plugin:${pluginId}`);
 
     const hookRollbackEntries = pluginHookRollback.get(pluginId) ?? [];
     for (const entry of hookRollbackEntries.toReversed()) {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1838,13 +1838,11 @@ export type OpenClawPluginDefinition = {
   reload?: OpenClawPluginReloadRegistration;
   nodeHostCommands?: OpenClawPluginNodeHostCommand[];
   securityAuditCollectors?: OpenClawPluginSecurityAuditCollector[];
-  register?: (api: OpenClawPluginApi) => void | Promise<void>;
-  activate?: (api: OpenClawPluginApi) => void | Promise<void>;
+  register?: (api: OpenClawPluginApi) => void;
+  activate?: (api: OpenClawPluginApi) => void;
 };
 
-export type OpenClawPluginModule =
-  | OpenClawPluginDefinition
-  | ((api: OpenClawPluginApi) => void | Promise<void>);
+export type OpenClawPluginModule = OpenClawPluginDefinition | ((api: OpenClawPluginApi) => void);
 
 export type PluginRegistrationMode = "full" | "setup-only" | "setup-runtime" | "cli-metadata";
 

--- a/src/test-utils/plugin-registration.ts
+++ b/src/test-utils/plugin-registration.ts
@@ -4,14 +4,14 @@ import type { OpenClawPluginApi, ProviderPlugin } from "../plugins/types.js";
 export { createCapturedPluginRegistration };
 
 type RegistrablePlugin = {
-  register(api: OpenClawPluginApi): void | Promise<void>;
+  register(api: OpenClawPluginApi): void;
 };
 
 export async function registerSingleProviderPlugin(params: {
-  register(api: OpenClawPluginApi): void | Promise<void>;
+  register(api: OpenClawPluginApi): void;
 }): Promise<ProviderPlugin> {
   const captured = createCapturedPluginRegistration();
-  await params.register(captured.api);
+  params.register(captured.api);
   const provider = captured.providers[0];
   if (!provider) {
     throw new Error("provider registration missing");
@@ -24,7 +24,7 @@ export async function registerProviderPlugins(
 ): Promise<ProviderPlugin[]> {
   const captured = createCapturedPluginRegistration();
   for (const plugin of plugins) {
-    await plugin.register(captured.api);
+    plugin.register(captured.api);
   }
   return captured.providers;
 }

--- a/test/helpers/media-generation/bundled-provider-builders.ts
+++ b/test/helpers/media-generation/bundled-provider-builders.ts
@@ -3,7 +3,7 @@ import { loadBundledPluginPublicSurfaceSync } from "../../../src/test-utils/bund
 
 type BundledPluginEntryModule = {
   default: {
-    register(api: OpenClawPluginApi): void | Promise<void>;
+    register(api: OpenClawPluginApi): void;
   };
 };
 

--- a/test/helpers/plugins/provider-registration.ts
+++ b/test/helpers/plugins/provider-registration.ts
@@ -18,7 +18,7 @@ type RegisteredProviderCollections = {
 };
 
 type ProviderPluginModule = {
-  register(api: ReturnType<typeof createTestPluginApi>): void | Promise<void>;
+  register(api: ReturnType<typeof createTestPluginApi>): void;
 };
 
 export async function registerProviderPlugin(params: {
@@ -33,7 +33,7 @@ export async function registerProviderPlugin(params: {
   const musicProviders: MusicGenerationProviderPlugin[] = [];
   const videoProviders: VideoGenerationProviderPlugin[] = [];
 
-  await params.plugin.register(
+  params.plugin.register(
     createTestPluginApi({
       id: params.id,
       name: params.name,


### PR DESCRIPTION
## Summary
- enforce synchronous plugin registration in both runtime and CLI metadata loads
- move webhooks secret resolution to request auth so registration stays synchronous

## Validation
- `pnpm test src/plugins/loader.test.ts -t "rejects async register functions"`
- `pnpm test src/plugins/loader.cli-metadata.test.ts -t "rejects async plugin registration when collecting CLI metadata"`
- `pnpm test extensions/webhooks/src/config.test.ts extensions/webhooks/index.test.ts extensions/webhooks/src/http.test.ts`
- `pnpm tsgo`
- `pnpm build`

## Related
- #67879
- #67891
- #67899
- #67900
- #64937
- #65183
- Supersedes #64640
