### PR TITLE
Twitch: add bundled setup entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI Codex/OAuth: keep OpenClaw as the canonical owner for imported Codex CLI OAuth sessions, stop writing refreshed credentials back into `.codex`, and prefer fresher OpenClaw credentials over stale imported CLI state so refresh recovery stays stable. Thanks @vincentkoc.
 - OpenAI Codex/OAuth: treat the OpenAI TLS prerequisites probe as advisory instead of a hard blocker, so Codex sign-in can still proceed when the speculative Node/OpenSSL precheck fails but the real OAuth flow still works. Thanks @vincentkoc.
 - Models status/OAuth health: align OAuth health reporting with the same effective credential view runtime uses, so expired refreshable sessions stop showing healthy by default and fresher imported Codex CLI credentials surface correctly in `models status`, doctor, and gateway auth status. Thanks @vincentkoc.
+- Twitch/setup: load Twitch through the bundled setup-entry discovery path and keep setup/status account detection aligned with runtime config. (#68008) Thanks @gumadeiras.
 
 ## 2026.4.15
 

--- a/extensions/twitch/index.test.ts
+++ b/extensions/twitch/index.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { assertBundledChannelEntries } from "../../test/helpers/bundled-channel-entry.ts";
+import entry from "./index.js";
+import setupEntry from "./setup-entry.js";
+
+describe("twitch bundled entries", () => {
+  assertBundledChannelEntries({
+    entry,
+    expectedId: "twitch",
+    expectedName: "Twitch",
+    setupEntry,
+  });
+
+  it("loads the setup-only channel plugin", () => {
+    const plugin = setupEntry.loadSetupPlugin?.();
+
+    expect(plugin?.id).toBe("twitch");
+    expect(plugin?.setupWizard).toBeDefined();
+  });
+});

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -15,6 +15,7 @@
     "extensions": [
       "./index.ts"
     ],
+    "setupEntry": "./setup-entry.ts",
     "install": {
       "minHostVersion": ">=2026.4.10"
     },

--- a/extensions/twitch/setup-entry.ts
+++ b/extensions/twitch/setup-entry.ts
@@ -1,0 +1,9 @@
+import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+
+export default defineBundledChannelSetupEntry({
+  importMetaUrl: import.meta.url,
+  plugin: {
+    specifier: "./src/setup-surface.js",
+    exportName: "twitchSetupPlugin",
+  },
+});

--- a/extensions/twitch/setup-entry.ts
+++ b/extensions/twitch/setup-entry.ts
@@ -3,7 +3,7 @@ import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entr
 export default defineBundledChannelSetupEntry({
   importMetaUrl: import.meta.url,
   plugin: {
-    specifier: "./src/setup-surface.js",
+    specifier: "./setup-plugin-api.js",
     exportName: "twitchSetupPlugin",
   },
 });

--- a/extensions/twitch/setup-plugin-api.ts
+++ b/extensions/twitch/setup-plugin-api.ts
@@ -1,0 +1,3 @@
+// Keep bundled setup entry imports narrow so setup loads do not pull the
+// broader Twitch channel plugin surface.
+export { twitchSetupPlugin } from "./src/setup-surface.js";

--- a/extensions/twitch/src/config.test.ts
+++ b/extensions/twitch/src/config.test.ts
@@ -202,4 +202,32 @@ describe("resolveTwitchAccountContext", () => {
     expect(context.accountId).toBe("secondary");
     expect(context.account?.username).toBe("second-bot");
   });
+
+  it("keeps account and token lookup aligned after account id normalization", () => {
+    const context = resolveTwitchAccountContext(
+      {
+        channels: {
+          twitch: {
+            accounts: {
+              Secondary: {
+                username: "second-bot",
+                accessToken: "oauth:second-token",
+                clientId: "second-client",
+                channel: "#second",
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolveTwitchAccountContext>[0],
+      "secondary",
+    );
+
+    expect(context.accountId).toBe("secondary");
+    expect(context.account?.username).toBe("second-bot");
+    expect(context.tokenResolution).toEqual({
+      token: "oauth:second-token",
+      source: "config",
+    });
+    expect(context.configured).toBe(true);
+  });
 });

--- a/extensions/twitch/src/config.test.ts
+++ b/extensions/twitch/src/config.test.ts
@@ -54,6 +54,30 @@ describe("getAccountConfig", () => {
     expect(result?.username).toBe("secondbot");
   });
 
+  it("normalizes account ids without reading inherited account properties", () => {
+    const accounts = Object.create({
+      inherited: {
+        username: "inherited-bot",
+        accessToken: "oauth:inherited",
+      },
+    }) as Record<string, unknown>;
+    accounts.Secondary = {
+      username: "secondbot",
+      accessToken: "oauth:secondary",
+    };
+
+    const cfg = {
+      channels: {
+        twitch: {
+          accounts,
+        },
+      },
+    };
+
+    expect(getAccountConfig(cfg, "SECONDARY\r\n")).toMatchObject({ username: "secondbot" });
+    expect(getAccountConfig(cfg, "inherited")).toBeNull();
+  });
+
   it("returns null for non-existent account ID", () => {
     const result = getAccountConfig(mockMultiAccountConfig, "nonexistent");
 
@@ -119,6 +143,21 @@ describe("listAccountIds", () => {
         },
       } as Parameters<typeof listAccountIds>[0]),
     ).toEqual(["default", "secondary"]);
+  });
+
+  it("normalizes configured account ids", () => {
+    expect(
+      listAccountIds({
+        channels: {
+          twitch: {
+            accounts: {
+              Secondary: { username: "secondbot" },
+              "Alerts\r\n\u001b[31m": { username: "alerts" },
+            },
+          },
+        },
+      } as Parameters<typeof listAccountIds>[0]),
+    ).toEqual(["alerts-31m", "secondary"]);
   });
 });
 

--- a/extensions/twitch/src/config.ts
+++ b/extensions/twitch/src/config.ts
@@ -1,4 +1,8 @@
-import { listCombinedAccountIds } from "openclaw/plugin-sdk/account-resolution";
+import {
+  listCombinedAccountIds,
+  normalizeAccountId,
+  resolveNormalizedAccountEntry,
+} from "openclaw/plugin-sdk/account-resolution";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { resolveTwitchToken, type TwitchTokenResolution } from "./token.js";
 import type { TwitchAccountConfig } from "./types.js";
@@ -36,14 +40,19 @@ export function getAccountConfig(
   }
 
   const cfg = coreConfig as OpenClawConfig;
+  const normalizedAccountId = normalizeAccountId(accountId);
   const twitch = cfg.channels?.twitch;
   // Access accounts via unknown to handle union type (single-account vs multi-account)
   const twitchRaw = twitch as Record<string, unknown> | undefined;
   const accounts = twitchRaw?.accounts as Record<string, TwitchAccountConfig> | undefined;
 
   // For default account, check base-level config first
