### PR TITLE
feat(node): add --daemon-env flag to openclaw node install

### DIFF
--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -1,3 +1,4 @@
+import { parseDaemonEnvEntries } from "../../commands/daemon-install-helpers.js";
 import { buildNodeInstallPlan } from "../../commands/node-daemon-install-helpers.js";
 import {
   DEFAULT_NODE_DAEMON_RUNTIME,
@@ -44,6 +45,7 @@ type NodeDaemonInstallOptions = {
   displayName?: string;
   runtime?: string;
   force?: boolean;
+  daemonEnv?: string[];
   json?: boolean;
 };
 
@@ -150,6 +152,19 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
       },
     });
 
+  // Merge any extra --daemon-env KEY=VALUE entries into the environment dict.
+  const extraEnv = parseDaemonEnvEntries(
+    Array.isArray(opts.daemonEnv) ? opts.daemonEnv : undefined,
+    (msg) => {
+      if (json) {
+        warnings.push(msg);
+      } else {
+        defaultRuntime.log(msg);
+      }
+    },
+  );
+  const mergedEnvironment = { ...environment, ...extraEnv };
+
   await installDaemonServiceAndEmit({
     serviceNoun: "Node",
     service,
@@ -162,7 +177,7 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
         stdout,
         programArguments,
         workingDirectory,
-        environment,
+        environment: mergedEnvironment,
         description,
       });
     },

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -82,6 +82,7 @@ export function registerNodeCli(program: Command) {
     .option("--display-name <name>", "Override node display name")
     .option("--runtime <runtime>", "Service runtime (node|bun). Default: node")
     .option("--force", "Reinstall/overwrite if already installed", false)
+    .option("--daemon-env <KEY=VALUE>", "Extra Environment= entry for the node systemd/launchd unit (repeatable)", (val: string, prev: string[]) => [...(prev ?? []), val], [] as string[])
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runNodeDaemonInstall(opts);

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -82,7 +82,7 @@ export function registerNodeCli(program: Command) {
     .option("--display-name <name>", "Override node display name")
     .option("--runtime <runtime>", "Service runtime (node|bun). Default: node")
     .option("--force", "Reinstall/overwrite if already installed", false)
-    .option("--daemon-env <KEY=VALUE>", "Extra Environment= entry for the node systemd/launchd unit (repeatable)", (val: string, prev: string[]) => [...(prev ?? []), val], [] as string[])
+    .option("--daemon-env <KEY=VALUE>", "Extra Environment= entry for the node systemd/launchd/schtasks unit (repeatable)", (val: string, prev: string[]) => [...(prev ?? []), val], [] as string[])
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runNodeDaemonInstall(opts);

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -310,6 +310,35 @@ export async function buildGatewayInstallPlan(params: {
   };
 }
 
+/**
+ * Parses an array of "KEY=VALUE" strings (from --daemon-env) into a plain
+ * object suitable for merging into the systemd/launchd unit environment dict.
+ * Entries without "=" or with an empty key are surfaced via the optional warn
+ * callback instead of being silently dropped.
+ */
+export function parseDaemonEnvEntries(
+  entries: string[] | undefined,
+  warn?: (msg: string) => void,
+): Record<string, string> {
+  if (!entries || entries.length === 0) return {};
+  const result: Record<string, string> = {};
+  for (const entry of entries) {
+    const eq = entry.indexOf("=");
+    if (eq === -1) {
+      warn?.(`--daemon-env: ignoring malformed entry ${JSON.stringify(entry)} (expected KEY=VALUE)`);
+      continue;
+    }
+    const key = entry.slice(0, eq).trim();
+    const value = entry.slice(eq + 1);
+    if (!key) {
+      warn?.(`--daemon-env: ignoring malformed entry ${JSON.stringify(entry)} (key is empty)`);
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
 export function gatewayInstallErrorHint(platform = process.platform): string {
   return platform === "win32"
     ? "Tip: native Windows now falls back to a per-user Startup-folder login item when Scheduled Task creation is denied; if install still fails, rerun from an elevated PowerShell or skip service install."


### PR DESCRIPTION
Fixes #68297
Related: #68240

## What

Mirrors the `--daemon-env` flag added to `openclaw onboard --install-daemon` in #68240, now for `openclaw node install`.

```bash
openclaw node install --host <gw> --port 18789 \
  --daemon-env OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1
```

## Why

When the gateway is LAN-bound (docker, headscale, VPC), the node service must run with `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1`. Without this flag, the only workaround is to write a systemd drop-in after install and restart the service — adding an unnecessary restart cycle.

## How

Same pattern as #68240:
- Add repeatable `--daemon-env <KEY=VALUE>` option to `src/cli/node-cli/register.ts`
- Parse entries via `parseDaemonEnvEntries()` (reused from `daemon-install-helpers.ts`, no new code)
- Merge into the `environment` dict before `service.install()` in `src/cli/node-cli/daemon.ts`

## Files changed

| File | Change |
|------|--------|
| `src/cli/node-cli/register.ts` | Add repeatable `--daemon-env` option to `install` subcommand |
| `src/cli/node-cli/daemon.ts` | Add `daemonEnv` to options type + merge into environment before install |