### PR TITLE
fix(whatsapp): deduplicate media in final reply when block streaming is disabled

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -106,6 +106,8 @@ export type AgentRunLoopResult =
       autoCompactionCount: number;
       /** Payload keys sent directly (not via pipeline) during tool flush. */
       directlySentBlockKeys?: Set<string>;
+      /** Media path normalizer used during block delivery — reuse for final payloads to avoid duplicate persistence. */
+      normalizeReplyMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
     }
   | { kind: "final"; payload: ReplyPayload };
 
@@ -1587,5 +1589,6 @@ export async function runAgentTurnWithFallback(params: {
     didLogHeartbeatStrip,
     autoCompactionCount,
     directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
+    normalizeReplyMediaPaths: directlySentBlockKeys.size > 0 ? normalizeReplyMediaPaths : undefined,
   };
 }

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -267,6 +267,71 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("deduplicates final media payloads against block keys when sharing the same normalizer", async () => {
+    // Regression test for #68056: when block streaming is disabled but media is sent
+    // via a direct block reply, the final payload must be deduplicated using the same
+    // normalizer instance so persisted media paths match.
+    const { createBlockReplyContentKey } = await import("./block-reply-pipeline.js");
+    const directlySentBlockKeys = new Set<string>();
+    const sharedNormalizer = async (payload: { mediaUrl?: string; mediaUrls?: string[] }) => ({
+      ...payload,
+      mediaUrl: "/persisted/chart.png",
+      mediaUrls: ["/persisted/chart.png"],
+    });
+    // Simulate block delivery: normalize and record key
+    const blockNormalized = await sharedNormalizer({ mediaUrl: "/tmp/chart.png" });
+    directlySentBlockKeys.add(
+      createBlockReplyContentKey({ text: "Here is your chart", ...blockNormalized }),
+    );
+
+    // Final payload with same original media, normalized by same instance → same key
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      directlySentBlockKeys,
+      replyToMode: "off",
+      payloads: [{ text: "Here is your chart", mediaUrl: "/tmp/chart.png" }],
+      normalizeMediaPaths: sharedNormalizer,
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("fails to deduplicate when block and final use different normalizer instances (pre-fix behavior)", async () => {
+    // Demonstrates the #68056 regression: separate normalizer instances produce
+    // different persisted paths, so the content key doesn't match.
+    const { createBlockReplyContentKey } = await import("./block-reply-pipeline.js");
+    const directlySentBlockKeys = new Set<string>();
+    // Block normalizer persists to path A
+    const blockNormalized = {
+      mediaUrl: "/persisted/a/chart.png",
+      mediaUrls: ["/persisted/a/chart.png"],
+    };
+    directlySentBlockKeys.add(
+      createBlockReplyContentKey({ text: "Here is your chart", ...blockNormalized }),
+    );
+    // Final normalizer persists to path B (different instance)
+    const finalNormalizer = async (payload: { mediaUrl?: string; mediaUrls?: string[] }) => ({
+      ...payload,
+      mediaUrl: "/persisted/b/chart.png",
+      mediaUrls: ["/persisted/b/chart.png"],
+    });
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      directlySentBlockKeys,
+      replyToMode: "off",
+      payloads: [{ text: "Here is your chart", mediaUrl: "/tmp/chart.png" }],
+      normalizeMediaPaths: finalNormalizer,
+    });
+
+    // With different normalizers, dedup fails → payload leaks through (the bug)
+    expect(replyPayloads).toHaveLength(1);
+  });
+
   it("does not suppress same-target replies when accountId differs", async () => {
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1224,6 +1224,7 @@ export async function runReplyAgent(params: {
       fallbackModel,
       fallbackAttempts,
       directlySentBlockKeys,
+      normalizeReplyMediaPaths: executionNormalizeReplyMediaPaths,
     } = runOutcome;
     let { didLogHeartbeatStrip, autoCompactionCount } = runOutcome;
 
@@ -1362,7 +1363,7 @@ export async function runReplyAgent(params: {
         to: sessionCtx.To,
       }),
       accountId: sessionCtx.AccountId,
-      normalizeMediaPaths: normalizeReplyMediaPaths,
+      normalizeMediaPaths: executionNormalizeReplyMediaPaths ?? normalizeReplyMediaPaths,
     });
     const { replyPayloads } = payloadResult;
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;


### PR DESCRIPTION
Fixes #68056

## Problem

When `blockStreaming: false`, a single media response is sent twice:

1. **Block path**: Media is sent immediately via `sendDirectBlockReply` (media-only, text stripped) because media cannot be reconstructed in the final response.
2. **Final path**: The final payload also carries the same media URL, goes through a **separate** `createReplyMediaPathNormalizer` instance, and the deduplication filter (`directlySentBlockKeys`) fails to match because the two normalizer instances produce different persisted file paths.

## Root Cause

`agent-runner-execution.ts` and `agent-runner.ts` each create their own `createReplyMediaPathNormalizer` instance. Each instance has its own `persistedMediaBySource` cache. When the same source media URL is persisted by both instances, they produce different output paths (unique filenames from `saveMediaBuffer`). The `createBlockReplyContentKey` function compares normalized paths, so the keys don't match and the final payload leaks through.

Regression from d21f07a39e (`fix: allow workspace-rooted absolute media paths in auto-reply`, 2026-04-14), which moved media persistence into `normalizeMediaSource` — before this change, only volatile paths were persisted, and remote URLs passed through unchanged (matching between instances).

## Fix

Return the block-delivery normalizer from `runAgentTurnWithFallback` and reuse it in `buildReplyPayloads`. When the execution normalizer is available (i.e., media was sent during block delivery), it takes precedence over the separate instance, ensuring the same persistence cache is used for both block and final payloads → identical content keys → proper deduplication.

## Tests

Added 3 test cases to `agent-runner-payloads.test.ts`:
- ✅ Existing replyToId dedup test (unchanged)
- ✅ Shared normalizer correctly deduplicates media payloads
- ✅ Separate normalizers fail to deduplicate (demonstrates pre-fix bug)