### PR TITLE
fix(plugins): allow explicitly enabled plugins to load when plugins.enabled is false

### DIFF
--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -254,7 +254,7 @@ describe("resolveEffectivePluginActivationState", () => {
     });
   });
 
-  it("preserves explicit selection even when plugins are globally disabled", () => {
+  it("activates explicitly enabled plugins even when plugins are globally disabled", () => {
     const rawConfig = {
       plugins: {
         enabled: false,
@@ -275,11 +275,11 @@ describe("resolveEffectivePluginActivationState", () => {
         activationSource: createPluginActivationSource({ config: rawConfig }),
       }),
     ).toEqual({
-      enabled: false,
-      activated: false,
+      enabled: true,
+      activated: true,
       explicitlyEnabled: true,
-      source: "disabled",
-      reason: "plugins disabled",
+      source: "explicit",
+      reason: "enabled in config",
     });
   });
 

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -264,7 +264,7 @@ export function resolvePluginActivationState(params: {
     rootConfig: activationSource.rootConfig,
   });
 
-  if (!params.config.enabled) {
+  if (!params.config.enabled && !explicitSelection.explicitlyEnabled) {
     return toPluginActivationState({
       enabled: false,
       activated: false,

--- a/src/secrets/runtime-config-collectors-plugins.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.test.ts
@@ -224,7 +224,7 @@ describe("collectPluginConfigAssignments", () => {
     expect(context.assignments).toHaveLength(0);
   });
 
-  it("skips assignments when plugins.enabled is false", () => {
+  it("collects assignments for explicitly enabled plugins even when plugins.enabled is false", () => {
     const config = asConfig({
       plugins: {
         enabled: false,
@@ -249,10 +249,7 @@ describe("collectPluginConfigAssignments", () => {
       loadablePluginOrigins: loadablePluginOrigins([["acpx", "bundled"]]),
     });
 
-    expect(context.assignments).toHaveLength(0);
-    expect(context.warnings.some((w) => w.code === "SECRETS_REF_IGNORED_INACTIVE_SURFACE")).toBe(
-      true,
-    );
+    expect(context.assignments).toHaveLength(1);
   });
 
   it("skips assignments when entry.enabled is false", () => {


### PR DESCRIPTION
Fixes #68249

## Problem
- Brave plugin enabled in config (\plugins.entries.brave.enabled: true\)
- But didn't load when \plugins.enabled\ was false/undefined
- \web_search\ tool was unavailable

## Root Cause
\esolvePluginActivationState\ returned early with \'plugins-disabled'\ without checking if the plugin was explicitly enabled.

## Solution
Check \explicitSelection.explicitlyEnabled\ before returning \'plugins-disabled'\.

## Testing
- Tested with \plugins.entries.brave.enabled: true\ and \plugins.enabled: false\
- Brave plugin now loads correctly
- \web_search\ tool is available

## Changes
\\\diff
- if (!params.config.enabled) {
+ if (!params.config.enabled && !explicitSelection.explicitlyEnabled) {
\\\

AI-assisted PR 🤖