### PR TITLE
fix: use normalized model lookup in resolveGatewayModelSupportsImages (#68272)

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1004,4 +1004,65 @@ describe("resolveGatewayModelSupportsImages", () => {
       }),
     ).resolves.toBe(true);
   });
+
+  test("recognizes image support for custom models with mixed-case IDs", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "MiniMax-M2.7",
+        provider: "minimax",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "MiniMax-M2.7",
+            name: "MiniMax-M2.7",
+            provider: "minimax",
+            input: ["text", "image"],
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("matches model via normalized comparison when casing differs", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "minimax-m2.7",
+        provider: "minimax",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "MiniMax-M2.7",
+            name: "MiniMax-M2.7",
+            provider: "minimax",
+            input: ["text", "image"],
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("returns false for custom model without image in input", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "MiniMax-M2.7",
+        provider: "minimax",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "MiniMax-M2.7",
+            name: "MiniMax-M2.7",
+            provider: "minimax",
+            input: ["text"],
+          },
+        ],
+      }),
+    ).resolves.toBe(false);
+  });
+
+  test("returns false when custom model is not in catalog at all", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "unknown-model",
+        provider: "minimax",
+        loadGatewayModelCatalog: async () => [],
+      }),
+    ).resolves.toBe(false);
+  });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -8,7 +8,7 @@ import {
 } from "../agents/agent-scope.js";
 import { lookupContextTokens, resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import { findModelInCatalog, type ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   inferUniqueProviderFromConfiguredModels,
   normalizeStoredOverrideModel,
@@ -1000,10 +1000,13 @@ export async function resolveGatewayModelSupportsImages(params: {
 
   try {
     const catalog = await params.loadGatewayModelCatalog();
-    const modelEntry = catalog.find(
-      (entry) =>
-        entry.id === params.model && (!params.provider || entry.provider === params.provider),
-    );
+    const modelEntry = params.provider
+      ? findModelInCatalog(catalog, params.provider, params.model)
+      : catalog.find(
+          (entry) =>
+            normalizeLowercaseStringOrEmpty(entry.id) ===
+            normalizeLowercaseStringOrEmpty(params.model),
+        );
     const normalizedProvider = normalizeOptionalLowercaseString(params.provider);
     const normalizedCandidates = [
       normalizeLowercaseStringOrEmpty(params.model),


### PR DESCRIPTION
## Problem
Image attachments are dropped with 'model does not support images' even when the model has image capability configured. The issue is in `resolveGatewayModelSupportsImages()` which uses case-sensitive exact matching on model ID, failing for custom models with mixed-case IDs (e.g. `minimax/MiniMax-M2.7`).

## Fix
Switch to `findModelInCatalog()` which normalizes both provider and model ID, matching the behavior already used elsewhere in the codebase.

## Changes
- `src/gateway/session-utils.ts`: Use `findModelInCatalog()` instead of direct map lookup
- `src/gateway/session-utils.test.ts`: 4 new tests for mixed-case, custom models, and replace mode

Fixes #68272