### PR TITLE
fix(memory): preserve publicArtifacts when multiple memory plugins register capability

### DIFF
--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -181,6 +181,46 @@ describe("memory plugin state", () => {
     ]);
   });
 
+  it("preserves existing public artifacts when another memory plugin registers other capability fields", async () => {
+    registerMemoryCapability("memory-core", {
+      publicArtifacts: {
+        async listArtifacts() {
+          return [
+            {
+              kind: "memory-root",
+              workspaceDir: "/tmp/workspace",
+              relativePath: "MEMORY.md",
+              absolutePath: "/tmp/workspace/MEMORY.md",
+              agentIds: ["main"],
+              contentType: "markdown" as const,
+            },
+          ];
+        },
+      },
+    });
+
+    registerMemoryCapability("active-memory", {
+      promptBuilder: () => ["active prompt"],
+      flushPlanResolver: () => createMemoryFlushPlan("memory/active.md"),
+    });
+
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/workspace",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/workspace/MEMORY.md",
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["active prompt"]);
+    expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/active.md");
+    expect(getMemoryCapabilityRegistration()).toMatchObject({
+      pluginId: "active-memory",
+    });
+  });
+
   it("passes citations mode through to the prompt builder", () => {
     registerMemoryPromptSection(({ citationsMode }) => [
       `citations: ${citationsMode ?? "default"}`,

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -171,7 +171,14 @@ export function registerMemoryCapability(
   pluginId: string,
   capability: MemoryPluginCapability,
 ): void {
-  memoryPluginState.capability = { pluginId, capability: { ...capability } };
+  const existingCapability = memoryPluginState.capability?.capability ?? {};
+  memoryPluginState.capability = {
+    pluginId,
+    capability: {
+      ...existingCapability,
+      ...capability,
+    },
+  };
 }
 
 export function getMemoryCapabilityRegistration(): MemoryPluginCapabilityRegistration | undefined {


### PR DESCRIPTION
## Summary

- **Problem:** `registerMemoryCapability()` in `src/plugins/memory-state.ts` uses direct assignment (overwrite), not merge. When a later memory plugin registers a capability without `publicArtifacts`, it wipes out an earlier plugin's `publicArtifacts` export, causing `listActiveMemoryPublicArtifacts()` to return an empty array.
- **Why it matters:** `memory-wiki` bridge mode depends on `listActiveMemoryPublicArtifacts()` to discover memory artifacts. When both `memory-core` and `active-memory` are enabled, `active-memory` loads after `memory-core` and overwrites the capability, so `wiki bridge import` always returns 0 artifacts, 0 workspaces.
- **What changed:** `registerMemoryCapability()` now shallow-merges with the existing capability registration instead of overwriting it entirely. Fields that the new plugin does not explicitly provide (e.g. `publicArtifacts`) are preserved from the previous registration.
- **What did NOT change (scope boundary):** No multi-plugin capability registry was introduced. No changes to plugin load order, bridge auto-sync strategy, or any other plugin's registration logic.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Related #66925
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `registerMemoryCapability()` replaced the entire `memoryPluginState.capability` object on every call. If Plugin B registers after Plugin A, Plugin B's capability overwrites Plugin A's entirely — any fields Plugin B doesn't include are lost.
- Missing detection / guardrail: No merge logic existed; the function assumed only one memory plugin would ever register.
- Contributing context: The memory plugin slot system allows only one active memory plugin, but dual-kind plugins and edge cases can result in multiple registrations hitting this path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/plugins/memory-state.test.ts`
- Scenario the test should lock in: `memory-core` registers `publicArtifacts`, then `active-memory` registers `promptBuilder` + `flushPlanResolver` without `publicArtifacts`. After both registrations, `listActiveMemoryPublicArtifacts()` should still return the artifacts from `memory-core`.
- Why this is the smallest reliable guardrail: The test directly exercises the registration merge logic and the public artifacts accessor without requiring any plugin loading infrastructure.

## User-visible / Behavior Changes

- Wiki bridge import (`openclaw wiki bridge import`) will now correctly discover and import memory artifacts when both `memory-core` and `active-memory` (or any other memory plugin) are enabled simultaneously.

## Diagram (if applicable)

```text
Before:
memory-core registers { publicArtifacts, promptBuilder, flushPlanResolver, runtime }
  → active-memory registers { promptBuilder, flushPlanResolver }
  → publicArtifacts is wiped out
  → listActiveMemoryPublicArtifacts() returns []

After:
memory-core registers { publicArtifacts, promptBuilder, flushPlanResolver, runtime }
  → active-memory registers { promptBuilder, flushPlanResolver }
  → publicArtifacts is preserved via shallow merge
  → listActiveMemoryPublicArtifacts() returns artifacts correctly
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Enable `memory-core`, `active-memory`, and `memory-wiki` (bridge mode)
2. Create `MEMORY.md` and `memory/*.md` files in the workspace
3. Run `openclaw wiki bridge import --json`
4. Before fix: `"artifactCount": 0, "workspaces": 0`
5. After fix: artifacts and workspaces are correctly discovered

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: unit test covers the exact registration order scenario from the issue
- Edge cases checked: later plugin CAN still override `publicArtifacts` if it explicitly provides one (intentional)
- What I did **not** verify: full end-to-end wiki bridge import with both plugins loaded (requires running gateway)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A later plugin that intentionally wants to clear a previously-set field (e.g. set `publicArtifacts` to `undefined`) cannot do so with shallow merge.
  - Mitigation: This is an extremely rare edge case. If a plugin explicitly provides a field, it takes effect; if it doesn't, the previous value is preserved — which is the correct default behavior. A future multi-plugin registry (Option B from the issue) would solve this more completely.