### PR TITLE
feat(gateway): warn when proxy env vars detected but providers not using them

### DIFF
--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -157,5 +157,27 @@ describe("gateway startup log", () => {
 
       expect(result).toBeNull();
     });
+
+    it("does not warn for RFC 1918 private LAN providers", async () => {
+      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+
+      const result = collectProxyEnvMismatch({
+        models: {
+          providers: {
+            "lan-ollama": {
+              baseUrl: "http://192.168.1.100:11434",
+              models: [],
+            },
+            "lan-vllm": {
+              baseUrl: "http://10.0.0.50:8000",
+              models: [],
+            },
+          },
+        },
+      });
+
+      expect(result).toBeNull();
+    });
   });
 });

--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { logGatewayStartup } from "./server-startup-log.js";
+import { collectProxyEnvMismatch, logGatewayStartup } from "./server-startup-log.js";
+
+vi.mock("../infra/net/proxy-env.js", () => ({
+  hasProxyEnvConfigured: vi.fn(() => false),
+}));
 
 describe("gateway startup log", () => {
   afterEach(() => {
@@ -71,5 +75,87 @@ describe("gateway startup log", () => {
       .map((call) => call[0])
       .filter((message) => message.startsWith("ready ("));
     expect(readyMessages).toEqual(["ready (3 plugins: alpha, beta, delta; 16.0s)"]);
+  });
+
+  describe("proxy env mismatch warning", () => {
+    it("warns when proxy env is set but remote providers lack proxy config", async () => {
+      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+
+      const result = collectProxyEnvMismatch({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [],
+            },
+            openrouter: {
+              baseUrl: "https://openrouter.ai/api/v1",
+              models: [],
+            },
+          },
+        },
+      });
+
+      expect(result).toContain("proxy env detected");
+      expect(result).toContain("openai");
+      expect(result).toContain("openrouter");
+      expect(result).toContain("env-proxy");
+    });
+
+    it("does not warn when all remote providers have proxy configured", async () => {
+      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+
+      const result = collectProxyEnvMismatch({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              request: { proxy: { mode: "env-proxy" } },
+              models: [],
+            },
+          },
+        },
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("does not warn when no proxy env is set", async () => {
+      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasProxyEnvConfigured).mockReturnValue(false);
+
+      const result = collectProxyEnvMismatch({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [],
+            },
+          },
+        },
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("does not warn for local providers", async () => {
+      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+
+      const result = collectProxyEnvMismatch({
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://localhost:11434",
+              models: [],
+            },
+          },
+        },
+      });
+
+      expect(result).toBeNull();
+    });
   });
 });

--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -158,6 +158,25 @@ describe("gateway startup log", () => {
       expect(result).toBeNull();
     });
 
