### PR TITLE
fix(agents): forward-compat supportsAdaptiveThinking for Claude 4.7+ models

### DIFF
--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -220,6 +220,54 @@ describe("anthropic provider replay hooks", () => {
     ).toBe(false);
   });
 
+  it("resolves claude-sonnet-4-7 refs from the 4.6 template family", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-7",
+      modelRegistry: createModelRegistry([
+        {
+          id: "claude-sonnet-4-6",
+          name: "Claude Sonnet 4.6",
+          provider: "anthropic",
+          api: "anthropic-messages",
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200_000,
+          maxTokens: 32_000,
+        } as ProviderRuntimeModel,
+      ]),
+    } as ProviderResolveDynamicModelContext);
+
+    expect(resolved).toMatchObject({
+      provider: "anthropic",
+      id: "claude-sonnet-4-7",
+      api: "anthropic-messages",
+      reasoning: true,
+    });
+  });
+
+  it("forward-compat: supportsXHighThinking matches future opus-4-8 model", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    expect(
+      provider.supportsXHighThinking?.({
+        provider: "anthropic",
+        modelId: "claude-opus-4-8",
+      } as never),
+    ).toBe(true);
+  });
+
+  it("forward-compat: adaptive thinking default for sonnet-4-7", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    expect(
+      provider.resolveDefaultThinkingLevel?.({
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-7",
+      } as never),
+    ).toBe("adaptive");
+  });
+
   it("resolves claude-cli synthetic oauth auth", async () => {
     readClaudeCliCredentialsForRuntimeMock.mockReset();
     readClaudeCliCredentialsForRuntimeMock.mockReturnValue({

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -50,11 +50,20 @@ const ANTHROPIC_OPUS_47_TEMPLATE_MODEL_IDS = [
   "claude-opus-4.5",
 ] as const;
 const ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS = ["claude-opus-4-5", "claude-opus-4.5"] as const;
+const ANTHROPIC_SONNET_47_MODEL_ID = "claude-sonnet-4-7";
+const ANTHROPIC_SONNET_47_DOT_MODEL_ID = "claude-sonnet-4.7";
+const ANTHROPIC_SONNET_47_TEMPLATE_MODEL_IDS = [
+  "claude-sonnet-4-6",
+  "claude-sonnet-4.6",
+  "claude-sonnet-4-5",
+  "claude-sonnet-4.5",
+] as const;
 const ANTHROPIC_SONNET_46_MODEL_ID = "claude-sonnet-4-6";
 const ANTHROPIC_SONNET_46_DOT_MODEL_ID = "claude-sonnet-4.6";
 const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet-4.5"] as const;
 const ANTHROPIC_MODERN_MODEL_PREFIXES = [
   "claude-opus-4-7",
+  "claude-sonnet-4-7",
   "claude-opus-4-6",
   "claude-sonnet-4-6",
   "claude-opus-4-5",
@@ -248,6 +257,14 @@ function resolveAnthropicForwardCompatModel(
     }) ??
     resolveAnthropic46ForwardCompatModel({
       ctx,
+      dashModelId: ANTHROPIC_SONNET_47_MODEL_ID,
+      dotModelId: ANTHROPIC_SONNET_47_DOT_MODEL_ID,
+      dashTemplateId: ANTHROPIC_SONNET_46_MODEL_ID,
+      dotTemplateId: ANTHROPIC_SONNET_46_DOT_MODEL_ID,
+      fallbackTemplateIds: ANTHROPIC_SONNET_47_TEMPLATE_MODEL_IDS,
+    }) ??
+    resolveAnthropic46ForwardCompatModel({
+      ctx,
       dashModelId: ANTHROPIC_SONNET_46_MODEL_ID,
       dotModelId: ANTHROPIC_SONNET_46_DOT_MODEL_ID,
       dashTemplateId: "claude-sonnet-4-5",
@@ -257,14 +274,11 @@ function resolveAnthropicForwardCompatModel(
   );
 }
 
+// All Claude Opus/Sonnet 4.6+ default to adaptive thinking.
+const ADAPTIVE_DEFAULT_PATTERN = /(opus|sonnet)-4[.-]([6-9]|\d{2,})/;
+
 function shouldUseAnthropicAdaptiveThinkingDefault(modelId: string): boolean {
-  const lowerModelId = normalizeLowercaseStringOrEmpty(modelId);
-  return (
-    lowerModelId.startsWith(ANTHROPIC_OPUS_46_MODEL_ID) ||
-    lowerModelId.startsWith(ANTHROPIC_OPUS_46_DOT_MODEL_ID) ||
-    lowerModelId.startsWith(ANTHROPIC_SONNET_46_MODEL_ID) ||
-    lowerModelId.startsWith(ANTHROPIC_SONNET_46_DOT_MODEL_ID)
-  );
+  return ADAPTIVE_DEFAULT_PATTERN.test(normalizeLowercaseStringOrEmpty(modelId));
 }
 
 function isAnthropicOpus47Model(modelId: string): boolean {
@@ -273,6 +287,13 @@ function isAnthropicOpus47Model(modelId: string): boolean {
     lowerModelId.startsWith(ANTHROPIC_OPUS_47_MODEL_ID) ||
     lowerModelId.startsWith(ANTHROPIC_OPUS_47_DOT_MODEL_ID)
   );
+}
+
+// Opus 4.7+ supports the native "xhigh" effort level.
+const OPUS_XHIGH_PATTERN = /opus-4[.-]([7-9]|\d{2,})/;
+
+function isAnthropicOpusXHighModel(modelId: string): boolean {
+  return OPUS_XHIGH_PATTERN.test(normalizeLowercaseStringOrEmpty(modelId));
 }
 
 function matchesAnthropicModernModel(modelId: string): boolean {
@@ -487,7 +508,7 @@ export function registerAnthropicPlugin(api: OpenClawPluginApi): void {
     buildReplayPolicy: buildAnthropicReplayPolicy,
     isModernModelRef: ({ modelId }) => matchesAnthropicModernModel(modelId),
     resolveReasoningOutputMode: () => "native",
-    supportsXHighThinking: ({ modelId }) => isAnthropicOpus47Model(modelId),
+    supportsXHighThinking: ({ modelId }) => isAnthropicOpusXHighModel(modelId),
     wrapStreamFn: wrapAnthropicProviderStream,
     resolveDefaultThinkingLevel: ({ modelId }) =>
       isAnthropicOpus47Model(modelId)

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -63,12 +63,19 @@ const ANTHROPIC_SONNET_46_DOT_MODEL_ID = "claude-sonnet-4.6";
 const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet-4.5"] as const;
 const ANTHROPIC_MODERN_MODEL_PREFIXES = [
   "claude-opus-4-7",
+  "claude-opus-4.7",
   "claude-sonnet-4-7",
+  "claude-sonnet-4.7",
   "claude-opus-4-6",
+  "claude-opus-4.6",
   "claude-sonnet-4-6",
+  "claude-sonnet-4.6",
   "claude-opus-4-5",
+  "claude-opus-4.5",
   "claude-sonnet-4-5",
+  "claude-sonnet-4.5",
   "claude-haiku-4-5",
+  "claude-haiku-4.5",
 ] as const;
 const ANTHROPIC_SETUP_TOKEN_NOTE_LINES = [
   "Anthropic setup-token auth is supported in OpenClaw.",

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -516,4 +516,94 @@ describe("anthropic transport stream", () => {
       undefined,
     );
   });
+
+  it("uses adaptive thinking for Claude Sonnet 4.7 transport runs", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-sonnet-4-7",
+        name: "Claude Sonnet 4.7",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Think about this." }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+          reasoning: "high",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(anthropicMessagesStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thinking: { type: "adaptive" },
+        output_config: { effort: "high" },
+      }),
+      undefined,
+    );
+  });
+
+  it("forward-compat: uses adaptive thinking for future Claude opus-4-8 model", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-opus-4-8",
+        name: "Claude Opus 4.8",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Think about the future." }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+          reasoning: "xhigh",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(anthropicMessagesStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thinking: { type: "adaptive" },
+        output_config: { effort: "xhigh" },
+      }),
+      undefined,
+    );
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -124,7 +124,7 @@ function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): Anthro
         return "max";
       }
       // Opus 4.7+ supports native xhigh effort.
