### PR TITLE
fix(ollama): allow baseUrl in plugin config schema

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -129,6 +129,19 @@ describe("ollama plugin", () => {
     });
   });
 
+  it("accepts plugin-level baseUrl for remote hosts", async () => {
+    const manifest = JSON.parse(
+      await import("node:fs/promises").then((fs) =>
+        fs.readFile(new URL("./openclaw.plugin.json", import.meta.url), "utf8"),
+      ),
+    );
+
+    expect(manifest.configSchema.properties.baseUrl).toMatchObject({
+      type: "string",
+      minLength: 1,
+    });
+  });
+
   it("skips ambient discovery when plugin discovery is disabled", async () => {
     const provider = registerProviderWithPluginConfig({ discovery: { enabled: false } });
 

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -26,6 +26,11 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "baseUrl": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Native Ollama API base URL, for example http://127.0.0.1:11434 or a remote host over LAN/Tailscale. Do not include /v1."
+      },
       "discovery": {
         "type": "object",
         "additionalProperties": false,


### PR DESCRIPTION
## Summary
- allow `extensions.ollama.config.baseUrl` in the Ollama plugin config schema
- add a focused test to lock the schema entry in place
- align plugin schema with existing runtime behavior and docs for remote Ollama hosts

## Problem
The Ollama plugin runtime already reads `pluginConfig.baseUrl`, and the docs describe configuring a custom base URL for remote hosts, but `extensions/ollama/openclaw.plugin.json` did not allow `baseUrl` in `configSchema`.

That meant users could follow the documented setup and still hit schema validation failures.

Fixes #68260.

## Testing
- `pnpm vitest run extensions/ollama/index.test.ts extensions/ollama/provider-discovery.import-guard.test.ts extensions/ollama/plugin-registration.contract.test.ts`

## Notes
- I also attempted the broader repo check chain during commit, but it was terminated by the local environment with `SIGKILL` after targeted tests had already passed. No failures were reported for the changed Ollama files before that termination.
