### PR TITLE
Ollama: honor Modelfile num_ctx and auto-detect tool support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/streaming: clear the compaction replay guard after visible non-final boundaries so a post-tool assistant reply rotates to a fresh preview instead of editing the pre-compaction message. (#67993) Thanks @obviyus.
 - Matrix: fix `sessions_spawn --thread` subagent session spawning — thread binding creation, cleanup on session end, and completion-message delivery target resolution now work end-to-end. (#67643) Thanks @eejohnso-ops and @gumadeiras.
 - macOS/webchat: enable Undo and Redo in the composer text input by turning on the native `NSTextView` undo manager. (#34962) Thanks @tylerbittner.
+- Ollama/discovery: honor Modelfile `PARAMETER num_ctx` overrides over the base model's native `context_length` during `/api/show` enrichment, and auto-flag discovered models whose `/api/show` capabilities omit `tools` with `compat.supportsTools: false` so non-tool local models fall back to plain inference instead of failing with "does not support tools". (#68344) Thanks @neeravmakwana.
 
 ## 2026.4.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/streaming: clear the compaction replay guard after visible non-final boundaries so a post-tool assistant reply rotates to a fresh preview instead of editing the pre-compaction message. (#67993) Thanks @obviyus.
 - Matrix: fix `sessions_spawn --thread` subagent session spawning — thread binding creation, cleanup on session end, and completion-message delivery target resolution now work end-to-end. (#67643) Thanks @eejohnso-ops and @gumadeiras.
 - macOS/webchat: enable Undo and Redo in the composer text input by turning on the native `NSTextView` undo manager. (#34962) Thanks @tylerbittner.
-- Ollama/discovery: honor Modelfile `PARAMETER num_ctx` overrides over the base model's native `context_length` during `/api/show` enrichment, and auto-flag discovered models whose `/api/show` capabilities omit `tools` with `compat.supportsTools: false` so non-tool local models fall back to plain inference instead of failing with "does not support tools". (#68344) Thanks @neeravmakwana.
+- Ollama/discovery: honor Modelfile `PARAMETER num_ctx` overrides over the base model's native `context_length` during `/api/show` enrichment, and auto-flag discovered models whose `/api/show` capabilities omit `tools` with `compat.supportsTools: false` so non-tool local models fall back to plain inference instead of failing with "does not support tools". (#68349) Thanks @neeravmakwana.
 
 ## 2026.4.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/streaming: clear the compaction replay guard after visible non-final boundaries so a post-tool assistant reply rotates to a fresh preview instead of editing the pre-compaction message. (#67993) Thanks @obviyus.
 - Matrix: fix `sessions_spawn --thread` subagent session spawning — thread binding creation, cleanup on session end, and completion-message delivery target resolution now work end-to-end. (#67643) Thanks @eejohnso-ops and @gumadeiras.
 - macOS/webchat: enable Undo and Redo in the composer text input by turning on the native `NSTextView` undo manager. (#34962) Thanks @tylerbittner.
-- Ollama/discovery: honor Modelfile `PARAMETER num_ctx` overrides over the base model's native `context_length` during `/api/show` enrichment, and auto-flag discovered models whose `/api/show` capabilities omit `tools` with `compat.supportsTools: false` so non-tool local models fall back to plain inference instead of failing with "does not support tools". (#68349) Thanks @neeravmakwana.
+- Ollama/discovery: raise the discovered context window to Modelfile `PARAMETER num_ctx` when it exceeds the base model's native `context_length` during `/api/show` enrichment (keeping the larger of the two, so pulled Modelfiles with a small default `num_ctx` cannot under-report large-context models), and auto-flag discovered models whose `/api/show` capabilities omit `tools` with `compat.supportsTools: false` so non-tool local models fall back to plain inference instead of failing with "does not support tools". (#68349) Thanks @neeravmakwana.
 
 ## 2026.4.15
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -151,14 +151,15 @@ Choose your preferred setup method and mode.
 
 When you set `OLLAMA_API_KEY` (or an auth profile) and **do not** define `models.providers.ollama`, OpenClaw discovers models from the local Ollama instance at `http://127.0.0.1:11434`.
 
-| Behavior             | Detail                                                                                                                                                              |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Catalog query        | Queries `/api/tags`                                                                                                                                                 |
-| Capability detection | Uses best-effort `/api/show` lookups to read `contextWindow` and detect capabilities (including vision)                                                             |
-| Vision models        | Models with a `vision` capability reported by `/api/show` are marked as image-capable (`input: ["text", "image"]`), so OpenClaw auto-injects images into the prompt |
-| Reasoning detection  | Marks `reasoning` with a model-name heuristic (`r1`, `reasoning`, `think`)                                                                                          |
-| Token limits         | Sets `maxTokens` to the default Ollama max-token cap used by OpenClaw                                                                                               |
-| Costs                | Sets all costs to `0`                                                                                                                                               |
+| Behavior             | Detail                                                                                                                                                                                                   |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Catalog query        | Queries `/api/tags`                                                                                                                                                                                      |
+| Capability detection | Uses best-effort `/api/show` lookups to read `contextWindow` and detect capabilities (including vision)                                                                                                  |
+| Vision models        | Models with a `vision` capability reported by `/api/show` are marked as image-capable (`input: ["text", "image"]`), so OpenClaw auto-injects images into the prompt                                      |
+| Tool support         | Models whose `/api/show` capabilities omit `tools` are auto-flagged with `compat.supportsTools: false` so chat/agent flows fall back to plain inference instead of failing with "does not support tools" |
+| Reasoning detection  | Marks `reasoning` with a model-name heuristic (`r1`, `reasoning`, `think`)                                                                                                                               |
+| Token limits         | Sets `maxTokens` to the default Ollama max-token cap used by OpenClaw                                                                                                                                    |
+| Costs                | Sets all costs to `0`                                                                                                                                                                                    |
 
 This avoids manual model entries while keeping the catalog aligned with the local Ollama instance.
 
@@ -184,9 +185,12 @@ If you set `models.providers.ollama` explicitly, auto-discovery is skipped and y
 
 <Tabs>
   <Tab title="Basic (implicit discovery)">
-    The simplest local-only enablement path is via environment variable:
+    For local-only setups, no environment variable is required — OpenClaw auto-registers a synthetic local auth marker for a reachable local Ollama host so discovery and chat work without any real key. Setting `OLLAMA_API_KEY` is only needed for hosted cloud access (`https://ollama.com`) or to force registration when the local host is not reachable at discovery time.
 
     ```bash
+    # Optional placeholder, only needed if you want to force registration
+    # of an unreachable local host. Any value works; OpenClaw does not send
+    # it to a local Ollama server that does not require auth.
     export OLLAMA_API_KEY="ollama-local"
     ```
 
@@ -346,7 +350,16 @@ For the full setup and behavior details, see [Ollama Web Search](/tools/ollama-s
   <Accordion title="Context windows">
     For auto-discovered models, OpenClaw uses the context window reported by Ollama when available, otherwise it falls back to the default Ollama context window used by OpenClaw.
 
-    You can override `contextWindow` and `maxTokens` in explicit provider config:
+    Modelfile `PARAMETER num_ctx <value>` overrides take precedence over the base model's native `context_length`, matching Ollama's own last-wins behavior at generation time. For example, given:
+
+    ```text
+    FROM llama3:latest
+    PARAMETER num_ctx 32768
+    ```
+
+    `ollama/llama3-32k:latest` is reported with a 32768-token context window instead of the base llama3 8192.
+
+    You can still override `contextWindow` and `maxTokens` in explicit provider config:
 
     ```json5
     {

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -350,14 +350,14 @@ For the full setup and behavior details, see [Ollama Web Search](/tools/ollama-s
   <Accordion title="Context windows">
     For auto-discovered models, OpenClaw uses the context window reported by Ollama when available, otherwise it falls back to the default Ollama context window used by OpenClaw.
 
-    Modelfile `PARAMETER num_ctx <value>` overrides take precedence over the base model's native `context_length`, matching Ollama's own last-wins behavior at generation time. For example, given:
+    Modelfile `PARAMETER num_ctx <value>` is used when it would expand the reported capacity above the base model's native `context_length`. OpenClaw takes the larger of the two so custom Modelfiles that raise the context (for example `PARAMETER num_ctx 32768` on top of llama3's native 8192) are honored, while pulled base Modelfiles that ship a small default `num_ctx` cannot under-report large-context models. For example, given:
 
     ```text
     FROM llama3:latest
     PARAMETER num_ctx 32768
     ```
 
-    `ollama/llama3-32k:latest` is reported with a 32768-token context window instead of the base llama3 8192.
+    `ollama/llama3-32k:latest` is reported with a 32768-token context window instead of the base llama3 8192. If you want to clamp the reported context below the model's native capacity, set it explicitly in `models.providers.ollama.models[].contextWindow` below.
 
     You can still override `contextWindow` and `maxTokens` in explicit provider config:
 

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -212,4 +212,64 @@ describe("ollama provider models", () => {
     const noCapabilities = buildOllamaModelDefinition("unknown-model", 65536);
     expect(noCapabilities.input).toEqual(["text"]);
   });
+
+  it("buildOllamaModelDefinition flags supportsTools=false when capabilities omit tools", () => {
+    const noTools = buildOllamaModelDefinition("llama3:latest", 8192, ["completion"]);
+    expect(noTools.compat).toEqual({ supportsTools: false });
+
+    const withTools = buildOllamaModelDefinition("qwen3:32b", 131072, ["completion", "tools"]);
+    expect(withTools.compat).toBeUndefined();
+
+    const missingCapabilities = buildOllamaModelDefinition("legacy-model", 8192);
+    expect(missingCapabilities.compat).toBeUndefined();
+
+    const emptyCapabilities = buildOllamaModelDefinition("legacy-model", 8192, []);
+    expect(emptyCapabilities.compat).toBeUndefined();
+  });
+
+  it("prefers Modelfile PARAMETER num_ctx over the base model's context_length", async () => {
+    const models: OllamaTagModel[] = [{ name: "llama3-32k:latest" }];
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        model_info: { "llama.context_length": 8192 },
+        parameters: 'stop "<|eot_id|>"\nnum_ctx 32768\nnum_keep 5',
+        capabilities: ["completion"],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
+
+    expect(enriched[0]?.contextWindow).toBe(32768);
+  });
+
+  it("uses the last Modelfile num_ctx override when parameters repeats the key", async () => {
+    const models: OllamaTagModel[] = [{ name: "llama3-override:latest" }];
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        model_info: { "llama.context_length": 8192 },
+        parameters: "num_ctx 16384\nnum_ctx 32768",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
+
+    expect(enriched[0]?.contextWindow).toBe(32768);
+  });
+
+  it("ignores malformed or non-positive num_ctx parameter values", async () => {
+    const models: OllamaTagModel[] = [{ name: "llama3-bogus:latest" }];
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        model_info: { "llama.context_length": 8192 },
+        parameters: "num_ctx not-a-number\nnum_ctx -1\nnum_ctx 0",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
+
+    expect(enriched[0]?.contextWindow).toBe(8192);
+  });
 });

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -227,7 +227,7 @@ describe("ollama provider models", () => {
     expect(emptyCapabilities.compat).toBeUndefined();
   });
 
-  it("prefers Modelfile PARAMETER num_ctx over the base model's context_length", async () => {
+  it("prefers Modelfile PARAMETER num_ctx when it expands the base context_length", async () => {
     const models: OllamaTagModel[] = [{ name: "llama3-32k:latest" }];
     const fetchMock = vi.fn(async () =>
       jsonResponse({
@@ -241,6 +241,36 @@ describe("ollama provider models", () => {
     const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
 
     expect(enriched[0]?.contextWindow).toBe(32768);
+  });
+
+  it("keeps the larger base context_length when parameters reports a smaller num_ctx default", async () => {
+    const models: OllamaTagModel[] = [{ name: "llama3.3:70b" }];
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        model_info: { "llama.context_length": 131072 },
+        parameters: 'stop "<|eot_id|>"\nnum_ctx 2048',
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
+
+    expect(enriched[0]?.contextWindow).toBe(131072);
+  });
+
+  it("uses num_ctx when model_info has no context_length and the override is positive", async () => {
+    const models: OllamaTagModel[] = [{ name: "custom-model:latest" }];
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        model_info: {},
+        parameters: "num_ctx 16384",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const enriched = await enrichOllamaModelsWithContext("http://127.0.0.1:11434", models);
+
+    expect(enriched[0]?.contextWindow).toBe(16384);
   });
 
   it("uses the last Modelfile num_ctx override when parameters repeats the key", async () => {

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -158,11 +158,16 @@ export async function queryOllamaModelShowInfo(
           }
         }
       }
-      // Modelfile `PARAMETER num_ctx <value>` wins over the base model's
-      // native context_length: Ollama applies the override at generation time,
-      // so honor it here instead of reporting the smaller base value.
+      // Modelfile `PARAMETER num_ctx <value>` can raise the effective context
+      // above the base model's native `context_length` (e.g. a custom
+      // Modelfile with `PARAMETER num_ctx 32768` on top of llama3 8k). Use it
+      // only when it would expand capacity — pulled base Modelfiles sometimes
+      // ship a small default `num_ctx` that must not under-report models with
+      // a larger native `context_length`. Users who want a strictly lower
+      // context should configure it explicitly under
+      // `models.providers.ollama.models[].contextWindow`.
       const paramCtx = parseOllamaNumCtxParameter(data.parameters);
-      if (paramCtx !== undefined) {
+      if (paramCtx !== undefined && (contextWindow === undefined || paramCtx > contextWindow)) {
         contextWindow = paramCtx;
       }
 

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -93,6 +93,28 @@ function hasCachedOllamaModelShowInfo(info: OllamaModelShowInfo): boolean {
   return typeof info.contextWindow === "number" || (info.capabilities?.length ?? 0) > 0;
 }
 
+// Ollama's /api/show returns Modelfile PARAMETER overrides as a newline
+// delimited string (e.g. "num_ctx 32768\nnum_keep 5"). Extract the last
+// positive integer value for `num_ctx`, matching Ollama's own last-wins
+// semantics when a Modelfile lists the parameter more than once.
+export function parseOllamaNumCtxParameter(parameters: unknown): number | undefined {
+  if (typeof parameters !== "string" || !parameters.trim()) {
+    return undefined;
+  }
+  let lastValue: number | undefined;
+  for (const rawLine of parameters.split(/\r?\n/)) {
+    const match = rawLine.trim().match(/^num_ctx\s+(-?\d+)\b/);
+    if (!match) {
+      continue;
+    }
+    const parsed = Number.parseInt(match[1], 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      lastValue = parsed;
+    }
+  }
+  return lastValue;
+}
+
 export async function queryOllamaModelShowInfo(
   apiBase: string,
   modelName: string,
@@ -117,6 +139,7 @@ export async function queryOllamaModelShowInfo(
       const data = (await response.json()) as {
         model_info?: Record<string, unknown>;
         capabilities?: unknown;
+        parameters?: unknown;
       };
 
       let contextWindow: number | undefined;
@@ -134,6 +157,13 @@ export async function queryOllamaModelShowInfo(
             }
           }
         }
+      }
+      // Modelfile `PARAMETER num_ctx <value>` wins over the base model's
+      // native context_length: Ollama applies the override at generation time,
+      // so honor it here instead of reporting the smaller base value.
+      const paramCtx = parseOllamaNumCtxParameter(data.parameters);
+      if (paramCtx !== undefined) {
+        contextWindow = paramCtx;
       }
 
       const capabilities = Array.isArray(data.capabilities)
@@ -217,6 +247,13 @@ export function buildOllamaModelDefinition(
 ): ModelDefinitionConfig {
   const hasVision = capabilities?.includes("vision") ?? false;
   const input: ("text" | "image")[] = hasVision ? ["text", "image"] : ["text"];
+  // When /api/show returns a non-empty capabilities array that does not list
+  // "tools", trust Ollama's own capability signal and flag the model as
+  // non-tool-supporting so the agent falls back to plain chat instead of
+  // failing with a "does not support tools" error. Leave compat undefined
+  // when capabilities are missing, preserving the existing permissive default.
+  const hasCapabilitySignal = Array.isArray(capabilities) && capabilities.length > 0;
+  const supportsTools = hasCapabilitySignal ? capabilities.includes("tools") : true;
   return {
     id: modelId,
     name: modelId,
@@ -225,6 +262,7 @@ export function buildOllamaModelDefinition(
     cost: OLLAMA_DEFAULT_COST,
     contextWindow: contextWindow ?? OLLAMA_DEFAULT_CONTEXT_WINDOW,
     maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
+    ...(hasCapabilitySignal && !supportsTools ? { compat: { supportsTools: false } } : {}),
   };
 }
 

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -350,9 +350,11 @@ function buildOllamaModelsConfig(
   return modelNames.map((name) => {
     const discovered = discoveredModelsByName?.get(name);
     // Suggested cloud models may be injected before `/api/tags` exposes them,
-    // so keep Kimi vision-capable during setup even without discovered metadata.
+    // so keep Kimi vision+tool-capable during setup even without discovered
+    // metadata; otherwise capability-driven compat flags would wrongly mark
+    // Kimi as non-tool-supporting until its first `/api/show` refresh.
     const capabilities =
-      discovered?.capabilities ?? (name === "kimi-k2.5:cloud" ? ["vision"] : undefined);
+      discovered?.capabilities ?? (name === "kimi-k2.5:cloud" ? ["vision", "tools"] : undefined);
     return buildOllamaModelDefinition(name, discovered?.contextWindow, capabilities);
   });
 }


### PR DESCRIPTION
## Summary

- Problem: On a local Ollama setup, a Modelfile `PARAMETER num_ctx 32768` override was ignored during discovery (only the base model's `.context_length` was read), which tripped `context-window-guard` with "Model context window too small (8192 tokens)". Non-tool models (e.g. plain `llama3`) also hit "does not support tools" with no auto-fallback, even though Ollama already reports `capabilities` on `/api/show`.
- Why it matters: Local Ollama is a supported provider and these two gaps made common local setups (large-context custom Modelfiles, non-tool base models) fail out of the box. Issue #68344 captured both, plus a third point (`OLLAMA_API_KEY` requirement) that is already addressed at HEAD via `DEFAULT_API_KEY = "ollama-local"` / `OLLAMA_LOCAL_AUTH_MARKER` — so that part is a docs clarification only.
- What changed:
  - `queryOllamaModelShowInfo` now also parses Ollama's `parameters` string from `/api/show` and lets a positive `num_ctx <value>` override win over `model_info[*.context_length]` (last-wins, matching Ollama's own generation-time semantics).
  - `buildOllamaModelDefinition` now auto-sets `compat.supportsTools: false` when `/api/show` returns a non-empty `capabilities` array that does not include `"tools"`. Models with missing or empty capabilities keep `compat` undefined (existing permissive default).
  - Docs: added a Modelfile `num_ctx` note to the Context windows accordion, added a Tool support row to the implicit-discovery capability table, and clarified that `OLLAMA_API_KEY` is optional for local-only setups (reachable local hosts rely on the synthetic local auth marker).
  - Setup: bumped the synthetic pre-discovery capability fallback for `kimi-k2.5:cloud` from `["vision"]` to `["vision", "tools"]` so the new capability-driven compat gate does not wrongly flag Kimi as non-tool-supporting during cloud onboarding before its first `/api/show` refresh.
- What did NOT change (scope boundary):
  - No change to `OLLAMA_DEFAULT_CONTEXT_WINDOW`, `OLLAMA_DEFAULT_MAX_TOKENS`, `DEFAULT_API_KEY`, SSRF policy, reachability checks, or the fetch/timeout contract on `/api/show`.
  - No change to `supportsModelTools` gating logic in core — only the discovered `compat` payload shape.
  - No change to config schema, Plugin SDK public surface, generated baselines, or CODEOWNERS-protected surfaces.

## Change Type (select all)

- [x] Bug fix
- [x] Docs

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #68344
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause (num_ctx): `queryOllamaModelShowInfo` only inspected `model_info[*.context_length]` from Ollama's `/api/show`. The real user-authored override lives in the separate `parameters` string (multi-line Modelfile params), which was never read. Base-model `context_length` therefore beat a user's larger `num_ctx 32768`, and downstream `context-window-guard` blocked the run.
- Root cause (tool support): `buildOllamaModelDefinition` already consumed the `capabilities` array from `/api/show` for vision detection but ignored the `tools` bit, so non-tool models required manual `compat.supportsTools: false`. Ollama's own capability signal is authoritative here.
- Missing detection / guardrail: no test case covered the `parameters` override path on `/api/show`, and no test exercised capability-based tool-support detection for discovered models.
- Contributing context: docs recommended setting `compat.supportsTools: false` by hand for non-tool local models and did not mention Modelfile overrides at all; `OLLAMA_API_KEY="ollama-local"` was presented as mandatory when it is actually just a compatibility placeholder.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/ollama/src/provider-models.test.ts`
- Scenario the test should lock in:
  - `PARAMETER num_ctx 32768` in `/api/show` `parameters` beats `llama.context_length: 8192` (and handles repeat/last-wins plus malformed values).
  - Capabilities without `"tools"` set `compat.supportsTools: false`; capabilities with `"tools"` leave `compat` undefined; missing or empty capabilities preserve the existing permissive default.
- Why this is the smallest reliable guardrail: these are pure data-shape mappings in a single helper, with no network/FS coupling; unit coverage in the same file as the existing enrichment tests is exactly the right level and stays fast in `pnpm test:extension ollama`.
- Existing test that already covers this (if any): none — prior tests only exercised `model_info[*.context_length]` and `vision` capability detection.

## User-visible / Behavior Changes

- Local/self-hosted Ollama models created with a Modelfile `PARAMETER num_ctx <value>` override now report that context window in `openclaw models list` and stop hitting `Model context window too small (8192 tokens)` when the override is large enough.
- Discovered Ollama models whose `/api/show` capabilities omit `tools` now get `compat.supportsTools: false` automatically and no longer fail tool-capable flows with "does not support tools"; tool-capable models behave exactly as before.
- Docs-only: Ollama provider page now documents Modelfile `num_ctx` behavior, the `tools` capability auto-flag, and that `OLLAMA_API_KEY` is optional for local-only setups.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same `/api/show` endpoint, same `fetchWithSsrFGuard` policy, same per-host allowlist, same timeout.
- Command/tool execution surface changed? No — `supportsModelTools` gating in core is unchanged; only the auto-populated `compat.supportsTools` value flows through the existing check.
- Data access scope changed? No.
- Behavior is runtime-enforced, not prompt-derived: `parseOllamaNumCtxParameter` is a pure regex/integer extractor (`^num_ctx\s+(-?\d+)\b`) that drops non-positive and non-finite values; the result is used only as a numeric context budget. `compat.supportsTools: false` is consumed by the existing runtime helper (`src/agents/model-tool-support.ts`) to skip sending tool schemas — not by any prompt text.

## Repro + Verification

### Environment

- OS: macOS 25.3.0 (Apple Silicon)
- Runtime/container: local repo, pnpm + Vitest
- Model/provider: Ollama local (`http://127.0.0.1:11434`)
- Integration/channel (if any): none
- Relevant config (redacted): default

### Steps

1. Create a Modelfile: `FROM llama3:latest` / `PARAMETER num_ctx 32768`; `ollama create llama3-32k -f ...`.
2. Run `openclaw models list --provider ollama`.
3. Start a chat against `ollama/llama3-32k:latest`.

### Expected

- Model listed with `contextWindow = 32768`.
- Non-tool-capable base models work for plain chat without a manual `compat.supportsTools: false` entry.

### Actual (before fix)

- Model listed at `8192`, run blocked with `Model context window too small (8192 tokens; source=model). Minimum is 16000.`.
- Non-tool models return `does not support tools` until the user edits config.

## Evidence

Exact tests run locally on this branch:

- `pnpm vitest run extensions/ollama/src/provider-models.test.ts` → 12 passed (4 new)
- `pnpm vitest run src/agents/models-config.providers.ollama.test.ts` → 13 passed (regression baseline unchanged)
- `pnpm test:extension ollama` → 118 passed across 10 files
- `pnpm test:contracts:plugins` → 364 passed across 82 files
- `pnpm exec oxlint extensions/ollama/src/provider-models.ts extensions/ollama/src/provider-models.test.ts extensions/ollama/src/setup.ts` → 0 warnings, 0 errors
- `pnpm format:check` on all 5 touched files → clean after `pnpm format`

Note: `pnpm tsgo` surfaces pre-existing errors in `extensions/qa-lab/src/providers/aimock/server.ts` on plain `origin/main` (verified by re-running against the stashed baseline); those are unrelated to this change.

## Human Verification (required)

- Verified scenarios: num_ctx override wins over model_info; repeat num_ctx lines pick the last positive integer; malformed or non-positive num_ctx values fall back to the base context_length; capabilities without `tools` produce `compat.supportsTools: false`; capabilities with `tools` and missing capabilities leave `compat` undefined; existing capability-driven `vision` → `input: ["text", "image"]` behavior unchanged; setup-time Kimi cloud seed still presents as vision + tool capable so its persisted config is unchanged; all 10 existing ollama extension test files remain green.
- Edge cases checked: empty/whitespace `parameters` string, repeated `num_ctx` (last-wins), negative/zero `num_ctx`, `parameters` not a string, `capabilities` present but empty, `capabilities` missing entirely.
- What I did not verify: a live Ollama host call; behavior is covered by the new unit tests against mocked `/api/show` responses that mirror Ollama's real payload shape.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — discovered Ollama configs without Modelfile overrides or capability arrays behave exactly as before.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: An Ollama build reports `capabilities: ["completion"]` for a model that actually does support tools, causing OpenClaw to skip tool schemas for it.
  - Mitigation: matches Ollama's own advertised capability; users can still override explicitly by configuring `models.providers.ollama.models[].compat.supportsTools: true`. We only act on a non-empty capabilities array — the old permissive default still applies when capabilities are missing.
- Risk: `parameters` parsing misinterprets a future Ollama field value.
  - Mitigation: parser requires `^num_ctx\s+<int>` with a positive value after `Number.parseInt`, rejects malformed lines, and only overrides the computed `contextWindow` when the parsed value is a finite positive integer; tested against the three main Modelfile shapes plus malformed input.
