### PR TITLE
fix: use native loading for doctor contract API to speed up status command

### DIFF
--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -8,6 +8,7 @@ import { discoverOpenClawPlugins } from "./discovery.js";
 import { getCachedPluginJitiLoader, type PluginJitiLoaderCache } from "./jiti-loader-cache.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import { resolvePluginCacheInputs, type PluginSourceRoots } from "./roots.js";
+import { shouldPreferNativeJiti } from "./sdk-alias.js";
 
 const CONTRACT_API_EXTENSIONS = [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts"] as const;
 const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
@@ -48,6 +49,7 @@ function getJiti(modulePath: string) {
     cache: jitiLoaders,
     modulePath,
     importerUrl: import.meta.url,
+    tryNative: shouldPreferNativeJiti(modulePath),
   });
 }
 


### PR DESCRIPTION
## Summary
Fixes openclaw#68282

The `openclaw status` and related status commands are slow on a fresh process because doctor contract loading uses the slow jiti path instead of native loading for built artifacts.

## Root Cause
The `getJiti` function in `doctor-contract-registry.ts` was not passing `tryNative` flag to `getCachedPluginJitiLoader`, causing built artifacts to be loaded through the slow jiti path instead of native loading.

## Fix
- Import `shouldPreferNativeJiti` from `sdk-alias.js`
- Pass `tryNative: shouldPreferNativeJiti(modulePath)` to `getCachedPluginJitiLoader`

This matches the pattern used in other loader functions (e.g., `loader.ts` line 443, `bundled-capability-runtime.ts` line 206, `runtime-plugin-boundary.ts` line 118')
    
## Test Plan
- [x] Relevant unit tests pass (src/plugins/doctor-contract-registry.test.ts - 4 tests passed)
- [x] Follows existing code style

Closes openclaw#68282