### PR TITLE
fix(ollama): allow baseUrl in plugin configSchema to match what the provider code already reads

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1,6 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
 import plugin from "./index.js";
+
+const OLLAMA_PLUGIN_MANIFEST_PATH = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "openclaw.plugin.json",
+);
+
+describe("ollama plugin manifest", () => {
+  const manifest = JSON.parse(
+    fs.readFileSync(OLLAMA_PLUGIN_MANIFEST_PATH, "utf8"),
+  ) as {
+    configSchema?: {
+      additionalProperties?: boolean;
+      properties?: Record<string, unknown>;
+    };
+  };
+
+  it("configSchema accepts baseUrl so remote Ollama endpoints can be configured (#68260)", () => {
+    // Runtime code in `extensions/ollama/provider-discovery.ts` + `index.ts`
+    // already reads `providerConfig.baseUrl` / `explicit.baseUrl`. The schema
+    // must allow the same field, otherwise `openclaw config set
+    // plugins.entries.ollama.config.baseUrl <url>` is rejected at validation
+    // and the config is stripped to `{}` at startup, leaving the provider
+    // stuck on the default `http://127.0.0.1:11434`.
+    expect(manifest.configSchema?.properties).toHaveProperty("baseUrl");
+    expect(manifest.configSchema?.properties?.baseUrl).toMatchObject({
+      type: "string",
+    });
+  });
+
+  it("configSchema keeps additionalProperties: false so unknown keys still error", () => {
+    // Guardrail against a future change flipping the schema back to permissive
+    // — the fix for #68260 is to extend the allowed property set, not to drop
+    // the allowlist entirely.
+    expect(manifest.configSchema?.additionalProperties).toBe(false);
+  });
+});
 
 const promptAndConfigureOllamaMock = vi.hoisted(() =>
   vi.fn(async () => ({

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -26,6 +26,7 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "baseUrl": { "type": "string" },
       "discovery": {
         "type": "object",
         "additionalProperties": false,
@@ -36,6 +37,10 @@
     }
   },
   "uiHints": {
+    "baseUrl": {
+      "label": "Ollama Server URL",
+      "help": "Base URL of the Ollama HTTP API (e.g. http://127.0.0.1:11434 for local, or http://<host>:11434 for a remote/Tailscale-reachable server). Leave empty to use the Ollama default of http://127.0.0.1:11434."
+    },
     "discovery": {
       "label": "Model Discovery",
       "help": "Plugin-owned controls for Ollama model auto-discovery."


### PR DESCRIPTION
## Summary

Fixes #68260 — the bundled Ollama plugin's \`configSchema\` was locked to \`discovery.enabled\` only (via \`additionalProperties: false\`), but the runtime code at \`extensions/ollama/provider-discovery.ts:70,149\` and \`extensions/ollama/index.ts:68,179\` still reads \`providerConfig.baseUrl\` / \`explicit.baseUrl\`. The schema over-restricted a field the code was still consuming, so:

- \`openclaw config set plugins.entries.ollama.config.baseUrl http://<host>:11434\` was rejected at validation
- The config was silently reset to \`{}\` on next gateway restart
- The provider fell back to the default \`http://127.0.0.1:11434\`, spamming \`Ollama could not be reached\` errors in \`gateway.err.log\` for anyone running a remote Ollama server (Tailscale / LAN / Docker \`host.docker.internal\` / etc.)

## Root cause

The reporter traced this cleanly: four distinct call sites in the ollama plugin runtime already branch on \`providerConfig.baseUrl\` being a trimmed string, so the field has been a first-class runtime input the whole time. The schema just never advertised it.

## Fix

Add \`baseUrl: { \"type\": \"string\" }\` to \`configSchema.properties\` in \`extensions/ollama/openclaw.plugin.json\`, plus a matching \`uiHints.baseUrl\` entry for the Control UI settings pane. The \`additionalProperties: false\` guardrail is preserved — this extends the allowlist rather than loosening it.

No runtime or provider code changes needed because the runtime already reads the field correctly.

## Test plan

- [x] Added two regression tests in \`extensions/ollama/index.test.ts\`:
  - \`configSchema accepts baseUrl so remote Ollama endpoints can be configured (#68260)\`
  - \`configSchema keeps additionalProperties: false so unknown keys still error\`
- [x] \`NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit\` — 245 baseline errors on main, 245 on branch (the 1 error is a pre-existing \`extensions/ollama/src/stream.ts:644\` issue unrelated to this fix).
- [x] \`pnpm exec oxlint\` on the test file — 0 warnings, 0 errors.

Local full vitest is blocked by pre-existing \`test/non-isolated-runner.ts\` drift (reproduces on \`main\`); CI exercises the new cases normally.

## Risk

- No behavior change for users who didn't set \`baseUrl\` (the field simply becomes an allowed no-op when absent).
- The runtime already handled the field correctly before this PR — this just stops validation from stripping it.
- Users who were hitting the rejection will get back the behavior they had before the schema tightened (presumably around when #65491 / #64501 et al. moved audio/cli provider detection onto the same validation path).