### PR TITLE
fix(ui): preserve optimistically-added user messages during loadChatHistory

### DIFF
--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -116,7 +116,7 @@ export type ChatState = {
   lastError: string | null;
   // Track optimistically-added user messages that haven't been confirmed by the server yet.
   // Maps client-generated temp ID -> the pending message object.
-  pendingChatMessagesById: Map<string, unknown>;
+  pendingChatMessagesById?: Map<string, unknown>;
 };
 
 export type ChatEventPayload = {
@@ -230,9 +230,13 @@ export async function loadChatHistory(state: ChatState) {
     }
     // Preserve any pending messages even on error (strip their _tempId)
     if (state.pendingChatMessagesById && state.pendingChatMessagesById.size > 0) {
-      const pendingMsgs = [...state.pendingChatMessagesById.values()].map(
-        ({ _tempId: _1, ...msg }) => msg,
-      );
+      const pendingMsgs: unknown[] = [];
+      for (const pendingMsg of state.pendingChatMessagesById.values()) {
+        const msg = pendingMsg as Record<string, unknown>;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { _tempId: _1, ...rest } = msg;
+        pendingMsgs.push(rest);
+      }
       state.chatMessages = [...state.chatMessages, ...pendingMsgs];
       state.pendingChatMessagesById.clear();
     }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -233,8 +233,7 @@ export async function loadChatHistory(state: ChatState) {
       const pendingMsgs: unknown[] = [];
       for (const pendingMsg of state.pendingChatMessagesById.values()) {
         const msg = pendingMsg as Record<string, unknown>;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { _tempId: _1, ...rest } = msg;
+        const { _tempId: _, ...rest } = msg;
         pendingMsgs.push(rest);
       }
       state.chatMessages = [...state.chatMessages, ...pendingMsgs];

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -114,6 +114,9 @@ export type ChatState = {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   lastError: string | null;
+  // Track optimistically-added user messages that haven't been confirmed by the server yet.
+  // Maps client-generated temp ID -> the pending message object.
+  pendingChatMessagesById: Map<string, unknown>;
 };
 
 export type ChatEventPayload = {
@@ -177,7 +180,37 @@ export async function loadChatHistory(state: ChatState) {
       return;
     }
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
+    const filteredMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
+
+    // Restore any pending local messages that aren't in the server history yet.
+    // This prevents optimistic user messages from being lost when loadChatHistory
+    // replaces chatMessages with server history (which may not include the message
+    // if context compaction occurred before the message was committed).
+    if (state.pendingChatMessagesById && state.pendingChatMessagesById.size > 0) {
+      // Build a fingerprint set from server messages to detect duplicates
+      const serverFingerprints = new Set<string>();
+      for (const m of filteredMessages) {
+        const msg = m as Record<string, unknown>;
+        const content = msg.content;
+        serverFingerprints.add(Array.isArray(content) ? JSON.stringify(content) : String(content));
+      }
+
+      // Find pending messages that need to be preserved (not yet in server history)
+      const pendingToKeep: unknown[] = [];
+      for (const pendingMsg of state.pendingChatMessagesById.values()) {
+        const pending = pendingMsg as Record<string, unknown>;
+        const content = pending.content;
+        const fingerprint = Array.isArray(content) ? JSON.stringify(content) : String(content);
+        if (!serverFingerprints.has(fingerprint)) {
+          pendingToKeep.push(pending);
+        }
+      }
+
+      state.chatMessages = [...filteredMessages, ...pendingToKeep];
+      state.pendingChatMessagesById.clear();
+    } else {
+      state.chatMessages = filteredMessages;
+    }
     state.chatThinkingLevel = res.thinkingLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
@@ -194,6 +227,14 @@ export async function loadChatHistory(state: ChatState) {
       state.lastError = formatMissingOperatorReadScopeMessage("existing chat history");
     } else {
       state.lastError = String(err);
+    }
+    // Preserve any pending messages even on error (strip their _tempId)
+    if (state.pendingChatMessagesById && state.pendingChatMessagesById.size > 0) {
+      const pendingMsgs = [...state.pendingChatMessagesById.values()].map(
+        ({ _tempId: _1, ...msg }) => msg,
+      );
+      state.chatMessages = [...state.chatMessages, ...pendingMsgs];
+      state.pendingChatMessagesById.clear();
     }
   } finally {
     if (isLatestChatHistoryRequest(state, requestVersion)) {
@@ -322,14 +363,20 @@ export async function sendChatMessage(
     }
   }
 
-  state.chatMessages = [
-    ...state.chatMessages,
-    {
-      role: "user",
-      content: contentBlocks,
-      timestamp: now,
-    },
-  ];
+  const tempId = generateUUID();
+  const userMessage = {
+    role: "user",
+    content: contentBlocks,
+    timestamp: now,
+    _tempId: tempId,
+  };
+  state.chatMessages = [...state.chatMessages, userMessage];
+
+  // Track as pending so loadChatHistory doesn't lose it
+  if (!state.pendingChatMessagesById) {
+    state.pendingChatMessagesById = new Map();
+  }
+  state.pendingChatMessagesById.set(tempId, userMessage);
 
   state.chatSending = true;
   state.lastError = null;


### PR DESCRIPTION
## Summary

When a user sends a message, it is optimistically added to `chatMessages` before the server confirms it. However, `loadChatHistory()` would later replace the entire `chatMessages` with the server history, causing the optimistic message to be lost (or appear as compressed metadata if context compaction had occurred).

## Root Cause

The `sendChatMessage` function adds the user message to `chatMessages` optimistically:
```typescript
state.chatMessages = [...state.chatMessages, userMessage];
```

But `loadChatHistory` unconditionally replaces `chatMessages` with the server response:
```typescript
state.chatMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
```

If the context was compacted before the message was committed to history, the message appears as a metadata block instead of the original text.

## Fix

1. **Track pending messages**: Add a `_tempId` field to optimistically-added messages and track them in a `pendingChatMessagesById` Map in `ChatState`

2. **Merge in `loadChatHistory`**: After receiving server history, remove optimistic messages from current `chatMessages` (those with `_tempId`), use server history as the base, then re-add pending messages that are not already in server history

3. **Error handling**: Preserve pending messages even when `loadChatHistory` fails to ensure no user messages are lost

## Files Changed

- `ui/src/ui/controllers/chat.ts`

## Testing

Manual testing shows:
- User messages now appear immediately in the Control UI chat
- No duplicate messages
- No metadata blocks replacing original text
- Works correctly when AI responds with tools used

## Related Issues

- Fixes #67961
- Related to #67699 (similar root cause)