### PR TITLE
Fix macos ssh host checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/streaming: clear the compaction replay guard after visible non-final boundaries so a post-tool assistant reply rotates to a fresh preview instead of editing the pre-compaction message. (#67993) Thanks @obviyus.
 - Matrix: fix `sessions_spawn --thread` subagent session spawning — thread binding creation, cleanup on session end, and completion-message delivery target resolution now work end-to-end. (#67643) Thanks @eejohnso-ops and @gumadeiras.
 - macOS/webchat: enable Undo and Redo in the composer text input by turning on the native `NSTextView` undo manager. (#34962) Thanks @tylerbittner.
+- macOS/remote SSH: require an already-trusted host key on the macOS remote command, gateway probe, port tunnel, and pairing probe paths by switching `StrictHostKeyChecking=accept-new` to `StrictHostKeyChecking=yes` and centralizing the shared SSH option fragments in `CommandResolver`, so first-time macOS remote connections no longer silently accept an unknown host key and must be trusted ahead of time via `~/.ssh/known_hosts`. (#68199)
 
 ## 2026.4.15
 

--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -3,6 +3,12 @@ import Foundation
 enum CommandResolver {
     private static let projectRootDefaultsKey = "openclaw.gatewayProjectRootPath"
     private static let helperName = "openclaw"
+    static let strictHostKeyCheckingSSHOptions = [
+        "-o", "StrictHostKeyChecking=yes",
+    ]
+    static let updateHostKeysSSHOptions = [
+        "-o", "UpdateHostKeys=yes",
+    ]
 
     static func gatewayEntrypoint(in root: URL) -> String? {
         let distEntry = root.appendingPathComponent("dist/index.js").path
@@ -397,9 +403,7 @@ enum CommandResolver {
         """
         let options: [String] = [
             "-o", "BatchMode=yes",
-            "-o", "StrictHostKeyChecking=accept-new",
-            "-o", "UpdateHostKeys=yes",
-        ]
+        ] + self.strictHostKeyCheckingSSHOptions + self.updateHostKeysSSHOptions
         let args = self.sshArguments(
             target: parsed,
             identity: settings.identity,

--- a/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
@@ -483,8 +483,7 @@ final class NodePairingApprovalPrompter {
                 "-o", "ConnectTimeout=5",
                 "-o", "NumberOfPasswordPrompts=0",
                 "-o", "PreferredAuthentications=publickey",
-                "-o", "StrictHostKeyChecking=accept-new",
-            ]
+            ] + CommandResolver.strictHostKeyCheckingSSHOptions
             guard let target = CommandResolver.makeSSHTarget(user: user, host: host, port: port) else {
                 return false
             }

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -200,9 +200,7 @@ enum RemoteGatewayProbe {
         let options = [
             "-o", "BatchMode=yes",
             "-o", "ConnectTimeout=5",
-            "-o", "StrictHostKeyChecking=accept-new",
-            "-o", "UpdateHostKeys=yes",
-        ]
+        ] + CommandResolver.strictHostKeyCheckingSSHOptions + CommandResolver.updateHostKeysSSHOptions
         let args = CommandResolver.sshArguments(
             target: parsed,
             identity: identity,

--- a/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
@@ -73,14 +73,12 @@ final class RemotePortTunnel {
         let options: [String] = [
             "-o", "BatchMode=yes",
             "-o", "ExitOnForwardFailure=yes",
-            "-o", "StrictHostKeyChecking=accept-new",
-            "-o", "UpdateHostKeys=yes",
             "-o", "ServerAliveInterval=15",
             "-o", "ServerAliveCountMax=3",
             "-o", "TCPKeepAlive=yes",
             "-N",
             "-L", "\(localPort):127.0.0.1:\(resolvedRemotePort)",
-        ]
+        ] + CommandResolver.strictHostKeyCheckingSSHOptions + CommandResolver.updateHostKeysSSHOptions
         let identity = settings.identity.trimmingCharacters(in: .whitespacesAndNewlines)
         let args = CommandResolver.sshArguments(
             target: parsed,

--- a/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
@@ -164,6 +164,9 @@ import Testing
         } else {
             #expect(Bool(false))
         }
+        #expect(cmd.contains("StrictHostKeyChecking=yes"))
+        #expect(!cmd.contains("StrictHostKeyChecking=accept-new"))
+        #expect(cmd.contains("UpdateHostKeys=yes"))
         #expect(cmd.contains("-i"))
         #expect(cmd.contains("/tmp/id_ed25519"))
         if let script = cmd.last {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: macOS remote SSH command, probe, tunnel, and pairing checks silently trusted first-seen host keys by using `StrictHostKeyChecking=accept-new`.
- Why it matters: first-connect remote sessions could establish trust without a pre-trusted `known_hosts` entry, weakening SSH host-authentication posture on the macOS remote path.
- What changed: centralized the strict host-key SSH option fragments in `CommandResolver`, switched the four macOS SSH call sites to `StrictHostKeyChecking=yes`, and added a regression assertion in `CommandResolverTests`.
- What did NOT change (scope boundary): no auth flow changes, no SSH identity selection changes, and no broader remote-mode refactor beyond the host-key policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related #<operator to fill>
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: multiple macOS remote SSH entry points hardcoded `StrictHostKeyChecking=accept-new`, so first-contact host trust was accepted instead of requiring an existing trusted host key.
- Missing detection / guardrail: the host-key policy was duplicated across four code paths and the remote command regression test did not assert the expected strict SSH flag.
- Contributing context (if known): the macOS remote docs already describe trusting the host key first, so shipped behavior had drifted from documented expectations.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift`
- Scenario the test should lock in: remote-mode SSH command generation must include `StrictHostKeyChecking=yes`, must not include `StrictHostKeyChecking=accept-new`, and must preserve `UpdateHostKeys=yes`.
- Why this is the smallest reliable guardrail: the macOS callers now share one helper for the host-key option fragments, so asserting the generated remote command catches drift on the shared policy path.
- Existing test that already covers this (if any): the existing `builds SSH command for remote mode` test covered the remote command shape but did not check host-key policy.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

- First-time macOS remote SSH connections now require the target host key to already be trusted in `~/.ssh/known_hosts`.
- Existing trusted hosts continue to work, including the existing `UpdateHostKeys=yes` behavior on the command, probe, and tunnel paths.
- Remote pairing detection now follows the same strict host-key posture as the rest of the macOS remote flows.

## Diagram (if applicable)

```text
Before:
[macOS remote flow] -> ssh ... StrictHostKeyChecking=accept-new -> unknown host key accepted

After:
[macOS remote flow] -> ssh ... StrictHostKeyChecking=yes -> existing trusted host key required
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux task runner
- Runtime/container: Codex workspace runner; Swift toolchain not installed
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): macOS remote SSH flows with host trust expected via `~/.ssh/known_hosts`

### Steps

1. Attempt `swift test --package-path apps/macos --filter CommandResolverTests`.
2. Run `git diff --check`.
3. Run `rg -n "accept-new" apps/macos/Sources -S` and inspect the updated macOS SSH diff plus test assertion.

### Expected

- macOS SSH sources do not emit `StrictHostKeyChecking=accept-new`.
- The remote command regression test asserts `StrictHostKeyChecking=yes`.
- Focused Swift tests pass when a Swift toolchain is available.

### Actual

- `git diff --check` passed.
- `rg -n "accept-new" apps/macos/Sources -S` returned no matches.
- The updated regression assertion in `CommandResolverTests` checks for `StrictHostKeyChecking=yes` and rejects `StrictHostKeyChecking=accept-new`.
- Focused Swift tests could not run in this environment because `swift` is not installed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation snippets:

- `git diff --check` -> clean
- `rg -n "accept-new" apps/macos/Sources -S` -> no matches
- `swift test --package-path apps/macos --filter CommandResolverTests` -> `swift: not installed`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the four macOS SSH entry points and confirmed they now all use the shared strict host-key option helper; confirmed the updated remote command test asserts the strict host-key setting.
- Edge cases checked: preserved the existing non-host-key SSH options on each path, including `UpdateHostKeys=yes` where it was already present and the pairing probe's auth-related SSH options.
- What you did **not** verify: macOS runtime behavior, live SSH first-connect behavior, or Swift package test execution in a macOS/Swift-capable environment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? No
- Config/env changes? No
- Migration needed? Yes
- If yes, exact upgrade steps: trust the remote host key before using macOS remote mode, for example by connecting once with `ssh` or by adding the expected host key to `~/.ssh/known_hosts`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - macOS users who relied on silent first-connect trust will now see host-key verification failures until they trust the remote host key explicitly.
  - Mitigation: this aligns runtime behavior with the existing docs and the error handling already surfaces host-key verification guidance.
- Risk:
  - Only the shared remote command path gained an explicit regression assertion in this environment.
  - Mitigation: the four callers now share the same strict host-key helper, reducing policy drift; additional macOS package coverage can be run once a Swift toolchain is available.