+    it("does not warn for providers with proxy-incapable APIs", async () => {
+      const { hasEnvHttpProxyConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
+
+      const result = collectProxyEnvMismatch({
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "https://remote-ollama.example.com",
+              api: "ollama",
+              models: [],
+            },
+          },
+        },
+      });
+
+      expect(result).toBeNull();
+    });
+
     it("does not warn for RFC 1918 private LAN providers", async () => {
       const { hasEnvHttpProxyConfigured } = await import("../infra/net/proxy-env.js");
       vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);

--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { collectProxyEnvMismatch, logGatewayStartup } from "./server-startup-log.js";
 
 vi.mock("../infra/net/proxy-env.js", () => ({
-  hasProxyEnvConfigured: vi.fn(() => false),
+  hasEnvHttpProxyConfigured: vi.fn(() => false),
 }));
 
 describe("gateway startup log", () => {
@@ -79,8 +79,8 @@ describe("gateway startup log", () => {
 
   describe("proxy env mismatch warning", () => {
     it("warns when proxy env is set but remote providers lack proxy config", async () => {
-      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
-      vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+      const { hasEnvHttpProxyConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
 
       const result = collectProxyEnvMismatch({
         models: {
@@ -104,8 +104,8 @@ describe("gateway startup log", () => {
     });
 
     it("does not warn when all remote providers have proxy configured", async () => {
-      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
-      vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+      const { hasEnvHttpProxyConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
 
       const result = collectProxyEnvMismatch({
         models: {
@@ -123,8 +123,8 @@ describe("gateway startup log", () => {
     });
 
     it("does not warn when no proxy env is set", async () => {
-      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
-      vi.mocked(hasProxyEnvConfigured).mockReturnValue(false);
+      const { hasEnvHttpProxyConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(false);
 
       const result = collectProxyEnvMismatch({
         models: {
@@ -141,8 +141,8 @@ describe("gateway startup log", () => {
     });
 
     it("does not warn for local providers", async () => {
-      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
-      vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+      const { hasEnvHttpProxyConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
 
       const result = collectProxyEnvMismatch({
         models: {
@@ -159,8 +159,8 @@ describe("gateway startup log", () => {
     });
 
     it("does not warn for RFC 1918 private LAN providers", async () => {
-      const { hasProxyEnvConfigured } = await import("../infra/net/proxy-env.js");
-      vi.mocked(hasProxyEnvConfigured).mockReturnValue(true);
+      const { hasEnvHttpProxyConfigured } = await import("../infra/net/proxy-env.js");
+      vi.mocked(hasEnvHttpProxyConfigured).mockReturnValue(true);
 
       const result = collectProxyEnvMismatch({
         models: {

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
 import { getResolvedLoggerSettings } from "../logging.js";
 import { collectEnabledInsecureOrDangerousFlags } from "../security/dangerous-config-flags.js";
 
@@ -42,6 +43,53 @@ export function logGatewayStartup(params: {
       "Run `openclaw security audit`.";
     params.log.warn(warning);
   }
+
+  const proxyWarning = collectProxyEnvMismatch(params.cfg);
+  if (proxyWarning) {
+    params.log.warn(proxyWarning);
+  }
+}
+
+function isLocalProviderUrl(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "[::1]" ||
+      host === "::1" ||
+      host.endsWith(".local")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function collectProxyEnvMismatch(cfg: OpenClawConfig): string | null {
+  if (!hasProxyEnvConfigured()) {
+    return null;
+  }
+
+  const providers = cfg.models?.providers ?? {};
+  const unconfigured: string[] = [];
+
+  for (const [name, provider] of Object.entries(providers)) {
+    if (isLocalProviderUrl(provider.baseUrl)) {
+      continue;
+    }
+    if (!provider.request?.proxy) {
+      unconfigured.push(name);
+    }
+  }
+
+  if (unconfigured.length === 0) {
+    return null;
+  }
+
+  return (
+    `proxy env detected (HTTP_PROXY/HTTPS_PROXY) but not used by providers: ${unconfigured.join(", ")}. ` +
+    `Consider setting models.providers.<name>.request.proxy.mode = "env-proxy"`
+  );
 }
 
 function formatReadyDetails(

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -1,10 +1,22 @@
 import chalk from "chalk";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveConfiguredModelRef } from "../agents/model-selection.js";
+import type { ModelApi } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasEnvHttpProxyConfigured } from "../infra/net/proxy-env.js";
 import { getResolvedLoggerSettings } from "../logging.js";
 import { collectEnabledInsecureOrDangerousFlags } from "../security/dangerous-config-flags.js";
+
+// APIs that support request.proxy/request.tls transport overrides.
+// Must stay in sync with SUPPORTED_TRANSPORT_APIS in provider-transport-stream.ts.
+const PROXY_CAPABLE_APIS = new Set<ModelApi>([
+  "openai-responses",
+  "openai-codex-responses",
+  "openai-completions",
+  "azure-openai-responses",
+  "anthropic-messages",
+  "google-generative-ai",
+]);
 
 export function logGatewayStartup(params: {
   cfg: OpenClawConfig;
@@ -91,6 +103,11 @@ export function collectProxyEnvMismatch(cfg: OpenClawConfig): string | null {
 
   for (const [name, provider] of Object.entries(providers)) {
     if (isLocalOrPrivateProviderUrl(provider.baseUrl)) {
+      continue;
+    }
+    // Skip providers whose API does not support transport overrides —
+    // recommending env-proxy for them would cause a runtime error.
+    if (provider.api && !PROXY_CAPABLE_APIS.has(provider.api)) {
       continue;
     }
     if (!provider.request?.proxy) {

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
+import { hasEnvHttpProxyConfigured } from "../infra/net/proxy-env.js";
 import { getResolvedLoggerSettings } from "../logging.js";
 import { collectEnabledInsecureOrDangerousFlags } from "../security/dangerous-config-flags.js";
 
@@ -77,7 +77,12 @@ function isLocalOrPrivateProviderUrl(baseUrl: string): boolean {
 }
 
 export function collectProxyEnvMismatch(cfg: OpenClawConfig): string | null {
-  if (!hasProxyEnvConfigured()) {
+  // Use hasEnvHttpProxyConfigured (not hasProxyEnvConfigured) because the
+  // env-proxy transport path follows resolveEnvHttpProxyUrl semantics which
+  // intentionally ignores ALL_PROXY. Checking hasProxyEnvConfigured would
+  // fire when only ALL_PROXY is set, but the suggested env-proxy fix would
+  // not actually pick up that variable — creating a persistent false-positive.
+  if (!hasEnvHttpProxyConfigured("https") && !hasEnvHttpProxyConfigured("http")) {
     return null;
   }
 
@@ -98,7 +103,7 @@ export function collectProxyEnvMismatch(cfg: OpenClawConfig): string | null {
   }
 
   return (
-    `proxy env detected (HTTP_PROXY/HTTPS_PROXY/ALL_PROXY) but not used by providers: ${unconfigured.join(", ")}. ` +
+    `proxy env detected (HTTP_PROXY/HTTPS_PROXY) but not used by providers: ${unconfigured.join(", ")}. ` +
     `Consider setting models.providers.<name>.request.proxy.mode = "env-proxy"`
   );
 }

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -50,16 +50,27 @@ export function logGatewayStartup(params: {
   }
 }
 
-function isLocalProviderUrl(baseUrl: string): boolean {
+function isLocalOrPrivateProviderUrl(baseUrl: string): boolean {
   try {
     const host = new URL(baseUrl).hostname.toLowerCase();
-    return (
+    if (
       host === "localhost" ||
       host === "127.0.0.1" ||
       host === "[::1]" ||
       host === "::1" ||
       host.endsWith(".local")
-    );
+    ) {
+      return true;
+    }
+    // RFC 1918 private networks — proxying LAN providers is typically undesired
+    if (
+      host.startsWith("10.") ||
+      host.startsWith("192.168.") ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+    ) {
+      return true;
+    }
+    return false;
   } catch {
     return false;
   }
@@ -74,7 +85,7 @@ export function collectProxyEnvMismatch(cfg: OpenClawConfig): string | null {
   const unconfigured: string[] = [];
 
   for (const [name, provider] of Object.entries(providers)) {
-    if (isLocalProviderUrl(provider.baseUrl)) {
+    if (isLocalOrPrivateProviderUrl(provider.baseUrl)) {
       continue;
     }
     if (!provider.request?.proxy) {
@@ -87,7 +98,7 @@ export function collectProxyEnvMismatch(cfg: OpenClawConfig): string | null {
   }
 
   return (
-    `proxy env detected (HTTP_PROXY/HTTPS_PROXY) but not used by providers: ${unconfigured.join(", ")}. ` +
+    `proxy env detected (HTTP_PROXY/HTTPS_PROXY/ALL_PROXY) but not used by providers: ${unconfigured.join(", ")}. ` +
     `Consider setting models.providers.<name>.request.proxy.mode = "env-proxy"`
   );
 }


### PR DESCRIPTION
## Problem

In proxy-required environments (WSL + Clash/Mihomo, corporate networks), OpenClaw provider requests silently timeout because they do not automatically use `HTTP_PROXY`/`HTTPS_PROXY` environment variables. The existing `models.providers.<provider>.request.proxy.mode = "env-proxy"` config option is hard to discover, leading to a confusing failure mode where the gateway starts normally but chat requests fail.

## Fix

Add a non-breaking startup warning in `logGatewayStartup()` when all of the following are true:
- `HTTP_PROXY` or `HTTPS_PROXY` (or lowercase variants) is detected in the environment
- At least one configured provider targets a remote endpoint (not localhost/127.0.0.1/::1/.local)
- That provider does not have `request.proxy` explicitly configured

Example warning:
```
proxy env detected (HTTP_PROXY/HTTPS_PROXY) but not used by providers: openai, openrouter. Consider setting models.providers.<name>.request.proxy.mode = "env-proxy"
```

This does **not**:
- Auto-enable env proxy for any provider
- Change existing proxy semantics
- Route local providers through a proxy

## Test

- 4 new test cases added to `server-startup-log.test.ts`:
  - Warns when proxy env set + remote providers lack proxy config
  - Does not warn when all remote providers have proxy configured
  - Does not warn when no proxy env is set
  - Does not warn for local providers (localhost, 127.0.0.1, etc.)
- All 7 tests pass (`pnpm test src/gateway/server-startup-log.test.ts`)
- `pnpm check` passes (lint, format, typecheck, import cycles)

## Checklist

- [x] Change scoped to issue #67060
- [x] Tests pass
- [x] No unrelated changes
- [x] AI Assisted

Closes #67060