### PR TITLE
fix(memory-search): thread cfg through getMemoryEmbeddingProvider so doctor stops emitting plugins.allow and memory-core false positives

### DIFF
--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import * as memoryEmbeddingProviderRuntime from "../plugins/memory-embedding-provider-runtime.js";
 import {
   clearMemoryEmbeddingProviders,
   registerMemoryEmbeddingProvider,
@@ -543,5 +544,36 @@ describe("memory search config", () => {
     });
     const resolved = resolveMemorySearchConfig(cfg, "main");
     expect(resolved?.sources).toContain("sessions");
+  });
+
+  it("threads cfg through provider lookups when resolving memory search config", () => {
+    const cfg = asConfig({
+      plugins: {
+        allow: [],
+        slots: {
+          memory: "none",
+        },
+        entries: {
+          "memory-core": {
+            enabled: false,
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "openai",
+          },
+        },
+      },
+    });
+    const providerSpy = vi.spyOn(memoryEmbeddingProviderRuntime, "getMemoryEmbeddingProvider");
+
+    const resolved = resolveMemorySearchConfig(cfg, "main");
+
+    expect(resolved?.provider).toBe("openai");
+    expect(providerSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(providerSpy.mock.calls.every((call) => call[1] === cfg)).toBe(true);
+    providerSpy.mockRestore();
   });
 });

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -568,12 +568,14 @@ describe("memory search config", () => {
       },
     });
     const providerSpy = vi.spyOn(memoryEmbeddingProviderRuntime, "getMemoryEmbeddingProvider");
+    try {
+      const resolved = resolveMemorySearchConfig(cfg, "main");
 
-    const resolved = resolveMemorySearchConfig(cfg, "main");
-
-    expect(resolved?.provider).toBe("openai");
-    expect(providerSpy.mock.calls.length).toBeGreaterThan(0);
-    expect(providerSpy.mock.calls.every((call) => call[1] === cfg)).toBe(true);
-    providerSpy.mockRestore();
+      expect(resolved?.provider).toBe("openai");
+      expect(providerSpy.mock.calls.length).toBeGreaterThan(0);
+      expect(providerSpy.mock.calls.every((call) => call[1] === cfg)).toBe(true);
+    } finally {
+      providerSpy.mockRestore();
+    }
   });
 });

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -142,6 +142,7 @@ function resolveStorePath(agentId: string, raw?: string): string {
 }
 
 function mergeConfig(
+  cfg: OpenClawConfig,
   defaults: MemorySearchConfig | undefined,
   overrides: MemorySearchConfig | undefined,
   agentId: string,
@@ -150,12 +151,13 @@ function mergeConfig(
   const sessionMemory =
     overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
   const provider = overrides?.provider ?? defaults?.provider ?? "auto";
-  const primaryAdapter = provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider);
+  const primaryAdapter =
+    provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider, cfg);
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
   const fallback = overrides?.fallback ?? defaults?.fallback ?? "none";
   const fallbackAdapter =
-    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback) : undefined;
+    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback, cfg) : undefined;
   const hasRemoteConfig = Boolean(
     overrideRemote?.baseUrl ||
     overrideRemote?.apiKey ||
@@ -381,13 +383,13 @@ export function resolveMemorySearchConfig(
 ): ResolvedMemorySearchConfig | null {
   const defaults = cfg.agents?.defaults?.memorySearch;
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
-  const resolved = mergeConfig(defaults, overrides, agentId);
+  const resolved = mergeConfig(cfg, defaults, overrides, agentId);
   if (!resolved.enabled) {
     return null;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider =
-    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);
+    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider, cfg);
   if (
     multimodalActive &&
     !(multimodalProvider?.supportsMultimodalEmbeddings?.({ model: resolved.model }) ?? false)


### PR DESCRIPTION
## Summary

- Problem: When memory is intentionally disabled (`plugins.entries.memory-core.enabled: false`, `plugins.slots.memory: "none"`), `openclaw doctor --non-interactive` emits two false-positive lines:
  - `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ...`
  - `Error: Bundled plugin public surface access blocked for "memory-core" via memory-core/runtime-api.js: disabled in config`
- Why it matters: The reporter has memory intentionally off and a real `plugins.allow` allowlist. Doctor should emit a clean informational result ("No active memory plugin is registered for the current config."), not fire warnings derived from a synthesized compat config. Runtime behavior is already correct; only the report was wrong.
- What changed: Threaded `cfg` through the three `getMemoryEmbeddingProvider` call sites in `src/agents/memory-search.ts` so the capability-resolution chain sees the real config instead of falling back to a compat view that drops `plugins.allow` and `plugins.entries`.
- What did NOT change (scope boundary): No loader changes (`src/plugins/loader.ts` untouched). No public SDK or config surface changes. `getMemoryEmbeddingProvider` already accepts an optional second `cfg` argument; this PR just starts passing it. Runtime memory-search behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68088
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `mergeConfig` in `src/agents/memory-search.ts` called `getMemoryEmbeddingProvider` without `cfg` at three sites. The capability-resolution chain (`listMemoryEmbeddingProviders` -> `resolvePluginCapabilityProviders` -> `resolveRuntimePluginRegistry`) falls back to a compat config view when `cfg` is missing. That compat view drops `plugins.allow` and `plugins.entries`, which makes the loader see an empty allowlist (first warning) and makes the memory-core activation guard see memory-core as effectively absent (second warning).
- Missing detection / guardrail: The only call site for `mergeConfig` already had the real `cfg` in scope (as the outer parameter of `resolveMemorySearchConfig`), so threading it through was mechanical - there was no test asserting it actually got passed. This PR adds one.
- Contributing context (if known): Reporter supplied a full trace stack, the root-cause analysis, and a verified diff:
  ```
  warnWhenAllowlistIsOpen (loader)
    loadOpenClawPlugins (loader)
    resolveRuntimePluginRegistry (loader)
    resolvePluginCapabilityProviders (capability-provider-runtime)
    listMemoryEmbeddingProviders (memory-embedding-provider-runtime)
    getMemoryEmbeddingProvider (memory-embedding-provider-runtime)
    mergeConfig (memory-search)
    resolveMemorySearchConfig (memory-search)
    noteMemorySearchHealth
  ```
  The reporter also confirmed locally that the patch eliminates both warnings and doctor ends with the correct informational result. Thanks to the reporter for the root-cause work.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/memory-search.test.ts`
- Scenario the test should lock in: When `resolveMemorySearchConfig(cfg, agentId)` runs with the reporter's disabled-memory config shape (`plugins.allow: []`, `plugins.entries["memory-core"].enabled: false`, `plugins.slots.memory: "none"`, a non-auto provider), every `getMemoryEmbeddingProvider` call must receive the real `cfg` object rather than `undefined`.
- Why this is the smallest reliable guardrail: The bug was a missing argument, not a missing feature. A spy on the provider lookup that asserts `cfg` is passed is the tightest possible coverage for this specific regression.
- Existing test that already covers this (if any): None. `src/agents/memory-search.test.ts` had 23 tests before; this PR adds 1.
- If no new test is added, why not: N/A. New test added (24 passing).

This contribution was developed with AI assistance (Codex).
