### PR TITLE
fix(codex): prevent gateway crash when app-server subprocess terminates abruptly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Docs: https://docs.openclaw.ai
 - Webchat/security: reject remote-host `file://` URLs in the media embedding path. (#67293) Thanks @pgondhi987.
 - Dreaming/memory-core: use the ingestion day, not the source file day, for daily recall dedupe so repeat sweeps of the same daily note can increment `dailyCount` across days instead of stalling at `1`. (#67091) Thanks @Bartok9.
 - Node-host/tools.exec: let approval binding distinguish known native binaries from mutable shell payload files, while still fail-closing unknown or racy file probes so absolute-path node-host commands like `/usr/bin/whoami` no longer get rejected as unsafe interpreter/runtime commands. (#66731) Thanks @tmimmanuel.
+- Codex/gateway: fix gateway crash when the codex-acp subprocess terminates abruptly; an unhandled EPIPE on the child stdin stream now routes through graceful client shutdown, rejecting pending requests instead of propagating as an uncaught exception that crashes the entire gateway daemon and all connected channels. Fixes #67886. (#67947) thanks @openperf
 
 ## 2026.4.14
 

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -199,6 +199,39 @@ describe("CodexAppServerClient", () => {
     expect(process.kill).toHaveBeenCalledWith("SIGKILL");
     expect(process.unref).toHaveBeenCalledTimes(1);
   });
+  it("handles stdin write errors without crashing the process", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+
+    // Start a pending request so we can verify it gets properly rejected.
+    const pending = harness.client.request("test/method");
+
+    // Simulate the child process closing its pipe — a write to the now-dead
+    // stdin emits an asynchronous EPIPE error on the stream.
+    harness.process.stdin.destroy(Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+
+    // The pending request must be rejected with the pipe error rather than
+    // an unhandled exception tearing down the gateway.
+    await expect(pending).rejects.toThrow("write EPIPE");
+
+    // Subsequent requests are rejected immediately (client is closed).
+    await expect(harness.client.request("another/method")).rejects.toThrow(
+      "codex app-server client is closed",
+    );
+  });
+
+  it("does not write to stdin after the child process exits", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+
+    // Simulate the child process exiting.
+    harness.process.emit("exit", 1, null);
+
+    // A notification after exit must not attempt a write.
+    harness.client.notify("late/event", { data: "ignored" });
+    expect(harness.writes).toHaveLength(0);
+  });
+
   it("reads the Codex version from the app-server user agent", () => {
     expect(readCodexVersionFromUserAgent("Codex Desktop/0.118.0")).toBe("0.118.0");
     expect(readCodexVersionFromUserAgent("openclaw/0.118.0 (macOS; test)")).toBe("0.118.0");

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -74,6 +74,13 @@ export class CodexAppServerClient {
         ),
       );
     });
+    // Guard against unhandled EPIPE / write-after-close errors on the stdin
+    // stream. When the child process terminates abruptly the pipe can break
+    // before the "exit" event fires, so a pending writeMessage() produces an
+    // asynchronous error on stdin that would otherwise crash the gateway.
+    child.stdin.on?.("error", (error) =>
+      this.closeWithError(error instanceof Error ? error : new Error(String(error))),
+    );
   }
 
   static start(options?: Partial<CodexAppServerStartOptions>): CodexAppServerClient {
@@ -212,6 +219,9 @@ export class CodexAppServerClient {
   }
 
   private writeMessage(message: RpcRequest | RpcResponse): void {
+    if (this.closed) {
+      return;
+    }
     this.child.stdin.write(`${JSON.stringify(message)}\n`);
   }
 
@@ -300,7 +310,9 @@ export class CodexAppServerClient {
       return;
     }
     this.closed = true;
+    this.lines.close();
     this.rejectPendingRequests(error);
+    closeCodexAppServerTransport(this.child);
   }
 
   private rejectPendingRequests(error: Error): void {

--- a/extensions/codex/src/app-server/transport.ts
+++ b/extensions/codex/src/app-server/transport.ts
@@ -4,6 +4,7 @@ export type CodexAppServerTransport = {
     end?: () => unknown;
     destroy?: () => unknown;
     unref?: () => unknown;
+    on?: (event: string, listener: (...args: unknown[]) => void) => unknown;
   };
   stdout: NodeJS.ReadableStream & {
     destroy?: () => unknown;

--- a/extensions/codex/src/app-server/transport.ts
+++ b/extensions/codex/src/app-server/transport.ts
@@ -4,7 +4,7 @@ export type CodexAppServerTransport = {
     end?: () => unknown;
     destroy?: () => unknown;
     unref?: () => unknown;
-    on?: (event: string, listener: (...args: unknown[]) => void) => unknown;
+    on?: (event: "error", listener: (error: Error) => void) => unknown;
   };
   stdout: NodeJS.ReadableStream & {
     destroy?: () => unknown;


### PR DESCRIPTION
### Summary

- **Problem**: When the `codex-acp` subprocess terminates abruptly (e.g. misconfigured binary, interactive prompt on stdout, deprecated config error), `CodexAppServerClient.writeMessage()` at `extensions/codex/src/app-server/client.ts:215` writes a JSON-RPC payload to the dead subprocess's `stdin`. Node.js emits an asynchronous `write EPIPE` error on the stream, and because no `error` event handler is registered on `child.stdin`, the error propagates as an unhandled exception that crashes the entire OpenClaw gateway daemon — taking down all connected channels.

- **Root Cause**: Three compounding defects in `CodexAppServerClient`:
  1. **No `error` handler on `child.stdin`** (constructor, line 57–77): the constructor registers `error`/`exit` handlers on the transport (`child`) itself, but never on `child.stdin`. When the pipe breaks, the stdin stream emits an `error` event that has no listener, causing Node.js to throw it as an uncaught exception.
  2. **`writeMessage()` does not check `this.closed`** (line 214–216): even after the client is marked closed by `closeWithError()`, async code paths like `handleServerRequest()` can still resume and call `writeMessage()`, triggering writes to a dead pipe.
  3. **`closeWithError()` performs incomplete cleanup** (line 298–304): unlike `close()` which closes the readline interface and shuts down the transport, `closeWithError()` only sets `closed = true` and rejects pending requests — leaving the readline active (processing more lines → more writes) and the transport open.

- **Fix**: Three targeted changes that address each root cause:
  1. Attach an `error` event handler on `child.stdin` in the constructor that routes errors through `closeWithError()`, preventing unhandled exceptions.
  2. Guard `writeMessage()` with a `this.closed` check, preventing writes to dead pipes from async continuations.
  3. Align `closeWithError()` cleanup with `close()`: close the readline interface and shut down the transport.

- **What changed**:
  - `extensions/codex/src/app-server/transport.ts`: added optional `on` method to the `stdin` type to support error event registration across stdio, websocket, and test transports.
  - `extensions/codex/src/app-server/client.ts`: added stdin error handler in constructor; added `closed` guard in `writeMessage()`; added `lines.close()` and `closeCodexAppServerTransport()` to `closeWithError()`.
  - `extensions/codex/src/app-server/client.test.ts`: added two tests — one verifying stdin EPIPE is caught and pending requests are rejected gracefully; one verifying `notify()` after child exit does not attempt writes.

- **What did NOT change (scope boundary)**:
  - `close()` behavior is unchanged — it already performed full cleanup.
  - `request()` call-site error handling is unchanged — its existing try/catch around `writeMessage()` continues to work.
  - WebSocket transport (`transport-websocket.ts`) is unchanged — its custom `Writable` stdin already buffers writes safely.
  - No changes to `handleLine()`, `handleResponse()`, `handleNotification()`, or any RPC protocol logic.
  - No changes to the transport lifecycle in `closeCodexAppServerTransport()`.

### Reproduction

1. Configure OpenClaw with a `codex-acp` binary that fails during initialization (e.g. a binary that writes an interactive prompt or error text to stdout, then exits immediately).
2. Start the gateway: `openclaw gateway`
3. The gateway attempts to send a JSON-RPC `initialize` payload to the dead subprocess's stdin.
4. **Before fix**: the gateway crashes with `Error: write EPIPE` as an unhandled exception.
5. **After fix**: the client closes gracefully, rejects the pending `initialize` request, and the gateway continues running.

### Risk / Mitigation

- **Risk**: `closeWithError()` now calls `closeCodexAppServerTransport()` which sends SIGTERM/SIGKILL to the child process. If the child has already exited (the common case), the signal is silently ignored. If the child is still running after a stdin error, terminating it is the correct behavior.
- **Mitigation**: Both `close()` and `closeWithError()` are guarded by `if (this.closed) return`, so only one can execute — no double-cleanup risk. The `closeCodexAppServerTransport()` force-kill timer is `unref()`'d, so it cannot keep the process alive. Two new tests validate the exact crash scenario and the post-exit write guard.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Codex extension
- [x] Plugin SDK (transport type)

### Linked Issue/PR

Fixes #67886