-  if (accountId === DEFAULT_ACCOUNT_ID) {
-    const accountFromAccounts = accounts?.[DEFAULT_ACCOUNT_ID];
+  if (normalizedAccountId === DEFAULT_ACCOUNT_ID) {
+    const accountFromAccounts = resolveNormalizedAccountEntry(
+      accounts,
+      DEFAULT_ACCOUNT_ID,
+      normalizeAccountId,
+    );
 
     // Base-level properties that can form an implicit default account
     const baseLevel = {
@@ -87,11 +96,12 @@ export function getAccountConfig(
   }
 
   // For non-default accounts, only check accounts object
-  if (!accounts || !accounts[accountId]) {
+  const account = resolveNormalizedAccountEntry(accounts, normalizedAccountId, normalizeAccountId);
+  if (!account) {
     return null;
   }
 
-  return accounts[accountId] as TwitchAccountConfig | null;
+  return account;
 }
 
 /**
@@ -113,16 +123,19 @@ export function listAccountIds(cfg: OpenClawConfig): string[] {
       typeof twitchRaw.channel === "string");
 
   return listCombinedAccountIds({
-    configuredAccountIds: Object.keys(accountMap ?? {}),
+    configuredAccountIds: Object.keys(accountMap ?? {}).map((accountId) =>
+      normalizeAccountId(accountId),
+    ),
     implicitAccountId: hasBaseLevelConfig ? DEFAULT_ACCOUNT_ID : undefined,
   });
 }
 
 export function resolveDefaultTwitchAccountId(cfg: OpenClawConfig): string {
-  const preferred =
+  const preferredRaw =
     typeof cfg.channels?.twitch?.defaultAccount === "string"
       ? cfg.channels.twitch.defaultAccount.trim()
       : "";
+  const preferred = preferredRaw ? normalizeAccountId(preferredRaw) : "";
   const ids = listAccountIds(cfg);
   if (preferred && ids.includes(preferred)) {
     return preferred;
@@ -137,7 +150,9 @@ export function resolveTwitchAccountContext(
   cfg: OpenClawConfig,
   accountId?: string | null,
 ): ResolvedTwitchAccountContext {
-  const resolvedAccountId = accountId?.trim() || resolveDefaultTwitchAccountId(cfg);
+  const resolvedAccountId = accountId?.trim()
+    ? normalizeAccountId(accountId)
+    : resolveDefaultTwitchAccountId(cfg);
   const account = getAccountConfig(cfg, resolvedAccountId);
   const tokenResolution = resolveTwitchToken(cfg, { accountId: resolvedAccountId });
   return {

--- a/extensions/twitch/src/setup-surface.test.ts
+++ b/extensions/twitch/src/setup-surface.test.ts
@@ -208,7 +208,7 @@ describe("setup surface helpers", () => {
       expect(defaultAccount?.clientId).toBe("test-client-id");
     });
 
-    it("writes env-token setup to the configured default account", async () => {
+    it("skips env-token shortcut for non-default accounts", async () => {
       mockPromptConfirm.mockReset().mockResolvedValue(true as never);
       mockPromptText
         .mockReset()
@@ -230,12 +230,9 @@ describe("setup surface helpers", () => {
         {} as Parameters<typeof configureWithEnvToken>[5],
       );
 
-      const secondaryAccount = result?.cfg.channels?.twitch?.accounts?.secondary as
-        | { username?: string; clientId?: string }
-        | undefined;
-      expect(secondaryAccount?.username).toBe("secondary-bot");
-      expect(secondaryAccount?.clientId).toBe("secondary-client");
-      expect(result?.cfg.channels?.twitch?.accounts?.default).toBeUndefined();
+      expect(result).toBeNull();
+      expect(mockPromptConfirm).not.toHaveBeenCalled();
+      expect(mockPromptText).not.toHaveBeenCalled();
     });
   });
 
@@ -402,6 +399,41 @@ describe("setup surface helpers", () => {
       expect(twitch?.accounts?.secondary?.accessToken).toBe("oauth:secondary");
       expect(twitch?.accounts?.default?.username).toBe("default-bot");
     });
+
+    it("persists a token instead of using env-token shortcut for non-default finalize", async () => {
+      process.env.OPENCLAW_TWITCH_ACCESS_TOKEN = "oauth:fromenv";
+      mockPromptText
+        .mockReset()
+        .mockResolvedValueOnce("secondary-bot" as never)
+        .mockResolvedValueOnce("oauth:persisted" as never)
+        .mockResolvedValueOnce("secondary-client" as never)
+        .mockResolvedValueOnce("#secondary" as never);
+      mockPromptConfirm.mockReset().mockResolvedValue(false as never);
+
+      const result = await twitchSetupWizard.finalize?.({
+        cfg: {
+          channels: {
+            twitch: {
+              accounts: {},
+            },
+          },
+        } as Parameters<NonNullable<typeof twitchSetupWizard.finalize>>[0]["cfg"],
+        accountId: "secondary",
+        credentialValues: {},
+        runtime: {} as Parameters<NonNullable<typeof twitchSetupWizard.finalize>>[0]["runtime"],
+        prompter: mockPrompter,
+        options: {},
+        forceAllowFrom: false,
+      });
+
+      const twitch = result?.cfg?.channels?.twitch;
+      expect(twitch?.accounts?.secondary?.accessToken).toBe("oauth:persisted");
+      expect(mockPromptConfirm).toHaveBeenCalledTimes(1);
+      expect(mockPromptConfirm).toHaveBeenCalledWith({
+        message: "Enable automatic token refresh (requires client secret and refresh token)?",
+        initialValue: false,
+      });
+    });
   });
 
   describe("setup-only plugin config", () => {
@@ -430,6 +462,32 @@ describe("setup surface helpers", () => {
 
       expect(twitchSetupPlugin.config.listAccountIds(cfg)).toEqual(["default", "secondary"]);
       expect(twitchSetupPlugin.config.defaultAccountId?.(cfg)).toBe("secondary");
+    });
+
+    it("normalizes exposed account ids", () => {
+      const cfg = {
+        channels: {
+          twitch: {
+            accounts: {
+              Secondary: {
+                username: "secondary-bot",
+                accessToken: "oauth:secondary",
+                clientId: "secondary-client",
+                channel: "#secondary",
+              },
+            },
+          },
+        },
+      } as Parameters<typeof twitchSetupPlugin.config.listAccountIds>[0];
+
+      expect(twitchSetupPlugin.config.listAccountIds(cfg)).toEqual(["secondary"]);
+      expect(twitchSetupPlugin.config.defaultAccountId?.(cfg)).toBe("secondary");
+      expect(twitchSetupPlugin.config.resolveAccount(cfg, "SECONDARY\r\n").accountId).toBe(
+        "secondary",
+      );
+      expect(twitchSetupPlugin.config.resolveAccount(cfg, "SECONDARY\r\n").username).toBe(
+        "secondary-bot",
+      );
     });
   });
 });

--- a/extensions/twitch/src/setup-surface.test.ts
+++ b/extensions/twitch/src/setup-surface.test.ts
@@ -20,6 +20,7 @@ import {
   promptRefreshTokenSetup,
   promptToken,
   promptUsername,
+  setTwitchAccount,
   twitchSetupPlugin,
   twitchSetupWizard,
 } from "./setup-surface.js";
@@ -315,6 +316,29 @@ describe("setup surface helpers", () => {
   });
 
   describe("setup wizard account routing", () => {
+    it("normalizes account ids before using them as config keys", () => {
+      const cfg = setTwitchAccount(
+        {} as Parameters<typeof setTwitchAccount>[0],
+        {
+          username: "normalized-bot",
+          accessToken: "oauth:normalized",
+          clientId: "normalized-client",
+          channel: "#normalized",
+        },
+        "__proto__",
+      );
+
+      expect(cfg.channels?.twitch?.accounts?.default?.username).toBe("normalized-bot");
+      expect(Object.prototype).not.toHaveProperty("username");
+      expect(
+        twitchSetupWizard.status?.resolveStatusLines?.({
+          cfg: {},
+          accountId: "Alerts\r\n\u001b[31m",
+          configured: false,
+        } as never),
+      ).toEqual(["Twitch (alerts-31m): needs username, token, and clientId"]);
+    });
+
     it("reports account-scoped DM policy config keys", () => {
       expect(
         twitchSetupWizard.dmPolicy?.resolveConfigKeys?.(

--- a/extensions/twitch/src/setup-surface.test.ts
+++ b/extensions/twitch/src/setup-surface.test.ts
@@ -313,20 +313,40 @@ describe("setup surface helpers", () => {
   });
 
   describe("setup wizard account routing", () => {
-    it("normalizes account ids before using them as config keys", () => {
-      const cfg = setTwitchAccount(
-        {} as Parameters<typeof setTwitchAccount>[0],
-        {
-          username: "normalized-bot",
-          accessToken: "oauth:normalized",
-          clientId: "normalized-client",
-          channel: "#normalized",
-        },
-        "__proto__",
-      );
+    it("rejects reserved account ids before using them as config keys", () => {
+      expect(() =>
+        setTwitchAccount(
+          {} as Parameters<typeof setTwitchAccount>[0],
+          {
+            username: "reserved-bot",
+            accessToken: "oauth:reserved",
+            clientId: "reserved-client",
+            channel: "#reserved",
+          },
+          "__proto__",
+        ),
+      ).toThrow("Invalid Twitch account id");
 
-      expect(cfg.channels?.twitch?.accounts?.default?.username).toBe("normalized-bot");
       expect(Object.prototype).not.toHaveProperty("username");
+    });
+
+    it("rejects reserved account ids before env-token writes", async () => {
+      await expect(
+        configureWithEnvToken(
+          {} as Parameters<typeof configureWithEnvToken>[0],
+          mockPrompter,
+          null,
+          "oauth:fromenv",
+          false,
+          {} as Parameters<typeof configureWithEnvToken>[5],
+          "__proto__",
+        ),
+      ).rejects.toThrow("Invalid Twitch account id");
+
+      expect(mockPromptConfirm).not.toHaveBeenCalled();
+    });
+
+    it("normalizes account ids before rendering status lines", () => {
       expect(
         twitchSetupWizard.status?.resolveStatusLines?.({
           cfg: {},

--- a/extensions/twitch/src/setup-surface.test.ts
+++ b/extensions/twitch/src/setup-surface.test.ts
@@ -28,9 +28,11 @@ import type { TwitchAccountConfig } from "./types.js";
 // Mock the helpers we're testing
 const mockPromptText = vi.fn();
 const mockPromptConfirm = vi.fn();
+const mockPromptNote = vi.fn();
 const mockPrompter: WizardPrompter = {
   text: mockPromptText,
   confirm: mockPromptConfirm,
+  note: mockPromptNote,
 } as unknown as WizardPrompter;
 const originalEnvToken = process.env.OPENCLAW_TWITCH_ACCESS_TOKEN;
 
@@ -259,6 +261,35 @@ describe("setup surface helpers", () => {
       expect(lines).toEqual(["Twitch (secondary): configured"]);
     });
 
+    it("reports status for the requested account override", async () => {
+      const lines = twitchSetupWizard.status?.resolveStatusLines?.({
+        cfg: {
+          channels: {
+            twitch: {
+              accounts: {
+                default: {
+                  username: "default-bot",
+                  accessToken: "oauth:default",
+                  clientId: "default-client",
+                  channel: "#default",
+                },
+                secondary: {
+                  username: "secondary-bot",
+                  accessToken: "oauth:secondary",
+                  clientId: "secondary-client",
+                  channel: "#secondary",
+                },
+              },
+            },
+          },
+        },
+        accountId: "secondary",
+        configured: true,
+      } as never);
+
+      expect(lines).toEqual(["Twitch (secondary): configured"]);
+    });
+
     it("reports env-token default account setup as configured", async () => {
       process.env.OPENCLAW_TWITCH_ACCESS_TOKEN = "oauth:fromenv";
 
@@ -280,6 +311,47 @@ describe("setup surface helpers", () => {
       expect(twitchSetupWizard.status?.resolveConfigured({ cfg })).toBe(true);
       const account = twitchSetupPlugin.config.resolveAccount(cfg, "default");
       expect(await twitchSetupPlugin.config.isConfigured?.(account, cfg)).toBe(true);
+    });
+  });
+
+  describe("setup wizard account routing", () => {
+    it("writes to the requested account when defaultAccount is not created yet", async () => {
+      mockPromptText
+        .mockReset()
+        .mockResolvedValueOnce("secondary-bot" as never)
+        .mockResolvedValueOnce("oauth:secondary" as never)
+        .mockResolvedValueOnce("secondary-client" as never)
+        .mockResolvedValueOnce("#secondary" as never);
+      mockPromptConfirm.mockReset().mockResolvedValue(false as never);
+
+      const result = await twitchSetupWizard.finalize?.({
+        cfg: {
+          channels: {
+            twitch: {
+              defaultAccount: "secondary",
+              accounts: {
+                default: {
+                  username: "default-bot",
+                  accessToken: "oauth:default",
+                  clientId: "default-client",
+                  channel: "#default",
+                },
+              },
+            },
+          },
+        } as Parameters<NonNullable<typeof twitchSetupWizard.finalize>>[0]["cfg"],
+        accountId: "secondary",
+        credentialValues: {},
+        runtime: {} as Parameters<NonNullable<typeof twitchSetupWizard.finalize>>[0]["runtime"],
+        prompter: mockPrompter,
+        options: {},
+        forceAllowFrom: false,
+      });
+
+      const twitch = result?.cfg?.channels?.twitch;
+      expect(twitch?.accounts?.secondary?.username).toBe("secondary-bot");
+      expect(twitch?.accounts?.secondary?.accessToken).toBe("oauth:secondary");
+      expect(twitch?.accounts?.default?.username).toBe("default-bot");
     });
   });
 

--- a/extensions/twitch/src/setup-surface.test.ts
+++ b/extensions/twitch/src/setup-surface.test.ts
@@ -315,6 +315,31 @@ describe("setup surface helpers", () => {
   });
 
   describe("setup wizard account routing", () => {
+    it("reports account-scoped DM policy config keys", () => {
+      expect(
+        twitchSetupWizard.dmPolicy?.resolveConfigKeys?.(
+          {
+            channels: {
+              twitch: {
+                defaultAccount: "secondary",
+              },
+            },
+          } as Parameters<
+            NonNullable<NonNullable<typeof twitchSetupWizard.dmPolicy>["resolveConfigKeys"]>
+          >[0],
+          undefined,
+        ),
+      ).toEqual({
+        policyKey: "channels.twitch.accounts.secondary.allowedRoles",
+        allowFromKey: "channels.twitch.accounts.secondary.allowFrom",
+      });
+
+      expect(twitchSetupWizard.dmPolicy?.resolveConfigKeys?.({} as never, "alerts")).toEqual({
+        policyKey: "channels.twitch.accounts.alerts.allowedRoles",
+        allowFromKey: "channels.twitch.accounts.alerts.allowFrom",
+      });
+    });
+
     it("writes to the requested account when defaultAccount is not created yet", async () => {
       mockPromptText
         .mockReset()

--- a/extensions/twitch/src/setup-surface.test.ts
+++ b/extensions/twitch/src/setup-surface.test.ts
@@ -20,6 +20,7 @@ import {
   promptRefreshTokenSetup,
   promptToken,
   promptUsername,
+  twitchSetupPlugin,
   twitchSetupWizard,
 } from "./setup-surface.js";
 import type { TwitchAccountConfig } from "./types.js";
@@ -31,6 +32,7 @@ const mockPrompter: WizardPrompter = {
   text: mockPromptText,
   confirm: mockPromptConfirm,
 } as unknown as WizardPrompter;
+const originalEnvToken = process.env.OPENCLAW_TWITCH_ACCESS_TOKEN;
 
 const mockAccount: TwitchAccountConfig = {
   username: "testbot",
@@ -45,6 +47,11 @@ describe("setup surface helpers", () => {
   });
 
   afterEach(() => {
+    if (originalEnvToken === undefined) {
+      delete process.env.OPENCLAW_TWITCH_ACCESS_TOKEN;
+    } else {
+      process.env.OPENCLAW_TWITCH_ACCESS_TOKEN = originalEnvToken;
+    }
     // Don't restoreAllMocks as it breaks module-level mocks
   });
 
@@ -250,6 +257,58 @@ describe("setup surface helpers", () => {
       } as never);
 
       expect(lines).toEqual(["Twitch (secondary): configured"]);
+    });
+
+    it("reports env-token default account setup as configured", async () => {
+      process.env.OPENCLAW_TWITCH_ACCESS_TOKEN = "oauth:fromenv";
+
+      const cfg = {
+        channels: {
+          twitch: {
+            accounts: {
+              default: {
+                username: "env-bot",
+                accessToken: "",
+                clientId: "env-client",
+                channel: "#env",
+              },
+            },
+          },
+        },
+      } as Parameters<NonNullable<typeof twitchSetupWizard.status>["resolveConfigured"]>[0]["cfg"];
+
+      expect(twitchSetupWizard.status?.resolveConfigured({ cfg })).toBe(true);
+      const account = twitchSetupPlugin.config.resolveAccount(cfg, "default");
+      expect(await twitchSetupPlugin.config.isConfigured?.(account, cfg)).toBe(true);
+    });
+  });
+
+  describe("setup-only plugin config", () => {
+    it("lists all configured Twitch accounts", () => {
+      const cfg = {
+        channels: {
+          twitch: {
+            defaultAccount: "secondary",
+            accounts: {
+              default: {
+                username: "default-bot",
+                accessToken: "oauth:default",
+                clientId: "default-client",
+                channel: "#default",
+              },
+              secondary: {
+                username: "secondary-bot",
+                accessToken: "oauth:secondary",
+                clientId: "secondary-client",
+                channel: "#secondary",
+              },
+            },
+          },
+        },
+      } as Parameters<typeof twitchSetupPlugin.config.listAccountIds>[0];
+
+      expect(twitchSetupPlugin.config.listAccountIds(cfg)).toEqual(["default", "secondary"]);
+      expect(twitchSetupPlugin.config.defaultAccountId?.(cfg)).toBe("secondary");
     });
   });
 });

--- a/extensions/twitch/src/setup-surface.ts
+++ b/extensions/twitch/src/setup-surface.ts
@@ -2,6 +2,7 @@
  * Twitch setup wizard surface for CLI setup.
  */
 
+import { getChatChannelMeta, type ChannelPlugin } from "openclaw/plugin-sdk/core";
 import {
   formatDocsLink,
   type ChannelSetupAdapter,
@@ -425,4 +426,38 @@ export const twitchSetupWizard: ChannelSetupWizard = {
       },
     };
   },
+};
+
+type ResolvedTwitchAccount = TwitchAccountConfig & { accountId?: string | null };
+
+export const twitchSetupPlugin: ChannelPlugin<ResolvedTwitchAccount> = {
+  id: channel,
+  meta: getChatChannelMeta(channel),
+  capabilities: {
+    chatTypes: ["group"],
+  },
+  config: {
+    listAccountIds: (cfg) => {
+      const accountId = resolveSetupAccountId(cfg);
+      return getAccountConfig(cfg, accountId) ? [accountId] : [];
+    },
+    resolveAccount: (cfg, accountId) => {
+      const resolvedAccountId = accountId ?? resolveSetupAccountId(cfg);
+      const account = getAccountConfig(cfg, resolvedAccountId);
+      const fallback = {
+        accountId: resolvedAccountId,
+        username: "",
+        accessToken: "",
+        clientId: "",
+        channel: "",
+        enabled: false,
+      };
+      return account ? { ...fallback, ...account } : fallback;
+    },
+    defaultAccountId: (cfg) => resolveSetupAccountId(cfg),
+    isConfigured: (account) => isAccountConfigured(account),
+    isEnabled: (account) => account.enabled !== false,
+  },
+  setup: twitchSetupAdapter,
+  setupWizard: twitchSetupWizard,
 };

--- a/extensions/twitch/src/setup-surface.ts
+++ b/extensions/twitch/src/setup-surface.ts
@@ -11,7 +11,13 @@ import {
   type OpenClawConfig,
   type WizardPrompter,
 } from "openclaw/plugin-sdk/setup";
-import { DEFAULT_ACCOUNT_ID, getAccountConfig, resolveDefaultTwitchAccountId } from "./config.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  getAccountConfig,
+  listAccountIds,
+  resolveDefaultTwitchAccountId,
+  resolveTwitchAccountContext,
+} from "./config.js";
 import type { TwitchAccountConfig, TwitchRole } from "./types.js";
 import { isAccountConfigured } from "./utils/twitch.js";
 
