### PR TITLE
fix(channels): parallelize status probes

### DIFF
--- a/src/cli/channels-cli.test.ts
+++ b/src/cli/channels-cli.test.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerChannelsCli } from "./channels-cli.js";
+
+const mocks = vi.hoisted(() => ({
+  channelsStatusCommand: vi.fn().mockResolvedValue(undefined),
+  noopAsync: vi.fn(async () => undefined),
+  defaultRuntime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.defaultRuntime,
+}));
+
+vi.mock("./cli-utils.js", () => ({
+  runCommandWithRuntime: async (_runtime: unknown, action: () => Promise<void>) => await action(),
+}));
+
+vi.mock("../commands/channels.js", () => ({
+  channelsAddCommand: mocks.noopAsync,
+  channelsCapabilitiesCommand: mocks.noopAsync,
+  channelsListCommand: mocks.noopAsync,
+  channelsLogsCommand: mocks.noopAsync,
+  channelsRemoveCommand: mocks.noopAsync,
+  channelsResolveCommand: mocks.noopAsync,
+  channelsStatusCommand: mocks.channelsStatusCommand,
+}));
+
+describe("channels cli", () => {
+  beforeEach(() => {
+    mocks.channelsStatusCommand.mockClear();
+  });
+
+  async function runChannelsCommand(argv: string[]) {
+    const program = new Command();
+    registerChannelsCli(program);
+    await program.parseAsync(argv, { from: "user" });
+  }
+
+  it("does not inject a commander timeout default for channels status --probe", async () => {
+    await runChannelsCommand(["channels", "status", "--probe"]);
+
+    const [opts, runtime] = mocks.channelsStatusCommand.mock.calls[0] ?? [];
+    expect(opts).toEqual(
+      expect.objectContaining({
+        probe: true,
+      }),
+    );
+    expect(opts).not.toHaveProperty("timeout");
+    expect(runtime).toEqual(expect.any(Object));
+  });
+
+  it("passes explicit timeout values through to channels status", async () => {
+    await runChannelsCommand(["channels", "status", "--probe", "--timeout", "5000"]);
+
+    expect(mocks.channelsStatusCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        probe: true,
+        timeout: "5000",
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -98,7 +98,7 @@ export function registerChannelsCli(program: Command) {
     .command("status")
     .description("Show gateway channel status (use status --deep for local)")
     .option("--probe", "Probe channel credentials", false)
-    .option("--timeout <ms>", "Timeout in ms", "10000")
+    .option("--timeout <ms>", "Timeout in ms")
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runChannelsCommand(async () => {

--- a/src/commands/channels.status.command-flow.test.ts
+++ b/src/commands/channels.status.command-flow.test.ts
@@ -120,6 +120,56 @@ describe("channelsStatusCommand SecretRef fallback flow", () => {
     listChannelPlugins.mockReturnValue([createTokenOnlyPlugin()]);
   });
 
+  it("uses a longer default timeout for live probe mode", async () => {
+    callGateway.mockResolvedValue({
+      ts: Date.now(),
+      channelOrder: [],
+      channelLabels: {},
+      channelDetailLabels: {},
+      channelSystemImages: {},
+      channelMeta: {},
+      channels: {},
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+    });
+    const { runtime } = createRuntimeCapture();
+
+    await channelsStatusCommand({ probe: true }, runtime as never);
+
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "channels.status",
+        params: { probe: true, timeoutMs: 30_000 },
+        timeoutMs: 30_000,
+      }),
+    );
+  });
+
+  it("keeps explicit timeout overrides for live probe mode", async () => {
+    callGateway.mockResolvedValue({
+      ts: Date.now(),
+      channelOrder: [],
+      channelLabels: {},
+      channelDetailLabels: {},
+      channelSystemImages: {},
+      channelMeta: {},
+      channels: {},
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+    });
+    const { runtime } = createRuntimeCapture();
+
+    await channelsStatusCommand({ probe: true, timeout: "5000" }, runtime as never);
+
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "channels.status",
+        params: { probe: true, timeoutMs: 5000 },
+        timeoutMs: 5000,
+      }),
+    );
+  });
+
   it("keeps read-only fallback output when SecretRefs are unresolved", async () => {
     callGateway.mockRejectedValue(new Error("gateway closed"));
     requireValidConfigSnapshot.mockResolvedValue({ secretResolved: false, channels: {} });

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -32,6 +32,9 @@ export type ChannelsStatusOptions = {
   timeout?: string;
 };
 
+const DEFAULT_CHANNEL_STATUS_TIMEOUT_MS = 10_000;
+const DEFAULT_CHANNEL_STATUS_PROBE_TIMEOUT_MS = 30_000;
+
 function appendEnabledConfiguredLinkedBits(bits: string[], account: Record<string, unknown>) {
   if (typeof account.enabled === "boolean") {
     bits.push(account.enabled ? "enabled" : "disabled");
@@ -281,7 +284,10 @@ export async function channelsStatusCommand(
   opts: ChannelsStatusOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
-  const timeoutMs = Number(opts.timeout ?? 10_000);
+  const timeoutMs = Number(
+    opts.timeout ??
+      (opts.probe ? DEFAULT_CHANNEL_STATUS_PROBE_TIMEOUT_MS : DEFAULT_CHANNEL_STATUS_TIMEOUT_MS),
+  );
   const statusLabel = opts.probe ? "Checking channel status (probe)…" : "Checking channel status…";
   const shouldLogStatus = opts.json !== true && !process.stderr.isTTY;
   if (shouldLogStatus) {

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -133,4 +133,110 @@ describe("channelsHandlers channels.status", () => {
       undefined,
     );
   });
+
+  it("probes channels concurrently while preserving account order", async () => {
+    vi.useFakeTimers();
+    try {
+      const respond = vi.fn();
+      mocks.listChannelPlugins.mockReturnValue([
+        {
+          id: "whatsapp",
+          config: {
+            listAccountIds: () => ["alpha", "beta"],
+            resolveAccount: (_cfg: unknown, accountId: string) => ({ accountId }),
+            isEnabled: () => true,
+            isConfigured: async () => true,
+          },
+          status: {
+            probeAccount: async ({ account }: { account: { accountId: string } }) => {
+              await new Promise((resolve) => setTimeout(resolve, 1_000));
+              return { ok: true, probeFor: account.accountId };
+            },
+            auditAccount: async ({
+              account,
+              probe,
+            }: {
+              account: { accountId: string };
+              probe?: { probeFor?: string };
+            }) => {
+              await new Promise((resolve) => setTimeout(resolve, 1_000));
+              return { ok: true, auditFor: account.accountId, sawProbeFor: probe?.probeFor };
+            },
+          },
+        },
+        {
+          id: "telegram",
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: (_cfg: unknown, accountId: string) => ({ accountId }),
+            isEnabled: () => true,
+            isConfigured: async () => true,
+          },
+          status: {
+            probeAccount: async ({ account }: { account: { accountId: string } }) => {
+              await new Promise((resolve) => setTimeout(resolve, 1_000));
+              return { ok: true, probeFor: account.accountId };
+            },
+          },
+        },
+      ]);
+      mocks.buildChannelUiCatalog.mockReturnValue({
+        order: ["whatsapp", "telegram"],
+        labels: { whatsapp: "WhatsApp", telegram: "Telegram" },
+        detailLabels: { whatsapp: "WhatsApp", telegram: "Telegram" },
+        systemImages: { whatsapp: undefined, telegram: undefined },
+        entries: { whatsapp: { id: "whatsapp" }, telegram: { id: "telegram" } },
+      });
+      mocks.buildChannelAccountSnapshot.mockImplementation(
+        async ({
+          accountId,
+          probe,
+          audit,
+        }: {
+          accountId: string;
+          probe?: unknown;
+          audit?: unknown;
+        }) => ({
+          accountId,
+          configured: true,
+          probe,
+          audit,
+        }),
+      );
+
+      const request = channelsHandlers["channels.status"](
+        createOptions(
+          { probe: true, timeoutMs: 2_000 },
+          {
+            respond,
+          },
+        ),
+      );
+
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(respond).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await request;
+
+      expect(respond).toHaveBeenCalledTimes(1);
+      const payload = respond.mock.calls[0]?.[1] as {
+        channelAccounts: {
+          whatsapp: Array<{ accountId: string; audit?: { sawProbeFor?: string } }>;
+          telegram: Array<{ accountId: string; probe?: { probeFor?: string } }>;
+        };
+      };
+      expect(payload.channelAccounts.whatsapp.map((entry) => entry.accountId)).toEqual([
+        "alpha",
+        "beta",
+      ]);
+      expect(payload.channelAccounts.whatsapp.map((entry) => entry.audit?.sawProbeFor)).toEqual([
+        "alpha",
+        "beta",
+      ]);
+      expect(payload.channelAccounts.telegram[0]?.probe?.probeFor).toBe("default");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -133,67 +133,71 @@ export const channelsHandlers: GatewayRequestHandlers = {
         cfg,
         accountIds,
       });
-      const accounts: ChannelAccountSnapshot[] = [];
       const resolvedAccounts: Record<string, unknown> = {};
-      for (const accountId of accountIds) {
+      const accountEntries = accountIds.map((accountId) => {
         const account = plugin.config.resolveAccount(cfg, accountId);
-        const enabled = isAccountEnabled(plugin, account);
         resolvedAccounts[accountId] = account;
-        let probeResult: unknown;
-        let lastProbeAt: number | null = null;
-        if (probe && enabled && plugin.status?.probeAccount) {
+        return {
+          accountId,
+          account,
+          enabled: isAccountEnabled(plugin, account),
+        };
+      });
+      // Preserve accountIds order in the payload while letting slow probes overlap.
+      const accounts = await Promise.all(
+        accountEntries.map(async ({ accountId, account, enabled }) => {
+          const probeAccount = plugin.status?.probeAccount;
+          const auditAccount = plugin.status?.auditAccount;
+          const shouldProbe = probe && enabled && typeof probeAccount === "function";
+          const shouldAudit = probe && enabled && typeof auditAccount === "function";
           let configured = true;
-          if (plugin.config.isConfigured) {
+          if ((shouldProbe || shouldAudit) && plugin.config.isConfigured) {
             configured = await plugin.config.isConfigured(account, cfg);
           }
-          if (configured) {
-            probeResult = await plugin.status.probeAccount({
+          let probeResult: unknown;
+          let lastProbeAt: number | null = null;
+          if (shouldProbe && configured && probeAccount) {
+            probeResult = await probeAccount({
               account,
               timeoutMs,
               cfg,
             });
             lastProbeAt = Date.now();
           }
-        }
-        let auditResult: unknown;
-        if (probe && enabled && plugin.status?.auditAccount) {
-          let configured = true;
-          if (plugin.config.isConfigured) {
-            configured = await plugin.config.isConfigured(account, cfg);
-          }
-          if (configured) {
-            auditResult = await plugin.status.auditAccount({
+          let auditResult: unknown;
+          if (shouldAudit && configured && auditAccount) {
+            auditResult = await auditAccount({
               account,
               timeoutMs,
               cfg,
               probe: probeResult,
             });
           }
-        }
-        const runtimeSnapshot = resolveRuntimeSnapshot(channelId, accountId, defaultAccountId);
-        const snapshot = await buildChannelAccountSnapshot({
-          plugin,
-          cfg,
-          accountId,
-          runtime: runtimeSnapshot,
-          probe: probeResult,
-          audit: auditResult,
-        });
-        if (lastProbeAt) {
-          snapshot.lastProbeAt = lastProbeAt;
-        }
-        const activity = getChannelActivity({
-          channel: channelId as never,
-          accountId,
-        });
-        if (snapshot.lastInboundAt == null) {
-          snapshot.lastInboundAt = activity.inboundAt;
-        }
-        if (snapshot.lastOutboundAt == null) {
-          snapshot.lastOutboundAt = activity.outboundAt;
-        }
-        accounts.push(snapshot);
-      }
+          const runtimeSnapshot = resolveRuntimeSnapshot(channelId, accountId, defaultAccountId);
+          const snapshot = await buildChannelAccountSnapshot({
+            plugin,
+            cfg,
+            accountId,
+            runtime: runtimeSnapshot,
+            probe: probeResult,
+            audit: auditResult,
+          });
+          if (lastProbeAt) {
+            snapshot.lastProbeAt = lastProbeAt;
+          }
+          const activity = getChannelActivity({
+            channel: channelId as never,
+            accountId,
+          });
+          if (snapshot.lastInboundAt == null) {
+            snapshot.lastInboundAt = activity.inboundAt;
+          }
+          if (snapshot.lastOutboundAt == null) {
+            snapshot.lastOutboundAt = activity.outboundAt;
+          }
+          return snapshot;
+        }),
+      );
       const defaultAccount =
         accounts.find((entry) => entry.accountId === defaultAccountId) ?? accounts[0];
       return { accounts, defaultAccountId, defaultAccount, resolvedAccounts };
@@ -214,28 +218,38 @@ export const channelsHandlers: GatewayRequestHandlers = {
     const channelsMap = payload.channels as Record<string, unknown>;
     const accountsMap = payload.channelAccounts as Record<string, unknown>;
     const defaultAccountIdMap = payload.channelDefaultAccountId as Record<string, unknown>;
-    for (const plugin of plugins) {
-      const { accounts, defaultAccountId, defaultAccount, resolvedAccounts } =
-        await buildChannelAccounts(plugin.id);
-      const fallbackAccount =
-        resolvedAccounts[defaultAccountId] ?? plugin.config.resolveAccount(cfg, defaultAccountId);
-      const summary = plugin.status?.buildChannelSummary
-        ? await plugin.status.buildChannelSummary({
-            account: fallbackAccount,
-            cfg,
-            defaultAccountId,
-            snapshot:
-              defaultAccount ??
-              ({
-                accountId: defaultAccountId,
-              } as ChannelAccountSnapshot),
-          })
-        : {
-            configured: defaultAccount?.configured ?? false,
-          };
-      channelsMap[plugin.id] = summary;
-      accountsMap[plugin.id] = accounts;
-      defaultAccountIdMap[plugin.id] = defaultAccountId;
+    const channelEntries = await Promise.all(
+      plugins.map(async (plugin) => {
+        const { accounts, defaultAccountId, defaultAccount, resolvedAccounts } =
+          await buildChannelAccounts(plugin.id);
+        const fallbackAccount =
+          resolvedAccounts[defaultAccountId] ?? plugin.config.resolveAccount(cfg, defaultAccountId);
+        const summary = plugin.status?.buildChannelSummary
+          ? await plugin.status.buildChannelSummary({
+              account: fallbackAccount,
+              cfg,
+              defaultAccountId,
+              snapshot:
+                defaultAccount ??
+                ({
+                  accountId: defaultAccountId,
+                } as ChannelAccountSnapshot),
+            })
+          : {
+              configured: defaultAccount?.configured ?? false,
+            };
+        return {
+          pluginId: plugin.id,
+          accounts,
+          defaultAccountId,
+          summary,
+        };
+      }),
+    );
+    for (const entry of channelEntries) {
+      channelsMap[entry.pluginId] = entry.summary;
+      accountsMap[entry.pluginId] = entry.accounts;
+      defaultAccountIdMap[entry.pluginId] = entry.defaultAccountId;
     }
 
     respond(true, payload, undefined);


### PR DESCRIPTION
## Summary

- Problem: `openclaw channels status --probe` timed out with multiple configured accounts because the gateway probed accounts sequentially and the CLI default timeout stayed at 10s.
- Why it matters: operators saw a misleading gateway-timeout error and lost live probe data even when the gateway itself was healthy.
- What changed: `channels.status` now overlaps per-channel and per-account probe work while preserving deterministic output order, and `channels status --probe` now defaults to a 30000ms timeout when `--timeout` is omitted.
- What did NOT change (scope boundary): per-account `probeAccount`/`auditAccount` contracts, non-probe `channels status`, and explicit `--timeout` behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67938
- Related #67937
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/gateway/server-methods/channels.ts` awaited probe/audit work in nested loops, so total probe time scaled with the sum of all accounts instead of the slowest account. `src/cli/channels-cli.ts` and `src/commands/channels/status.ts` also kept the omitted-timeout default at 10000ms, which was too short for multi-account probe runs.
- Missing detection / guardrail: there was no regression coverage asserting concurrent probe scheduling or the probe-mode default timeout.
- Contributing context (if known): slow channels such as Telegram can already consume most of a 10s per-account budget, so sequential probing made the aggregate request exceed the CLI timeout quickly.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/channels.status.test.ts`, `src/commands/channels.status.command-flow.test.ts`, `src/cli/channels-cli.test.ts`
- Scenario the test should lock in: probe mode overlaps account work without reordering account output, probe mode uses a 30000ms default when `--timeout` is omitted, and explicit `--timeout` still wins.
- Why this is the smallest reliable guardrail: the regression sits in gateway request assembly and CLI option/default plumbing; these tests hit both seams directly without needing live channel credentials.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw channels status --probe` now completes much faster on multi-account setups because probe work is no longer serialized across every account.
- Omitting `--timeout` in probe mode now uses 30000ms instead of 10000ms.
- Non-probe `openclaw channels status` still defaults to 10000ms.

## Diagram (if applicable)

```text
Before:
[channels status --probe] -> [gateway probes account 1] -> [account 2] -> [account 3] -> [CLI hits 10s timeout]

After:
[channels status --probe] -> [gateway probes accounts concurrently] -> [results kept in account order] -> [CLI receives payload within the larger default budget]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): channel status gateway path
- Relevant config (redacted): multi-account channel config, no secrets needed for tests

### Steps

1. Configure multiple channel accounts and run `openclaw channels status --probe`.
2. Observe that the old path serialized per-account probes and could exceed the default timeout.
3. Run the same command after this change and verify the request overlaps account work and uses the higher default timeout when omitted.

### Expected

- Probe mode should not time out solely because multiple configured accounts are probed sequentially.

### Actual

- Before this change, the CLI could fail with `gateway timeout after 10000ms` even when the gateway was reachable.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted tests for gateway probe concurrency/order, probe-mode timeout defaulting, explicit timeout override behavior, and CLI option passthrough; full `pnpm build`; full `pnpm check`.
- Edge cases checked: non-probe status keeps the 10s default; account payload order remains stable even when work overlaps.
- What you did **not** verify: live multi-account probe timing against real external channel credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: parallel probe scheduling could expose ordering assumptions in status payload assembly.
  - Mitigation: results are collected with `Promise.all(...)`, and regression coverage asserts stable account ordering.
- Risk: a longer default probe timeout could delay failure when a user expects a hard 10s limit.
  - Mitigation: this only applies when `--probe` is used without an explicit override, and `--timeout` still takes precedence.
