### PR TITLE
fix(discord): fail closed when bot identity is unavailable

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -74,6 +74,7 @@ function createPreflightArgs(params: {
   discordConfig: DiscordConfig;
   data: DiscordMessageEvent;
   client: DiscordClient;
+  botUserId?: string;
 }): Parameters<typeof preflightDiscordMessage>[0] {
   return createDiscordPreflightArgs(params);
 }
@@ -1094,6 +1095,51 @@ describe("preflightDiscordMessage", () => {
       routeSpy.mockRestore();
       ensureSpy.mockRestore();
     }
+  });
+
+  it("drops guild message without mention when mention detection falls back to route patterns", async () => {
+    const channelId = "channel-no-bot-id";
+    const guildId = "guild-no-bot-id";
+    const message = createDiscordMessage({
+      id: "m-no-bot-id",
+      channelId,
+      content: "hello without mention",
+      author: { id: "user-1", bot: false, username: "alice" },
+    });
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: {
+          ...DEFAULT_PREFLIGHT_CFG,
+          messages: {
+            groupChat: {
+              mentionPatterns: ["\\bopenclaw\\b"],
+            },
+          },
+        } as import("openclaw/plugin-sdk/config-runtime").OpenClawConfig,
+        discordConfig: {} as DiscordConfig,
+        data: createGuildEvent({
+          channelId,
+          guildId,
+          author: message.author,
+          message,
+        }),
+        client: createGuildTextClient(channelId),
+      }),
+      botUserId: undefined,
+      guildEntries: {
+        [guildId]: {
+          channels: {
+            [channelId]: {
+              enabled: true,
+              requireMention: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toBeNull();
   });
 });
 

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -973,7 +973,7 @@ export async function preflightDiscordMessage(
     `[discord-preflight] shouldRequireMention=${shouldRequireMention} baseRequireMention=${shouldRequireMentionByConfig} boundThreadSession=${isBoundThreadSession} mentionDecision.shouldSkip=${mentionDecision.shouldSkip} wasMentioned=${wasMentioned}`,
   );
   if (isGuildMessage && shouldRequireMention) {
-    if (botId && mentionDecision.shouldSkip) {
+    if (mentionDecision.shouldSkip) {
       logDebug(`[discord-preflight] drop: no-mention`);
       logVerbose(`discord: drop guild message (mention required, botId=${botId})`);
       logger.info(

--- a/extensions/discord/src/monitor/provider.startup.test.ts
+++ b/extensions/discord/src/monitor/provider.startup.test.ts
@@ -70,7 +70,7 @@ vi.mock("./presence.js", () => ({
   resolveDiscordPresenceUpdate: vi.fn(() => undefined),
 }));
 
-import { createDiscordMonitorClient } from "./provider.startup.js";
+import { createDiscordMonitorClient, fetchDiscordBotIdentity } from "./provider.startup.js";
 
 describe("createDiscordMonitorClient", () => {
   it("adds listener compat for legacy voice plugins", () => {
@@ -120,6 +120,59 @@ describe("createDiscordMonitorClient", () => {
     expect(registerVoiceClientSpy).toHaveBeenCalledTimes(1);
     expect(result.client.listeners).toEqual(
       expect.arrayContaining([expect.objectContaining({ type: "legacy-voice-listener" })]),
+    );
+  });
+});
+
+describe("fetchDiscordBotIdentity", () => {
+  it("throws when fetchUser('@me') fails", async () => {
+    const runtime = {
+      error: vi.fn(),
+    };
+    const logStartupPhase = vi.fn();
+
+    await expect(
+      fetchDiscordBotIdentity({
+        client: {
+          fetchUser: vi.fn(async () => {
+            throw new Error("boom");
+          }),
+        } as never,
+        runtime: runtime as never,
+        logStartupPhase,
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "discord: failed to fetch bot identity: Error: boom",
+    );
+    expect(logStartupPhase).toHaveBeenCalledWith("fetch-bot-identity:error", "Error: boom");
+  });
+
+  it("throws when fetchUser('@me') returns a user without an id", async () => {
+    const runtime = {
+      error: vi.fn(),
+    };
+    const logStartupPhase = vi.fn();
+
+    await expect(
+      fetchDiscordBotIdentity({
+        client: {
+          fetchUser: vi.fn(async () => ({
+            username: "openclaw",
+          })),
+        } as never,
+        runtime: runtime as never,
+        logStartupPhase,
+      }),
+    ).rejects.toThrow("discord bot identity did not include a user id");
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "discord: failed to fetch bot identity: Error: discord bot identity did not include a user id",
+    );
+    expect(logStartupPhase).toHaveBeenCalledWith(
+      "fetch-bot-identity:error",
+      "Error: discord bot identity did not include a user id",
     );
   });
 });

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -216,9 +216,12 @@ export async function fetchDiscordBotIdentity(params: {
   params.logStartupPhase("fetch-bot-identity:start");
   try {
     const botUser = await params.client.fetchUser("@me");
-    const botUserId = botUser?.id;
+    const botUserId = normalizeOptionalString(botUser?.id);
     const botUserName =
       normalizeOptionalString(botUser?.username) ?? normalizeOptionalString(botUser?.globalName);
+    if (!botUserId) {
+      throw new Error("discord bot identity did not include a user id");
+    }
     params.logStartupPhase(
       "fetch-bot-identity:done",
       `botUserId=${botUserId ?? "<missing>"} botUserName=${botUserName ?? "<missing>"}`,
@@ -227,7 +230,7 @@ export async function fetchDiscordBotIdentity(params: {
   } catch (err) {
     params.runtime.error?.(danger(`discord: failed to fetch bot identity: ${String(err)}`));
     params.logStartupPhase("fetch-bot-identity:error", String(err));
-    return { botUserId: undefined, botUserName: undefined };
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary

- Problem: Discord startup swallows `fetchUser("@me")` failures and leaves `botUserId` unset, which lets guild preflight skip the no-mention drop in degraded startup.
- Why it matters: A failed bot identity fetch turns `requireMention` into a soft guard and can route unmentioned guild traffic into the agent.
- What changed: Startup now fails closed when the Discord bot identity fetch fails or returns no user id, and preflight drops on the computed mention decision even if `botUserId` is absent.
- What did NOT change (scope boundary): This PR does not change mention pattern semantics, route resolution, or Discord ACL policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42219
- Related #49218
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `fetchDiscordBotIdentity()` caught `client.fetchUser("@me")` failures and returned `{ botUserId: undefined }`, then guild preflight only enforced the no-mention drop behind `if (botId && mentionDecision.shouldSkip)`.
- Missing detection / guardrail: There was no regression test for degraded startup with a missing bot id, and startup treated missing identity as recoverable even though mention gating depends on it.
- Contributing context (if known): `mentionDecision.shouldSkip` already encoded the right answer from route mention patterns, but the extra `botId` guard overrode it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/provider.startup.test.ts` and `extensions/discord/src/monitor/message-handler.preflight.test.ts`
- Scenario the test should lock in: startup rejects missing/failed bot identity fetches, and guild preflight still drops unmentioned messages when only route mention patterns are available.
- Why this is the smallest reliable guardrail: The bug lives in two pure Discord monitor seams, so focused tests lock the trust-boundary behavior without broader gateway setup.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Discord monitor startup now aborts instead of continuing in a degraded state when the bot identity cannot be fetched.
- Guild channels with `requireMention: true` no longer accept unmentioned traffic after a bot-id lookup failure.

## Diagram (if applicable)

```text
Before:
[startup fetchUser("@me") fails] -> [botUserId undefined] -> [guild preflight sees mentionDecision.shouldSkip=true but botId=false] -> [message continues]

After:
[startup fetchUser("@me") fails] -> [startup aborts]

Defense in depth:
[guild preflight + botUserId missing + mentionDecision.shouldSkip=true] -> [drop message]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS local dev
- Runtime/container: Node via pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Discord monitor
- Relevant config (redacted): guild channel with `requireMention: true`; Discord group mention patterns configured

### Steps

1. Simulate Discord startup with `client.fetchUser("@me")` throwing or returning no `id`.
2. Send a guild message without a bot mention into a `requireMention: true` channel.
3. Observe preflight and startup behavior.

### Expected

- Startup fails closed on missing bot identity.
- Unmentioned guild traffic is dropped when mention gating says to skip.

### Actual

- Verified by focused regression tests and local gates.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Ran targeted Discord monitor tests, `pnpm check`, and `pnpm build` on this branch.
- Edge cases checked: `fetchUser("@me")` throws; `fetchUser("@me")` returns a user without `id`; guild preflight has mention patterns but no `botUserId`.
- What you did **not** verify: Live Discord traffic against a real bot token.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Discord monitor startup now fails in environments where bot identity fetch intermittently fails.
  - Mitigation: This is the safer failure mode because mention gating depends on the bot id; tests lock the intended fail-closed behavior.
