### PR TITLE
fix(feishu): resolve card-action chat type before dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI Codex/OAuth: treat the OpenAI TLS prerequisites probe as advisory instead of a hard blocker, so Codex sign-in can still proceed when the speculative Node/OpenSSL precheck fails but the real OAuth flow still works. Thanks @vincentkoc.
 - Models status/OAuth health: align OAuth health reporting with the same effective credential view runtime uses, so expired refreshable sessions stop showing healthy by default and fresher imported Codex CLI credentials surface correctly in `models status`, doctor, and gateway auth status. Thanks @vincentkoc.
 - Twitch/setup: load Twitch through the bundled setup-entry discovery path and keep setup/status account detection aligned with runtime config. (#68008) Thanks @gumadeiras.
+- Feishu/card actions: resolve card-action chat type from the Feishu chat API when stored context is missing, preferring `chat_mode` over `chat_type`, so DM-originated card actions no longer bypass `dmPolicy` by falling through to the group handling path. (#68201)
 
 ## 2026.4.15
 

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -448,6 +448,60 @@ describe("Feishu Card Action Handler", () => {
     expect(createFeishuClientMock).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to p2p when Feishu chat API returns an error", async () => {
+    createFeishuClientMock.mockReturnValueOnce({
+      im: {
+        chat: {
+          get: vi.fn().mockResolvedValue({ code: 99, msg: "not found" }),
+        },
+      },
+    });
+    const event = createCardActionEvent({
+      token: "tok9d",
+      chatId: "oc_unknown_chat_456",
+      actionValue: { text: "/help" },
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            chat_type: "p2p",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("falls back to p2p when Feishu chat API throws", async () => {
+    createFeishuClientMock.mockReturnValueOnce({
+      im: {
+        chat: {
+          get: vi.fn().mockRejectedValue(new Error("network failure")),
+        },
+      },
+    });
+    const event = createCardActionEvent({
+      token: "tok9e",
+      chatId: "oc_broken_chat_789",
+      actionValue: { text: "/help" },
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            chat_type: "p2p",
+          }),
+        }),
+      }),
+    );
+  });
+
   it("drops duplicate structured callback tokens", async () => {
     const event = createStructuredQuickActionEvent({
       token: "tok10",

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -25,8 +25,13 @@ vi.mock("./bot.js", () => ({
   handleFeishuMessage: vi.fn(),
 }));
 
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const sendCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
 
 vi.mock("./send.js", () => ({
   sendCardFeishu: sendCardFeishuMock,
@@ -89,6 +94,13 @@ describe("Feishu Card Action Handler", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    createFeishuClientMock.mockReset().mockReturnValue({
+      im: {
+        chat: {
+          get: vi.fn().mockResolvedValue({ code: 0, data: { chat_type: "group" } }),
+        },
+      },
+    });
     vi.mocked(handleFeishuMessage)
       .mockReset()
       .mockResolvedValue(undefined as never);
@@ -352,6 +364,88 @@ describe("Feishu Card Action Handler", () => {
         }),
       }),
     );
+  });
+
+  it("resolves DM chat type from the Feishu chat API when card context omits it", async () => {
+    createFeishuClientMock.mockReturnValueOnce({
+      im: {
+        chat: {
+          get: vi.fn().mockResolvedValue({ code: 0, data: { chat_type: "p2p" } }),
+        },
+      },
+    });
+    const event = createCardActionEvent({
+      token: "tok9b",
+      chatId: "oc_dm_chat_123",
+      actionValue: { text: "/help" },
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            chat_id: "oc_dm_chat_123",
+            chat_type: "p2p",
+          }),
+        }),
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses resolved DM chat type when building approval cards without stored context", async () => {
+    createFeishuClientMock.mockReturnValueOnce({
+      im: {
+        chat: {
+          get: vi.fn().mockResolvedValue({ code: 0, data: { chat_mode: "p2p" } }),
+        },
+      },
+    });
+    const event = createCardActionEvent({
+      token: "tok9c",
+      chatId: "oc_dm_chat_234",
+      actionValue: createFeishuCardInteractionEnvelope({
+        k: "meta",
+        a: FEISHU_APPROVAL_REQUEST_ACTION,
+        m: {
+          command: "/new",
+          prompt: "Start a fresh session?",
+        },
+        c: {
+          u: "u123",
+          h: "oc_dm_chat_234",
+          e: Date.now() + 60_000,
+        },
+      }),
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime, accountId: "main" });
+
+    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        card: expect.objectContaining({
+          body: expect.objectContaining({
+            elements: expect.arrayContaining([
+              expect.objectContaining({
+                tag: "action",
+                actions: expect.arrayContaining([
+                  expect.objectContaining({
+                    value: expect.objectContaining({
+                      c: expect.objectContaining({
+                        t: "p2p",
+                      }),
+                    }),
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledTimes(1);
   });
 
   it("drops duplicate structured callback tokens", async () => {

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -175,6 +175,9 @@ function normalizeResolvedCardActionChatType(value: unknown): "p2p" | "group" | 
   return undefined;
 }
 
+const resolvedChatTypeCache = new Map<string, { value: "p2p" | "group"; expiresAt: number }>();
+const CHAT_TYPE_CACHE_TTL_MS = 30 * 60_000;
+
 async function resolveCardActionChatType(params: {
   event: FeishuCardActionEvent;
   account: ReturnType<typeof resolveFeishuRuntimeAccount>;
@@ -191,6 +194,12 @@ async function resolveCardActionChatType(params: {
     return "p2p";
   }
 
+  const now = Date.now();
+  const cached = resolvedChatTypeCache.get(chatId);
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
+  }
+
   try {
     const response = (await createFeishuClient(params.account).im.chat.get({
       path: { chat_id: chatId },
@@ -200,19 +209,21 @@ async function resolveCardActionChatType(params: {
         normalizeResolvedCardActionChatType(response.data?.chat_mode) ??
         normalizeResolvedCardActionChatType(response.data?.chat_type);
       if (resolvedChatType) {
+        resolvedChatTypeCache.set(chatId, { value: resolvedChatType, expiresAt: now + CHAT_TYPE_CACHE_TTL_MS });
         return resolvedChatType;
       }
       params.log(
-        `feishu[${params.account.accountId}]: card action ${params.event.token} missing chat type for ${chatId}; defaulting to p2p`,
+        `feishu[${params.account.accountId}]: card action missing chat type for chat; defaulting to p2p`,
       );
     } else {
       params.log(
-        `feishu[${params.account.accountId}]: failed to resolve chat type for ${chatId}: ${response.msg ?? "unknown error"}; defaulting to p2p`,
+        `feishu[${params.account.accountId}]: failed to resolve chat type: ${response.msg ?? "unknown error"}; defaulting to p2p`,
       );
     }
   } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
     params.log(
-      `feishu[${params.account.accountId}]: failed to resolve chat type for ${chatId}: ${String(err)}; defaulting to p2p`,
+      `feishu[${params.account.accountId}]: failed to resolve chat type: ${message}; defaulting to p2p`,
     );
   }
 

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -164,9 +164,9 @@ async function dispatchSyntheticCommand(params: {
 // We check chat_mode first because it directly indicates conversation type.
 // "private" maps to "p2p" as the safe-failure direction (restrictive DM
 // policy) — a private group chat misclassified as p2p is safer than the
-// reverse. "topic" is treated as group semantics.
+// reverse. "topic" and "public" are treated as group semantics.
 function normalizeResolvedCardActionChatType(value: unknown): "p2p" | "group" | undefined {
-  if (value === "group" || value === "topic") {
+  if (value === "group" || value === "topic" || value === "public") {
     return "group";
   }
   if (value === "p2p" || value === "private") {

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -158,8 +158,15 @@ async function dispatchSyntheticCommand(params: {
   });
 }
 
+// Feishu's im.chat.get returns two fields:
+//   chat_mode: conversation type — "p2p" | "group" | "topic"
+//   chat_type: privacy classification — "private" | "public"
+// We check chat_mode first because it directly indicates conversation type.
+// "private" maps to "p2p" as the safe-failure direction (restrictive DM
+// policy) — a private group chat misclassified as p2p is safer than the
+// reverse. "topic" is treated as group semantics.
 function normalizeResolvedCardActionChatType(value: unknown): "p2p" | "group" | undefined {
-  if (value === "group") {
+  if (value === "group" || value === "topic") {
     return "group";
   }
   if (value === "p2p" || value === "private") {
@@ -190,8 +197,8 @@ async function resolveCardActionChatType(params: {
     })) as { code?: number; msg?: string; data?: { chat_type?: unknown; chat_mode?: unknown } };
     if (response.code === 0) {
       const resolvedChatType =
-        normalizeResolvedCardActionChatType(response.data?.chat_type) ??
-        normalizeResolvedCardActionChatType(response.data?.chat_mode);
+        normalizeResolvedCardActionChatType(response.data?.chat_mode) ??
+        normalizeResolvedCardActionChatType(response.data?.chat_type);
       if (resolvedChatType) {
         return resolvedChatType;
       }

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -177,6 +177,7 @@ function normalizeResolvedCardActionChatType(value: unknown): "p2p" | "group" | 
 
 const resolvedChatTypeCache = new Map<string, { value: "p2p" | "group"; expiresAt: number }>();
 const CHAT_TYPE_CACHE_TTL_MS = 30 * 60_000;
+const CHAT_TYPE_CACHE_MAX_SIZE = 5_000;
 
 function pruneChatTypeCache(now: number): void {
   for (const [key, entry] of resolvedChatTypeCache.entries()) {
@@ -184,6 +185,20 @@ function pruneChatTypeCache(now: number): void {
       resolvedChatTypeCache.delete(key);
     }
   }
+  if (resolvedChatTypeCache.size > CHAT_TYPE_CACHE_MAX_SIZE) {
+    const excess = resolvedChatTypeCache.size - CHAT_TYPE_CACHE_MAX_SIZE;
+    const iter = resolvedChatTypeCache.keys();
+    for (let i = 0; i < excess; i++) {
+      const key = iter.next().value;
+      if (key !== undefined) {
+        resolvedChatTypeCache.delete(key);
+      }
+    }
+  }
+}
+
+function sanitizeLogValue(v: string): string {
+  return v.replace(/[\r\n]/g, " ").slice(0, 500);
 }
 
 async function resolveCardActionChatType(params: {
@@ -202,9 +217,10 @@ async function resolveCardActionChatType(params: {
     return "p2p";
   }
 
+  const cacheKey = `${params.account.accountId}:${chatId}`;
   const now = Date.now();
   pruneChatTypeCache(now);
-  const cached = resolvedChatTypeCache.get(chatId);
+  const cached = resolvedChatTypeCache.get(cacheKey);
   if (cached) {
     return cached.value;
   }
@@ -218,7 +234,7 @@ async function resolveCardActionChatType(params: {
         normalizeResolvedCardActionChatType(response.data?.chat_mode) ??
         normalizeResolvedCardActionChatType(response.data?.chat_type);
       if (resolvedChatType) {
-        resolvedChatTypeCache.set(chatId, { value: resolvedChatType, expiresAt: now + CHAT_TYPE_CACHE_TTL_MS });
+        resolvedChatTypeCache.set(cacheKey, { value: resolvedChatType, expiresAt: now + CHAT_TYPE_CACHE_TTL_MS });
         return resolvedChatType;
       }
       params.log(
@@ -226,13 +242,13 @@ async function resolveCardActionChatType(params: {
       );
     } else {
       params.log(
-        `feishu[${params.account.accountId}]: failed to resolve chat type: ${response.msg ?? "unknown error"}; defaulting to p2p`,
+        `feishu[${params.account.accountId}]: failed to resolve chat type: ${sanitizeLogValue(response.msg ?? "unknown error")}; defaulting to p2p`,
       );
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown";
     params.log(
-      `feishu[${params.account.accountId}]: failed to resolve chat type: ${message}; defaulting to p2p`,
+      `feishu[${params.account.accountId}]: failed to resolve chat type: ${sanitizeLogValue(message)}; defaulting to p2p`,
     );
   }
 

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -2,6 +2,7 @@ import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
 import { decodeFeishuCardAction, buildFeishuCardActionTextFallback } from "./card-interaction.js";
+import { createFeishuClient } from "./client.js";
 import {
   createApprovalCard,
   FEISHU_APPROVAL_CANCEL_ACTION,
@@ -104,7 +105,7 @@ function releaseFeishuCardActionToken(params: { token: string; accountId: string
 function buildSyntheticMessageEvent(
   event: FeishuCardActionEvent,
   content: string,
-  chatType?: "p2p" | "group",
+  chatType: "p2p" | "group",
 ): FeishuMessageEvent {
   return {
     sender: {
@@ -117,7 +118,7 @@ function buildSyntheticMessageEvent(
     message: {
       message_id: `card-action-${event.token}`,
       chat_id: event.context.chat_id || event.operator.open_id,
-      chat_type: chatType ?? (event.context.chat_id ? "group" : "p2p"),
+      chat_type: chatType,
       message_type: "text",
       content: JSON.stringify({ text: content }),
     },
@@ -136,18 +137,79 @@ async function dispatchSyntheticCommand(params: {
   cfg: ClawdbotConfig;
   event: FeishuCardActionEvent;
   command: string;
+  account: ReturnType<typeof resolveFeishuRuntimeAccount>;
   botOpenId?: string;
   runtime?: RuntimeEnv;
   accountId?: string;
   chatType?: "p2p" | "group";
 }): Promise<void> {
+  const resolvedChatType = await resolveCardActionChatType({
+    event: params.event,
+    account: params.account,
+    chatType: params.chatType,
+    log: params.runtime?.log ?? console.log,
+  });
   await handleFeishuMessage({
     cfg: params.cfg,
-    event: buildSyntheticMessageEvent(params.event, params.command, params.chatType),
+    event: buildSyntheticMessageEvent(params.event, params.command, resolvedChatType),
     botOpenId: params.botOpenId,
     runtime: params.runtime,
     accountId: params.accountId,
   });
+}
+
+function normalizeResolvedCardActionChatType(value: unknown): "p2p" | "group" | undefined {
+  if (value === "group") {
+    return "group";
+  }
+  if (value === "p2p" || value === "private") {
+    return "p2p";
+  }
+  return undefined;
+}
+
+async function resolveCardActionChatType(params: {
+  event: FeishuCardActionEvent;
+  account: ReturnType<typeof resolveFeishuRuntimeAccount>;
+  chatType?: "p2p" | "group";
+  log: (message: string) => void;
+}): Promise<"p2p" | "group"> {
+  const explicitChatType = normalizeResolvedCardActionChatType(params.chatType);
+  if (explicitChatType) {
+    return explicitChatType;
+  }
+
+  const chatId = params.event.context.chat_id?.trim();
+  if (!chatId) {
+    return "p2p";
+  }
+
+  try {
+    const response = (await createFeishuClient(params.account).im.chat.get({
+      path: { chat_id: chatId },
+    })) as { code?: number; msg?: string; data?: { chat_type?: unknown; chat_mode?: unknown } };
+    if (response.code === 0) {
+      const resolvedChatType =
+        normalizeResolvedCardActionChatType(response.data?.chat_type) ??
+        normalizeResolvedCardActionChatType(response.data?.chat_mode);
+      if (resolvedChatType) {
+        return resolvedChatType;
+      }
+      params.log(
+        `feishu[${params.account.accountId}]: card action ${params.event.token} missing chat type for ${chatId}; defaulting to p2p`,
+      );
+    } else {
+      params.log(
+        `feishu[${params.account.accountId}]: failed to resolve chat type for ${chatId}: ${response.msg ?? "unknown error"}; defaulting to p2p`,
+      );
+    }
+  } catch (err) {
+    params.log(
+      `feishu[${params.account.accountId}]: failed to resolve chat type for ${chatId}: ${String(err)}; defaulting to p2p`,
+    );
+  }
+
+  return "p2p";
 }
 
 async function sendInvalidInteractionNotice(params: {
@@ -246,7 +308,12 @@ export async function handleFeishuCardAction(params: {
             prompt,
             sessionKey: envelope.c?.s,
             expiresAt: Date.now() + FEISHU_APPROVAL_CARD_TTL_MS,
-            chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
+            chatType: await resolveCardActionChatType({
+              event,
+              account,
+              chatType: envelope.c?.t,
+              log,
+            }),
             confirmLabel: command === "/reset" ? "Reset" : "Confirm",
           }),
           accountId,
@@ -282,10 +349,11 @@ export async function handleFeishuCardAction(params: {
           cfg,
           event,
           command,
+          account,
           botOpenId: params.botOpenId,
           runtime,
           accountId,
-          chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
+          chatType: envelope.c?.t,
         });
         completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
         return;
@@ -311,6 +379,7 @@ export async function handleFeishuCardAction(params: {
       cfg,
       event,
       command: content,
+      account,
       botOpenId: params.botOpenId,
       runtime,
       accountId,

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -178,6 +178,14 @@ function normalizeResolvedCardActionChatType(value: unknown): "p2p" | "group" | 
 const resolvedChatTypeCache = new Map<string, { value: "p2p" | "group"; expiresAt: number }>();
 const CHAT_TYPE_CACHE_TTL_MS = 30 * 60_000;
 
+function pruneChatTypeCache(now: number): void {
+  for (const [key, entry] of resolvedChatTypeCache.entries()) {
+    if (entry.expiresAt <= now) {
+      resolvedChatTypeCache.delete(key);
+    }
+  }
+}
+
 async function resolveCardActionChatType(params: {
   event: FeishuCardActionEvent;
   account: ReturnType<typeof resolveFeishuRuntimeAccount>;
@@ -195,8 +203,9 @@ async function resolveCardActionChatType(params: {
   }
 
   const now = Date.now();
+  pruneChatTypeCache(now);
   const cached = resolvedChatTypeCache.get(chatId);
-  if (cached && cached.expiresAt > now) {
+  if (cached) {
     return cached.value;
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Feishu card actions without stored chat context were inferred as group messages whenever `chat_id` was present, which is true for both direct and group callbacks.
- Why it matters: DM-originated card actions could bypass the normal direct-message policy path because the synthetic event skipped into group handling.
- What changed: Card-action dispatch now prefers explicit card context, otherwise resolves the chat type through the Feishu chat API and falls back to the restrictive direct-message path when the type is still unknown.
- What did NOT change (scope boundary): This does not change Feishu allowlist policy semantics, card payload schema, or reply routing outside the missing-chat-type fallback path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related NVIDIA-dev/openclaw-tracking#459
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `extensions/feishu/src/card-action.ts` treated any callback with a truthy `context.chat_id` as a group chat, even though Feishu includes `chat_id` for direct-message callbacks too.
- Missing detection / guardrail: Card-action tests covered explicit `chatType` values, but they did not lock in the missing-context fallback path for direct-message callbacks or approval-card propagation.
- Contributing context (if known): Approval cards reused the same fallback value, so an initial misclassification could persist into later confirmation actions.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/bot.card-action.test.ts`
- Scenario the test should lock in: a DM card action and approval request with missing stored `chatType` must resolve to the direct-message path before dispatch.
- Why this is the smallest reliable guardrail: the bug lives entirely in synthetic event construction and approval-card context propagation, so focused card-action tests catch it without a live Feishu tenant.
- Existing test that already covers this (if any): existing card-action tests already cover explicit `p2p` callbacks and duplicate-token behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Feishu DM card actions without stored `chatType` now resolve as direct messages before dispatch, so restrictive `dmPolicy` settings apply consistently.
- Approval cards created from those callbacks now persist `t: "p2p"` instead of inheriting an incorrect group fallback.
- When chat type is missing, the handler now performs a read-only Feishu chat lookup and otherwise defaults to the restrictive direct-message path.

## Diagram (if applicable)

```text
Before:
[card action without t] -> [chat_id present] -> [group fallback] -> [direct-message policy skipped]

After:
[card action without t] -> [explicit t or chat lookup] -> [p2p/group] -> [normal policy path]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: When card context omits `chatType`, the handler now issues a read-only `im.chat.get` lookup to resolve the conversation mode. The lookup is limited to the existing Feishu integration credentials, and the fallback remains the restrictive direct-message path if the lookup fails or returns incomplete data.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-107-generic x86_64 GNU/Linux
- Runtime/container: Node.js v22.14.0 in the task workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): restrictive `channels.feishu.dmPolicy` modes remain unchanged; tests use mocked Feishu chat lookups

### Steps

1. Run `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/feishu/src/bot.card-action.test.ts extensions/feishu/src/monitor.card-action.lifecycle.test.ts`.
2. Simulate a Feishu card action with missing stored `chatType` and a chat lookup that returns `p2p`.
3. Simulate an approval-request card action with missing stored `chatType` and assert the generated card context stores `t: "p2p"`.

### Expected

- DM-originated card actions without stored context resolve to the direct-message path.
- Approval cards created from those callbacks persist the resolved direct-message type.

### Actual

- The targeted Vitest command exited with code 0 after the patch, including the new DM fallback and approval-card regression cases.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation command:
`node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/feishu/src/bot.card-action.test.ts extensions/feishu/src/monitor.card-action.lifecycle.test.ts`

Result:
Targeted Feishu card-action tests and lifecycle regression checks exited 0 after the fix, including the new missing-`chatType` DM assertions.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the synthetic-event fallback in `extensions/feishu/src/card-action.ts`, confirmed approval-card creation now uses the same resolver, and ran the targeted Vitest command above.
- Edge cases checked: explicit stored `chatType` still short-circuits the lookup path; empty `chat_id` still defaults to the direct-message path; Feishu `private` chat responses collapse to direct handling.
- What you did **not** verify: live Feishu callbacks against a real tenant, or ambiguous group callbacks when the Feishu chat lookup fails in production.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Card actions that arrive without stored `chatType` now depend on a chat lookup and may fall back to the restrictive direct-message path if Feishu does not return chat metadata.
  - Mitigation: Explicit `chatType` stored in generated cards still bypasses the lookup, and the new tests lock in the direct-message fallback and approval-card propagation behavior.

