### PR TITLE
Fix: dedupe section title/desc in single-section config view (Resolves #68003)

### DIFF
--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -433,6 +433,10 @@ export function renderConfigForm(props: ConfigFormProps) {
     `;
   }
 
+  // Hide the per-card header in single-section/subsection views because the
+  // enclosing page already renders the same title/description in its hero.
+  const hideCardHeader = Boolean(activeSection);
+
   const renderSectionCard = (params: {
     id: string;
     sectionKey: string;
@@ -443,15 +447,19 @@ export function renderConfigForm(props: ConfigFormProps) {
     path: Array<string | number>;
   }) => html`
     <section class="config-section-card" id=${params.id}>
-      <div class="config-section-card__header">
-        <span class="config-section-card__icon">${getSectionIcon(params.sectionKey)}</span>
-        <div class="config-section-card__titles">
-          <h3 class="config-section-card__title">${params.label}</h3>
-          ${params.description
-            ? html`<p class="config-section-card__desc">${params.description}</p>`
-            : nothing}
-        </div>
-      </div>
+      ${hideCardHeader
+        ? nothing
+        : html`
+            <div class="config-section-card__header">
+              <span class="config-section-card__icon">${getSectionIcon(params.sectionKey)}</span>
+              <div class="config-section-card__titles">
+                <h3 class="config-section-card__title">${params.label}</h3>
+                ${params.description
+                  ? html`<p class="config-section-card__desc">${params.description}</p>`
+                  : nothing}
+              </div>
+            </div>
+          `}
       <div class="config-section-card__content">
         ${renderNode({
           schema: params.node,

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -491,6 +491,57 @@ describe("config view", () => {
     expect(input?.placeholder).toBe("Structured value (SecretRef) - edit the config file directly");
   });
 
+  it("does not duplicate section title/description in single-section view", () => {
+    const { container } = renderConfigView({
+      activeSection: "gateway",
+      schema: {
+        type: "object",
+        properties: {
+          gateway: {
+            type: "object",
+            properties: {
+              mode: { type: "string" },
+            },
+          },
+        },
+      },
+      formValue: { gateway: { mode: "local" } },
+      originalValue: { gateway: { mode: "local" } },
+    });
+
+    const hero = container.querySelector(".config-section-hero");
+    expect(hero).not.toBeNull();
+    expect(container.querySelector(".config-section-card")).not.toBeNull();
+    expect(container.querySelector(".config-section-card__header")).toBeNull();
+  });
+
+  it("renders per-card headers when no single section is active", () => {
+    const { container } = renderConfigView({
+      activeSection: null,
+      schema: {
+        type: "object",
+        properties: {
+          gateway: {
+            type: "object",
+            properties: {
+              mode: { type: "string" },
+            },
+          },
+          agents: {
+            type: "object",
+            properties: {},
+          },
+        },
+      },
+      formValue: { gateway: { mode: "local" } },
+      originalValue: { gateway: { mode: "local" } },
+    });
+
+    expect(container.querySelector(".config-section-hero")).toBeNull();
+    const headers = container.querySelectorAll(".config-section-card__header");
+    expect(headers.length).toBeGreaterThanOrEqual(1);
+  });
+
   it("keeps malformed non-SecretRef object values editable when raw mode is unavailable", () => {
     const onFormPatch = vi.fn();
     const { container } = renderConfigView({


### PR DESCRIPTION
Fixes #68003.

## Summary

In the Control UI settings, when a single section is active (e.g. Automation → Approvals), the section title/description was rendered twice: once in the top hero and again in the nested `config-section-card` header.

This PR hides the per-card header when `renderConfigForm` is invoked with an `activeSection`, keeping the hero as the single source of the title/description. Multi-section (root) views still show the per-card headers.

## Changes

- `ui/src/ui/views/config-form.render.ts`: skip `config-section-card__header` when `activeSection` is set.
- `ui/src/ui/views/config.browser.test.ts`: add regression tests for single-section (hero-only) and multi-section (per-card headers) rendering.

## Test plan
- [x] `pnpm test ui/src/ui/views/config.browser.test.ts` (18 passed)
- [x] `pnpm test ui/src/ui/config-form.browser.test.ts` (14 passed)
- [x] `pnpm lint` on the touched files (0 warnings, 0 errors)

## AI-assisted
- Marked as AI-assisted.
- Lightly tested (scoped tests pass; manual browser verification not performed).