### PR TITLE
fix(memory-core): activate on wiki CLI subcommand

### DIFF
--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "memory-core",
   "kind": "memory",
+  "activation": {
+    "onCommands": ["wiki"]
+  },
   "commandAliases": [
     {
       "name": "dreaming",

--- a/src/plugins/activation-planner.test.ts
+++ b/src/plugins/activation-planner.test.ts
@@ -21,6 +21,9 @@ describe("resolveManifestActivationPluginIds", () => {
       plugins: [
         {
           id: "memory-core",
+          activation: {
+            onCommands: ["wiki"],
+          },
           commandAliases: [{ name: "dreaming", kind: "runtime-slash", cliCommand: "memory" }],
           providers: [],
           channels: [],
@@ -102,6 +105,22 @@ describe("resolveManifestActivationPluginIds", () => {
         },
       }),
     ).toEqual(["demo-channel"]);
+  });
+
+  it("activates memory-core when a wiki CLI subcommand is invoked", () => {
+    // Regression: memory-core's manifest only declared a commandAlias with
+    // cliCommand="memory", so `openclaw wiki ...` loaded memory-wiki alone
+    // without memory-core. The capability singleton stayed empty, wiki CLI
+    // reported 0 artifacts, and `wiki bridge import` pruned synced sources.
+    // Fix adds activation.onCommands=["wiki"] to the memory-core manifest.
+    expect(
+      resolveManifestActivationPluginIds({
+        trigger: {
+          kind: "command",
+          command: "wiki",
+        },
+      }),
+    ).toEqual(["memory-core"]);
   });
 
   it("matches provider, agent harness, channel, and route triggers from manifest-owned metadata", () => {


### PR DESCRIPTION
## Problem

The CLI activation loader in `src/plugins/activation-planner.ts` filters plugins
by `plugin.activation.onCommands` (or `commandAliases[].cliCommand`). memory-core's
manifest only declared a `commandAliases` entry with `cliCommand: "memory"`, so
invoking `openclaw wiki …` loaded `memory-wiki` alone — **without memory-core**.

memory-wiki depends on memory-core having registered its capability singleton.
With memory-core not activated, the capability registration is empty, and CLI
`wiki` commands report 0 artifacts. Worse, `openclaw wiki bridge import` prunes
all synced source pages because it observes an empty public-artifact list and
assumes upstream has dropped them.

Reproduced 2026-04-17 against `openclaw@2026.4.16`:
`openclaw wiki doctor` returned 0 artifacts permanently, even with a correct
gateway-side registration. Running `wiki bridge import` destructively removed
all previously-synced source pages from `~/.openclaw/wiki/main/sources/`.

## Fix

Add `"activation": { "onCommands": ["wiki"] }` to
`extensions/memory-core/openclaw.plugin.json`. This signals to
`activation-planner.ts` that memory-core must be loaded whenever a `wiki`
subcommand is invoked, so the capability singleton is populated before
memory-wiki runs.

## Test

New case in `src/plugins/activation-planner.test.ts` — constructs a manifest
with `activation.onCommands: ["wiki"]` and verifies
`resolveManifestActivationPluginIds` returns the plugin id for the `wiki`
command, following the pattern of the existing
"matches command triggers from activation metadata" test.

## Validation after fix

- `openclaw wiki doctor` → `Wiki doctor: healthy` with non-zero artifact count
- `openclaw wiki bridge import` is safe to run from the shell (no pruning)
