### PR TITLE
fix(ollama): add baseUrl to configSchema and wire it through discovery

### DIFF
--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -36,6 +36,7 @@ const PROVIDER_ID = "ollama";
 const DEFAULT_API_KEY = "ollama-local";
 
 type OllamaPluginConfig = {
+  baseUrl?: string;
   discovery?: {
     enabled?: boolean;
   };
@@ -171,6 +172,13 @@ export default definePluginEntry({
             ollamaKey.trim().length > 0 &&
             ollamaKey.trim() !== DEFAULT_API_KEY;
           const explicitApiKey = readStringValue(explicit?.apiKey);
+          // pluginConfig.baseUrl lets users configure a remote endpoint via
+          // plugins.entries.ollama.config.baseUrl without needing to also
+          // set models.providers.ollama.baseUrl.
+          const pluginBaseUrl =
+            typeof pluginConfig.baseUrl === "string" && pluginConfig.baseUrl.trim()
+              ? pluginConfig.baseUrl.trim()
+              : undefined;
           if (hasExplicitModels && explicit) {
             return {
               provider: {
@@ -178,7 +186,9 @@ export default definePluginEntry({
                 baseUrl:
                   typeof explicit.baseUrl === "string" && explicit.baseUrl.trim()
                     ? resolveOllamaApiBase(explicit.baseUrl)
-                    : OLLAMA_DEFAULT_BASE_URL,
+                    : pluginBaseUrl
+                      ? resolveOllamaApiBase(pluginBaseUrl)
+                      : OLLAMA_DEFAULT_BASE_URL,
                 api: explicit.api ?? "ollama",
                 apiKey: resolveOllamaDiscoveryApiKey({
                   env: ctx.env,
@@ -191,13 +201,14 @@ export default definePluginEntry({
           if (
             !hasRealOllamaKey &&
             !hasMeaningfulExplicitConfig &&
+            !pluginBaseUrl &&
             shouldSkipAmbientOllamaDiscovery(ctx.env)
           ) {
             return null;
           }
 
-          const provider = await buildOllamaProvider(explicit?.baseUrl, {
-            quiet: !hasRealOllamaKey && !hasMeaningfulExplicitConfig,
+          const provider = await buildOllamaProvider(explicit?.baseUrl ?? pluginBaseUrl, {
+            quiet: !hasRealOllamaKey && !hasMeaningfulExplicitConfig && !pluginBaseUrl,
           });
           if (provider.models.length === 0 && !ollamaKey && !explicit?.apiKey) {
             return null;

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -26,6 +26,10 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "baseUrl": {
+        "type": "string",
+        "description": "Base URL of the Ollama API endpoint (e.g. http://100.x.y.z:11434). Overrides the default http://127.0.0.1:11434."
+      },
       "discovery": {
         "type": "object",
         "additionalProperties": false,
@@ -36,6 +40,10 @@
     }
   },
   "uiHints": {
+    "baseUrl": {
+      "label": "API Base URL",
+      "help": "Base URL for the Ollama API. Use this to point OpenClaw at a remote or Tailscale-accessible Ollama instance instead of localhost."
+    },
     "discovery": {
       "label": "Model Discovery",
       "help": "Plugin-owned controls for Ollama model auto-discovery."

--- a/extensions/ollama/provider-discovery.ts
+++ b/extensions/ollama/provider-discovery.ts
@@ -13,6 +13,7 @@ const DEFAULT_API_KEY = "ollama-local";
 const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
 
 type OllamaPluginConfig = {
+  baseUrl?: string;
   discovery?: {
     enabled?: boolean;
   };
@@ -141,6 +142,10 @@ async function runOllamaDiscovery(ctx: ProviderCatalogContext) {
     ollamaKey.trim().length > 0 &&
     ollamaKey.trim() !== DEFAULT_API_KEY;
   const explicitApiKey = readStringValue(explicit?.apiKey);
+  const pluginBaseUrl =
+    typeof pluginConfig.baseUrl === "string" && pluginConfig.baseUrl.trim()
+      ? pluginConfig.baseUrl.trim()
+      : undefined;
   if (hasExplicitModels && explicit) {
     return {
       provider: {
@@ -148,7 +153,9 @@ async function runOllamaDiscovery(ctx: ProviderCatalogContext) {
         baseUrl:
           typeof explicit.baseUrl === "string" && explicit.baseUrl.trim()
             ? resolveOllamaApiBase(explicit.baseUrl)
-            : OLLAMA_DEFAULT_BASE_URL,
+            : pluginBaseUrl
+              ? resolveOllamaApiBase(pluginBaseUrl)
+              : OLLAMA_DEFAULT_BASE_URL,
         api: explicit.api ?? "ollama",
         apiKey: resolveOllamaDiscoveryApiKey({
           env: ctx.env,
@@ -161,13 +168,14 @@ async function runOllamaDiscovery(ctx: ProviderCatalogContext) {
   if (
     !hasRealOllamaKey &&
     !hasMeaningfulExplicitConfig &&
+    !pluginBaseUrl &&
     shouldSkipAmbientOllamaDiscovery(ctx.env)
   ) {
     return null;
   }
 
-  const provider = await buildOllamaProvider(explicit?.baseUrl, {
-    quiet: !hasRealOllamaKey && !hasMeaningfulExplicitConfig,
+  const provider = await buildOllamaProvider(explicit?.baseUrl ?? pluginBaseUrl, {
+    quiet: !hasRealOllamaKey && !hasMeaningfulExplicitConfig && !pluginBaseUrl,
   });
   if (provider.models?.length === 0 && !ollamaKey && !explicit?.apiKey) {
     return null;


### PR DESCRIPTION
## Summary

- The Ollama plugin's `configSchema` had `additionalProperties: false` with only `discovery.enabled` allowed, rejecting any `plugins.entries.ollama.config.baseUrl` at startup
- Values set via `openclaw config set plugins.entries.ollama.config.baseUrl "http://..."` were silently stripped and the provider fell back to `http://127.0.0.1:11434`
- Fix: add `baseUrl` as an optional string property to the configSchema, add it to `OllamaPluginConfig`, and in the discovery run use `pluginConfig.baseUrl` as a fallback when `models.providers.ollama.baseUrl` is not set

## Behaviour

- `plugins.entries.ollama.config.baseUrl = "http://100.x.y.z:11434"` now passes schema validation and is used as the Ollama endpoint
- `models.providers.ollama.baseUrl` continues to work and takes precedence over the plugin-level setting
- Ambient discovery is only skipped in tests/CI when neither `pluginBaseUrl` nor explicit config is provided

## Test plan

- [ ] `openclaw config set plugins.entries.ollama.config.baseUrl "http://100.x.y.z:11434"` — no validation error on gateway restart
- [ ] Gateway connects to the remote Ollama endpoint instead of `127.0.0.1:11434`
- [ ] `models.providers.ollama.baseUrl` still takes precedence when both are set
- [ ] Existing `discovery.enabled` config still works as before