### PR TITLE
fix(discord): strip channel: prefix from conversationId in thread binding adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: normalize prefixed channel targets only at the thread-binding API boundary, so `sessions_spawn({ runtime: "acp", thread: true })` can create child threads from Discord channels without breaking current-channel ACP bindings. (#68034) Thanks @Zetarcos.
 - Discord: harden inbound thread metadata handling against partial Carbon channel getters, so non-command thread messages and queued jobs no longer crash when `name`, `parentId`, `parent`, or `ownerId` requires fetched raw data.
 - Discord: let `message` tool reactions resolve `user:<id>` DM targets and preserve `channels.discord.guilds.<guild>.channels.<channel>.requireMention: false` during reply-stage activation fallback. Fixes #70165 and #69441.
 - Telegram/webhooks: lower the grammY webhook callback timeout to 5s so Telegram gets an early 200 response instead of retrying long-running updates as read timeouts. (#70146) Thanks @friday-james.

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.test.ts
@@ -70,6 +70,35 @@ describe("resolveChannelIdForBinding", () => {
     expect(restGet).not.toHaveBeenCalled();
   });
 
+  it("normalizes prefixed explicit channelId without resolving route", async () => {
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "thread-1",
+      channelId: "channel:123456789012345678",
+    });
+
+    expect(resolved).toBe("123456789012345678");
+    expect(createDiscordRestClient).not.toHaveBeenCalled();
+    expect(restGet).not.toHaveBeenCalled();
+  });
+
+  it("strips channel prefix before resolving route", async () => {
+    restGet.mockResolvedValueOnce({
+      id: "123456789012345678",
+      type: ChannelType.GuildText,
+    });
+
+    const resolved = await resolveChannelIdForBinding({
+      accountId: "default",
+      threadId: "channel:123456789012345678",
+    });
+
+    expect(resolved).toBe("123456789012345678");
+    const route = JSON.stringify(restGet.mock.calls[0]?.[0] ?? null);
+    expect(route).toContain("123456789012345678");
+    expect(route).not.toContain("channel:");
+  });
+
   it("returns parent channel for thread channels", async () => {
     restGet.mockResolvedValueOnce({
       id: "thread-1",

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.ts
@@ -5,6 +5,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { createDiscordRestClient } from "../client.js";
 import { sendMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
 import { createThreadDiscord } from "../send.messages.js";
+import { resolveDiscordChannelId } from "../target-parsing.js";
 import { resolveThreadBindingPersonaFromRecord } from "./thread-bindings.persona.js";
 import {
   BINDINGS_BY_THREAD_ID,
@@ -48,6 +49,18 @@ function isThreadChannelType(type: unknown): boolean {
     type === ChannelType.PrivateThread ||
     type === ChannelType.AnnouncementThread
   );
+}
+
+function normalizeDiscordBindingChannelId(raw?: string | null): string | null {
+  const trimmed = normalizeOptionalString(raw) ?? "";
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    return resolveDiscordChannelId(trimmed);
+  } catch {
+    return null;
+  }
 }
 
 export function summarizeDiscordError(err: unknown): string {
@@ -233,9 +246,13 @@ export async function resolveChannelIdForBinding(params: {
   threadId: string;
   channelId?: string;
 }): Promise<string | null> {
-  const explicit = params.channelId?.trim();
+  const explicit = normalizeDiscordBindingChannelId(params.channelId);
   if (explicit) {
     return explicit;
+  }
+  const lookupThreadId = normalizeDiscordBindingChannelId(params.threadId);
+  if (!lookupThreadId) {
+    return null;
   }
   try {
     const rest = createDiscordRestClient(
@@ -245,7 +262,7 @@ export async function resolveChannelIdForBinding(params: {
       },
       params.cfg,
     ).rest;
-    const channel = (await rest.get(Routes.channel(params.threadId))) as {
+    const channel = (await rest.get(Routes.channel(lookupThreadId))) as {
       id?: string;
       type?: number;
       parent_id?: string;
@@ -267,7 +284,7 @@ export async function resolveChannelIdForBinding(params: {
     return channelId || null;
   } catch (err) {
     logVerbose(
-      `discord thread binding channel resolve failed for ${params.threadId}: ${summarizeDiscordError(err)}`,
+      `discord thread binding channel resolve failed for ${lookupThreadId}: ${summarizeDiscordError(err)}`,
     );
     return null;
   }

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts
@@ -984,6 +984,105 @@ describe("thread binding lifecycle", () => {
     expect(usedTokenNew).toBe(true);
   });
 
+  it("normalizes prefixed parentConversationId before creating child thread bindings", async () => {
+    createThreadBindingManager({
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+      idleTimeoutMs: 24 * 60 * 60 * 1000,
+      maxAgeMs: 0,
+    });
+
+    hoisted.restGet.mockClear();
+    hoisted.createThreadDiscord.mockClear();
+    hoisted.createThreadDiscord.mockResolvedValueOnce({ id: "thread-created-parent-normalized" });
+
+    const bound = await getSessionBindingService().bind({
+      targetSessionKey: "agent:codex:acp:test-parent-normalized",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1491611525914558668",
+        parentConversationId: "channel:1491611525914558667",
+      },
+      placement: "child",
+      metadata: {
+        agentId: "codex",
+        label: "Codex ACP bind test",
+        threadName: "Codex ACP bind test",
+      },
+    });
+
+    expect(bound).toMatchObject({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "thread-created-parent-normalized",
+      },
+    });
+    expect(hoisted.createThreadDiscord).toHaveBeenCalledWith(
+      "1491611525914558667",
+      expect.objectContaining({ autoArchiveMinutes: 60 }),
+      expect.objectContaining({ accountId: "default" }),
+    );
+    expect(hoisted.restGet).not.toHaveBeenCalled();
+  });
+
+  it("preserves prefixed current channel conversation ids as binding keys", async () => {
+    createThreadBindingManager({
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+      idleTimeoutMs: 24 * 60 * 60 * 1000,
+      maxAgeMs: 0,
+    });
+
+    hoisted.restGet.mockClear();
+    hoisted.restPost.mockClear();
+
+    const service = getSessionBindingService();
+    const bound = await service.bind({
+      targetSessionKey: "agent:codex:acp:current-channel",
+      targetKind: "session",
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1491611525914558667",
+      },
+      placement: "current",
+      metadata: {
+        agentId: "codex",
+      },
+    });
+
+    expect(bound).toMatchObject({
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1491611525914558667",
+      },
+    });
+    expect(
+      service.resolveByConversation({
+        channel: "discord",
+        accountId: "default",
+        conversationId: "channel:1491611525914558667",
+      }),
+    ).toMatchObject({
+      targetSessionKey: "agent:codex:acp:current-channel",
+    });
+    expect(
+      service.resolveByConversation({
+        channel: "discord",
+        accountId: "default",
+        conversationId: "1491611525914558667",
+      }),
+    ).toBeNull();
+    expect(hoisted.restGet).not.toHaveBeenCalled();
+    expect(hoisted.restPost).not.toHaveBeenCalled();
+  });
+
   it("binds current Discord DMs as direct conversation bindings", async () => {
     createThreadBindingManager({
       accountId: "default",

--- a/extensions/discord/src/monitor/thread-bindings.manager.ts
+++ b/extensions/discord/src/monitor/thread-bindings.manager.ts
@@ -15,6 +15,7 @@ import {
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { createDiscordRestClient } from "../client.js";
+import { resolveDiscordChannelId } from "../target-parsing.js";
 import {
   createThreadForBinding,
   createWebhookForChannel,
@@ -65,6 +66,18 @@ import {
 
 function registerManager(manager: ThreadBindingManager) {
   MANAGERS_BY_ACCOUNT_ID.set(manager.accountId, manager);
+}
+
+function normalizeChildBindingParentChannelId(raw?: string | null): string | undefined {
+  const trimmed = normalizeOptionalString(raw) ?? "";
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    return resolveDiscordChannelId(trimmed);
+  } catch {
+    return undefined;
+  }
 }
 
 function unregisterManager(accountId: string, manager: ThreadBindingManager) {
@@ -632,11 +645,12 @@ export function createThreadBindingManager(
           ? normalizeOptionalString(metadata.agentId)
           : undefined;
       let threadId: string | undefined;
-      let channelId = normalizeOptionalString(input.conversation.parentConversationId);
+      let channelId: string | undefined;
       let createThread = false;
 
       if (placement === "child") {
         createThread = true;
+        channelId = normalizeChildBindingParentChannelId(input.conversation.parentConversationId);
         if (!channelId && conversationId) {
           const cfg = resolveCurrentCfg();
           channelId =


### PR DESCRIPTION
## Summary

When `sessions_spawn({ thread: true })` is called from a Discord channel, the `channel:` prefix on the conversation ID survives into the Discord thread binding adapter's `bind()` function, causing `GET /channels/channel:<id>` — an invalid Discord API path. The error is swallowed by `logVerbose` (no-op in production), `bind()` returns `null`, and the spawn fails with `thread_binding_invalid` / `BINDING_CREATE_FAILED`.

Fixes #62685, #63329.

## Root cause

`resolveConversationRefForThreadBinding` calls `resolvePluginConversationRefForThreadBinding` first. For Discord, this calls `resolveDiscordCurrentConversationIdentity({ originatingTo: "channel:<id>", chatType: "group" })`, which returns `"channel:<id>"` (prefix preserved by `normalizeDiscordTarget`). The non-null result triggers an **early return**, bypassing `resolveConversationIdFromTargets` — the existing fix that strips the prefix — entirely.

## Fix

Strip `channel:` at the `bind()` entry point, before `conversationId` propagates downstream:

```diff
-      const conversationId = normalizeOptionalString(input.conversation.conversationId) ?? "";
+      // Strip "channel:" prefix — must not appear in raw Discord API calls. It survives
+      // into bind() via resolvePluginConversationRefForThreadBinding's early return,
+      // bypassing the resolveConversationIdFromTargets stripping step.
+      const conversationId = (normalizeOptionalString(input.conversation.conversationId) ?? "").replace(/^channel:/i, "");
```

## Why `bind()` rather than `resolveChannelIdForBinding`

The fix suggested in #63329 targets `resolveChannelIdForBinding`. That covers `placement === "child"` but not `placement === "current"`, where `conversationId` is used directly as `threadId` without going through `resolveChannelIdForBinding`. Fixing at the `bind()` entry covers both paths.

## Testing

Confirmed working on OC 2026.4.15 with patch applied to dist:

```ts
sessions_spawn({
  runtime: "acp",
  thread: true,
  agentId: "claude",
  mode: "session",
  task: "...",
  cwd: "/path/to/workspace"  // explicit cwd required
})
```

Result: thread created in Discord channel, ACP session bound (`agent:claude:acp:176fb9e6`).

**Note:** explicit `cwd` is required — default cwd resolution from a Discord message turn may exit with `cwd_resolution_failed` before thread binding is attempted.
