### PR TITLE
[codex] CLI/Doctor: skip gateway token warning in trusted-proxy mode

### DIFF
--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -298,6 +298,56 @@ describe("doctor command", () => {
     expect(warned).toBe(false);
   });
 
+  it("skips gateway auth warning in trusted-proxy mode", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "trusted-proxy",
+            trustedProxy: {
+              userHeader: "x-forwarded-user",
+            },
+          },
+        },
+      },
+    });
+
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    const warned = terminalNoteMock.mock.calls.some(([message]) =>
+      String(message).includes("Gateway auth is off or missing a token"),
+    );
+    expect(warned).toBe(false);
+  });
+
+  it("skips gateway auth warning in password mode", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "password",
+            password: "password-value", // pragma: allowlist secret
+          },
+        },
+      },
+    });
+
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    const warned = terminalNoteMock.mock.calls.some(([message]) =>
+      String(message).includes("Gateway auth is off or missing a token"),
+    );
+    expect(warned).toBe(false);
+  });
+
   it("warns when token and password are both configured and gateway.auth.mode is unset", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -164,7 +164,7 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     authConfig: ctx.cfg.gateway?.auth,
     tailscaleMode: ctx.cfg.gateway?.tailscale?.mode ?? "off",
   });
-  const needsToken = auth.mode !== "password" && (auth.mode !== "token" || !auth.token);
+  const needsToken = auth.mode === "none" || (auth.mode === "token" && !auth.token);
   if (!needsToken) {
     return;
   }


### PR DESCRIPTION
Fixes #56982

## Summary
- stop `openclaw doctor` from warning that gateway auth is off or missing a token when `gateway.auth.mode` is `"trusted-proxy"`
- keep the warning only for `gateway.auth.mode="none"` and `gateway.auth.mode="token"` without a resolved token
- add regression coverage for `trusted-proxy` and `password` modes

## Root Cause
`runGatewayAuthHealth()` used a broad negative check that treated non-password modes as token-required, so `trusted-proxy` incorrectly fell into the default token warning path.

## Impact
Trusted-proxy installs stop getting a misleading doctor warning and the autofix prompt no longer nudges them toward token auth.

## Validation
- AI-assisted: Codex + Claude Code
- `pnpm build`
- `pnpm check`
- `pnpm test -- --run src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts`
- `pnpm test -- --run src/commands/doctor-security.test.ts`
- `pnpm test` was not clean locally due failures outside this change:
  - `src/agents/sandbox/registry.test.ts` lock-timeout failure on `containers.json.lock`
  - Vitest worker `ERR_WORKER_OUT_OF_MEMORY`