@@ -348,13 +354,11 @@ export const twitchSetupWizard: ChannelSetupWizard = {
     configuredHint: "configured",
     unconfiguredHint: "needs setup",
     resolveConfigured: ({ cfg }) => {
-      const account = getAccountConfig(cfg, resolveSetupAccountId(cfg));
-      return account ? isAccountConfigured(account) : false;
+      return resolveTwitchAccountContext(cfg, resolveSetupAccountId(cfg)).configured;
     },
     resolveStatusLines: ({ cfg }) => {
       const accountId = resolveSetupAccountId(cfg);
-      const account = getAccountConfig(cfg, accountId);
-      const configured = account ? isAccountConfigured(account) : false;
+      const configured = resolveTwitchAccountContext(cfg, accountId).configured;
       return [
         `Twitch${accountId !== DEFAULT_ACCOUNT_ID ? ` (${accountId})` : ""}: ${configured ? "configured" : "needs username, token, and clientId"}`,
       ];
@@ -437,25 +441,27 @@ export const twitchSetupPlugin: ChannelPlugin<ResolvedTwitchAccount> = {
     chatTypes: ["group"],
   },
   config: {
-    listAccountIds: (cfg) => {
-      const accountId = resolveSetupAccountId(cfg);
-      return getAccountConfig(cfg, accountId) ? [accountId] : [];
-    },
+    listAccountIds: (cfg) => listAccountIds(cfg),
     resolveAccount: (cfg, accountId) => {
-      const resolvedAccountId = accountId ?? resolveSetupAccountId(cfg);
+      const resolvedAccountId = accountId ?? resolveDefaultTwitchAccountId(cfg);
       const account = getAccountConfig(cfg, resolvedAccountId);
-      const fallback = {
+      if (!account) {
+        return {
+          accountId: resolvedAccountId,
+          username: "",
+          accessToken: "",
+          clientId: "",
+          channel: "",
+          enabled: false,
+        };
+      }
+      return {
         accountId: resolvedAccountId,
-        username: "",
-        accessToken: "",
-        clientId: "",
-        channel: "",
-        enabled: false,
+        ...account,
       };
-      return account ? { ...fallback, ...account } : fallback;
     },
-    defaultAccountId: (cfg) => resolveSetupAccountId(cfg),
-    isConfigured: (account) => isAccountConfigured(account),
+    defaultAccountId: (cfg) => resolveDefaultTwitchAccountId(cfg),
+    isConfigured: (account, cfg) => resolveTwitchAccountContext(cfg, account?.accountId).configured,
     isEnabled: (account) => account.enabled !== false,
   },
   setup: twitchSetupAdapter,

--- a/extensions/twitch/src/setup-surface.ts
+++ b/extensions/twitch/src/setup-surface.ts
@@ -208,6 +208,11 @@ export async function configureWithEnvToken(
   dmPolicy: ChannelSetupDmPolicy,
   accountId: string = resolveSetupAccountId(cfg),
 ): Promise<{ cfg: OpenClawConfig } | null> {
+  const resolvedAccountId = normalizeAccountId(accountId);
+  if (resolvedAccountId !== DEFAULT_ACCOUNT_ID) {
+    return null;
+  }
+
   const useEnv = await prompter.confirm({
     message: "Twitch env var OPENCLAW_TWITCH_ACCESS_TOKEN detected. Use env token?",
     initialValue: true,
@@ -227,11 +232,17 @@ export async function configureWithEnvToken(
       accessToken: "",
       enabled: true,
     },
-    accountId,
+    resolvedAccountId,
   );
 
   if (forceAllowFrom && dmPolicy.promptAllowFrom) {
-    return { cfg: await dmPolicy.promptAllowFrom({ cfg: cfgWithAccount, prompter, accountId }) };
+    return {
+      cfg: await dmPolicy.promptAllowFrom({
+        cfg: cfgWithAccount,
+        prompter,
+        accountId: resolvedAccountId,
+      }),
+    };
   }
 
   return { cfg: cfgWithAccount };
@@ -400,7 +411,7 @@ export const twitchSetupWizard: ChannelSetupWizard = {
 
     const envToken = process.env.OPENCLAW_TWITCH_ACCESS_TOKEN?.trim();
 
-    if (envToken && !account?.accessToken) {
+    if (accountId === DEFAULT_ACCOUNT_ID && envToken && !account?.accessToken) {
       const envResult = await configureWithEnvToken(
         cfg,
         prompter,
@@ -469,7 +480,7 @@ export const twitchSetupPlugin: ChannelPlugin<ResolvedTwitchAccount> = {
   config: {
     listAccountIds: (cfg) => listAccountIds(cfg),
     resolveAccount: (cfg, accountId) => {
-      const resolvedAccountId = accountId ?? resolveDefaultTwitchAccountId(cfg);
+      const resolvedAccountId = normalizeAccountId(accountId ?? resolveDefaultTwitchAccountId(cfg));
       const account = getAccountConfig(cfg, resolvedAccountId);
       if (!account) {
         return {

--- a/extensions/twitch/src/setup-surface.ts
+++ b/extensions/twitch/src/setup-surface.ts
@@ -10,6 +10,7 @@ import {
   type ChannelSetupWizard,
   type OpenClawConfig,
   type WizardPrompter,
+  normalizeAccountId,
 } from "openclaw/plugin-sdk/setup";
 import {
   DEFAULT_ACCOUNT_ID,
@@ -26,11 +27,11 @@ const channel = "twitch" as const;
 function resolveSetupAccountId(cfg: OpenClawConfig, requestedAccountId?: string): string {
   const requested = requestedAccountId?.trim();
   if (requested) {
-    return requested;
+    return normalizeAccountId(requested);
   }
 
   const preferred = cfg.channels?.twitch?.defaultAccount?.trim();
-  return preferred || resolveDefaultTwitchAccountId(cfg);
+  return preferred ? normalizeAccountId(preferred) : resolveDefaultTwitchAccountId(cfg);
 }
 
 export function setTwitchAccount(
@@ -38,7 +39,8 @@ export function setTwitchAccount(
   account: Partial<TwitchAccountConfig>,
   accountId: string = resolveSetupAccountId(cfg),
 ): OpenClawConfig {
-  const existing = getAccountConfig(cfg, accountId);
+  const resolvedAccountId = normalizeAccountId(accountId);
+  const existing = getAccountConfig(cfg, resolvedAccountId);
   const merged: TwitchAccountConfig = {
     username: account.username ?? existing?.username ?? "",
     accessToken: account.accessToken ?? existing?.accessToken ?? "",
@@ -67,7 +69,7 @@ export function setTwitchAccount(
           ...((
             (cfg.channels as Record<string, unknown>)?.twitch as Record<string, unknown> | undefined
           )?.accounts as Record<string, unknown> | undefined),
-          [accountId]: merged,
+          [resolvedAccountId]: merged,
         },
       },
     },

--- a/extensions/twitch/src/setup-surface.ts
+++ b/extensions/twitch/src/setup-surface.ts
@@ -2,6 +2,7 @@
  * Twitch setup wizard surface for CLI setup.
  */
 
+import { normalizeOptionalAccountId } from "openclaw/plugin-sdk/account-id";
 import { getChatChannelMeta, type ChannelPlugin } from "openclaw/plugin-sdk/core";
 import {
   formatDocsLink,
@@ -23,11 +24,20 @@ import type { TwitchAccountConfig, TwitchRole } from "./types.js";
 import { isAccountConfigured } from "./utils/twitch.js";
 
 const channel = "twitch" as const;
+const INVALID_ACCOUNT_ID_MESSAGE = "Invalid Twitch account id";
+
+function normalizeRequestedSetupAccountId(accountId: string): string {
+  const normalized = normalizeOptionalAccountId(accountId);
+  if (!normalized) {
+    throw new Error(INVALID_ACCOUNT_ID_MESSAGE);
+  }
+  return normalized;
+}
 
 function resolveSetupAccountId(cfg: OpenClawConfig, requestedAccountId?: string): string {
   const requested = requestedAccountId?.trim();
   if (requested) {
-    return normalizeAccountId(requested);
+    return normalizeRequestedSetupAccountId(requested);
   }
 
   const preferred = cfg.channels?.twitch?.defaultAccount?.trim();
@@ -39,7 +49,9 @@ export function setTwitchAccount(
   account: Partial<TwitchAccountConfig>,
   accountId: string = resolveSetupAccountId(cfg),
 ): OpenClawConfig {
-  const resolvedAccountId = normalizeAccountId(accountId);
+  const resolvedAccountId = accountId.trim()
+    ? normalizeRequestedSetupAccountId(accountId)
+    : resolveSetupAccountId(cfg);
   const existing = getAccountConfig(cfg, resolvedAccountId);
   const merged: TwitchAccountConfig = {
     username: account.username ?? existing?.username ?? "",
@@ -208,7 +220,9 @@ export async function configureWithEnvToken(
   dmPolicy: ChannelSetupDmPolicy,
   accountId: string = resolveSetupAccountId(cfg),
 ): Promise<{ cfg: OpenClawConfig } | null> {
-  const resolvedAccountId = normalizeAccountId(accountId);
+  const resolvedAccountId = accountId.trim()
+    ? normalizeRequestedSetupAccountId(accountId)
+    : resolveSetupAccountId(cfg);
   if (resolvedAccountId !== DEFAULT_ACCOUNT_ID) {
     return null;
   }

--- a/extensions/twitch/src/setup-surface.ts
+++ b/extensions/twitch/src/setup-surface.ts
@@ -285,8 +285,15 @@ function setTwitchGroupPolicy(
 const twitchDmPolicy: ChannelSetupDmPolicy = {
   label: "Twitch",
   channel,
-  policyKey: "channels.twitch.allowedRoles",
-  allowFromKey: "channels.twitch.accounts.<default>.allowFrom",
+  policyKey: "channels.twitch.accounts.default.allowedRoles",
+  allowFromKey: "channels.twitch.accounts.default.allowFrom",
+  resolveConfigKeys: (cfg, accountId) => {
+    const resolvedAccountId = resolveSetupAccountId(cfg, accountId);
+    return {
+      policyKey: `channels.twitch.accounts.${resolvedAccountId}.allowedRoles`,
+      allowFromKey: `channels.twitch.accounts.${resolvedAccountId}.allowFrom`,
+    };
+  },
   getCurrent: (cfg, accountId) => {
     const account = getAccountConfig(cfg, resolveSetupAccountId(cfg, accountId));
     if (account?.allowedRoles?.includes("all")) {

--- a/extensions/twitch/src/setup-surface.ts
+++ b/extensions/twitch/src/setup-surface.ts
@@ -28,6 +28,10 @@ function resolveSetupAccountId(cfg: OpenClawConfig): string {
   return preferred || resolveDefaultTwitchAccountId(cfg);
 }
 
+function resolveSetupTargetAccountId(cfg: OpenClawConfig, accountId?: string | null): string {
+  return accountId?.trim() || resolveSetupAccountId(cfg);
+}
+
 export function setTwitchAccount(
   cfg: OpenClawConfig,
   account: Partial<TwitchAccountConfig>,
@@ -199,6 +203,7 @@ export async function configureWithEnvToken(
   envToken: string,
   forceAllowFrom: boolean,
   dmPolicy: ChannelSetupDmPolicy,
+  accountId: string = resolveSetupAccountId(cfg),
 ): Promise<{ cfg: OpenClawConfig } | null> {
   const useEnv = await prompter.confirm({
     message: "Twitch env var OPENCLAW_TWITCH_ACCESS_TOKEN detected. Use env token?",
@@ -211,15 +216,19 @@ export async function configureWithEnvToken(
   const username = await promptUsername(prompter, account);
   const clientId = await promptClientId(prompter, account);
 
-  const cfgWithAccount = setTwitchAccount(cfg, {
-    username,
-    clientId,
-    accessToken: "",
-    enabled: true,
-  });
+  const cfgWithAccount = setTwitchAccount(
+    cfg,
+    {
+      username,
+      clientId,
+      accessToken: "",
+      enabled: true,
+    },
+    accountId,
+  );
 
   if (forceAllowFrom && dmPolicy.promptAllowFrom) {
-    return { cfg: await dmPolicy.promptAllowFrom({ cfg: cfgWithAccount, prompter }) };
+    return { cfg: await dmPolicy.promptAllowFrom({ cfg: cfgWithAccount, prompter, accountId }) };
   }
 
   return { cfg: cfgWithAccount };
@@ -229,9 +238,10 @@ function setTwitchAccessControl(
   cfg: OpenClawConfig,
   allowedRoles: TwitchRole[],
   requireMention: boolean,
+  accountId?: string | null,
 ): OpenClawConfig {
-  const accountId = resolveSetupAccountId(cfg);
-  const account = getAccountConfig(cfg, accountId);
+  const resolvedAccountId = resolveSetupTargetAccountId(cfg, accountId);
+  const account = getAccountConfig(cfg, resolvedAccountId);
   if (!account) {
     return cfg;
   }
@@ -243,12 +253,15 @@ function setTwitchAccessControl(
       allowedRoles,
       requireMention,
     },
-    accountId,
+    resolvedAccountId,
   );
 }
 
-function resolveTwitchGroupPolicy(cfg: OpenClawConfig): "open" | "allowlist" | "disabled" {
-  const account = getAccountConfig(cfg, resolveSetupAccountId(cfg));
+function resolveTwitchGroupPolicy(
+  cfg: OpenClawConfig,
+  accountId?: string | null,
+): "open" | "allowlist" | "disabled" {
+  const account = getAccountConfig(cfg, resolveSetupTargetAccountId(cfg, accountId));
   if (account?.allowedRoles?.includes("all")) {
     return "open";
   }
@@ -261,10 +274,11 @@ function resolveTwitchGroupPolicy(cfg: OpenClawConfig): "open" | "allowlist" | "
 function setTwitchGroupPolicy(
   cfg: OpenClawConfig,
   policy: "open" | "allowlist" | "disabled",
+  accountId?: string | null,
 ): OpenClawConfig {
   const allowedRoles: TwitchRole[] =
     policy === "open" ? ["all"] : policy === "allowlist" ? ["moderator", "vip"] : [];
-  return setTwitchAccessControl(cfg, allowedRoles, true);
+  return setTwitchAccessControl(cfg, allowedRoles, true, accountId);
 }
 
 const twitchDmPolicy: ChannelSetupDmPolicy = {
@@ -272,8 +286,8 @@ const twitchDmPolicy: ChannelSetupDmPolicy = {
   channel,
   policyKey: "channels.twitch.allowedRoles",
   allowFromKey: "channels.twitch.accounts.<default>.allowFrom",
-  getCurrent: (cfg) => {
-    const account = getAccountConfig(cfg, resolveSetupAccountId(cfg));
+  getCurrent: (cfg, accountId) => {
+    const account = getAccountConfig(cfg, resolveSetupTargetAccountId(cfg, accountId));
     if (account?.allowedRoles?.includes("all")) {
       return "open";
     }
@@ -282,14 +296,14 @@ const twitchDmPolicy: ChannelSetupDmPolicy = {
     }
     return "disabled";
   },
-  setPolicy: (cfg, policy) => {
+  setPolicy: (cfg, policy, accountId) => {
     const allowedRoles: TwitchRole[] =
       policy === "open" ? ["all"] : policy === "allowlist" ? [] : ["moderator"];
-    return setTwitchAccessControl(cfg, allowedRoles, true);
+    return setTwitchAccessControl(cfg, allowedRoles, true, accountId);
   },
-  promptAllowFrom: async ({ cfg, prompter }) => {
-    const accountId = resolveSetupAccountId(cfg);
-    const account = getAccountConfig(cfg, accountId);
+  promptAllowFrom: async ({ cfg, prompter, accountId }) => {
+    const resolvedAccountId = resolveSetupTargetAccountId(cfg, accountId);
+    const account = getAccountConfig(cfg, resolvedAccountId);
     const existingAllowFrom = account?.allowFrom ?? [];
 
     const entry = await prompter.text({
@@ -309,7 +323,7 @@ const twitchDmPolicy: ChannelSetupDmPolicy = {
         ...(account ?? undefined),
         allowFrom,
       },
-      accountId,
+      resolvedAccountId,
     );
   },
 };
@@ -318,16 +332,16 @@ const twitchGroupAccess: NonNullable<ChannelSetupWizard["groupAccess"]> = {
   label: "Twitch chat",
   placeholder: "",
   skipAllowlistEntries: true,
-  currentPolicy: ({ cfg }) => resolveTwitchGroupPolicy(cfg),
-  currentEntries: ({ cfg }) => {
-    const account = getAccountConfig(cfg, resolveSetupAccountId(cfg));
+  currentPolicy: ({ cfg, accountId }) => resolveTwitchGroupPolicy(cfg, accountId),
+  currentEntries: ({ cfg, accountId }) => {
+    const account = getAccountConfig(cfg, resolveSetupTargetAccountId(cfg, accountId));
     return account?.allowFrom ?? [];
   },
-  updatePrompt: ({ cfg }) => {
-    const account = getAccountConfig(cfg, resolveSetupAccountId(cfg));
+  updatePrompt: ({ cfg, accountId }) => {
+    const account = getAccountConfig(cfg, resolveSetupTargetAccountId(cfg, accountId));
     return Boolean(account?.allowedRoles?.length || account?.allowFrom?.length);
   },
-  setPolicy: ({ cfg, policy }) => setTwitchGroupPolicy(cfg, policy),
+  setPolicy: ({ cfg, accountId, policy }) => setTwitchGroupPolicy(cfg, policy, accountId),
   resolveAllowlist: async () => [],
   applyAllowlist: ({ cfg }) => cfg,
 };
@@ -346,27 +360,29 @@ export const twitchSetupAdapter: ChannelSetupAdapter = {
 
 export const twitchSetupWizard: ChannelSetupWizard = {
   channel,
-  resolveAccountIdForConfigure: ({ defaultAccountId }) => defaultAccountId,
+  resolveAccountIdForConfigure: ({ cfg, accountOverride }) =>
+    resolveSetupTargetAccountId(cfg, accountOverride),
   resolveShouldPromptAccountIds: () => false,
   status: {
     configuredLabel: "configured",
     unconfiguredLabel: "needs username, token, and clientId",
     configuredHint: "configured",
     unconfiguredHint: "needs setup",
-    resolveConfigured: ({ cfg }) => {
-      return resolveTwitchAccountContext(cfg, resolveSetupAccountId(cfg)).configured;
+    resolveConfigured: ({ cfg, accountId }) => {
+      return resolveTwitchAccountContext(cfg, resolveSetupTargetAccountId(cfg, accountId))
+        .configured;
     },
-    resolveStatusLines: ({ cfg }) => {
-      const accountId = resolveSetupAccountId(cfg);
-      const configured = resolveTwitchAccountContext(cfg, accountId).configured;
+    resolveStatusLines: ({ cfg, accountId }) => {
+      const resolvedAccountId = resolveSetupTargetAccountId(cfg, accountId);
+      const configured = resolveTwitchAccountContext(cfg, resolvedAccountId).configured;
       return [
-        `Twitch${accountId !== DEFAULT_ACCOUNT_ID ? ` (${accountId})` : ""}: ${configured ? "configured" : "needs username, token, and clientId"}`,
+        `Twitch${resolvedAccountId !== DEFAULT_ACCOUNT_ID ? ` (${resolvedAccountId})` : ""}: ${configured ? "configured" : "needs username, token, and clientId"}`,
       ];
     },
   },
   credentials: [],
-  finalize: async ({ cfg, prompter, forceAllowFrom }) => {
-    const accountId = resolveSetupAccountId(cfg);
+  finalize: async ({ cfg, accountId: requestedAccountId, prompter, forceAllowFrom }) => {
+    const accountId = resolveSetupTargetAccountId(cfg, requestedAccountId);
     const account = getAccountConfig(cfg, accountId);
 
     if (!account || !isAccountConfigured(account)) {
@@ -383,6 +399,7 @@ export const twitchSetupWizard: ChannelSetupWizard = {
         envToken,
         forceAllowFrom,
         twitchDmPolicy,
+        accountId,
       );
       if (envResult) {
         return envResult;
@@ -411,7 +428,7 @@ export const twitchSetupWizard: ChannelSetupWizard = {
 
     const cfgWithAllowFrom =
       forceAllowFrom && twitchDmPolicy.promptAllowFrom
-        ? await twitchDmPolicy.promptAllowFrom({ cfg: cfgWithAccount, prompter })
+        ? await twitchDmPolicy.promptAllowFrom({ cfg: cfgWithAccount, prompter, accountId })
         : cfgWithAccount;
 
     return { cfg: cfgWithAllowFrom };

--- a/extensions/twitch/src/setup-surface.ts
+++ b/extensions/twitch/src/setup-surface.ts
@@ -23,13 +23,14 @@ import { isAccountConfigured } from "./utils/twitch.js";
 
 const channel = "twitch" as const;
 
-function resolveSetupAccountId(cfg: OpenClawConfig): string {
+function resolveSetupAccountId(cfg: OpenClawConfig, requestedAccountId?: string): string {
+  const requested = requestedAccountId?.trim();
+  if (requested) {
+    return requested;
+  }
+
   const preferred = cfg.channels?.twitch?.defaultAccount?.trim();
   return preferred || resolveDefaultTwitchAccountId(cfg);
-}
-
-function resolveSetupTargetAccountId(cfg: OpenClawConfig, accountId?: string | null): string {
-  return accountId?.trim() || resolveSetupAccountId(cfg);
 }
 
 export function setTwitchAccount(
@@ -238,9 +239,9 @@ function setTwitchAccessControl(
   cfg: OpenClawConfig,
   allowedRoles: TwitchRole[],
   requireMention: boolean,
-  accountId?: string | null,
+  accountId?: string,
 ): OpenClawConfig {
-  const resolvedAccountId = resolveSetupTargetAccountId(cfg, accountId);
+  const resolvedAccountId = resolveSetupAccountId(cfg, accountId);
   const account = getAccountConfig(cfg, resolvedAccountId);
   if (!account) {
     return cfg;
@@ -259,9 +260,9 @@ function setTwitchAccessControl(
 
 function resolveTwitchGroupPolicy(
   cfg: OpenClawConfig,
-  accountId?: string | null,
+  accountId?: string,
 ): "open" | "allowlist" | "disabled" {
-  const account = getAccountConfig(cfg, resolveSetupTargetAccountId(cfg, accountId));
+  const account = getAccountConfig(cfg, resolveSetupAccountId(cfg, accountId));
   if (account?.allowedRoles?.includes("all")) {
     return "open";
   }
@@ -274,7 +275,7 @@ function resolveTwitchGroupPolicy(
 function setTwitchGroupPolicy(
   cfg: OpenClawConfig,
   policy: "open" | "allowlist" | "disabled",
-  accountId?: string | null,
+  accountId?: string,
 ): OpenClawConfig {
   const allowedRoles: TwitchRole[] =
     policy === "open" ? ["all"] : policy === "allowlist" ? ["moderator", "vip"] : [];
@@ -287,7 +288,7 @@ const twitchDmPolicy: ChannelSetupDmPolicy = {
   policyKey: "channels.twitch.allowedRoles",
   allowFromKey: "channels.twitch.accounts.<default>.allowFrom",
   getCurrent: (cfg, accountId) => {
-    const account = getAccountConfig(cfg, resolveSetupTargetAccountId(cfg, accountId));
+    const account = getAccountConfig(cfg, resolveSetupAccountId(cfg, accountId));
     if (account?.allowedRoles?.includes("all")) {
       return "open";
     }
@@ -302,7 +303,7 @@ const twitchDmPolicy: ChannelSetupDmPolicy = {
     return setTwitchAccessControl(cfg, allowedRoles, true, accountId);
   },
   promptAllowFrom: async ({ cfg, prompter, accountId }) => {
-    const resolvedAccountId = resolveSetupTargetAccountId(cfg, accountId);
+    const resolvedAccountId = resolveSetupAccountId(cfg, accountId);
     const account = getAccountConfig(cfg, resolvedAccountId);
     const existingAllowFrom = account?.allowFrom ?? [];
 
@@ -334,11 +335,11 @@ const twitchGroupAccess: NonNullable<ChannelSetupWizard["groupAccess"]> = {
   skipAllowlistEntries: true,
   currentPolicy: ({ cfg, accountId }) => resolveTwitchGroupPolicy(cfg, accountId),
   currentEntries: ({ cfg, accountId }) => {
-    const account = getAccountConfig(cfg, resolveSetupTargetAccountId(cfg, accountId));
+    const account = getAccountConfig(cfg, resolveSetupAccountId(cfg, accountId));
     return account?.allowFrom ?? [];
   },
   updatePrompt: ({ cfg, accountId }) => {
-    const account = getAccountConfig(cfg, resolveSetupTargetAccountId(cfg, accountId));
+    const account = getAccountConfig(cfg, resolveSetupAccountId(cfg, accountId));
     return Boolean(account?.allowedRoles?.length || account?.allowFrom?.length);
   },
   setPolicy: ({ cfg, accountId, policy }) => setTwitchGroupPolicy(cfg, policy, accountId),
@@ -361,7 +362,7 @@ export const twitchSetupAdapter: ChannelSetupAdapter = {
 export const twitchSetupWizard: ChannelSetupWizard = {
   channel,
   resolveAccountIdForConfigure: ({ cfg, accountOverride }) =>
-    resolveSetupTargetAccountId(cfg, accountOverride),
+    resolveSetupAccountId(cfg, accountOverride),
   resolveShouldPromptAccountIds: () => false,
   status: {
     configuredLabel: "configured",
@@ -369,11 +370,10 @@ export const twitchSetupWizard: ChannelSetupWizard = {
     configuredHint: "configured",
     unconfiguredHint: "needs setup",
     resolveConfigured: ({ cfg, accountId }) => {
-      return resolveTwitchAccountContext(cfg, resolveSetupTargetAccountId(cfg, accountId))
-        .configured;
+      return resolveTwitchAccountContext(cfg, resolveSetupAccountId(cfg, accountId)).configured;
     },
     resolveStatusLines: ({ cfg, accountId }) => {
-      const resolvedAccountId = resolveSetupTargetAccountId(cfg, accountId);
+      const resolvedAccountId = resolveSetupAccountId(cfg, accountId);
       const configured = resolveTwitchAccountContext(cfg, resolvedAccountId).configured;
       return [
         `Twitch${resolvedAccountId !== DEFAULT_ACCOUNT_ID ? ` (${resolvedAccountId})` : ""}: ${configured ? "configured" : "needs username, token, and clientId"}`,
@@ -382,7 +382,7 @@ export const twitchSetupWizard: ChannelSetupWizard = {
   },
   credentials: [],
   finalize: async ({ cfg, accountId: requestedAccountId, prompter, forceAllowFrom }) => {
-    const accountId = resolveSetupTargetAccountId(cfg, requestedAccountId);
+    const accountId = resolveSetupAccountId(cfg, requestedAccountId);
     const account = getAccountConfig(cfg, accountId);
 
     if (!account || !isAccountConfigured(account)) {

--- a/extensions/twitch/src/token.test.ts
+++ b/extensions/twitch/src/token.test.ts
@@ -65,6 +65,27 @@ describe("token", () => {
       expect(result.source).toBe("config");
     });
 
+    it("should resolve token from normalized account id", () => {
+      const result = resolveTwitchToken(
+        {
+          channels: {
+            twitch: {
+              accounts: {
+                Secondary: {
+                  username: "secondary",
+                  accessToken: "oauth:secondary-token",
+                },
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        { accountId: "secondary" },
+      );
+
+      expect(result.token).toBe("oauth:secondary-token");
+      expect(result.source).toBe("config");
+    });
+
     it("should prioritize config token over env var (simplified config)", () => {
       process.env.OPENCLAW_TWITCH_ACCESS_TOKEN = "oauth:env-token";
 

--- a/extensions/twitch/src/token.ts
+++ b/extensions/twitch/src/token.ts
@@ -9,8 +9,12 @@
  * 2. Environment variable: OPENCLAW_TWITCH_ACCESS_TOKEN (default account only)
  */
 
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  resolveNormalizedAccountEntry,
+} from "openclaw/plugin-sdk/account-resolution";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
 
 export type TwitchTokenSource = "env" | "config" | "none";
 
@@ -56,10 +60,8 @@ export function resolveTwitchToken(
 
   // Get merged account config (handles both simplified and multi-account patterns)
   const twitchCfg = cfg?.channels?.twitch;
-  const accountCfg =
-    accountId === DEFAULT_ACCOUNT_ID
-      ? (twitchCfg?.accounts?.[DEFAULT_ACCOUNT_ID] as Record<string, unknown> | undefined)
-      : (twitchCfg?.accounts?.[accountId] as Record<string, unknown> | undefined);
+  const accounts = twitchCfg?.accounts as Record<string, Record<string, unknown>> | undefined;
+  const accountCfg = resolveNormalizedAccountEntry(accounts, accountId, normalizeAccountId);
 
   // For default account, also check base-level config
   let token: string | undefined;


### PR DESCRIPTION
## Summary

- Problem: Twitch had channel metadata but no bundled setup entry, so setup/status surfaces could report confusing duplicate/fallback states.
- Why it matters: bundled channels should expose a setup entry consistently for config/status flows.
- What changed: add the Twitch setup entry and a lightweight setup-only channel plugin surface.
- What did NOT change (scope boundary): Twitch runtime behavior and credential semantics are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Twitch extension declared channel metadata but did not declare a `setupEntry`, so setup discovery fell back to generic catalog/status behavior.
- Missing detection / guardrail: channel metadata/setup-entry parity was not enforced for Twitch.
- Contributing context (if known): setup status flows increasingly rely on setup-entry metadata rather than loading full channel runtimes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/twitch/src/setup-surface.test.ts`, `pnpm config:channels:check`
- Scenario the test should lock in: Twitch setup surface remains loadable and bundled channel metadata stays consistent.
- Why this is the smallest reliable guardrail: it validates the plugin-owned setup surface and generated channel metadata check.
- Existing test that already covers this (if any): Twitch setup-surface tests cover setup behavior.
- If no new test is added, why not: existing scoped coverage plus metadata check covers this narrow entry declaration.

## User-visible / Behavior Changes

- Twitch appears through the normal setup-entry path instead of generic fallback setup/status behavior.

## Diagram (if applicable)

```text
Before:
Twitch metadata -> no setup entry -> fallback setup/status row

After:
Twitch metadata -> setup entry -> Twitch setup adapter/status
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm
- Model/provider: N/A
- Integration/channel (if any): Twitch
- Relevant config (redacted): N/A

### Steps

1. Run bundled channel metadata checks.
2. Run Twitch setup-surface tests.
3. Build and profile Twitch extension memory.

### Expected

- Twitch setup entry loads and metadata checks pass.

### Actual

- Before this fix, Twitch had no setup entry.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Twitch setup tests, bundled channel config metadata check, build, extension memory profile, commit hook `pnpm check`.
- Edge cases checked: setup-only plugin surface avoids loading unrelated runtime setup.
- What you did **not** verify: live Twitch API authentication.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: setup-only channel plugin metadata could drift from runtime metadata.
  - Mitigation: it uses `getChatChannelMeta(channel)` instead of duplicating labels/docs metadata.
