### PR TITLE
fix: honor the active memory plugin in doctor checks

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -151,6 +151,7 @@ describe("noteMemorySearchHealth", () => {
     getActiveMemorySearchManager.mockResolvedValue({
       manager: {
         status: () => ({ workspaceDir: "/tmp/agent-default/workspace", backend: "builtin" }),
+        probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
         close: vi.fn(async () => {}),
       },
     });
@@ -169,6 +170,55 @@ describe("noteMemorySearchHealth", () => {
     await noteMemorySearchHealth(cfg, {});
 
     expect(note).not.toHaveBeenCalled();
+  });
+
+  it("uses active runtime embedding probe for non-core memory plugins", async () => {
+    const nonCoreCfg = {
+      plugins: {
+        slots: {
+          memory: "memory-lancedb-pro",
+        },
+      },
+    } as OpenClawConfig;
+
+    await noteMemorySearchHealth(nonCoreCfg, {});
+
+    expect(getActiveMemorySearchManager).toHaveBeenCalledWith({
+      cfg: nonCoreCfg,
+      agentId: "agent-default",
+      purpose: "status",
+    });
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("surfaces runtime probe failures for non-core memory plugins without touching memory-core metadata", async () => {
+    const nonCoreCfg = {
+      plugins: {
+        slots: {
+          memory: "memory-lancedb-pro",
+        },
+      },
+    } as OpenClawConfig;
+    getActiveMemorySearchManager.mockResolvedValueOnce({
+      manager: {
+        status: () => ({ workspaceDir: "/tmp/agent-default/workspace", backend: "builtin" }),
+        probeEmbeddingAvailability: vi.fn(async () => ({
+          ok: false,
+          error: "missing OPENAI_API_KEY",
+        })),
+        close: vi.fn(async () => {}),
+      },
+    });
+
+    await noteMemorySearchHealth(nonCoreCfg, {});
+
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain(
+      'Active memory plugin "memory-lancedb-pro" is selected, but embeddings are not ready.',
+    );
+    expect(message).toContain("missing OPENAI_API_KEY");
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
   });
 
   it("warns when local provider with default model but gateway probe reports not ready", async () => {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -22,6 +22,7 @@ import {
   type DreamingArtifactsAuditSummary,
   type ShortTermAuditSummary,
 } from "../plugin-sdk/memory-core-engine-runtime.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
 import {
   getActiveMemorySearchManager,
   resolveActiveMemoryBackendConfig,
@@ -31,6 +32,14 @@ import { note } from "../terminal/note.js";
 import { resolveUserPath } from "../utils.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 import { isRecord } from "./doctor/shared/legacy-config-record-shared.js";
+
+function selectedMemorySlotPluginId(cfg: OpenClawConfig): string | null {
+  return normalizePluginsConfig(cfg.plugins).slots.memory ?? null;
+}
+
+function shouldUseBundledMemoryCoreDoctor(cfg: OpenClawConfig): boolean {
+  return selectedMemorySlotPluginId(cfg) === "memory-core";
+}
 
 function resolveSuggestedRemoteMemoryProvider(): string | undefined {
   return listBuiltinAutoSelectMemoryEmbeddingProviderDoctorMetadata().find(
@@ -108,6 +117,9 @@ function buildDreamingArtifactIssueNote(audit: DreamingArtifactsAuditSummary): s
 }
 
 export async function noteMemoryRecallHealth(cfg: OpenClawConfig): Promise<void> {
+  if (!shouldUseBundledMemoryCoreDoctor(cfg)) {
+    return;
+  }
   try {
     const context = await resolveRuntimeMemoryAuditContext(cfg);
     const workspaceDir = context?.workspaceDir?.trim();
@@ -142,6 +154,9 @@ export async function maybeRepairMemoryRecallHealth(params: {
   cfg: OpenClawConfig;
   prompter: DoctorPrompter;
 }): Promise<void> {
+  if (!shouldUseBundledMemoryCoreDoctor(params.cfg)) {
+    return;
+  }
   try {
     const context = await resolveRuntimeMemoryAuditContext(params.cfg);
     const workspaceDir = context?.workspaceDir?.trim();
@@ -234,6 +249,41 @@ export async function noteMemorySearchHealth(
   const agentDir = resolveAgentDir(cfg, agentId);
   const resolved = resolveMemorySearchConfig(cfg, agentId);
   const hasRemoteApiKey = hasConfiguredMemorySecretInput(resolved?.remote?.apiKey);
+  if (!shouldUseBundledMemoryCoreDoctor(cfg)) {
+    const { manager, error } = await getActiveMemorySearchManager({
+      cfg,
+      agentId,
+      purpose: "status",
+    });
+    if (!manager) {
+      note(
+        `Active memory plugin "${selectedMemorySlotPluginId(cfg) ?? "unknown"}" is selected, but memory search is unavailable${error ? `: ${error}` : "."}`,
+        "Memory search",
+      );
+      return;
+    }
+    try {
+      const embedding = await manager.probeEmbeddingAvailability();
+      if (embedding.ok) {
+        return;
+      }
+      const gatewayProbeWarning = buildGatewayProbeWarning(opts?.gatewayMemoryProbe);
+      note(
+        [
+          `Active memory plugin "${selectedMemorySlotPluginId(cfg) ?? "unknown"}" is selected, but embeddings are not ready.`,
+          embedding.error ? `Details: ${embedding.error}` : null,
+          gatewayProbeWarning ? gatewayProbeWarning : null,
+          `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        "Memory search",
+      );
+      return;
+    } finally {
+      await manager.close?.().catch(() => undefined);
+    }
+  }
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -1172,7 +1172,13 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       process.platform === "win32"
         ? ["cmd.exe", "/d", "/s", "/c", "echo ok"]
         : ["/bin/sh", "-lc", "echo ok"];
-    const cases = [
+    const cases: Array<{
+      label: string;
+      command?: string[];
+      env?: Record<string, string>;
+      message: string;
+      details: string[];
+    }> = [
       {
         label: "blocked override",
         env: { CLASSPATH: "/tmp/evil-classpath" },


### PR DESCRIPTION
## Summary
- skip bundled memory-core recall/repair doctor paths when another memory plugin owns the active slot
- probe the active runtime memory manager for embedding readiness so doctor output matches the selected backend
- fix a strict typing issue in system-run env test cases that was blocking repo-wide tsgo on current main

## Verification
- corepack pnpm tsgo
- corepack pnpm check:no-conflict-markers
- corepack pnpm tool-display:check
- corepack pnpm check:host-env-policy:swift
- corepack pnpm lint
- corepack pnpm lint:webhook:no-low-level-body-read
- corepack pnpm lint:auth:no-pairing-store-group
- corepack pnpm lint:auth:pairing-account-scope
- corepack pnpm check:import-cycles
- corepack pnpm check:madge-import-cycles
- corepack pnpm exec vitest run src/commands/doctor-memory-search.test.ts src/node-host/invoke-system-run.test.ts