### PR TITLE
fix(memory-lancedb): get memory records through ltm list command

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -35,6 +35,12 @@ type MemoryEntry = {
   createdAt: number;
 };
 
+type MemoryListEntry = Omit<MemoryEntry, "vector">;
+
+type MemoryListOptions = {
+  orderByCreatedAt?: boolean;
+};
+
 type MemorySearchResult = {
   entry: MemoryEntry;
   score: number;
@@ -48,7 +54,18 @@ type LegacyBeforeAgentStartContext = { prependContext: string } | undefined;
 
 const TABLE_NAME = "memories";
 
-class MemoryDB {
+function parsePositiveIntegerOption(value: string | undefined, flag: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export class MemoryDB {
   private db: LanceDB.Connection | null = null;
   private table: LanceDB.Table | null = null;
   private initPromise: Promise<void> | null = null;
@@ -133,6 +150,27 @@ class MemoryDB {
     });
 
     return mapped.filter((r) => r.score >= minScore);
+  }
+
+  async list(limit?: number, options: MemoryListOptions = {}): Promise<MemoryListEntry[]> {
+    await this.ensureInitialized();
+
+    const rows = await this.table!.query()
+      .select(["id", "text", "importance", "category", "createdAt"])
+      .toArray();
+
+    const entries = rows.map((row) => ({
+      id: row.id as string,
+      text: row.text as string,
+      importance: row.importance as number,
+      category: row.category as MemoryEntry["category"],
+      createdAt: row.createdAt as number,
+    }));
+    if (options.orderByCreatedAt) {
+      entries.sort((a, b) => b.createdAt - a.createdAt);
+    }
+
+    return limit === undefined ? entries : entries.slice(0, limit);
   }
 
   async delete(id: string): Promise<boolean> {
@@ -502,9 +540,14 @@ export default definePluginEntry({
         memory
           .command("list")
           .description("List memories")
-          .action(async () => {
-            const count = await db.count();
-            console.log(`Total memories: ${count}`);
+          .option("--limit <n>", "Max results")
+          .option("--order-by-created-at", "Order memories by createdAt descending", false)
+          .action(async (opts) => {
+            const limit = parsePositiveIntegerOption(opts.limit, "--limit");
+            const entries = await db.list(limit, {
+              orderByCreatedAt: Boolean(opts.orderByCreatedAt),
+            });
+            console.log(JSON.stringify(entries, null, 2));
           });
 
         memory

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -65,7 +65,7 @@ function parsePositiveIntegerOption(value: string | undefined, flag: string): nu
   return parsed;
 }
 
-export class MemoryDB {
+class MemoryDB {
   private db: LanceDB.Connection | null = null;
   private table: LanceDB.Table | null = null;
   private initPromise: Promise<void> | null = null;
@@ -155,9 +155,13 @@ export class MemoryDB {
   async list(limit?: number, options: MemoryListOptions = {}): Promise<MemoryListEntry[]> {
     await this.ensureInitialized();
 
-    const rows = await this.table!.query()
-      .select(["id", "text", "importance", "category", "createdAt"])
-      .toArray();
+    let query = this.table!.query().select(["id", "text", "importance", "category", "createdAt"]);
+    // Push limit to LanceDB only when we don't need to sort in-memory.
+    if (!options.orderByCreatedAt && limit !== undefined) {
+      query = query.limit(limit);
+    }
+
+    const rows = await query.toArray();
 
     const entries = rows.map((row) => ({
       id: row.id as string,


### PR DESCRIPTION
## Summary

- Problem: `ltm list` only printed a memory count instead of listing stored memories(ltm status already did count action).
- Why it matters: Users could not inspect LanceDB-backed long-term memory entries from the CLI.
- What changed: `ltm list` now returns memory entries as JSON, supports `--limit`, and can optionally order by creation time with `--order-by-created-at`.
- What did NOT change (scope boundary): `ltm stats` remains the count-only command; search/recall behavior is unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage

## User-visible / Behavior Changes

- `ltm list` now prints memory entries as pretty JSON instead of `Total memories: <count>`.
- `ltm list --limit <n>` limits the number of returned entries.
- `ltm list --order-by-created-at` returns newer memories first.
- `ltm stats` still prints the total count.
