### PR TITLE
fix(memory): split restoreMemoryPluginState into restore/merge for cache-hit bug

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -62,6 +62,7 @@ import {
   getMemoryRuntime,
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
+  mergeMemoryPluginState,
   restoreMemoryPluginState,
 } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
@@ -1442,7 +1443,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       restoreRegisteredAgentHarnesses(cached.agentHarnesses);
       restoreRegisteredCompactionProviders(cached.compactionProviders);
       restoreRegisteredMemoryEmbeddingProviders(cached.memoryEmbeddingProviders);
-      restoreMemoryPluginState({
+      mergeMemoryPluginState({
         capability: cached.memoryCapability,
         corpusSupplements: cached.memoryCorpusSupplements,
         promptBuilder: cached.memoryPromptBuilder,

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -274,6 +274,28 @@ describe("memory plugin state", () => {
     expect(getMemoryRuntime()).toBe(runtime);
   });
 
+  it("restoreMemoryPluginState preserves a live capability when restoring empty state", () => {
+    const runtime = createMemoryRuntime();
+    registerMemoryCapability("memory-core", {
+      promptBuilder: () => ["core prompt"],
+      runtime,
+    });
+
+    // A stale or cache-hit snapshot with no capability must not clobber a
+    // live registration. Previously this path reset memoryPluginState.capability
+    // to undefined, which caused listActiveMemoryPublicArtifacts to return []
+    // and memory-wiki bridge imports to prune all synced source pages.
+    restoreMemoryPluginState({
+      capability: undefined,
+      corpusSupplements: [],
+      promptSupplements: [],
+    });
+
+    expect(getMemoryCapabilityRegistration()).toMatchObject({ pluginId: "memory-core" });
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["core prompt"]);
+    expect(getMemoryRuntime()).toBe(runtime);
+  });
+
   it("clearMemoryPluginState resets both registries", () => {
     registerMemoryState({
       promptSection: ["stale section"],

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -11,6 +11,7 @@ import {
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
   listActiveMemoryPublicArtifacts,
+  mergeMemoryPluginState,
   registerMemoryCapability,
   registerMemoryCorpusSupplement,
   registerMemoryFlushPlanResolver,
@@ -274,7 +275,7 @@ describe("memory plugin state", () => {
     expect(getMemoryRuntime()).toBe(runtime);
   });
 
-  it("restoreMemoryPluginState preserves a live capability when restoring empty state", () => {
+  it("mergeMemoryPluginState preserves a live capability when merging empty state", () => {
     const runtime = createMemoryRuntime();
     registerMemoryCapability("memory-core", {
       promptBuilder: () => ["core prompt"],
@@ -282,10 +283,13 @@ describe("memory plugin state", () => {
     });
 
     // A stale or cache-hit snapshot with no capability must not clobber a
-    // live registration. Previously this path reset memoryPluginState.capability
-    // to undefined, which caused listActiveMemoryPublicArtifacts to return []
-    // and memory-wiki bridge imports to prune all synced source pages.
-    restoreMemoryPluginState({
+    // live registration. Previously the cache-hit path called
+    // restoreMemoryPluginState, which reset memoryPluginState.capability to
+    // undefined and caused listActiveMemoryPublicArtifacts to return [] and
+    // memory-wiki bridge imports to prune all synced source pages. The
+    // cache-hit path now calls mergeMemoryPluginState (this function), which
+    // only overwrites fields carrying a non-empty value.
+    mergeMemoryPluginState({
       capability: undefined,
       corpusSupplements: [],
       promptSupplements: [],
@@ -294,6 +298,30 @@ describe("memory plugin state", () => {
     expect(getMemoryCapabilityRegistration()).toMatchObject({ pluginId: "memory-core" });
     expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["core prompt"]);
     expect(getMemoryRuntime()).toBe(runtime);
+  });
+
+  it("restoreMemoryPluginState clears a live capability when swap-restoring empty state", () => {
+    const runtime = createMemoryRuntime();
+    registerMemoryCapability("memory-core", {
+      promptBuilder: () => ["core prompt"],
+      runtime,
+    });
+    registerMemoryPromptSupplement("stale", () => ["stale supplement"]);
+
+    // restoreMemoryPluginState is the destructive swap used by rollback paths
+    // where newly-registered state from a failed plugin must be wiped back to
+    // the captured pre-register snapshot — even when that snapshot is empty.
+    // Without this semantic, loader.ts's register-rollback path would leave
+    // stale supplements behind (covered by loader.test.ts "clears
+    // newly-registered memory plugin registries when plugin register fails").
+    restoreMemoryPluginState({
+      capability: undefined,
+      corpusSupplements: [],
+      promptSupplements: [],
+    });
+
+    expect(getMemoryCapabilityRegistration()).toBeUndefined();
+    expect(listMemoryPromptSupplements()).toHaveLength(0);
   });
 
   it("clearMemoryPluginState resets both registries", () => {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -302,17 +302,27 @@ export async function listActiveMemoryPublicArtifacts(params: {
 }
 
 export function restoreMemoryPluginState(state: MemoryPluginState): void {
-  memoryPluginState.capability = state.capability
-    ? {
-        pluginId: state.capability.pluginId,
-        capability: { ...state.capability.capability },
-      }
-    : undefined;
-  memoryPluginState.corpusSupplements = [...state.corpusSupplements];
-  memoryPluginState.promptBuilder = state.promptBuilder;
-  memoryPluginState.promptSupplements = [...state.promptSupplements];
-  memoryPluginState.flushPlanResolver = state.flushPlanResolver;
-  memoryPluginState.runtime = state.runtime;
+  if (state.capability) {
+    memoryPluginState.capability = {
+      pluginId: state.capability.pluginId,
+      capability: { ...state.capability.capability },
+    };
+  }
+  if (state.corpusSupplements && state.corpusSupplements.length > 0) {
+    memoryPluginState.corpusSupplements = [...state.corpusSupplements];
+  }
+  if (state.promptBuilder) {
+    memoryPluginState.promptBuilder = state.promptBuilder;
+  }
+  if (state.promptSupplements && state.promptSupplements.length > 0) {
+    memoryPluginState.promptSupplements = [...state.promptSupplements];
+  }
+  if (state.flushPlanResolver) {
+    memoryPluginState.flushPlanResolver = state.flushPlanResolver;
+  }
+  if (state.runtime) {
+    memoryPluginState.runtime = state.runtime;
+  }
 }
 
 export function clearMemoryPluginState(): void {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -302,6 +302,30 @@ export async function listActiveMemoryPublicArtifacts(params: {
 }
 
 export function restoreMemoryPluginState(state: MemoryPluginState): void {
+  memoryPluginState.capability = state.capability
+    ? {
+        pluginId: state.capability.pluginId,
+        capability: { ...state.capability.capability },
+      }
+    : undefined;
+  memoryPluginState.corpusSupplements = [...state.corpusSupplements];
+  memoryPluginState.promptBuilder = state.promptBuilder;
+  memoryPluginState.promptSupplements = [...state.promptSupplements];
+  memoryPluginState.flushPlanResolver = state.flushPlanResolver;
+  memoryPluginState.runtime = state.runtime;
+}
+
+/**
+ * Additive counterpart to {@link restoreMemoryPluginState}: only overwrites
+ * each field when the incoming state carries a non-empty value. Intended for
+ * cache-hit paths in the plugin loader that must NOT clobber a live
+ * capability when the cached snapshot predates the capability's registration.
+ *
+ * Use {@link restoreMemoryPluginState} (full swap) for rollback on failed
+ * plugin registration, where each field MUST revert to its pre-register
+ * value regardless of whether the saved previous value was empty.
+ */
+export function mergeMemoryPluginState(state: MemoryPluginState): void {
   if (state.capability) {
     memoryPluginState.capability = {
       pluginId: state.capability.pluginId,


### PR DESCRIPTION
## Problem

`restoreMemoryPluginState` unconditionally overwrites `memoryPluginState.capability` with `undefined` when the restoring state has no capability (typical for a cached plugin-registry snapshot taken before the capability was registered).

Normal gateway operation calls this many times per second via `resolvePluginProviders → resolveRuntimePluginRegistry → loadOpenClawPlugins` on the cache-hit path (`loader.ts:1445`). The effect: memory-core's registration is silently wiped, `listActiveMemoryPublicArtifacts` returns `[]`, and any memory-wiki bridge import that runs during that window prunes all previously-synced source pages because it concludes upstream artifacts disappeared.

Reproduced 2026-04-17 against `openclaw@2026.4.16` with `memory-wiki.vaultMode=bridge`: gateway-side `bridgePublicArtifactCount` dropped from 559 → 0 within ~400 ms of plugin load.

## First attempt (superseded)

The first attempt made `restoreMemoryPluginState` itself additive. That fixed cache-hit but regressed the register-rollback path. `loader.ts` uses restore in three places with distinct intent:

1. **Cache hit** (`loader.ts:1445`) — wants additive. Don't clobber a live capability with an empty cached snapshot.
2. **Snapshot revert** (`loader.ts:2229`) — wants destructive swap. Snapshot probe must not leak registered state into the global.
3. **Register rollback** (`loader.ts:2245`) — wants destructive swap. Stale supplements registered by a failing plugin must be wiped back to the pre-register snapshot — even when that snapshot is empty.

Making restore itself additive broke #3. Test ``loader.test.ts > loadOpenClawPlugins > clears newly-registered memory plugin registries when plugin register fails`` failed in three CI workflows (`checks-fast-bundled`, `checks-node-agentic-agents-plugins`, `checks-node-core`) — all one root cause.

## Fix (this revision)

Split into two functions with distinct contracts:

- **\`restoreMemoryPluginState\`** — destructive full-state swap, unchanged from pre-PR semantics. Used at lines 2229 and 2245.
- **\`mergeMemoryPluginState\`** — additive merge. Only overwrites fields carrying a non-empty value. Used at line 1445.

## Tests

- Renamed ``restoreMemoryPluginState preserves a live capability when restoring empty state`` → ``mergeMemoryPluginState preserves a live capability when merging empty state`` (the contract now belongs to merge).
- Added ``restoreMemoryPluginState clears a live capability when swap-restoring empty state`` — locks in the destructive contract that register-rollback depends on.
- The previously-failing ``clears newly-registered memory plugin registries when plugin register fails`` now passes without modification.

Full plugins suite (\`vitest.plugins.config.ts\`): **1015/1015 pass** locally.

## Validation after fix

- \`openclaw wiki doctor\` → \`Wiki doctor: healthy\` with 559 exported artifacts
- \`openclaw gateway call wiki.status\` → \`bridgePublicArtifactCount\` stable at 559