### PR TITLE
fix(ui): hide section card header in single-section settings views

### DIFF
--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -433,6 +433,8 @@ export function renderConfigForm(props: ConfigFormProps) {
     `;
   }
 
+  const isSingleTopLevelSection = filteredEntries.length === 1 && !subsectionContext;
+
   const renderSectionCard = (params: {
     id: string;
     sectionKey: string;
@@ -443,15 +445,19 @@ export function renderConfigForm(props: ConfigFormProps) {
     path: Array<string | number>;
   }) => html`
     <section class="config-section-card" id=${params.id}>
-      <div class="config-section-card__header">
-        <span class="config-section-card__icon">${getSectionIcon(params.sectionKey)}</span>
-        <div class="config-section-card__titles">
-          <h3 class="config-section-card__title">${params.label}</h3>
-          ${params.description
-            ? html`<p class="config-section-card__desc">${params.description}</p>`
-            : nothing}
-        </div>
-      </div>
+      ${!isSingleTopLevelSection
+        ? html`
+            <div class="config-section-card__header">
+              <span class="config-section-card__icon">${getSectionIcon(params.sectionKey)}</span>
+              <div class="config-section-card__titles">
+                <h3 class="config-section-card__title">${params.label}</h3>
+                ${params.description
+                  ? html`<p class="config-section-card__desc">${params.description}</p>`
+                  : nothing}
+              </div>
+            </div>
+          `
+        : nothing}
       <div class="config-section-card__content">
         ${renderNode({
           schema: params.node,


### PR DESCRIPTION
Closes #68003

When a single section is displayed in Control UI settings, the section title and description were rendered twice: once in the top section hero and again in the nested section card header. This change suppresses the section card header when only one top-level section is visible, avoiding the duplication while preserving headers in multi-section views.