### PR TITLE
[AI-assisted] fix(agents): mark failed TTS tool synthesis as an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/assistant media: require `operator.read` scope for assistant-media file and metadata requests on identity-bearing HTTP auth paths so callers without a read scope can no longer access assistant media. (#68175) Thanks @eleqtrizit.
 - Exec approvals/display: escape raw control characters (including newline and carriage return) in the shared and macOS approval-prompt command sanitizers, so trailing command payloads no longer render on hidden extra lines in the approval UI. (#68198)
 - OpenAI Codex/OAuth + Pi: keep imported Codex CLI OAuth bootstrap, Pi auth export, and runtime overlay handling aligned so Codex sessions survive refresh and health checks without leaking transient CLI state into saved auth files. Thanks @vincentkoc.
+- Agents/TTS: report failed speech synthesis as a real tool error so unconfigured providers no longer feed successful TTS failure output back into agent loops. (#67980) Thanks @lawrence3699.
 
 ## 2026.4.15
 

--- a/src/agents/tools/tts-tool.test.ts
+++ b/src/agents/tools/tts-tool.test.ts
@@ -41,4 +41,17 @@ describe("createTtsTool", () => {
     });
     expect(JSON.stringify(result.content)).not.toContain("MEDIA:");
   });
+
+  it("throws when synthesis fails so the agent records a tool error", async () => {
+    textToSpeechSpy.mockResolvedValue({
+      success: false,
+      error: "TTS conversion failed: openai: not configured",
+    });
+
+    const tool = createTtsTool();
+
+    await expect(tool.execute("call-1", { text: "hello" })).rejects.toThrow(
+      "TTS conversion failed: openai: not configured",
+    );
+  });
 });

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -49,15 +49,7 @@ export function createTtsTool(opts?: {
         };
       }
 
-      return {
-        content: [
-          {
-            type: "text",
-            text: result.error ?? "TTS conversion failed",
-          },
-        ],
-        details: { error: result.error },
-      };
+      throw new Error(result.error ?? "TTS conversion failed");
     },
   };
 }


### PR DESCRIPTION
## Summary

- Problem: the `tts` agent tool returned failed synthesis attempts as normal tool results, so the agent loop recorded them as successful tool calls.
- Why it matters: on the Google/Gemini transport, successful tool results are serialized as `{ output: ... }` while errored tool results are serialized as `{ error: ... }`, so unconfigured TTS providers were being fed back to the model as normal output instead of a real tool failure.
- What changed: `src/agents/tools/tts-tool.ts` now throws when `textToSpeech()` reports failure, and `src/agents/tools/tts-tool.test.ts` adds a regression test for that path.
- What did NOT change (scope boundary): this does not change loop detection defaults, retry policy, or `<final>` semantics from #67744; it only fixes the TTS tool failure classification path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #67744
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/agents/tools/tts-tool.ts` returned a normal `AgentToolResult` even when `textToSpeech()` returned `{ success: false, error: ... }`. In the agent runtime, non-throwing tool executions are treated as successful unless the wrapper marks them otherwise. That meant the stored `toolResult.isError` flag stayed false, and the Google transport serialized the failure as normal tool output.
- Missing detection / guardrail: there was no regression test asserting that failed TTS synthesis must surface as a real tool error.
- Contributing context (if known): `src/agents/pi-tool-definition-adapter.ts` already wraps thrown tool executions into structured `status: "error"` results, but the TTS tool never used that path for synthesis failures.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/agents/tools/tts-tool.test.ts`
- Scenario the test should lock in: when `textToSpeech()` reports `success: false`, the TTS tool must throw so the agent runtime records the tool call as an error.
- Why this is the smallest reliable guardrail: the failure classification bug originates in the tool boundary itself; success-path coverage already existed, and adapter coverage for thrown tool errors already exists in `src/agents/pi-tool-definition-adapter.test.ts`.
- Existing test that already covers this (if any): `src/agents/pi-tool-definition-adapter.test.ts` already covers thrown tool errors being normalized into structured error results.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

When TTS synthesis fails because no provider is configured (or another synthesis error occurs), the agent now receives a real tool error instead of a successful tool result carrying failure text as normal output.

## Diagram (if applicable)

```text
Before:
[user asks for voice] -> [tts tool returns content text + details.error] -> [toolResult recorded as success] -> [Gemini sees functionResponse.output]

After:
[user asks for voice] -> [tts tool throws] -> [adapter wraps structured tool error] -> [toolResult recorded as error] -> [Gemini sees functionResponse.error]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node `v24.14.0`
- Model/provider: N/A for local test; root-cause verification checked Google/Gemini transport serialization in `src/agents/google-transport-stream.ts`
- Integration/channel (if any): none for local regression test
- Relevant config (redacted): none

### Steps

1. Mock `textToSpeech()` to return `{ success: false, error: "TTS conversion failed: openai: not configured" }`.
2. Execute `createTtsTool().execute("call-1", { text: "hello" })`.
3. Observe whether the tool resolves a normal result or throws.

### Expected

- Failed TTS synthesis should propagate as a tool error so the agent runtime can mark the tool result as errored.

### Actual

- Before this change, the tool resolved a normal result object.
- After this change, the tool throws the synthesis error, which the adapter/runtime already converts into a structured tool error.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the bad behavior with a failing regression test, then confirmed the new test passes; re-ran the existing success-path TTS tool test; re-ran the existing adapter test that covers thrown tool error normalization.
- Edge cases checked: confirmed the only production caller of `createTtsTool` is the normal OpenClaw tool registry path in `src/agents/openclaw-tools.ts`, which goes through the tool adapter that already wraps thrown tool errors.
- What you did **not** verify: I did not run an end-to-end Telegram/Gemini loop reproduction.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: any direct caller that invokes `createTtsTool().execute(...)` outside the normal adapter path would now receive a rejection instead of a resolved error payload.
  - Mitigation: searched call sites; the only production caller is `src/agents/openclaw-tools.ts`, which routes through the adapter path that already normalizes thrown tool errors.

## Testing

Passed:
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm test src/agents/tools/tts-tool.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm test src/agents/tools/tts-tool.test.ts src/agents/pi-tool-definition-adapter.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm build`

Unrelated failure on current checkout:
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm check`
  - Fails in untouched qa-lab code: `extensions/qa-lab/src/providers/aimock/server.ts` cannot resolve `@copilotkit/aimock` and has existing implicit-`any` errors.

AI assistance:
- This PR was prepared with Codex assistance.
