### PR TITLE
fix: prevent formatter from breaking HTML export template placeholders (#68062)

### DIFF
--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -58,31 +58,16 @@
       {{SESSION_DATA}}
     </script>
 
-    <!-- Vendored libraries -->
-    <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
-    </script>
+    <!-- Vendored libraries (placeholders must stay on one line for .replace() substitution) -->
+    <!-- oxfmt-ignore -->
+    <script>{{MARKED_JS}}</script>
 
     <!-- highlight.js -->
-    <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
-    </script>
+    <!-- oxfmt-ignore -->
+    <script>{{HIGHLIGHT_JS}}</script>
 
     <!-- Main application code -->
-    <script>
-      {
-        {
-          JS;
-        }
-      }
-    </script>
+    <!-- oxfmt-ignore -->
+    <script>{{JS}}</script>
   </body>
 </html>

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -79,6 +79,17 @@ function now() {
   return new Date("2026-02-24T00:00:00.000Z").toISOString();
 }
 
+describe("export html template placeholders", () => {
+  it("contains exact placeholder strings that generateHtml expects to replace", () => {
+    // These placeholders must appear as literal strings (not reformatted by oxfmt/prettier).
+    // If a formatter breaks them (e.g. `{{JS}}` → `{ { JS; } }`), the viewer JS
+    // is never injected and the exported HTML renders blank (#68062).
+    for (const placeholder of ["{{CSS}}", "{{JS}}", "{{SESSION_DATA}}", "{{MARKED_JS}}", "{{HIGHLIGHT_JS}}"]) {
+      expect(templateHtml).toContain(placeholder);
+    }
+  });
+});
+
 describe("export html security hardening", () => {
   it("escapes raw HTML from markdown blocks", () => {
     const attack = "<img src=x onerror=alert(1)>";


### PR DESCRIPTION
## Problem

The `/export` command generates HTML that contains session data in the embedded payload, but when opened in a browser the conversation area renders blank.

## Root Cause

The code formatter (oxfmt) was reformatting the template placeholders like `{{MARKED_JS}}` into multi-line blocks:
```html
<script>
  {
    {
      MARKED_JS;
    }
  }
</script>
```

This broke the `.replace()` substitution that injects the actual JS code at export time, since the placeholder no longer matched the expected pattern.

## Fix

- Collapsed the template placeholders back to single-line format: `<script>{{MARKED_JS}}</script>`
- Added `<!-- oxfmt-ignore -->` comments to prevent the formatter from breaking them again
- Added a test to verify placeholders remain on single lines

Fixes #68062