### PR TITLE
windows-acl: replace console.warn with structured logWarn

### DIFF
--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import { runExec } from "../process/exec.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { logWarn } from "../logger.js";
 
 export type ExecFn = typeof runExec;
 
@@ -278,10 +279,7 @@ async function resolveCurrentUserSid(exec: ExecFn): Promise<string | null> {
   } catch (err) {
     // Log but do not propagate — SID resolution is best-effort.
     // Callers fall back to env-based resolution when this returns null.
-    console.warn("[windows-acl] resolveCurrentUserSid failed:", String(err));
-    // TODO: replace with a structured logger call once a lightweight per-module
-    // logger is available; console.warn can be noisy on constrained Windows hosts
-    // (e.g. strict output-capture environments or CI runners with limited stdio).
+    logWarn(`[windows-acl] resolveCurrentUserSid failed: ${String(err)}`);
     return null;
   }
 }


### PR DESCRIPTION
Fixes the TODO in resolveCurrentUserSid by using `logWarn` from the structured logger instead of `console.warn`. 

This avoids noisy output in constrained Windows hosts (e.g. strict output-capture environments or CI runners with limited stdio).

The change is minimal and preserves the existing behavior while addressing the comment.