### PR TITLE
fix(agents): add file and filePath aliases to read tool diagnostic path check

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -83,6 +83,38 @@ describe("handleToolExecutionStart read path checks", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("does not warn when read tool uses file alias", async () => {
+    const { ctx, warn, onBlockReplyFlush } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-1b",
+      args: { file: "/tmp/example.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when read tool uses filePath alias", async () => {
+    const { ctx, warn, onBlockReplyFlush } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-1c",
+      args: { filePath: "/tmp/example.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("warns when read tool has neither path nor file_path", async () => {
     const { ctx, warn } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -115,7 +115,7 @@ describe("handleToolExecutionStart read path checks", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("warns when read tool has neither path nor file_path", async () => {
+  it("warns when read tool has no recognized path alias", async () => {
     const { ctx, warn } = createTestContext();
 
     const evt: ToolExecutionStartEvent = {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -586,7 +586,11 @@ export function handleToolExecutionStart(
           ? record.path
           : typeof record.file_path === "string"
             ? record.file_path
-            : "";
+            : typeof record.file === "string"
+              ? record.file
+              : typeof record.filePath === "string"
+                ? record.filePath
+                : "";
       const filePath = filePathValue.trim();
       if (!filePath) {
         const argsPreview = readStringValue(args)?.slice(0, 200);


### PR DESCRIPTION
## Summary

- The `read` tool diagnostic guard in `handleToolExecutionStart` only checked `path` and `file_path` when deciding whether to emit a "read tool called without path" warning
- Models like Claude commonly use `file` and `filePath` as the parameter name
- This triggered false-positive log warnings even though the tool itself succeeds via normalization in `normalizeToolParams()`

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #60008

## Root Cause

`handleToolExecutionStart` resolves the read tool path from `record.path` and `record.file_path` only. The `file` and `filePath` aliases — which Claude models commonly emit — were not checked, causing spurious warnings that can flood logs and cascade into retry loops.

## Fix

Extended the ternary chain to also check `record.file` and `record.filePath` before falling back to the empty string. Added test cases for both new aliases.