### PR TITLE
fix(agents): filter bundled tools through final policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - Cron/isolated-agent: preserve `trusted: false` on isolated cron awareness events mirrored into the main session, and forward the optional `trusted` flag through the gateway cron wrapper so explicit trust downgrades survive session-key scoping. (#68210)
 - Agents/fallback: recognize bare leading ZenMux `402 ...` quota-refresh errors without misclassifying plain numeric `402 ...` text, and keep the embedded fallback regression coverage stable. (#47579) Thanks @bwjoke.
 - Failover/google: only treat `INTERNAL` status payloads as retryable timeouts when they also carry a `500` code, so malformed non-500 payloads do not enter the retry path. (#68238) Thanks @altaywtf and @Openbling.
+- Agents/tools: filter bundled MCP/LSP tools through the final owner-only and tool-policy pipeline after merging them into the effective tool list, so existing allowlists, deny rules, sandbox policy, subagent policy, and owner-only restrictions apply to bundled tools the same way they apply to core tools. (#68195)
 
 ## 2026.4.15
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -106,6 +106,7 @@ import {
   compactWithSafetyTimeout,
   resolveCompactionTimeoutMs,
 } from "./compaction-safety-timeout.js";
+import { applyFinalEffectiveToolPolicy } from "./effective-tool-policy.js";
 import { buildEmbeddedExtensionFactories } from "./extensions.js";
 import { applyExtraParamsToAgent } from "./extra-params.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
@@ -554,11 +555,26 @@ export async function compactEmbeddedPiSessionDirect(
           ],
         })
       : undefined;
-    const effectiveTools = [
-      ...tools,
-      ...(bundleMcpRuntime?.tools ?? []),
-      ...(bundleLspRuntime?.tools ?? []),
-    ];
+    const effectiveTools = applyFinalEffectiveToolPolicy({
+      tools: [...tools, ...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
+      config: params.config,
+      sandboxToolPolicy: sandbox?.tools,
+      sessionKey: sandboxSessionKey,
+      modelProvider: model.provider,
+      modelId,
+      messageProvider: resolvedMessageProvider,
+      agentAccountId: params.agentAccountId,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+      warn: (message) => log.warn(message),
+    });
     const allowedToolNames = collectAllowedToolNames({ tools: effectiveTools });
     logProviderToolSchemaDiagnostics({
       tools: effectiveTools,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -555,8 +555,8 @@ export async function compactEmbeddedPiSessionDirect(
           ],
         })
       : undefined;
-    const effectiveTools = applyFinalEffectiveToolPolicy({
-      tools: [...tools, ...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
+    const filteredBundledTools = applyFinalEffectiveToolPolicy({
+      bundledTools: [...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
       config: params.config,
       sandboxToolPolicy: sandbox?.tools,
       sessionKey: sandboxSessionKey,
@@ -576,6 +576,7 @@ export async function compactEmbeddedPiSessionDirect(
       senderIsOwner: params.senderIsOwner,
       warn: (message) => log.warn(message),
     });
+    const effectiveTools = [...tools, ...filteredBundledTools];
     const allowedToolNames = collectAllowedToolNames({ tools: effectiveTools });
     logProviderToolSchemaDiagnostics({
       tools: effectiveTools,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -560,7 +560,12 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
       sandboxToolPolicy: sandbox?.tools,
       sessionKey: sandboxSessionKey,
-      agentId: effectiveSkillAgentId,
+      // Intentionally omit explicit agentId: the core tools just built with
+      // createOpenClawCodingTools(...) also omit it, so both paths resolve
+      // agentId the same way via resolveAgentIdFromSessionKey(sessionKey).
+      // Passing effectiveSkillAgentId here would diverge from the core-tool
+      // policy for legacy/non-agent session keys where the two sources fall
+      // back to different ids.
       modelProvider: model.provider,
       modelId,
       messageProvider: resolvedMessageProvider,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -560,6 +560,7 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
       sandboxToolPolicy: sandbox?.tools,
       sessionKey: sandboxSessionKey,
+      agentId: effectiveSkillAgentId,
       modelProvider: model.provider,
       modelId,
       messageProvider: resolvedMessageProvider,

--- a/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
@@ -61,4 +61,35 @@ describe("applyFinalEffectiveToolPolicy", () => {
       "effective tool policy: dropping caller-provided groupId that does not match session-derived group context",
     );
   });
+
+  it("drops caller-provided groupId when session encodes no group context (fail-closed)", () => {
+    const warnings: string[] = [];
+    applyFinalEffectiveToolPolicy({
+      bundledTools: [makeTool("mcp__bundle__read")],
+      // Direct/non-group session key: no session-derived group ids. A caller
+      // supplying a groupId here has no server-verified ground truth; it
+      // must be dropped so a spoofed group cannot reach a permissive policy.
+      sessionKey: "agent:alice:main",
+      groupId: "admin-group",
+      groupChannel: "#admin",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings).toContain(
+      "effective tool policy: dropping caller-provided groupId that does not match session-derived group context",
+    );
+  });
+
+  it("leaves groupId untouched when caller did not supply one", () => {
+    const warnings: string[] = [];
+    applyFinalEffectiveToolPolicy({
+      bundledTools: [makeTool("mcp__bundle__read")],
+      sessionKey: "agent:alice:main",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings).not.toContain(
+      "effective tool policy: dropping caller-provided groupId that does not match session-derived group context",
+    );
+  });
 });

--- a/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
@@ -92,4 +92,29 @@ describe("applyFinalEffectiveToolPolicy", () => {
       "effective tool policy: dropping caller-provided groupId that does not match session-derived group context",
     );
   });
+
+  it("does not emit unknown-entry warnings for core tool allowlists in the bundled pass", () => {
+    const warnings: string[] = [];
+    applyFinalEffectiveToolPolicy({
+      bundledTools: [makeTool("mcp__bundle__read")],
+      // Core tool names like `read` and `exec` are not in the bundled-only
+      // input here, but they are valid core tools resolved by the first
+      // pass. The bundled pass must not warn about them as "unknown".
+      config: { tools: { allow: ["read", "exec", "mcp__bundle__read"] } },
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings.some((w) => w.includes("unknown entries"))).toBe(false);
+  });
+
+  it("still warns on genuinely unknown entries in the bundled pass", () => {
+    const warnings: string[] = [];
+    applyFinalEffectiveToolPolicy({
+      bundledTools: [makeTool("mcp__bundle__read")],
+      config: { tools: { allow: ["mcp__bundle__read", "totally-made-up-tool"] } },
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings.some((w) => w.includes("totally-made-up-tool"))).toBe(true);
+  });
 });

--- a/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
@@ -16,21 +16,31 @@ function makeTool(name: string, ownerOnly = false): AnyAgentTool {
 describe("applyFinalEffectiveToolPolicy", () => {
   it("filters bundled tools through the configured allowlist", () => {
     const filtered = applyFinalEffectiveToolPolicy({
-      tools: [makeTool("message"), makeTool("mcp__bundle__fs_delete")],
-      config: { tools: { allow: ["message"] } },
+      bundledTools: [makeTool("mcp__bundle__fs_delete"), makeTool("mcp__bundle__fs_read")],
+      config: { tools: { allow: ["mcp__bundle__fs_read"] } },
       warn: () => {},
     });
 
-    expect(filtered.map((tool) => tool.name)).toEqual(["message"]);
+    expect(filtered.map((tool) => tool.name)).toEqual(["mcp__bundle__fs_read"]);
   });
 
-  it("applies owner-only filtering after bundle tools are merged", () => {
+  it("applies owner-only filtering to bundled tools", () => {
     const filtered = applyFinalEffectiveToolPolicy({
-      tools: [makeTool("message"), makeTool("mcp__bundle__admin", true)],
+      bundledTools: [makeTool("mcp__bundle__read"), makeTool("mcp__bundle__admin", true)],
       senderIsOwner: false,
       warn: () => {},
     });
 
-    expect(filtered.map((tool) => tool.name)).toEqual(["message"]);
+    expect(filtered.map((tool) => tool.name)).toEqual(["mcp__bundle__read"]);
+  });
+
+  it("returns the empty array unchanged when there are no bundled tools", () => {
+    const filtered = applyFinalEffectiveToolPolicy({
+      bundledTools: [],
+      config: { tools: { allow: ["message"] } },
+      warn: () => {},
+    });
+
+    expect(filtered).toEqual([]);
   });
 });

--- a/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
@@ -43,4 +43,22 @@ describe("applyFinalEffectiveToolPolicy", () => {
 
     expect(filtered).toEqual([]);
   });
+
+  it("drops caller-provided groupId when it disagrees with session-derived group context", () => {
+    const warnings: string[] = [];
+    applyFinalEffectiveToolPolicy({
+      bundledTools: [makeTool("mcp__bundle__read")],
+      // Session key encodes a concrete group (discord room 111); caller tries
+      // to override with a different group id so a more permissive group
+      // policy for group 222 could be consulted.
+      sessionKey: "agent:alice:discord:group:111",
+      groupId: "222",
+      groupChannel: "#different",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings).toContain(
+      "effective tool policy: dropping caller-provided groupId that does not match session-derived group context",
+    );
+  });
 });

--- a/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool } from "../tools/common.js";
+import { applyFinalEffectiveToolPolicy } from "./effective-tool-policy.js";
+
+function makeTool(name: string, ownerOnly = false): AnyAgentTool {
+  return {
+    name,
+    label: name,
+    description: name,
+    parameters: { type: "object", properties: {} },
+    ownerOnly,
+    execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+  };
+}
+
+describe("applyFinalEffectiveToolPolicy", () => {
+  it("filters bundled tools through the configured allowlist", () => {
+    const filtered = applyFinalEffectiveToolPolicy({
+      tools: [makeTool("message"), makeTool("mcp__bundle__fs_delete")],
+      config: { tools: { allow: ["message"] } },
+      warn: () => {},
+    });
+
+    expect(filtered.map((tool) => tool.name)).toEqual(["message"]);
+  });
+
+  it("applies owner-only filtering after bundle tools are merged", () => {
+    const filtered = applyFinalEffectiveToolPolicy({
+      tools: [makeTool("message"), makeTool("mcp__bundle__admin", true)],
+      senderIsOwner: false,
+      warn: () => {},
+    });
+
+    expect(filtered.map((tool) => tool.name)).toEqual(["message"]);
+  });
+});

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -66,8 +66,14 @@ function resolveTrustedGroupId(params: FinalEffectiveToolPolicyParams): {
   const sessionGroupIds = resolveGroupContextFromSessionKey(params.sessionKey).groupIds ?? [];
   const spawnedGroupIds = resolveGroupContextFromSessionKey(params.spawnedBy).groupIds ?? [];
   const trusted = [...sessionGroupIds, ...spawnedGroupIds];
+  // Fail-closed: if the session/spawnedBy keys do not encode a group context,
+  // we have no server-verified ground truth to compare the caller value
+  // against. A non-group session (direct, subagent, cron) should not consult
+  // a group-scoped tool policy at all, and accepting the caller's groupId
+  // here would let an attacker widen bundled-tool availability by sending
+  // an arbitrary group id.
   if (trusted.length === 0) {
-    return { groupId: params.groupId, dropped: false };
+    return { groupId: null, dropped: true };
   }
   if (trusted.includes(callerGroupId)) {
     return { groupId: params.groupId, dropped: false };

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -18,7 +18,12 @@ import {
 import type { AnyAgentTool } from "../tools/common.js";
 
 type FinalEffectiveToolPolicyParams = {
-  tools: AnyAgentTool[];
+  // Tools appended to the core tool set after `createOpenClawCodingTools()`
+  // has already applied owner-only and tool-policy filtering (e.g. bundled
+  // MCP/LSP tools). Only these are filtered here; re-running the pipeline over
+  // the already-filtered core tools would drop plugin tools whose WeakMap
+  // metadata no longer survives core-tool wrapping/normalization.
+  bundledTools: AnyAgentTool[];
   config?: OpenClawConfig;
   sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
   sessionKey?: string;
@@ -42,6 +47,9 @@ type FinalEffectiveToolPolicyParams = {
 export function applyFinalEffectiveToolPolicy(
   params: FinalEffectiveToolPolicyParams,
 ): AnyAgentTool[] {
+  if (params.bundledTools.length === 0) {
+    return params.bundledTools;
+  }
   const {
     agentId,
     globalPolicy,
@@ -85,7 +93,7 @@ export function applyFinalEffectiveToolPolicy(
     isSubagentSessionKey(params.sessionKey) && params.sessionKey
       ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey)
       : undefined;
-  const ownerFiltered = applyOwnerOnlyToolPolicy(params.tools, params.senderIsOwner === true);
+  const ownerFiltered = applyOwnerOnlyToolPolicy(params.bundledTools, params.senderIsOwner === true);
   return applyToolPolicyPipeline({
     tools: ownerFiltered,
     toolMeta: (tool) => getPluginToolMeta(tool),

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -1,0 +1,112 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getPluginToolMeta } from "../../plugins/tools.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
+import {
+  resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
+  resolveSubagentToolPolicyForSession,
+} from "../pi-tools.policy.js";
+import {
+  applyToolPolicyPipeline,
+  buildDefaultToolPolicyPipelineSteps,
+} from "../tool-policy-pipeline.js";
+import {
+  applyOwnerOnlyToolPolicy,
+  mergeAlsoAllowPolicy,
+  resolveToolProfilePolicy,
+} from "../tool-policy.js";
+import type { AnyAgentTool } from "../tools/common.js";
+
+type FinalEffectiveToolPolicyParams = {
+  tools: AnyAgentTool[];
+  config?: OpenClawConfig;
+  sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
+  sessionKey?: string;
+  agentId?: string;
+  modelProvider?: string;
+  modelId?: string;
+  messageProvider?: string;
+  agentAccountId?: string | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+  senderIsOwner?: boolean;
+  warn: (message: string) => void;
+};
+
+export function applyFinalEffectiveToolPolicy(
+  params: FinalEffectiveToolPolicyParams,
+): AnyAgentTool[] {
+  const {
+    agentId,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    profile,
+    providerProfile,
+    profileAlsoAllow,
+    providerProfileAlsoAllow,
+  } = resolveEffectiveToolPolicy({
+    config: params.config,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
+  });
+
+  const groupPolicy = resolveGroupToolPolicy({
+    config: params.config,
+    sessionKey: params.sessionKey,
+    spawnedBy: params.spawnedBy,
+    messageProvider: params.messageProvider,
+    groupId: params.groupId,
+    groupChannel: params.groupChannel,
+    groupSpace: params.groupSpace,
+    accountId: params.agentAccountId,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
+  const profilePolicy = resolveToolProfilePolicy(profile);
+  const providerProfilePolicy = resolveToolProfilePolicy(providerProfile);
+  const profilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(profilePolicy, profileAlsoAllow);
+  const providerProfilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(
+    providerProfilePolicy,
+    providerProfileAlsoAllow,
+  );
+  const subagentPolicy =
+    isSubagentSessionKey(params.sessionKey) && params.sessionKey
+      ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey)
+      : undefined;
+  const ownerFiltered = applyOwnerOnlyToolPolicy(params.tools, params.senderIsOwner === true);
+  return applyToolPolicyPipeline({
+    tools: ownerFiltered,
+    toolMeta: (tool) => getPluginToolMeta(tool),
+    warn: params.warn,
+    steps: [
+      ...buildDefaultToolPolicyPipelineSteps({
+        profilePolicy: profilePolicyWithAlsoAllow,
+        profile,
+        profileUnavailableCoreWarningAllowlist: profilePolicy?.allow,
+        providerProfilePolicy: providerProfilePolicyWithAlsoAllow,
+        providerProfile,
+        providerProfileUnavailableCoreWarningAllowlist: providerProfilePolicy?.allow,
+        globalPolicy,
+        globalProviderPolicy,
+        agentPolicy,
+        agentProviderPolicy,
+        groupPolicy,
+        agentId,
+      }),
+      { policy: params.sandboxToolPolicy, label: "sandbox tools.allow" },
+      { policy: subagentPolicy, label: "subagent tools.allow" },
+    ],
+  });
+}

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -3,6 +3,7 @@ import { getPluginToolMeta } from "../../plugins/tools.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
 import {
   resolveEffectiveToolPolicy,
+  resolveGroupContextFromSessionKey,
   resolveGroupToolPolicy,
   resolveSubagentToolPolicyForSession,
 } from "../pi-tools.policy.js";
@@ -17,6 +18,16 @@ import {
 } from "../tool-policy.js";
 import type { AnyAgentTool } from "../tools/common.js";
 
+/**
+ * Identity inputs used by `resolveGroupToolPolicy` to look up channel/group
+ * tool policy. These fields are an authorization signal (they can widen
+ * bundled-tool availability via a group-scoped allowlist), so callers MUST
+ * pass values derived from server-verified session metadata (session key,
+ * inbound transport event), not from tool-call or model-controlled input.
+ * The helper cross-checks caller-provided `groupId` against session-derived
+ * group ids and drops the caller value when they disagree, but it cannot
+ * detect drift on fields that have no session-bound counterpart.
+ */
 type FinalEffectiveToolPolicyParams = {
   // Tools appended to the core tool set after `createOpenClawCodingTools()`
   // has already applied owner-only and tool-policy filtering (e.g. bundled
@@ -44,11 +55,37 @@ type FinalEffectiveToolPolicyParams = {
   warn: (message: string) => void;
 };
 
+function resolveTrustedGroupId(params: FinalEffectiveToolPolicyParams): {
+  groupId: string | null | undefined;
+  dropped: boolean;
+} {
+  const callerGroupId = (params.groupId ?? "").trim();
+  if (!callerGroupId) {
+    return { groupId: params.groupId, dropped: false };
+  }
+  const sessionGroupIds = resolveGroupContextFromSessionKey(params.sessionKey).groupIds ?? [];
+  const spawnedGroupIds = resolveGroupContextFromSessionKey(params.spawnedBy).groupIds ?? [];
+  const trusted = [...sessionGroupIds, ...spawnedGroupIds];
+  if (trusted.length === 0) {
+    return { groupId: params.groupId, dropped: false };
+  }
+  if (trusted.includes(callerGroupId)) {
+    return { groupId: params.groupId, dropped: false };
+  }
+  return { groupId: null, dropped: true };
+}
+
 export function applyFinalEffectiveToolPolicy(
   params: FinalEffectiveToolPolicyParams,
 ): AnyAgentTool[] {
   if (params.bundledTools.length === 0) {
     return params.bundledTools;
+  }
+  const trustedGroup = resolveTrustedGroupId(params);
+  if (trustedGroup.dropped) {
+    params.warn(
+      "effective tool policy: dropping caller-provided groupId that does not match session-derived group context",
+    );
   }
   const {
     agentId,
@@ -73,9 +110,9 @@ export function applyFinalEffectiveToolPolicy(
     sessionKey: params.sessionKey,
     spawnedBy: params.spawnedBy,
     messageProvider: params.messageProvider,
-    groupId: params.groupId,
-    groupChannel: params.groupChannel,
-    groupSpace: params.groupSpace,
+    groupId: trustedGroup.groupId,
+    groupChannel: trustedGroup.dropped ? null : params.groupChannel,
+    groupSpace: trustedGroup.dropped ? null : params.groupSpace,
     accountId: params.agentAccountId,
     senderId: params.senderId,
     senderName: params.senderName,

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -10,6 +10,7 @@ import {
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
+  type ToolPolicyPipelineStep,
 } from "../tool-policy-pipeline.js";
 import {
   applyOwnerOnlyToolPolicy,
@@ -137,27 +138,38 @@ export function applyFinalEffectiveToolPolicy(
       ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey)
       : undefined;
   const ownerFiltered = applyOwnerOnlyToolPolicy(params.bundledTools, params.senderIsOwner === true);
+  // Suppress unavailable-core-tool warnings on every step of this pass.
+  // `applyToolPolicyPipeline` infers `coreToolNames` from the `tools` array
+  // it's filtering, and this pass only sees the bundled MCP/LSP subset.
+  // Normal core allowlist entries (e.g. `tools.allow: ["read", "exec"]`)
+  // would look "unknown" relative to that reduced set even though they are
+  // valid core names already resolved by `createOpenClawCodingTools()` in
+  // the first pass — keeping those warnings on would pollute logs and evict
+  // real diagnostics from the shared warning cache. Genuinely unknown
+  // entries (typos) still surface through the `otherEntries` path in
+  // `applyToolPolicyPipeline`.
+  const pipelineSteps: ToolPolicyPipelineStep[] = [
+    ...buildDefaultToolPolicyPipelineSteps({
+      profilePolicy: profilePolicyWithAlsoAllow,
+      profile,
+      profileUnavailableCoreWarningAllowlist: profilePolicy?.allow,
+      providerProfilePolicy: providerProfilePolicyWithAlsoAllow,
+      providerProfile,
+      providerProfileUnavailableCoreWarningAllowlist: providerProfilePolicy?.allow,
+      globalPolicy,
+      globalProviderPolicy,
+      agentPolicy,
+      agentProviderPolicy,
+      groupPolicy,
+      agentId,
+    }),
+    { policy: params.sandboxToolPolicy, label: "sandbox tools.allow" },
+    { policy: subagentPolicy, label: "subagent tools.allow" },
+  ].map((step) => ({ ...step, suppressUnavailableCoreToolWarning: true }));
   return applyToolPolicyPipeline({
     tools: ownerFiltered,
     toolMeta: (tool) => getPluginToolMeta(tool),
     warn: params.warn,
-    steps: [
-      ...buildDefaultToolPolicyPipelineSteps({
-        profilePolicy: profilePolicyWithAlsoAllow,
-        profile,
-        profileUnavailableCoreWarningAllowlist: profilePolicy?.allow,
-        providerProfilePolicy: providerProfilePolicyWithAlsoAllow,
-        providerProfile,
-        providerProfileUnavailableCoreWarningAllowlist: providerProfilePolicy?.allow,
-        globalPolicy,
-        globalProviderPolicy,
-        agentPolicy,
-        agentProviderPolicy,
-        groupPolicy,
-        agentId,
-      }),
-      { policy: params.sandboxToolPolicy, label: "sandbox tools.allow" },
-      { policy: subagentPolicy, label: "subagent tools.allow" },
-    ],
+    steps: pipelineSteps,
   });
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -125,6 +125,7 @@ import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
+import { applyFinalEffectiveToolPolicy } from "../effective-tool-policy.js";
 import { buildEmbeddedExtensionFactories } from "../extensions.js";
 import { applyExtraParamsToAgent, resolveAgentTransportOverride } from "../extra-params.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
@@ -678,11 +679,27 @@ export async function runEmbeddedAttempt(
           ],
         })
       : undefined;
-    const effectiveTools = [
-      ...tools,
-      ...(bundleMcpRuntime?.tools ?? []),
-      ...(bundleLspRuntime?.tools ?? []),
-    ];
+    const effectiveTools = applyFinalEffectiveToolPolicy({
+      tools: [...tools, ...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
+      config: params.config,
+      sandboxToolPolicy: sandbox?.tools,
+      sessionKey: sandboxSessionKey,
+      agentId: sessionAgentId,
+      modelProvider: params.provider,
+      modelId: params.modelId,
+      messageProvider: params.messageChannel ?? params.messageProvider,
+      agentAccountId: params.agentAccountId,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+      warn: (message) => log.warn(message),
+    });
     const allowedToolNames = collectAllowedToolNames({
       tools: effectiveTools,
       clientTools,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -679,8 +679,8 @@ export async function runEmbeddedAttempt(
           ],
         })
       : undefined;
-    const effectiveTools = applyFinalEffectiveToolPolicy({
-      tools: [...tools, ...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
+    const filteredBundledTools = applyFinalEffectiveToolPolicy({
+      bundledTools: [...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
       config: params.config,
       sandboxToolPolicy: sandbox?.tools,
       sessionKey: sandboxSessionKey,
@@ -700,6 +700,7 @@ export async function runEmbeddedAttempt(
       senderIsOwner: params.senderIsOwner,
       warn: (message) => log.warn(message),
     });
+    const effectiveTools = [...tools, ...filteredBundledTools];
     const allowedToolNames = collectAllowedToolNames({
       tools: effectiveTools,
       clientTools,

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -174,7 +174,7 @@ function buildScopedGroupIdCandidates(groupId?: string | null): string[] {
   return [raw];
 }
 
-function resolveGroupContextFromSessionKey(sessionKey?: string | null): {
+export function resolveGroupContextFromSessionKey(sessionKey?: string | null): {
   channel?: string;
   groupIds?: string[];
 } {

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -70,6 +70,9 @@ export const MessageActionParamsSchema = Type.Object(
     params: Type.Record(Type.String(), Type.Unknown()),
     accountId: Type.Optional(Type.String()),
     requesterSenderId: Type.Optional(Type.String()),
+    // Deprecated on the wire: the gateway derives owner status from the
+    // authenticated caller's scopes and ignores any value sent here. Kept
+    // optional to avoid rejecting existing clients that still include it.
     senderIsOwner: Type.Optional(Type.Boolean()),
     sessionKey: Type.Optional(Type.String()),
     sessionId: Type.Optional(Type.String()),

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -70,9 +70,10 @@ export const MessageActionParamsSchema = Type.Object(
     params: Type.Record(Type.String(), Type.Unknown()),
     accountId: Type.Optional(Type.String()),
     requesterSenderId: Type.Optional(Type.String()),
-    // Deprecated on the wire: the gateway derives owner status from the
-    // authenticated caller's scopes and ignores any value sent here. Kept
-    // optional to avoid rejecting existing clients that still include it.
+    // Honored only when the RPC caller has the full operator scope set
+    // (shared-secret bearer or `operator.admin`). For narrowly-scoped
+    // callers (e.g. `operator.write`-only) the gateway forces this to
+    // `false` regardless of the value sent here.
     senderIsOwner: Type.Optional(Type.Boolean()),
     sessionKey: Type.Optional(Type.String()),
     sessionId: Type.Optional(Type.String()),

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -156,14 +156,17 @@ async function runPollWithClient(
   return { respond };
 }
 
-async function runMessageActionRequest(params: Record<string, unknown>) {
+async function runMessageActionRequest(
+  params: Record<string, unknown>,
+  client?: { connect?: { scopes?: string[] } } | null,
+) {
   const respond = vi.fn();
   await sendHandlers["message.action"]({
     params: params as never,
     respond,
     context: makeContext(),
     req: { type: "req", id: "1", method: "message.action" },
-    client: null as never,
+    client: (client ?? null) as never,
     isWebchatConnect: () => false,
   });
   return { respond };
@@ -953,5 +956,70 @@ describe("gateway send mirroring", () => {
       undefined,
       { channel: "whatsapp" },
     );
+  });
+
+  it("ignores client-provided senderIsOwner and derives it from authenticated scopes", async () => {
+    const capture = { senderIsOwner: undefined as boolean | undefined };
+    const reactPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "WhatsApp owner-derivation test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"], reactions: true },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["react"] }),
+        supportsAction: ({ action }) => action === "react",
+        handleAction: async ({ senderIsOwner }) => {
+          capture.senderIsOwner = senderIsOwner;
+          return jsonResult({ ok: true });
+        },
+      },
+    };
+    mocks.getChannelPlugin.mockReturnValue(reactPlugin);
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "whatsapp", source: "test", plugin: reactPlugin },
+      ]),
+      "send-test-owner-derive-non-admin",
+    );
+
+    await runMessageActionRequest(
+      {
+        channel: "whatsapp",
+        action: "react",
+        params: { chatJid: "+15551234567", messageId: "wamid.x", emoji: "✅" },
+        senderIsOwner: true,
+        idempotencyKey: "idem-owner-derive-non-admin",
+      },
+      { connect: { scopes: ["operator.write"] } },
+    );
+    expect(capture.senderIsOwner).toBe(false);
+
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "whatsapp", source: "test", plugin: reactPlugin },
+      ]),
+      "send-test-owner-derive-admin",
+    );
+    await runMessageActionRequest(
+      {
+        channel: "whatsapp",
+        action: "react",
+        params: { chatJid: "+15551234567", messageId: "wamid.y", emoji: "✅" },
+        senderIsOwner: false,
+        idempotencyKey: "idem-owner-derive-admin",
+      },
+      { connect: { scopes: ["operator.admin"] } },
+    );
+    expect(capture.senderIsOwner).toBe(true);
   });
 });

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -958,7 +958,7 @@ describe("gateway send mirroring", () => {
     );
   });
 
-  it("ignores client-provided senderIsOwner and derives it from authenticated scopes", async () => {
+  it("forces senderIsOwner=false for narrowly-scoped callers but honors it for full operators", async () => {
     const capture = { senderIsOwner: undefined as boolean | undefined };
     const reactPlugin: ChannelPlugin = {
       id: "whatsapp",
@@ -985,13 +985,17 @@ describe("gateway send mirroring", () => {
       },
     };
     mocks.getChannelPlugin.mockReturnValue(reactPlugin);
+
+    // Narrowly-scoped caller (e.g. gateway-forwarding least-privilege path
+    // that only requests operator.write): wire senderIsOwner=true must be
+    // forced to false so a non-admin scoped caller cannot unlock owner-only
+    // channel actions.
     setActivePluginRegistry(
       createTestRegistry([
         { pluginId: "whatsapp", source: "test", plugin: reactPlugin },
       ]),
       "send-test-owner-derive-non-admin",
     );
-
     await runMessageActionRequest(
       {
         channel: "whatsapp",
@@ -1004,22 +1008,44 @@ describe("gateway send mirroring", () => {
     );
     expect(capture.senderIsOwner).toBe(false);
 
+    // Full operator (admin-scoped): the trusted runtime is allowed to
+    // forward the real channel-sender ownership bit. Wire true → true.
     setActivePluginRegistry(
       createTestRegistry([
         { pluginId: "whatsapp", source: "test", plugin: reactPlugin },
       ]),
-      "send-test-owner-derive-admin",
+      "send-test-owner-derive-admin-true",
     );
     await runMessageActionRequest(
       {
         channel: "whatsapp",
         action: "react",
         params: { chatJid: "+15551234567", messageId: "wamid.y", emoji: "✅" },
-        senderIsOwner: false,
-        idempotencyKey: "idem-owner-derive-admin",
+        senderIsOwner: true,
+        idempotencyKey: "idem-owner-derive-admin-true",
       },
       { connect: { scopes: ["operator.admin"] } },
     );
     expect(capture.senderIsOwner).toBe(true);
+
+    // Full operator forwarding a non-owner sender: wire false → false
+    // (admin scope does not inflate ownership on its own).
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "whatsapp", source: "test", plugin: reactPlugin },
+      ]),
+      "send-test-owner-derive-admin-false",
+    );
+    await runMessageActionRequest(
+      {
+        channel: "whatsapp",
+        action: "react",
+        params: { chatJid: "+15551234567", messageId: "wamid.z", emoji: "✅" },
+        senderIsOwner: false,
+        idempotencyKey: "idem-owner-derive-admin-false",
+      },
+      { connect: { scopes: ["operator.admin"] } },
+    );
+    expect(capture.senderIsOwner).toBe(false);
   });
 });

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -218,12 +218,22 @@ export const sendHandlers: GatewayRequestHandlers = {
       idempotencyKey: string;
     };
     // Owner status is an authorization signal used to unlock owner-only
-    // channel actions and owner-only tool policy. Derive it from the
-    // authenticated gateway client scopes so a non-admin caller cannot
-    // spoof owner identity by setting `senderIsOwner: true` on the wire.
-    // Any `senderIsOwner` on the request payload is ignored.
+    // channel actions and owner-only tool policy. The legitimate propagation
+    // path is the trusted runtime forwarding a real channel-sender ownership
+    // bit through the gateway RPC — but that wire value must not be honored
+    // for callers who are not already full operators. Per SECURITY.md,
+    // shared-secret bearer and admin-scoped callers get the full default
+    // operator scope set (including `operator.admin`); those callers are
+    // trusted to forward `senderIsOwner`. Narrowly-scoped callers
+    // (e.g. `operator.write`-only, including the gateway-forwarding
+    // least-privilege path) are not trusted to assert ownership, so their
+    // wire value is forced to `false` to prevent a non-admin scoped caller
+    // from unlocking owner-only channel actions by setting
+    // `senderIsOwner: true` on the request.
     const callerScopes = client?.connect?.scopes ?? [];
-    const senderIsOwner = Array.isArray(callerScopes) && callerScopes.includes(ADMIN_SCOPE);
+    const callerIsFullOperator =
+      Array.isArray(callerScopes) && callerScopes.includes(ADMIN_SCOPE);
+    const senderIsOwner = callerIsFullOperator && request.senderIsOwner === true;
     const idem = request.idempotencyKey;
     const dedupeKey = `message.action:${idem}`;
     const cached = context.dedupe.get(dedupeKey);

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -34,6 +34,7 @@ import {
   validatePollParams,
   validateSendParams,
 } from "../protocol/index.js";
+import { ADMIN_SCOPE } from "../method-scopes.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 
@@ -185,7 +186,7 @@ function cacheGatewayDedupeFailure(params: {
 }
 
 export const sendHandlers: GatewayRequestHandlers = {
-  "message.action": async ({ params, respond, context }) => {
+  "message.action": async ({ params, respond, context, client }) => {
     const p = params;
     if (!validateMessageActionParams(p)) {
       respond(
@@ -216,6 +217,13 @@ export const sendHandlers: GatewayRequestHandlers = {
       };
       idempotencyKey: string;
     };
+    // Owner status is an authorization signal used to unlock owner-only
+    // channel actions and owner-only tool policy. Derive it from the
+    // authenticated gateway client scopes so a non-admin caller cannot
+    // spoof owner identity by setting `senderIsOwner: true` on the wire.
+    // Any `senderIsOwner` on the request payload is ignored.
+    const callerScopes = client?.connect?.scopes ?? [];
+    const senderIsOwner = Array.isArray(callerScopes) && callerScopes.includes(ADMIN_SCOPE);
     const idem = request.idempotencyKey;
     const dedupeKey = `message.action:${idem}`;
     const cached = context.dedupe.get(dedupeKey);
@@ -265,7 +273,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           params: request.params,
           accountId: normalizeOptionalString(request.accountId) ?? undefined,
           requesterSenderId: normalizeOptionalString(request.requesterSenderId) ?? undefined,
-          senderIsOwner: request.senderIsOwner,
+          senderIsOwner,
           sessionKey: normalizeOptionalString(request.sessionKey) ?? undefined,
           sessionId: normalizeOptionalString(request.sessionId) ?? undefined,
           agentId: normalizeOptionalString(request.agentId) ?? undefined,


### PR DESCRIPTION
# fix(agents): filter bundled tools through final policy

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Embedded Pi run and compaction paths appended bundled MCP/LSP tools after the core tool set had already gone through owner-only and tool-policy filtering.
- Why it matters: Bundled tools could remain callable even when existing allowlists, deny rules, sandbox policy, subagent policy, or owner-only restrictions should have blocked them.
- What changed: Added a shared final-tool filter, applied it after the bundle-tool merge in both embedded runner paths, and added regression coverage for allowlist and owner-only cases.
- What did NOT change (scope boundary): This does not introduce a new policy model or change bundle runtime creation; it only enforces the existing policy decisions on the final merged tool list.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related #<operator to fill>
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `compact.ts` and `run/attempt.ts` built `effectiveTools` by appending bundled MCP/LSP tools after `createOpenClawCodingTools()` had already enforced owner-only and tool-policy filtering on the core tool set.
- Missing detection / guardrail: There was no focused regression test asserting that bundled tools are filtered after the final merge step.
- Contributing context (if known): The same post-filter merge pattern existed in both the normal embedded run path and the compaction path.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/effective-tool-policy.test.ts`
- Scenario the test should lock in: A bundled tool merged into the final effective tool list is removed when an allowlist or owner-only restriction would exclude it.
- Why this is the smallest reliable guardrail: The bug is in final tool-list assembly, so the narrowest reliable check is a unit test around the post-merge filtering step itself.
- Existing test that already covers this (if any): None found for the merged-tool path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Bundled MCP/LSP tools now disappear from embedded Pi runs when existing tool policy would deny them.
- Non-owner senders no longer receive bundled tools that are marked owner-only after the final merge step.

## Diagram (if applicable)

```text
Before:
[core tools -> filtered] + [bundle tools -> unfiltered append] -> [agent can see denied bundled tools]

After:
[core tools -> filtered] + [bundle tools] -> [final owner/policy filter] -> [agent sees only allowed tools]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation: This change narrows the effective execution and data-access surface by applying the existing policy gates to bundled tools after merge. The main compatibility risk is that a deployment relying on the old bypass behavior may stop exposing a bundled tool; mitigation is that the helper reuses the same policy resolution already used for core tools and adds targeted regression coverage for the merged-tool path.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-107-generic x86_64
- Runtime/container: Codex task workspace
- Model/provider: <operator to fill>
- Integration/channel (if any): N/A
- Relevant config (redacted): Existing embedded Pi tool policy with a restricted allowlist / owner-only rule applied to the final effective tool set

### Steps

1. Create an effective tool list containing an allowed core tool and a bundled MCP/LSP tool.
2. Apply an allowlist or owner-only restriction that should exclude the bundled tool.
3. Run the final embedded-runner tool filter and verify only the permitted tool remains.

### Expected

- Bundled MCP/LSP tools inherit the same final owner-only and tool-policy decisions as core tools.

### Actual

- Added a shared post-merge filter in both embedded runner paths; `pnpm exec vitest run src/agents/pi-embedded-runner/effective-tool-policy.test.ts` passed with `1` file and `2` tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands run:

- `pnpm exec vitest run src/agents/pi-embedded-runner/effective-tool-policy.test.ts`
- `pnpm exec oxlint src/agents/pi-embedded-runner/effective-tool-policy.ts src/agents/pi-embedded-runner/effective-tool-policy.test.ts src/agents/pi-embedded-runner/compact.ts src/agents/pi-embedded-runner/run/attempt.ts`
- `pnpm exec tsx --eval "(async () => { await import('./src/agents/pi-embedded-runner/effective-tool-policy.ts'); await import('./src/agents/pi-embedded-runner/compact.ts'); await import('./src/agents/pi-embedded-runner/run/attempt.ts'); console.log('imports-ok'); })().catch((err) => { console.error(err); process.exit(1); });"`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed the new helper removes bundled tools for restricted allowlist and non-owner cases; confirmed the helper imports cleanly and both embedded runner call sites resolve after the wiring change.
- Edge cases checked: Rebased the branch onto the latest `upstream/main` and reran the targeted unit test afterward; kept the warning-allowlist behavior aligned with the existing `createOpenClawCodingTools()` pipeline.
- What you did **not** verify: I did not run a full-repo typecheck or full `pnpm check`; `pnpm exec tsc -p tsconfig.json --noEmit --pretty false --incremental false` exhausted heap in this environment, and the commit hook reports unrelated baseline repo errors outside this diff.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - A deployment that accidentally depended on bundled tools bypassing policy may stop exposing those tools after this change.
- Mitigation:
  - The filter reuses the same owner-only and tool-policy resolution already applied to core tools, and the new regression test locks in the intended merged-tool behavior.
- Risk:
  - The normal run path and compaction path could drift if they reimplement filtering separately in the future.
- Mitigation:
  - Both paths now call the same shared helper.
