### PR TITLE
fix: surface Lobster workflow path errors

### DIFF
--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -105,6 +105,67 @@ describe("createEmbeddedLobsterRunner", () => {
     }
   });
 
+  it("surfaces missing file errors for file-like workflow paths", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lobster-runner-"));
+
+    try {
+      const runtime = {
+        runToolRequest: vi.fn(),
+        resumeToolRequest: vi.fn(),
+      };
+
+      const runner = createEmbeddedLobsterRunner({
+        loadRuntime: vi.fn().mockResolvedValue(runtime),
+      });
+
+      await expect(
+        runner.run({
+          action: "run",
+          pipeline: "lobster/missing-workflow.lobster",
+          cwd: tempDir,
+          timeoutMs: 2000,
+          maxStdoutBytes: 4096,
+        }),
+      ).rejects.toThrow(/ENOENT|no such file or directory/i);
+      expect(runtime.runToolRequest).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps inline pipelines with slash-containing args on the pipeline path", async () => {
+    const runtime = {
+      runToolRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        status: "ok",
+        output: [],
+        requiresApproval: null,
+      }),
+      resumeToolRequest: vi.fn(),
+    };
+
+    const runner = createEmbeddedLobsterRunner({
+      loadRuntime: vi.fn().mockResolvedValue(runtime),
+    });
+
+    await runner.run({
+      action: "run",
+      pipeline: "exec --json=true echo docs/tools/lobster.md",
+      cwd: process.cwd(),
+      timeoutMs: 2000,
+      maxStdoutBytes: 4096,
+    });
+
+    expect(runtime.runToolRequest).toHaveBeenCalledWith({
+      pipeline: "exec --json=true echo docs/tools/lobster.md",
+      ctx: expect.objectContaining({
+        cwd: process.cwd(),
+        mode: "tool",
+      }),
+    });
+  });
+
   it("returns a parse error when workflow args are invalid JSON", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lobster-runner-"));
     const workflowPath = path.join(tempDir, "workflow.lobster");

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -133,6 +133,34 @@ describe("createEmbeddedLobsterRunner", () => {
     }
   });
 
+  it("surfaces missing file errors for workflow paths with spaces", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lobster-runner-"));
+
+    try {
+      const runtime = {
+        runToolRequest: vi.fn(),
+        resumeToolRequest: vi.fn(),
+      };
+
+      const runner = createEmbeddedLobsterRunner({
+        loadRuntime: vi.fn().mockResolvedValue(runtime),
+      });
+
+      await expect(
+        runner.run({
+          action: "run",
+          pipeline: "lobster workflows/missing-workflow.lobster",
+          cwd: tempDir,
+          timeoutMs: 2000,
+          maxStdoutBytes: 4096,
+        }),
+      ).rejects.toThrow(/ENOENT|no such file or directory/i);
+      expect(runtime.runToolRequest).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps inline pipelines with slash-containing args on the pipeline path", async () => {
     const runtime = {
       runToolRequest: vi.fn().mockResolvedValue({

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -176,6 +176,8 @@ function throwOnErrorEnvelope(envelope: LobsterEnvelope): Extract<LobsterEnvelop
   throw new Error(envelope.error.message);
 }
 
+const WORKFLOW_FILE_EXTS = new Set([".lobster", ".yaml", ".yml", ".json"]);
+
 async function resolveWorkflowFile(candidate: string, cwd: string) {
   const { stat } = await import("node:fs/promises");
   const resolved = path.isAbsolute(candidate) ? candidate : path.resolve(cwd, candidate);
@@ -184,18 +186,24 @@ async function resolveWorkflowFile(candidate: string, cwd: string) {
     throw new Error("Workflow path is not a file");
   }
   const ext = path.extname(resolved).toLowerCase();
-  if (![".lobster", ".yaml", ".yml", ".json"].includes(ext)) {
+  if (!WORKFLOW_FILE_EXTS.has(ext)) {
     throw new Error("Workflow file must end in .lobster, .yaml, .yml, or .json");
   }
   return resolved;
 }
 
 function looksLikeWorkflowFileCandidate(candidate: string) {
-  if (!candidate || /\s/.test(candidate)) {
+  if (!candidate) {
     return false;
   }
   const ext = path.extname(candidate).toLowerCase();
-  return [".lobster", ".yaml", ".yml", ".json"].includes(ext) || /[\\/]/.test(candidate);
+  if (WORKFLOW_FILE_EXTS.has(ext)) {
+    return true;
+  }
+  if (/\s/.test(candidate)) {
+    return false;
+  }
+  return /[\\/]/.test(candidate);
 }
 
 async function detectWorkflowFile(candidate: string, cwd: string) {

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -190,6 +190,14 @@ async function resolveWorkflowFile(candidate: string, cwd: string) {
   return resolved;
 }
 
+function looksLikeWorkflowFileCandidate(candidate: string) {
+  if (!candidate || /\s/.test(candidate)) {
+    return false;
+  }
+  const ext = path.extname(candidate).toLowerCase();
+  return [".lobster", ".yaml", ".yml", ".json"].includes(ext) || /[\\/]/.test(candidate);
+}
+
 async function detectWorkflowFile(candidate: string, cwd: string) {
   const trimmed = candidate.trim();
   if (!trimmed || trimmed.includes("|")) {
@@ -197,7 +205,10 @@ async function detectWorkflowFile(candidate: string, cwd: string) {
   }
   try {
     return await resolveWorkflowFile(trimmed, cwd);
-  } catch {
+  } catch (error) {
+    if (looksLikeWorkflowFileCandidate(trimmed)) {
+      throw error;
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- preserve missing-file errors when the Lobster tool input is clearly a workflow path
- keep inline pipeline strings with slash-containing arguments on the pipeline execution path
- add regression coverage for both cases

## Testing
- pnpm exec vitest run extensions/lobster/src/lobster-runner.test.ts extensions/lobster/src/lobster-tool.test.ts
- git commit hook `pnpm check` suite

Fixes openclaw/openclaw#68101