### PR TITLE
fix: MS Teams OAuth on Windows and browser.cdpUrl security redaction

### DIFF
--- a/extensions/msteams/src/setup-surface.test.ts
+++ b/extensions/msteams/src/setup-surface.test.ts
@@ -67,7 +67,15 @@ describe("msteams setup surface", () => {
     child.emit("exit", 0, null);
 
     await expect(result).resolves.toBeUndefined();
-    expect(spawn).toHaveBeenCalledWith(process.platform === "darwin" ? "open" : "xdg-open", [url], {
+    const expectedCmd =
+      process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+    const expectedArgs =
+      process.platform === "darwin"
+        ? [url]
+        : process.platform === "win32"
+          ? ["/c", "start", '""', url]
+          : [url];
+    expect(spawn).toHaveBeenCalledWith(expectedCmd, expectedArgs, {
       stdio: "ignore",
       shell: false,
     });

--- a/extensions/msteams/src/setup-surface.ts
+++ b/extensions/msteams/src/setup-surface.ts
@@ -31,8 +31,13 @@ const setMSTeamsGroupPolicy = createTopLevelChannelGroupPolicySetter({
 
 export function openDelegatedOAuthUrl(url: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    const cmd = process.platform === "darwin" ? "open" : "xdg-open";
-    const child = spawn(cmd, [url], { stdio: "ignore", shell: false });
+    const [cmd, args]: [string, string[]] =
+      process.platform === "darwin"
+        ? ["open", [url]]
+        : process.platform === "win32"
+          ? ["cmd", ["/c", "start", '""', url]]
+          : ["xdg-open", [url]];
+    const child = spawn(cmd, args, { stdio: "ignore", shell: false });
     child.once("error", reject);
     child.once("exit", (code, signal) => {
       if (code === 0) {

--- a/src/shared/net/redact-sensitive-url.test.ts
+++ b/src/shared/net/redact-sensitive-url.test.ts
@@ -49,6 +49,8 @@ describe("sensitive URL config metadata", () => {
     expect(isSensitiveUrlConfigPath("models.providers.*.baseUrl")).toBe(true);
     expect(isSensitiveUrlConfigPath("mcp.servers.remote.url")).toBe(true);
     expect(isSensitiveUrlConfigPath("gateway.remote.url")).toBe(false);
+    expect(isSensitiveUrlConfigPath("browser.cdpUrl")).toBe(true);
+    expect(isSensitiveUrlConfigPath("browser.profiles.default.cdpUrl")).toBe(true);
   });
 
   it("uses an explicit url-secret hint tag", () => {

--- a/src/shared/net/redact-sensitive-url.ts
+++ b/src/shared/net/redact-sensitive-url.ts
@@ -28,6 +28,9 @@ export function isSensitiveUrlConfigPath(path: string): boolean {
   if (path.endsWith(".request.proxy.url")) {
     return true;
   }
+  if (path.endsWith(".cdpUrl")) {
+    return true;
+  }
   return /^mcp\.servers\.(?:\*|[^.]+)\.url$/.test(path);
 }
 


### PR DESCRIPTION
## Summary
This PR fixes two issues reported in #67738:
1. MS Teams OAuth on Windows fails because explorer.exe exits with code 1
2. browser.cdpUrl is not included in sensitive URL config paths for security redaction

## Root Cause
1. **Windows OAuth**: `explorer.exe <url>` delegates to the running Explorer shell and exits with code 1, causing the OAuth promise to reject even though the browser opened correctly.
2. **Security**: `.cdpUrl` config paths (Chrome DevTools Protocol URLs) can contain sensitive credentials but were not being redacted.

## Fix
1. **Windows OAuth**: Use `cmd /c start "" URL` instead of `explorer.exe`, which exits 0 on success.
2. **Security**: Added `.cdpUrl` to the list of sensitive URL config paths.
3. **Tests**: Updated test assertions to handle all three platforms (darwin, win32, linux) and added test coverage for the new `.cdpUrl` path.

## Test Plan
- [x] Unit tests pass for msteams setup-surface
- [x] Unit tests pass for redact-sensitive-url
- [x] Test assertions cover all three platforms

Closes openclaw#67738