### PR TITLE
fix(session): only persist user-selected auth profile overrides across /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1740,9 +1740,13 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     const storePath = await createStorePath("openclaw-reset-model-auth-auto-");
     const sessionKey = "agent:main:telegram:dm:auto-model-auth";
     const existingSessionId = "existing-session-model-auth-auto";
+    // Mirrors the failover-selection shape written by agent-runner-execution.ts:
+    // both the model pair and the auth profile are marked as auto-selected, so
+    // neither should survive a user-issued /new or /reset.
     const overrides = {
       providerOverride: "openrouter",
       modelOverride: "google/gemini-2.5-flash",
+      modelOverrideSource: "auto",
       authProfileOverride: "auto-profile",
       authProfileOverrideSource: "auto",
       authProfileOverrideCompactionCount: 3,
@@ -1791,6 +1795,73 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
       expect(result.sessionEntry.providerOverride, testCase.name).toBeUndefined();
       expect(result.sessionEntry.modelOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.authProfileOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.authProfileOverrideSource, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.authProfileOverrideCompactionCount, testCase.name).toBeUndefined();
+    }
+  });
+
+  it("preserves user-pinned model override across /new and /reset even when auth profile is auto-selected", async () => {
+    // Regression guard for the mixed-source case flagged by Codex/Greptile:
+    // model/provider overrides are tracked by `modelOverrideSource` (set to
+    // "user" by applyModelOverrideToSessionEntry when the user runs /model),
+    // which is independent of `authProfileOverrideSource`. An auto-selected
+    // auth profile must not drop the user-pinned model pair on reset.
+    const storePath = await createStorePath("openclaw-reset-user-model-auto-auth-");
+    const sessionKey = "agent:main:telegram:dm:user-model-auto-auth";
+    const existingSessionId = "existing-session-user-model-auto-auth";
+    const overrides = {
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-5",
+      modelOverrideSource: "user",
+      authProfileOverride: "auto-profile",
+      authProfileOverrideSource: "auto",
+      authProfileOverrideCompactionCount: 1,
+    } as const;
+    const cases = [
+      {
+        name: "new preserves user model override and drops auto auth profile",
+        body: "/new",
+      },
+      {
+        name: "reset preserves user model override and drops auto auth profile",
+        body: "/reset",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: { ...overrides },
+      });
+
+      const cfg = {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          From: "user-model-auto-auth",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession, testCase.name).toBe(true);
+      expect(result.resetTriggered, testCase.name).toBe(true);
+      expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
+      expect(result.sessionEntry.providerOverride, testCase.name).toBe(overrides.providerOverride);
+      expect(result.sessionEntry.modelOverride, testCase.name).toBe(overrides.modelOverride);
       expect(result.sessionEntry.authProfileOverride, testCase.name).toBeUndefined();
       expect(result.sessionEntry.authProfileOverrideSource, testCase.name).toBeUndefined();
       expect(result.sessionEntry.authProfileOverrideCompactionCount, testCase.name).toBeUndefined();

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1736,6 +1736,67 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("does not preserve auto-selected auth profile overrides across /new and /reset", async () => {
+    const storePath = await createStorePath("openclaw-reset-model-auth-auto-");
+    const sessionKey = "agent:main:telegram:dm:auto-model-auth";
+    const existingSessionId = "existing-session-model-auth-auto";
+    const overrides = {
+      providerOverride: "openrouter",
+      modelOverride: "google/gemini-2.5-flash",
+      authProfileOverride: "auto-profile",
+      authProfileOverrideSource: "auto",
+      authProfileOverrideCompactionCount: 3,
+    } as const;
+    const cases = [
+      {
+        name: "new drops auto-selected auth profile overrides",
+        body: "/new",
+      },
+      {
+        name: "reset drops auto-selected auth profile overrides",
+        body: "/reset",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: { ...overrides },
+      });
+
+      const cfg = {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: testCase.body,
+          RawBody: testCase.body,
+          CommandBody: testCase.body,
+          From: "auto-model-auth",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession, testCase.name).toBe(true);
+      expect(result.resetTriggered, testCase.name).toBe(true);
+      expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
+      expect(result.sessionEntry.providerOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.modelOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.authProfileOverride, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.authProfileOverrideSource, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.authProfileOverrideCompactionCount, testCase.name).toBeUndefined();
+    }
+  });
+
   it("preserves spawned session ownership metadata across /new and /reset", async () => {
     const storePath = await createStorePath("openclaw-reset-spawned-metadata-");
     const sessionKey = "subagent:owned-child";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -480,10 +480,19 @@ export async function initSessionState(params: {
       persistedTrace = entry.traceLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      const isUserOverride = entry.authProfileOverrideSource === "user";
-      if (isUserOverride) {
+      // Gate model/provider and auth-profile carry-overs independently, matching
+      // the canonical pattern in src/gateway/session-reset-service.ts.
+      // `modelOverrideSource` is newer than the field pair; older persisted
+      // sessions can still carry user-selected overrides without the source
+      // field set, so treat an absent source as legacy user state.
+      const preserveLegacyUserModelOverride =
+        entry.modelOverrideSource === "user" ||
+        (entry.modelOverrideSource === undefined && Boolean(entry.modelOverride));
+      if (preserveLegacyUserModelOverride && entry.modelOverride) {
         persistedModelOverride = entry.modelOverride;
         persistedProviderOverride = entry.providerOverride;
+      }
+      if (entry.authProfileOverrideSource === "user" && entry.authProfileOverride) {
         persistedAuthProfileOverride = entry.authProfileOverride;
         persistedAuthProfileOverrideSource = entry.authProfileOverrideSource;
         persistedAuthProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -480,11 +480,14 @@ export async function initSessionState(params: {
       persistedTrace = entry.traceLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
-      persistedAuthProfileOverride = entry.authProfileOverride;
-      persistedAuthProfileOverrideSource = entry.authProfileOverrideSource;
-      persistedAuthProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;
+      const isUserOverride = entry.authProfileOverrideSource === "user";
+      if (isUserOverride) {
+        persistedModelOverride = entry.modelOverride;
+        persistedProviderOverride = entry.providerOverride;
+        persistedAuthProfileOverride = entry.authProfileOverride;
+        persistedAuthProfileOverrideSource = entry.authProfileOverrideSource;
+        persistedAuthProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;
+      }
       // Explicit /new and /reset should rotate the underlying CLI conversation too.
       // Keep the model/auth choice, but force the next turn to mint a fresh CLI binding.
       persistedLabel = entry.label;


### PR DESCRIPTION
## Summary

`/new` and `/reset` currently persist `providerOverride`, `modelOverride`, and `authProfileOverride` onto the successor session entry unconditionally — including overrides that were never set by the user (auto-selected via failover, compaction-driven reassignment, etc.). That defeats the contract that these commands start a clean session and re-apply routing defaults.

This PR gates the carry-over on `authProfileOverrideSource === "user"`. If the override was user-set via `/model` or `/auth` it survives the reset; if it was auto-selected it is dropped, as expected.

**Scope:** one guard in `src/auto-reply/reply/session.ts`, plus a regression test that seeds an auto-selected override and asserts every override field is cleared after both `/new` and `/reset`.

## Why this matters

Users hitting `/new` after the system temporarily routed them onto a fallback model would previously keep that fallback pinned on the fresh session even though they explicitly asked to start clean. The bug is silent — nothing flags that the override survived — and only user-initiated overrides (`/model`, `/auth`) should be sticky across resets.

## Test plan

- [x] Added `does not preserve auto-selected auth profile overrides across /new and /reset` to `src/auto-reply/reply/session.test.ts`.
- [x] Ran the targeted vitest suites under a memory-sandbox:
  - `test/vitest/vitest.auto-reply-reply.config.ts`
  - `test/vitest/vitest.full-core-unit-fast.config.ts`
  - `src/sessions/model-overrides.test.ts`
  All passed locally.
- [x] Pre-existing user-override behaviour (carry-over when `authProfileOverrideSource === "user"`) unchanged and still covered by existing cases.


Made with [Cursor](https://cursor.com)