### PR TITLE
fix: update reasoning stream message to include Feishu support

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -501,7 +501,7 @@ export async function handleDirectiveOnly(
       directives.reasoningLevel === "off"
         ? formatDirectiveAck("Reasoning visibility disabled.")
         : directives.reasoningLevel === "stream"
-          ? formatDirectiveAck("Reasoning stream enabled (Telegram only).")
+          ? formatDirectiveAck("Reasoning stream enabled (Telegram/Feishu).")
           : formatDirectiveAck("Reasoning visibility enabled."),
     );
   }


### PR DESCRIPTION
## Summary
Updates the confirmation message shown when enabling reasoning stream mode to correctly indicate that the feature works in both Telegram and Feishu (Lark) channels.

## Root Cause
The reasoning stream feature was implemented for both Telegram and Feishu channels (as evidenced by ), but the confirmation message shown to users incorrectly stated 'Telegram only'.

## Fix
Changed the message from:
- 'Reasoning stream enabled (Telegram only).'

To:
- 'Reasoning stream enabled (Telegram/Feishu).'

## Test Plan
- [x] Verified Feishu extension has reasoning stream support ( function)
- [x] Existing directive parsing tests pass
- [x] No functional changes, only UI text update

Closes openclaw#68305