### PR TITLE
Matrix: forward dangerouslyAllowPrivateNetwork config to client SSRF policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI Codex/OAuth + Pi: keep imported Codex CLI OAuth bootstrap, Pi auth export, and runtime overlay handling aligned so Codex sessions survive refresh and health checks without leaking transient CLI state into saved auth files. Thanks @vincentkoc.
 - Agents/TTS: report failed speech synthesis as a real tool error so unconfigured providers no longer feed successful TTS failure output back into agent loops. (#67980) Thanks @lawrence3699.
 - Gateway/wake: allow unknown properties on wake payloads so external senders like Paperclip can attach opaque metadata without failing schema validation. (#68355) Thanks @kagura-agent.
+- Matrix: honor `channels.matrix.network.dangerouslyAllowPrivateNetwork` when creating clients for private-network homeservers. (#68332) Thanks @kagura-agent.
 
 ## 2026.4.15
 

--- a/extensions/matrix/src/matrix/client/create-client.test.ts
+++ b/extensions/matrix/src/matrix/client/create-client.test.ts
@@ -86,6 +86,61 @@ describe("createMatrixClient", () => {
     });
   });
 
+  it("derives ssrfPolicy from allowPrivateNetwork when no explicit policy is provided", async () => {
+    await createMatrixClient({
+      homeserver: "https://matrix.example.org",
+      userId: "@bot:example.org",
+      accessToken: "tok",
+      persistStorage: false,
+      allowPrivateNetwork: true,
+    });
+
+    expect(MatrixClientMock).toHaveBeenCalledWith(
+      "https://matrix.example.org",
+      "tok",
+      expect.objectContaining({
+        ssrfPolicy: { allowPrivateNetwork: true },
+      }),
+    );
+  });
+
+  it("prefers explicit ssrfPolicy over allowPrivateNetwork", async () => {
+    const explicitPolicy = { allowPrivateNetwork: true, customField: "test" };
+    await createMatrixClient({
+      homeserver: "https://matrix.example.org",
+      userId: "@bot:example.org",
+      accessToken: "tok",
+      persistStorage: false,
+      allowPrivateNetwork: false,
+      ssrfPolicy: explicitPolicy as never,
+    });
+
+    expect(MatrixClientMock).toHaveBeenCalledWith(
+      "https://matrix.example.org",
+      "tok",
+      expect.objectContaining({
+        ssrfPolicy: explicitPolicy,
+      }),
+    );
+  });
+
+  it("leaves ssrfPolicy undefined when allowPrivateNetwork is falsy and no explicit policy", async () => {
+    await createMatrixClient({
+      homeserver: "https://matrix.example.org",
+      userId: "@bot:example.org",
+      accessToken: "tok",
+      persistStorage: false,
+    });
+
+    expect(MatrixClientMock).toHaveBeenCalledWith(
+      "https://matrix.example.org",
+      "tok",
+      expect.objectContaining({
+        ssrfPolicy: undefined,
+      }),
+    );
+  });
+
   it("skips persistent storage wiring when persistence is disabled", async () => {
     await createMatrixClient({
       homeserver: "https://matrix.example.org",

--- a/extensions/matrix/src/matrix/client/create-client.ts
+++ b/extensions/matrix/src/matrix/client/create-client.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/ssrf-dispatcher";
+import { ssrfPolicyFromDangerouslyAllowPrivateNetwork } from "openclaw/plugin-sdk/ssrf-policy";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SsrFPolicy } from "../../runtime-api.js";
 import type { MatrixClient } from "../sdk.js";
@@ -95,7 +96,8 @@ export async function createMatrixClient(params: {
     idbSnapshotPath: storagePaths?.idbSnapshotPath,
     cryptoDatabasePrefix,
     autoBootstrapCrypto: params.autoBootstrapCrypto,
-    ssrfPolicy: params.ssrfPolicy,
+    ssrfPolicy:
+      params.ssrfPolicy ?? ssrfPolicyFromDangerouslyAllowPrivateNetwork(params.allowPrivateNetwork),
     dispatcherPolicy: params.dispatcherPolicy,
   });
 }

--- a/extensions/matrix/src/matrix/client/create-client.ts
+++ b/extensions/matrix/src/matrix/client/create-client.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
 import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/ssrf-dispatcher";
-import { ssrfPolicyFromDangerouslyAllowPrivateNetwork } from "openclaw/plugin-sdk/ssrf-policy";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { SsrFPolicy } from "../../runtime-api.js";
+import {
+  ssrfPolicyFromDangerouslyAllowPrivateNetwork,
+  type SsrFPolicy,
+} from "../../runtime-api.js";
 import type { MatrixClient } from "../sdk.js";
 import { resolveValidatedMatrixHomeserverUrl } from "./config.js";
 import {


### PR DESCRIPTION
Fixes #68299

**Problem:** `createMatrixClient` ignores the `network.dangerouslyAllowPrivateNetwork` configuration, so self-hosted Matrix homeservers on private IPs (192.168.x.x, localhost, etc.) are blocked with `resolves to private/internal/special-use IP address`.

**Fix:** When no explicit `ssrfPolicy` is provided, derive it from the `allowPrivateNetwork` config via `ssrfPolicyFromDangerouslyAllowPrivateNetwork()`, matching the pattern used by other extensions.

**Changes:**
- `extensions/matrix/src/matrix/client/create-client.ts`: Fall back to `ssrfPolicyFromDangerouslyAllowPrivateNetwork(params.allowPrivateNetwork)` when `ssrfPolicy` is not set
- Added tests verifying the fallback behavior