### PR TITLE
fix(discord): treat heartbeat ACKs as liveness signal for stale-socket detection

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -228,6 +228,44 @@ describe("runDiscordGatewayLifecycle", () => {
     expect(connectedCall![0].lastConnectedAt).toBeTypeOf("number");
   });
 
+  it("advances lastEventAt when Carbon metrics report inbound traffic (e.g. heartbeat ACKs)", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { emitter, gateway } = createGatewayHarness();
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    let resolveWait: (() => void) | undefined;
+    waitForDiscordGatewayStopMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWait = resolve;
+        }),
+    );
+
+    const { lifecycleParams, statusSink } = createLifecycleHarness({ gateway });
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    await Promise.resolve();
+
+    const baselinePatchCount = statusSink.mock.calls.length;
+    emitter.emit("metrics", { messagesReceived: 7 });
+    emitter.emit("metrics", { messagesReceived: 7 });
+    emitter.emit("metrics", { messagesReceived: 12 });
+
+    const newCalls = statusSink.mock.calls.slice(baselinePatchCount);
+    const livenessPatches = newCalls.filter((call) => {
+      const patch = (call[0] ?? {}) as Record<string, unknown>;
+      return (
+        typeof patch.lastEventAt === "number" &&
+        patch.connected === undefined &&
+        patch.lastDisconnect === undefined
+      );
+    });
+    expect(livenessPatches).toHaveLength(2);
+
+    resolveWait?.();
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+  });
+
   it("handles queued disallowed intents errors without waiting for gateway events", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const {

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -151,6 +151,25 @@ export async function runDiscordGatewayLifecycle(params: {
     mutableGateway.state.sequence = null;
     mutableGateway.sequence = null;
   };
+  // Discord's gateway sends a HeartbeatAck (op 11) every ~41.25s as keep-alive,
+  // which Carbon's ConnectionMonitor counts in `messagesReceived`. The monitor
+  // emits a `metrics` event on its own interval (60s by default). Treat any
+  // increase in `messagesReceived` between ticks as proof the socket is alive,
+  // so idle agents (no inbound messages, just heartbeat ACKs) don't get
+  // false-flagged as stale by the channel health monitor.
+  let lastObservedMessagesReceived = 0;
+  const onGatewayMetrics = (metrics: unknown) => {
+    const received =
+      typeof (metrics as { messagesReceived?: number } | undefined)?.messagesReceived === "number"
+        ? (metrics as { messagesReceived: number }).messagesReceived
+        : 0;
+    if (received > lastObservedMessagesReceived) {
+      lastObservedMessagesReceived = received;
+      pushStatus({ lastEventAt: Date.now() });
+    }
+  };
+  gatewayEmitter?.on("metrics", onGatewayMetrics);
+
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
     const at = Date.now();
@@ -330,6 +349,7 @@ export async function runDiscordGatewayLifecycle(params: {
     reconnectStallWatchdog.stop();
     clearHelloWatch();
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
+    gatewayEmitter?.removeListener("metrics", onGatewayMetrics);
     params.abortSignal?.removeEventListener("abort", onAbort);
     if (params.voiceManager) {
       await params.voiceManager.destroy();


### PR DESCRIPTION
## Summary

- **Problem:** All Discord agents cycle through stale-socket restarts on a ~35 min interval (30 min default `staleEventThresholdMs` + 5 min check interval), each costing ~90s offline due to the Discord rate-limit startup delay. Systemic, around the clock, all 10 bots.
- **Why it matters:** Agents appear offline repeatedly; silent/quiet agents are worst-hit because they have no messageCreate traffic to refresh liveness.
- **Root cause:** `lastEventAt` in `provider.lifecycle.ts` only advances on (a) inbound messageCreate events and (b) WebSocket lifecycle debug events ("opened"/"closed"/reconnect backoff). Discord's HeartbeatAck (op 11, every ~41.25s) was ignored even though Carbon's `ConnectionMonitor` counts it in `messagesReceived` and emits the metric every 60s. Idle-but-healthy agents hit the stale threshold and get wrongly restarted.
- **What changed:** Attach a `metrics` listener in the Discord lifecycle. When Carbon's `messagesReceived` counter increases between ticks, push `lastEventAt: now`. Heartbeat ACKs now count as liveness proof, so quiet agents stop getting false-flagged. Genuine dead sockets still trigger restarts because the counter stops incrementing.
- **What did NOT change (scope boundary):** No change to `channel-health-monitor.ts`, `channel-health-policy.ts`, or any thresholds. No change to Slack/Telegram/other providers. No change to Carbon internals. No config default change — the existing `channelStaleEventThresholdMinutes` override added as a runtime band-aid can be reverted after this lands.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Related: prior stale-socket work #38643, #39083, #30153

## User-visible / Behavior Changes

Discord agents that have been quiet (no channel traffic) no longer get health-monitor-restarted every ~35 minutes. No config changes required. Operators who bumped `channelStaleEventThresholdMinutes` as a workaround can revert to the 30 min default.

## Security Impact (required)

None. The fix observes an existing metrics event already emitted by Carbon's `ConnectionMonitor`; no new network activity, no new credentials, no new permissions.

## Evidence

- **Symptom (gateway.log, 2026-04-17):** 45+ stale-socket restarts across all 10 agents between 06:02 and 11:27 EDT. Pattern: every ~35 min per agent. Full log entries of the form:
  `[health-monitor] [discord:<agent>] health-monitor: restarting (reason: stale-socket)`
- **Verified root cause in code:**
  - `src/gateway/channel-health-policy.ts:126-129` — stale detection: `eventAge = now - lastEventAt; if (eventAge > threshold) return "stale-socket"`.
  - `src/discord/monitor/provider.lifecycle.ts:154-243` (pre-fix) — `onGatewayDebug` is the only hook that advances `lastEventAt` for lifecycle events, and debug events only fire on connection open/close/reconnect backoff.
  - `src/discord/monitor/provider.ts:705` — only other hook; fires only on messageCreate.
  - `@buape/carbon` `GatewayPlugin.js:136` calls `monitor.recordMessageReceived()` on every inbound WS payload, including HeartbeatAck (op 11). `ConnectionMonitor` emits `metrics` every 60s with the cumulative `messagesReceived` counter — currently consumed only by `gateway-logging.ts` for `logVerbose`.
- **Fix touches the implicated code path:** new `onGatewayMetrics` handler in `provider.lifecycle.ts` alongside the existing `onGatewayDebug`.
- **Regression test:** `provider.lifecycle.test.ts` — `advances lastEventAt when Carbon metrics report inbound traffic (e.g. heartbeat ACKs)`. Asserts two `lastEventAt` patches are pushed when `messagesReceived` goes 0 → 7 → 7 → 12 (second 7 correctly suppressed).
- **Tests:** 411 tests pass in `src/discord/monitor/` + `src/gateway/channel-health-*`. `pnpm tsgo` clean. `pnpm format:fix` applied.