### PR TITLE
fix: apply canonical-to-binding normalization on provider-resolved ACP command contexts

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -22,7 +22,9 @@ import {
   type SessionBindingPlacement,
   type SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { resetTaskRegistryForTests } from "../tasks/task-registry.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import * as acpSpawnParentStream from "./acp-spawn-parent-stream.js";
 
 function createDefaultSpawnConfig(): OpenClawConfig {
@@ -518,6 +520,7 @@ describe("spawnAcpDirect", () => {
   afterEach(() => {
     resetTaskRegistryForTests();
     sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();
+    setActivePluginRegistry(createTestRegistry());
     clearRuntimeConfigSnapshot();
   });
 
@@ -577,6 +580,57 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls).toHaveLength(2);
     expect(transcriptCalls[0]?.threadId).toBeUndefined();
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
+  });
+
+  it("normalizes provider-resolved Discord thread binding conversation ids on sessions_spawn", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "discord",
+              label: "Discord",
+            }),
+            messaging: {
+              resolveInboundConversation: () => ({
+                conversationId: " channel:parent-channel ",
+                parentConversationId: " channel:guild-channel ",
+              }),
+            },
+          },
+        },
+      ]),
+    );
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(result.status, JSON.stringify(result)).toBe("accepted");
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        placement: "child",
+        conversation: expect.objectContaining({
+          channel: "discord",
+          accountId: "default",
+          conversationId: "parent-channel",
+          parentConversationId: "guild-channel",
+        }),
+      }),
+    );
   });
 
   it("spawns Matrix thread-bound ACP sessions from top-level room targets", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -41,7 +41,10 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { areHeartbeatsEnabled } from "../infra/heartbeat-wake.js";
-import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
+import {
+  normalizeProviderConversationId,
+  resolveConversationIdFromTargets,
+} from "../infra/outbound/conversation-id.js";
 import { normalizeConversationTargetRef } from "../infra/outbound/session-binding-normalization.js";
 import {
   getSessionBindingService,
@@ -309,13 +312,15 @@ function resolvePluginConversationRefForThreadBinding(params: {
       : getChannelPlugin(params.channelId)?.messaging?.resolveInboundConversation?.(
           resolverParams,
         ));
-  const conversationId = normalizeOptionalString(resolvedConversation?.conversationId);
+  const conversationId = normalizeProviderConversationId(resolvedConversation?.conversationId);
   if (!conversationId) {
     return null;
   }
   return normalizeConversationTargetRef({
     conversationId,
-    parentConversationId: resolvedConversation?.parentConversationId,
+    parentConversationId: normalizeProviderConversationId(
+      resolvedConversation?.parentConversationId,
+    ),
   });
 }
 

--- a/src/channels/conversation-binding-context.test.ts
+++ b/src/channels/conversation-binding-context.test.ts
@@ -92,8 +92,111 @@ describe("resolveConversationBindingContext", () => {
       channel: "line",
       accountId: "default",
       conversationId: "user:U1234567890abcdef1234567890abcdef",
-      parentConversationId: "room:R1234567890abcdef1234567890abcd",
+      parentConversationId: "R1234567890abcdef1234567890abcd",
     });
+  });
+
+  it("strips channel prefixes from provider-resolved Discord guild conversations", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "discord",
+              label: "Discord",
+            }),
+            bindings: {
+              resolveCommandConversation: () => ({
+                conversationId: " channel:1469172413324460032 ",
+                parentConversationId: " channel:1468841521313878109 ",
+              }),
+            },
+          },
+        },
+      ]),
+    );
+
+    expect(
+      resolveConversationBindingContext({
+        cfg: {} as OpenClawConfig,
+        channel: "discord",
+        accountId: " default ",
+        originatingTo: "ignored",
+      }),
+    ).toEqual({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "1469172413324460032",
+      parentConversationId: "1468841521313878109",
+    });
+  });
+
+  it("preserves provider-resolved Discord DM user identities", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "discord",
+              label: "Discord",
+            }),
+            bindings: {
+              resolveCommandConversation: () => ({
+                conversationId: " user:123456789012345 ",
+              }),
+            },
+          },
+        },
+      ]),
+    );
+
+    expect(
+      resolveConversationBindingContext({
+        cfg: {} as OpenClawConfig,
+        channel: "discord",
+        accountId: " default ",
+        originatingTo: "ignored",
+      }),
+    ).toEqual({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "user:123456789012345",
+    });
+  });
+
+  it("returns null when the provider resolves a prefix-only conversation id", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "discord",
+              label: "Discord",
+            }),
+            bindings: {
+              resolveCommandConversation: () => ({
+                conversationId: " channel: ",
+              }),
+            },
+          },
+        },
+      ]),
+    );
+
+    expect(
+      resolveConversationBindingContext({
+        cfg: {} as OpenClawConfig,
+        channel: "discord",
+        accountId: " default ",
+        originatingTo: "ignored",
+      }),
+    ).toBeNull();
   });
 
   it("normalizes focused binding conversation ids before returning binding context", () => {

--- a/src/channels/conversation-binding-context.ts
+++ b/src/channels/conversation-binding-context.ts
@@ -1,5 +1,8 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
+import {
+  normalizeProviderConversationId,
+  resolveConversationIdFromTargets,
+} from "../infra/outbound/conversation-id.js";
 import { getActivePluginChannelRegistry } from "../plugins/runtime.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -160,11 +163,13 @@ export function resolveConversationBindingContext(
     fallbackTo: params.fallbackTo ?? undefined,
   });
   if (resolvedByProvider?.conversationId) {
-    const providerConversationId = normalizeOptionalString(resolvedByProvider.conversationId);
+    const providerConversationId = normalizeProviderConversationId(
+      resolvedByProvider.conversationId,
+    );
     if (!providerConversationId) {
       return null;
     }
-    const providerParentConversationId = normalizeOptionalString(
+    const providerParentConversationId = normalizeProviderConversationId(
       resolvedByProvider.parentConversationId,
     );
     const resolvedParentConversationId =

--- a/src/infra/outbound/conversation-id.ts
+++ b/src/infra/outbound/conversation-id.ts
@@ -12,6 +12,26 @@ function resolveExplicitConversationTargetId(target: string): string | undefined
   return undefined;
 }
 
+export function normalizeProviderConversationId(
+  raw: string | undefined | null,
+): string | undefined {
+  const trimmed = normalizeOptionalString(raw);
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const stripped = resolveConversationIdFromTargets({ targets: [trimmed] });
+  if (stripped) {
+    return stripped;
+  }
+
+  if (trimmed.endsWith(":")) {
+    return undefined;
+  }
+
+  return trimmed;
+}
+
 export function resolveConversationIdFromTargets(params: {
   threadId?: string | number;
   targets: Array<string | undefined | null>;


### PR DESCRIPTION
AI-assisted PR. Targeted local tests run and manual Discord repro/verification performed.

## Summary

- Problem: Discord ACP thread-bound spawn could fail because the provider-resolved command path passed canonical conversation ids like `channel:<id>` through unchanged, eventually reaching Discord binding/channel resolution where a raw platform id was expected.
- Why it matters: `/acp ... --thread auto` and `sessions_spawn(... thread: true ...)` could fail with `thread_binding_invalid`, preventing ACP sessions from creating/binding their Discord thread.
- What changed: added a shared `normalizeProviderConversationId()` helper next to the existing outbound conversation-id normalization logic, then used it in both `resolveConversationBindingContext()` and the `sessions_spawn` plugin-resolved path.
- What did NOT change (scope boundary): no plugin output format changes, no Discord adapter-specific patching, no change to DM `user:<id>` semantics, no unrelated thread-binding refactor.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64017
- Related #63329
- Related #63686
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the provider-resolved branch in `resolveConversationBindingContext()` skipped the same canonical-to-binding normalization that the fallback path already relied on, so plugin-resolved ids like `channel:<id>` could flow unchanged into Discord thread binding.
- Missing detection / guardrail: there was no unit coverage asserting provider-resolved command contexts normalize canonical `channel:` ids while preserving DM `user:` identities.
- Contributing context (if known): the same normalization gap also existed in the `sessions_spawn` plugin-resolved path. Existing code already had the right normalization convention in shared conversation-id utilities, but these two entry points were not using it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/channels/conversation-binding-context.test.ts`
  - `src/agents/acp-spawn.test.ts`
- Scenario the test should lock in: provider-resolved Discord guild conversation ids normalize `channel:<id>` to `<id>`, preserve `user:<id>` for DM identity, reject prefix-only inputs like `channel:`, and apply the same rules on the `sessions_spawn` plugin-resolved path.
- Why this is the smallest reliable guardrail: the bug is a normalization gap at the command/plugin boundary, so focused unit coverage on that boundary catches the regression without requiring live Discord setup.
- Existing test that already covers this (if any): none for the provider-resolved branch; one existing expectation was updated from `room:<id>` to `<id>` because `room:` is already part of the shared strip convention and the old expectation encoded the missing normalization.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Discord ACP thread-bound spawn no longer passes canonical `channel:<id>` values into downstream binding/channel resolution on the provider-resolved command path.
- `sessions_spawn(... runtime: "acp", thread: true ...)` now applies the same normalization semantics.
- DM `user:<id>` conversation identities remain unchanged.
- Degenerate prefix-only values like `channel:` are now rejected instead of being passed through.

## Diagram (if applicable)

```text
Before:
[user runs ACP thread spawn]
  -> [provider resolves conversationId = "channel:<id>"]
  -> [provider branch passes value through unchanged]
  -> [Discord binding/channel lookup expects raw id]
  -> [bind fails]
  -> [thread_binding_invalid]

After:
[user runs ACP thread spawn]
  -> [provider resolves conversationId = "channel:<id>"]
  -> [shared normalization converts to "<id>"]
  -> [Discord binding/channel lookup receives raw id]
  -> [thread bind succeeds]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS (local dev machine)
- Runtime/container: local OpenClaw install + source checkout
- Model/provider: N/A for the bug itself; local testing performed from existing OpenClaw sessions
- Integration/channel (if any): Discord guild text channel with ACP thread binding enabled
- Relevant config (redacted):
  - `channels.discord.threadBindings.enabled = true`
  - `channels.discord.threadBindings.spawnAcpSessions = true`
  - `session.threadBindings.enabled = true`

### Steps

1. In a Discord guild text channel with ACP/thread binding enabled, run `/acp action:spawn value:claude --thread auto`.
2. Reproduce the same path through runtime tools with `sessions_spawn({ runtime: "acp", agentId: "claude", thread: true, mode: "session" })`.
3. Repeat for `codex` and `gemini`.

### Expected

- ACP thread-bound session is created and bound successfully.

### Actual

- Received:
  ```json
  {
    "status": "error",
    "errorCode": "thread_binding_invalid",
    "error": "Session binding adapter failed to bind target conversation"
  }
  ```

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Sanitized evidence:
- Before fix, local session transcripts captured repeated `thread_binding_invalid` / `Session binding adapter failed to bind target conversation` failures for `claude`, `codex`, and `gemini`.
- After fix, targeted source tests passed:
  - `vitest run src/channels/conversation-binding-context.test.ts`
  - `vitest run src/agents/acp-spawn.test.ts`
- After applying the same fix locally for runtime verification, ACP spawn completed normally instead of failing at thread binding.

## Human Verification (required)

- Verified scenarios:
  - reproduced failure before fix for ACP thread-bound spawn
  - confirmed fix normalizes provider-resolved `channel:<id>` to raw id
  - confirmed DM `user:<id>` is preserved
  - confirmed prefix-only values like `channel:` are rejected
  - confirmed `sessions_spawn` path uses the same helper/semantics
- Edge cases checked:
  - raw unprefixed ids remain unchanged
  - `room:` / `conversation:` / `group:` / `dm:` follow existing shared strip semantics
- What you did **not** verify:
  - did not add or run a live Discord end-to-end test in repo CI
  - did not broaden scope into unrelated pre-existing test failures already present on `main`

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: `N/A`

## Risks and Mitigations

- Risk:
  - normalization changes a second entry point (`sessions_spawn`) in addition to the primary command-context path.
- Mitigation:
  - both sites now share one helper with explicit unit coverage instead of maintaining separate prefix logic.

- Risk:
  - over-normalizing DM identities would regress `user:<id>` routing.
- Mitigation:
  - the helper reuses existing conversation-id normalization semantics and intentionally preserves `user:<id>`.

- Risk:
  - malformed canonical prefix-only inputs could silently leak through.
- Mitigation:
  - the helper rejects degenerate values like `channel:` / `dm:` by returning `undefined`.
