### PR TITLE
feat(memory-core): expose vectorScore and textScore in hybrid search results

### DIFF
--- a/extensions/memory-core/src/memory/hybrid.test.ts
+++ b/extensions/memory-core/src/memory/hybrid.test.ts
@@ -60,7 +60,11 @@ describe("memory hybrid helpers", () => {
     const a = merged.find((r) => r.path === "memory/a.md");
     const b = merged.find((r) => r.path === "memory/b.md");
     expect(a?.score).toBeCloseTo(0.7 * 0.9);
+    expect(a?.vectorScore).toBeCloseTo(0.9);
+    expect(a?.textScore).toBe(0);
     expect(b?.score).toBeCloseTo(0.3 * 1.0);
+    expect(b?.vectorScore).toBe(0);
+    expect(b?.textScore).toBeCloseTo(1.0);
   });
 
   it("mergeHybridResults prefers keyword snippet when ids overlap", async () => {
@@ -94,5 +98,7 @@ describe("memory hybrid helpers", () => {
     expect(merged).toHaveLength(1);
     expect(merged[0]?.snippet).toBe("kw-a");
     expect(merged[0]?.score).toBeCloseTo(0.5 * 0.2 + 0.5 * 1.0);
+    expect(merged[0]?.vectorScore).toBeCloseTo(0.2);
+    expect(merged[0]?.textScore).toBeCloseTo(1.0);
   });
 });

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -140,6 +140,8 @@ export async function mergeHybridResults(params: {
     };
   });
 
+  // Keep component scores as raw retrieval diagnostics; temporal decay and MMR
+  // only adjust or reorder the combined ranking score.
   const temporalDecayConfig = { ...DEFAULT_TEMPORAL_DECAY_CONFIG, ...params.temporalDecay };
   const decayed = await applyTemporalDecayToHybridResults({
     results: merged,

--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -72,6 +72,8 @@ export async function mergeHybridResults(params: {
     startLine: number;
     endLine: number;
     score: number;
+    vectorScore: number;
+    textScore: number;
     snippet: string;
     source: HybridSource;
   }>
@@ -131,6 +133,8 @@ export async function mergeHybridResults(params: {
       startLine: entry.startLine,
       endLine: entry.endLine,
       score,
+      vectorScore: entry.vectorScore,
+      textScore: entry.textScore,
       snippet: entry.snippet,
       source: entry.source,
     };

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -5,6 +5,8 @@ export type MemorySearchResult = {
   startLine: number;
   endLine: number;
   score: number;
+  vectorScore?: number;
+  textScore?: number;
   snippet: string;
   source: MemorySource;
   citation?: string;

--- a/src/memory-host-sdk/host/types.ts
+++ b/src/memory-host-sdk/host/types.ts
@@ -5,6 +5,8 @@ export type MemorySearchResult = {
   startLine: number;
   endLine: number;
   score: number;
+  vectorScore?: number;
+  textScore?: number;
   snippet: string;
   source: MemorySource;
   citation?: string;


### PR DESCRIPTION
## Summary

- Problem: mergeHybridResults computes vectorScore and textScore per
  result but drops them when building the return object. Only the
  weighted combined score survives.
- Why it matters: operators running multi-agent setups need to compare
  retrieval quality across embedding models and weight configs. The
  combined score hides which component drove the ranking.
- What changed: two fields (vectorScore, textScore) now pass through
  the merge result in hybrid.ts. MemorySearchResult in memory-host-sdk
  adds them as optional fields.
- What did NOT change: scoring math, temporal decay, MMR re-ranking,
  minScore filtering. The combined score field stays the primary
  ranking signal.

## Change Type

- [x] Feature

## Scope

- [x] Memory / storage
- [x] API / contracts

## Linked Issue/PR

- Closes #68166

## Root Cause

N/A

## Regression Test Plan

- Coverage level:
  - [x] Unit test
- Target test: extensions/memory-core/src/memory/hybrid.test.ts
- Scenario: existing mergeHybridResults tests now assert vectorScore
  and textScore on each result. Disjoint ids (one component is 0)
  and overlapping ids (both contribute).
- Why smallest reliable: the merge function is pure. Unit tests cover
  the full branch space; no live gateway required.
- Existing test that already covers this: hybrid.test.ts covered the
  combined score; six new assertions extend those same tests.

## User-visible / Behavior Changes

- MemorySearchResult adds optional vectorScore and textScore fields.
- memory_search results include component scores when hybrid search
  is active. Consumers that don't read these fields see no difference.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Linux 6.14)
- Runtime: Node 22.22.0, pnpm 10.32.1
- Model/provider: N/A (unit tests only)

### Steps

1. pnpm install
2. node scripts/test-extension.mjs memory-core

### Expected

hybrid.test.ts passes with vectorScore/textScore assertions.

### Actual

46 passed, 1 pre-existing failure (dreaming-phases fixture paths,
unrelated, same on main).

## Evidence

- [x] Failing test/log before + passing after

## Human Verification

- Verified: full memory-core suite (47 files, 431 tests passing).
- Edge cases: overlapping ids, disjoint ids, keyword-only results.
- Not verified: live gateway end-to-end with a real embedding provider.

## Review Conversations

- [x] N/A -- initial submission.

## Compatibility / Migration

- Backward compatible? Yes, new fields are optional.
- Config/env changes? No
- Migration needed? No

## Disclosure

Claude Code helped me straighten out my word salad for this PR.