### PR TITLE
Preserve unsent media payloads after block streaming

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -187,7 +187,7 @@ describe("buildReplyPayloads media filter integration", () => {
     await expectSameTargetRepliesSuppressed({ provider: "lark", to: "ou_abc123" });
   });
 
-  it("drops all final payloads when block pipeline streamed successfully", async () => {
+  it("preserves unsent media final payloads after successful block streaming", async () => {
     const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
       didStream: () => true,
       isAborted: () => false,
@@ -197,8 +197,34 @@ describe("buildReplyPayloads media filter integration", () => {
       stop: () => {},
       hasBuffered: () => false,
     };
-    // shouldDropFinalPayloads short-circuits to [] when the pipeline streamed
-    // without aborting, so hasSentPayload is never reached.
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      replyToMode: "all",
+      payloads: [{ text: "response", mediaUrl: "file:///tmp/photo.jpg", replyToId: "post-123" }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]).toMatchObject({
+      text: "response",
+      mediaUrl: "file:///tmp/photo.jpg",
+      replyToId: "post-123",
+    });
+  });
+
+  it("drops unsent text-only final payloads after successful block streaming", async () => {
+    const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
+      didStream: () => true,
+      isAborted: () => false,
+      hasSentPayload: () => false,
+      enqueue: () => {},
+      flush: async () => {},
+      stop: () => {},
+      hasBuffered: () => false,
+    };
+
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
       blockStreamingEnabled: true,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -158,9 +158,10 @@ export async function buildReplyPayloads(params: {
   ).filter(isRenderablePayload);
   const silentFilteredPayloads = params.silentExpected ? [] : replyTaggedPayloads;
 
-  // Drop final payloads only when block streaming succeeded end-to-end.
-  // If streaming aborted (e.g., timeout), fall back to final payloads.
-  const shouldDropFinalPayloads =
+  // Keep media/error final payloads even after block streaming succeeds.
+  // Plain text finals are still suppressed after a successful stream so text_end
+  // block replies do not get duplicated as a trailing final message.
+  const shouldFilterSuccessfulStreamFinals =
     params.blockStreamingEnabled &&
     Boolean(params.blockReplyPipeline?.didStream()) &&
     !params.blockReplyPipeline?.isAborted();
@@ -214,17 +215,21 @@ export async function buildReplyPayloads(params: {
       })
     : dedupedPayloads;
   // Filter out payloads already sent via pipeline or directly during tool flush.
-  const filteredPayloads = shouldDropFinalPayloads
-    ? mediaFilteredPayloads.filter((payload) => payload.isError)
-    : params.blockStreamingEnabled
+  const filteredPayloads = params.blockStreamingEnabled
+    ? mediaFilteredPayloads.filter((payload) => {
+        if (params.blockReplyPipeline?.hasSentPayload(payload)) {
+          return false;
+        }
+        if (!shouldFilterSuccessfulStreamFinals) {
+          return true;
+        }
+        return payload.isError || resolveSendableOutboundReplyParts(payload).hasMedia;
+      })
+    : params.directlySentBlockKeys?.size
       ? mediaFilteredPayloads.filter(
-          (payload) => !params.blockReplyPipeline?.hasSentPayload(payload),
+          (payload) => !params.directlySentBlockKeys!.has(createBlockReplyContentKey(payload)),
         )
-      : params.directlySentBlockKeys?.size
-        ? mediaFilteredPayloads.filter(
-            (payload) => !params.directlySentBlockKeys!.has(createBlockReplyContentKey(payload)),
-          )
-        : mediaFilteredPayloads;
+      : mediaFilteredPayloads;
   const replyPayloads = suppressMessagingToolReplies ? [] : filteredPayloads;
 
   return {


### PR DESCRIPTION
## Summary

- preserve unsent media final payloads after successful block streaming
- keep duplicate suppression for already-sent block payloads via `blockReplyPipeline.hasSentPayload(payload)`
- keep successful streamed text-only final payloads suppressed so `text_end` block replies do not get duplicated
- keep post-stream error payloads preserved

## Issue

When block streaming succeeded, `buildReplyPayloads` dropped all final payloads except errors. That also dropped media/file payloads that were produced as final agent output and had not been sent by the block pipeline, so Telegram media could be lost after streamed text.

This PR narrows the change to media/error final payloads only. Plain text final payloads after a successful stream remain suppressed to preserve existing duplicate coalescing behavior.

## Tests

- `git diff --check`
- `PATH=/opt/node-v22.22.0/bin:$PATH corepack pnpm check:no-conflict-markers`
- `PATH=/opt/node-v22.22.0/bin:$PATH corepack pnpm exec vitest run --config vitest.config.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts --testNamePattern "(preserves unsent media final payloads|drops unsent text-only final payloads|coalesces duplicate text_end block replies)"` - 2 files, 3 targeted tests passed
- `PATH=/opt/node-v22.22.0/bin:$PATH OPENCLAW_VITEST_MAX_WORKERS=2 NODE_OPTIONS=--max-old-space-size=6144 corepack pnpm exec node $(PATH=/opt/node-v22.22.0/bin:$PATH corepack pnpm bin)/vitest run --config test/vitest/vitest.auto-reply-reply.config.ts` - 100 files, 1082 tests passed