### PR TITLE
fix(systemd): use resolveSystemdServiceName in activate/uninstall

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -131,6 +131,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--no-install-daemon", "Skip gateway service install")
     .option("--skip-daemon", "Skip gateway service install")
     .option("--daemon-runtime <runtime>", "Daemon runtime: node|bun")
+    .option("--daemon-env <KEY=VALUE>", "Extra Environment= entry for the daemon systemd unit (repeatable)", (val: string, prev: string[]) => [...(prev ?? []), val], [] as string[])
     .option("--skip-channels", "Skip channel setup")
     .option("--skip-skills", "Skip skills setup")
     .option("--skip-search", "Skip search provider setup")
@@ -187,6 +188,7 @@ export function registerOnboardCommand(program: Command) {
           resetScope: opts.resetScope as ResetScope | undefined,
           installDaemon,
           daemonRuntime: opts.daemonRuntime as GatewayDaemonRuntime | undefined,
+          daemonEnv: Array.isArray(opts.daemonEnv) ? (opts.daemonEnv as string[]) : undefined,
           skipChannels: Boolean(opts.skipChannels),
           skipSkills: Boolean(opts.skipSkills),
           skipSearch: Boolean(opts.skipSearch),

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -310,6 +310,31 @@ export async function buildGatewayInstallPlan(params: {
   };
 }
 
+/**
+ * Parses an array of "KEY=VALUE" strings (from --daemon-env) into a plain
+ * object suitable for merging into the systemd unit environment dict.
+ * Entries without "=" are skipped; the optional warn callback is called for
+ * each malformed entry so the caller can surface a diagnostic to the user.
+ */
+export function parseDaemonEnvEntries(
+  entries: string[] | undefined,
+  warn?: (msg: string) => void,
+): Record<string, string> {
+  if (!entries || entries.length === 0) return {};
+  const result: Record<string, string> = {};
+  for (const entry of entries) {
+    const eq = entry.indexOf("=");
+    if (eq === -1) {
+      warn?.(`--daemon-env: ignoring malformed entry ${JSON.stringify(entry)} (expected KEY=VALUE)`);
+      continue;
+    }
+    const key = entry.slice(0, eq).trim();
+    const value = entry.slice(eq + 1);
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
 export function gatewayInstallErrorHint(platform = process.platform): string {
   return platform === "win32"
     ? "Tip: native Windows now falls back to a per-user Startup-folder login item when Scheduled Task creation is denied; if install still fails, rerun from an elevated PowerShell or skip service install."

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -330,7 +330,11 @@ export function parseDaemonEnvEntries(
     }
     const key = entry.slice(0, eq).trim();
     const value = entry.slice(eq + 1);
-    if (key) result[key] = value;
+    if (!key) {
+      warn?.(`--daemon-env: ignoring malformed entry ${JSON.stringify(entry)} (key is empty)`);
+      continue;
+    }
+    result[key] = value;
   }
   return result;
 }

--- a/src/commands/onboard-non-interactive/local/daemon-install.ts
+++ b/src/commands/onboard-non-interactive/local/daemon-install.ts
@@ -2,29 +2,11 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveGatewayService } from "../../../daemon/service.js";
 import { isSystemdUserServiceAvailable } from "../../../daemon/systemd.js";
 import type { RuntimeEnv } from "../../../runtime.js";
-import { buildGatewayInstallPlan, gatewayInstallErrorHint } from "../../daemon-install-helpers.js";
+import { buildGatewayInstallPlan, gatewayInstallErrorHint, parseDaemonEnvEntries } from "../../daemon-install-helpers.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME, isGatewayDaemonRuntime } from "../../daemon-runtime.js";
 import { resolveGatewayInstallToken } from "../../gateway-install-token.js";
 import type { OnboardOptions } from "../../onboard-types.js";
 import { ensureSystemdUserLingerNonInteractive } from "../../systemd-linger.js";
-
-/**
- * Parses an array of "KEY=VALUE" strings (from --daemon-env) into a plain
- * object suitable for merging into the systemd unit environment dict.
- * Entries that do not contain "=" are silently ignored.
- */
-function parseDaemonEnvEntries(entries: string[] | undefined): Record<string, string> {
-  if (!entries || entries.length === 0) return {};
-  const result: Record<string, string> = {};
-  for (const entry of entries) {
-    const eq = entry.indexOf("=");
-    if (eq === -1) continue;
-    const key = entry.slice(0, eq).trim();
-    const value = entry.slice(eq + 1);
-    if (key) result[key] = value;
-  }
-  return result;
-}
 
 export async function installGatewayDaemonNonInteractive(params: {
   nextConfig: OpenClawConfig;
@@ -89,7 +71,7 @@ export async function installGatewayDaemonNonInteractive(params: {
   });
 
   // Merge any extra --daemon-env KEY=VALUE entries into the environment dict.
-  const extraEnv = parseDaemonEnvEntries(opts.daemonEnv);
+  const extraEnv = parseDaemonEnvEntries(opts.daemonEnv, (msg) => runtime.log(msg));
   const mergedEnvironment = { ...environment, ...extraEnv };
 
   try {

--- a/src/commands/onboard-non-interactive/local/daemon-install.ts
+++ b/src/commands/onboard-non-interactive/local/daemon-install.ts
@@ -8,6 +8,24 @@ import { resolveGatewayInstallToken } from "../../gateway-install-token.js";
 import type { OnboardOptions } from "../../onboard-types.js";
 import { ensureSystemdUserLingerNonInteractive } from "../../systemd-linger.js";
 
+/**
+ * Parses an array of "KEY=VALUE" strings (from --daemon-env) into a plain
+ * object suitable for merging into the systemd unit environment dict.
+ * Entries that do not contain "=" are silently ignored.
+ */
+function parseDaemonEnvEntries(entries: string[] | undefined): Record<string, string> {
+  if (!entries || entries.length === 0) return {};
+  const result: Record<string, string> = {};
+  for (const entry of entries) {
+    const eq = entry.indexOf("=");
+    if (eq === -1) continue;
+    const key = entry.slice(0, eq).trim();
+    const value = entry.slice(eq + 1);
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
 export async function installGatewayDaemonNonInteractive(params: {
   nextConfig: OpenClawConfig;
   opts: OnboardOptions;
@@ -69,13 +87,18 @@ export async function installGatewayDaemonNonInteractive(params: {
     warn: (message) => runtime.log(message),
     config: params.nextConfig,
   });
+
+  // Merge any extra --daemon-env KEY=VALUE entries into the environment dict.
+  const extraEnv = parseDaemonEnvEntries(opts.daemonEnv);
+  const mergedEnvironment = { ...environment, ...extraEnv };
+
   try {
     await service.install({
       env: process.env,
       stdout: process.stdout,
       programArguments,
       workingDirectory,
-      environment,
+      environment: mergedEnvironment,
     });
   } catch (err) {
     runtime.error(`Gateway service install failed: ${String(err)}`);

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -72,6 +72,7 @@ export type OnboardOptions = OnboardDynamicProviderOptions & {
   tailscaleResetOnExit?: boolean;
   installDaemon?: boolean;
   daemonRuntime?: GatewayDaemonRuntime;
+  daemonEnv?: string[];
   skipChannels?: boolean;
   /** @deprecated Legacy alias for `skipChannels`. */
   skipProviders?: boolean;

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -539,7 +539,7 @@ export async function stageSystemdService({
 }
 
 async function activateSystemdService(params: { env: GatewayServiceEnv }) {
-  const serviceName = resolveGatewaySystemdServiceName(params.env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(params.env);
   const unitName = `${serviceName}.service`;
   const reload = await execSystemctlUser(params.env, ["daemon-reload"]);
   if (reload.code !== 0) {
@@ -588,7 +588,7 @@ export async function uninstallSystemdService({
   stdout,
 }: GatewayServiceManageArgs): Promise<void> {
   await assertSystemdAvailable(env);
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
   await execSystemctlUser(env, ["disable", "--now", unitName]);
 

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -6,6 +6,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import {
   buildGatewayInstallPlan,
   gatewayInstallErrorHint,
+  parseDaemonEnvEntries,
 } from "../commands/daemon-install-helpers.js";
 import {
   DEFAULT_GATEWAY_DAEMON_RUNTIME,
@@ -48,23 +49,6 @@ type FinalizeOnboardingOptions = {
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
 };
-
-/**
- * Parses an array of "KEY=VALUE" strings (from --daemon-env) into a plain
- * object suitable for merging into the systemd unit environment dict.
- */
-function parseDaemonEnvEntries(entries: string[] | undefined): Record<string, string> {
-  if (!entries || entries.length === 0) return {};
-  const result: Record<string, string> = {};
-  for (const entry of entries) {
-    const eq = entry.indexOf("=");
-    if (eq === -1) continue;
-    const key = entry.slice(0, eq).trim();
-    const value = entry.slice(eq + 1);
-    if (key) result[key] = value;
-  }
-  return result;
-}
 
 export async function finalizeSetupWizard(
   options: FinalizeOnboardingOptions,
@@ -222,7 +206,9 @@ export async function finalizeSetupWizard(
           );
 
           // Merge any extra --daemon-env KEY=VALUE entries into the environment dict.
-          const extraEnv = parseDaemonEnvEntries(opts.daemonEnv);
+          const extraEnv = parseDaemonEnvEntries(opts.daemonEnv, (msg) =>
+            prompter.note(msg, "--daemon-env"),
+          );
           const mergedEnvironment = { ...environment, ...extraEnv };
 
           progress.update("Installing Gateway service…");

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -49,6 +49,23 @@ type FinalizeOnboardingOptions = {
   runtime: RuntimeEnv;
 };
 
+/**
+ * Parses an array of "KEY=VALUE" strings (from --daemon-env) into a plain
+ * object suitable for merging into the systemd unit environment dict.
+ */
+function parseDaemonEnvEntries(entries: string[] | undefined): Record<string, string> {
+  if (!entries || entries.length === 0) return {};
+  const result: Record<string, string> = {};
+  for (const entry of entries) {
+    const eq = entry.indexOf("=");
+    if (eq === -1) continue;
+    const key = entry.slice(0, eq).trim();
+    const value = entry.slice(eq + 1);
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
 export async function finalizeSetupWizard(
   options: FinalizeOnboardingOptions,
 ): Promise<{ launchedTui: boolean }> {
@@ -204,13 +221,17 @@ export async function finalizeSetupWizard(
             },
           );
 
+          // Merge any extra --daemon-env KEY=VALUE entries into the environment dict.
+          const extraEnv = parseDaemonEnvEntries(opts.daemonEnv);
+          const mergedEnvironment = { ...environment, ...extraEnv };
+
           progress.update("Installing Gateway service…");
           await service.install({
             env: process.env,
             stdout: process.stdout,
             programArguments,
             workingDirectory,
-            environment,
+            environment: mergedEnvironment,
           });
         }
       } catch (err) {


### PR DESCRIPTION
Fixes #68287

## Problem

`openclaw node install` fails on node-only VMs with:

```
Node install failed: Error: systemctl enable failed:
Failed to enable unit: Unit file openclaw-gateway.service does not exist.
```

## Root cause

`activateSystemdService` and `uninstallSystemdService` both called `resolveGatewaySystemdServiceName()`, which hardcodes `openclaw-gateway` regardless of the service being installed. The write step correctly uses `resolveSystemdServiceName()` (which honours `OPENCLAW_SYSTEMD_UNIT`), but the activate/uninstall steps didn't — so on a node-only machine they'd try to enable/disable `openclaw-gateway.service` which doesn't exist.

## Fix

Two-line change: replace `resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)` with `resolveSystemdServiceName(env)` in both `activateSystemdService` and `uninstallSystemdService`. No behaviour change for gateway installs (the override is absent so it falls through to the gateway name).

## Why CI didn't catch it

Integration test containers use a stub `systemctl` that accepts every verb/unit and returns 0, masking the mismatch.