### PR TITLE
fix(cron): preserve untrusted awareness event labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Models status/OAuth health: align OAuth health reporting with the same effective credential view runtime uses, so expired refreshable sessions stop showing healthy by default and fresher imported Codex CLI credentials surface correctly in `models status`, doctor, and gateway auth status. Thanks @vincentkoc.
 - Twitch/setup: load Twitch through the bundled setup-entry discovery path and keep setup/status account detection aligned with runtime config. (#68008) Thanks @gumadeiras.
 - Feishu/card actions: resolve card-action chat type from the Feishu chat API when stored context is missing, preferring `chat_mode` over `chat_type`, so DM-originated card actions no longer bypass `dmPolicy` by falling through to the group handling path. (#68201)
+- Cron/isolated-agent: preserve `trusted: false` on isolated cron awareness events mirrored into the main session, and forward the optional `trusted` flag through the gateway cron wrapper so explicit trust downgrades survive session-key scoping. (#68210)
 
 ## 2026.4.15
 

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -324,6 +324,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(enqueueSystemEvent).toHaveBeenCalledWith("Morning briefing complete.", {
       sessionKey: "agent:main:main",
       contextKey: "cron-direct-delivery:v1:run-123:telegram::123456:",
+      trusted: false,
     });
   });
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -351,6 +351,7 @@ async function queueCronAwarenessSystemEvent(params: {
         agentId: params.agentId,
       }),
       contextKey: params.deliveryIdempotencyKey,
+      trusted: false,
     });
   } catch (err) {
     await logCronDeliveryWarn(

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -62,7 +62,7 @@ export type CronServiceDeps = {
   maxMissedJobsPerRestart?: number;
   enqueueSystemEvent: (
     text: string,
-    opts?: { agentId?: string; sessionKey?: string; contextKey?: string },
+    opts?: { agentId?: string; sessionKey?: string; contextKey?: string; trusted?: boolean },
   ) => void;
   requestHeartbeatNow: (opts?: { reason?: string; agentId?: string; sessionKey?: string }) => void;
   runHeartbeatOnce?: (opts?: {

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -140,6 +140,47 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("preserves trust downgrades when cron enqueues system events", () => {
+    const cfg = createCronConfig("server-cron-untrusted");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const cronDeps = (
+        state.cron as unknown as {
+          state?: {
+            deps?: {
+              enqueueSystemEvent?: (optsText: string, opts?: {
+                agentId?: string;
+                sessionKey?: string;
+                contextKey?: string;
+                trusted?: boolean;
+              }) => void;
+            };
+          };
+        }
+      ).state?.deps;
+
+      cronDeps?.enqueueSystemEvent?.("hello", {
+        sessionKey: "discord:channel:ops",
+        contextKey: "cron:test",
+        trusted: false,
+      });
+
+      expect(enqueueSystemEventMock).toHaveBeenCalledWith("hello", {
+        sessionKey: "agent:main:discord:channel:ops",
+        contextKey: "cron:test",
+        trusted: false,
+      });
+    } finally {
+      state.cron.stop();
+    }
+  });
+
   it("blocks private webhook URLs via SSRF-guarded fetch", async () => {
     const cfg = createCronConfig("server-cron-ssrf");
     loadConfigMock.mockReturnValue(cfg);

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -285,7 +285,11 @@ export function buildGatewayCronService(params: {
         agentId,
         requestedSessionKey: opts?.sessionKey,
       });
-      enqueueSystemEvent(text, { sessionKey, contextKey: opts?.contextKey });
+      enqueueSystemEvent(text, {
+        sessionKey,
+        contextKey: opts?.contextKey,
+        trusted: opts?.trusted,
+      });
     },
     requestHeartbeatNow: (opts) => {
       const { agentId, sessionKey } = resolveCronWakeTarget(opts);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Isolated cron delivery awareness text was queued into the main session without an explicit trust downgrade, and the gateway cron wrapper could drop a caller-provided `trusted: false` flag.
- Why it matters: Externally influenced or agent-generated cron text could appear in the main prompt as trusted `System:` content instead of `System (untrusted):`, weakening the trust-label boundary.
- What changed: `queueCronAwarenessSystemEvent()` now enqueues awareness text with `trusted: false`, `server-cron.ts` now forwards the optional `trusted` flag, and focused regressions were added for both paths.
- What did NOT change (scope boundary): This does not change cron delivery routing, webhook authentication, or system-event rendering semantics beyond preserving the existing untrusted label.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related #<operator to fill>
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `src/cron/isolated-agent/delivery-dispatch.ts` queued isolated cron awareness text without `trusted: false`, so `enqueueSystemEvent()` fell back to its default trusted label. `src/gateway/server-cron.ts` also failed to forward an explicit trust downgrade through the cron service wrapper.
- Missing detection / guardrail: No regression test asserted that the queued awareness event stayed untrusted or that the gateway cron wrapper preserved `trusted: false`.
- Contributing context (if known): Other external-content enqueue paths already downgrade trust explicitly, so these cron-specific paths drifted from the established contract.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`, `src/gateway/server-cron.test.ts`
- Scenario the test should lock in: isolated cron awareness events keep `trusted: false` when mirrored into the main session, and the gateway cron wrapper preserves an explicit trust downgrade when it scopes the session key.
- Why this is the smallest reliable guardrail: Both behaviors are pure local trust-metadata plumbing and can be asserted directly without standing up webhook delivery or a live gateway.
- Existing test that already covers this (if any): `delivery-dispatch.double-announce.test.ts` already covered awareness queueing, but it did not assert trust metadata.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

- Main-session cron awareness text sourced from isolated cron delivery now remains labeled as untrusted.
- Gateway cron callers that already pass `trusted: false` now keep that label after session-key scoping.

## Diagram (if applicable)

```text
Before:
[isolated cron output] -> queueCronAwarenessSystemEvent -> enqueueSystemEvent(default trusted)
                       -> main session shows System:

After:
[isolated cron output] -> queueCronAwarenessSystemEvent(trusted=false)
                       -> enqueueSystemEvent(trusted=false)
                       -> main session shows System (untrusted):
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux 6.8.0-107-generic x86_64
- Runtime/container: local source checkout
- Model/provider: N/A
- Integration/channel (if any): cron isolated-agent delivery and gateway cron service
- Relevant config (redacted): `session.mainKey: "main"`, temp cron store paths from the test harness

### Steps

1. Run `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`.
2. Run `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-cron.test.ts`.
3. Confirm the awareness enqueue expectation and cron-wrapper expectation both require `trusted: false`.

### Expected

- Isolated cron awareness text mirrored into the main session is queued with `trusted: false`.
- The gateway cron wrapper preserves `trusted: false` while scoping the session key.

### Actual

- Both targeted Vitest commands exited successfully with the new trust assertions in place.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence snippets:

- `src/cron/isolated-agent/delivery-dispatch.ts` now enqueues awareness text with `trusted: false`.
- `src/gateway/server-cron.ts` now forwards `trusted: opts?.trusted`.
- Validation commands run:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-cron.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the final diff, confirmed the isolated cron awareness enqueue now sets `trusted: false`, and confirmed the gateway cron wrapper preserves the trust flag while rewriting the session key.
- Edge cases checked: verified the added gateway regression covers a non-default scoped session key (`discord:channel:ops`) so trust propagation survives session canonicalization.
- What you did **not** verify: I did not run a live webhook-to-main-session repro outside the targeted Vitest coverage.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Another future cron enqueue path could still forget to mark externally influenced text as untrusted if it bypasses these tested helpers.
  - Mitigation: This patch covers the isolated-awareness path directly, preserves the trust flag in the shared gateway cron wrapper, and adds regressions for both behaviors.
