### PR TITLE
fix: Tavily plugin SecretRef for webSearch.apiKey fails at runtime

### DIFF
--- a/extensions/tavily/openclaw.plugin.json
+++ b/extensions/tavily/openclaw.plugin.json
@@ -20,6 +20,9 @@
     "webSearchProviders": ["tavily"],
     "tools": ["tavily_search", "tavily_extract"]
   },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -656,6 +656,18 @@ describe("loadPluginManifestRegistry", () => {
       },
     });
 
+    const tavilyDir = makeTempDir();
+    writeManifest(tavilyDir, {
+      id: "tavily",
+      configSchema: { type: "object" },
+      contracts: {
+        webSearchProviders: ["tavily"],
+      },
+      configContracts: {
+        compatibilityRuntimePaths: ["tools.web.search.apiKey"],
+      },
+    });
+
     const otherDir = makeTempDir();
     writeManifest(otherDir, {
       id: "google",
@@ -669,6 +681,11 @@ describe("loadPluginManifestRegistry", () => {
       createPluginCandidate({
         idHint: "brave",
         rootDir: dir,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "tavily",
+        rootDir: tavilyDir,
         origin: "bundled",
       }),
       createPluginCandidate({
@@ -688,7 +705,7 @@ describe("loadPluginManifestRegistry", () => {
             ),
         )
         .map((plugin) => plugin.id),
-    ).toEqual(["brave"]);
+    ).toEqual(["brave", "tavily"]);
   });
   it("does not promote legacy top-level capability fields into contracts", () => {
     const dir = makeTempDir();


### PR DESCRIPTION
## Problem

Tavily plugin's `webSearch.apiKey` accepts SecretRef during config validation but fails at runtime with `unresolved in active runtime snapshot`. Other plugins like Brave work fine with SecretRef.

## Root Cause

Tavily's plugin manifest (`openclaw.plugin.json`) was missing the `configContracts.compatibilityRuntimePaths` declaration that registers it as a handler for the `tools.web.search.apiKey` compatibility runtime path. Brave and MiniMax already had this declaration.

## Fix

Added the missing `configContracts` section to Tavily's plugin manifest and added a test to verify all web-search plugins declare compatible runtime paths.

Fixes #68028