### PR TITLE
fix(memory-core): read dreaming config from selected slot

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -121,7 +121,9 @@ function emitMemorySecretResolveDiagnostics(
 }
 
 function resolveMemoryPluginConfig(cfg: OpenClawConfig): Record<string, unknown> {
-  const entry = asRecord(cfg.plugins?.entries?.["memory-core"]);
+  const configuredSlot = typeof cfg.plugins?.slots?.memory === "string" ? cfg.plugins.slots.memory.trim() : "";
+  const pluginId = configuredSlot || "memory-core";
+  const entry = asRecord(cfg.plugins?.entries?.[pluginId]);
   return asRecord(entry?.config) ?? {};
 }
 

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -122,7 +122,7 @@ function emitMemorySecretResolveDiagnostics(
 
 function resolveMemoryPluginConfig(cfg: OpenClawConfig): Record<string, unknown> {
   const configuredSlot = typeof cfg.plugins?.slots?.memory === "string" ? cfg.plugins.slots.memory.trim() : "";
-  const pluginId = configuredSlot || "memory-core";
+  const pluginId = !configuredSlot || configuredSlot.toLowerCase() === "none" ? "memory-core" : configuredSlot;
   const entry = asRecord(cfg.plugins?.entries?.[pluginId]);
   return asRecord(entry?.config) ?? {};
 }

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -394,7 +394,7 @@ describe("memory cli", () => {
               config: {
                 dreaming: {
                   enabled: true,
-                  cron: "0 3 * * *",
+                  frequency: "0 3 * * *",
                 },
               },
             },
@@ -420,6 +420,39 @@ describe("memory cli", () => {
       await runMemoryCli(["status"]);
 
       expect(log).toHaveBeenCalledWith(expect.stringContaining("Dreaming: 0 3 * * *"));
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("falls back to memory-core dreaming config when the memory slot is none", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      loadConfig.mockReturnValue({
+        plugins: {
+          slots: { memory: "none" },
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 */8 * * *",
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        probeVectorAvailability: vi.fn(async () => true),
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(["status"]);
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("Dreaming: 15 */8 * * *"));
       expect(close).toHaveBeenCalled();
     });
   });

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -384,6 +384,46 @@ describe("memory cli", () => {
     });
   });
 
+  it("reads dreaming config from the selected memory slot during status", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      loadConfig.mockReturnValue({
+        plugins: {
+          slots: { memory: "memory-lancedb-pro" },
+          entries: {
+            "memory-lancedb-pro": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  cron: "0 3 * * *",
+                },
+              },
+            },
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        probeVectorAvailability: vi.fn(async () => true),
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(["status"]);
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("Dreaming: 0 3 * * *"));
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
   it("repairs invalid recall metadata and stale locks with status --fix", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");

--- a/extensions/memory-core/src/dreaming-command.test.ts
+++ b/extensions/memory-core/src/dreaming-command.test.ts
@@ -14,7 +14,8 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function resolveStoredDreaming(config: OpenClawConfig): Record<string, unknown> {
-  const entry = asRecord(config.plugins?.entries?.["memory-core"]);
+  const pluginId = config.plugins?.slots?.memory || "memory-core";
+  const entry = asRecord(config.plugins?.entries?.[pluginId]);
   const pluginConfig = asRecord(entry?.config);
   return asRecord(pluginConfig?.dreaming) ?? {};
 }
@@ -161,6 +162,46 @@ describe("memory-core /dreaming command", () => {
     expect(result.text).toContain("Dreaming enabled.");
   });
 
+  it("persists dreaming config on the selected memory slot", async () => {
+    const { command, runtime, getRuntimeConfig } = createHarness({
+      plugins: {
+        slots: {
+          memory: "memory-lancedb-pro",
+        },
+        entries: {
+          "memory-lancedb-pro": {
+            config: {
+              dreaming: {
+                frequency: "0 3 * * *",
+              },
+            },
+          },
+          "memory-core": {
+            config: {
+              dreaming: {
+                frequency: "15 */8 * * *",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const result = await command.handler(createCommandContext("on"));
+
+    expect(runtime.config.writeConfigFile).toHaveBeenCalledTimes(1);
+    expect(resolveStoredDreaming(getRuntimeConfig())).toMatchObject({
+      enabled: true,
+      frequency: "0 3 * * *",
+    });
+    const memoryCoreEntry = asRecord(getRuntimeConfig().plugins?.entries?.["memory-core"]);
+    const memoryCoreConfig = asRecord(memoryCoreEntry?.config);
+    expect(asRecord(memoryCoreConfig?.dreaming)).toMatchObject({
+      frequency: "15 */8 * * *",
+    });
+    expect(result.text).toContain("Dreaming enabled.");
+  });
+
   it("returns status without mutating config", async () => {
     const { command, runtime } = createHarness({
       plugins: {
@@ -187,6 +228,45 @@ describe("memory-core /dreaming command", () => {
     expect(result.text).toContain("- enabled: off (America/Los_Angeles)");
     expect(result.text).toContain("- sweep cadence: 15 */8 * * *");
     expect(result.text).toContain("- promotion policy: score>=0.8, recalls>=3, uniqueQueries>=3");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("shows selected-slot dreaming status without mutating config", async () => {
+    const { command, runtime } = createHarness({
+      plugins: {
+        slots: {
+          memory: "memory-lancedb-pro",
+        },
+        entries: {
+          "memory-lancedb-pro": {
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: "0 3 * * *",
+              },
+            },
+          },
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: false,
+                frequency: "15 */8 * * *",
+              },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+        },
+      },
+    });
+
+    const result = await command.handler(createCommandContext("status"));
+
+    expect(result.text).toContain("- enabled: on (America/New_York)");
+    expect(result.text).toContain("- sweep cadence: 0 3 * * *");
     expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
   });
 

--- a/extensions/memory-core/src/dreaming-command.test.ts
+++ b/extensions/memory-core/src/dreaming-command.test.ts
@@ -14,7 +14,8 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function resolveStoredDreaming(config: OpenClawConfig): Record<string, unknown> {
-  const pluginId = config.plugins?.slots?.memory || "memory-core";
+  const configuredSlot = config.plugins?.slots?.memory;
+  const pluginId = !configuredSlot || configuredSlot === "none" ? "memory-core" : configuredSlot;
   const entry = asRecord(config.plugins?.entries?.[pluginId]);
   const pluginConfig = asRecord(entry?.config);
   return asRecord(pluginConfig?.dreaming) ?? {};

--- a/extensions/memory-core/src/dreaming-command.ts
+++ b/extensions/memory-core/src/dreaming-command.ts
@@ -1,20 +1,20 @@
 import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
-import { resolveMemoryDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
+import {
+  resolveMemoryCorePluginConfig,
+  resolveMemoryDreamingConfig,
+  resolveMemoryDreamingPluginId,
+} from "openclaw/plugin-sdk/memory-core-host-status";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { asRecord } from "./dreaming-shared.js";
 import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
 
-function resolveMemoryCorePluginConfig(cfg: OpenClawConfig): Record<string, unknown> {
-  const entry = asRecord(cfg.plugins?.entries?.["memory-core"]);
-  return asRecord(entry?.config) ?? {};
-}
-
 function updateDreamingEnabledInConfig(cfg: OpenClawConfig, enabled: boolean): OpenClawConfig {
   const entries = { ...cfg.plugins?.entries };
-  const existingEntry = asRecord(entries["memory-core"]) ?? {};
+  const pluginId = resolveMemoryDreamingPluginId(cfg);
+  const existingEntry = asRecord(entries[pluginId]) ?? {};
   const existingConfig = asRecord(existingEntry.config) ?? {};
   const existingSleep = asRecord(existingConfig.dreaming) ?? {};
-  entries["memory-core"] = {
+  entries[pluginId] = {
     ...existingEntry,
     config: {
       ...existingConfig,


### PR DESCRIPTION
## Summary
- read memory CLI dreaming config from the selected memory slot instead of hardcoding `memory-core`
- keep `openclaw memory status --deep` truthful when a non-core memory plugin owns the slot
- add regression coverage for selected-slot dreaming config

## Testing
- node node_modules/vitest/vitest.mjs run extensions/memory-core/src/cli.test.ts