### PR TITLE
[AI-assisted] fix(approvals): clarify stale approval replies

### DIFF
--- a/src/auto-reply/reply/commands-approve.test.ts
+++ b/src/auto-reply/reply/commands-approve.test.ts
@@ -895,7 +895,8 @@ describe("handleApproveCommand", () => {
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Failed to submit approval");
-    expect(result?.reply?.text).toContain("unknown or expired approval id");
+    expect(result?.reply?.text).toContain("approval request is no longer available");
+    expect(result?.reply?.text).toContain("gateway restarted");
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
     expect(callGatewayMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -972,7 +973,7 @@ describe("handleApproveCommand", () => {
           SenderId: "123",
         },
         setup: () => callGatewayMock.mockRejectedValue(new Error("unknown or expired approval id")),
-        expectedText: "unknown or expired approval id",
+        expectedText: "approval request is no longer available",
         expectGatewayCalls: 2,
       },
       {

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -81,6 +81,12 @@ function buildResolvedByLabel(params: Parameters<CommandHandler>[0]): string {
 }
 
 function formatApprovalSubmitError(error: unknown): string {
+  if (isApprovalNotFoundError(error)) {
+    return (
+      "This approval request is no longer available. If you typed the ID manually, double-check it. " +
+      "It may have expired or the gateway restarted. Re-request the action and try again."
+    );
+  }
   return formatErrorMessage(error);
 }
 


### PR DESCRIPTION
## Summary

AI-assisted: Codex was used to triage the issue, reproduce it with tests, implement the fix, and run local validation.

- Problem: stale approval callbacks and `/approve` retries surfaced the raw gateway error `unknown or expired approval id`.
- Why it matters: users do not get any actionable recovery guidance after approval expiry or a gateway restart.
- What changed: `commands-approve` now maps approval-not-found failures to a clearer reply that tells users the request is no longer available, mentions expiry/restart, and tells them to re-request the action.
- What did NOT change (scope boundary): pending approvals are still not persisted across restarts; this PR does not change approval lifecycle or retry semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #64664
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: approval-not-found failures in `src/auto-reply/reply/commands-approve.ts` were passed straight through `formatErrorMessage`, so the chat reply exposed the raw gateway text instead of approval-specific guidance.
- Missing detection / guardrail: the approval reply path had no special-case formatting for the existing `isApprovalNotFoundError(...)` sentinel.
- Contributing context (if known): the same not-found sentinel covers stale callbacks after restart/expiry and manual `/approve` attempts with unavailable IDs.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/commands-approve.test.ts`
- Scenario the test should lock in: plugin-only approval routing and Telegram `/approve` unknown-id replies should surface actionable guidance instead of the raw `unknown or expired approval id` text.
- Why this is the smallest reliable guardrail: it exercises the exact reply surface without changing approval state or restart behavior.
- Existing test that already covers this (if any): existing not-found approval reply cases in `src/auto-reply/reply/commands-approve.test.ts`
- If no new test is added, why not: N/A — the existing cases were tightened to capture the regression.

## User-visible / Behavior Changes

- Approval submissions that hit a stale or unavailable approval ID now say the request is no longer available, mention expiry/restart, and tell the user to re-request the action instead of surfacing the raw gateway error.

## Diagram (if applicable)

```text
Before:
[stale approval button or /approve retry] -> [gateway not-found error] -> ["unknown or expired approval id"]

After:
[stale approval button or /approve retry] -> [gateway not-found error] -> [actionable re-request guidance]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local shell, Node `v25.8.0`, pnpm `10.32.1`
- Model/provider: N/A
- Integration/channel (if any): approval reply path (`/approve` / channel approval callbacks)
- Relevant config (redacted): N/A (covered by unit tests)

### Steps

1. Trigger `handleApproveCommand(...)` with a gateway rejection `new Error("unknown or expired approval id")`.
2. Observe the reply text before the fix.
3. Apply the patch and rerun the same cases.

### Expected

- The reply should tell the user the approval request is no longer available and that they should re-request the action.

### Actual

- Before the fix, the reply surfaced `❌ Failed to submit approval: unknown or expired approval id`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before:

```text
AssertionError: expected '❌ Failed to submit approval: unknown …' to contain 'approval request is no longer available'
```

After:

```text
Test Files  1 passed (1)
Tests       18 passed (18)
```

## Human Verification (required)

- Verified scenarios: the plugin-only approval routing case and the Telegram `/approve` unknown-id case in `src/auto-reply/reply/commands-approve.test.ts`; repo `pnpm check`; repo `pnpm build`; `codex review --base origin/main` (no findings).
- Edge cases checked: wording stays accurate for manually typed IDs by explicitly telling users to double-check the ID if they entered it themselves.
- What you did **not** verify: a live Telegram/Discord approval callback tap against a running gateway after restart.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the same not-found sentinel is used for both stale callbacks and manual ID mistakes, so the copy must stay accurate for both.
  - Mitigation: the new message explicitly mentions manual ID re-checks and only says expiry/restart may be the cause.
