### PR TITLE
docs(acp): Add explicit warning on Docker deployment for ACP tools

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -471,6 +471,11 @@ Notes:
 
 ACP sessions currently run on the host runtime, not inside the OpenClaw sandbox.
 
+> [!WARNING]
+> **Docker Deployment Note:** Because ACP sessions execute on the host runtime, any CLI harness adapters (e.g., `@google/gemini-cli`, `@mariozechner/pi-coding-agent`, `claude-code`) **must** be installed globally on the `openclaw-gateway` container.
+> 
+> Do **not** install ACP harnesses in the `openclaw-sandbox` container. The Gateway host directly orchestrates ACP binaries, so they must be present in the Gateway's system path.
+
 Current limitations:
 
 - If the requester session is sandboxed, ACP spawns are blocked for both `sessions_spawn({ runtime: "acp" })` and `/acp spawn`.


### PR DESCRIPTION
Add explicit warning on Docker deployment for ACP tools

Clarifies that ACP harness CLI tools (such as `@google/gemini-cli`, `@mariozechner/pi-coding-agent`) must be installed on the `gateway` container rather than the `sandbox` container because ACP sessions execute on the host runtime.

Found during infrastructure refactoring where installing ACP harnesses in the sandbox caused spawn failures.