### PR TITLE
fix(lobster): surface file-not-found error for workflow-like pipeline paths

### DIFF
--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -323,6 +323,25 @@ describe("createEmbeddedLobsterRunner", () => {
     ).rejects.toThrow(/approve required/);
   });
 
+  it("throws a clear error when a file-like pipeline path does not exist", async () => {
+    const runner = createEmbeddedLobsterRunner({
+      loadRuntime: vi.fn().mockResolvedValue({
+        runToolRequest: vi.fn(),
+        resumeToolRequest: vi.fn(),
+      }),
+    });
+
+    await expect(
+      runner.run({
+        action: "run",
+        pipeline: "lobster/haiku-ppc64-hidden-alias-autofix-once.lobster",
+        cwd: process.cwd(),
+        timeoutMs: 2000,
+        maxStdoutBytes: 4096,
+      }),
+    ).rejects.toThrow();
+  });
+
   it("aborts long-running embedded work", async () => {
     const runtime = {
       runToolRequest: vi.fn(

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -339,7 +339,7 @@ describe("createEmbeddedLobsterRunner", () => {
         timeoutMs: 2000,
         maxStdoutBytes: 4096,
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/no such file|ENOENT/i);
   });
 
   it("aborts long-running embedded work", async () => {

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -190,6 +190,17 @@ async function resolveWorkflowFile(candidate: string, cwd: string) {
   return resolved;
 }
 
+const WORKFLOW_FILE_EXTENSIONS = new Set([".lobster", ".yaml", ".yml", ".json"]);
+
+function looksLikeWorkflowFileCandidate(candidate: string): boolean {
+  const ext = path.extname(candidate).toLowerCase();
+  return (
+    WORKFLOW_FILE_EXTENSIONS.has(ext) ||
+    candidate.includes("/") ||
+    candidate.includes(path.sep)
+  );
+}
+
 async function detectWorkflowFile(candidate: string, cwd: string) {
   const trimmed = candidate.trim();
   if (!trimmed || trimmed.includes("|")) {
@@ -197,7 +208,10 @@ async function detectWorkflowFile(candidate: string, cwd: string) {
   }
   try {
     return await resolveWorkflowFile(trimmed, cwd);
-  } catch {
+  } catch (err) {
+    if (looksLikeWorkflowFileCandidate(trimmed)) {
+      throw err;
+    }
     return null;
   }
 }

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -184,7 +184,7 @@ async function resolveWorkflowFile(candidate: string, cwd: string) {
     throw new Error("Workflow path is not a file");
   }
   const ext = path.extname(resolved).toLowerCase();
-  if (![".lobster", ".yaml", ".yml", ".json"].includes(ext)) {
+  if (!WORKFLOW_FILE_EXTENSIONS.has(ext)) {
     throw new Error("Workflow file must end in .lobster, .yaml, .yml, or .json");
   }
   return resolved;
@@ -194,10 +194,11 @@ const WORKFLOW_FILE_EXTENSIONS = new Set([".lobster", ".yaml", ".yml", ".json"])
 
 function looksLikeWorkflowFileCandidate(candidate: string): boolean {
   const ext = path.extname(candidate).toLowerCase();
+  const firstToken = (candidate.split(/\s+/)[0] ?? candidate);
   return (
     WORKFLOW_FILE_EXTENSIONS.has(ext) ||
-    candidate.includes("/") ||
-    candidate.includes(path.sep)
+    firstToken.includes("/") ||
+    firstToken.includes(path.sep)
   );
 }
 


### PR DESCRIPTION
## Summary

- `detectWorkflowFile` was silently swallowing all errors from `resolveWorkflowFile`
- A path like `lobster/haiku-ppc64-hidden-alias-autofix-once.lobster` that doesn't exist on disk was returned as `null`, causing the caller to fall back to treating it as an inline pipeline name
- This produced the misleading error: `Unknown command: lobster/haiku-ppc64-hidden-alias-autofix-once.lobster`
- Fix: add `looksLikeWorkflowFileCandidate` — inputs with a workflow extension (`.lobster`, `.yaml`, `.yml`, `.json`) or a path separator are treated as file references; when `resolveWorkflowFile` throws for such inputs, re-throw instead of swallowing the error

## Test plan

- [ ] `pipeline: "lobster/my-workflow.lobster"` with a non-existent path throws, not falls back to pipeline parsing
- [ ] `pipeline: "exec --json=true echo hi"` (no extension, no path separator) still silently returns null and falls back to pipeline parsing as before
- [ ] Existing workflow-file detection tests pass