### PR TITLE
fix(memory-core): downgrade narrative cleanup WARN to debug for missing-scope errors

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -573,6 +573,7 @@ describe("generateAndAppendDreamNarrative", () => {
 
   function createMockLogger() {
     return {
+      debug: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
@@ -675,6 +676,27 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(subagent.waitForRun.mock.calls[1][0]).toMatchObject({ timeoutMs: 120_000 });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("narrative session cleanup failed for rem phase"),
+    );
+  });
+
+  it("logs debug (not warn) when deleteSession fails due to missing scope", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("");
+    subagent.deleteSession.mockRejectedValue(new Error("missing scope: operator.admin"));
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["some memory"] },
+      logger,
+    });
+
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("narrative session cleanup failed"),
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("narrative session cleanup skipped for light phase"),
     );
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -51,6 +51,7 @@ export type NarrativePhaseData = {
 };
 
 type Logger = {
+  debug?: (message: string) => void;
   info: (message: string) => void;
   warn: (message: string) => void;
   error: (message: string) => void;
@@ -932,9 +933,18 @@ export async function generateAndAppendDreamNarrative(params: {
     try {
       await params.subagent.deleteSession({ sessionKey });
     } catch (cleanupErr) {
-      params.logger.warn(
-        `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupErr)}`,
-      );
+      const errMsg = formatErrorMessage(cleanupErr);
+      // Cleanup is best-effort; permission errors are expected when the cron
+      // session lacks operator.admin scope — log at debug to avoid noise.
+      if (/missing scopes?:/i.test(errMsg)) {
+        params.logger.debug?.(
+          `memory-core: narrative session cleanup skipped for ${params.data.phase} phase (insufficient scope): ${errMsg}`,
+        );
+      } else {
+        params.logger.warn(
+          `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${errMsg}`,
+        );
+      }
     }
 
     await scrubDreamingNarrativeArtifacts(params.logger).catch((scrubErr: unknown) => {


### PR DESCRIPTION
## Summary

- `deleteSession` during dreaming narrative cleanup fails with `missing scope: operator.admin` when the cron session lacks admin permissions
- This is expected best-effort behavior, but the `warn` log fires on every dreaming cycle, flooding the logs
- Fix: detect `/missing scopes?:/i` in the error message and log at `debug` level instead of `warn`
- Added optional `debug` field to the local `Logger` type so callers without a debug method compile cleanly

## Test plan

- [ ] `missing scope: operator.admin` error → `logger.debug` called, `logger.warn` not called for cleanup
- [ ] Other errors (e.g. `"still active"`) → `logger.warn` still called as before
- [ ] Dreaming cycle logs are quiet when `operator.admin` scope is absent