### PR TITLE
fix(discord): use normalized target in parseDiscordExplicitTarget

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -465,6 +465,49 @@ describe("discordPlugin security", () => {
   });
 });
 
+describe("discordPlugin messaging parseExplicitTarget", () => {
+  it("preserves user:/channel: kind prefix in the outbound `to` (regression: Unknown Channel)", () => {
+    // Regression: previously returned `target.id` (a bare snowflake) which was
+    // downstream re-parsed as a guild channel id, causing Discord error 10003
+    // "Unknown Channel" for DM cron deliveries. See #68179.
+    const parseExplicitTarget = discordPlugin.messaging?.parseExplicitTarget;
+    if (!parseExplicitTarget) {
+      throw new Error("Expected discordPlugin.messaging.parseExplicitTarget to be defined");
+    }
+
+    expect(parseExplicitTarget({ raw: "<@123>" })).toEqual({
+      to: "user:123",
+      chatType: "direct",
+    });
+    expect(parseExplicitTarget({ raw: "user:123" })).toEqual({
+      to: "user:123",
+      chatType: "direct",
+    });
+    expect(parseExplicitTarget({ raw: "channel:456" })).toEqual({
+      to: "channel:456",
+      chatType: "channel",
+    });
+    // Bare snowflake falls back to defaultKind "channel".
+    expect(parseExplicitTarget({ raw: "789" })).toEqual({
+      to: "channel:789",
+      chatType: "channel",
+    });
+  });
+
+  it("infers direct chat type from a user-prefixed `to`", () => {
+    // Paired check with parseExplicitTarget: inferTargetChatType consumes the
+    // same helper, so a bare snowflake must never be presented as `to` from
+    // the producer side (that would default to "channel" and mis-route DMs).
+    const inferTargetChatType = discordPlugin.messaging?.inferTargetChatType;
+    if (!inferTargetChatType) {
+      throw new Error("Expected discordPlugin.messaging.inferTargetChatType to be defined");
+    }
+
+    expect(inferTargetChatType({ to: "user:123" })).toBe("direct");
+    expect(inferTargetChatType({ to: "channel:456" })).toBe("channel");
+  });
+});
+
 describe("discordPlugin groups", () => {
   it("uses plugin-owned group policy resolvers", () => {
     const cfg = {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -376,7 +376,10 @@ function parseDiscordExplicitTarget(raw: string) {
       return null;
     }
     return {
-      to: target.id,
+      // Use normalized `user:<id>` / `channel:<id>` so session/cron explicit targets
+      // are not reduced to bare snowflakes (ambiguous vs guild channel ids → Discord
+      // "Unknown Channel" on outbound cron delivery).
+      to: target.normalized,
       chatType: target.kind === "user" ? ("direct" as const) : ("channel" as const),
     };
   } catch {


### PR DESCRIPTION
## Problem

`parseDiscordExplicitTarget` in `extensions/discord/src/channel.ts` currently returns `to: target.id`, stripping the `user:` / `channel:` kind prefix that `parseDiscordTarget` produces as `target.normalized`.

That function is wired into both:
- `parseExplicitTarget: ({ raw }) => parseDiscordExplicitTarget(raw)`
- `inferTargetChatType: ({ to }) => parseDiscordExplicitTarget(to)?.chatType`

For explicit Discord targets coming from cron / session configs (e.g. `user:773179501735444523`), the outbound path then sees a bare snowflake. Downstream channel resolution treats that as a guild channel id, cannot find it, and Discord returns **Unknown Channel**:

```
[delivery-recovery] Retry failed for delivery <uuid>: Unknown Channel
[delivery-recovery] Delivery recovery complete: 0 recovered, 3 failed, 1 skipped (max retries), 0 deferred
```

This reproduces on every Discord-DM cron job that uses an explicit `user:<id>` target.

## Fix

Return `target.normalized` instead of `target.id` in `parseDiscordExplicitTarget`, so the kind prefix survives. `chatType` is already derived from `target.kind`, so no other behavior changes — `inferTargetChatType` continues to work correctly, and direct-message resolution now sees `user:<id>` and takes the DM code path.

```diff
     return {
-      to: target.id,
+      // Use normalized `user:<id>` / `channel:<id>` so session/cron explicit targets
+      // are not reduced to bare snowflakes (ambiguous vs guild channel ids → Discord
+      // "Unknown Channel" on outbound cron delivery).
+      to: target.normalized,
       chatType: target.kind === "user" ? ("direct" as const) : ("channel" as const),
     };
```

## Test evidence

Targeted Discord channel-adapter and target-parsing tests all pass against the patched branch:

```
$ node --no-maglev node_modules/vitest/vitest.mjs run \
    extensions/discord/src/channel.test.ts \
    extensions/discord/src/targets.test.ts

 Test Files  2 passed (2)
      Tests  27 passed (27)
   Duration  20.30s
```

This patch has been running in production on the OpenClaw deployment that originally hit the bug for several weeks; after applying it, "Unknown Channel" cron failures on `user:<id>` Discord targets stopped.

## Notes

- Branched from `v2026.4.14`.
- Single-file, 3-line functional change (plus a code comment).
- No config or API surface changes.

Made with [Cursor](https://cursor.com)