### PR TITLE
fix(media): anchor sanitizeMimeType regex and reject trailing garbage (#9795)

### DIFF
--- a/src/media-understanding/apply.sanitize-mime.test.ts
+++ b/src/media-understanding/apply.sanitize-mime.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeMimeType } from "./apply.js";
+
+describe("sanitizeMimeType", () => {
+  it("accepts a plain type/subtype", () => {
+    expect(sanitizeMimeType("text/plain")).toBe("text/plain");
+    expect(sanitizeMimeType("application/json")).toBe("application/json");
+  });
+
+  it("lowercases and trims the input", () => {
+    expect(sanitizeMimeType("  Text/Plain  ")).toBe("text/plain");
+    expect(sanitizeMimeType("IMAGE/PNG")).toBe("image/png");
+  });
+
+  it("strips RFC 7231 parameters while keeping the type/subtype", () => {
+    expect(sanitizeMimeType("text/plain; charset=utf-8")).toBe("text/plain");
+    expect(sanitizeMimeType("application/json;charset=utf-8")).toBe("application/json");
+    expect(sanitizeMimeType("text/plain  ;  boundary=abc")).toBe("text/plain");
+  });
+
+  it("rejects inputs with invalid characters after the subtype (regression for #9795)", () => {
+    expect(sanitizeMimeType("text/plain<script>alert(1)</script>")).toBeUndefined();
+    expect(sanitizeMimeType("text/plain garbage")).toBeUndefined();
+    expect(sanitizeMimeType("text/plain\nContent-Type: text/html")).toBeUndefined();
+  });
+
+  it("rejects inputs missing a type or subtype", () => {
+    expect(sanitizeMimeType("textplain")).toBeUndefined();
+    expect(sanitizeMimeType("/plain")).toBeUndefined();
+    expect(sanitizeMimeType("text/")).toBeUndefined();
+  });
+
+  it("returns undefined for blank or missing input", () => {
+    expect(sanitizeMimeType(undefined)).toBeUndefined();
+    expect(sanitizeMimeType("")).toBeUndefined();
+    expect(sanitizeMimeType("   ")).toBeUndefined();
+  });
+});

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -74,12 +74,18 @@ const TEXT_EXT_MIME = new Map<string, string>([
   [".xml", "application/xml"],
 ]);
 
-function sanitizeMimeType(value?: string): string | undefined {
+// Exported for direct testing; kept narrow since this is the single MIME
+// validator for media-understanding inputs.
+export function sanitizeMimeType(value?: string): string | undefined {
   const trimmed = normalizeOptionalLowercaseString(value);
   if (!trimmed) {
     return undefined;
   }
-  const match = trimmed.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)/);
+  // Anchor both ends; allow optional RFC 7231 parameters after the type/subtype.
+  // Trailing garbage (e.g. `text/plain<script>` or `text/plain\ngarbage`) is
+  // rejected outright instead of silently truncated. Input is already
+  // lowercased by normalizeOptionalLowercaseString.
+  const match = trimmed.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)(?:\s*;.*)?$/);
   return match?.[1];
 }
 


### PR DESCRIPTION
## Summary

- **Problem**: `sanitizeMimeType` in `src/media-understanding/apply.ts` used an unanchored regex (`/^(type/subtype)/`). A string like `text/plain<script>...` or `text/plain garbage` silently matched and returned `text/plain`, accepting the overall value as a valid MIME even though the input was not a well-formed RFC 7231 media type.
- **Why it matters**: The function is the single input validator for `textHint` and mime strings coming into `applyMediaUnderstanding`. Accepting malformed values risks surprising callers that rely on it to reject garbage (e.g. hints propagated from untrusted text). Reported as a security input-validation bug in #9795.
- **What changed**: The regex is now end-anchored with an optional RFC 7231 parameters tail (`(?:\s*;.*)?$`). Parameters are still dropped from the returned value, but anything else after the subtype (whitespace + garbage, control characters, junk) causes the function to return `undefined`.
- **What did NOT change (scope boundary)**: No change to `normalizeMimeType` in `src/media/mime.ts` (which already splits on `;`), no change to any caller of `sanitizeMimeType`, no change to the allowed character class for type/subtype. The function was exported purely so the new regression test can exercise it directly.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] API / contracts

## Linked Issue/PR

- Closes #9795
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: the pattern was `/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)/` with no end anchor, so any valid-looking prefix was captured and the rest was ignored.
- Missing detection / guardrail: no direct unit test for this helper existed (it was internal and only exercised through the broader `applyMediaUnderstanding` suite).

## Regression Test Plan

- [x] Unit test
- Target test or file: `src/media-understanding/apply.sanitize-mime.test.ts` (new)
- Scenarios locked in:
  - Plain `type/subtype` accepted.
  - RFC parameters (`; charset=utf-8`, `  ;  boundary=...`) stripped to just `type/subtype`.
  - Trailing garbage (`<script>`, spaces + junk, embedded newlines) rejected (returns `undefined`).
  - Missing type or subtype rejected.
  - Empty / whitespace / undefined input returns `undefined`.
- Why this is the smallest reliable guardrail: the helper has a single responsibility; pinning it in isolation catches both the original bug shape and future regex tweaks without needing to stand up the full media-understanding pipeline.

## User-visible / Behavior Changes

Very narrow: values that previously coerced to a type/subtype despite invalid trailing bytes now cause the caller to see `mimeType` as `undefined`, which then falls back to the existing detection paths. No config changes.

## Security Impact (required)

- New permissions/capabilities? No
- Tightens input validation on the MIME normalization surface used for media-understanding file attachments.

## Verification

- `pnpm test src/media-understanding/apply.sanitize-mime.test.ts` — 6 passed
- `pnpm test 'src/media-understanding/**/*.test.ts'` — 131 passed (full media-understanding suite, on the pre-cherry-pick branch)
- `pnpm check` — 0 warnings, 0 errors (pre-cherry-pick branch)

## Human Verification

- Verified scenarios: manually tried each regex input from the issue report against the updated pattern, confirmed the capture group only returns when the entire string is a valid `type/subtype` optionally followed by `;...`.
- Edge cases checked: CR/LF injection (`text/plain\nContent-Type: text/html`) now rejected; upper-case input still lowercased before matching via `normalizeOptionalLowercaseString`.
- What I did not verify: real-world corpora of MIME values seen in production (relying on the RFC 7231 shape only).

## Compatibility / Migration

- Backward compatible? Yes for well-formed input.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a caller that previously relied on lenient behavior for malformed `textHint` values will now get `undefined` and fall through to detection.
  - Mitigation: that was a latent bug in the caller; the downstream `applyMediaUnderstanding` suite continues to pass (131/131) on the scoped run, so no regressions were surfaced.