-      return modelId.includes("opus-4") ? "xhigh" : "high";
+      return /opus-4[.-]([7-9]|\d{2,})/.test(modelId) ? "xhigh" : "high";
     default:
       return "high";
   }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -99,21 +99,16 @@ type MutableAssistantOutput = {
   errorMessage?: string;
 };
 
-function isClaudeOpus47Model(modelId: string): boolean {
-  return modelId.includes("opus-4-7") || modelId.includes("opus-4.7");
-}
-
 function isClaudeOpus46Model(modelId: string): boolean {
   return modelId.includes("opus-4-6") || modelId.includes("opus-4.6");
 }
 
+// All Claude Opus/Sonnet 4.6+ use adaptive thinking (type: "adaptive" + output_config.effort)
+// instead of budget-based thinking (type: "enabled" + budget_tokens).
+const ADAPTIVE_THINKING_PATTERN = /(opus|sonnet)-4[.-]([6-9]|\d{2,})/;
+
 function supportsAdaptiveThinking(modelId: string): boolean {
-  return (
-    isClaudeOpus47Model(modelId) ||
-    isClaudeOpus46Model(modelId) ||
-    modelId.includes("sonnet-4-6") ||
-    modelId.includes("sonnet-4.6")
-  );
+  return ADAPTIVE_THINKING_PATTERN.test(modelId);
 }
 
 function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): AnthropicAdaptiveEffort {
@@ -124,10 +119,12 @@ function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): Anthro
     case "medium":
       return "medium";
     case "xhigh":
