### PR TITLE
feat(elevenlabs): register eleven_v3 in TTS model allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Control UI: refine the agent Tool Access panel with compact live-tool chips, collapsible tool groups, direct per-tool toggles, and clearer runtime/source provenance. (#71405) Thanks @BunsDev.
 - Memory-core/hybrid search: expose raw `vectorScore` and `textScore` alongside the combined `score` on hybrid memory search results, so callers can inspect vector-versus-text retrieval contribution before temporal decay or MMR reordering. Fixes #68166. (#68286) Thanks @ajfonthemove.
 - Providers/Xiaomi: add MiMo TTS as a bundled speech provider with MP3/WAV output and voice-note Opus transcoding. Fixes #52376. (#55614) Thanks @zoujiejun.
+- Providers/ElevenLabs: include `eleven_v3` in the bundled TTS model catalog so model selection surfaces can offer ElevenLabs v3. (#68321) Thanks @itsuzef.
 
 ### Fixes
 

--- a/docs/providers/elevenlabs.md
+++ b/docs/providers/elevenlabs.md
@@ -43,6 +43,9 @@ export ELEVENLABS_API_KEY="..."
 }
 ```
 
+Set `modelId` to `eleven_v3` to use ElevenLabs v3 TTS. OpenClaw keeps
+`eleven_multilingual_v2` as the default for existing installs.
+
 ## Speech-to-text
 
 Use Scribe v2 for inbound audio attachments and short recorded voice segments:

--- a/extensions/elevenlabs/elevenlabs.live.test.ts
+++ b/extensions/elevenlabs/elevenlabs.live.test.ts
@@ -25,14 +25,14 @@ const registerElevenLabsPlugin = () =>
   });
 
 describeLive("elevenlabs plugin live", () => {
-  it("synthesizes speech through the registered provider", async () => {
+  it("synthesizes speech through the registered provider with eleven_v3", async () => {
     const { speechProviders } = await registerElevenLabsPlugin();
     const provider = requireRegisteredProvider(speechProviders, "elevenlabs");
 
     const audioFile = await provider.synthesize({
-      text: "OpenClaw ElevenLabs text to speech integration test OK.",
+      text: "OpenClaw ElevenLabs eleven v three text to speech integration test OK.",
       cfg: { plugins: { enabled: true } } as never,
-      providerConfig: { apiKey: ELEVENLABS_KEY },
+      providerConfig: { apiKey: ELEVENLABS_KEY, modelId: "eleven_v3" },
       target: "audio-file",
       timeoutMs: 45_000,
     });

--- a/extensions/elevenlabs/speech-provider.test.ts
+++ b/extensions/elevenlabs/speech-provider.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { isValidVoiceId } from "./speech-provider.js";
+import { buildElevenLabsSpeechProvider, isValidVoiceId } from "./speech-provider.js";
 
 describe("elevenlabs speech provider", () => {
+  it("exposes the current ElevenLabs TTS model catalog", () => {
+    const provider = buildElevenLabsSpeechProvider();
+
+    expect(provider.models).toEqual(
+      expect.arrayContaining(["eleven_v3", "eleven_multilingual_v2"]),
+    );
+  });
+
   it("validates ElevenLabs voice ID length and character rules", () => {
     const cases = [
       { value: "pMsXgVXv3BLzUgSXRplE", expected: true },

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -37,6 +37,7 @@ const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
 };
 
 const ELEVENLABS_TTS_MODELS = [
+  "eleven_v3",
   "eleven_multilingual_v2",
   "eleven_turbo_v2_5",
   "eleven_monolingual_v1",


### PR DESCRIPTION
## Summary

- Adds `eleven_v3` to `ELEVENLABS_TTS_MODELS` in the bundled ElevenLabs speech provider
- The model already worked end-to-end (the API call passes `model_id` straight through with no validation), but was absent from the allowlist so it never appeared in the in-product model picker or any catalog metadata that enumerates supported models

## Test plan

- [ ] `pnpm test extensions/elevenlabs/speech-provider.test.ts` — passes
- [ ] Manually set `modelId: "eleven_v3"` in `~/.openclaw/openclaw.json` and confirm TTS voice notes render correctly via WA