### PR TITLE
fix(discord): fail fast when bot identity fetch fails (#42219)

### DIFF
--- a/.agents/skills/openclaw-security-fix-driver/SKILL.md
+++ b/.agents/skills/openclaw-security-fix-driver/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: openclaw-security-fix-driver
+description: End-to-end driver for fixing open security issues in the OpenClaw repo. Use whenever the user asks to "work through" or "drive" security issues, "fix the top N security bugs", "land security fixes", "clear the security backlog", "triage and patch security reports at scale", or to coordinate a multi-issue security fix campaign. Also use when the user names a specific security issue to fix end-to-end (for example "fix issue #40297", "drive openclaw/openclaw#40297 through merge", "fix this security bug: <URL>", or "take issue 40297 through the full flow") — in that case the skill runs in single-issue mode and skips discovery. Also use for requests that ask to rank open security issues by importance, batch-fix them, and drive PRs through review and merge. Always delegate PR mechanics to `$openclaw-pr-maintainer`, GHSA-class work to `$openclaw-ghsa-maintainer`, and close/hardening-only decisions to `$security-triage`.
+---
+
+# OpenClaw Security Fix Driver
+
+This skill orchestrates a safe, resumable security fix workflow in the OpenClaw repo. It is **not** a replacement for maintainer skills — it calls them. Think of it as a control loop that runs the four phases end-to-end:
+
+1. **Discover & rank** the top open security issues (batch mode only)
+2. **Fix** each one (root cause → code → tests → local gates)
+3. **Land** via the existing PR maintainer flow (review nudge → merge)
+4. **Report** a manager-facing summary per merged fix
+
+Every long-running step is checkpointed to a ledger on disk so work can resume across sessions without redoing it.
+
+## Modes of operation
+
+The skill runs in one of two modes, chosen from how the user framed the request.
+
+### Batch mode (default)
+
+The user wants to work many issues — phrasings like "fix the top security issues", "clear the security backlog", "drive the top N security bugs through merge." Run **all four phases**, starting at Phase 1. This is the mode described through most of this doc.
+
+### Single-issue mode
+
+The user named a specific issue — an issue number (`#40297`, `issue 40297`), a GitHub URL (`https://github.com/openclaw/openclaw/issues/40297`), or a GHSA id (`GHSA-xxxx-xxxx-xxxx`). Examples:
+
+- "fix issue #40297"
+- "drive openclaw/openclaw#40297 to merge"
+- "take this security bug end-to-end: <URL>"
+- "run the security fix flow on GHSA-xxxx-xxxx-xxxx"
+
+In single-issue mode, **skip Phase 1 entirely**. Jump straight to the fix loop for the named issue. The rest of the flow is identical: same ledger, same checkpoints (C2–C6), same delegation to `$openclaw-pr-maintainer` / `$openclaw-ghsa-maintainer`, same manager-facing report.
+
+Single-issue mode steps:
+
+1. **Parse the target.** Extract the issue number (or GHSA id) from the user's message. Reject ambiguous input — do not guess. If the user mentioned a repo-qualified ref (`owner/repo#N`) that is not `openclaw/openclaw`, stop and ask.
+2. **Load the issue** with `gh issue view <N> --repo openclaw/openclaw --json number,title,body,labels,url,state,createdAt,updatedAt,author` plus `--comments`. For a GHSA id, use `gh api /repos/openclaw/openclaw/security-advisories/<GHSA>` and hand the issue to `$openclaw-ghsa-maintainer`.
+3. **Verify the security framing.** Read the body and comments against the "Deep-read signals" in `references/ranking.md`. If the report is clearly out of scope (private-LAN `ws://`, prompt injection in workspace memory, already-trusted precondition), stop and hand to `$security-triage` — do **not** fabricate a fix just because the user named the issue.
+4. **Record in the ledger.** Upsert the issue with `scripts/ledger.py upsert-issue` at `stage: queued`, mode marker `"invocationMode": "single-issue"`, and the importance score computed per `references/ranking.md`. If the issue is already present (prior campaign run or resume), reuse the existing entry and continue from its current stage per `references/ledger.md`.
+5. **Enter Phase 2 (Per-issue fix loop).** From here, behavior is identical to batch mode: root-cause → checkpoint C2 → implement → test at C3 → hand to `$openclaw-pr-maintainer` for Phase 3 → write the manager report in Phase 4.
+
+In single-issue mode the bulk-action checkpoint (**C4**) effectively collapses — there is no "batch of 5", so C4 never fires unless the user later asks the skill to take on more issues.
+
+**When to use the delegated skills directly instead of this skill:**
+
+- Just a triage close/keep decision, no fix intent → `$security-triage`
+- Reviewing an existing PR someone else filed → `$openclaw-pr-maintainer`
+- Cutting a release after fixes land → `$openclaw-release-maintainer`
+
+Use this skill when the user wants the fix driven through — whether one issue or many.
+
+## Non-negotiable safety rules
+
+These come from the repo's `CLAUDE.md` and are load-bearing for this workflow. Do not relax them without explicit user approval in the chat.
+
+- Use repo-root-relative file paths in all responses (e.g. `src/telegram/index.ts:80`), never absolute paths.
+- Respect `CODEOWNERS` on security-sensitive surfaces (pairing, auth, gateway ingress, secrets, crypto). Do not drive-by-clean files covered by security `CODEOWNERS` unless a listed owner is already reviewing with you.
+- Do **not** modify the `.git` folder. Do **not** touch git worktrees, stashes, or branch checkouts unless the user explicitly asks.
+- Never use `--no-verify`, `--no-gpg-sign`, or `--amend` after a hook failure. Fix the root cause and create a new commit.
+- Never force-push `main` and never create merge commits on `main`; rebase onto latest `origin/main` before push.
+- For bulk close/reopen that would affect more than 5 PRs or issues, stop and ask for explicit confirmation with the exact count.
+- Treat release and `npm publish` as explicit-approval actions even after all fixes land.
+- Use `scripts/committer "<msg>" <file...>` for commits so staging stays scoped; avoid broad `git add -A`.
+
+## Checkpoints that pause for approval
+
+The driver pauses at each of these points and waits for the user in the chat before proceeding. This is the main knob that keeps long runs safe.
+
+| # | Checkpoint | What to confirm |
+| - | ---------- | --------------- |
+| C1 | Batch kickoff | The ranked top-N list, the ceiling `N`, and whether to run end-to-end or stop after each issue |
+| C2 | Per-issue fix | The root-cause analysis and the proposed patch, before writing code |
+| C3 | Pre-PR | Targeted tests green, `pnpm check` green, and `pnpm build` when the touched surface warrants |
+| C4 | Bulk action (>5) | Any cross-issue action that would file, close, or comment on more than 5 PRs/issues |
+| C5 | Reviewer nudge | Which accounts to tag, and the wording of the nudge |
+| C6 | Release-adjacent | Anything that would cut a tag, bump `package.json`, or call `npm publish` |
+
+Checkpoints exist because the cost of a mistake on a security PR (an unreviewed force-land, a premature advisory disclosure, a bad patch merged) is much higher than the cost of a short wait.
+
+## Phase 1 — Discover and rank
+
+> **Batch mode only.** In single-issue mode, skip this phase entirely (see "Modes of operation" above) and go straight to Phase 2 with the user's named issue. The single issue still gets scored per `references/ranking.md` so the ledger entry is comparable to batch runs, but no wide discovery happens.
+
+The goal of this phase is a deterministic top-N list of open security issues, scored by importance, with a short justification per issue. **Labels alone are not enough** — many real security issues in this repo are filed without a `security` label, and many labeled `security` are hardening-only noise. Discovery and ranking both run in two passes: a cheap candidate sweep, then a content-aware deep read.
+
+### Pass 1 — Wide candidate sweep
+
+Cast a wide net, even at the cost of false positives (Pass 2 will filter):
+
+```bash
+.agents/skills/openclaw-security-fix-driver/scripts/rank_security_issues.sh --limit 300
+```
+
+The helper collects candidates from multiple signals and deduplicates by issue number:
+
+1. **Label variants** — `security`, `type:security`, `severity:*`, `CVSS-*`, `ghsa`, `vuln`, `hardening`, `auth`, `crypto`, `pairing`
+2. **Title/body keyword search** via `gh search issues` for terms like `RCE`, `auth bypass`, `signature`, `HMAC`, `CSRF`, `SSRF`, `injection`, `path traversal`, `token leak`, `spoof`, `impersonat`, `privilege escalation`, `sandbox escape`, `TOCTOU`, `replay`, `MITM`, `deserializ`, `prototype pollution`
+3. **Surface mentions** — issues that reference `CODEOWNERS`-covered security paths (`src/gateway/auth*`, `src/channels/**/pairing*`, `src/channels/**/secrets*`, webhook verification, signature routines)
+4. **GHSA cross-reference** — `gh api /repos/openclaw/openclaw/security-advisories` so the driver sees advisories even when no public issue exists
+
+Pass 1 emits a candidate JSON array on stdout. Treat its preliminary score as a **rough bucket**, not the final rank.
+
+### Pass 2 — Deep read and re-score
+
+Labels and keyword matches miss two real cases:
+
+- A report filed as a "bug" with no `security` label that is actually an auth bypass (needs promotion).
+- A report labeled `security` that turns out to be a hardening suggestion or an out-of-scope prompt-injection claim (needs demotion or skip).
+
+For each candidate, **read the issue in full** before locking in a score:
+
+1. Load the issue body, all comments, and any linked GHSA:
+
+   ```bash
+   gh issue view <N> --repo openclaw/openclaw --json number,title,body,labels,url,createdAt,updatedAt,author,comments
+   ```
+
+2. Read the content against the signals in `references/ranking.md` §"Deep-read signals". The key questions:
+
+   - **Is there a concrete trust-boundary crossing described?** (unauth → auth, LAN → loopback, plugin → core, sandbox escape). Vague "could be exploited" language without a mechanism is a demotion signal.
+   - **Is there a reproducer or a clearly-named file/function?** Reproducers + code pointers raise confidence and thus rank.
+   - **Does the reporter distinguish trust-boundary bypass from hardening?** If the report is explicit that it's hardening-only, treat it as hardening.
+   - **What shipped version does it apply to?** Use `git tag --sort=-creatordate | head -1` and `git show <tag>:<path>` to verify the bug exists in the latest released bytes, not just `main`.
+   - **Are there disqualifier matches?** `SECURITY.md` out-of-scope classes (private-LAN `ws://`, prompt injection in workspace memory files, "attacker already has operator admin") → skip to triage, regardless of how serious the body sounds.
+   - **Reporter context** — a detailed report with CVSS vector + PoC from an experienced reporter outranks a one-line "this seems insecure" even at the same keyword-match level.
+
+3. Re-score using the rubric. The Pass-1 score may go up, go down, or stay the same. Save both the Pass-1 and Pass-2 scores in the ledger so re-ranks are auditable.
+
+### Presenting the rank
+
+After Pass 2, sort by final score (tie-break per `references/ranking.md`) and present the top 10 in chat with:
+
+- Rank number, issue number, final total score and component breakdown
+- One-sentence "why this rank" that cites the specific signals (keyword + code pointer + shipped-tag evidence + any demotions)
+- URL
+
+The full ranked JSON — including Pass-1 vs Pass-2 deltas — goes into the ledger. This is what makes the rank defensible if a reviewer asks "why did you prioritize X over Y?"
+
+### GHSA handoff
+
+GHSA-class issues (surfaced via `gh api /repos/openclaw/openclaw/security-advisories` or labeled `ghsa`) must be handed to `$openclaw-ghsa-maintainer` for the actual patch/publish flow. The driver keeps them in the ledger and tracks status, but it does not drive the patch itself.
+
+### Checkpoint C1
+
+Show the user the top 10 with breakdowns and confirm scope: how many to work, serial vs parallel, and whether GHSA entries should be forwarded to the GHSA maintainer skill immediately. If the user disagrees with a specific rank, re-open Pass 2 for that candidate rather than tweaking numbers ad hoc — the goal is that the rank can always be explained from the evidence.
+
+## Phase 2 — Per-issue fix loop
+
+For each issue in the confirmed batch, follow `references/fix-workflow.md`. The short version:
+
+1. **Read the issue and linked code** verbatim before forming a theory. Quote the report and quote the implicated code with repo-root-relative file:line refs.
+2. **Decide disposition** against the close bar from `$security-triage`:
+   - Close / hardening-only / out of scope → hand off to `$security-triage` (record `skipped: triage` in the ledger) and move on.
+   - Real bug on the shipped surface → continue to fix.
+3. **Write the root-cause analysis** in 3–8 lines. Explain the trust boundary that was crossed, not just the symptom.
+4. **Propose the patch** and pause at **C2** for approval. Include: files touched, why this fix is minimal and correct, risk of regression, and test plan.
+5. **Implement** using `Edit`/`Write`. Keep changes scoped; follow the architecture boundaries from `CLAUDE.md` (plugin-sdk seams, channel boundary, etc.).
+6. **Test** with the narrowest meaningful gate first, then widen:
+   - `pnpm test <path-or-filter>` for the touched area
+   - `pnpm check` before pushing
+   - `pnpm build` when the change can affect build output, packaging, lazy loading, module boundaries, or published surfaces (this is the explicit `CLAUDE.md` hard gate)
+   - If `pnpm tsgo` fails, triage by coherent surface per `CLAUDE.md`, not raw error count
+7. **Regression test** — if you can add one that would have caught the bug, add it. If you genuinely cannot, say so explicitly in the PR body and the ledger.
+8. Pause at **C3** with the green gate results before commit.
+
+Prompt-cache and dynamic-import hygiene from `CLAUDE.md` apply here too: if the fix touches model/tool payload assembly, make ordering deterministic and prefer tail-mutating truncation; if it touches lazy-loading boundaries, re-check `pnpm build` for `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings.
+
+## Phase 3 — Land via the PR maintainer
+
+Invoke `$openclaw-pr-maintainer` for the actual PR lifecycle. This skill should supply the maintainer skill with:
+
+- A clean, scoped commit staged via `scripts/committer "<msg>" <file...>`
+- A PR title and body following `.github/pull_request_template.md`, including:
+  - Issue link, affected versions, trust-model framing
+  - Root-cause analysis (from Phase 2)
+  - Fix summary and why it is minimal
+  - Verification (`pnpm test`, `pnpm check`, `pnpm build` outputs, and any manual steps)
+  - Risk/rollback notes
+- A short changelog entry (only for user-facing security changes; pure test/meta changes do not need one per `CLAUDE.md`)
+
+Push and PR filing follow the `/landpr` global prompt flow referenced in `CLAUDE.md`. Do not create merge commits on `main`; rebase.
+
+**Reviewer nudging** is a separate checkpoint (**C5**). Do not tag individuals without the user's confirmation of the reviewer set. When nudging:
+
+- Tag the relevant `CODEOWNERS` for the touched path and, for GHSA-derived fixes, the advisory owner.
+- Keep the nudge message factual: what changed, what tests ran, what is blocking review. Do not pressure individual reviewers beyond one polite follow-up per business day.
+- "Permitted merge account" escalation (asking a maintainer with merge rights to land) only happens after two reviewer-acked approvals, all required checks green, and **C4** approval if this is part of a bulk action.
+
+For GHSA-class issues, the entire land phase is owned by `$openclaw-ghsa-maintainer`. The driver's job is to record the handoff and watch for completion in the ledger.
+
+## Phase 4 — Manager summary and ledger update
+
+After each merge, write a summary to `.agents/state/security-fix-driver/reports/<issue-number>.md` using the template in `references/reporting.md`. The summary is the manager-facing artifact; it should be short, plain-English, and linkable.
+
+Then update the ledger entry for that issue to `merged` with:
+
+- PR URL and merged commit SHA
+- Land date
+- Surface/severity tags
+- Link to the written report
+
+Keep one rolling `.agents/state/security-fix-driver/reports/INDEX.md` that lists every merged fix in the campaign. That index is the first thing the manager reads.
+
+## The ledger
+
+The ledger is the persistence layer that makes long runs safe to resume. It lives at:
+
+```
+.agents/state/security-fix-driver/ledger.json
+```
+
+Schema, state machine, and atomic-update contract are in `references/ledger.md`. Use `scripts/ledger.py` for all reads/writes so updates stay atomic. Never hand-edit the ledger mid-run.
+
+Because `.agents/state/` is local to the developer, add it to `.git/info/exclude` (not `.gitignore`) per the `CLAUDE.md` rule about local-only ignores. The driver's first run prints the one-line append command for the user.
+
+## Idempotent resume
+
+When the skill starts, it does this in order:
+
+1. Load the ledger and list in-flight issues by state
+2. For each, show the user the current state and the next action
+3. Ask which to continue, which to skip, which to retry
+4. Resume the loop from the lowest unfinished stage for each selected issue
+
+Resume never silently redrafts a PR or reopens a closed issue. If an issue's PR is already open, the driver switches to `$openclaw-pr-maintainer` for review/land actions rather than filing a new PR.
+
+## Error handling
+
+Common failure modes and how to react:
+
+- **Tests fail after the fix**: do not mark `tested`. Record the failing test name and message in the ledger `notes` and pause for the user.
+- **Hook fails at commit**: do **not** `--amend` or `--no-verify`. Fix the reported issue, re-stage, and create a new commit.
+- **PR CI fails**: read the failing job, treat as a new sub-fix in the same issue's ledger entry. Do not squash-force-push without the user's approval.
+- **Reviewer requests changes**: apply via new commits on the branch; do not rebase-squash until approval is final and merge is imminent.
+- **Merge conflicts on `main`**: rebase locally, rerun the relevant gates, force-push the branch (never `main`).
+- **Issue turns out to be duplicate or invalid mid-fix**: stop, hand to `$security-triage`, record `skipped: <reason>` in the ledger.
+
+## What NOT to do
+
+- Do not open more than one PR per issue unless the user explicitly asks.
+- Do not combine multiple unrelated security fixes into one PR; one fix per PR keeps review and bisection sane.
+- Do not push `main` directly, even for trivial fixes.
+- Do not modify release, publish, or `package.json` version fields without **C6** approval.
+- Do not tag reviewers or post "bump" comments beyond the cadence agreed at **C5**.
+- Do not include real phone numbers, user data, or live credentials in PR bodies, reports, or tests per `CLAUDE.md`.
+
+## Reference files
+
+- `references/ranking.md` — importance scoring rubric with worked examples
+- `references/fix-workflow.md` — per-issue playbook with gate commands
+- `references/reporting.md` — manager-facing summary template
+- `references/ledger.md` — ledger JSON schema, state machine, atomic-update contract
+
+## Scripts
+
+- `scripts/rank_security_issues.sh` — `gh` query + deterministic ranking
+- `scripts/ledger.py` — atomic ledger read/write helper

--- a/.agents/skills/openclaw-security-fix-driver/references/fix-workflow.md
+++ b/.agents/skills/openclaw-security-fix-driver/references/fix-workflow.md
@@ -1,0 +1,155 @@
+# Per-Issue Fix Workflow
+
+This is the playbook that runs **once per issue** in the ranked batch. It assumes the batch was already approved at checkpoint C1 and the issue is not disqualified.
+
+## Stage 0 — Load the issue
+
+Always load from the authoritative source, not from a cached summary:
+
+```bash
+gh issue view <N> --repo openclaw/openclaw --json number,title,body,labels,url,state,createdAt,updatedAt
+gh issue view <N> --repo openclaw/openclaw --comments
+```
+
+For GHSA-class issues (`ghsa` label or private advisory), **stop here** and hand to `$openclaw-ghsa-maintainer`. Record `stage: handed-off-ghsa` in the ledger and continue to the next issue.
+
+## Stage 1 — Read code before writing any theory
+
+Before forming a root-cause theory, read the exact implicated code. The reason is that security reports are frequently either mis-scoped (the bug is in a different file than claimed), already fixed on `main`, or describing a symptom whose cause is upstream of the quoted code.
+
+Minimum reads:
+
+- Every file named in the issue or its comments
+- The direct callers of the implicated function (one hop)
+- The relevant test file(s) for the surface
+- The owning `AGENTS.md` / `CLAUDE.md` for boundary rules (`extensions/AGENTS.md`, `src/channels/AGENTS.md`, `src/plugins/AGENTS.md`, `src/plugin-sdk/AGENTS.md`, `src/gateway/protocol/AGENTS.md` as applicable)
+
+Verify shipped state for any report that claims a specific version is affected:
+
+```bash
+git tag --sort=-creatordate | head
+git tag --contains <suspected-fix-commit>  # if known
+git show <latest-tag>:<path/to/file>        # spot-check the shipped bytes
+```
+
+If the bug is already fixed in the latest shipped tag, record `skipped: fixed-pre-release` and hand to `$security-triage` to close cleanly.
+
+## Stage 2 — Root-cause analysis
+
+Write 3–8 lines that answer four questions:
+
+1. **Trust boundary**: which boundary is the attacker crossing (unauth → auth, LAN → loopback, plugin → core, etc.)?
+2. **Mechanism**: what code enables the crossing? Quote with repo-root-relative `file:line`.
+3. **Why the current guard fails**: where does the existing check not apply, or where is it missing?
+4. **Minimal fix shape**: what is the smallest change that closes the boundary without breaking adjacent behavior?
+
+Keep this analysis under 200 words. If it runs longer, the scope is probably too wide; split into multiple issues.
+
+## Stage 3 — Propose the patch (checkpoint C2)
+
+Present to the user:
+
+- The root-cause analysis from stage 2
+- The exact files you intend to touch (repo-root-relative)
+- The diff shape ("add a signature check in `verifyInbound(...)`", not the full diff)
+- The risk analysis (what adjacent behavior could regress, what public surfaces are touched)
+- The test plan (what new test(s), what existing test(s) will cover the change)
+
+**Wait for user confirmation** before writing code. This is the single most valuable gate in the campaign because a wrong fix merged into `main` costs far more than the five minutes of review here.
+
+## Stage 4 — Implement
+
+Rules:
+
+- One fix per PR. No drive-by cleanup of unrelated files.
+- Honor architecture boundaries: `src/plugin-sdk/*` is the public extension contract; core must stay extension-agnostic; channel plugins do not deep-import core.
+- No `@ts-nocheck`, no `any` escape hatches, no inline lint suppressions unless the code is intentionally correct and the rule cannot express it (then comment the reason).
+- Prefer `zod` / existing schema helpers at external boundaries.
+- Do not introduce new runtime import cycles (`pnpm check:import-cycles` must stay green).
+- If the change touches lazy-loading/module boundaries, keep dynamic and static imports separated via a `*.runtime.ts` seam.
+
+## Stage 5 — Test (checkpoint C3)
+
+Run gates in this order, from narrowest to widest:
+
+```bash
+# Narrow — direct coverage of the change
+pnpm test <path-or-filter>
+
+# Broad — format, lint, typecheck
+pnpm check
+
+# Build — only when the change can affect build output, packaging,
+# lazy-loading/module boundaries, or published surfaces
+pnpm build
+```
+
+Per `CLAUDE.md`: `pnpm build` is a **hard gate** for the categories above before pushing `main`-bound work.
+
+Regression test rule: if a test written before the fix would have caught the bug, add it. If adding a test is genuinely infeasible (for example, the bug lives in an OS-specific code path the suite cannot run), say so explicitly in the PR body and in the ledger `notes`.
+
+If `pnpm tsgo` fails, follow the `CLAUDE.md` triage: group by coherent surface, fix the root mismatch at the source-of-truth type, then rerun — not a big-bang sweep of every error.
+
+Show the user the output of every gate that ran, and pause for confirmation before commit. This is **C3**.
+
+## Stage 6 — Commit and open the PR
+
+Commit with the repo-provided helper to keep staging scoped:
+
+```bash
+scripts/committer "security(<surface>): <short imperative summary>" path/to/file1 path/to/file2
+```
+
+Examples of good commit subjects:
+
+- `security(gateway): enforce device-token binding on reconnect`
+- `security(pairing): require signed nonce on non-loopback connect`
+- `security(webhook): verify HMAC before invoking handler`
+
+Then hand off to `$openclaw-pr-maintainer` for the PR lifecycle with the following inputs ready:
+
+- PR title = commit subject
+- PR body following `.github/pull_request_template.md`, including:
+  - Linked issue (`Fixes #N`)
+  - Affected versions / shipped tags
+  - Root-cause analysis from stage 2
+  - Fix summary and why it is minimal
+  - Verification: exact gate commands run and their results
+  - Risk / rollback notes
+  - Test plan checkboxes
+- Changelog entry **only** for user-facing behavior changes (pure test/meta changes skip the changelog per `CLAUDE.md`)
+
+The PR maintainer skill owns the rest: close labels, search for related issues, evidence bar, reviewer nudging cadence, and landing.
+
+## Stage 7 — Drive to merge (checkpoints C4, C5)
+
+The driver's ongoing job after PR filing is:
+
+1. Watch CI; if it fails, loop back to stage 5 with the failure as the next sub-fix.
+2. Wait for reviews. Do **not** ping individual reviewers without **C5** approval of who to tag and the wording.
+3. Respond to review feedback with new commits on the branch. No amend, no force-push until the final rebase right before merge (and only if the PR maintainer flow calls for it).
+4. After required approvals and green CI, hand the merge action to `$openclaw-pr-maintainer` (the `/landpr` flow). Do not click merge yourself.
+5. If the action is part of a batch and would cross the **>5 PR threshold**, stop and get explicit **C4** confirmation before continuing.
+
+## Stage 8 — Post-merge
+
+After merge, update the ledger:
+
+```
+stage: merged
+prUrl: <url>
+mergedSha: <sha>
+mergedAt: <iso timestamp>
+```
+
+Then write the manager-facing report per `references/reporting.md` and append to `INDEX.md`. Only after the report is written and committed (or saved locally) does the driver move to the next issue in the batch.
+
+## When to stop the whole campaign
+
+Stop the loop and ask the user before continuing if any of these happen:
+
+- A fix fails its gate twice with different root causes (signal that the scope is wrong)
+- A reviewer requests a redesign rather than a tweak
+- Two or more PRs in the batch hit merge conflicts on the same file (indicates shared surface work that wants one bigger fix)
+- Any action would require touching a file covered by security `CODEOWNERS` that has not acknowledged the campaign
+- Anything release-adjacent comes up (see **C6**)

--- a/.agents/skills/openclaw-security-fix-driver/references/ledger.md
+++ b/.agents/skills/openclaw-security-fix-driver/references/ledger.md
@@ -1,0 +1,139 @@
+# Ledger
+
+The ledger is a single JSON file on disk that stores the state of the whole campaign. Its purpose is to make the skill **idempotent** and **resumable**: every long-running step writes to the ledger, and restarting the skill always picks up where the last session left off.
+
+Path:
+
+```
+.agents/state/security-fix-driver/ledger.json
+```
+
+Add `.agents/state/` to `.git/info/exclude` (not to `.gitignore`, per `CLAUDE.md` local-only-ignore rule).
+
+## Schema
+
+```json
+{
+  "version": 1,
+  "campaign": {
+    "startedAt": "2026-04-16T10:00:00Z",
+    "rankLimit": 100,
+    "lastRankedAt": "2026-04-16T10:05:00Z"
+  },
+  "issues": [
+    {
+      "number": 68123,
+      "url": "https://github.com/openclaw/openclaw/issues/68123",
+      "title": "Unauthenticated webhook signature bypass",
+      "labels": ["security", "severity:high"],
+      "invocationMode": "batch",
+      "score": {
+        "total": 24,
+        "severity": 8,
+        "exploitability": 5,
+        "blastRadius": 5,
+        "recency": 2,
+        "surfaceSensitivity": 4
+      },
+      "surface": "gateway ingress",
+      "stage": "merged",
+      "handoff": null,
+      "files": [
+        "src/webhooks/verify.ts",
+        "src/webhooks/verify.test.ts"
+      ],
+      "prUrl": "https://github.com/openclaw/openclaw/pull/68156",
+      "prNumber": 68156,
+      "branch": "fix/webhook-hmac-verify",
+      "mergedSha": "abc1234567890abcdef",
+      "mergedAt": "2026-04-16T16:22:00Z",
+      "reportPath": ".agents/state/security-fix-driver/reports/68123.md",
+      "gates": {
+        "pnpmTest": { "ran": true, "passed": true, "filter": "src/webhooks" },
+        "pnpmCheck": { "ran": true, "passed": true },
+        "pnpmBuild": { "ran": true, "passed": true }
+      },
+      "notes": [],
+      "history": [
+        { "at": "2026-04-16T10:12:00Z", "stage": "queued" },
+        { "at": "2026-04-16T11:03:00Z", "stage": "analyzing" },
+        { "at": "2026-04-16T11:40:00Z", "stage": "fix-drafted" },
+        { "at": "2026-04-16T12:15:00Z", "stage": "tested" },
+        { "at": "2026-04-16T12:25:00Z", "stage": "pr-filed" },
+        { "at": "2026-04-16T15:02:00Z", "stage": "review-requested" },
+        { "at": "2026-04-16T16:22:00Z", "stage": "merged" }
+      ]
+    }
+  ]
+}
+```
+
+## State machine
+
+```
+queued
+  └─> analyzing
+        └─> fix-drafted         ──┐
+              └─> tested          │
+                    └─> pr-filed  │
+                          └─> review-requested
+                                └─> merged
+                                └─> changes-requested ──> tested (loop)
+                                └─> ci-failed ──────────> tested (loop)
+                                └─> blocked
+  └─> skipped        (disqualified, triage-only, or duplicate)
+  └─> handed-off-ghsa (GHSA-class; driver does not own landing)
+```
+
+Terminal stages: `merged`, `skipped`, `handed-off-ghsa`.
+Recoverable non-terminal: `blocked` (records reason, waits for human).
+
+## `invocationMode` field
+
+Each issue entry carries `"invocationMode": "batch" | "single-issue"` to record how the driver first picked it up. This is purely informational (metrics, audit) — the state machine and checkpoints are identical across modes, except that:
+
+- `batch` entries were selected by Phase 1 and have a `pass1Score` / `pass2Score` split on the score object.
+- `single-issue` entries were named by the user directly; their `score` is computed by the same rubric but there is no Pass-1/Pass-2 split.
+
+If the user later asks the driver to absorb a single-issue entry into a batch (or vice versa), update the marker in place and append a history entry — do not duplicate the issue.
+
+## Update contract
+
+All writes must be atomic — the ledger is read by humans and by the driver between steps, so a torn write is a correctness bug. Rules:
+
+- Always write via `scripts/ledger.py` which writes to a temp file in the same directory and renames on top of the ledger.
+- Always append a new entry to `history` when changing `stage`; never overwrite history.
+- Never delete entries. Use `stage: skipped` with a `notes` entry explaining why.
+- Do not mutate `score` after the initial rank unless the user explicitly asks for a re-rank (which bumps `campaign.lastRankedAt`).
+
+## Resume algorithm
+
+On skill start:
+
+1. Read the ledger.
+2. Group issues by terminal vs in-flight stage.
+3. For each in-flight issue, compute the next action:
+   - `analyzing` → re-present root-cause (C2 gate)
+   - `fix-drafted` → run gates (C3 gate)
+   - `tested` → commit + open PR
+   - `pr-filed` / `review-requested` → delegate to `$openclaw-pr-maintainer` for status
+   - `changes-requested` / `ci-failed` → jump back to the fix loop
+   - `blocked` → show the blocker and ask the user
+4. Present the list to the user with: issue number, title, stage, next action, last-updated timestamp.
+5. Ask which issues to continue, which to skip, which to retry.
+6. For each selected issue, run the next action.
+
+Resume must never:
+
+- Reopen or reclose a GitHub issue silently
+- File a second PR for an issue that already has an open driver-owned PR
+- Push to an existing branch without confirming the branch is still the driver's
+- Re-run `pnpm test` / `pnpm build` without surfacing the previous result first
+
+## History and audit
+
+Each stage transition adds `{ at, stage, by? }` to `history`. If the transition was triggered by a GitHub event (CI failure, review), add `cause` (`"ci"`, `"review"`, `"merge"`, `"human"`). This is the audit trail shown to the manager if they ask "when did issue N's PR go green?"
+
+## Concurrency
+
+The driver is single-threaded per session. Do not run two driver sessions against the same ledger simultaneously — the file-rename write is safe against torn writes, not against last-writer-wins races. The ledger's top-level `lockedBy` field is reserved for a future multi-session extension; for now, leave it absent.

--- a/.agents/skills/openclaw-security-fix-driver/references/ranking.md
+++ b/.agents/skills/openclaw-security-fix-driver/references/ranking.md
@@ -1,0 +1,159 @@
+# Importance Ranking Rubric
+
+The goal of the ranking step is a **deterministic, explainable** ordering of open security issues so reviewers can see why issue A is above issue B. Never present a score without the component breakdown.
+
+Ranking runs in two passes. **Pass 1** is the cheap candidate sweep from the ranker script — it uses labels, title/body keywords, and surface mentions, and emits a preliminary score. **Pass 2** is the deep read that actually decides the rank: load the full issue body + comments + any linked GHSA, evaluate the signals below, and re-score. Pass-1 is a filter to avoid reading 5,000 issues; Pass-2 is where the real judgment happens. Labels alone never decide the rank.
+
+## Score formula
+
+`total = severity + exploitability + blast_radius + recency + surface_sensitivity`
+
+Range: 0 – 28. Tie-break order: `surface_sensitivity`, then `severity`, then oldest `updatedAt`.
+
+## Deep-read signals (Pass 2)
+
+Before touching numbers, read the issue body, all comments, and any linked GHSA. The signals below adjust score components up or down and, more importantly, tell you whether the issue is a real trust-boundary bug, a hardening suggestion, or noise.
+
+### Promotion signals (push a candidate up)
+
+- **Named trust-boundary crossing** — the body explicitly describes crossing unauth → auth, LAN → loopback, plugin → core, untrusted input → privileged execution, sandbox → host, or similar. "Boundary" language, not just "exploit."
+- **Concrete code pointer** — a specific file, function, or line number whose current behavior you can verify. Bonus if the pointer is inside a path in security `CODEOWNERS`.
+- **Reproducer present** — a script, curl, request payload, or test case that demonstrates the flaw. Reports with reproducers are both higher-severity in expectation and lower-risk to fix (you can validate the fix against the repro).
+- **CVSS vector string** (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`) — treat the base score as authoritative for the `severity` component.
+- **Present in latest shipped tag** — verified via `git show <tag>:<path>`. Raises the `recency` component; "only in `main`" lowers it.
+- **Experienced reporter context** — prior valid advisories from the same reporter, references to upstream CVEs, linked academic/industry disclosures. Not a score bump by itself, but raises confidence when the body is otherwise terse.
+- **Missing security label, but body is clearly a security report** — promote the candidate even though label-only discovery would miss it. This is one of the most common cases.
+
+### Demotion signals (push a candidate down or to skip)
+
+- **Hardening-only framing** — the body says "defense in depth", "additional layer", or proposes tightening an already-enforced guard with no described bypass.
+- **Vague "could be exploited" without a mechanism** — no file, no call path, no payload. Demote until the reporter supplies specifics; do not invent a mechanism to justify the rank.
+- **Trust-model mismatch** — the report's precondition is "attacker has operator admin", "attacker has root on the host", or "attacker has already paired their device." Those are already-trusted positions per `SECURITY.md`; demote hard.
+- **Out-of-scope classes** (disqualifiers, below) — private-LAN `ws://`, prompt injection in workspace memory files, same-user process boundary on a developer machine. Zero the score and route to `$security-triage`.
+- **Already fixed on the latest shipped tag** — verify with `git tag --contains <fix-commit>` if the report names one, or `git show <tag>:<path>` to inspect. Close as "fixed pre-release."
+- **Security-labeled but actually UX** — a `security` label applied during triage on something that turns out to be a usability or error-message concern. Remove from the campaign.
+- **Speculation about attacker motives** — "an attacker could want to..." with no concrete path. Lower confidence; re-read for a real mechanism before scoring.
+
+### Content the ranker script cannot see by itself
+
+The Pass-1 helper is a keyword + label scan. It will miss:
+
+- Reports filed as `bug` or `question` that are actually security issues
+- Security reports whose title is generic (e.g. "WhatsApp reply goes to wrong chat") but whose body describes a routing-integrity bypass
+- Issues whose severity is only visible in a long comment thread
+- Duplicate chains where the original and most informative report lives on a different issue number
+
+Pass 2 catches these. Always read the body and comments, not just the title and labels.
+
+## Components
+
+### 1. Severity (0 – 10)
+
+Prefer explicit signals in this order:
+
+1. CVSS score from the issue body or linked GHSA (use the `Base Score` as-is, rounded to int)
+2. Repo labels: `severity:critical` = 9, `severity:high` = 7, `severity:medium` = 5, `severity:low` = 3
+3. Keyword fallback on title/body: `RCE`, `auth bypass`, `privilege escalation`, `secret leak` → 8; `DoS`, `info leak` → 5; `hardening`, `defense in depth` → 2
+
+### 2. Exploitability (0 – 5)
+
+How easy is it to reach from an attacker's likely position?
+
+| Score | Meaning |
+| ----- | ------- |
+| 5 | Unauthenticated remote (public ingress, no pairing) |
+| 4 | Authenticated remote (paired device / operator token) |
+| 3 | Local LAN with same-host pairing |
+| 2 | Local same-user process boundary |
+| 1 | Requires already-trusted plugin or operator-admin |
+| 0 | Requires physical access or developer-only flag |
+
+`CLAUDE.md` trust model is explicit that `ws://` on private LAN is allowed and **not** a vulnerability on its own. Passive LAN observation alone scores 0 here.
+
+### 3. Blast radius (0 – 5)
+
+How many users / channels / surfaces does the bug affect?
+
+| Score | Meaning |
+| ----- | ------- |
+| 5 | All users on all channels (core gateway, auth, session, shared tool) |
+| 4 | All users on one major channel (WhatsApp, Telegram, Slack, Discord, iMessage) |
+| 3 | Most users on an optional channel (Matrix, Signal, Feishu, etc.) |
+| 2 | One plugin / one provider |
+| 1 | Opt-in feature, small cohort |
+| 0 | Dev-only or test-only path |
+
+### 4. Recency / age (0 – 3)
+
+Older unpatched issues on shipped tags are worse, not better.
+
+| Score | Meaning |
+| ----- | ------- |
+| 3 | Open > 60 days and present in latest shipped tag |
+| 2 | Open 30 – 60 days and present in latest shipped tag |
+| 1 | Open < 30 days and present in latest shipped tag |
+| 0 | Only present on `main`, not in any shipped tag (still real, just lower campaign priority) |
+
+Verify "present in latest shipped tag" with `git tag --sort=-creatordate | head -1` then `git show <tag>:<path>`.
+
+### 5. Surface sensitivity (0 – 5)
+
+Does the touched code sit on a security-critical surface?
+
+| Score | Surface |
+| ----- | ------- |
+| 5 | Auth, pairing, device identity, signature verification, secret storage |
+| 4 | Gateway ingress, protocol handshake, trusted-proxy, webhook HMAC |
+| 3 | Sandboxing, command policy, approval handlers |
+| 2 | Channel outbound (reply routing, recipient resolution) |
+| 1 | Provider runtime (model auth forwarding, usage endpoints) |
+| 0 | Docs, tests, developer tooling |
+
+Cross-check `CODEOWNERS` for the touched path. Anything in a security-focused `CODEOWNERS` entry should not go below 3 here.
+
+## Disqualifiers (score to 0, skip)
+
+Even if a report scores high on paper, route to `$security-triage` and skip this campaign if any apply:
+
+- Report is about `ws://` on private LAN pairing without a real trust-boundary bypass (explicitly out of scope per `CLAUDE.md`)
+- Report is about prompt injection in user-owned workspace memory files (out of scope per `SECURITY.md`)
+- Report's prerequisite is "attacker already has operator admin" (already-trusted)
+- Duplicate of an existing open or fixed issue
+- Fixed before the latest shipped tag (close as "fixed pre-release")
+
+## Worked examples
+
+### Example A — Unauthenticated webhook signature bypass
+
+- CVSS 8.1 → severity 8
+- Public ingress, no auth → exploitability 5
+- All users on all webhook channels → blast radius 5
+- Open 45 days, present in latest tag → recency 2
+- Webhook HMAC is on gateway ingress → surface 4
+- **Total: 24**
+
+### Example B — Hardening: add CSRF token to an internal admin form
+
+- `hardening` label → severity 2
+- Local admin only → exploitability 1
+- Opt-in admin UI → blast radius 1
+- Open 15 days, only on `main` → recency 0
+- Approval handler surface → surface 3
+- **Total: 7**
+
+### Example C — Prompt injection marker in a shared workspace memory file
+
+- Keyword "injection" suggests 5, but `SECURITY.md` marks this class out of scope → disqualifier triggers, **total 0**, route to `$security-triage`.
+
+## Presenting the rank to the user
+
+Always show the top 10 in chat with this shape:
+
+```
+#1  issue 68123  total=24  sev=8 expl=5 blast=5 recency=2 surface=4
+    Unauthenticated webhook signature bypass (src/webhooks/verify.ts)
+    https://github.com/openclaw/openclaw/issues/68123
+#2  ...
+```
+
+Full JSON goes into the ledger. Ranks never change mid-campaign unless the user asks to re-rank; new issues filed during the campaign are appended at the end of the queue.

--- a/.agents/skills/openclaw-security-fix-driver/references/reporting.md
+++ b/.agents/skills/openclaw-security-fix-driver/references/reporting.md
@@ -1,0 +1,89 @@
+# Manager-facing Summary Template
+
+The report is what the manager sees. Keep it short, plain-English, and linkable. The target reader is a busy manager who wants to know in 60 seconds: what was broken, what you changed, why it's safe, and where the proof is.
+
+Save one file per merged fix to:
+
+```
+.agents/state/security-fix-driver/reports/<issue-number>.md
+```
+
+And update the rolling index at:
+
+```
+.agents/state/security-fix-driver/reports/INDEX.md
+```
+
+## Per-fix report template
+
+```markdown
+# Issue #<N> — <short title>
+
+**Surface:** <e.g. gateway ingress / pairing / webhook HMAC / plugin auth>
+**Severity:** <critical | high | medium | low> (score <0-28>)
+**Shipped tags affected:** <list of tags, or "main only">
+**PR:** <url>
+**Landed commit:** <sha link>
+**Merged:** <iso date>
+
+## What was broken
+
+2–4 sentences in plain English. Name the trust boundary that was crossed. No jargon the manager would have to look up.
+
+## Why it matters
+
+1–2 sentences on who could exploit it and what they could gain. If exploitability is low, say so and why (e.g., "requires paired device already" or "defense in depth only").
+
+## The fix
+
+3–5 sentences describing the change. Use repo-root-relative file paths, e.g. `src/gateway/auth.ts:142`. Explain **why this fix is minimal and correct**, not every line of the diff.
+
+## Why this fix works
+
+One paragraph. The goal is to convince a reader that the fix actually closes the trust boundary rather than papering over a symptom. Reference the specific guard added and the invariant it enforces.
+
+## Risk and rollback
+
+One paragraph. What adjacent behavior could regress, and what tests cover it. How to roll back if needed (usually: revert the merge commit, which the landed-commit link above points to).
+
+## Verification
+
+- Unit tests: `<list of new/updated tests with file:line>`
+- Local gates: `pnpm test <filter>` ✓, `pnpm check` ✓, `pnpm build` <✓ or n/a with reason>
+- CI: <link to the green run>
+- Manual verification: <only if applicable, 1 line>
+
+## Reporter credit
+
+<GitHub handle and link, only if the reporter is listed publicly on the issue. Omit entirely for private advisories unless the reporter has given explicit permission; when in doubt, defer to `$openclaw-ghsa-maintainer`.>
+```
+
+## INDEX.md template
+
+The index is a running table. Sort newest-merged first so the manager sees the latest work at the top.
+
+```markdown
+# OpenClaw Security Fix Campaign — Index
+
+| Date | Issue | Surface | Severity | PR | Report |
+| ---- | ----- | ------- | -------- | -- | ------ |
+| 2026-04-16 | #68123 | gateway ingress | high (24) | [#68156](https://github.com/openclaw/openclaw/pull/68156) | [68123.md](./68123.md) |
+| 2026-04-15 | #67994 | pairing          | medium (16) | [#68041](https://github.com/openclaw/openclaw/pull/68041) | [67994.md](./67994.md) |
+
+_Last updated: <iso date>_  Campaign start: <iso date>  Fixes landed: <N>  In-flight: <M>
+```
+
+## Writing rules
+
+- **One page, not three.** If the report runs past one screen, trim it.
+- **Plain English.** The phrase "unauthenticated remote attacker" is fine. The phrase "byzantine adversary under standard model" is not.
+- **Link, do not paste.** Link to the PR, the commit, the issue, the CI run. Do not paste diffs into the report.
+- **No live secrets, no real phone numbers, no real user data.** Placeholders only, per `CLAUDE.md`.
+- **Attribute reporters correctly.** For public issues, credit the reporter by GitHub handle if they were publicly involved. For GHSA-private flow, credit is owned by `$openclaw-ghsa-maintainer`, not by this report.
+- **No speculation about attacker identity or intent.** Stick to what the code does and what the fix changes.
+
+## When to batch reports
+
+If a single issue caused multiple PRs (for example, the fix needed a core change and a channel plugin change), make one report that lists all PRs in the **PR** line and walks through both changes in **The fix**. Do not write a separate report per PR.
+
+If a single PR fixes multiple linked issues, write one report filed under the lowest issue number, and cross-link from the other issue numbers' reports with a one-line pointer: `See [./<lowest>.md](./<lowest>.md)`.

--- a/.agents/skills/openclaw-security-fix-driver/scripts/ledger.py
+++ b/.agents/skills/openclaw-security-fix-driver/scripts/ledger.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Atomic ledger helper for the openclaw-security-fix-driver skill.
+
+Usage:
+  ledger.py init                         # create empty ledger
+  ledger.py load                         # print ledger JSON
+  ledger.py upsert-issue <path.json>     # insert or merge one issue object
+  ledger.py set-stage <number> <stage> [--notes "..."] [--cause ci|review|merge|human]
+  ledger.py set-field <number> <dotted.path> <json-value>
+  ledger.py list [--stage merged|queued|...]
+  ledger.py resume-plan                  # list next action per in-flight issue
+
+The ledger path defaults to:
+  .agents/state/security-fix-driver/ledger.json
+Override with --ledger <path>.
+
+Writes go to <ledger>.tmp and rename on top, so concurrent reads never see a
+torn file. This is not safe against two concurrent writers — keep the driver
+single-threaded per session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LEDGER = Path(".agents/state/security-fix-driver/ledger.json")
+
+TERMINAL_STAGES = {"merged", "skipped", "handed-off-ghsa"}
+ALL_STAGES = {
+    "queued", "analyzing", "fix-drafted", "tested",
+    "pr-filed", "review-requested", "merged",
+    "changes-requested", "ci-failed", "blocked",
+    "skipped", "handed-off-ghsa",
+}
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "version": 1,
+            "campaign": {"startedAt": now_iso(), "rankLimit": 100, "lastRankedAt": None},
+            "issues": [],
+        }
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def atomic_write(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=False)
+        f.write("\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+def find_issue(data: dict[str, Any], number: int) -> dict[str, Any] | None:
+    for issue in data.get("issues", []):
+        if issue.get("number") == number:
+            return issue
+    return None
+
+
+def cmd_init(args) -> int:
+    path = Path(args.ledger)
+    if path.exists() and not args.force:
+        print(f"ledger already exists at {path}; pass --force to overwrite", file=sys.stderr)
+        return 1
+    atomic_write(path, load(Path("/nonexistent")))  # start fresh
+    print(str(path))
+    return 0
+
+
+def cmd_load(args) -> int:
+    data = load(Path(args.ledger))
+    json.dump(data, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def cmd_upsert_issue(args) -> int:
+    path = Path(args.ledger)
+    data = load(path)
+    with open(args.json_path, "r", encoding="utf-8") as f:
+        incoming = json.load(f)
+    number = incoming["number"]
+    existing = find_issue(data, number)
+    if existing is None:
+        incoming.setdefault("stage", "queued")
+        incoming.setdefault("history", [{"at": now_iso(), "stage": incoming["stage"]}])
+        data["issues"].append(incoming)
+    else:
+        # Shallow merge, preserve history and terminal stages
+        if existing.get("stage") in TERMINAL_STAGES and "stage" in incoming:
+            incoming.pop("stage", None)
+        existing.update({k: v for k, v in incoming.items() if k != "history"})
+    atomic_write(path, data)
+    return 0
+
+
+def cmd_set_stage(args) -> int:
+    if args.stage not in ALL_STAGES:
+        print(f"unknown stage: {args.stage}", file=sys.stderr)
+        return 2
+    path = Path(args.ledger)
+    data = load(path)
+    issue = find_issue(data, args.number)
+    if issue is None:
+        print(f"issue {args.number} not in ledger", file=sys.stderr)
+        return 1
+    if issue.get("stage") in TERMINAL_STAGES and args.stage != issue.get("stage"):
+        print(f"issue {args.number} is already terminal ({issue.get('stage')}); refusing to overwrite", file=sys.stderr)
+        return 1
+    issue["stage"] = args.stage
+    entry: dict[str, Any] = {"at": now_iso(), "stage": args.stage}
+    if args.cause:
+        entry["cause"] = args.cause
+    issue.setdefault("history", []).append(entry)
+    if args.notes:
+        issue.setdefault("notes", []).append({"at": now_iso(), "text": args.notes})
+    atomic_write(path, data)
+    return 0
+
+
+def _set_by_path(obj: dict[str, Any], dotted: str, value: Any) -> None:
+    keys = dotted.split(".")
+    cur = obj
+    for k in keys[:-1]:
+        if k not in cur or not isinstance(cur[k], dict):
+            cur[k] = {}
+        cur = cur[k]
+    cur[keys[-1]] = value
+
+
+def cmd_set_field(args) -> int:
+    path = Path(args.ledger)
+    data = load(path)
+    issue = find_issue(data, args.number)
+    if issue is None:
+        print(f"issue {args.number} not in ledger", file=sys.stderr)
+        return 1
+    try:
+        value = json.loads(args.json_value)
+    except json.JSONDecodeError:
+        value = args.json_value  # treat as string
+    _set_by_path(issue, args.dotted_path, value)
+    atomic_write(path, data)
+    return 0
+
+
+def cmd_list(args) -> int:
+    data = load(Path(args.ledger))
+    issues = data.get("issues", [])
+    if args.stage:
+        issues = [i for i in issues if i.get("stage") == args.stage]
+    for i in issues:
+        score = i.get("score", {}).get("total", "-")
+        print(f"{i.get('number','?'):>6}  {i.get('stage','?'):<20}  score={score:<4}  {i.get('title','')}")
+    return 0
+
+
+def cmd_resume_plan(args) -> int:
+    data = load(Path(args.ledger))
+    next_action = {
+        "queued":            "rank-confirm then analyze",
+        "analyzing":         "present root-cause at C2",
+        "fix-drafted":       "run gates at C3",
+        "tested":            "commit + open PR via $openclaw-pr-maintainer",
+        "pr-filed":          "watch CI, request review",
+        "review-requested":  "nudge reviewers at C5 cadence",
+        "changes-requested": "apply review feedback, rerun gates",
+        "ci-failed":         "diagnose failing check, rerun gates",
+        "blocked":           "surface blocker to user",
+    }
+    for i in data.get("issues", []):
+        stage = i.get("stage", "queued")
+        if stage in TERMINAL_STAGES:
+            continue
+        n = i.get("number", "?")
+        title = i.get("title", "")
+        print(f"#{n}  stage={stage}  -> {next_action.get(stage, '?')}  :: {title}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--ledger", default=str(DEFAULT_LEDGER))
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s_init = sub.add_parser("init")
+    s_init.add_argument("--force", action="store_true")
+    s_init.set_defaults(func=cmd_init)
+
+    sub.add_parser("load").set_defaults(func=cmd_load)
+
+    s_up = sub.add_parser("upsert-issue")
+    s_up.add_argument("json_path")
+    s_up.set_defaults(func=cmd_upsert_issue)
+
+    s_st = sub.add_parser("set-stage")
+    s_st.add_argument("number", type=int)
+    s_st.add_argument("stage")
+    s_st.add_argument("--notes")
+    s_st.add_argument("--cause", choices=["ci", "review", "merge", "human"])
+    s_st.set_defaults(func=cmd_set_stage)
+
+    s_sf = sub.add_parser("set-field")
+    s_sf.add_argument("number", type=int)
+    s_sf.add_argument("dotted_path")
+    s_sf.add_argument("json_value")
+    s_sf.set_defaults(func=cmd_set_field)
+
+    s_ls = sub.add_parser("list")
+    s_ls.add_argument("--stage")
+    s_ls.set_defaults(func=cmd_list)
+
+    sub.add_parser("resume-plan").set_defaults(func=cmd_resume_plan)
+
+    args = p.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/openclaw-security-fix-driver/scripts/rank_security_issues.sh
+++ b/.agents/skills/openclaw-security-fix-driver/scripts/rank_security_issues.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Fetch open security issues from openclaw/openclaw, dedupe, and rank by
+# importance per references/ranking.md. Emits a JSON array on stdout.
+#
+# Usage:
+#   rank_security_issues.sh [--limit N] [--repo owner/name]
+#
+# Requires: gh (authenticated), jq
+
+set -euo pipefail
+
+LIMIT=100
+REPO="openclaw/openclaw"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --limit) LIMIT="$2"; shift 2 ;;
+    --repo)  REPO="$2";  shift 2 ;;
+    -h|--help)
+      sed -n '2,10p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Label variants we treat as "security-related". Pass 1 is intentionally wide;
+# Pass 2 (the deep read in the skill) handles demotion and skip decisions.
+LABELS=(
+  "security"
+  "type:security"
+  "severity:critical"
+  "severity:high"
+  "severity:medium"
+  "severity:low"
+  "ghsa"
+  "CVSS"
+  "vuln"
+  "hardening"
+  "auth"
+  "crypto"
+  "pairing"
+)
+
+# Keyword queries — cover terms that commonly appear in security reports whose
+# labels do not include "security". Each line is one search query; the helper
+# unions the results. Keep queries targeted so the body-match stays precise.
+KEYWORD_QUERIES=(
+  "security OR vulnerability OR GHSA OR CVSS OR CVE"
+  "RCE OR \"remote code execution\" OR \"arbitrary code\""
+  "\"auth bypass\" OR \"authentication bypass\" OR \"authorization bypass\""
+  "\"privilege escalation\" OR \"privesc\" OR \"sandbox escape\""
+  "SSRF OR CSRF OR \"path traversal\" OR \"directory traversal\""
+  "\"prototype pollution\" OR deserialization OR \"insecure deserialization\""
+  "\"signature\" OR HMAC OR \"token leak\" OR \"secret leak\""
+  "\"impersonate\" OR \"spoof\" OR replay OR MITM OR \"man-in-the-middle\""
+  "injection AND (command OR shell OR SQL OR header)"
+  "TOCTOU OR \"race condition\" AND (auth OR token OR pairing)"
+)
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Source 1: label-driven candidates. gh issue list supports one --label per
+# call; union via loop.
+: > "$tmp/raw.ndjson"
+for label in "${LABELS[@]}"; do
+  gh issue list \
+    --repo "$REPO" \
+    --state open \
+    --label "$label" \
+    --limit "$LIMIT" \
+    --json number,title,body,labels,url,createdAt,updatedAt,author \
+    --jq '.[] | @json' >> "$tmp/raw.ndjson" 2>/dev/null || true
+done
+
+# Source 2: title+body keyword search for issues the label query would miss.
+# This is where reports filed as "bug" or "question" that are actually security
+# issues get picked up.
+for q in "${KEYWORD_QUERIES[@]}"; do
+  gh search issues \
+    --repo "$REPO" \
+    --state open \
+    --match title,body \
+    --limit "$LIMIT" \
+    --json number,title,body,labels,url,createdAt,updatedAt,author \
+    -- "$q" \
+    --jq '.[] | @json' >> "$tmp/raw.ndjson" 2>/dev/null || true
+done
+
+# Source 3: comment-match pass for long-running threads where the security
+# framing only appears after the reporter's first message. Narrower query to
+# avoid pulling everything with the word "token."
+gh search issues \
+  --repo "$REPO" \
+  --state open \
+  --match comments \
+  --limit "$LIMIT" \
+  --json number,title,body,labels,url,createdAt,updatedAt,author \
+  -- "\"auth bypass\" OR \"signature verification\" OR \"trust boundary\" OR GHSA" \
+  --jq '.[] | @json' >> "$tmp/raw.ndjson" 2>/dev/null || true
+
+# Source 4: GHSA cross-reference — advisories that may not have a public issue.
+# Emit a synthetic record per advisory so Pass 2 can load it the same way.
+gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --jq '
+  .[] | {
+    number: (.ghsa_id | ltrimstr("GHSA-") | gsub("-"; "") | ("9"+.)[0:9] | tonumber? // 900000000),
+    title: ("[GHSA] " + .summary),
+    body:  (.description // ""),
+    labels: [{ name: "ghsa" }],
+    url:   .html_url,
+    createdAt: .published_at,
+    updatedAt: .updated_at,
+    author: { login: (.credits[0].user.login // "unknown") },
+    ghsaId: .ghsa_id
+  } | @json
+' >> "$tmp/raw.ndjson" 2>/dev/null || true
+
+# Dedupe by number, then score. Scoring is intentionally simple and readable;
+# the skill can refine per references/ranking.md before presenting.
+jq -s '
+  unique_by(.number)
+  | map(
+      . as $i
+      | ($i.labels // []) as $labels
+      | ($labels | map(.name) | join(" ")) as $labelstr
+      | (
+          if ($labelstr | test("severity:critical";"i")) then 9
+          elif ($labelstr | test("severity:high";"i")) then 7
+          elif ($labelstr | test("severity:medium";"i")) then 5
+          elif ($labelstr | test("severity:low";"i")) then 3
+          elif (($i.title + " " + ($i.body // "")) | test("RCE|auth bypass|privilege escalation|secret leak";"i")) then 8
+          elif (($i.title + " " + ($i.body // "")) | test("DoS|info leak";"i")) then 5
+          else 2
+          end
+        ) as $severity
+      | (
+          if (($i.body // "") | test("unauth|public (ingress|endpoint)";"i")) then 5
+          elif (($i.body // "") | test("paired|operator token";"i")) then 4
+          elif (($i.body // "") | test("LAN|loopback";"i")) then 3
+          else 2
+          end
+        ) as $exploit
+      | (
+          if (($i.title + " " + ($i.body // "")) | test("gateway|all channels|core";"i")) then 5
+          elif (($i.title + " " + ($i.body // "")) | test("whatsapp|telegram|slack|discord|imessage";"i")) then 4
+          elif (($i.title + " " + ($i.body // "")) | test("matrix|signal|feishu";"i")) then 3
+          else 2
+          end
+        ) as $blast
+      | ((now - ($i.createdAt | fromdateiso8601)) / 86400) as $ageDays
+      | (
+          if $ageDays > 60 then 3
+          elif $ageDays > 30 then 2
+          elif $ageDays > 0  then 1
+          else 0
+          end
+        ) as $recency
+      | (
+          if ($labelstr | test("auth|pairing|identity|signature|secret";"i")) then 5
+          elif ($labelstr | test("gateway|protocol|trusted-proxy|webhook";"i")) then 4
+          elif ($labelstr | test("sandbox|approval|policy";"i")) then 3
+          elif ($labelstr | test("channel|outbound|reply";"i")) then 2
+          elif ($labelstr | test("provider|usage";"i")) then 1
+          else 0
+          end
+        ) as $surface
+      | . + {
+          score: {
+            total:              ($severity + $exploit + $blast + $recency + $surface),
+            severity:           $severity,
+            exploitability:     $exploit,
+            blastRadius:        $blast,
+            recency:            $recency,
+            surfaceSensitivity: $surface
+          }
+        }
+    )
+  | sort_by(-.score.total, -.score.surfaceSensitivity, -.score.severity, .createdAt)
+  | .[:'"$LIMIT"']
+' "$tmp/raw.ndjson"

--- a/extensions/discord/src/monitor/provider.startup.test.ts
+++ b/extensions/discord/src/monitor/provider.startup.test.ts
@@ -70,7 +70,7 @@ vi.mock("./presence.js", () => ({
   resolveDiscordPresenceUpdate: vi.fn(() => undefined),
 }));
 
-import { createDiscordMonitorClient } from "./provider.startup.js";
+import { createDiscordMonitorClient, fetchDiscordBotIdentity } from "./provider.startup.js";
 
 describe("createDiscordMonitorClient", () => {
   it("adds listener compat for legacy voice plugins", () => {
@@ -121,5 +121,54 @@ describe("createDiscordMonitorClient", () => {
     expect(result.client.listeners).toEqual(
       expect.arrayContaining([expect.objectContaining({ type: "legacy-voice-listener" })]),
     );
+  });
+});
+
+describe("fetchDiscordBotIdentity", () => {
+  const makeRuntime = () =>
+    ({
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    }) as unknown as Parameters<typeof fetchDiscordBotIdentity>[0]["runtime"];
+
+  it("returns identity on success", async () => {
+    const logStartupPhase = vi.fn();
+    const client = {
+      fetchUser: vi.fn().mockResolvedValue({ id: "bot-123", username: "openclaw-bot" }),
+    } as unknown as Parameters<typeof fetchDiscordBotIdentity>[0]["client"];
+    const result = await fetchDiscordBotIdentity({
+      client,
+      runtime: makeRuntime(),
+      logStartupPhase,
+    });
+    expect(result).toEqual({ botUserId: "bot-123", botUserName: "openclaw-bot" });
+    expect(logStartupPhase).toHaveBeenCalledWith("fetch-bot-identity:start");
+  });
+
+  it("rethrows when fetchUser rejects so the supervisor can restart", async () => {
+    const runtime = makeRuntime();
+    const logStartupPhase = vi.fn();
+    const failure = new Error("network down");
+    const client = {
+      fetchUser: vi.fn().mockRejectedValue(failure),
+    } as unknown as Parameters<typeof fetchDiscordBotIdentity>[0]["client"];
+    await expect(
+      fetchDiscordBotIdentity({ client, runtime, logStartupPhase }),
+    ).rejects.toBe(failure);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("failed to fetch bot identity"));
+    expect(logStartupPhase).toHaveBeenCalledWith("fetch-bot-identity:error", expect.any(String));
+  });
+
+  it("throws when fetchUser resolves without an id (prevents degraded mention-gating)", async () => {
+    const runtime = makeRuntime();
+    const logStartupPhase = vi.fn();
+    const client = {
+      fetchUser: vi.fn().mockResolvedValue({ username: "openclaw-bot" }),
+    } as unknown as Parameters<typeof fetchDiscordBotIdentity>[0]["client"];
+    await expect(
+      fetchDiscordBotIdentity({ client, runtime, logStartupPhase }),
+    ).rejects.toThrow(/no id/);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("no id"));
   });
 });

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -214,21 +214,31 @@ export async function fetchDiscordBotIdentity(params: {
   logStartupPhase: (phase: string, details?: string) => void;
 }) {
   params.logStartupPhase("fetch-bot-identity:start");
+  let botUser: Awaited<ReturnType<Client["fetchUser"]>>;
   try {
-    const botUser = await params.client.fetchUser("@me");
-    const botUserId = botUser?.id;
-    const botUserName =
-      normalizeOptionalString(botUser?.username) ?? normalizeOptionalString(botUser?.globalName);
-    params.logStartupPhase(
-      "fetch-bot-identity:done",
-      `botUserId=${botUserId ?? "<missing>"} botUserName=${botUserName ?? "<missing>"}`,
-    );
-    return { botUserId, botUserName };
+    botUser = await params.client.fetchUser("@me");
   } catch (err) {
+    // Fail fast: running without botUserId silently disables self-message
+    // filtering and the guild mention-gate (see issue #42219). Let the
+    // provider supervisor restart us instead of serving in that state.
     params.runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
     params.logStartupPhase("fetch-bot-identity:error", String(err));
-    return { botUserId: undefined, botUserName: undefined };
+    throw err instanceof Error ? err : new Error(`discord: fetch bot identity failed: ${String(err)}`);
   }
+  const botUserId = botUser?.id;
+  const botUserName =
+    normalizeOptionalString(botUser?.username) ?? normalizeOptionalString(botUser?.globalName);
+  if (!botUserId) {
+    const message = "discord: fetchUser(\"@me\") returned no id";
+    params.runtime.error?.(danger(message));
+    params.logStartupPhase("fetch-bot-identity:error", message);
+    throw new Error(message);
+  }
+  params.logStartupPhase(
+    "fetch-bot-identity:done",
+    `botUserId=${botUserId} botUserName=${botUserName ?? "<missing>"}`,
+  );
+  return { botUserId, botUserName };
 }
 
 export function registerDiscordMonitorListeners(params: {


### PR DESCRIPTION
## Summary

- **Problem**: When `Client.fetchUser("@me")` rejects (transient network / proxy blip) at Discord monitor startup, `fetchDiscordBotIdentity` currently swallows the error and returns `{ botUserId: undefined, botUserName: undefined }`. The provider continues running in a degraded state, which silently disables self-message filtering (`author.id === botUserId`, `message-handler.preflight.ts:380`) and — because the mention-gate drop is guarded by `if (botId && mentionDecision.shouldSkip)` (`message-handler.preflight.ts:976`) — lets guild messages bypass `requireMention: true`.
- **Why it matters**: Guild channels configured with `requireMention: true` are supposed to ignore unmentioned messages. In the degraded state, every message in those channels is forwarded to the agent, breaking the documented access control. Self-reply loops also become possible.
- **What changed**: `fetchDiscordBotIdentity` now rethrows on `fetchUser("@me")` failure and also throws when the API returns a user without an id. Logging/phase reporting stays the same. The provider supervisor restart path already handles startup errors (same shape we use for `applicationId` at `provider.ts:720`).
- **What did NOT change (scope boundary)**: No changes to the mention-gate logic itself or to the defense-in-depth guard wording in `message-handler.preflight.ts`; keeping scope tight to the fail-fast fix.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #42219
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `fetchDiscordBotIdentity` caught and logged the error, then returned `undefined` for both fields. The caller (`provider.ts:991`) assigned those into `botUserId`/`botUserName` and continued.
- Missing detection / guardrail: no test asserted that a `fetchUser` failure should abort provider startup; the existing `applicationId` path at `provider.ts:720` already throws on `!applicationId`, so this was inconsistent.
- Contributing context: regression from the refactor that split Discord monitor startup into `provider.startup.ts`; the previous inline implementation allegedly also swallowed the error (see issue reporter notes).

## Regression Test Plan

- [x] Unit test
- Target test or file: `extensions/discord/src/monitor/provider.startup.test.ts`
- Scenarios the new coverage locks in:
  - `fetchDiscordBotIdentity` rejects with the underlying error when `client.fetchUser` rejects.
  - `fetchDiscordBotIdentity` throws when the Discord API resolves with a user object that has no `id`.
  - Success path still returns the normalized `{ botUserId, botUserName }` pair.
- Why this is the smallest reliable guardrail: the bug lives entirely inside this exported helper; a unit test pinned to its contract catches both regression shapes (swallowed throw, missing id) without needing a full Discord client harness.

## User-visible / Behavior Changes

If the Discord API call to fetch the bot's own user fails at startup, the provider now errors out and the supervisor retries, instead of serving traffic with mention-gating disabled. Error is logged via `runtime.error` with the same `danger(...)` wording as before.

## Security Impact (required)

- New permissions/capabilities? No
- Removes a silent bypass of `requireMention: true` on Discord guild channels when the bot identity cannot be resolved.

## Verification

- `pnpm test extensions/discord/src/monitor/provider.startup.test.ts` — 4 passed
- `pnpm test extensions/discord/src/monitor` — 501 passed
- `pnpm check` — 0 warnings, 0 errors (lint + tsgo + import-cycles + madge)

## Human Verification

- Verified scenarios:
  - New unit tests exercise the three branches (success / rejected / missing id).
  - Inspected call site at `extensions/discord/src/monitor/provider.ts:991` — destructure still type-checks; `botUserId` is now narrowed to `string` on the happy path, consumers already tolerate that (`botUserId ?? botUserName ?? ""`, `botId && ...` checks remain valid).
- Edge cases checked: API returning an empty-string `id` is covered by the falsy-id check; transient errors at non-`Error` type are wrapped into an `Error` before rethrow.
- What I did not verify: live Discord API behavior (unit-test only); the existing supervisor restart loop has been around for both `applicationId` failure and transport-level Discord gateway failures.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a transient `fetchUser("@me")` failure that previously caused a silent degradation now aborts startup until the supervisor retries.
  - Mitigation: matches the existing `applicationId` handling at `provider.ts:720`; restart cadence unchanged.