### PR TITLE
fix(bootstrap): workspace bootstrap prompt routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/bootstrap: resolve bootstrap from workspace truth instead of stale session transcript markers, keep embedded bootstrap instructions on the hidden user-context path, suppress normal `/new` and `/reset` greetings while `BOOTSTRAP.md` is still pending, and make the embedded runner read the bootstrap ritual before replying normally.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
 - OpenAI Codex/Responses: unify native Responses API capability detection so Codex OAuth requests emit the required `store: false` field on the native Responses path. (#67918) Thanks @obviyus.
 - WhatsApp/setup: guard personal-phone and allowlist prompt values so setup fails with clear validation errors instead of crashing on undefined prompt text. (#67895) Thanks @lawrence3699.
@@ -21,12 +22,6 @@ Docs: https://docs.openclaw.ai
 
 - Anthropic/models: default Anthropic selections, `opus` aliases, Claude CLI defaults, and bundled image understanding to Claude Opus 4.7.
 - Google/TTS: add Gemini text-to-speech support to the bundled `google` plugin, including provider registration, voice selection, WAV reply output, PCM telephony output, and setup/docs guidance. (#67515) Thanks @barronlroth.
-- Control UI/Overview: add a Model Auth status card showing OAuth token health and provider rate-limit pressure at a glance, with attention callouts when OAuth tokens are expiring or expired. Backed by a new `models.authStatus` gateway method that strips credentials and caches for 60s. (#66211) Thanks @omarshahine.
-- Memory/LanceDB: add cloud storage support to `memory-lancedb` so durable memory indexes can run on remote object storage instead of local disk only. (#63502) Thanks @rugvedS07.
-- GitHub Copilot/memory search: add a GitHub Copilot embedding provider for memory search, and expose a dedicated Copilot embedding host helper so plugins can reuse the transport while honoring remote overrides, token refresh, and safer payload validation. (#61718) Thanks @feiskyer and @vincentkoc.
-- Agents/local models: add experimental `agents.defaults.experimental.localModelLean: true` to drop heavyweight default tools like `browser`, `cron`, and `message`, reducing prompt size for weaker local-model setups without changing the normal path. (#66495) Thanks @ImLukeF.
-- Packaging/plugins: localize bundled plugin runtime deps to their owning extensions, trim the published docs payload, and tighten install/package-manager guardrails so published builds stay leaner and core stops carrying extension-owned runtime baggage. (#67099) Thanks @vincentkoc.
-- QA/Matrix: split Matrix live QA into a source-linked `qa-matrix` runner and keep repo-private `qa-*` surfaces out of packaged and published builds. (#66723) Thanks @gumadeiras.
 - Docs/showcase: add a scannable hero, complete section jump links, and a responsive video grid for community examples. (#48493) Thanks @jchopard69.
 
 ### Fixes

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -107,6 +107,18 @@ describe("resolveBootstrapContextForRun", () => {
     expect(extra?.content).toBe("extra");
   });
 
+  it("keeps BOOTSTRAP.md available in shared injected context for non-attempt consumers", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP.md"), "ritual", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+
+    const result = await resolveBootstrapContextForRun({ workspaceDir });
+
+    expect(result.bootstrapFiles.some((file) => file.name === "BOOTSTRAP.md")).toBe(true);
+    expect(result.contextFiles.some((file) => file.path.endsWith("BOOTSTRAP.md"))).toBe(true);
+    expect(result.contextFiles.some((file) => file.path.endsWith("AGENTS.md"))).toBe(true);
+  });
+
   it("uses heartbeat-only bootstrap files in lightweight heartbeat mode", async () => {
     const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
     await fs.writeFile(path.join(workspaceDir, "HEARTBEAT.md"), "check inbox", "utf8");

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -15,6 +15,7 @@ import {
 import {
   DEFAULT_HEARTBEAT_FILENAME,
   filterBootstrapFilesForSession,
+  isWorkspaceBootstrapPending,
   loadWorkspaceBootstrapFiles,
   type WorkspaceBootstrapFile,
 } from "./workspace.js";
@@ -272,3 +273,5 @@ export async function resolveBootstrapContextForRun(params: {
   });
   return { bootstrapFiles, contextFiles };
 }
+
+export { isWorkspaceBootstrapPending };

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -95,15 +95,11 @@ import {
   scrubAnthropicRefusalMagic,
 } from "./run/helpers.js";
 import {
-  DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
-  DEFAULT_REASONING_ONLY_RETRY_LIMIT,
   resolveAckExecutionFastPathInstruction,
-  extractPlanningOnlyPlanDetails,
-  resolveEmptyResponseRetryInstruction,
   resolveIncompleteTurnPayloadText,
+  extractPlanningOnlyPlanDetails,
   resolvePlanningOnlyRetryLimit,
   resolvePlanningOnlyRetryInstruction,
-  resolveReasoningOnlyRetryInstruction,
   STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
@@ -114,7 +110,6 @@ import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import { resolveEffectiveRuntimeModel, resolveHookModelSelection } from "./run/setup.js";
 import { mergeAttemptToolMediaPayloads } from "./run/tool-media-payloads.js";
 import {
-  resolveLiveToolResultMaxChars,
   sessionLikelyHasOversizedToolResults,
   truncateOversizedToolResultsInSession,
 } from "./tool-result-truncation.js";
@@ -300,6 +295,7 @@ export async function runEmbeddedPiAgent(
         modelId,
         hookRunner,
         hookContext: hookCtx,
+        e2eTraceContext: params.e2eTraceContext,
       });
       provider = hookSelection.provider;
       modelId = hookSelection.modelId;
@@ -447,8 +443,6 @@ export async function runEmbeddedPiAgent(
       });
       const executionContract = strictAgenticActive ? "strict-agentic" : "default";
       const maxPlanningOnlyRetryAttempts = resolvePlanningOnlyRetryLimit(executionContract);
-      const maxReasoningOnlyRetryAttempts = DEFAULT_REASONING_ONLY_RETRY_LIMIT;
-      const maxEmptyResponseRetryAttempts = DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT;
 
       const MAX_TIMEOUT_COMPACTION_ATTEMPTS = 2;
       const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
@@ -464,13 +458,9 @@ export async function runEmbeddedPiAgent(
       let runLoopIterations = 0;
       let overloadProfileRotations = 0;
       let planningOnlyRetryAttempts = 0;
-      let reasoningOnlyRetryAttempts = 0;
-      let emptyResponseRetryAttempts = 0;
       let sameModelIdleTimeoutRetries = 0;
       let lastRetryFailoverReason: FailoverReason | null = null;
       let planningOnlyRetryInstruction: string | null = null;
-      let reasoningOnlyRetryInstruction: string | null = null;
-      let emptyResponseRetryInstruction: string | null = null;
       const ackExecutionFastPathInstruction = resolveAckExecutionFastPathInstruction({
         provider,
         modelId,
@@ -654,8 +644,6 @@ export async function runEmbeddedPiAgent(
           const promptAdditions = [
             ackExecutionFastPathInstruction,
             planningOnlyRetryInstruction,
-            reasoningOnlyRetryInstruction,
-            emptyResponseRetryInstruction,
           ].filter(
             (value): value is string => typeof value === "string" && value.trim().length > 0,
           );
@@ -755,10 +743,6 @@ export async function runEmbeddedPiAgent(
             silentExpected: params.silentExpected,
             bootstrapContextMode: params.bootstrapContextMode,
             bootstrapContextRunKind: params.bootstrapContextRunKind,
-            toolsAllow: params.toolsAllow,
-            disableMessageTool: params.disableMessageTool,
-            requireExplicitMessageTarget: params.requireExplicitMessageTarget,
-            internalEvents: params.internalEvents,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
@@ -1101,11 +1085,6 @@ export async function runEmbeddedPiAgent(
                   const truncResult = await truncateOversizedToolResultsInSession({
                     sessionFile: params.sessionFile,
                     contextWindowTokens: ctxInfo.tokens,
-                    maxCharsOverride: resolveLiveToolResultMaxChars({
-                      contextWindowTokens: ctxInfo.tokens,
-                      cfg: params.config,
-                      agentId: sessionAgentId,
-                    }),
                     sessionId: params.sessionId,
                     sessionKey: params.sessionKey,
                   });
@@ -1131,16 +1110,10 @@ export async function runEmbeddedPiAgent(
             }
             if (!toolResultTruncationAttempted) {
               const contextWindowTokens = ctxInfo.tokens;
-              const toolResultMaxChars = resolveLiveToolResultMaxChars({
-                contextWindowTokens,
-                cfg: params.config,
-                agentId: sessionAgentId,
-              });
               const hasOversized = attempt.messagesSnapshot
                 ? sessionLikelyHasOversizedToolResults({
                     messages: attempt.messagesSnapshot,
                     contextWindowTokens,
-                    maxCharsOverride: toolResultMaxChars,
                   })
                 : false;
 
@@ -1153,7 +1126,6 @@ export async function runEmbeddedPiAgent(
                 const truncResult = await truncateOversizedToolResultsInSession({
                   sessionFile: params.sessionFile,
                   contextWindowTokens,
-                  maxCharsOverride: toolResultMaxChars,
                   sessionId: params.sessionId,
                   sessionKey: params.sessionKey,
                 });
@@ -1205,6 +1177,8 @@ export async function runEmbeddedPiAgent(
                   lastTurnTotal,
                 }),
                 systemPromptReport: attempt.systemPromptReport,
+                systemPromptText: attempt.systemPromptText,
+                developerPromptText: attempt.developerPromptText,
                 finalPromptText: attempt.finalPromptText,
                 replayInvalid: resolveReplayInvalidForAttempt(),
                 livenessState: "blocked",
@@ -1260,6 +1234,8 @@ export async function runEmbeddedPiAgent(
                     lastTurnTotal,
                   }),
                   systemPromptReport: attempt.systemPromptReport,
+                  systemPromptText: attempt.systemPromptText,
+                  developerPromptText: attempt.developerPromptText,
                   finalPromptText: attempt.finalPromptText,
                   replayInvalid: resolveReplayInvalidForAttempt(),
                   livenessState: "blocked",
@@ -1299,6 +1275,8 @@ export async function runEmbeddedPiAgent(
                     lastTurnTotal,
                   }),
                   systemPromptReport: attempt.systemPromptReport,
+                  systemPromptText: attempt.systemPromptText,
+                  developerPromptText: attempt.developerPromptText,
                   finalPromptText: attempt.finalPromptText,
                   replayInvalid: resolveReplayInvalidForAttempt(),
                   livenessState: "blocked",
@@ -1669,6 +1647,8 @@ export async function runEmbeddedPiAgent(
                 agentMeta,
                 aborted,
                 systemPromptReport: attempt.systemPromptReport,
+                systemPromptText: attempt.systemPromptText,
+                developerPromptText: attempt.developerPromptText,
                 finalPromptText: attempt.finalPromptText,
                 finalAssistantVisibleText,
                 finalAssistantRawText,
@@ -1684,7 +1664,14 @@ export async function runEmbeddedPiAgent(
             };
           }
 
-          const payloadCount = payloadsWithToolMedia?.length ?? 0;
+          // Detect incomplete turns where prompt() resolved prematurely and the
+          // runner would otherwise drop an empty reply.
+          const incompleteTurnText = resolveIncompleteTurnPayloadText({
+            payloadCount: payloadsWithToolMedia?.length ?? 0,
+            aborted,
+            timedOut,
+            attempt,
+          });
           const nextPlanningOnlyRetryInstruction = resolvePlanningOnlyRetryInstruction({
             provider,
             modelId,
@@ -1693,22 +1680,8 @@ export async function runEmbeddedPiAgent(
             timedOut,
             attempt,
           });
-          const nextReasoningOnlyRetryInstruction = resolveReasoningOnlyRetryInstruction({
-            provider: activeErrorContext.provider,
-            modelId: activeErrorContext.model,
-            aborted,
-            timedOut,
-            attempt,
-          });
-          const nextEmptyResponseRetryInstruction = resolveEmptyResponseRetryInstruction({
-            provider: activeErrorContext.provider,
-            modelId: activeErrorContext.model,
-            payloadCount,
-            aborted,
-            timedOut,
-            attempt,
-          });
           if (
+            !incompleteTurnText &&
             nextPlanningOnlyRetryInstruction &&
             planningOnlyRetryAttempts < maxPlanningOnlyRetryAttempts
           ) {
@@ -1746,51 +1719,6 @@ export async function runEmbeddedPiAgent(
             );
             continue;
           }
-          if (
-            !nextPlanningOnlyRetryInstruction &&
-            nextReasoningOnlyRetryInstruction &&
-            reasoningOnlyRetryAttempts < maxReasoningOnlyRetryAttempts
-          ) {
-            reasoningOnlyRetryAttempts += 1;
-            reasoningOnlyRetryInstruction = nextReasoningOnlyRetryInstruction;
-            log.warn(
-              `reasoning-only assistant turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
-                `with visible-answer continuation`,
-            );
-            continue;
-          }
-          const reasoningOnlyRetriesExhausted =
-            !nextPlanningOnlyRetryInstruction &&
-            nextReasoningOnlyRetryInstruction &&
-            reasoningOnlyRetryAttempts >= maxReasoningOnlyRetryAttempts;
-          if (
-            !nextPlanningOnlyRetryInstruction &&
-            !nextReasoningOnlyRetryInstruction &&
-            nextEmptyResponseRetryInstruction &&
-            emptyResponseRetryAttempts < maxEmptyResponseRetryAttempts
-          ) {
-            emptyResponseRetryAttempts += 1;
-            emptyResponseRetryInstruction = nextEmptyResponseRetryInstruction;
-            log.warn(
-              `empty response detected: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} ` +
-                `with visible-answer continuation`,
-            );
-            continue;
-          }
-          const incompleteTurnText = resolveIncompleteTurnPayloadText({
-            payloadCount,
-            aborted,
-            timedOut,
-            attempt,
-          });
-          if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
-            log.warn(
-              `reasoning-only retries exhausted: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${activeErrorContext.provider}/${activeErrorContext.model} attempts=${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} — surfacing incomplete-turn error`,
-            );
-          }
           if (!incompleteTurnText && nextPlanningOnlyRetryInstruction && strictAgenticActive) {
             log.warn(
               `strict-agentic run exhausted planning-only retries: runId=${params.runId} sessionId=${params.sessionId} ` +
@@ -1826,6 +1754,8 @@ export async function runEmbeddedPiAgent(
                 agentMeta,
                 aborted,
                 systemPromptReport: attempt.systemPromptReport,
+                systemPromptText: attempt.systemPromptText,
+                developerPromptText: attempt.developerPromptText,
                 finalPromptText: attempt.finalPromptText,
                 finalAssistantVisibleText,
                 finalAssistantRawText,
@@ -1839,64 +1769,6 @@ export async function runEmbeddedPiAgent(
               messagingToolSentTargets: attempt.messagingToolSentTargets,
               successfulCronAdds: attempt.successfulCronAdds,
             };
-          }
-          if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
-            const replayInvalid = resolveReplayInvalidForAttempt(
-              "⚠️ Agent couldn't generate a response. Please try again.",
-            );
-            const livenessState = resolveRunLivenessState({
-              payloadCount: 0,
-              aborted,
-              timedOut,
-              attempt,
-              incompleteTurnText: "⚠️ Agent couldn't generate a response. Please try again.",
-            });
-            attempt.setTerminalLifecycleMeta?.({
-              replayInvalid,
-              livenessState,
-            });
-            if (lastProfileId) {
-              await maybeMarkAuthProfileFailure({
-                profileId: lastProfileId,
-                reason: resolveAuthProfileFailureReason(assistantFailoverReason),
-              });
-            }
-            return {
-              payloads: [
-                {
-                  text: "⚠️ Agent couldn't generate a response. Please try again.",
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta,
-                aborted,
-                systemPromptReport: attempt.systemPromptReport,
-                finalPromptText: attempt.finalPromptText,
-                finalAssistantVisibleText,
-                finalAssistantRawText,
-                replayInvalid,
-                livenessState,
-              },
-              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-              messagingToolSentTexts: attempt.messagingToolSentTexts,
-              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-              messagingToolSentTargets: attempt.messagingToolSentTargets,
-              successfulCronAdds: attempt.successfulCronAdds,
-            };
-          }
-          if (
-            !nextPlanningOnlyRetryInstruction &&
-            !nextReasoningOnlyRetryInstruction &&
-            nextEmptyResponseRetryInstruction &&
-            emptyResponseRetryAttempts >= maxEmptyResponseRetryAttempts
-          ) {
-            log.warn(
-              `empty response retries exhausted: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${activeErrorContext.provider}/${activeErrorContext.model} attempts=${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} — surfacing incomplete-turn error`,
-            );
           }
           if (incompleteTurnText) {
             const replayInvalid = resolveReplayInvalidForAttempt(incompleteTurnText);
@@ -1938,6 +1810,8 @@ export async function runEmbeddedPiAgent(
                 agentMeta,
                 aborted,
                 systemPromptReport: attempt.systemPromptReport,
+                systemPromptText: attempt.systemPromptText,
+                developerPromptText: attempt.developerPromptText,
                 finalPromptText: attempt.finalPromptText,
                 finalAssistantVisibleText,
                 finalAssistantRawText,
@@ -1993,6 +1867,8 @@ export async function runEmbeddedPiAgent(
               agentMeta,
               aborted,
               systemPromptReport: attempt.systemPromptReport,
+              systemPromptText: attempt.systemPromptText,
+              developerPromptText: attempt.developerPromptText,
               finalPromptText: attempt.finalPromptText,
               finalAssistantVisibleText,
               finalAssistantRawText,

--- a/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
@@ -19,6 +19,7 @@ export async function resolveAttemptBootstrapContext<
   contextInjectionMode: "always" | "continuation-skip";
   bootstrapContextMode?: string;
   bootstrapContextRunKind?: string;
+  workspaceBootstrapPending?: boolean;
   sessionFile: string;
   hasCompletedBootstrapTurn: (sessionFile: string) => Promise<boolean>;
   resolveBootstrapContextForRun: () => Promise<TContext>;
@@ -29,6 +30,7 @@ export async function resolveAttemptBootstrapContext<
   }
 > {
   const isContinuationTurn =
+    !params.workspaceBootstrapPending &&
     params.contextInjectionMode === "continuation-skip" &&
     params.bootstrapContextRunKind !== "heartbeat" &&
     (await params.hasCompletedBootstrapTurn(params.sessionFile));

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -3,15 +3,26 @@ import type {
   ContextEnginePromptCacheInfo,
   ContextEngineRuntimeContext,
 } from "../../../context-engine/types.js";
+import type { E2ETraceCollector } from "../../../infra/e2e-trace.js";
+import {
+  endE2ETraceSpan,
+  recordMeasuredE2ETraceSpan,
+  startE2ETraceSpan,
+} from "../../../infra/e2e-trace.js";
 import type {
   PluginHookAgentContext,
   PluginHookBeforeAgentStartResult,
+  PluginHookBeforePromptChannelsResult,
   PluginHookBeforePromptBuildResult,
 } from "../../../plugins/types.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../music-generation-task-status.js";
+import type {
+  PromptChannelRoutingEvent,
+  PromptChannelRoutingResult,
+} from "../../prompt-channels.types.js";
 import { prependSystemPromptAdditionAfterCacheBoundary } from "../../system-prompt-cache-boundary.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { buildActiveVideoGenerationTaskPromptContextForSession } from "../../video-generation-task-status.js";
@@ -21,7 +32,13 @@ import { shouldInjectHeartbeatPromptForTrigger } from "./trigger-policy.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
 export type PromptBuildHookRunner = {
-  hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
+  hasHooks: (
+    hookName: "before_prompt_channels" | "before_prompt_build" | "before_agent_start",
+  ) => boolean;
+  runBeforePromptChannels?: (
+    event: PromptChannelRoutingEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforePromptChannelsResult | undefined>;
   runBeforePromptBuild: (
     event: { prompt: string; messages: unknown[] },
     ctx: PluginHookAgentContext,
@@ -38,7 +55,12 @@ export async function resolvePromptBuildHookResult(params: {
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
+  e2eTraceContext?: E2ETraceCollector;
 }): Promise<PluginHookBeforePromptBuildResult> {
+  const hookStartedAt = Date.now();
+  startE2ETraceSpan(params.e2eTraceContext, "pre_turn_hooks", {
+    startedAt: hookStartedAt,
+  });
   const promptBuildResult = params.hookRunner?.hasHooks("before_prompt_build")
     ? await params.hookRunner
         .runBeforePromptBuild(
@@ -71,6 +93,22 @@ export async function resolvePromptBuildHookResult(params: {
             return undefined;
           })
       : undefined);
+  const hookEndedAt = Date.now();
+  endE2ETraceSpan(params.e2eTraceContext, "pre_turn_hooks", {
+    endedAt: hookEndedAt,
+  });
+  const activeMemoryTag = "<active_memory_plugin>";
+  const containsActiveMemory =
+    promptBuildResult?.prependContext?.includes(activeMemoryTag) ||
+    legacyResult?.prependContext?.includes(activeMemoryTag) ||
+    promptBuildResult?.systemPrompt?.includes(activeMemoryTag) ||
+    legacyResult?.systemPrompt?.includes(activeMemoryTag);
+  if (containsActiveMemory) {
+    recordMeasuredE2ETraceSpan(params.e2eTraceContext, "active_memory", {
+      durationMs: hookEndedAt - hookStartedAt,
+      endedAt: hookEndedAt,
+    });
+  }
   return {
     systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
     prependContext: joinPresentTextSegments([
@@ -85,6 +123,31 @@ export async function resolvePromptBuildHookResult(params: {
       promptBuildResult?.appendSystemContext,
       legacyResult?.appendSystemContext,
     ]),
+  };
+}
+
+export async function resolvePromptChannelHookResult(params: {
+  event: PromptChannelRoutingEvent;
+  hookCtx: PluginHookAgentContext;
+  hookRunner?: PromptBuildHookRunner | null;
+}): Promise<PromptChannelRoutingResult> {
+  const promptChannelPromise =
+    params.hookRunner?.hasHooks("before_prompt_channels") &&
+    params.hookRunner.runBeforePromptChannels
+      ? params.hookRunner.runBeforePromptChannels(params.event, params.hookCtx)
+      : undefined;
+  const promptChannelResult = promptChannelPromise
+    ? await promptChannelPromise.catch((hookErr: unknown) => {
+        log.warn(`before_prompt_channels hook failed: ${String(hookErr)}`);
+        return undefined;
+      })
+    : undefined;
+  return {
+    systemAdditions: promptChannelResult?.systemAdditions,
+    developerAdditions: promptChannelResult?.developerAdditions,
+    userAdditions: promptChannelResult?.userAdditions,
+    memorySectionTarget: promptChannelResult?.memorySectionTarget,
+    contextFileRoutes: promptChannelResult?.contextFileRoutes,
   };
 }
 
@@ -226,8 +289,6 @@ export function buildAfterTurnRuntimeContext(params: {
   >;
   workspaceDir: string;
   agentDir: string;
-  tokenBudget?: number;
-  currentTokenCount?: number;
   promptCache?: ContextEnginePromptCacheInfo;
 }): ContextEngineRuntimeContext {
   return {
@@ -254,16 +315,6 @@ export function buildAfterTurnRuntimeContext(params: {
       extraSystemPrompt: params.attempt.extraSystemPrompt,
       ownerNumbers: params.attempt.ownerNumbers,
     }),
-    ...(typeof params.tokenBudget === "number" &&
-      Number.isFinite(params.tokenBudget) &&
-      params.tokenBudget > 0
-      ? { tokenBudget: Math.floor(params.tokenBudget) }
-      : {}),
-    ...(typeof params.currentTokenCount === "number" &&
-      Number.isFinite(params.currentTokenCount) &&
-      params.currentTokenCount > 0
-      ? { currentTokenCount: Math.floor(params.currentTokenCount) }
-      : {}),
     ...(params.promptCache ? { promptCache: params.promptCache } : {}),
   };
 }

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts
@@ -15,6 +15,7 @@ async function resolveBootstrapContext(params: {
   contextInjectionMode?: "always" | "continuation-skip";
   bootstrapContextMode?: string;
   bootstrapContextRunKind?: string;
+  workspaceBootstrapPending?: boolean;
   completed?: boolean;
   resolver?: () => Promise<{ bootstrapFiles: unknown[]; contextFiles: unknown[] }>;
 }) {
@@ -30,6 +31,7 @@ async function resolveBootstrapContext(params: {
     contextInjectionMode: params.contextInjectionMode ?? "always",
     bootstrapContextMode: params.bootstrapContextMode ?? "full",
     bootstrapContextRunKind: params.bootstrapContextRunKind ?? "default",
+    workspaceBootstrapPending: params.workspaceBootstrapPending ?? false,
     sessionFile: "/tmp/session.jsonl",
     hasCompletedBootstrapTurn,
     resolveBootstrapContextForRun,
@@ -72,6 +74,25 @@ describe("embedded attempt context injection", () => {
     expect(result.isContinuationTurn).toBe(false);
     expect(result.bootstrapFiles).toEqual([{ name: "AGENTS.md" }]);
     expect(result.contextFiles).toEqual([{ path: "AGENTS.md" }]);
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let stale session markers suppress pending workspace bootstrap", async () => {
+    const resolver = vi.fn(async () => ({
+      bootstrapFiles: [{ name: "AGENTS.md" }, { name: "BOOTSTRAP.md" }],
+      contextFiles: [{ path: "AGENTS.md" }],
+    }));
+
+    const { result, hasCompletedBootstrapTurn } = await resolveBootstrapContext({
+      contextInjectionMode: "continuation-skip",
+      workspaceBootstrapPending: true,
+      completed: true,
+      resolver,
+    });
+
+    expect(result.isContinuationTurn).toBe(false);
+    expect(hasCompletedBootstrapTurn).not.toHaveBeenCalled();
+    expect(result.bootstrapFiles).toEqual([{ name: "AGENTS.md" }, { name: "BOOTSTRAP.md" }]);
     expect(resolver).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -15,6 +15,7 @@ import {
   resolveAttemptFsWorkspaceOnly,
   resolveEmbeddedAgentStreamFn,
   resolveUnknownToolGuardThreshold,
+  resolvePromptChannelHookResult,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
   shouldWarnOnOrphanedUserRepair,
@@ -60,9 +61,10 @@ describe("resolvePromptBuildHookResult", () => {
   function createLegacyOnlyHookRunner() {
     return {
       hasHooks: vi.fn(
-        (hookName: "before_prompt_build" | "before_agent_start") =>
+        (hookName: "before_prompt_channels" | "before_prompt_build" | "before_agent_start") =>
           hookName === "before_agent_start",
       ),
+      runBeforePromptChannels: vi.fn(async () => undefined),
       runBeforePromptBuild: vi.fn(async () => undefined),
       runBeforeAgentStart: vi.fn(async () => ({ prependContext: "from-hook" })),
     };
@@ -127,6 +129,66 @@ describe("resolvePromptBuildHookResult", () => {
     expect(result.prependContext).toBe("prompt context\n\nlegacy context");
     expect(result.prependSystemContext).toBe("prompt prepend\n\nlegacy prepend");
     expect(result.appendSystemContext).toBe("prompt append\n\nlegacy append");
+  });
+});
+
+describe("resolvePromptChannelHookResult", () => {
+  it("returns empty routing when no hook is registered", async () => {
+    const result = await resolvePromptChannelHookResult({
+      event: {
+        prompt: "hello",
+        promptMode: "full",
+        contextFiles: [],
+        toolNames: [],
+        includeMemorySection: true,
+      },
+      hookCtx: {},
+    });
+
+    expect(result).toEqual({
+      systemAdditions: undefined,
+      developerAdditions: undefined,
+      userAdditions: undefined,
+      memorySectionTarget: undefined,
+      contextFileRoutes: undefined,
+    });
+  });
+
+  it("returns routed additions from before_prompt_channels hooks", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: "before_prompt_channels") => hookName === "before_prompt_channels",
+      ),
+      runBeforePromptChannels: vi.fn(async () => ({
+        systemAdditions: "## Autonomy and Persistence\nTake action.",
+        memorySectionTarget: "user" as const,
+        contextFileRoutes: {
+          "AGENTS.md": "developer" as const,
+          "MEMORY.md": "user" as const,
+        },
+      })),
+    };
+
+    const event = {
+      prompt: "hello",
+      promptMode: "full" as const,
+      contextFiles: [{ path: "AGENTS.md", content: "agents" }],
+      toolNames: ["read"],
+      includeMemorySection: true,
+    };
+    const result = await resolvePromptChannelHookResult({
+      event,
+      hookCtx: {},
+      hookRunner: hookRunner as never,
+    });
+
+    expect(hookRunner.runBeforePromptChannels).toHaveBeenCalledWith(event, {});
+    expect(result.systemAdditions).toContain("## Autonomy and Persistence");
+    expect(result.memorySectionTarget).toBe("user");
+    expect(result.contextFileRoutes).toEqual({
+      "AGENTS.md": "developer",
+      "MEMORY.md": "user",
+    });
   });
 });
 
@@ -424,33 +486,19 @@ describe("resolveAttemptFsWorkspaceOnly", () => {
 });
 
 describe("resolveUnknownToolGuardThreshold", () => {
-  it("returns the default threshold when no loop-detection config is provided", () => {
-    expect(resolveUnknownToolGuardThreshold(undefined)).toBe(10);
-    expect(resolveUnknownToolGuardThreshold({})).toBe(10);
+  it("returns undefined when loop detection is disabled", () => {
+    expect(resolveUnknownToolGuardThreshold({ enabled: false, unknownToolThreshold: 4 })).toBe(
+      undefined,
+    );
+    expect(resolveUnknownToolGuardThreshold(undefined)).toBe(undefined);
   });
 
-  it("stays on even when tools.loopDetection.enabled is false (safety net)", () => {
-    // The unknown-tool guard has no false-positive surface — the tool is
-    // objectively not registered — so it is always on regardless of the
-    // opt-in genericRepeat/pingPong/pollNoProgress detectors.
-    expect(resolveUnknownToolGuardThreshold({ enabled: false })).toBe(10);
-    expect(resolveUnknownToolGuardThreshold({ enabled: false, unknownToolThreshold: 3 })).toBe(3);
+  it("uses the default threshold when loop detection is enabled without an override", () => {
+    expect(resolveUnknownToolGuardThreshold({ enabled: true })).toBe(10);
   });
 
   it("uses the configured threshold override when provided", () => {
     expect(resolveUnknownToolGuardThreshold({ enabled: true, unknownToolThreshold: 4 })).toBe(4);
-  });
-
-  it("falls back to the default threshold when the override is non-positive", () => {
-    expect(resolveUnknownToolGuardThreshold({ unknownToolThreshold: 0 })).toBe(10);
-    expect(resolveUnknownToolGuardThreshold({ unknownToolThreshold: -5 })).toBe(10);
-    expect(
-      resolveUnknownToolGuardThreshold({ unknownToolThreshold: Number.NaN }),
-    ).toBe(10);
-  });
-
-  it("floors fractional overrides", () => {
-    expect(resolveUnknownToolGuardThreshold({ unknownToolThreshold: 3.7 })).toBe(3);
   });
 });
 
@@ -1739,9 +1787,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     );
 
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]));
-    const stream = wrapped({ api: "google-gemini" } as never, { messages } as never, {} as never) as
-      | FakeWrappedStream
-      | Promise<FakeWrappedStream>;
+    const stream = wrapped(
+      { api: "google-gemini" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
     await Promise.resolve(stream);
 
     expect(baseFn).toHaveBeenCalledTimes(1);
@@ -2850,8 +2900,6 @@ describe("buildAfterTurnRuntimeContext", () => {
       },
       workspaceDir: "/tmp/workspace",
       agentDir: "/tmp/agent",
-      tokenBudget: 1050000,
-      currentTokenCount: 232393,
     });
 
     expect(legacy).toMatchObject({
@@ -2860,8 +2908,6 @@ describe("buildAfterTurnRuntimeContext", () => {
       model: "gpt-5.4",
       workspaceDir: "/tmp/workspace",
       agentDir: "/tmp/agent",
-      tokenBudget: 1050000,
-      currentTokenCount: 232393,
     });
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -29,7 +29,6 @@ import {
   resolveProviderTextTransforms,
   transformProviderSystemPrompt,
 } from "../../../plugins/provider-runtime.js";
-import { getPluginToolMeta } from "../../../plugins/tools.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { normalizeOptionalLowercaseString } from "../../../shared/string-coerce.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
@@ -50,6 +49,7 @@ import {
 import {
   FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
   hasCompletedBootstrapTurn,
+  isWorkspaceBootstrapPending,
   makeBootstrapWarn,
   resolveBootstrapContextForRun,
   resolveContextInjectionMode,
@@ -87,11 +87,7 @@ import {
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
-import {
-  createClientToolNameConflictError,
-  findClientToolNameConflicts,
-  toClientToolDefinitions,
-} from "../../pi-tool-definition-adapter.js";
+import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
 import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
@@ -115,12 +111,13 @@ import { resolveSystemPromptOverride } from "../../system-prompt-override.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { resolveAgentTimeoutMs } from "../../timeout.js";
+import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
 import { UNKNOWN_TOOL_THRESHOLD } from "../../tool-loop-detection.js";
 import {
   resolveTranscriptPolicy,
   shouldAllowProviderOwnedThinkingReplay,
 } from "../../transcript-policy.js";
-import { derivePromptTokens, normalizeUsage, type NormalizedUsage } from "../../usage.js";
+import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
@@ -160,19 +157,14 @@ import {
 } from "../stream-resolution.js";
 import {
   applySystemPromptOverrideToSession,
-  buildEmbeddedSystemPrompt,
+  buildEmbeddedPromptChannels,
+  buildEmbeddedUserPromptPrefix,
   createSystemPromptOverride,
 } from "../system-prompt.js";
 import { dropThinkingBlocks } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
-import {
-  installContextEngineLoopHook,
-  installToolResultContextGuard,
-} from "../tool-result-context-guard.js";
-import {
-  resolveLiveToolResultMaxChars,
-  truncateOversizedToolResultsInSessionManager,
-} from "../tool-result-truncation.js";
+import { installToolResultContextGuard } from "../tool-result-context-guard.js";
+import { truncateOversizedToolResultsInSessionManager } from "../tool-result-truncation.js";
 import {
   logProviderToolSchemaDiagnostics,
   normalizeProviderToolSchemas,
@@ -182,11 +174,9 @@ import { mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import {
   assembleAttemptContextEngine,
-  buildLoopPromptCacheInfo,
   buildContextEnginePromptCacheInfo,
   findCurrentAttemptAssistantMessage,
   finalizeAttemptContextEngineTurn,
-  resolvePromptCacheTouchTimestamp,
   resolveAttemptBootstrapContext,
   runAttemptContextEngineBootstrap,
 } from "./attempt.context-engine-helpers.js";
@@ -195,6 +185,7 @@ import {
   mergeOrphanedTrailingUserPrompt,
   prependSystemPromptAddition,
   resolveAttemptFsWorkspaceOnly,
+  resolvePromptChannelHookResult,
   resolveAttemptPrependSystemContext,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
@@ -226,7 +217,6 @@ import {
   wrapStreamFnRepairMalformedToolCallArguments,
 } from "./attempt.tool-call-argument-repair.js";
 import {
-  sanitizeReplayToolCallIdsForStream,
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.tool-call-normalization.js";
@@ -248,6 +238,18 @@ import {
 } from "./preemptive-compaction.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
+function mergePrivilegedPromptChannels(systemPrompt: string, developerPrompt?: string): string {
+  const system = systemPrompt.trim();
+  const developer = developerPrompt?.trim();
+  if (!developer) {
+    return system;
+  }
+  if (!system) {
+    return developer;
+  }
+  return `${system}\n\n${developer}`;
+}
+
 export {
   appendAttemptCacheTtlIfNeeded,
   composeSystemPromptWithHookContext,
@@ -258,12 +260,14 @@ export {
   mergeOrphanedTrailingUserPrompt,
   prependSystemPromptAddition,
   resolveAttemptFsWorkspaceOnly,
+  resolvePromptChannelHookResult,
   resolveAttemptPrependSystemContext,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
   shouldWarnOnOrphanedUserRepair,
   shouldInjectHeartbeatPrompt,
 } from "./attempt.prompt-helpers.js";
+import { endE2ETraceSpan, startE2ETraceSpan } from "../../../infra/e2e-trace.js";
 export {
   buildSessionsYieldContextMessage,
   persistSessionsYieldContextMessage,
@@ -296,21 +300,11 @@ const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 export function resolveUnknownToolGuardThreshold(loopDetection?: {
   enabled?: boolean;
   unknownToolThreshold?: number;
-}): number {
-  // The unknown-tool guard is a safety net against the model hallucinating a
-  // tool name or calling a tool that has since been removed from the allowlist
-  // (for example after a `skills.allowBundled` config change). After `threshold`
-  // consecutive unknown-tool attempts the stream wrapper rewrites the assistant
-  // message content to tell the model to stop, which breaks otherwise-infinite
-  // Tool-not-found loops against the provider. Unlike the genericRepeat /
-  // pingPong / pollNoProgress detectors this guard has no false-positive
-  // surface because the tool is objectively not registered in this run, so it
-  // stays on regardless of `tools.loopDetection.enabled`.
-  const raw = loopDetection?.unknownToolThreshold;
-  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
-    return Math.floor(raw);
+}): number | undefined {
+  if (loopDetection?.enabled !== true) {
+    return undefined;
   }
-  return UNKNOWN_TOOL_THRESHOLD;
+  return loopDetection.unknownToolThreshold ?? UNKNOWN_TOOL_THRESHOLD;
 }
 
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
@@ -384,7 +378,7 @@ export async function runEmbeddedAttempt(
   // Proxy bootstrap must happen before timeout tuning so the timeouts wrap the
   // active EnvHttpProxyAgent instead of being replaced by a bare proxy dispatcher.
   ensureGlobalUndiciEnvProxyDispatcher();
-  ensureGlobalUndiciStreamTimeouts({ timeoutMs: params.timeoutMs });
+  ensureGlobalUndiciStreamTimeouts();
 
   log.debug(
     `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,
@@ -448,14 +442,16 @@ export async function runEmbeddedAttempt(
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const contextInjectionMode = resolveContextInjectionMode(params.config);
+    const workspaceBootstrapPending = await isWorkspaceBootstrapPending(effectiveWorkspace);
     const {
       bootstrapFiles: hookAdjustedBootstrapFiles,
-      contextFiles,
+      contextFiles: resolvedContextFiles,
       shouldRecordCompletedBootstrapTurn,
     } = await resolveAttemptBootstrapContext({
       contextInjectionMode,
       bootstrapContextMode: params.bootstrapContextMode,
       bootstrapContextRunKind: params.bootstrapContextRunKind,
+      workspaceBootstrapPending,
       sessionFile: params.sessionFile,
       hasCompletedBootstrapTurn,
       resolveBootstrapContextForRun: async () =>
@@ -473,11 +469,17 @@ export async function runEmbeddedAttempt(
           runKind: params.bootstrapContextRunKind,
         }),
     });
+    const contextFiles = resolvedContextFiles.filter(
+      (file) => !/(^|[\\/])BOOTSTRAP\.md$/iu.test(file.path.trim()),
+    );
+    const bootstrapFilesForInjectionStats = hookAdjustedBootstrapFiles.filter(
+      (file) => file.name !== DEFAULT_BOOTSTRAP_FILENAME,
+    );
     const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
     const bootstrapAnalysis = analyzeBootstrapBudget({
       files: buildBootstrapInjectionStats({
-        bootstrapFiles: hookAdjustedBootstrapFiles,
+        bootstrapFiles: bootstrapFilesForInjectionStats,
         injectedFiles: contextFiles,
       }),
       bootstrapMaxChars,
@@ -493,10 +495,7 @@ export async function runEmbeddedAttempt(
     const workspaceNotes = hookAdjustedBootstrapFiles.some(
       (file) => file.name === DEFAULT_BOOTSTRAP_FILENAME && !file.missing,
     )
-      ? [
-          "If BOOTSTRAP.md is present in Project Context, it overrides the normal first greeting. Read it and follow its instructions first, then update or delete it when complete.",
-          "Reminder: commit your changes in this workspace after edits.",
-        ]
+      ? ["Reminder: commit your changes in this workspace after edits."]
       : undefined;
 
     const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
@@ -787,41 +786,73 @@ export async function runEmbeddedAttempt(
       },
     });
 
-    const builtAppendPrompt =
-      resolveSystemPromptOverride({
-        config: params.config,
-        agentId: sessionAgentId,
-      }) ??
-      buildEmbeddedSystemPrompt({
-        workspaceDir: effectiveWorkspace,
-        defaultThinkLevel: params.thinkLevel,
-        reasoningLevel: params.reasoningLevel ?? "off",
-        extraSystemPrompt: params.extraSystemPrompt,
-        ownerNumbers: params.ownerNumbers,
-        ownerDisplay: ownerDisplay.ownerDisplay,
-        ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
-        reasoningTagHint,
-        heartbeatPrompt,
-        skillsPrompt: effectiveSkillsPrompt,
-        docsPath: docsPath ?? undefined,
-        ttsHint,
-        workspaceNotes,
-        reactionGuidance,
+    const explicitSystemPromptOverride = resolveSystemPromptOverride({
+      config: params.config,
+      agentId: sessionAgentId,
+    });
+    const hookRunner = getGlobalHookRunner();
+    const promptChannelHookCtx = {
+      runId: params.runId,
+      agentId: sessionAgentId,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      workspaceDir: params.workspaceDir,
+      modelProviderId: params.model.provider,
+      modelId: params.model.id,
+      messageProvider: params.messageProvider ?? undefined,
+      trigger: params.trigger,
+      channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+    };
+    const promptChannelRouting = await resolvePromptChannelHookResult({
+      event: {
+        prompt: params.prompt,
         promptMode: effectivePromptMode,
-        acpEnabled: params.config?.acp?.enabled !== false,
-        runtimeInfo,
-        messageToolHints,
-        sandboxInfo,
-        tools: effectiveTools,
-        modelAliasLines: buildModelAliasLines(params.config),
-        userTimezone,
-        userTime,
-        userTimeFormat,
         contextFiles,
+        toolNames: effectiveTools.map((tool) => tool.name),
         includeMemorySection: !params.contextEngine || params.contextEngine.info.id === "legacy",
         memoryCitationsMode: params.config?.memory?.citations,
-        promptContribution,
-      });
+      },
+      hookCtx: promptChannelHookCtx,
+      hookRunner,
+    });
+    const builtPromptChannels =
+      explicitSystemPromptOverride !== undefined
+        ? {
+            systemPrompt: explicitSystemPromptOverride,
+            developerPrompt: undefined,
+          }
+        : buildEmbeddedPromptChannels({
+            workspaceDir: effectiveWorkspace,
+            defaultThinkLevel: params.thinkLevel,
+            reasoningLevel: params.reasoningLevel ?? "off",
+            extraSystemPrompt: params.extraSystemPrompt,
+            ownerNumbers: params.ownerNumbers,
+            ownerDisplay: ownerDisplay.ownerDisplay,
+            ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
+            reasoningTagHint,
+            heartbeatPrompt,
+            skillsPrompt: effectiveSkillsPrompt,
+            docsPath: docsPath ?? undefined,
+            ttsHint,
+            workspaceNotes,
+            reactionGuidance,
+            promptMode: effectivePromptMode,
+            acpEnabled: params.config?.acp?.enabled !== false,
+            runtimeInfo,
+            messageToolHints,
+            sandboxInfo,
+            tools: effectiveTools,
+            modelAliasLines: buildModelAliasLines(params.config),
+            userTimezone,
+            userTime,
+            userTimeFormat,
+            contextFiles,
+            includeMemorySection:
+              !params.contextEngine || params.contextEngine.info.id === "legacy",
+            memoryCitationsMode: params.config?.memory?.citations,
+            promptContribution,
+            routing: promptChannelRouting,
+          });
     const appendPrompt = transformProviderSystemPrompt({
       provider: params.provider,
       config: params.config,
@@ -836,9 +867,27 @@ export async function runEmbeddedAttempt(
         runtimeChannel,
         runtimeCapabilities,
         agentId: sessionAgentId,
-        systemPrompt: builtAppendPrompt,
+        systemPrompt: builtPromptChannels.systemPrompt,
       },
     });
+    let systemPromptCoreText = appendPrompt;
+    let developerPromptText = builtPromptChannels.developerPrompt?.trim() || undefined;
+    const userPromptPrefixText = buildEmbeddedUserPromptPrefix({
+      promptMode: effectivePromptMode,
+      includeMemorySection: !params.contextEngine || params.contextEngine.info.id === "legacy",
+      toolNames: effectiveTools.map((tool) => tool.name),
+      memoryCitationsMode: params.config?.memory?.citations,
+      contextFiles,
+      bootstrapPending: workspaceBootstrapPending,
+      routing: promptChannelRouting,
+    });
+    const privilegedPromptState: {
+      systemPrompt: string;
+      developerPrompt?: string;
+    } = {
+      systemPrompt: systemPromptCoreText,
+      ...(developerPromptText ? { developerPrompt: developerPromptText } : {}),
+    };
     const systemPromptReport = buildSystemPromptReport({
       source: "run",
       generatedAt: Date.now(),
@@ -861,13 +910,16 @@ export async function runEmbeddedAttempt(
         });
         return { mode: runtime.mode, sandboxed: runtime.sandboxed };
       })(),
-      systemPrompt: appendPrompt,
+      systemPrompt: systemPromptCoreText,
+      developerPrompt: developerPromptText,
       bootstrapFiles: hookAdjustedBootstrapFiles,
       injectedFiles: contextFiles,
       skillsPrompt,
       tools: effectiveTools,
     });
-    const systemPromptOverride = createSystemPromptOverride(appendPrompt);
+    const systemPromptOverride = createSystemPromptOverride(
+      mergePrivilegedPromptChannels(systemPromptCoreText, developerPromptText),
+    );
     let systemPromptText = systemPromptOverride();
 
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
@@ -897,8 +949,6 @@ export async function runEmbeddedAttempt(
       sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
-        config: params.config,
-        contextWindowTokens: params.contextTokenBudget,
         inputProvenance: params.inputProvenance,
         allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
         allowedToolNames,
@@ -916,7 +966,6 @@ export async function runEmbeddedAttempt(
           attempt: params,
           workspaceDir: effectiveWorkspace,
           agentDir,
-          tokenBudget: params.contextTokenBudget,
         }),
         runMaintenance: async (contextParams) =>
           await runContextEngineMaintenance({
@@ -943,7 +992,6 @@ export async function runEmbeddedAttempt(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
-        contextTokenBudget: params.contextTokenBudget,
       });
       applyPiAutoCompactionGuard({
         settingsManager,
@@ -972,9 +1020,6 @@ export async function runEmbeddedAttempt(
         await resourceLoader.reload();
       }
 
-      // Get hook runner early so it's available when creating tools
-      const hookRunner = getGlobalHookRunner();
-
       const { builtInTools, customTools } = splitSdkTools({
         tools: effectiveTools,
         sandboxEnabled: !!sandbox?.enabled,
@@ -986,37 +1031,6 @@ export async function runEmbeddedAttempt(
         cfg: params.config,
         agentId: sessionAgentId,
       });
-      // Exact raw names of every tool registered for this run, including
-      // bundled/plugin tools. Used as the raw-name set for the trusted local
-      // MEDIA: passthrough gate: a normalized alias is not sufficient — the
-      // emitted tool name must match an exact registration of this run.
-      const builtinToolNames = new Set(
-        effectiveTools.flatMap((tool) => {
-          const name = (tool.name ?? "").trim();
-          return name ? [name] : [];
-        }),
-      );
-      // Admission-time conflict check only against non-plugin core tools, to
-      // preserve prior behavior where client tools may coexist with unrelated
-      // plugin tool names. MEDIA passthrough is still gated by the raw-name
-      // set above, so a client tool that normalize-collides with a plugin
-      // tool cannot inherit the plugin's local-media trust.
-      const coreBuiltinToolNames = new Set(
-        effectiveTools.flatMap((tool) => {
-          const name = (tool.name ?? "").trim();
-          if (!name || getPluginToolMeta(tool)) {
-            return [];
-          }
-          return [name];
-        }),
-      );
-      const clientToolNameConflicts = findClientToolNameConflicts({
-        tools: clientTools ?? [],
-        existingToolNames: coreBuiltinToolNames,
-      });
-      if (clientToolNameConflicts.length > 0) {
-        throw createClientToolNameConflictError(clientToolNameConflicts);
-      }
       const clientToolDefs = clientTools
         ? toClientToolDefinitions(
             clientTools,
@@ -1053,53 +1067,21 @@ export async function runEmbeddedAttempt(
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
-      let prePromptMessageCount = activeSession.messages.length;
       abortSessionForYield = () => {
         yieldAbortSettled = Promise.resolve(activeSession.abort());
       };
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
       };
-      if (params.contextEngine?.info?.ownsCompaction !== true) {
-        removeToolResultContextGuard = installToolResultContextGuard({
-          agent: activeSession.agent,
-          contextWindowTokens: Math.max(
-            1,
-            Math.floor(
-              params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
-            ),
+      removeToolResultContextGuard = installToolResultContextGuard({
+        agent: activeSession.agent,
+        contextWindowTokens: Math.max(
+          1,
+          Math.floor(
+            params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
           ),
-        });
-      } else {
-        removeToolResultContextGuard = installContextEngineLoopHook({
-          agent: activeSession.agent,
-          contextEngine: params.contextEngine,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          sessionFile: params.sessionFile,
-          tokenBudget: params.contextTokenBudget,
-          modelId: params.modelId,
-          getPrePromptMessageCount: () => prePromptMessageCount,
-          getRuntimeContext: ({ messages, prePromptMessageCount: loopPrePromptMessageCount }) =>
-            buildAfterTurnRuntimeContext({
-              attempt: params,
-              workspaceDir: effectiveWorkspace,
-              agentDir,
-              tokenBudget: params.contextTokenBudget,
-              promptCache:
-                promptCache ??
-                buildLoopPromptCacheInfo({
-                  messagesSnapshot: messages,
-                  prePromptMessageCount: loopPrePromptMessageCount,
-                  retention: effectivePromptCacheRetention,
-                  fallbackLastCacheTouchAt: readLastCacheTtlTimestamp(sessionManager, {
-                    provider: params.provider,
-                    modelId: params.modelId,
-                  }),
-                }),
-            }),
-        });
-      }
+        ),
+      });
       const cacheTrace = createCacheTrace({
         cfg: params.config,
         env: process.env,
@@ -1179,6 +1161,20 @@ export async function runEmbeddedAttempt(
           output: providerTextTransforms.output,
           transformSystemPrompt: false,
         });
+      }
+
+      if (developerPromptText) {
+        const baseStreamFn = activeSession.agent.streamFn;
+        activeSession.agent.streamFn = ((model, context, options) =>
+          baseStreamFn(
+            model,
+            {
+              ...context,
+              openclawSystemPrompt: privilegedPromptState.systemPrompt,
+              developerPrompt: privilegedPromptState.developerPrompt,
+            } as typeof context,
+            options,
+          )) as typeof activeSession.agent.streamFn;
       }
 
       const { effectiveExtraParams } = applyExtraParamsToAgent(
@@ -1278,23 +1274,25 @@ export async function runEmbeddedAttempt(
           if (!Array.isArray(messages)) {
             return inner(model, context, options);
           }
-          const nextMessages = sanitizeReplayToolCallIdsForStream({
-            messages: messages as AgentMessage[],
-            mode,
-            allowedToolNames,
-            preserveNativeAnthropicToolUseIds: transcriptPolicy.preserveNativeAnthropicToolUseIds,
-            preserveReplaySafeThinkingToolCallIds: shouldAllowProviderOwnedThinkingReplay({
-              modelApi: (model as { api?: unknown })?.api as string | null | undefined,
-              policy: transcriptPolicy,
-            }),
-            repairToolUseResultPairing: transcriptPolicy.repairToolUseResultPairing,
+          const allowProviderOwnedThinkingReplay = shouldAllowProviderOwnedThinkingReplay({
+            modelApi: (model as { api?: unknown })?.api as string | null | undefined,
+            policy: transcriptPolicy,
           });
-          if (nextMessages === messages) {
+          const sanitized = sanitizeToolCallIdsForCloudCodeAssist(
+            messages as AgentMessage[],
+            mode,
+            {
+              preserveNativeAnthropicToolUseIds: transcriptPolicy.preserveNativeAnthropicToolUseIds,
+              preserveReplaySafeThinkingToolCallIds: allowProviderOwnedThinkingReplay,
+              allowedToolNames,
+            },
+          );
+          if (sanitized === messages) {
             return inner(model, context, options);
           }
           const nextContext = {
             ...(context as unknown as Record<string, unknown>),
-            messages: nextMessages,
+            messages: sanitized,
           } as unknown;
           return inner(model, nextContext as typeof context, options);
         };
@@ -1600,7 +1598,6 @@ export async function runEmbeddedAttempt(
           sessionKey: sandboxSessionKey,
           sessionId: params.sessionId,
           agentId: sessionAgentId,
-          builtinToolNames,
           internalEvents: params.internalEvents,
         }),
       );
@@ -1743,6 +1740,7 @@ export async function runEmbeddedAttempt(
       let promptError: unknown = null;
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
       let promptErrorSource: "prompt" | "compaction" | "precheck" | null = null;
+      let prePromptMessageCount = activeSession.messages.length;
       let skipPromptSubmission = false;
       try {
         const promptStartedAt = Date.now();
@@ -1756,6 +1754,9 @@ export async function runEmbeddedAttempt(
             preserveExactPrompt: heartbeatPrompt,
           },
         );
+        if (userPromptPrefixText) {
+          effectivePrompt = `${userPromptPrefixText}\n\n${effectivePrompt}`;
+        }
         const hookCtx = {
           runId: params.runId,
           agentId: hookAgentId,
@@ -1774,6 +1775,7 @@ export async function runEmbeddedAttempt(
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
+          e2eTraceContext: params.e2eTraceContext,
         });
         {
           if (hookResult?.prependContext) {
@@ -1784,12 +1786,20 @@ export async function runEmbeddedAttempt(
           }
           const legacySystemPrompt = normalizeOptionalString(hookResult?.systemPrompt) ?? "";
           if (legacySystemPrompt) {
-            applySystemPromptOverrideToSession(activeSession, legacySystemPrompt);
-            systemPromptText = legacySystemPrompt;
+            systemPromptCoreText = legacySystemPrompt;
+            privilegedPromptState.systemPrompt = systemPromptCoreText;
+            applySystemPromptOverrideToSession(
+              activeSession,
+              mergePrivilegedPromptChannels(systemPromptCoreText, developerPromptText),
+            );
+            systemPromptText = mergePrivilegedPromptChannels(
+              systemPromptCoreText,
+              developerPromptText,
+            );
             log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
           }
           const prependedOrAppendedSystemPrompt = composeSystemPromptWithHookContext({
-            baseSystemPrompt: systemPromptText,
+            baseSystemPrompt: systemPromptCoreText,
             prependSystemContext: resolveAttemptPrependSystemContext({
               sessionKey: params.sessionKey,
               trigger: params.trigger,
@@ -1800,8 +1810,16 @@ export async function runEmbeddedAttempt(
           if (prependedOrAppendedSystemPrompt) {
             const prependSystemLen = hookResult?.prependSystemContext?.trim().length ?? 0;
             const appendSystemLen = hookResult?.appendSystemContext?.trim().length ?? 0;
-            applySystemPromptOverrideToSession(activeSession, prependedOrAppendedSystemPrompt);
-            systemPromptText = prependedOrAppendedSystemPrompt;
+            systemPromptCoreText = prependedOrAppendedSystemPrompt;
+            privilegedPromptState.systemPrompt = systemPromptCoreText;
+            applySystemPromptOverrideToSession(
+              activeSession,
+              mergePrivilegedPromptChannels(systemPromptCoreText, developerPromptText),
+            );
+            systemPromptText = mergePrivilegedPromptChannels(
+              systemPromptCoreText,
+              developerPromptText,
+            );
             log.debug(
               `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
             );
@@ -1904,6 +1922,7 @@ export async function runEmbeddedAttempt(
             : undefined;
 
         try {
+          const promptBuildStartedAt = Date.now();
           // Idempotent cleanup: prune old image blocks to limit context
           // growth. Only mutates turns older than a few assistant replies;
           // the delay also reduces prompt-cache churn.
@@ -1995,39 +2014,17 @@ export async function runEmbeddedAttempt(
 
           const reserveTokens = settingsManager.getCompactionReserveTokens();
           const contextTokenBudget = params.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;
-          const preemptiveCompaction =
-            params.contextEngine?.info?.ownsCompaction === true
-              ? {
-                  route: "fits" as const,
-                  shouldCompact: false,
-                  estimatedPromptTokens: 0,
-                  promptBudgetBeforeReserve: 0,
-                  overflowTokens: 0,
-                  toolResultReducibleChars: 0,
-                  effectiveReserveTokens: reserveTokens,
-                }
-              : shouldPreemptivelyCompactBeforePrompt({
-                  messages: activeSession.messages,
-                  systemPrompt: systemPromptText,
-                  prompt: effectivePrompt,
-                  contextTokenBudget,
-                  reserveTokens,
-                  toolResultMaxChars: resolveLiveToolResultMaxChars({
-                    contextWindowTokens: contextTokenBudget,
-                    cfg: params.config,
-                    agentId: sessionAgentId,
-                  }),
-                });
+          const preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
+            messages: activeSession.messages,
+            systemPrompt: systemPromptText,
+            prompt: effectivePrompt,
+            contextTokenBudget,
+            reserveTokens,
+          });
           if (preemptiveCompaction.route === "truncate_tool_results_only") {
-            const toolResultMaxChars = resolveLiveToolResultMaxChars({
-              contextWindowTokens: contextTokenBudget,
-              cfg: params.config,
-              agentId: sessionAgentId,
-            });
             const truncationResult = truncateOversizedToolResultsInSessionManager({
               sessionManager,
               contextWindowTokens: contextTokenBudget,
-              maxCharsOverride: toolResultMaxChars,
               sessionFile: params.sessionFile,
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
@@ -2094,6 +2091,16 @@ export async function runEmbeddedAttempt(
               inFlightPrompt: effectivePrompt,
             });
 
+            startE2ETraceSpan(params.e2eTraceContext, "prompt_build", {
+              startedAt: promptBuildStartedAt,
+            });
+            const modelCallStartedAt = Date.now();
+            endE2ETraceSpan(params.e2eTraceContext, "prompt_build", {
+              endedAt: modelCallStartedAt,
+            });
+            startE2ETraceSpan(params.e2eTraceContext, "agent_model", {
+              startedAt: modelCallStartedAt,
+            });
             // Only pass images option if there are actually images to pass
             // This avoids potential issues with models that don't expect the images parameter
             if (imageResult.images.length > 0) {
@@ -2103,8 +2110,13 @@ export async function runEmbeddedAttempt(
             } else {
               await abortable(activeSession.prompt(effectivePrompt));
             }
+            endE2ETraceSpan(params.e2eTraceContext, "agent_model");
           }
         } catch (err) {
+          endE2ETraceSpan(params.e2eTraceContext, "agent_model", {
+            status: "error",
+            attrs: { error: err instanceof Error ? err.name || "Error" : "error" },
+          });
           yieldAborted =
             yieldDetected &&
             isRunnerAbortError(err) &&
@@ -2262,18 +2274,13 @@ export async function runEmbeddedAttempt(
                 changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
               }
             : undefined;
-        const fallbackLastCacheTouchAt = readLastCacheTtlTimestamp(sessionManager, {
-          provider: params.provider,
-          modelId: params.modelId,
-        });
         promptCache = buildContextEnginePromptCacheInfo({
           retention: effectivePromptCacheRetention,
           lastCallUsage,
           observation: promptCacheObservation,
-          lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
-            lastCallUsage,
-            assistantTimestamp: currentAttemptAssistant?.timestamp,
-            fallbackLastCacheTouchAt,
+          lastCacheTouchAt: readLastCacheTtlTimestamp(sessionManager, {
+            provider: params.provider,
+            modelId: params.modelId,
           }),
         });
 
@@ -2295,13 +2302,10 @@ export async function runEmbeddedAttempt(
 
         // Let the active context engine run its post-turn lifecycle.
         if (params.contextEngine) {
-          const runtimeCurrentTokenCount = derivePromptTokens(lastCallUsage);
           const afterTurnRuntimeContext = buildAfterTurnRuntimeContext({
             attempt: params,
             workspaceDir: effectiveWorkspace,
             agentDir,
-            tokenBudget: params.contextTokenBudget,
-            currentTokenCount: runtimeCurrentTokenCount,
             promptCache,
           });
           await finalizeAttemptContextEngineTurn({
@@ -2515,6 +2519,8 @@ export async function runEmbeddedAttempt(
         bootstrapPromptWarningSignaturesSeen: bootstrapPromptWarning.warningSignaturesSeen,
         bootstrapPromptWarningSignature: bootstrapPromptWarning.signature,
         systemPromptReport,
+        systemPromptText: systemPromptCoreText,
+        developerPromptText,
         finalPromptText,
         messagesSnapshot,
         assistantTexts,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -3,6 +3,7 @@ import type { ReplyPayload } from "../../../auto-reply/reply-payload.js";
 import type { ReplyOperation } from "../../../auto-reply/reply/reply-run-registry.js";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { E2ETraceCollector } from "../../../infra/e2e-trace.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
@@ -102,6 +103,7 @@ export type RunEmbeddedPiAgentParams = {
   timeoutMs: number;
   runId: string;
   abortSignal?: AbortSignal;
+  e2eTraceContext?: E2ETraceCollector;
   replyOperation?: ReplyOperation;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;

--- a/src/agents/pi-embedded-runner/run/setup.ts
+++ b/src/agents/pi-embedded-runner/run/setup.ts
@@ -1,12 +1,12 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { E2ETraceCollector } from "../../../infra/e2e-trace.js";
+import { startE2ETraceSpan } from "../../../infra/e2e-trace.js";
 import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import type { PluginHookBeforeAgentStartResult } from "../../../plugins/types.js";
 import {
   CONTEXT_WINDOW_HARD_MIN_TOKENS,
   CONTEXT_WINDOW_WARN_BELOW_TOKENS,
   evaluateContextWindowGuard,
-  formatContextWindowBlockMessage,
-  formatContextWindowWarningMessage,
   resolveContextWindowInfo,
   type ContextWindowInfo,
 } from "../../context-window-guard.js";
@@ -43,6 +43,7 @@ export async function resolveHookModelSelection(params: {
   modelId: string;
   hookRunner?: HookRunnerLike | null;
   hookContext: HookContext;
+  e2eTraceContext?: E2ETraceCollector;
 }) {
   let provider = params.provider;
   let modelId = params.modelId;
@@ -55,6 +56,9 @@ export async function resolveHookModelSelection(params: {
   //
   // Legacy compatibility: before_agent_start is also checked for override
   // fields if present. New hook takes precedence when both are set.
+  if (hookRunner?.hasHooks("before_model_resolve") || hookRunner?.hasHooks("before_agent_start")) {
+    startE2ETraceSpan(params.e2eTraceContext, "pre_turn_hooks");
+  }
   if (hookRunner?.hasHooks("before_model_resolve")) {
     try {
       modelResolveOverride = await hookRunner.runBeforeModelResolve(
@@ -128,33 +132,19 @@ export function resolveEffectiveRuntimeModel(params: {
     warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
     hardMinTokens: CONTEXT_WINDOW_HARD_MIN_TOKENS,
   });
-  const runtimeBaseUrl =
-    typeof (params.runtimeModel as { baseUrl?: unknown }).baseUrl === "string"
-      ? (params.runtimeModel as { baseUrl: string }).baseUrl
-      : undefined;
   if (ctxGuard.shouldWarn) {
     log.warn(
-      formatContextWindowWarningMessage({
-        provider: params.provider,
-        modelId: params.modelId,
-        guard: ctxGuard,
-        runtimeBaseUrl,
-      }),
+      `low context window: ${params.provider}/${params.modelId} ctx=${ctxGuard.tokens} (warn<${CONTEXT_WINDOW_WARN_BELOW_TOKENS}) source=${ctxGuard.source}`,
     );
   }
   if (ctxGuard.shouldBlock) {
-    const message = formatContextWindowBlockMessage({
-      guard: ctxGuard,
-      runtimeBaseUrl,
-    });
     log.error(
-      `blocked model (context window too small): ${params.provider}/${params.modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}; ${message}`,
+      `blocked model (context window too small): ${params.provider}/${params.modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}`,
     );
-    throw new FailoverError(message, {
-      reason: "unknown",
-      provider: params.provider,
-      model: params.modelId,
-    });
+    throw new FailoverError(
+      `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
+      { reason: "unknown", provider: params.provider, model: params.modelId },
+    );
   }
 
   return {

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -73,6 +73,8 @@ export type EmbeddedRunAttemptResult = {
   bootstrapPromptWarningSignaturesSeen?: string[];
   bootstrapPromptWarningSignature?: string;
   systemPromptReport?: SessionSystemPromptReport;
+  systemPromptText?: string;
+  developerPromptText?: string;
   finalPromptText?: string;
   messagesSnapshot: AgentMessage[];
   assistantTexts: string[];

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -3,8 +3,13 @@ import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { MemoryCitationsMode } from "../../config/types.memory.js";
 import type { ResolvedTimeFormat } from "../date-time.js";
 import type { EmbeddedContextFile } from "../pi-embedded-helpers.js";
+import type { PromptChannelRoutingResult } from "../prompt-channels.types.js";
 import type { ProviderSystemPromptContribution } from "../system-prompt-contribution.js";
-import { buildAgentSystemPrompt } from "../system-prompt.js";
+import {
+  buildAgentPromptChannels,
+  buildAgentSystemPrompt,
+  buildAgentUserPromptPrefix,
+} from "../system-prompt.js";
 import type { PromptMode } from "../system-prompt.types.js";
 import type { EmbeddedSandboxInfo } from "./types.js";
 import type { ReasoningLevel, ThinkLevel } from "./utils.js";
@@ -56,6 +61,7 @@ export function buildEmbeddedSystemPrompt(params: {
   includeMemorySection?: boolean;
   memoryCitationsMode?: MemoryCitationsMode;
   promptContribution?: ProviderSystemPromptContribution;
+  routing?: PromptChannelRoutingResult;
 }): string {
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
@@ -86,8 +92,90 @@ export function buildEmbeddedSystemPrompt(params: {
     includeMemorySection: params.includeMemorySection,
     memoryCitationsMode: params.memoryCitationsMode,
     promptContribution: params.promptContribution,
+    routing: params.routing,
   });
 }
+
+export function buildEmbeddedPromptChannels(params: {
+  workspaceDir: string;
+  defaultThinkLevel?: ThinkLevel;
+  reasoningLevel?: ReasoningLevel;
+  extraSystemPrompt?: string;
+  ownerNumbers?: string[];
+  ownerDisplay?: "raw" | "hash";
+  ownerDisplaySecret?: string;
+  reasoningTagHint: boolean;
+  heartbeatPrompt?: string;
+  skillsPrompt?: string;
+  docsPath?: string;
+  ttsHint?: string;
+  reactionGuidance?: {
+    level: "minimal" | "extensive";
+    channel: string;
+  };
+  workspaceNotes?: string[];
+  promptMode?: PromptMode;
+  acpEnabled?: boolean;
+  runtimeInfo: {
+    agentId?: string;
+    host: string;
+    os: string;
+    arch: string;
+    node: string;
+    model: string;
+    provider?: string;
+    capabilities?: string[];
+    channel?: string;
+    channelActions?: string[];
+    canvasRootDir?: string;
+  };
+  messageToolHints?: string[];
+  sandboxInfo?: EmbeddedSandboxInfo;
+  tools: AgentTool[];
+  modelAliasLines: string[];
+  userTimezone: string;
+  userTime?: string;
+  userTimeFormat?: ResolvedTimeFormat;
+  contextFiles?: EmbeddedContextFile[];
+  includeMemorySection?: boolean;
+  memoryCitationsMode?: MemoryCitationsMode;
+  promptContribution?: ProviderSystemPromptContribution;
+  routing?: PromptChannelRoutingResult;
+}): { systemPrompt: string; developerPrompt?: string } {
+  return buildAgentPromptChannels({
+    workspaceDir: params.workspaceDir,
+    defaultThinkLevel: params.defaultThinkLevel,
+    reasoningLevel: params.reasoningLevel,
+    extraSystemPrompt: params.extraSystemPrompt,
+    ownerNumbers: params.ownerNumbers,
+    ownerDisplay: params.ownerDisplay,
+    ownerDisplaySecret: params.ownerDisplaySecret,
+    reasoningTagHint: params.reasoningTagHint,
+    heartbeatPrompt: params.heartbeatPrompt,
+    skillsPrompt: params.skillsPrompt,
+    docsPath: params.docsPath,
+    ttsHint: params.ttsHint,
+    workspaceNotes: params.workspaceNotes,
+    reactionGuidance: params.reactionGuidance,
+    promptMode: params.promptMode,
+    acpEnabled: params.acpEnabled,
+    runtimeInfo: params.runtimeInfo,
+    messageToolHints: params.messageToolHints,
+    sandboxInfo: params.sandboxInfo,
+    toolNames: params.tools.map((tool) => tool.name),
+    modelAliasLines: params.modelAliasLines,
+    userTimezone: params.userTimezone,
+    userTime: params.userTime,
+    userTimeFormat: params.userTimeFormat,
+    contextFiles: params.contextFiles,
+    includeMemorySection: params.includeMemorySection,
+    memoryCitationsMode: params.memoryCitationsMode,
+    promptContribution: params.promptContribution,
+    routing: params.routing,
+  });
+}
+
+export { buildAgentUserPromptPrefix, buildAgentUserPromptPrefix as buildEmbeddedUserPromptPrefix };
 
 export function createSystemPromptOverride(
   systemPrompt: string,

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -1,4 +1,5 @@
 import type { CliSessionBinding, SessionSystemPromptReport } from "../../config/sessions/types.js";
+import type { E2ETrace } from "../../infra/e2e-trace.js";
 import type { MessagingToolSend } from "../pi-embedded-messaging.types.js";
 
 export type EmbeddedPiAgentMeta = {
@@ -77,6 +78,12 @@ export type ToolSummaryTrace = {
   tools: string[];
   failures?: number;
   totalToolTimeMs?: number;
+  topSlowTools?: Array<{
+    name: string;
+    calls: number;
+    totalMs: number;
+    maxMs?: number;
+  }>;
 };
 
 export type CompletionTrace = {
@@ -92,6 +99,18 @@ export type ContextManagementTrace = {
   postCompactionContextInjected?: boolean;
 };
 
+export type TurnTimingTrace = {
+  totalDurationMs: number;
+  toolDurationMs?: number;
+  nonToolDurationMs?: number;
+  topSlowTools?: Array<{
+    name: string;
+    calls: number;
+    totalMs: number;
+    maxMs?: number;
+  }>;
+};
+
 export type EmbeddedRunLivenessState = "working" | "paused" | "blocked" | "abandoned";
 
 export type EmbeddedPiRunMeta = {
@@ -99,6 +118,8 @@ export type EmbeddedPiRunMeta = {
   agentMeta?: EmbeddedPiAgentMeta;
   aborted?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
+  systemPromptText?: string;
+  developerPromptText?: string;
   finalPromptText?: string;
   finalAssistantVisibleText?: string;
   finalAssistantRawText?: string;
@@ -127,6 +148,8 @@ export type EmbeddedPiRunMeta = {
   toolSummary?: ToolSummaryTrace;
   completion?: CompletionTrace;
   contextManagement?: ContextManagementTrace;
+  timingTrace?: TurnTimingTrace;
+  e2eTrace?: E2ETrace;
 };
 
 export type EmbeddedPiRunResult = {

--- a/src/agents/prompt-channels.types.ts
+++ b/src/agents/prompt-channels.types.ts
@@ -1,0 +1,22 @@
+import type { MemoryCitationsMode } from "../config/types.memory.js";
+import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
+import type { PromptMode } from "./system-prompt.types.js";
+
+export type PromptChannelTarget = "system" | "developer" | "user";
+
+export type PromptChannelRoutingResult = {
+  systemAdditions?: string;
+  developerAdditions?: string;
+  userAdditions?: string;
+  memorySectionTarget?: "system" | "user";
+  contextFileRoutes?: Record<string, PromptChannelTarget>;
+};
+
+export type PromptChannelRoutingEvent = {
+  prompt: string;
+  promptMode: PromptMode;
+  contextFiles: EmbeddedContextFile[];
+  toolNames: string[];
+  includeMemorySection: boolean;
+  memoryCitationsMode?: MemoryCitationsMode;
+};

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -79,12 +79,14 @@ export function buildSystemPromptReport(params: {
   bootstrapTruncation?: SessionSystemPromptReport["bootstrapTruncation"];
   sandbox?: SessionSystemPromptReport["sandbox"];
   systemPrompt: string;
+  developerPrompt?: string;
   bootstrapFiles: WorkspaceBootstrapFile[];
   injectedFiles: EmbeddedContextFile[];
   skillsPrompt: string;
   tools: AgentTool[];
 }): SessionSystemPromptReport {
   const systemPrompt = params.systemPrompt.trim();
+  const developerPrompt = params.developerPrompt?.trim() ?? "";
   const projectContext = extractBetween(
     systemPrompt,
     "\n# Project Context\n",
@@ -112,6 +114,14 @@ export function buildSystemPromptReport(params: {
       projectContextChars,
       nonProjectContextChars: Math.max(0, systemPrompt.length - projectContextChars),
     },
+    ...(developerPrompt
+      ? {
+          developerPrompt: {
+            chars: developerPrompt.length,
+            projectContextChars: developerPrompt.length,
+          },
+        }
+      : {}),
     injectedWorkspaceFiles: buildBootstrapInjectionStats({
       bootstrapFiles: params.bootstrapFiles,
       injectedFiles: params.injectedFiles,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1,10 +1,190 @@
-import { describe, expect, it } from "vitest";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearMemoryPluginState, registerMemoryPromptSection } from "../plugins/memory-state.js";
 import { typedCases } from "../test-utils/typed-cases.js";
 import { buildSubagentSystemPrompt } from "./subagent-system-prompt.js";
-import { buildAgentSystemPrompt, buildRuntimeLine } from "./system-prompt.js";
+import {
+  buildAgentPromptChannels,
+  buildAgentSystemPrompt,
+  buildAgentUserPromptPrefix,
+  buildRuntimeLine,
+} from "./system-prompt.js";
 
 describe("buildAgentSystemPrompt", () => {
+  afterEach(() => {
+    clearMemoryPluginState();
+  });
+
+  it("keeps the OpenClaw assistant intro for GPT-5 family models", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      runtimeInfo: {
+        model: "github-copilot/gpt-5.4",
+      },
+    });
+
+    expect(prompt.startsWith("You are a personal assistant running inside OpenClaw.")).toBe(true);
+  });
+
+  it("keeps core prompts generic when no prompt-routing plugin contribution is applied", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).not.toContain("## Autonomy and Persistence");
+  });
+
+  it("keeps all context files in the system prompt when no routing contribution is applied", () => {
+    const channels = buildAgentPromptChannels({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [
+        { path: "AGENTS.md", content: "agents guidance" },
+        { path: "notes.md", content: "normal project context" },
+        { path: "SOUL.md", content: "persona guidance" },
+        { path: "IDENTITY.md", content: "identity guidance" },
+        { path: "USER.md", content: "user guidance" },
+      ],
+    });
+
+    expect(channels.systemPrompt).toContain("## notes.md");
+    expect(channels.systemPrompt).toContain("## AGENTS.md");
+    expect(channels.systemPrompt).toContain("## SOUL.md");
+    expect(channels.systemPrompt).toContain("## IDENTITY.md");
+    expect(channels.systemPrompt).toContain("## USER.md");
+    expect(channels.developerPrompt).toBeUndefined();
+  });
+
+  it("includes base memory guidance in the system prompt when no routing contribution is applied", () => {
+    registerMemoryPromptSection(() => ["## Memory Recall", "Use memory carefully.", ""]);
+    const channels = buildAgentPromptChannels({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["memory_search"],
+      includeMemorySection: true,
+    });
+
+    expect(channels.systemPrompt).toContain("## Memory Recall");
+  });
+
+  it("keeps the user prompt prefix empty when no routing contribution is applied", () => {
+    registerMemoryPromptSection(() => ["## Memory Recall", "Use memory carefully.", ""]);
+    const promptPrefix = buildAgentUserPromptPrefix({
+      toolNames: ["memory_search"],
+      includeMemorySection: true,
+    });
+
+    expect(promptPrefix).toBeUndefined();
+  });
+
+  it("keeps bootstrap instructions out of the privileged prompt when bootstrap is pending", () => {
+    const channels = buildAgentPromptChannels({
+      workspaceDir: "/tmp/openclaw",
+      bootstrapPending: true,
+    });
+
+    expect(channels.systemPrompt).not.toContain("## Bootstrap");
+    expect(channels.systemPrompt).not.toContain("Bootstrap is pending for this workspace.");
+  });
+
+  it("adds bootstrap-specific prelude text to the user prompt prefix when bootstrap is pending", () => {
+    const promptPrefix = buildAgentUserPromptPrefix({ bootstrapPending: true });
+
+    expect(promptPrefix).toContain("[Bootstrap pending]");
+    expect(promptPrefix).toContain(
+      "Before producing any user-visible reply, you MUST read BOOTSTRAP.md from the workspace",
+    );
+    expect(promptPrefix).toContain(
+      "Do not greet the user, offer help, answer the message, or reply normally",
+    );
+    expect(promptPrefix).toContain(
+      "Your first user-visible reply for a bootstrap-pending workspace must follow BOOTSTRAP.md",
+    );
+  });
+
+  it("routes developer and user context when a routing contribution is applied", () => {
+    registerMemoryPromptSection(() => ["## Memory Recall", "Use memory carefully.", ""]);
+    const channels = buildAgentPromptChannels({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [
+        { path: "AGENTS.md", content: "agents guidance" },
+        { path: "USER.md", content: "user guidance" },
+        { path: "/tmp/openclaw/MEMORY.md", content: "Promoted From Short-Term Memory" },
+        { path: "notes.md", content: "normal project context" },
+      ],
+      routing: {
+        systemAdditions: "## Autonomy and Persistence\nTake action.",
+        contextFileRoutes: {
+          "AGENTS.md": "developer",
+          "USER.md": "developer",
+          "/tmp/openclaw/MEMORY.md": "user",
+        },
+        memorySectionTarget: "user",
+      },
+      toolNames: ["memory_search"],
+      includeMemorySection: true,
+    });
+    const promptPrefix = buildAgentUserPromptPrefix({
+      toolNames: ["memory_search"],
+      includeMemorySection: true,
+      contextFiles: [
+        { path: "AGENTS.md", content: "agents guidance" },
+        { path: "USER.md", content: "user guidance" },
+        { path: "/tmp/openclaw/MEMORY.md", content: "Promoted From Short-Term Memory" },
+        { path: "notes.md", content: "normal project context" },
+      ],
+      routing: {
+        contextFileRoutes: {
+          "AGENTS.md": "developer",
+          "USER.md": "developer",
+          "/tmp/openclaw/MEMORY.md": "user",
+        },
+        memorySectionTarget: "user",
+      },
+    });
+
+    expect(channels.systemPrompt).toContain("## Autonomy and Persistence");
+    expect(channels.systemPrompt).toContain("## notes.md");
+    expect(channels.systemPrompt).not.toContain("## AGENTS.md");
+    expect(channels.systemPrompt).not.toContain("## USER.md");
+    expect(channels.systemPrompt).not.toContain("## /tmp/openclaw/MEMORY.md");
+    expect(channels.developerPrompt).toContain("# Developer Context");
+    expect(channels.developerPrompt).toContain("## AGENTS.md");
+    expect(channels.developerPrompt).toContain("## USER.md");
+    expect(promptPrefix).toContain("# User Context");
+    expect(promptPrefix).toContain("## Memory Recall");
+    expect(promptPrefix).toContain("## /tmp/openclaw/MEMORY.md");
+    expect(promptPrefix).toContain("Promoted From Short-Term Memory");
+  });
+
+  it("keeps routed dynamic files out of the system prompt channel", () => {
+    const channels = buildAgentPromptChannels({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [
+        { path: "heartbeat.md", content: "dynamic system context" },
+        { path: "USER.md", content: "dynamic user context" },
+      ],
+      routing: {
+        contextFileRoutes: {
+          "USER.md": "user",
+        },
+      },
+    });
+    const promptPrefix = buildAgentUserPromptPrefix({
+      contextFiles: [
+        { path: "heartbeat.md", content: "dynamic system context" },
+        { path: "USER.md", content: "dynamic user context" },
+      ],
+      routing: {
+        contextFileRoutes: {
+          "USER.md": "user",
+        },
+      },
+    });
+
+    expect(channels.systemPrompt).toContain("## heartbeat.md");
+    expect(channels.systemPrompt).not.toContain("## USER.md");
+    expect(promptPrefix).toContain("## USER.md");
+    expect(promptPrefix).toContain("dynamic user context");
+  });
+
   it("formats owner section for plain, hash, and missing owner lists", () => {
     const cases = typedCases<{
       name: string;
@@ -409,19 +589,6 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Reminder: commit your changes in this workspace after edits.");
   });
 
-  it("includes BOOTSTRAP override guidance in workspace notes when provided", () => {
-    const prompt = buildAgentSystemPrompt({
-      workspaceDir: "/tmp/openclaw",
-      workspaceNotes: [
-        "If BOOTSTRAP.md is present in Project Context, it overrides the normal first greeting. Read it and follow its instructions first, then update or delete it when complete.",
-      ],
-    });
-
-    expect(prompt).toContain("BOOTSTRAP.md is present in Project Context");
-    expect(prompt).toContain("it overrides the normal first greeting");
-    expect(prompt).toContain("Read it and follow its instructions first");
-  });
-
   it("shows timezone section for 12h, 24h, and timezone-only modes", () => {
     const cases = [
       {
@@ -598,9 +765,9 @@ describe("buildAgentSystemPrompt", () => {
       ],
     });
 
-    expect(prompt).toContain(
-      "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
-    );
+    expect(prompt).toContain("# Project Context");
+    expect(prompt).toContain("## ./SOUL.md");
+    expect(prompt).toContain("## dir\\SOUL.md");
   });
 
   it("omits project context when no context files are injected", () => {
@@ -620,7 +787,8 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("message: Send messages and channel actions");
     expect(prompt).toContain("### message tool");
-    expect(prompt).toContain(`respond with ONLY: ${SILENT_REPLY_TOKEN}`);
+    expect(prompt).toContain("avoid sending a second duplicate assistant reply in chat");
+    expect(prompt).not.toContain("## Silent Replies");
   });
 
   it("reapplies provider prompt contributions", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1,6 +1,5 @@
 import { createHmac, createHash } from "node:crypto";
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { resolveChannelApprovalCapability } from "../channels/plugins/approvals.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
@@ -20,6 +19,7 @@ import {
   normalizePromptCapabilityIds,
   normalizeStructuredPromptSection,
 } from "./prompt-cache-stability.js";
+import type { PromptChannelRoutingResult, PromptChannelTarget } from "./prompt-channels.types.js";
 import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./system-prompt-cache-boundary.js";
 import type {
@@ -119,6 +119,77 @@ function buildProjectContextSection(params: {
   return lines;
 }
 
+function buildDeveloperContextSection(files: EmbeddedContextFile[]) {
+  if (files.length === 0) {
+    return [];
+  }
+  return [
+    "# Developer Context",
+    "",
+    "The following developer-role context files have been loaded:",
+    "",
+    ...files.flatMap((file) => [
+      `## ${file.path}`,
+      "",
+      sanitizeContextFileContentForPrompt(file.content),
+      "",
+    ]),
+  ];
+}
+
+function buildUserContextSection(files: EmbeddedContextFile[]) {
+  if (files.length === 0) {
+    return [];
+  }
+  return [
+    "# User Context",
+    "",
+    "The following user-role context files have been loaded:",
+    "",
+    ...files.flatMap((file) => [
+      `## ${file.path}`,
+      "",
+      sanitizeContextFileContentForPrompt(file.content),
+      "",
+    ]),
+  ];
+}
+
+function normalizeContextFileRoutes(
+  routes?: Record<string, PromptChannelTarget>,
+): Record<string, PromptChannelTarget> {
+  const normalized: Record<string, PromptChannelTarget> = {};
+  for (const [pathKey, target] of Object.entries(routes ?? {})) {
+    const normalizedPath = normalizeContextFilePath(pathKey);
+    if (!normalizedPath) {
+      continue;
+    }
+    normalized[normalizedPath] = target;
+  }
+  return normalized;
+}
+
+function splitPromptAdditionLines(value?: string): string[] {
+  const trimmed = value?.trim();
+  return trimmed ? [trimmed, ""] : [];
+}
+
+function mergePrivilegedPromptChannels(systemPrompt: string, developerPrompt?: string): string {
+  const system = systemPrompt.trim();
+  const developer = developerPrompt?.trim();
+  if (!developer) {
+    return system;
+  }
+  if (!system) {
+    return developer;
+  }
+  return `${system}\n\n${developer}`;
+}
+
+function buildAgentIdentityLine(_runtimeModel?: string): string {
+  return "You are a personal assistant running inside OpenClaw.";
+}
+
 function buildHeartbeatSection(params: { isMinimal: boolean; heartbeatPrompt?: string }) {
   if (params.isMinimal || !params.heartbeatPrompt) {
     return [];
@@ -179,6 +250,53 @@ function buildMemorySection(params: {
     availableTools: params.availableTools,
     citationsMode: params.citationsMode,
   });
+}
+
+export function buildAgentUserPromptPrefix(params: {
+  promptMode?: PromptMode;
+  includeMemorySection?: boolean;
+  toolNames?: string[];
+  memoryCitationsMode?: MemoryCitationsMode;
+  contextFiles?: EmbeddedContextFile[];
+  bootstrapPending?: boolean;
+  routing?: PromptChannelRoutingResult;
+}): string | undefined {
+  const promptMode = params.promptMode ?? "full";
+  const isMinimal = promptMode === "minimal" || promptMode === "none";
+  const availableTools = new Set(
+    (params.toolNames ?? []).map((tool) => normalizeLowercaseStringOrEmpty(tool)).filter(Boolean),
+  );
+  const routeMap = normalizeContextFileRoutes(params.routing?.contextFileRoutes);
+  const memorySection =
+    params.routing?.memorySectionTarget === "user"
+      ? buildMemorySection({
+          isMinimal,
+          includeMemorySection: params.includeMemorySection,
+          availableTools,
+          citationsMode: params.memoryCitationsMode,
+        })
+      : [];
+  const userContextFiles = sortContextFilesForPrompt(params.contextFiles ?? []).filter(
+    (file) => routeMap[normalizeContextFilePath(file.path)] === "user",
+  );
+  const text = [
+    ...(params.bootstrapPending
+      ? [
+          "[Bootstrap pending]",
+          "Before producing any user-visible reply, you MUST read BOOTSTRAP.md from the workspace and follow it.",
+          "Do not greet the user, offer help, answer the message, or reply normally until after you have read and are following BOOTSTRAP.md.",
+          "Your first user-visible reply for a bootstrap-pending workspace must follow BOOTSTRAP.md, not a generic greeting.",
+          "",
+        ]
+      : []),
+    ...splitPromptAdditionLines(params.routing?.userAdditions),
+    ...memorySection,
+    ...buildUserContextSection(userContextFiles),
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  return text || undefined;
 }
 
 function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: boolean) {
@@ -312,7 +430,7 @@ function buildMessagingSection(params: {
     "- Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)",
     "- Cross-session messaging → use sessions_send(sessionKey, message)",
     "- Sub-agent orchestration → use subagents(action=list|steer|kill)",
-    `- Runtime-generated completion events may ask for a user update. Rewrite those in your normal assistant voice and send the update (do not forward raw internal metadata or default to ${SILENT_REPLY_TOKEN}).`,
+    "- Runtime-generated completion events may ask for a user update. Rewrite those in your normal assistant voice and send the update; do not forward raw internal metadata.",
     "- Never use exec/curl for provider messaging; OpenClaw handles all routing internally.",
     params.availableTools.has("message")
       ? [
@@ -321,7 +439,7 @@ function buildMessagingSection(params: {
           "- Use `message` for proactive sends + channel actions (polls, reactions, etc.).",
           "- For `action=send`, include `to` and `message`.",
           `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
-          `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
+          "- If you use `message` (`action=send`) to deliver your user-visible reply, avoid sending a second duplicate assistant reply in chat.",
           params.inlineButtonsEnabled
             ? "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`."
             : params.runtimeChannel
@@ -426,7 +544,60 @@ export function buildAgentSystemPrompt(params: {
   includeMemorySection?: boolean;
   memoryCitationsMode?: MemoryCitationsMode;
   promptContribution?: ProviderSystemPromptContribution;
+  routing?: PromptChannelRoutingResult;
 }) {
+  const channels = buildAgentPromptChannels(params);
+  return mergePrivilegedPromptChannels(channels.systemPrompt, channels.developerPrompt);
+}
+
+export function buildAgentPromptChannels(params: {
+  workspaceDir: string;
+  defaultThinkLevel?: ThinkLevel;
+  reasoningLevel?: ReasoningLevel;
+  extraSystemPrompt?: string;
+  ownerNumbers?: string[];
+  ownerDisplay?: OwnerIdDisplay;
+  ownerDisplaySecret?: string;
+  reasoningTagHint?: boolean;
+  toolNames?: string[];
+  toolSummaries?: Record<string, string>;
+  modelAliasLines?: string[];
+  userTimezone?: string;
+  userTime?: string;
+  userTimeFormat?: ResolvedTimeFormat;
+  contextFiles?: EmbeddedContextFile[];
+  skillsPrompt?: string;
+  heartbeatPrompt?: string;
+  docsPath?: string;
+  workspaceNotes?: string[];
+  ttsHint?: string;
+  promptMode?: PromptMode;
+  acpEnabled?: boolean;
+  runtimeInfo?: {
+    agentId?: string;
+    host?: string;
+    os?: string;
+    arch?: string;
+    node?: string;
+    model?: string;
+    defaultModel?: string;
+    shell?: string;
+    channel?: string;
+    capabilities?: string[];
+    repoRoot?: string;
+    canvasRootDir?: string;
+  };
+  messageToolHints?: string[];
+  sandboxInfo?: EmbeddedSandboxInfo;
+  reactionGuidance?: {
+    level: "minimal" | "extensive";
+    channel: string;
+  };
+  includeMemorySection?: boolean;
+  memoryCitationsMode?: MemoryCitationsMode;
+  promptContribution?: ProviderSystemPromptContribution;
+  routing?: PromptChannelRoutingResult;
+}): { systemPrompt: string; developerPrompt?: string } {
   const acpEnabled = params.acpEnabled !== false;
   const sandboxedRuntime = params.sandboxInfo?.enabled === true;
   const acpSpawnRuntimeEnabled = acpEnabled && !sandboxedRuntime;
@@ -610,12 +781,6 @@ export function buildAgentSystemPrompt(params: {
     skillsPrompt,
     readToolName,
   });
-  const memorySection = buildMemorySection({
-    isMinimal,
-    includeMemorySection: params.includeMemorySection,
-    availableTools,
-    citationsMode: params.memoryCitationsMode,
-  });
   const docsSection = buildDocsSection({
     docsPath: params.docsPath,
     isMinimal,
@@ -625,12 +790,13 @@ export function buildAgentSystemPrompt(params: {
 
   // For "none" mode, return just the basic identity line
   if (promptMode === "none") {
-    return "You are a personal assistant running inside OpenClaw.";
+    return { systemPrompt: buildAgentIdentityLine(params.runtimeInfo?.model) };
   }
 
   const lines = [
-    "You are a personal assistant running inside OpenClaw.",
+    buildAgentIdentityLine(runtimeInfo?.model),
     "",
+    ...splitPromptAdditionLines(params.routing?.systemAdditions),
     "## Tooling",
     "Tool availability (filtered by policy):",
     "Tool names are case-sensitive. Call tools exactly as listed.",
@@ -711,7 +877,6 @@ export function buildAgentSystemPrompt(params: {
     "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
     "",
     ...skillsSection,
-    ...memorySection,
     // Skip self-update for subagent/none modes
     hasGateway && !isMinimal ? "## OpenClaw Self-Update" : "",
     hasGateway && !isMinimal
@@ -864,8 +1029,32 @@ export function buildAgentSystemPrompt(params: {
     (file) => typeof file.path === "string" && file.path.trim().length > 0,
   );
   const orderedContextFiles = sortContextFilesForPrompt(validContextFiles);
-  const stableContextFiles = orderedContextFiles.filter((file) => !isDynamicContextFile(file.path));
-  const dynamicContextFiles = orderedContextFiles.filter((file) => isDynamicContextFile(file.path));
+  const routeMap = normalizeContextFileRoutes(params.routing?.contextFileRoutes);
+  const developerContextFiles = orderedContextFiles.filter(
+    (file) => routeMap[normalizeContextFilePath(file.path)] === "developer",
+  );
+  const stableContextFiles = orderedContextFiles.filter(
+    (file) =>
+      !isDynamicContextFile(file.path) &&
+      routeMap[normalizeContextFilePath(file.path)] !== "developer" &&
+      routeMap[normalizeContextFilePath(file.path)] !== "user",
+  );
+  const dynamicContextFiles = orderedContextFiles.filter(
+    (file) =>
+      isDynamicContextFile(file.path) &&
+      routeMap[normalizeContextFilePath(file.path)] !== "developer" &&
+      routeMap[normalizeContextFilePath(file.path)] !== "user",
+  );
+  if (params.routing?.memorySectionTarget !== "user") {
+    lines.push(
+      ...buildMemorySection({
+        isMinimal,
+        includeMemorySection: params.includeMemorySection,
+        availableTools,
+        citationsMode: params.memoryCitationsMode,
+      }),
+    );
+  }
   lines.push(
     ...buildProjectContextSection({
       files: stableContextFiles,
@@ -873,24 +1062,6 @@ export function buildAgentSystemPrompt(params: {
       dynamic: false,
     }),
   );
-
-  // Skip silent replies for subagent/none modes
-  if (!isMinimal) {
-    lines.push(
-      "## Silent Replies",
-      `When you have nothing to say, respond with ONLY: ${SILENT_REPLY_TOKEN}`,
-      "",
-      "⚠️ Rules:",
-      "- It must be your ENTIRE message — nothing else",
-      `- Never append it to an actual response (never include "${SILENT_REPLY_TOKEN}" in real replies)`,
-      "- Never wrap it in markdown or code blocks",
-      "",
-      `❌ Wrong: "Here's help... ${SILENT_REPLY_TOKEN}"`,
-      `❌ Wrong: "${SILENT_REPLY_TOKEN}"`,
-      `✅ Right: ${SILENT_REPLY_TOKEN}`,
-      "",
-    );
-  }
 
   // Keep large stable prompt context above this seam so Anthropic-family
   // transports can reuse it across labs and turns. Dynamic group/session
@@ -923,7 +1094,19 @@ export function buildAgentSystemPrompt(params: {
     `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
   );
 
-  return lines.filter(Boolean).join("\n");
+  return {
+    systemPrompt: lines.filter(Boolean).join("\n"),
+    developerPrompt: (() => {
+      const developerLines = [
+        ...splitPromptAdditionLines(params.routing?.developerAdditions),
+        ...buildDeveloperContextSection(developerContextFiles),
+      ];
+      if (developerLines.length === 0) {
+        return undefined;
+      }
+      return developerLines.filter(Boolean).join("\n");
+    })(),
+  };
 }
 
 export function buildRuntimeLine(

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -14,7 +14,9 @@ import {
   DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
   filterBootstrapFilesForSession,
+  isWorkspaceBootstrapPending,
   loadWorkspaceBootstrapFiles,
+  resolveWorkspaceBootstrapStatus,
   resolveDefaultAgentWorkspaceDir,
   type WorkspaceBootstrapFile,
 } from "./workspace.js";
@@ -172,6 +174,50 @@ describe("ensureAgentWorkspace", () => {
       "utf-8",
     );
     expect(persisted).toContain('"setupCompletedAt": "2026-03-15T02:30:00.000Z"');
+  });
+
+  it("reports bootstrap pending while BOOTSTRAP.md exists and completion is unset", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expect(isWorkspaceBootstrapPending(tempDir)).resolves.toBe(true);
+    await expect(resolveWorkspaceBootstrapStatus(tempDir)).resolves.toMatchObject({
+      phase: "pending",
+      bootstrapExists: true,
+    });
+  });
+
+  it("reports bootstrap complete after BOOTSTRAP.md deletion sets setupCompletedAt", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await fs.unlink(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expect(isWorkspaceBootstrapPending(tempDir)).resolves.toBe(false);
+    await expect(resolveWorkspaceBootstrapStatus(tempDir)).resolves.toMatchObject({
+      phase: "complete",
+      bootstrapExists: false,
+    });
+  });
+
+  it("does not reopen bootstrap when BOOTSTRAP.md is restored after completion", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await fs.unlink(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_BOOTSTRAP_FILENAME,
+      content: "# restored bootstrap",
+    });
+
+    await expect(resolveWorkspaceBootstrapStatus(tempDir)).resolves.toMatchObject({
+      phase: "complete",
+      bootstrapExists: true,
+    });
   });
 
   it("writes the current fenced HEARTBEAT template body into new workspaces", async () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -166,6 +166,15 @@ type WorkspaceSetupState = {
   setupCompletedAt?: string;
 };
 
+export type WorkspaceBootstrapPhase = "pending" | "complete";
+
+export type WorkspaceBootstrapStatus = {
+  phase: WorkspaceBootstrapPhase;
+  bootstrapExists: boolean;
+  bootstrapSeededAt?: string;
+  setupCompletedAt?: string;
+};
+
 /** Set of recognized bootstrap filenames for runtime validation */
 const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_AGENTS_FILENAME,
@@ -261,6 +270,30 @@ async function readWorkspaceSetupStateForDir(dir: string): Promise<WorkspaceSetu
 export async function isWorkspaceSetupCompleted(dir: string): Promise<boolean> {
   const state = await readWorkspaceSetupStateForDir(dir);
   return typeof state.setupCompletedAt === "string" && state.setupCompletedAt.trim().length > 0;
+}
+
+export async function resolveWorkspaceBootstrapStatus(
+  dir: string,
+): Promise<WorkspaceBootstrapStatus> {
+  const resolvedDir = resolveUserPath(dir);
+  const [state, bootstrapExists] = await Promise.all([
+    readWorkspaceSetupStateForDir(resolvedDir),
+    fileExists(path.join(resolvedDir, DEFAULT_BOOTSTRAP_FILENAME)),
+  ]);
+  const setupCompletedAt =
+    typeof state.setupCompletedAt === "string" && state.setupCompletedAt.trim().length > 0
+      ? state.setupCompletedAt
+      : undefined;
+  return {
+    phase: setupCompletedAt ? "complete" : bootstrapExists ? "pending" : "complete",
+    bootstrapExists,
+    bootstrapSeededAt: state.bootstrapSeededAt,
+    setupCompletedAt,
+  };
+}
+
+export async function isWorkspaceBootstrapPending(dir: string): Promise<boolean> {
+  return (await resolveWorkspaceBootstrapStatus(dir)).phase === "pending";
 }
 
 async function writeWorkspaceSetupState(

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -4,6 +4,7 @@ import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { resolveEmbeddedFullAccessState } from "../../agents/pi-embedded-runner/sandbox-info.js";
 import type { EmbeddedFullAccessBlockedReason } from "../../agents/pi-embedded-runner/types.js";
+import { isWorkspaceBootstrapPending } from "../../agents/workspace.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import {
   resolveSessionFilePath,
@@ -43,7 +44,10 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { buildReplyPromptBodies } from "./prompt-prelude.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { resolveQueueSettings } from "./queue/settings-runtime.js";
-import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+import {
+  buildBareSessionResetBootstrapPendingPrompt,
+  buildBareSessionResetPrompt,
+} from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents } from "./session-system-events.js";
 import { buildSessionStartupContextPrelude, shouldApplyStartupContext } from "./startup-context.js";
 import { resolveTypingMode } from "./typing-mode.js";
@@ -320,15 +324,23 @@ export async function runPreparedReply(
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
   const startupAction = /^\/reset(?:\s|$)/.test(normalizedCommandBody) ? "reset" : "new";
+  const workspaceBootstrapPending =
+    isBareSessionReset || isFirstTurnInSession
+      ? await isWorkspaceBootstrapPending(workspaceDir)
+      : false;
   const startupContextPrelude =
-    isBareSessionReset && shouldApplyStartupContext({ cfg, action: startupAction })
+    isBareSessionReset &&
+    !workspaceBootstrapPending &&
+    shouldApplyStartupContext({ cfg, action: startupAction })
       ? await buildSessionStartupContextPrelude({
           workspaceDir,
           cfg,
         })
       : null;
   const baseBodyFinal = isBareSessionReset
-    ? buildBareSessionResetPrompt(cfg)
+    ? workspaceBootstrapPending
+      ? buildBareSessionResetBootstrapPendingPrompt(cfg)
+      : buildBareSessionResetPrompt(cfg)
     : stripPromptThinkingDirectives(baseBody);
   const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
   const inboundUserContext = buildInboundUserContextPrefix(

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -1,17 +1,32 @@
 import { describe, it, expect } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+import {
+  buildBareSessionResetBootstrapPendingPrompt,
+  buildBareSessionResetPrompt,
+} from "./session-reset-prompt.js";
 
 describe("buildBareSessionResetPrompt", () => {
   it("includes the explicit Session Startup instruction for bare /new and /reset", () => {
     const prompt = buildBareSessionResetPrompt();
     expect(prompt).toContain("Execute your Session Startup sequence now");
     expect(prompt).toContain("read the required files before responding to the user");
-    expect(prompt).toContain("If BOOTSTRAP.md exists in the provided Project Context");
-    expect(prompt).toContain("read it and follow its instructions first");
+    expect(prompt).toContain("If bootstrap is still pending for this workspace");
+    expect(prompt).toContain("read BOOTSTRAP.md from the workspace");
     expect(prompt).not.toContain(
       "If runtime-provided startup context is included for this first turn",
     );
+  });
+
+  it("builds a bootstrap-pending reset prompt that suppresses the normal first greeting", () => {
+    const prompt = buildBareSessionResetBootstrapPendingPrompt();
+    expect(prompt).toContain("while bootstrap is still pending for this workspace");
+    expect(prompt).toContain(
+      "Before producing any user-visible reply, you MUST read BOOTSTRAP.md from the workspace now",
+    );
+    expect(prompt).toContain(
+      "Do not greet the user, offer help, answer the message, or reply normally",
+    );
+    expect(prompt).toContain("Your first user-visible reply must follow BOOTSTRAP.md");
   });
 
   it("appends current time line so agents know the date", () => {

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -2,7 +2,10 @@ import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const BARE_SESSION_RESET_PROMPT_BASE =
-  "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. If BOOTSTRAP.md exists in the provided Project Context, read it and follow its instructions first. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+  "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. If bootstrap is still pending for this workspace, then before producing any user-visible reply you MUST read BOOTSTRAP.md from the workspace and follow it. Do not greet the user, offer help, answer the message, or reply normally until after you have read and are following BOOTSTRAP.md. Only once bootstrap is complete should you greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+
+const BARE_SESSION_RESET_BOOTSTRAP_PENDING_PROMPT_BASE =
+  "A new session was started via /new or /reset while bootstrap is still pending for this workspace. Before producing any user-visible reply, you MUST read BOOTSTRAP.md from the workspace now and follow it. Do not greet the user, offer help, answer the message, or reply normally until after you have read and are following BOOTSTRAP.md. Your first user-visible reply must follow BOOTSTRAP.md, not a generic greeting. If the runtime model differs from default_model in the system prompt, mention the default model only after following BOOTSTRAP.md. Do not mention internal steps, files, tools, or reasoning.";
 
 /**
  * Build the bare session reset prompt, appending the current date/time so agents
@@ -12,6 +15,17 @@ const BARE_SESSION_RESET_PROMPT_BASE =
 export function buildBareSessionResetPrompt(cfg?: OpenClawConfig, nowMs?: number): string {
   return appendCronStyleCurrentTimeLine(
     BARE_SESSION_RESET_PROMPT_BASE,
+    cfg ?? {},
+    nowMs ?? Date.now(),
+  );
+}
+
+export function buildBareSessionResetBootstrapPendingPrompt(
+  cfg?: OpenClawConfig,
+  nowMs?: number,
+): string {
+  return appendCronStyleCurrentTimeLine(
+    BARE_SESSION_RESET_BOOTSTRAP_PENDING_PROMPT_BASE,
     cfg ?? {},
     nowMs ?? Date.now(),
   );


### PR DESCRIPTION
## Summary

This is a clean replacement for the earlier bootstrap PR branch.

It changes bootstrap to follow workspace truth instead of session transcript heuristics.

- add an explicit workspace bootstrap status resolver in the workspace layer
- treat pending workspace bootstrap as authoritative even when stale session markers exist
- keep `BOOTSTRAP.md` available in shared injected context for non-attempt consumers
- stop autoloading `BOOTSTRAP.md` into the embedded attempt context and instead add a hidden bootstrap prelude to the user prompt prefix
- harden bare `/new` and `/reset` so bootstrap-pending workspaces suppress the normal first greeting and read `BOOTSTRAP.md` first
- add a changelog entry for the bootstrap fix

## What changed

The runtime now resolves bootstrap state from workspace state plus current `BOOTSTRAP.md` presence:

```ts
phase = setupCompletedAt ? "complete" : bootstrapExists ? "pending" : "complete";
```

The embedded attempt path now uses that workspace truth before applying continuation-skip logic:

```ts
const workspaceBootstrapPending = await isWorkspaceBootstrapPending(effectiveWorkspace);
const isContinuationTurn =
  !workspaceBootstrapPending &&
  contextInjectionMode === "continuation-skip" &&
  ...
```

That means a stale `openclaw:bootstrap-context:full` transcript marker can no longer suppress bootstrap when the workspace still has a pending `BOOTSTRAP.md` flow.

For prompt assembly, the embedded runner keeps `BOOTSTRAP.md` out of embedded injected context and instead prepends a bootstrap-only hidden user-context prelude:

```text
[Bootstrap pending]
Before producing any user-visible reply, you MUST read BOOTSTRAP.md from the workspace and follow it.
Do not greet the user, offer help, answer the message, or reply normally until after you have read and are following BOOTSTRAP.md.
Your first user-visible reply for a bootstrap-pending workspace must follow BOOTSTRAP.md, not a generic greeting.
```

Shared non-attempt consumers still receive `BOOTSTRAP.md` in their injected context, so this change stays scoped to the embedded attempt behavior.

For bare `/new` and `/reset`, the reply path now checks workspace bootstrap state before adding startup context. When bootstrap is still pending, it skips the normal startup prelude and uses a bootstrap-specific reset prompt that requires reading `BOOTSTRAP.md` before any normal greeting.

## Validation

Focused bootstrap regressions passed:

```bash
env PATH=/opt/homebrew/opt/node@24/bin:$PATH npm_config_cache=/tmp/openclaw-npm-cache \
pnpm exec vitest run \
  src/agents/workspace.test.ts \
  src/agents/bootstrap-files.test.ts \
  src/agents/system-prompt.test.ts \
  src/auto-reply/reply/session-reset-prompt.test.ts \
  src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts
```

Result:

```text
Test Files  5 passed (5)
Tests       120 passed (120)
```

I also manually validated the headless gateway path against an isolated dev gateway: the first turn included the hidden bootstrap prelude, the model read `BOOTSTRAP.md`, and the first visible reply followed the bootstrap ritual instead of a generic greeting.
