### PR TITLE
fix(memory-core): downgrade cleanup warning to debug when missing operator.admin scope

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -576,6 +576,7 @@ describe("generateAndAppendDreamNarrative", () => {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
+      debug: vi.fn(),
     };
   }
 
@@ -675,6 +676,28 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(subagent.waitForRun.mock.calls[1][0]).toMatchObject({ timeoutMs: 120_000 });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("narrative session cleanup failed for rem phase"),
+    );
+  });
+
+  it("logs debug message when cleanup fails due to missing operator.admin scope", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("");
+    subagent.waitForRun.mockResolvedValue({ status: "ok" });
+    subagent.deleteSession.mockRejectedValue(new Error("missing scope: operator.admin"));
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["some memory"] },
+      logger,
+    });
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("narrative session cleanup skipped for light phase"),
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("narrative session cleanup failed"),
     );
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -932,9 +932,18 @@ export async function generateAndAppendDreamNarrative(params: {
     try {
       await params.subagent.deleteSession({ sessionKey });
     } catch (cleanupErr) {
-      params.logger.warn(
-        `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupErr)}`,
-      );
+      const errMsg = formatErrorMessage(cleanupErr);
+      // Missing operator.admin scope is expected when running in main session;
+      // treat as best-effort cleanup and log at debug level only.
+      if (errMsg.includes("missing scope: operator.admin")) {
+        params.logger.debug(
+          `memory-core: narrative session cleanup skipped for ${params.data.phase} phase (missing operator.admin scope)`,
+        );
+      } else {
+        params.logger.warn(
+          `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${errMsg}`,
+        );
+      }
     }
 
     await scrubDreamingNarrativeArtifacts(params.logger).catch((scrubErr: unknown) => {


### PR DESCRIPTION
## Summary
The memory-core plugin's dreaming feature generates a warning log every 4 hours when narrative session cleanup fails due to missing operator.admin scope. This is expected behavior since the dreaming cron runs in the main session which lacks this scope.

## Root Cause
The `subagent.deleteSession()` method requires `operator.admin` permission, but the dreaming cron job runs in the main session which does not have this scope. The cleanup is best-effort and the core dreaming/promotion functionality still works correctly.

## Fix
When `deleteSession()` fails with "missing scope: operator.admin", log at `debug` level instead of `warn` since this is expected behavior. Other cleanup failures still log at `warn` level.

## Changes
- `dreaming-narrative.ts`: Check error message for 'missing scope: operator.admin' and use `logger.debug` instead of `logger.warn`
- `dreaming-narrative.test.ts`: Add test coverage for the new behavior and add `debug` mock to `createMockLogger`

## Test Plan
- [x] Unit tests pass (43 tests in dreaming-narrative.test.ts)
- [x] New test verifies debug logging for missing scope error
- [x] New test verifies warn logging is NOT called for missing scope error

Closes openclaw#68074