### PR TITLE
Infra/fetch-guard: keep guarded fetch on HTTP/1 when pinDns is disabled (#68104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/streaming: clear the compaction replay guard after visible non-final boundaries so a post-tool assistant reply rotates to a fresh preview instead of editing the pre-compaction message. (#67993) Thanks @obviyus.
 - Matrix: fix `sessions_spawn --thread` subagent session spawning — thread binding creation, cleanup on session end, and completion-message delivery target resolution now work end-to-end. (#67643) Thanks @eejohnso-ops and @gumadeiras.
 - macOS/webchat: enable Undo and Redo in the composer text input by turning on the native `NSTextView` undo manager. (#34962) Thanks @tylerbittner.
+- Infra/fetch-guard: keep guarded provider HTTP requests on HTTP/1.1 even when DNS pinning is disabled and no custom dispatcher policy is set, so undici 8's default ALPN HTTP/2 path no longer trips `HTTP/2: "stream timeout after ..."` aborts before the caller's own timeout fires on long-running Google Gemini `image_generate` calls. (#68104)
 
 ## 2026.4.15
 

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -450,6 +450,39 @@ describe("fetchWithSsrFGuard hardening", () => {
     }
   });
 
+  it("forces HTTP/1 dispatcher when DNS pinning is disabled with no explicit policy", async () => {
+    // Regression for openclaw#68104: without this, pinDns:false + no
+    // dispatcherPolicy would leave requests on the ambient global dispatcher,
+    // and undici 8's default ALPN HTTP/2 path could trip
+    // `HTTP/2: "stream timeout after ..."` before the caller's own timeout.
+    const lookupFn = createPublicLookup();
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: envHttpProxyAgentCtor,
+      ProxyAgent: proxyAgentCtor,
+      fetch: vi.fn(async () => okResponse()),
+    };
+    const fetchImpl = vi.fn(async () => okResponse());
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://public.example/resource",
+      fetchImpl,
+      lookupFn,
+      pinDns: false,
+    });
+
+    expect(agentCtor).toHaveBeenCalledWith({ allowH2: false });
+    expect(envHttpProxyAgentCtor).not.toHaveBeenCalled();
+    expect(proxyAgentCtor).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://public.example/resource",
+      expect.objectContaining({
+        dispatcher: expect.any(Object),
+      }),
+    );
+    await result.release();
+  });
+
   it("keeps explicit proxy transport policy when DNS pinning is disabled", async () => {
     const lookupFn = createPublicLookup();
     (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -127,7 +127,15 @@ function createPolicyDispatcherWithoutPinnedDns(
   dispatcherPolicy?: PinnedDispatcherPolicy,
 ): Dispatcher | null {
   if (!dispatcherPolicy) {
-    return null;
+    // Without a caller-supplied policy we would otherwise fall through to the
+    // ambient global dispatcher. Undici 8 negotiates HTTP/2 via ALPN by
+    // default, and the resulting h2 stream timeout (InformationalError
+    // `HTTP/2: "stream timeout after ..."` from undici's client-h2) has been
+    // observed to abort long provider responses before the caller's own
+    // timeout fires (openclaw#68104). Keep this path on HTTP/1.1 so the
+    // pinDns-disabled branch still matches the HTTP/1-only posture used by
+    // the pinned and explicit-proxy branches.
+    return createHttp1Agent();
   }
 
   if (dispatcherPolicy.mode === "direct") {

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -125,7 +125,7 @@ function assertExplicitProxySupportsPinnedDns(
 
 function createPolicyDispatcherWithoutPinnedDns(
   dispatcherPolicy?: PinnedDispatcherPolicy,
-): Dispatcher | null {
+): Dispatcher {
   if (!dispatcherPolicy) {
     // Without a caller-supplied policy we would otherwise fall through to the
     // ambient global dispatcher. Undici 8 negotiates HTTP/2 via ALPN by


### PR DESCRIPTION
## Summary

- Problem: Google Gemini `image_generate` calls intermittently fail with `HTTP/2: "stream timeout after 12000"` well before the provider's own 60s timeout (openclaw#68104).
- Why it matters: Users lose long-running image generations (and any other guarded provider call that runs with `pinDns: false` and no custom dispatcher policy) to a transport-level abort the caller never asked for.
- What changed: In `fetchWithSsrFGuard`, the "DNS pinning disabled + no caller policy" branch now returns a dedicated HTTP/1 `undici` agent (`createHttp1Agent()`, i.e. `allowH2: false`) instead of returning `null` and falling through to the ambient global dispatcher.
- What did NOT change (scope boundary): SSRF policy (private-network allowlisting, `resolvePinnedHostnameWithPolicy`, explicit-proxy enforcement), redirect handling, timeout guard, audit capture, public API, and config/schema/help surfaces are all untouched.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations
- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #68104
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `createPolicyDispatcherWithoutPinnedDns` in `src/infra/net/fetch-guard.ts` returned `null` when the caller passed `pinDns: false` without a `dispatcherPolicy`. With no dispatcher attached, the request resolved through Node's built-in `fetch`, which uses the global `undici` dispatcher. Since bumping to `undici` 8, the default global agent negotiates HTTP/2 via ALPN, and `generativelanguage.googleapis.com` supports HTTP/2. The undici h2 client then applies its own stream timeout (see `client-h2.js`, `InformationalError("HTTP/2: \"stream timeout after ${requestTimeout}\"")`), which aborts long Gemini `image_generate` responses before the provider-level 60s timeout fires. Every other branch in this function (pinned DNS + direct, pinned DNS + env proxy, pinned DNS + explicit proxy, unpinned DNS + explicit proxy) was already pinned to HTTP/1 via `HTTP1_ONLY_DISPATCHER_OPTIONS`; only the unpinned-DNS + no-policy branch slipped through.
- Missing detection / guardrail: `fetch-guard.ssrf.test.ts` exercised `pinDns: false` only with an explicit `dispatcherPolicy` (and the Google/OpenAI-compat provider tests mock `postJsonRequest` / `fetch`, so they never see the real dispatcher wiring). The unpinned-DNS + no-policy code path had no regression coverage.
- Contributing context: Undici 8's default-on HTTP/2 + openclaw's existing preference to keep guarded dispatchers on HTTP/1.1 until the h2 path has been re-validated end-to-end.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/infra/net/fetch-guard.ssrf.test.ts` — new case `forces HTTP/1 dispatcher when DNS pinning is disabled with no explicit policy`.
- Scenario the test should lock in: `fetchWithSsrFGuard({ pinDns: false, /* no dispatcherPolicy */ })` must construct an `undici` `Agent` with `{ allowH2: false }` and attach it as `init.dispatcher`, never falling through to the ambient global dispatcher.
- Why this is the smallest reliable guardrail: it pins the exact constructor options of the dispatcher that the fix path creates, so any future "return `null` here again" regression (or mixed ambient-dispatcher regression) fails the assertion directly, without needing a live network or a contrived h2 timeout.
- Existing test that already covers this (if any): none — the closest existing `pinDns: false` case always supplies an explicit proxy policy.

## User-visible / Behavior Changes

- Guarded provider HTTP requests that run with `pinDns: false` and no custom dispatcher policy (Google Gemini `image_generate`, OpenAI-compatible multipart audio, Google TTS, etc.) now consistently negotiate HTTP/1.1 the same way every other guarded path already did. Users who hit openclaw#68104 on long Gemini `image_generate` requests should stop seeing `HTTP/2: "stream timeout after 12000"` aborts before the caller's own timeout fires.
- No config, schema, or default-value changes.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same URLs, same headers, same timeout, same SSRF policy; only the transport ALPN preference changed from "let the OS decide" to "HTTP/1.1").
- Command/tool execution surface changed? No
- Data access scope changed? No

**Runtime controls explicitly unchanged:** the SSRF pipeline still calls `resolvePinnedHostnameWithPolicy(parsedUrl.hostname, ...)` before any dispatcher is constructed, so hostname allowlisting, private-network enforcement, and proxy-endpoint SSRF checks are all identical. The fix is a runtime transport tweak on an already-allowlisted, already-policy-checked request; it does not rely on prompt text or caller cooperation.

## Repro + Verification

### Environment

- OS: macOS 25.3 (host) — same code path applies on all platforms since it is provider-agnostic.
- Runtime: Node 22+ via `pnpm test` harness (vitest).
- Model/provider: Google Gemini `image_generate` (reporter) — reproducible in unit test against `fetchWithSsrFGuard` directly.

### Steps

1. `pnpm test src/infra/net/fetch-guard.ssrf.test.ts`
2. `pnpm test src/infra/net` (full infra/net suite)
3. `pnpm test extensions/google/image-generation-provider.test.ts extensions/google/speech-provider.test.ts src/media-understanding/openai-compatible-audio.pin-dns.test.ts extensions/minimax/music-generation-provider.test.ts` (all other `pinDns: false` callers)

### Expected

- All existing cases green; new regression case green; no neighbouring provider test regresses.

### Actual

- `src/infra/net/fetch-guard.ssrf.test.ts`: 42/42 passed (was 41/41; +1 new case).
- `src/infra/net`: 87/87 passed across 6 files.
- Related provider tests: 21/21 passed across 4 files.

## Evidence

- [x] Failing case converted to a passing regression test (see `src/infra/net/fetch-guard.ssrf.test.ts` — the new `forces HTTP/1 dispatcher...` case fails against the prior `return null` implementation because no dispatcher is attached and `agentCtor` is never called).

## Human Verification

- Verified scenarios:
  - New regression test asserts `Agent` is constructed with `{ allowH2: false }` and that `init.dispatcher` is populated on the final `fetchImpl` call.
  - Existing `keeps explicit proxy transport policy when DNS pinning is disabled` case still passes, proving the explicit-proxy branch is untouched.
  - `extensions/google/image-generation-provider.test.ts` (mocks global fetch; now silently also receives an `init.dispatcher` but asserts use `objectContaining({ body, method })`, so unaffected).
- Edge cases checked:
  - `closeDispatcher` is compatible with the agent returned by `createHttp1Agent()` (same shape used by the existing pinned and explicit-proxy branches).
  - No new lint errors reported on touched files.
  - SSRF hostname/policy checks still run before dispatcher construction (call site unchanged).
- What I did not verify:
  - A live end-to-end Gemini `image_generate` round-trip (requires network + API keys); the h2 stream-timeout trigger is upstream behavior and not deterministically reproducible offline.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A provider endpoint that previously benefited from HTTP/2 multiplexing on the ambient dispatcher would no longer get it on this branch.
  - Mitigation: Every other guarded branch in the same function already uses HTTP/1-only agents, so this is a consistency fix rather than a new constraint; callers that want HTTP/2 can still opt in by providing a `dispatcherPolicy` and the explicit wiring for it.

## Tests Run

- `pnpm test src/infra/net/fetch-guard.ssrf.test.ts` — 42 passed.
- `pnpm test src/infra/net` — 87 passed across 6 files.
- `pnpm test extensions/google/image-generation-provider.test.ts extensions/google/speech-provider.test.ts src/media-understanding/openai-compatible-audio.pin-dns.test.ts extensions/minimax/music-generation-provider.test.ts` — 21 passed across 4 files.


Made with [Cursor](https://cursor.com)