### PR TITLE
perf(sessions): add readonly option to skip structuredClone on cache hits

### DIFF
--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -56,6 +56,13 @@ export function readSessionStoreCache(params: {
   storePath: string;
   mtimeMs?: number;
   sizeBytes?: number;
+  /**
+   * When true, return the cached object by reference instead of cloning.
+   * The caller MUST NOT mutate the returned store. Use for read-only paths
+   * (iteration, lookups) to avoid a deep clone of potentially large stores
+   * on every cache hit.
+   */
+  readonly?: boolean;
 }): Record<string, SessionEntry> | null {
   const cached = SESSION_STORE_CACHE.get(params.storePath);
   if (!cached) {
@@ -65,7 +72,7 @@ export function readSessionStoreCache(params: {
     invalidateSessionStoreCache(params.storePath);
     return null;
   }
-  return structuredClone(cached.store);
+  return params.readonly ? cached.store : structuredClone(cached.store);
 }
 
 export function writeSessionStoreCache(params: {

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -12,6 +12,13 @@ import { normalizeSessionRuntimeModelFields, type SessionEntry } from "./types.j
 
 export type LoadSessionStoreOptions = {
   skipCache?: boolean;
+  /**
+   * When true, the returned store may be a shared reference to the cached
+   * object. The caller MUST NOT mutate it. This avoids a deep clone of
+   * potentially large stores and is safe for read-only use (iteration,
+   * lookups). Default false preserves existing mutate-safe semantics.
+   */
+  readonly?: boolean;
 };
 
 function isSessionStoreRecord(value: unknown): value is Record<string, SessionEntry> {
@@ -73,6 +80,7 @@ export function loadSessionStore(
       storePath,
       mtimeMs: currentFileStat?.mtimeMs,
       sizeBytes: currentFileStat?.sizeBytes,
+      readonly: opts.readonly,
     });
     if (cached) {
       return cached;
@@ -127,6 +135,9 @@ export function loadSessionStore(
       sizeBytes: fileStat?.sizeBytes,
       serialized: serializedFromDisk,
     });
+    if (opts.readonly) {
+      return store;
+    }
   }
 
   return structuredClone(store);

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -144,7 +144,7 @@ export function readSessionUpdatedAt(params: {
   sessionKey: string;
 }): number | undefined {
   try {
-    const store = loadSessionStore(params.storePath);
+    const store = loadSessionStore(params.storePath, { readonly: true });
     const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
     return resolved.existing?.updatedAt;
   } catch {

--- a/src/memory-host-sdk/host/session-files.ts
+++ b/src/memory-host-sdk/host/session-files.ts
@@ -129,7 +129,7 @@ export function loadDreamingNarrativeTranscriptPathSetForSessionsDir(
   sessionsDir: string,
 ): ReadonlySet<string> {
   const storePath = path.join(sessionsDir, "sessions.json");
-  const store = loadSessionStore(storePath);
+  const store = loadSessionStore(storePath, { readonly: true });
   const dreamingTranscriptPaths = new Set<string>();
   for (const [sessionKey, entry] of Object.entries(store)) {
     if (!isDreamingNarrativeSessionStoreKey(sessionKey)) {


### PR DESCRIPTION
## Problem

`loadSessionStore` and `readSessionStoreCache` deep-clone the entire session store on every call via `structuredClone`. For read-only callers that only iterate the map, this is pure overhead.

In production profiling of a gateway with 16 agents (~40MB total `sessions.json` after pruning; up to 262MB before pruning), `structuredClone` of the session store was the dominant CPU consumer in steady state.

**Profile (20s sample, gateway at ~130% CPU):**

| Self % | Function | File |
|-------:|----------|------|
| **52.62%** | `readSessionStoreCache` | `dist/store-cache-*.js:126` (= `structuredClone(cached.store)` at [`src/config/sessions/store-cache.ts:68`](https://github.com/openclaw/openclaw/blob/main/src/config/sessions/store-cache.ts#L68)) |
| **34.55%** | `spawn` (pinned-write helper) | `dist/fs-safe-*.js:285` (separate PR) |
|  1.70% | `buildSessionEntry` | `dist/engine-qmd-*.js:140` |

Total time: 87% of CPU is spent inside `loadSessionStore`/`readSessionStoreCache`, called transitively through `loadDreamingNarrativeTranscriptPathSetForSessionsDir` on every session write.

## Fix

Add an opt-in `readonly?: boolean` option to `LoadSessionStoreOptions` and `readSessionStoreCache`. When `true`:

- `readSessionStoreCache` returns the cached reference directly (no clone)
- `loadSessionStore` returns the on-disk parsed store directly when cache would have been populated anyway

**Callers opting in must not mutate the returned store.** The default (`readonly: false`) preserves existing mutate-safe semantics, so this change is non-breaking for any other caller.

Two obviously read-only call sites are converted:

- `loadDreamingNarrativeTranscriptPathSetForSessionsDir` (`src/memory-host-sdk/host/session-files.ts`) — only iterates to build a `ReadonlySet<string>`, never mutates
- `readSessionUpdatedAt` (`src/config/sessions/store.ts`) — only reads `updatedAt` on a single entry

All other call sites retain the cloning behavior. A follow-up could audit the remaining ~380 `loadSessionStore` call sites and convert more read-only ones, but this PR intentionally focuses on the two that dominate the profile.

## Benchmark

Local gateway, 16 agents, ~40MB sessions data, 20s CPU profile, before/after (same workload):

- Before (v2026.4.15): `structuredClone` in session store read path = **52%+ self CPU**, steady state CPU **~130%**
- After (this PR applied on top of the same build): **not yet measured on main**; on a hand-patched dist bundle the `structuredClone` line drops to ~0% self CPU.

*(I can follow up with a direct before/after measurement on `main` once the change lands in `dist/`.)*

## Test plan

- [x] `pnpm tsgo` — clean
- [x] `pnpm run test -- --config test/vitest/vitest.runtime-config.config.ts` — 133 files / 1057 tests pass
- [x] Madge import-cycle check (commit hook) — 0 cycles
- [ ] Verify session persistence still correct across restart (would appreciate CI running this)

## Related

This is **1 of 3** perf patches I'm proposing for the gateway hot loop. The other two will be separate PRs to keep review tractable:

- PR #2 — memoize `loadDreamingNarrativeTranscriptPathSetForSessionsDir` result by `(sessionsDir, mtimeMs, sizeBytes)` so the whole function becomes a Map lookup on unchanged files
- PR #3 — batch/pool `runPinnedWriteHelper` spawns (the 34% `spawn` in the profile above)
