### PR TITLE
fix(browser): return undefined ssrfPolicy when browser.ssrfPolicy is unset

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -307,9 +307,9 @@ describe("browser config", () => {
     });
   });
 
-  it("defaults browser SSRF policy to strict mode when unset", () => {
+  it("returns undefined browser SSRF policy when unset", () => {
     const resolved = resolveBrowserConfig({});
-    expect(resolved.ssrfPolicy).toEqual({});
+    expect(resolved.ssrfPolicy).toBeUndefined();
   });
 
   it("supports explicit strict mode by disabling private network access", () => {

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -143,9 +143,13 @@ function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | 
     !allowedHostnames &&
     !hostnameAllowlist
   ) {
-    // Keep the default policy object present so CDP guards still enforce
-    // fail-closed private-network checks on unconfigured installs.
-    return {};
+    // Return undefined when no ssrfPolicy is configured. The CDP fetch helpers
+    // treat undefined as "allow private network" (they default to
+    // { allowPrivateNetwork: true } via the `?? { allowPrivateNetwork: true }`
+    // fallback). Returning {} here instead causes assertCdpEndpointAllowed to
+    // run the SSRF check with an empty policy, which blocks private IPs such as
+    // those used in WSL→Windows remote CDP setups (e.g. 172.29.x.x).
+    return undefined;
   }
 
   return {

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -143,12 +143,14 @@ function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | 
     !allowedHostnames &&
     !hostnameAllowlist
   ) {
-    // Return undefined when no ssrfPolicy is configured. The CDP fetch helpers
-    // treat undefined as "allow private network" (they default to
-    // { allowPrivateNetwork: true } via the `?? { allowPrivateNetwork: true }`
-    // fallback). Returning {} here instead causes assertCdpEndpointAllowed to
-    // run the SSRF check with an empty policy, which blocks private IPs such as
-    // those used in WSL→Windows remote CDP setups (e.g. 172.29.x.x).
+    // Return undefined when no ssrfPolicy is configured so that:
+    // 1. assertCdpEndpointAllowed short-circuits (its guard is `if (!ssrfPolicy) return`)
+    //    rather than running an SSRF check with an empty policy that blocks private IPs
+    //    (e.g. WSL→Windows remote CDP on 172.29.x.x).
+    // 2. Navigation guards (redactBlockedTabUrls, assertExistingSessionPostInteractionNavigation)
+    //    also short-circuit, which is correct — they only enforce restrictions when
+    //    dangerouslyAllowPrivateNetwork:false or allowedHostnames is explicitly set.
+    //    An empty `{}` policy would have passed those checks anyway; undefined is equivalent.
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- `resolveBrowserSsrFPolicy` was returning `{}` (empty object) when `browser.ssrfPolicy` was not configured
- The CDP fetch helper uses `ssrfPolicy ?? { allowPrivateNetwork: true }` — so `{}` (truthy) bypassed the default, blocking private network IPs like `172.29.x.x` used in WSL→Windows remote CDP setups
- `assertCdpEndpointAllowed` also exits early only when `!ssrfPolicy` — `{}` caused it to run the SSRF check and block the connection
- Fix: return `undefined` when no policy is configured, letting the CDP helpers apply their own permissive default for remote connections

## Root cause

`openclaw browser status` and `openclaw browser tabs` reported `running: false` / empty tabs for healthy remote CDP endpoints on private LANs because the empty policy object treated unconfigured installs the same as explicitly restricted ones.

## Test plan

- [ ] `resolveBrowserConfig({})` now returns `ssrfPolicy: undefined`
- [ ] WSL→Windows Chrome remote CDP setup with `cdpUrl=http://172.29.x.x:9223` and no `browser.ssrfPolicy` config: `openclaw browser status` shows running, `openclaw browser tabs` shows live tabs
- [ ] Explicit `ssrfPolicy: { dangerouslyAllowPrivateNetwork: false }` still returns `{ dangerouslyAllowPrivateNetwork: false }` (existing explicit deny)
- [ ] All existing browser config tests pass