### PR TITLE
fix: hide duplicate section title in single-section settings view

### DIFF
--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -443,15 +443,17 @@ export function renderConfigForm(props: ConfigFormProps) {
     path: Array<string | number>;
   }) => html`
     <section class="config-section-card" id=${params.id}>
-      <div class="config-section-card__header">
-        <span class="config-section-card__icon">${getSectionIcon(params.sectionKey)}</span>
-        <div class="config-section-card__titles">
-          <h3 class="config-section-card__title">${params.label}</h3>
-          ${params.description
-            ? html`<p class="config-section-card__desc">${params.description}</p>`
-            : nothing}
-        </div>
-      </div>
+      ${activeSection
+        ? nothing
+        : html`<div class="config-section-card__header">
+            <span class="config-section-card__icon">${getSectionIcon(params.sectionKey)}</span>
+            <div class="config-section-card__titles">
+              <h3 class="config-section-card__title">${params.label}</h3>
+              ${params.description
+                ? html`<p class="config-section-card__desc">${params.description}</p>`
+                : nothing}
+            </div>
+          </div>`}
       <div class="config-section-card__content">
         ${renderNode({
           schema: params.node,


### PR DESCRIPTION
Fixes #68003

## Problem
In the Control UI settings, when opening a single section (e.g., Automation), the section title and description appeared twice:
1. In the top hero area
2. In the nested section card header

## Fix
Conditionally hide the section card header when `activeSection` is set, since the hero already displays the section title and description. The card header is only shown in the root/multi-section view where no hero is rendered.

## Changes
- `ui/src/ui/views/config-form.render.ts`: Wrap section card header in `activeSection ? nothing : ...` guard