### PR TITLE
fix(pi-embedded-runner): retry silent stopReason=error turns (non-frontier models)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram/polling: bound the persisted-offset confirmation `getUpdates` probe with a client-side timeout so a zombie socket cannot hang polling recovery before the runner watchdog starts. (#50368) Thanks @boticlaw.
+- Agents/Pi runner: retry silent `stopReason=error` turns with no output when no side effects ran, so non-frontier providers that briefly return empty error turns get another chance instead of ending the session early. (#68310) Thanks @Chased1k.
 - Plugins/memory: preserve the active memory capability when read-only snapshot plugin loads run, so status and provider discovery paths no longer wipe memory public artifacts. (#69219) Thanks @zeroaltitude.
 - Plugins: keep only the highest-precedence manifest when distinct discovered plugins share an id, so lower-precedence global or workspace duplicates no longer load beside bundled or config-selected plugins. (#41626) Thanks @Tortes.
 - fix(security): block MINIMAX_API_HOST workspace env injection and remove env-driven URL routing [AI-assisted]. (#67300) Thanks @pgondhi987.

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import type { GraphThreadMessage } from "../graph-thread.js";
 import { _resetThreadParentContextCachesForTest } from "../thread-parent-context.js";
+import "./message-handler-mock-support.test-support.js";
 import { getRuntimeApiMockState } from "./message-handler-mock-support.test-support.js";
 import { createMSTeamsMessageHandler } from "./message-handler.js";
 import { createMessageHandlerDeps } from "./message-handler.test-support.js";

--- a/extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { _resetThreadParentContextCachesForTest } from "../thread-parent-context.js";
+import "./message-handler-mock-support.test-support.js";
 import { getRuntimeApiMockState } from "./message-handler-mock-support.test-support.js";
 import { createMSTeamsMessageHandler } from "./message-handler.js";
 import {

--- a/extensions/qqbot/src/tools/channel.ts
+++ b/extensions/qqbot/src/tools/channel.ts
@@ -1,5 +1,6 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { getAccessToken } from "../api.js";
 import { listQQBotAccountIds, resolveQQBotAccount } from "../config.js";
 import { debugError, debugLog } from "../utils/debug-log.js";
@@ -170,8 +171,15 @@ export function registerChannelTool(api: OpenClawPluginApi): void {
           debugLog(`[qqbot-channel-api] >>> ${method} ${url} (timeout: ${DEFAULT_TIMEOUT_MS}ms)`);
 
           let res: Response;
+          let release = async () => {};
           try {
-            res = await fetch(url, fetchOptions);
+            const guarded = await fetchWithSsrFGuard({
+              url,
+              init: fetchOptions,
+              auditContext: `qqbot.channel-api${p.path}`,
+            });
+            res = guarded.response;
+            release = guarded.release;
           } catch (err) {
             clearTimeout(timeoutId);
             if (err instanceof Error && err.name === "AbortError") {
@@ -192,45 +200,49 @@ export function registerChannelTool(api: OpenClawPluginApi): void {
 
           debugLog(`[qqbot-channel-api] <<< Status: ${res.status} ${res.statusText}`);
 
-          const rawBody = await res.text();
-          if (!rawBody || rawBody.trim() === "") {
-            if (res.ok) {
-              return json({ success: true, status: res.status, path: p.path });
-            }
-            return json({
-              error: `API returned ${res.status} ${res.statusText}`,
-              status: res.status,
-              path: p.path,
-            });
-          }
-
-          let parsed: unknown;
           try {
-            parsed = JSON.parse(rawBody);
-          } catch {
-            parsed = rawBody;
-          }
+            const rawBody = await res.text();
+            if (!rawBody || rawBody.trim() === "") {
+              if (res.ok) {
+                return json({ success: true, status: res.status, path: p.path });
+              }
+              return json({
+                error: `API returned ${res.status} ${res.statusText}`,
+                status: res.status,
+                path: p.path,
+              });
+            }
 
-          if (!res.ok) {
-            const errMsg =
-              typeof parsed === "object" && parsed && "message" in parsed
-                ? String((parsed as { message?: unknown }).message)
-                : `${res.status} ${res.statusText}`;
-            debugError(`[qqbot-channel-api] Error [${method} ${p.path}]: ${errMsg}`);
+            let parsed: unknown;
+            try {
+              parsed = JSON.parse(rawBody);
+            } catch {
+              parsed = rawBody;
+            }
+
+            if (!res.ok) {
+              const errMsg =
+                typeof parsed === "object" && parsed && "message" in parsed
+                  ? String((parsed as { message?: unknown }).message)
+                  : `${res.status} ${res.statusText}`;
+              debugError(`[qqbot-channel-api] Error [${method} ${p.path}]: ${errMsg}`);
+              return json({
+                error: errMsg,
+                status: res.status,
+                path: p.path,
+                details: parsed,
+              });
+            }
+
             return json({
-              error: errMsg,
+              success: true,
               status: res.status,
               path: p.path,
-              details: parsed,
+              data: parsed,
             });
+          } finally {
+            await release();
           }
-
-          return json({
-            success: true,
-            status: res.status,
-            path: p.path,
-            data: parsed,
-          });
         } catch (err) {
           return json({
             error: formatErrorMessage(err),

--- a/src/agents/pi-embedded-runner/run.empty-error-retry.test.ts
+++ b/src/agents/pi-embedded-runner/run.empty-error-retry.test.ts
@@ -153,4 +153,38 @@ describe("runEmbeddedPiAgent silent-error retry", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.isError).toBeFalsy();
   });
+
+  it("does not retry when the failed attempt recorded side effects", async () => {
+    // If the errored turn already sent a message / added a cron / ran a
+    // mutating tool whose result wasn't captured as replay-safe,
+    // resubmission would duplicate those actions. Mirror the gate used by
+    // the other retry resolvers (resolveEmptyResponseRetryInstruction et al.)
+    // and surface the incomplete-turn error instead of retrying blind.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          stopReason: "error",
+          provider: "ollama",
+          model: "glm-5.1:cloud",
+          content: [],
+          usage: { input: 100, output: 0, totalTokens: 100 },
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        replayMetadata: {
+          hadPotentialSideEffects: true,
+          replaySafe: false,
+        },
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-skip-side-effects",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+  });
 });

--- a/src/agents/pi-embedded-runner/run.empty-error-retry.test.ts
+++ b/src/agents/pi-embedded-runner/run.empty-error-retry.test.ts
@@ -1,0 +1,156 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedClassifyFailoverReason,
+  mockedGlobalHookRunner,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+
+// Regression coverage for the silent-error retry in runEmbeddedPiAgent.
+//
+// Symptom: ollama/glm-5.1 occasionally ends a turn with stopReason="error" and
+// zero output tokens after a successful tool-call sequence. The user sees no
+// reply and has to nudge. The existing empty-response retry path is gated on
+// the strict-agentic contract (gpt-5 only), so non-frontier models fell
+// through to "incomplete turn detected". This suite locks in a narrower,
+// model-agnostic resubmission.
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+
+function emptyErrorAttempt(
+  provider: string,
+  model: string,
+  outputTokens = 0,
+): EmbeddedRunAttemptResult {
+  return makeAttemptResult({
+    assistantTexts: [],
+    lastAssistant: {
+      stopReason: "error",
+      provider,
+      model,
+      content: [],
+      usage: { input: 100, output: outputTokens, totalTokens: 100 + outputTokens },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+  });
+}
+
+function successAttempt(provider: string, model: string): EmbeddedRunAttemptResult {
+  return makeAttemptResult({
+    assistantTexts: ["Done."],
+    lastAssistant: {
+      stopReason: "stop",
+      provider,
+      model,
+      content: [{ type: "text", text: "Done." }],
+      usage: { input: 100, output: 5, totalTokens: 105 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+  });
+}
+
+describe("runEmbeddedPiAgent silent-error retry", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+    mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+    mockedClassifyFailoverReason.mockReturnValue(null);
+  });
+
+  it("retries when a turn ends with stopReason=error and zero output tokens", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(emptyErrorAttempt("ollama", "glm-5.1:cloud"));
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("ollama", "glm-5.1:cloud"));
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-basic",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.isError).toBeFalsy();
+  });
+
+  it("caps retries at MAX_EMPTY_ERROR_RETRIES and surfaces incomplete-turn error", async () => {
+    // 1 initial + 3 retries = 4 attempts, all returning empty-error.
+    for (let i = 0; i < 4; i += 1) {
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(emptyErrorAttempt("ollama", "glm-5.1:cloud"));
+    }
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-exhausted",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(4);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+  });
+
+  it("does not retry when stopReason=error but output tokens > 0", async () => {
+    // Model produced something before erroring; surfacing that text is better
+    // than silent resubmission.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyErrorAttempt("ollama", "glm-5.1:cloud", 12),
+    );
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-skip-with-output",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry when stopReason=stop and output=0 (out of scope)", async () => {
+    // Clean stop with no output is a legitimate silent reply (e.g. NO_REPLY
+    // token path), not a crash. This retry must not trigger there.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          stopReason: "stop",
+          provider: "ollama",
+          model: "glm-5.1:cloud",
+          content: [],
+          usage: { input: 100, output: 0, totalTokens: 100 },
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-skip-clean-stop",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries for frontier models too — the fix is model-agnostic", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyErrorAttempt("anthropic", "claude-opus-4-7"),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("anthropic", "claude-opus-4-7"));
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      runId: "run-empty-error-retry-frontier",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.isError).toBeFalsy();
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1933,6 +1933,13 @@ export async function runEmbeddedPiAgent(
           // Content-empty guard: a reasoning-only error (content has thinking
           // blocks) is a distinct failure mode handled elsewhere; only retry
           // when the assistant truly produced nothing.
+          //
+          // Side-effect guard: if the failed attempt already recorded potential
+          // side effects (messaging tool sent, cron add, mutating tool
+          // call that wasn't round-tripped as replay-safe), resubmission can
+          // duplicate those actions. Mirror the gate the other retry resolvers
+          // use (resolveEmptyResponseRetryInstruction, reasoning-only, planning-
+          // only), which short-circuit on attempt.replayMetadata.hadPotentialSideEffects.
           const silentErrorContent = sessionLastAssistant?.content as Array<unknown> | undefined;
           if (
             incompleteTurnText &&
@@ -1942,6 +1949,7 @@ export async function runEmbeddedPiAgent(
             sessionLastAssistant?.stopReason === "error" &&
             ((sessionLastAssistant?.usage as { output?: number } | undefined)?.output ?? 0) === 0 &&
             (silentErrorContent?.length ?? 0) === 0 &&
+            !attempt.replayMetadata.hadPotentialSideEffects &&
             emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
           ) {
             emptyErrorRetries += 1;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -489,6 +489,13 @@ export async function runEmbeddedPiAgent(
       });
       let rateLimitProfileRotations = 0;
       let timeoutCompactionAttempts = 0;
+      // Silent-error retry: non-strict-agentic models (e.g. ollama/glm-5.1) can
+      // end a turn with stopReason="error" + zero output tokens, producing no
+      // user-visible text. The existing empty-response retry is gated on
+      // isStrictAgenticSupportedProviderModel (gpt-5 only). This is an
+      // orthogonal, model-agnostic resubmission.
+      const MAX_EMPTY_ERROR_RETRIES = 3;
+      let emptyErrorRetries = 0;
       const overloadFailoverBackoffMs = resolveOverloadFailoverBackoffMs(params.config);
       const overloadProfileRotationLimit = resolveOverloadProfileRotationLimit(params.config);
       const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit(params.config);
@@ -1910,6 +1917,42 @@ export async function runEmbeddedPiAgent(
               `empty response retries exhausted: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} attempts=${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} — surfacing incomplete-turn error`,
             );
+          }
+          // ── silent-error retry ────────────────────────────────────────────
+          // Observed with ollama/glm-5.1: a turn can end with stopReason="error"
+          // and zero output tokens AND empty content after a successful
+          // tool-call sequence, producing no user-visible text at all. The
+          // existing empty-response retry path (resolveEmptyResponseRetryInstruction)
+          // is gated on the strict-agentic contract (gpt-5 only), so non-frontier
+          // models fall through to "incomplete turn detected" → silent gap
+          // until the user nudges. This is a narrower, model-agnostic
+          // resubmission: same prompt, same session transcript (tool results
+          // already captured), no instruction injection. Placed before the
+          // incompleteTurnText return so it actually gets a chance to fire.
+          //
+          // Content-empty guard: a reasoning-only error (content has thinking
+          // blocks) is a distinct failure mode handled elsewhere; only retry
+          // when the assistant truly produced nothing.
+          const silentErrorContent = sessionLastAssistant?.content as Array<unknown> | undefined;
+          if (
+            incompleteTurnText &&
+            !aborted &&
+            !promptError &&
+            !timedOut &&
+            sessionLastAssistant?.stopReason === "error" &&
+            ((sessionLastAssistant?.usage as { output?: number } | undefined)?.output ?? 0) === 0 &&
+            (silentErrorContent?.length ?? 0) === 0 &&
+            emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
+          ) {
+            emptyErrorRetries += 1;
+            log.warn(
+              `[empty-error-retry] stopReason=error output=0; resubmitting ` +
+                `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +
+                `provider=${sessionLastAssistant?.provider ?? provider} ` +
+                `model=${sessionLastAssistant?.model ?? model.id} ` +
+                `sessionKey=${params.sessionKey ?? params.sessionId}`,
+            );
+            continue;
           }
           if (incompleteTurnText) {
             const replayInvalid = resolveReplayInvalidForAttempt(incompleteTurnText);


### PR DESCRIPTION
## Summary

- Adds a narrow, model-agnostic resubmission in the embedded runner attempt loop for turns that end with `stopReason="error"` + `usage.output=0` + empty `content[]`. Bounded at 3 retries. Placed before the `incompleteTurnText` surface-to-user return so it actually gets a chance to fire.
- Primary symptom: ollama/glm-5.1:cloud occasionally ends a turn this way after a successful tool-call sequence. The existing empty-response retry path (`resolveEmptyResponseRetryInstruction` in `src/agents/pi-embedded-runner/run/incomplete-turn.ts`) is gated on the strict-agentic contract (gpt-5 family only), so non-frontier models fall through to \"incomplete turn detected\" with `payloads=0` and no recovery — the user sees no reply and has to nudge.
- Also observed rarely on `claude-opus-4-7`. The guard conditions (error + zero output + empty content) are themselves vendor-neutral, so no model gating.

Closes #68281.

## Why the content-empty guard is load-bearing

A reasoning-only error — where the assistant produced thinking blocks before the turn errored — also has `output=0` against the typed `usage` shape. Without the `content.length === 0` check the retry fires for those too and breaks the existing `planning-only retry when the assistant ended in error` coverage. Empty content distinguishes a silent crash from \"the model produced hidden tokens before erroring.\"

## Evidence

Corpus scan across ~412 session files in a long-running agent showed 23 user-nudge events (\"boop\" / \"ahem\" / \".\" / \"continue\"). 19/23 immediately follow a turn matching exactly this signature (stopReason=error, output=0, empty content, ollama/glm-5.1:cloud). See linked issue for more detail.

## Test plan

- [x] New `src/agents/pi-embedded-runner/run.empty-error-retry.test.ts`:
  - Retries for ollama/glm-5.1:cloud → succeeds on 2nd attempt
  - Caps at `MAX_EMPTY_ERROR_RETRIES = 3` → 4 total attempts → surfaces incomplete-turn error
  - Does NOT retry when `output > 0` (preserve produced text)
  - Does NOT retry when `stopReason=stop` + `output=0` (NO_REPLY path)
  - Retries for `anthropic/claude-opus-4-7` too (model-agnostic)
- [x] `pnpm test src/agents/pi-embedded-runner` → 629/629 pass locally on this branch
- [x] `pnpm test src/agents/pi-embedded-runner/run.empty-error-retry.test.ts` → 5/5 pass
- [x] oxfmt / oxlint clean
- [ ] CI (will populate after push)

## Notes

- Related but distinct from #68076: that bug is `stopReason=stop payloads=0` caused by an OpenRouter `baseUrl` misconfiguration (a config fix). This PR addresses the `stopReason=error` variant (a transient model/transport crash with no existing retry path for non-frontier models). Test case 4 explicitly leaves the `stop + output=0` scenario alone.
- No changelog entry added per the repo guideline that pure bug fixes without user-visible wording changes can land without one; happy to add `### Fixes: GLM 5.1 / non-frontier models auto-retry silent error turns.` to the active version block if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)