### PR TITLE
fix(cli): prefer live channel logout [AI-assisted]

### DIFF
--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -18,6 +18,8 @@ const mocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
   ensureChannelSetupPluginInstalled: vi.fn(),
   loadChannelSetupPluginRegistrySnapshotForChannel: vi.fn(),
+  callGatewayFromCli: vi.fn(),
+  buildGatewayConnectionDetails: vi.fn(),
   login: vi.fn(),
   logoutAccount: vi.fn(),
   resolveAccount: vi.fn(),
@@ -67,6 +69,14 @@ vi.mock("../commands/channel-setup/plugin-install.js", () => ({
     mocks.loadChannelSetupPluginRegistrySnapshotForChannel,
 }));
 
+vi.mock("./gateway-rpc.js", () => ({
+  callGatewayFromCli: mocks.callGatewayFromCli,
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  buildGatewayConnectionDetails: mocks.buildGatewayConnectionDetails,
+}));
+
 describe("channel-auth", () => {
   const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
   const plugin = {
@@ -98,6 +108,19 @@ describe("channel-auth", () => {
       cfg: { channels: { whatsapp: {} } },
       installed: true,
       pluginId: "whatsapp",
+    });
+    mocks.callGatewayFromCli.mockReset();
+    mocks.callGatewayFromCli.mockResolvedValue({
+      channel: "whatsapp",
+      accountId: "default-account",
+      cleared: true,
+      loggedOut: true,
+    });
+    mocks.buildGatewayConnectionDetails.mockReset();
+    mocks.buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://127.0.0.1:18789",
+      message: "Gateway local loopback",
+      urlSource: "local loopback",
     });
     mocks.loadChannelSetupPluginRegistrySnapshotForChannel.mockReturnValue({
       channels: [{ plugin }],
@@ -174,11 +197,16 @@ describe("channel-auth", () => {
 
     await runChannelLogout({}, runtime);
 
-    expect(mocks.logoutAccount).toHaveBeenCalledWith(
-      expect.objectContaining({
-        cfg: autoEnabledCfg,
-      }),
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith(
+      "channels.logout",
+      {},
+      {
+        channel: "whatsapp",
+        accountId: "default-account",
+      },
+      { expectFinal: false },
     );
+    expect(mocks.logoutAccount).not.toHaveBeenCalled();
     expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
       nextConfig: autoEnabledCfg,
       baseHash: "config-1",
@@ -368,6 +396,29 @@ describe("channel-auth", () => {
   it("runs logout with resolved account and explicit account id", async () => {
     await runChannelLogout({ channel: "whatsapp", account: " acct-2 " }, runtime);
 
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith(
+      "channels.logout",
+      {
+        channel: "whatsapp",
+        account: " acct-2 ",
+      },
+      {
+        channel: "whatsapp",
+        accountId: "acct-2",
+      },
+      { expectFinal: false },
+    );
+    expect(mocks.resolveAccount).not.toHaveBeenCalled();
+    expect(mocks.logoutAccount).not.toHaveBeenCalled();
+    expect(mocks.setVerbose).not.toHaveBeenCalled();
+  });
+
+  it("falls back to local logout when the default local gateway is unreachable", async () => {
+    mocks.callGatewayFromCli.mockRejectedValueOnce(new Error("gateway timeout after 10000ms"));
+
+    await runChannelLogout({ channel: "whatsapp", account: " acct-2 " }, runtime);
+
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledOnce();
     expect(mocks.resolveAccount).toHaveBeenCalledWith({ channels: { whatsapp: {} } }, "acct-2");
     expect(mocks.logoutAccount).toHaveBeenCalledWith({
       cfg: { channels: { whatsapp: {} } },
@@ -375,7 +426,9 @@ describe("channel-auth", () => {
       account: { id: "resolved-account" },
       runtime,
     });
-    expect(mocks.setVerbose).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("Gateway not reachable; cleared stored channel auth locally."),
+    );
   });
 
   it("throws when channel does not support logout", async () => {

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -12,17 +12,19 @@ import {
   type OpenClawConfig,
 } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { setVerbose } from "../globals.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
+import { callGatewayFromCli, type GatewayRpcOpts } from "./gateway-rpc.js";
 
 type ChannelAuthOptions = {
   channel?: string;
   account?: string;
   verbose?: boolean;
-};
+} & GatewayRpcOpts;
 
 type ChannelPlugin = NonNullable<ReturnType<typeof getChannelPlugin>>;
 type ChannelAuthMode = "login" | "logout";
@@ -134,6 +136,33 @@ function resolveAccountContext(
   return { accountId };
 }
 
+function normalizeGatewayLogoutErrorMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).toLowerCase();
+}
+
+function shouldUseLocalLogoutFallback(opts: ChannelAuthOptions, error: unknown): boolean {
+  if (normalizeOptionalString(opts.url)) {
+    return false;
+  }
+  const message = normalizeGatewayLogoutErrorMessage(error);
+  const looksLikeReachabilityFailure = [
+    "gateway timeout",
+    "gateway closed",
+    "econnrefused",
+    "enotfound",
+    "ehostunreach",
+    "etimedout",
+    "connection refused",
+    "socket hang up",
+    "fetch failed",
+  ].some((pattern) => message.includes(pattern));
+  if (!looksLikeReachabilityFailure) {
+    return false;
+  }
+  const connection = buildGatewayConnectionDetails();
+  return connection.urlSource === "local loopback";
+}
+
 export async function runChannelLogin(
   opts: ChannelAuthOptions,
   runtime: RuntimeEnv = defaultRuntime,
@@ -198,8 +227,24 @@ export async function runChannelLogout(
   if (!logoutAccount) {
     throw new Error(`Channel ${channelInput} does not support logout`);
   }
-  // Auth-only flow: resolve account + clear session state only.
   const { accountId } = resolveAccountContext(plugin, opts, cfg);
+  try {
+    await callGatewayFromCli(
+      "channels.logout",
+      opts,
+      { channel: channelInput, accountId },
+      { expectFinal: false },
+    );
+    return;
+  } catch (error) {
+    if (!shouldUseLocalLogoutFallback(opts, error)) {
+      throw error;
+    }
+  }
+  runtime.log(
+    "Gateway not reachable; cleared stored channel auth locally. Restart the gateway if it is still running to fully disconnect the live session.",
+  );
+  // Offline fallback: clear persisted auth even when the local gateway is down.
   const account = plugin.config.resolveAccount(cfg, accountId);
   await logoutAccount({
     cfg,


### PR DESCRIPTION
## Summary

- Problem: `openclaw channels logout --channel whatsapp` only cleared stored auth on disk from the CLI process; it did not call the live gateway logout path that actually stops the running channel session.
- Why it matters: users can believe WhatsApp is disconnected while the gateway keeps the in-memory session alive and continues replying.
- What changed: `runChannelLogout` now tries the gateway `channels.logout` RPC first and only falls back to local auth cleanup when the default local loopback gateway is unreachable.
- What did NOT change (scope boundary): `channels remove` behavior and config deletion semantics are unchanged; this PR only fixes the logout/session mismatch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67746
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the CLI logout path in `src/cli/channel-auth.ts` called the plugin's local `logoutAccount` helper directly, while the gateway logout path in `src/gateway/server-methods/channels.ts` is the code path that stops the live channel runtime and marks it logged out.
- Missing detection / guardrail: the CLI tests only covered local auth cleanup; they did not assert that logout reaches the live gateway when one is running.
- Contributing context (if known): WhatsApp logout is especially visible because clearing disk creds alone does not tear down an already-running in-memory web session.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/channel-auth.test.ts`
- Scenario the test should lock in: `runChannelLogout` uses the gateway `channels.logout` RPC for a live session and only falls back to local cleanup when the default local gateway is unreachable.
- Why this is the smallest reliable guardrail: the bug is in the CLI routing choice before any provider-specific runtime logic runs.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw channels logout --channel whatsapp` now logs out the running local gateway session when the default loopback gateway is reachable.
- If the local loopback gateway is down, the command still clears stored auth locally and prints a warning that a running gateway would need a restart to fully disconnect the live session.

## Diagram (if applicable)

```text
Before:
CLI logout -> local auth cleanup only -> live gateway session can keep running

After:
CLI logout -> gateway channels.logout -> live session stops
             -> fallback to local auth cleanup only when local gateway is unreachable
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (Yes)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: the CLI now makes a gateway RPC to the already-supported `channels.logout` method before falling back locally. The fallback stays limited to the default local loopback gateway reachability case to avoid silently masking explicit remote/logout failures.

## Repro + Verification

### Environment

- OS: macOS 15.7.5 for local validation; issue report was Ubuntu 24.04 / WSL2
- Runtime/container: Node v24.14.0, pnpm 10.33.0
- Model/provider: N/A for the regression test path
- Integration/channel (if any): WhatsApp logout path via CLI
- Relevant config (redacted): default local loopback gateway assumptions in CLI tests

### Steps

1. Start with a configured channel that supports logout and a running local gateway session.
2. Run `openclaw channels logout --channel whatsapp`.
3. Observe whether the CLI uses the live gateway logout path or only clears local auth files.

### Expected

- The running local gateway session is stopped via `channels.logout`.

### Actual

- Before this change, the CLI only called local `logoutAccount`, which does not stop the live gateway session.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the routing bug with focused failing tests in `src/cli/channel-auth.test.ts`, then verified the fixed behavior with the updated tests; also ran `pnpm build` and `pnpm check` on the patched tree.
- Edge cases checked: local fallback only triggers when the default local loopback gateway is unreachable; explicit logout failures still surface instead of silently pretending the live session was closed.
- What you did **not** verify: I did not run a live WhatsApp account against a real gateway/phone pair.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a running gateway that is reachable but does not accept `channels.logout` for the resolved channel will now surface that failure instead of silently doing local-only cleanup.
  - Mitigation: local fallback is intentionally limited to the unreachable-default-loopback case so the CLI does not claim a live logout succeeded when it did not.
