### PR TITLE
fix: surface billing/surface_error chat event to web UI

### DIFF
--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -202,6 +202,10 @@ export type ChatRunState = {
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
   abortedRuns: Map<string, number>;
+  /** Runs that already had a terminal chat event (error/final) broadcast.
+   *  Used to prevent duplicate error events when both the chat.send .catch()
+   *  path and the lifecycle error grace timer attempt to surface the error. */
+  terminalChatSent: Set<string>;
   clear: () => void;
 };
 
@@ -212,6 +216,7 @@ export function createChatRunState(): ChatRunState {
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
+  const terminalChatSent = new Set<string>();
 
   const clear = () => {
     registry.clear();
@@ -220,6 +225,7 @@ export function createChatRunState(): ChatRunState {
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
     abortedRuns.clear();
+    terminalChatSent.clear();
   };
 
   return {
@@ -229,6 +235,7 @@ export function createChatRunState(): ChatRunState {
     deltaSentAt,
     deltaLastBroadcastLen,
     abortedRuns,
+    terminalChatSent,
     clear,
   };
 }
@@ -645,6 +652,13 @@ export function createAgentEventHandler({
     clearAgentRunContext(evt.runId);
     agentRunSeq.delete(evt.runId);
     agentRunSeq.delete(clientRunId);
+    // Deferred cleanup: the terminalChatSent guard must survive past this
+    // function because the broadcastChatError in chat.ts may race with us.
+    // Clean up after a short delay so the set does not grow unbounded.
+    setTimeout(() => {
+      chatRunState.terminalChatSent.delete(clientRunId);
+      chatRunState.terminalChatSent.delete(evt.runId);
+    }, 30_000).unref?.();
 
     if (sessionKey) {
       void persistGatewaySessionLifecycleEvent({ sessionKey, event: evt }).catch(() => undefined);
@@ -668,13 +682,26 @@ export function createAgentEventHandler({
 
   const scheduleTerminalLifecycleError = (
     evt: AgentEventPayload,
-    opts?: { skipChatErrorFinal?: boolean },
+    _opts?: { skipChatErrorFinal?: boolean },
   ) => {
     clearPendingTerminalLifecycleError(evt.runId);
     const delayMs = Math.max(1, Math.min(Math.floor(lifecycleErrorRetryGraceMs), 2_147_483_647));
     const timer = setTimeout(() => {
       pendingTerminalLifecycleErrors.delete(evt.runId);
-      finalizeLifecycleEvent(evt, opts);
+      // Re-evaluate skipChatErrorFinal at fire time instead of using the stale
+      // closure value captured at schedule time.  When a chat.send run resolves
+      // normally (e.g. billing surface_error → continue_normal), .finally()
+      // removes the run from chatAbortControllers before this timer fires.  The
+      // stale captured value would still be `true`, suppressing the error chat
+      // event and leaving the web UI stuck forever.  Re-checking ensures the
+      // error is surfaced when the .catch() path did not already handle it.
+      //
+      // For the throw path (where .catch() *does* fire and already broadcasts
+      // the error), the terminalChatSent guard in emitChatFinal prevents a
+      // duplicate error event.
+      const chatLink = chatRunState.registry.peek(evt.runId);
+      const skipChatErrorFinal = isChatSendRunActive(evt.runId) && !chatLink;
+      finalizeLifecycleEvent(evt, { skipChatErrorFinal });
     }, delayMs);
     timer.unref?.();
     pendingTerminalLifecycleErrors.set(evt.runId, timer);
@@ -813,6 +840,14 @@ export function createAgentEventHandler({
     stopReason?: string,
     errorKind?: ErrorKind,
   ) => {
+    // Guard against duplicate terminal chat events.  The chat.send .catch()
+    // path (broadcastChatError) marks the run in terminalChatSent; if the
+    // lifecycle error grace timer fires afterwards we must not emit a second
+    // error event.
+    if (chatRunState.terminalChatSent.has(clientRunId)) {
+      return;
+    }
+    chatRunState.terminalChatSent.add(clientRunId);
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId);
     // Flush any throttled delta so streaming clients receive the complete text
     // before the final event. The 150 ms throttle in emitChatDelta may have

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -680,10 +680,7 @@ export function createAgentEventHandler({
     }
   };
 
-  const scheduleTerminalLifecycleError = (
-    evt: AgentEventPayload,
-    _opts?: { skipChatErrorFinal?: boolean },
-  ) => {
+  const scheduleTerminalLifecycleError = (evt: AgentEventPayload) => {
     clearPendingTerminalLifecycleError(evt.runId);
     const delayMs = Math.max(1, Math.min(Math.floor(lifecycleErrorRetryGraceMs), 2_147_483_647));
     const timer = setTimeout(() => {
@@ -1026,7 +1023,7 @@ export function createAgentEventHandler({
       if (isAborted || lifecycleErrorRetryGraceMs <= 0) {
         finalizeLifecycleEvent(evt, { skipChatErrorFinal });
       } else {
-        scheduleTerminalLifecycleError(evt, { skipChatErrorFinal });
+        scheduleTerminalLifecycleError(evt);
       }
       return;
     }

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -840,8 +840,10 @@ export function createAgentEventHandler({
     // Guard against duplicate terminal chat events.  The chat.send .catch()
     // path (broadcastChatError) marks the run in terminalChatSent; if the
     // lifecycle error grace timer fires afterwards we must not emit a second
-    // error event.
-    if (chatRunState.terminalChatSent.has(clientRunId)) {
+    // error event.  However, a successful "done" terminal must always be
+    // allowed through so that a run that recovers after a retryable error is
+    // not stuck in the error state for up to 30 s while the marker persists.
+    if (chatRunState.terminalChatSent.has(clientRunId) && jobState === "error") {
       return;
     }
     chatRunState.terminalChatSent.add(clientRunId);

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -283,6 +283,7 @@ function createChatContext(): Pick<
   | "chatDeltaSentAt"
   | "chatDeltaLastBroadcastLen"
   | "chatAbortedRuns"
+  | "chatTerminalSent"
   | "removeChatRun"
   | "dedupe"
   | "loadGatewayModelCatalog"
@@ -298,6 +299,7 @@ function createChatContext(): Pick<
     chatDeltaSentAt: new Map(),
     chatDeltaLastBroadcastLen: new Map(),
     chatAbortedRuns: new Map(),
+    chatTerminalSent: new Set(),
     removeChatRun: vi.fn(),
     dedupe: new Map(),
     loadGatewayModelCatalog: async () =>

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1575,11 +1575,17 @@ function broadcastSideResult(params: {
 }
 
 function broadcastChatError(params: {
-  context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession" | "agentRunSeq">;
+  context: Pick<
+    GatewayRequestContext,
+    "broadcast" | "nodeSendToSession" | "agentRunSeq" | "chatTerminalSent"
+  >;
   runId: string;
   sessionKey: string;
   errorMessage?: string;
 }) {
+  // Mark the run so the lifecycle error grace timer in server-chat.ts
+  // skips the duplicate emitChatFinal call.
+  params.context.chatTerminalSent.add(params.runId);
   const seq = nextChatSeq({ agentRunSeq: params.context.agentRunSeq }, params.runId);
   const payload = {
     runId: params.runId,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1586,6 +1586,13 @@ function broadcastChatError(params: {
   // Mark the run so the lifecycle error grace timer in server-chat.ts
   // skips the duplicate emitChatFinal call.
   params.context.chatTerminalSent.add(params.runId);
+  // Deferred cleanup: if chat.send fails before an agent run starts (pre-run
+  // failure), no lifecycle terminal event is emitted and finalizeLifecycleEvent
+  // never runs, so the marker would persist indefinitely.  Clean up after 30 s
+  // (matching the cleanup delay in server-chat.ts finalizeLifecycleEvent).
+  setTimeout(() => {
+    params.context.chatTerminalSent.delete(params.runId);
+  }, 30_000).unref?.();
   const seq = nextChatSeq({ agentRunSeq: params.context.agentRunSeq }, params.runId);
   const payload = {
     runId: params.runId,

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -67,6 +67,10 @@ export type GatewayRequestContext = {
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
   chatDeltaLastBroadcastLen: Map<string, number>;
+  /** Runs that already had a terminal chat event (error/final) broadcast.
+   *  Used to prevent duplicate error events between the chat.send .catch()
+   *  path and the lifecycle error grace timer in server-chat.ts. */
+  chatTerminalSent: Set<string>;
   addChatRun: (sessionId: string, entry: { sessionKey: string; clientRunId: string }) => void;
   removeChatRun: (
     sessionId: string,

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -43,6 +43,7 @@ describe("createGatewayRequestContext", () => {
       chatRunBuffers: new Map(),
       chatDeltaSentAt: new Map(),
       chatDeltaLastBroadcastLen: new Map(),
+      chatTerminalSent: new Set(),
       addChatRun: vi.fn(),
       removeChatRun: vi.fn(),
       subscribeSessionEvents: vi.fn(),

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -37,6 +37,7 @@ export type GatewayRequestContextParams = {
   chatRunBuffers: GatewayRequestContext["chatRunBuffers"];
   chatDeltaSentAt: GatewayRequestContext["chatDeltaSentAt"];
   chatDeltaLastBroadcastLen: GatewayRequestContext["chatDeltaLastBroadcastLen"];
+  chatTerminalSent: GatewayRequestContext["chatTerminalSent"];
   addChatRun: GatewayRequestContext["addChatRun"];
   removeChatRun: GatewayRequestContext["removeChatRun"];
   subscribeSessionEvents: GatewayRequestContext["subscribeSessionEvents"];
@@ -130,6 +131,7 @@ export function createGatewayRequestContext(
     chatRunBuffers: params.chatRunBuffers,
     chatDeltaSentAt: params.chatDeltaSentAt,
     chatDeltaLastBroadcastLen: params.chatDeltaLastBroadcastLen,
+    chatTerminalSent: params.chatTerminalSent,
     addChatRun: params.addChatRun,
     removeChatRun: params.removeChatRun,
     subscribeSessionEvents: params.subscribeSessionEvents,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -665,6 +665,7 @@ export async function startGatewayServer(
       chatRunBuffers: chatRunState.buffers,
       chatDeltaSentAt: chatRunState.deltaSentAt,
       chatDeltaLastBroadcastLen: chatRunState.deltaLastBroadcastLen,
+      chatTerminalSent: chatRunState.terminalChatSent,
       addChatRun,
       removeChatRun,
       subscribeSessionEvents: sessionEventSubscribers.subscribe,


### PR DESCRIPTION
## Summary

- Fix a web-UI deadlock when a model request fails with a billing error (`402 insufficient_balance`). The root cause was a stale closure capturing `skipChatErrorFinal=true` at schedule time, so the lifecycle grace timer kept suppressing the error even after `.finally()` cleaned up.
- Re-evaluate `skipChatErrorFinal` at timer fire time so the error is correctly surfaced after normal promise resolution.
- Add a `terminalChatSent` idempotency guard preventing duplicate `chat` error events on the throw path.
- Remove vestigial `_opts` parameter from `scheduleTerminalLifecycleError`.
- Add deferred cleanup for `chatTerminalSent` in `broadcastChatError` to prevent unbounded set growth on pre-run failures.
- Allow successful `done` terminal to override prior error marker in `emitChatFinal`, so runs that recover after a retryable error are not stuck in error state.

## Test plan

- [x] `server-chat.agent-events.test.ts` — passed
- [x] `server.chat.gateway-server-chat.test.ts` — passed
- [x] `server.chat.gateway-server-chat-b.test.ts` — passed
- [x] `chat-abort.test.ts` — passed
- [x] `chat.directive-tags.test.ts` — passed
- [x] 124 total tests passed
- [x] TypeScript type check passed (no new errors)