-      if (isClaudeOpus47Model(modelId)) {
-        return "xhigh";
+      // Opus 4.6 predates native xhigh effort; map to "max" instead.
+      if (isClaudeOpus46Model(modelId)) {
+        return "max";
       }
-      return isClaudeOpus46Model(modelId) ? "max" : "high";
+      // Opus 4.7+ supports native xhigh effort.
+      return modelId.includes("opus-4") ? "xhigh" : "high";
     default:
       return "high";
   }


### PR DESCRIPTION
Closes #67888

## Summary

Replace hardcoded model-ID checks with regex-based forward-compatible patterns so that future Claude model versions (4.8, 4.9, …) automatically get correct adaptive thinking and effort mapping without requiring code changes.

### Changes

**`src/agents/anthropic-transport-stream.ts`**
- `supportsAdaptiveThinking()` — replace hardcoded `includes()` checks with `/(opus|sonnet)-4[.-]([6-9]|\d{2,})/` regex. This covers all Opus/Sonnet 4.6+ models including the previously missing Sonnet 4.7.
- `mapThinkingLevelToEffort()` — make `xhigh` mapping forward-compatible: Opus 4.6 → `"max"`, Opus 4.7+ → `"xhigh"`, others → `"high"`.
- Remove unused `isClaudeOpus47Model()` helper (replaced by the regex pattern).

**`extensions/anthropic/register.runtime.ts`**
- Add Sonnet 4.7 constants, template model IDs, and forward-compat model resolution.
- Add `"claude-sonnet-4-7"` to `ANTHROPIC_MODERN_MODEL_PREFIXES`.
- `shouldUseAnthropicAdaptiveThinkingDefault()` — replace hardcoded list with `/(opus|sonnet)-4[.-]([6-9]|\d{2,})/` regex.
- `supportsXHighThinking` — replace `isAnthropicOpus47Model` with forward-compat `/opus-4[.-]([7-9]|\d{2,})/` regex (Opus 4.7+).

### Tests added
- Sonnet 4.7 uses adaptive thinking with correct effort
- Future Opus 4.8 gets adaptive thinking + xhigh effort (forward-compat proof)
- Sonnet 4.7 dynamic model resolution from 4.6 template
- Future Opus 4.8 passes `supportsXHighThinking`
- Sonnet 4.7 gets "adaptive" default thinking level

## Test plan
- [x] `pnpm test src/agents/anthropic-transport-stream.test.ts` — 10 passed
- [x] `pnpm test extensions/anthropic/index.test.ts` — 13 passed
- [x] CI