### PR TITLE
docs: use relative links in provider index to fix localization #68139

### DIFF
--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -11,7 +11,7 @@ title: "Provider Directory"
 OpenClaw can use many LLM providers. Pick a provider, authenticate, then set the
 default model as `provider/model`.
 
-Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugin)/etc.)? See [Channels](/channels).
+Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugin)/etc.)? See [Channels](../channels).
 
 ## Quick start
 
@@ -26,66 +26,66 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 ## Provider docs
 
-- [Alibaba Model Studio](/providers/alibaba)
-- [Amazon Bedrock](/providers/bedrock)
-- [Anthropic (API + Claude CLI)](/providers/anthropic)
-- [Arcee AI (Trinity models)](/providers/arcee)
-- [BytePlus (International)](/concepts/model-providers#byteplus-international)
-- [Chutes](/providers/chutes)
-- [ComfyUI](/providers/comfy)
-- [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
-- [DeepSeek](/providers/deepseek)
-- [fal](/providers/fal)
-- [Fireworks](/providers/fireworks)
-- [GitHub Copilot](/providers/github-copilot)
-- [GLM models](/providers/glm)
-- [Google (Gemini)](/providers/google)
-- [Groq (LPU inference)](/providers/groq)
-- [Hugging Face (Inference)](/providers/huggingface)
-- [inferrs (local models)](/providers/inferrs)
-- [Kilocode](/providers/kilocode)
-- [LiteLLM (unified gateway)](/providers/litellm)
-- [LM Studio (local models)](/providers/lmstudio)
-- [MiniMax](/providers/minimax)
-- [Mistral](/providers/mistral)
-- [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)
-- [NVIDIA](/providers/nvidia)
-- [Ollama (cloud + local models)](/providers/ollama)
-- [OpenAI (API + Codex)](/providers/openai)
-- [OpenCode](/providers/opencode)
-- [OpenCode Go](/providers/opencode-go)
-- [OpenRouter](/providers/openrouter)
-- [Perplexity (web search)](/providers/perplexity-provider)
-- [Qianfan](/providers/qianfan)
-- [Qwen Cloud](/providers/qwen)
-- [Runway](/providers/runway)
-- [SGLang (local models)](/providers/sglang)
-- [StepFun](/providers/stepfun)
-- [Synthetic](/providers/synthetic)
-- [Together AI](/providers/together)
-- [Venice (Venice AI, privacy-focused)](/providers/venice)
-- [Vercel AI Gateway](/providers/vercel-ai-gateway)
-- [Vydra](/providers/vydra)
-- [vLLM (local models)](/providers/vllm)
-- [Volcengine (Doubao)](/providers/volcengine)
-- [xAI](/providers/xai)
-- [Xiaomi](/providers/xiaomi)
-- [Z.AI](/providers/zai)
+- [Alibaba Model Studio](./alibaba)
+- [Amazon Bedrock](./bedrock)
+- [Anthropic (API + Claude CLI)](./anthropic)
+- [Arcee AI (Trinity models)](./arcee)
+- [BytePlus (International)](../concepts/model-providers#byteplus-international)
+- [Chutes](./chutes)
+- [ComfyUI](./comfy)
+- [Cloudflare AI Gateway](./cloudflare-ai-gateway)
+- [DeepSeek](./deepseek)
+- [fal](./fal)
+- [Fireworks](./fireworks)
+- [GitHub Copilot](./github-copilot)
+- [GLM models](./glm)
+- [Google (Gemini)](./google)
+- [Groq (LPU inference)](./groq)
+- [Hugging Face (Inference)](./huggingface)
+- [inferrs (local models)](./inferrs)
+- [Kilocode](./kilocode)
+- [LiteLLM (unified gateway)](./litellm)
+- [LM Studio (local models)](./lmstudio)
+- [MiniMax](./minimax)
+- [Mistral](./mistral)
+- [Moonshot AI (Kimi + Kimi Coding)](./moonshot)
+- [NVIDIA](./nvidia)
+- [Ollama (cloud + local models)](./ollama)
+- [OpenAI (API + Codex)](./openai)
+- [OpenCode](./opencode)
+- [OpenCode Go](./opencode-go)
+- [OpenRouter](./openrouter)
+- [Perplexity (web search)](./perplexity-provider)
+- [Qianfan](./qianfan)
+- [Qwen Cloud](./qwen)
+- [Runway](./runway)
+- [SGLang (local models)](./sglang)
+- [StepFun](./stepfun)
+- [Synthetic](./synthetic)
+- [Together AI](./together)
+- [Venice (Venice AI, privacy-focused)](./venice)
+- [Vercel AI Gateway](./vercel-ai-gateway)
+- [Vydra](./vydra)
+- [vLLM (local models)](./vllm)
+- [Volcengine (Doubao)](./volcengine)
+- [xAI](./xai)
+- [Xiaomi](./xiaomi)
+- [Z.AI](./zai)
 
 ## Shared overview pages
 
-- [Additional bundled variants](/providers/models#additional-bundled-provider-variants) - Anthropic Vertex, Copilot Proxy, and Gemini CLI OAuth
-- [Image Generation](/tools/image-generation) - Shared `image_generate` tool, provider selection, and failover
-- [Music Generation](/tools/music-generation) - Shared `music_generate` tool, provider selection, and failover
-- [Video Generation](/tools/video-generation) - Shared `video_generate` tool, provider selection, and failover
+- [Additional bundled variants](./models#additional-bundled-provider-variants) - Anthropic Vertex, Copilot Proxy, and Gemini CLI OAuth
+- [Image Generation](../tools/image-generation) - Shared `image_generate` tool, provider selection, and failover
+- [Music Generation](../tools/music-generation) - Shared `music_generate` tool, provider selection, and failover
+- [Video Generation](../tools/video-generation) - Shared `video_generate` tool, provider selection, and failover
 
 ## Transcription providers
 
-- [Deepgram (audio transcription)](/providers/deepgram)
+- [Deepgram (audio transcription)](./deepgram)
 
 ## Community tools
 
-- [Claude Max API Proxy](/providers/claude-max-api-proxy) - Community proxy for Claude subscription credentials (verify Anthropic policy/terms before use)
+- [Claude Max API Proxy](./claude-max-api-proxy) - Community proxy for Claude subscription credentials (verify Anthropic policy/terms before use)
 
 For the full provider catalog (xAI, Groq, Mistral, etc.) and advanced configuration,
-see [Model providers](/concepts/model-providers).
+see [Model providers](../concepts/model-providers).

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -11,7 +11,7 @@ title: "Provider Directory"
 OpenClaw can use many LLM providers. Pick a provider, authenticate, then set the
 default model as `provider/model`.
 
-Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugin)/etc.)? See [Channels](../channels).
+Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugin)/etc.)? See [Channels](/docs/channels).
 
 ## Quick start
 
@@ -26,66 +26,66 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 ## Provider docs
 
-- [Alibaba Model Studio](./alibaba)
-- [Amazon Bedrock](./bedrock)
-- [Anthropic (API + Claude CLI)](./anthropic)
-- [Arcee AI (Trinity models)](./arcee)
-- [BytePlus (International)](../concepts/model-providers#byteplus-international)
-- [Chutes](./chutes)
-- [ComfyUI](./comfy)
-- [Cloudflare AI Gateway](./cloudflare-ai-gateway)
-- [DeepSeek](./deepseek)
-- [fal](./fal)
-- [Fireworks](./fireworks)
-- [GitHub Copilot](./github-copilot)
-- [GLM models](./glm)
-- [Google (Gemini)](./google)
-- [Groq (LPU inference)](./groq)
-- [Hugging Face (Inference)](./huggingface)
-- [inferrs (local models)](./inferrs)
-- [Kilocode](./kilocode)
-- [LiteLLM (unified gateway)](./litellm)
-- [LM Studio (local models)](./lmstudio)
-- [MiniMax](./minimax)
-- [Mistral](./mistral)
-- [Moonshot AI (Kimi + Kimi Coding)](./moonshot)
-- [NVIDIA](./nvidia)
-- [Ollama (cloud + local models)](./ollama)
-- [OpenAI (API + Codex)](./openai)
-- [OpenCode](./opencode)
-- [OpenCode Go](./opencode-go)
-- [OpenRouter](./openrouter)
-- [Perplexity (web search)](./perplexity-provider)
-- [Qianfan](./qianfan)
-- [Qwen Cloud](./qwen)
-- [Runway](./runway)
-- [SGLang (local models)](./sglang)
-- [StepFun](./stepfun)
-- [Synthetic](./synthetic)
-- [Together AI](./together)
-- [Venice (Venice AI, privacy-focused)](./venice)
-- [Vercel AI Gateway](./vercel-ai-gateway)
-- [Vydra](./vydra)
-- [vLLM (local models)](./vllm)
-- [Volcengine (Doubao)](./volcengine)
-- [xAI](./xai)
-- [Xiaomi](./xiaomi)
-- [Z.AI](./zai)
+- [Alibaba Model Studio](/docs/providers/alibaba)
+- [Amazon Bedrock](/docs/providers/bedrock)
+- [Anthropic (API + Claude CLI)](/docs/providers/anthropic)
+- [Arcee AI (Trinity models)](/docs/providers/arcee)
+- [BytePlus (International)](/docs/concepts/model-providers#byteplus-international)
+- [Chutes](/docs/providers/chutes)
+- [ComfyUI](/docs/providers/comfy)
+- [Cloudflare AI Gateway](/docs/providers/cloudflare-ai-gateway)
+- [DeepSeek](/docs/providers/deepseek)
+- [fal](/docs/providers/fal)
+- [Fireworks](/docs/providers/fireworks)
+- [GitHub Copilot](/docs/providers/github-copilot)
+- [GLM models](/docs/providers/glm)
+- [Google (Gemini)](/docs/providers/google)
+- [Groq (LPU inference)](/docs/providers/groq)
+- [Hugging Face (Inference)](/docs/providers/huggingface)
+- [inferrs (local models)](/docs/providers/inferrs)
+- [Kilocode](/docs/providers/kilocode)
+- [LiteLLM (unified gateway)](/docs/providers/litellm)
+- [LM Studio (local models)](/docs/providers/lmstudio)
+- [MiniMax](/docs/providers/minimax)
+- [Mistral](/docs/providers/mistral)
+- [Moonshot AI (Kimi + Kimi Coding)](/docs/providers/moonshot)
+- [NVIDIA](/docs/providers/nvidia)
+- [Ollama (cloud + local models)](/docs/providers/ollama)
+- [OpenAI (API + Codex)](/docs/providers/openai)
+- [OpenCode](/docs/providers/opencode)
+- [OpenCode Go](/docs/providers/opencode-go)
+- [OpenRouter](/docs/providers/openrouter)
+- [Perplexity (web search)](/docs/providers/perplexity-provider)
+- [Qianfan](/docs/providers/qianfan)
+- [Qwen Cloud](/docs/providers/qwen)
+- [Runway](/docs/providers/runway)
+- [SGLang (local models)](/docs/providers/sglang)
+- [StepFun](/docs/providers/stepfun)
+- [Synthetic](/docs/providers/synthetic)
+- [Together AI](/docs/providers/together)
+- [Venice (Venice AI, privacy-focused)](/docs/providers/venice)
+- [Vercel AI Gateway](/docs/providers/vercel-ai-gateway)
+- [Vydra](/docs/providers/vydra)
+- [vLLM (local models)](/docs/providers/vllm)
+- [Volcengine (Doubao)](/docs/providers/volcengine)
+- [xAI](/docs/providers/xai)
+- [Xiaomi](/docs/providers/xiaomi)
+- [Z.AI](/docs/providers/zai)
 
 ## Shared overview pages
 
-- [Additional bundled variants](./models#additional-bundled-provider-variants) - Anthropic Vertex, Copilot Proxy, and Gemini CLI OAuth
-- [Image Generation](../tools/image-generation) - Shared `image_generate` tool, provider selection, and failover
-- [Music Generation](../tools/music-generation) - Shared `music_generate` tool, provider selection, and failover
-- [Video Generation](../tools/video-generation) - Shared `video_generate` tool, provider selection, and failover
+- [Additional bundled variants](/docs/providers/models#additional-bundled-provider-variants) - Anthropic Vertex, Copilot Proxy, and Gemini CLI OAuth
+- [Image Generation](/docs/tools/image-generation) - Shared `image_generate` tool, provider selection, and failover
+- [Music Generation](/docs/tools/music-generation) - Shared `music_generate` tool, provider selection, and failover
+- [Video Generation](/docs/tools/video-generation) - Shared `video_generate` tool, provider selection, and failover
 
 ## Transcription providers
 
-- [Deepgram (audio transcription)](./deepgram)
+- [Deepgram (audio transcription)](/docs/providers/deepgram)
 
 ## Community tools
 
-- [Claude Max API Proxy](./claude-max-api-proxy) - Community proxy for Claude subscription credentials (verify Anthropic policy/terms before use)
+- [Claude Max API Proxy](/docs/providers/claude-max-api-proxy) - Community proxy for Claude subscription credentials (verify Anthropic policy/terms before use)
 
 For the full provider catalog (xAI, Groq, Mistral, etc.) and advanced configuration,
-see [Model providers](../concepts/model-providers).
+see [Model providers](/docs/concepts/model-providers).

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -11,7 +11,7 @@ title: "Provider Directory"
 OpenClaw can use many LLM providers. Pick a provider, authenticate, then set the
 default model as `provider/model`.
 
-Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugin)/etc.)? See [Channels](/docs/channels).
+Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugin)/etc.)? See [Channels](/channels).
 
 ## Quick start
 
@@ -26,66 +26,66 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 ## Provider docs
 
-- [Alibaba Model Studio](/docs/providers/alibaba)
-- [Amazon Bedrock](/docs/providers/bedrock)
-- [Anthropic (API + Claude CLI)](/docs/providers/anthropic)
-- [Arcee AI (Trinity models)](/docs/providers/arcee)
-- [BytePlus (International)](/docs/concepts/model-providers#byteplus-international)
-- [Chutes](/docs/providers/chutes)
-- [ComfyUI](/docs/providers/comfy)
-- [Cloudflare AI Gateway](/docs/providers/cloudflare-ai-gateway)
-- [DeepSeek](/docs/providers/deepseek)
-- [fal](/docs/providers/fal)
-- [Fireworks](/docs/providers/fireworks)
-- [GitHub Copilot](/docs/providers/github-copilot)
-- [GLM models](/docs/providers/glm)
-- [Google (Gemini)](/docs/providers/google)
-- [Groq (LPU inference)](/docs/providers/groq)
-- [Hugging Face (Inference)](/docs/providers/huggingface)
-- [inferrs (local models)](/docs/providers/inferrs)
-- [Kilocode](/docs/providers/kilocode)
-- [LiteLLM (unified gateway)](/docs/providers/litellm)
-- [LM Studio (local models)](/docs/providers/lmstudio)
-- [MiniMax](/docs/providers/minimax)
-- [Mistral](/docs/providers/mistral)
-- [Moonshot AI (Kimi + Kimi Coding)](/docs/providers/moonshot)
-- [NVIDIA](/docs/providers/nvidia)
-- [Ollama (cloud + local models)](/docs/providers/ollama)
-- [OpenAI (API + Codex)](/docs/providers/openai)
-- [OpenCode](/docs/providers/opencode)
-- [OpenCode Go](/docs/providers/opencode-go)
-- [OpenRouter](/docs/providers/openrouter)
-- [Perplexity (web search)](/docs/providers/perplexity-provider)
-- [Qianfan](/docs/providers/qianfan)
-- [Qwen Cloud](/docs/providers/qwen)
-- [Runway](/docs/providers/runway)
-- [SGLang (local models)](/docs/providers/sglang)
-- [StepFun](/docs/providers/stepfun)
-- [Synthetic](/docs/providers/synthetic)
-- [Together AI](/docs/providers/together)
-- [Venice (Venice AI, privacy-focused)](/docs/providers/venice)
-- [Vercel AI Gateway](/docs/providers/vercel-ai-gateway)
-- [Vydra](/docs/providers/vydra)
-- [vLLM (local models)](/docs/providers/vllm)
-- [Volcengine (Doubao)](/docs/providers/volcengine)
-- [xAI](/docs/providers/xai)
-- [Xiaomi](/docs/providers/xiaomi)
-- [Z.AI](/docs/providers/zai)
+- [Alibaba Model Studio](/providers/alibaba)
+- [Amazon Bedrock](/providers/bedrock)
+- [Anthropic (API + Claude CLI)](/providers/anthropic)
+- [Arcee AI (Trinity models)](/providers/arcee)
+- [BytePlus (International)](/concepts/model-providers#byteplus-international)
+- [Chutes](/providers/chutes)
+- [ComfyUI](/providers/comfy)
+- [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
+- [DeepSeek](/providers/deepseek)
+- [fal](/providers/fal)
+- [Fireworks](/providers/fireworks)
+- [GitHub Copilot](/providers/github-copilot)
+- [GLM models](/providers/glm)
+- [Google (Gemini)](/providers/google)
+- [Groq (LPU inference)](/providers/groq)
+- [Hugging Face (Inference)](/providers/huggingface)
+- [inferrs (local models)](/providers/inferrs)
+- [Kilocode](/providers/kilocode)
+- [LiteLLM (unified gateway)](/providers/litellm)
+- [LM Studio (local models)](/providers/lmstudio)
+- [MiniMax](/providers/minimax)
+- [Mistral](/providers/mistral)
+- [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)
+- [NVIDIA](/providers/nvidia)
+- [Ollama (cloud + local models)](/providers/ollama)
+- [OpenAI (API + Codex)](/providers/openai)
+- [OpenCode](/providers/opencode)
+- [OpenCode Go](/providers/opencode-go)
+- [OpenRouter](/providers/openrouter)
+- [Perplexity (web search)](/providers/perplexity-provider)
+- [Qianfan](/providers/qianfan)
+- [Qwen Cloud](/providers/qwen)
+- [Runway](/providers/runway)
+- [SGLang (local models)](/providers/sglang)
+- [StepFun](/providers/stepfun)
+- [Synthetic](/providers/synthetic)
+- [Together AI](/providers/together)
+- [Venice (Venice AI, privacy-focused)](/providers/venice)
+- [Vercel AI Gateway](/providers/vercel-ai-gateway)
+- [Vydra](/providers/vydra)
+- [vLLM (local models)](/providers/vllm)
+- [Volcengine (Doubao)](/providers/volcengine)
+- [xAI](/providers/xai)
+- [Xiaomi](/providers/xiaomi)
+- [Z.AI](/providers/zai)
 
 ## Shared overview pages
 
-- [Additional bundled variants](/docs/providers/models#additional-bundled-provider-variants) - Anthropic Vertex, Copilot Proxy, and Gemini CLI OAuth
-- [Image Generation](/docs/tools/image-generation) - Shared `image_generate` tool, provider selection, and failover
-- [Music Generation](/docs/tools/music-generation) - Shared `music_generate` tool, provider selection, and failover
-- [Video Generation](/docs/tools/video-generation) - Shared `video_generate` tool, provider selection, and failover
+- [Additional bundled variants](/providers/models#additional-bundled-provider-variants) - Anthropic Vertex, Copilot Proxy, and Gemini CLI OAuth
+- [Image Generation](/tools/image-generation) - Shared `image_generate` tool, provider selection, and failover
+- [Music Generation](/tools/music-generation) - Shared `music_generate` tool, provider selection, and failover
+- [Video Generation](/tools/video-generation) - Shared `video_generate` tool, provider selection, and failover
 
 ## Transcription providers
 
-- [Deepgram (audio transcription)](/docs/providers/deepgram)
+- [Deepgram (audio transcription)](/providers/deepgram)
 
 ## Community tools
 
-- [Claude Max API Proxy](/docs/providers/claude-max-api-proxy) - Community proxy for Claude subscription credentials (verify Anthropic policy/terms before use)
+- [Claude Max API Proxy](/providers/claude-max-api-proxy) - Community proxy for Claude subscription credentials (verify Anthropic policy/terms before use)
 
 For the full provider catalog (xAI, Groq, Mistral, etc.) and advanced configuration,
-see [Model providers](/docs/concepts/model-providers).
+see [Model providers](/concepts/model-providers).

--- a/scripts/docs-i18n/localized_links.go
+++ b/scripts/docs-i18n/localized_links.go
@@ -343,9 +343,9 @@ func splitURLSuffix(raw string) (string, string) {
 
 func prefixLocaleRoute(lang, route string) string {
 	if route == "/" {
-		return "/" + lang
+		return "/" + lang + "/docs"
 	}
-	return "/" + lang + route
+	return "/" + lang + "/docs" + route
 }
 
 func (ri *routeIndex) routeHasLocalePrefix(route string) bool {


### PR DESCRIPTION
## Summary

- Problem: Links on localized documentation pages (e.g., German `/de/docs/providers/index`) were 404ing because they pointed to the domain root (e.g., `/providers/ollama`) instead of the localized documentation path (e.g., `/de/docs/providers/ollama`).
- Why it matters: This broke the onboarding and configuration flow for non-English users.
- What changed: Standardized all internal links in `docs/providers/index.md` to be standard root-relative paths (e.g., `/providers/ollama`) to comply with `docs/AGENTS.md`.
- Underlying Fix: Patched the i18n relocalizer (`scripts/docs-i18n/localized_links.go`) to correctly include the `/docs` segment when rewriting root-relative links for localized sites.
- Verification: Verified that `node scripts/docs-link-audit.mjs` passes with 0 broken links in the English source.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68139
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The i18n relocalizer was prepending the language code (e.g., `/de`) but omitting the `/docs` segment that the localized documentation site requires. This caused standard root-relative links (mandated by Mintlify/`AGENTS.md`) to resolve incorrectly on the localized domain.
- Missing detection / guardrail: The relocalizer lacked a test case or configuration to ensure compatibility with the specific sub-path requirements of the localized docs host (`openclaw-ai.com/<lang>/docs/...`).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `scripts/docs-i18n/localized_links_test.go`
- Scenario the test should lock in: Rewritten localized links should include the `/docs` segment after the language code.

## User-visible / Behavior Changes

Users on localized documentation sites will now be correctly redirected to the localized version of provider pages instead of hitting a 404 at the domain root.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Source: [Ollama](/providers/ollama)
Old Relocalizer: /de/providers/ollama (404)
New Relocalizer: /de/docs/providers/ollama (Works)
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Darwin
- Runtime/container: Native

### Steps

1. Run `node scripts/docs-link-audit.mjs` to confirm English links are valid.
2. (Manual/Pipeline) Run `scripts/docs-i18n` and verify rewritten links include `/docs`.

### Expected

- Links resolve to the localized sub-hierarchy.

### Actual

- English link audit: `checked_internal_links=2848, broken_links=0`.

## Evidence

Attach at least one:

- [x] Trace/log snippets: `checked_internal_links=2848, broken_links=0`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified the patch in `scripts/docs-i18n/localized_links.go` ensures the `/docs` segment is present.
- Re-standardized `docs/providers/index.md` to use the `/path` format required by Mintlify.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: If a future deployment moves docs away from the `/docs` sub-path, this will need to be updated.
  - Mitigation: Centralized link rewriting logic in `localized_links.go` makes this a single point of change.
