### PR TITLE
fix(openrouter): surface reasoning_details visible-text as user output (#68261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals/display: escape raw control characters (including newline and carriage return) in the shared and macOS approval-prompt command sanitizers, so trailing command payloads no longer render on hidden extra lines in the approval UI. (#68198)
 - OpenAI Codex/OAuth + Pi: keep imported Codex CLI OAuth bootstrap, Pi auth export, and runtime overlay handling aligned so Codex sessions survive refresh and health checks without leaking transient CLI state into saved auth files. Thanks @vincentkoc.
 - Agents/TTS: report failed speech synthesis as a real tool error so unconfigured providers no longer feed successful TTS failure output back into agent loops. (#67980) Thanks @lawrence3699.
+- OpenRouter/reasoning_details: route visible-text items (`response.output_text`, `response.text`, `text`) inside OpenRouter `reasoning_details` to the user-visible text block so Gemini 2.5 Flash, Grok 4.x, and similar proxies that emit the final answer inside `reasoning_details` stop returning `stopReason=stop payloads=0`. (#68261)
 
 ## 2026.4.15
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2075,7 +2075,7 @@ describe("openai transport stream", () => {
     ]);
   });
 
-  it("keeps reasoning.text and visible-text from the same reasoning_details chunk", async () => {
+  it("preserves reasoning.text, visible-text, and tool_calls from the same reasoning_details chunk", async () => {
     const model = {
       id: "openrouter/google/gemini-2.5-flash",
       name: "Gemini 2.5 Flash",
@@ -2134,7 +2134,7 @@ describe("openai transport stream", () => {
       {
         id: "chatcmpl-mix",
         object: "chat.completion.chunk" as const,
-        choices: [{ index: 0, delta: {}, logprobs: null, finish_reason: "stop" }],
+        choices: [{ index: 0, delta: {}, logprobs: null, finish_reason: "tool_calls" }],
       },
     ] as const;
     async function* mockStream() {
@@ -2145,10 +2145,14 @@ describe("openai transport stream", () => {
 
     await __testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
 
+    // All three signals coexist in a single chunk: the reasoning trace, the
+    // visible reply, and the tool-call fragment. None may be dropped or the
+    // turn loses either the answer or the tool invocation.
+    expect(output.stopReason).toBe("toolUse");
     expect(output.content).toMatchObject([
       { type: "thinking", thinking: "think" },
       { type: "text", text: "visible" },
+      { type: "toolCall", id: "call_1", name: "lookup", arguments: { q: "x" } },
     ]);
-    expect(output.content.some((b) => (b as { type?: string }).type === "toolCall")).toBe(false);
   });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2017,4 +2017,61 @@ describe("openai transport stream", () => {
       { type: "thinking", thinking: " Still thinking.", thinkingSignature: "reasoning_details" },
     ]);
   });
+
+  it("surfaces reasoning_details visible-text as text while keeping reasoning.text as thinking", async () => {
+    const model = {
+      id: "openrouter/google/gemini-2.5-flash",
+      name: "Gemini 2.5 Flash",
+      api: "openai-completions",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+    const output = {
+      role: "assistant" as const,
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+    const stream: { push(event: unknown): void } = { push() {} };
+    const chunk = (delta: Record<string, unknown>, finish: string | null = null) => ({
+      id: "chatcmpl-vis",
+      object: "chat.completion.chunk" as const,
+      choices: [{ index: 0, delta, logprobs: null, finish_reason: finish }],
+    });
+    const mockChunks = [
+      chunk({ reasoning_details: [{ type: "reasoning.text", text: "thinking..." }] }),
+      chunk({ reasoning_details: [{ type: "response.output_text", text: "hello" }] }),
+      chunk({ reasoning_details: [{ type: "text", text: " world" }] }),
+      chunk({}, "stop"),
+    ] as const;
+    async function* mockStream() {
+      for (const c of mockChunks) {
+        yield c as never;
+      }
+    }
+
+    await __testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
+
+    expect(output.stopReason).toBe("stop");
+    expect(output.content).toMatchObject([
+      { type: "thinking", thinking: "thinking...", thinkingSignature: "reasoning_details" },
+      { type: "text", text: "hello world" },
+    ]);
+  });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2074,4 +2074,81 @@ describe("openai transport stream", () => {
       { type: "text", text: "hello world" },
     ]);
   });
+
+  it("keeps reasoning.text and visible-text from the same reasoning_details chunk", async () => {
+    const model = {
+      id: "openrouter/google/gemini-2.5-flash",
+      name: "Gemini 2.5 Flash",
+      api: "openai-completions",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+    const output = {
+      role: "assistant" as const,
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+    const stream: { push(event: unknown): void } = { push() {} };
+    const mockChunks = [
+      {
+        id: "chatcmpl-mix",
+        object: "chat.completion.chunk" as const,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              reasoning_details: [
+                { type: "reasoning.text", text: "think" },
+                { type: "response.output_text", text: "visible" },
+              ],
+              tool_calls: [
+                {
+                  id: "call_1",
+                  type: "function" as const,
+                  function: { name: "lookup", arguments: '{"q":"x"}' },
+                },
+              ],
+            } as Record<string, unknown>,
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-mix",
+        object: "chat.completion.chunk" as const,
+        choices: [{ index: 0, delta: {}, logprobs: null, finish_reason: "stop" }],
+      },
+    ] as const;
+    async function* mockStream() {
+      for (const c of mockChunks) {
+        yield c as never;
+      }
+    }
+
+    await __testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
+
+    expect(output.content).toMatchObject([
+      { type: "thinking", thinking: "think" },
+      { type: "text", text: "visible" },
+    ]);
+    expect(output.content.some((b) => (b as { type?: string }).type === "toolCall")).toBe(false);
+  });
 });

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1136,7 +1136,6 @@ async function processOpenAICompletionsStream(
       continue;
     }
     const reasoningDeltas = getCompletionsReasoningDeltas(choice.delta as Record<string, unknown>);
-    let emittedVisibleTextFromReasoning = false;
     for (const reasoningDelta of reasoningDeltas) {
       if (reasoningDelta.kind === "text") {
         flushPendingThinkingDelta();
@@ -1153,7 +1152,6 @@ async function processOpenAICompletionsStream(
           delta: reasoningDelta.text,
           partial: output,
         });
-        emittedVisibleTextFromReasoning = true;
       } else if (currentBlock?.type === "toolCall") {
         if (!pendingThinkingDelta) {
           pendingThinkingDelta = { signature: reasoningDelta.signature, text: reasoningDelta.text };
@@ -1164,12 +1162,11 @@ async function processOpenAICompletionsStream(
         appendThinkingDelta({ signature: reasoningDelta.signature, text: reasoningDelta.text });
       }
     }
-    // Mirror the `choice.delta.content` branch above: once a chunk emitted
-    // user-visible text, skip `tool_calls` in the same delta so a text block
-    // and tool-call block are not opened in the same iteration.
-    if (emittedVisibleTextFromReasoning) {
-      continue;
-    }
+    // Fall through to `tool_calls` processing intentionally: if a chunk
+    // carries both `reasoning_details` visible text and a `tool_calls`
+    // fragment, dropping the fragment here would lose tool-invocation state
+    // when `finish_reason` is `tool_calls`. `finishCurrentBlock()` below
+    // correctly finalizes the open text block before the tool-call block.
     if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
       for (const toolCall of choice.delta.tool_calls) {
         if (

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1137,14 +1137,30 @@ async function processOpenAICompletionsStream(
     }
     const reasoningDelta = getCompletionsReasoningDelta(choice.delta as Record<string, unknown>);
     if (reasoningDelta) {
-      if (currentBlock?.type === "toolCall") {
+      if (reasoningDelta.kind === "text") {
+        flushPendingThinkingDelta();
+        if (!currentBlock || currentBlock.type !== "text") {
+          finishCurrentBlock();
+          currentBlock = { type: "text", text: "" };
+          output.content.push(currentBlock);
+          stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+        }
+        currentBlock.text += reasoningDelta.text;
+        stream.push({
+          type: "text_delta",
+          contentIndex: blockIndex(),
+          delta: reasoningDelta.text,
+          partial: output,
+        });
+      } else if (currentBlock?.type === "toolCall") {
+        const thinkingBuffered = { signature: reasoningDelta.signature, text: reasoningDelta.text };
         if (!pendingThinkingDelta) {
-          pendingThinkingDelta = { ...reasoningDelta };
+          pendingThinkingDelta = thinkingBuffered;
         } else {
           pendingThinkingDelta.text += reasoningDelta.text;
         }
       } else {
-        appendThinkingDelta(reasoningDelta);
+        appendThinkingDelta({ signature: reasoningDelta.signature, text: reasoningDelta.text });
       }
     }
     if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
@@ -1196,27 +1212,45 @@ async function processOpenAICompletionsStream(
 }
 
 function getCompletionsReasoningDelta(delta: Record<string, unknown>): {
+  kind: "thinking" | "text";
   signature: string;
   text: string;
 } | null {
   const reasoningDetails = delta.reasoning_details;
   if (Array.isArray(reasoningDetails)) {
-    let text = "";
+    let thinkingText = "";
+    let visibleText = "";
     for (const item of reasoningDetails) {
       const detail = item as { type?: unknown; text?: unknown };
-      if (detail.type === "reasoning.text" && typeof detail.text === "string" && detail.text) {
-        text += detail.text;
+      if (typeof detail.text !== "string" || !detail.text) {
+        continue;
+      }
+      // Some OpenRouter upstreams (e.g. Gemini 2.5, Grok 4.x) deliver the
+      // assistant's visible answer inside `reasoning_details` using the
+      // OpenAI Responses-style content types rather than `choice.delta.content`.
+      // Treat those as visible text; keep `reasoning.*` items as thinking.
+      if (
+        detail.type === "response.output_text" ||
+        detail.type === "response.text" ||
+        detail.type === "text"
+      ) {
+        visibleText += detail.text;
+      } else if (detail.type === "reasoning.text") {
+        thinkingText += detail.text;
       }
     }
-    if (text) {
-      return { signature: "reasoning_details", text };
+    if (visibleText) {
+      return { kind: "text", signature: "reasoning_details", text: visibleText };
+    }
+    if (thinkingText) {
+      return { kind: "thinking", signature: "reasoning_details", text: thinkingText };
     }
   }
   const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"] as const;
   for (const field of reasoningFields) {
     const value = delta[field];
     if (typeof value === "string" && value.length > 0) {
-      return { signature: field, text: value };
+      return { kind: "thinking", signature: field, text: value };
     }
   }
   return null;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1135,8 +1135,9 @@ async function processOpenAICompletionsStream(
       });
       continue;
     }
-    const reasoningDelta = getCompletionsReasoningDelta(choice.delta as Record<string, unknown>);
-    if (reasoningDelta) {
+    const reasoningDeltas = getCompletionsReasoningDeltas(choice.delta as Record<string, unknown>);
+    let emittedVisibleTextFromReasoning = false;
+    for (const reasoningDelta of reasoningDeltas) {
       if (reasoningDelta.kind === "text") {
         flushPendingThinkingDelta();
         if (!currentBlock || currentBlock.type !== "text") {
@@ -1152,16 +1153,22 @@ async function processOpenAICompletionsStream(
           delta: reasoningDelta.text,
           partial: output,
         });
+        emittedVisibleTextFromReasoning = true;
       } else if (currentBlock?.type === "toolCall") {
-        const thinkingBuffered = { signature: reasoningDelta.signature, text: reasoningDelta.text };
         if (!pendingThinkingDelta) {
-          pendingThinkingDelta = thinkingBuffered;
+          pendingThinkingDelta = { signature: reasoningDelta.signature, text: reasoningDelta.text };
         } else {
           pendingThinkingDelta.text += reasoningDelta.text;
         }
       } else {
         appendThinkingDelta({ signature: reasoningDelta.signature, text: reasoningDelta.text });
       }
+    }
+    // Mirror the `choice.delta.content` branch above: once a chunk emitted
+    // user-visible text, skip `tool_calls` in the same delta so a text block
+    // and tool-call block are not opened in the same iteration.
+    if (emittedVisibleTextFromReasoning) {
+      continue;
     }
     if (choice.delta.tool_calls && choice.delta.tool_calls.length > 0) {
       for (const toolCall of choice.delta.tool_calls) {
@@ -1211,11 +1218,16 @@ async function processOpenAICompletionsStream(
   }
 }
 
-function getCompletionsReasoningDelta(delta: Record<string, unknown>): {
+type CompletionsReasoningDelta = {
   kind: "thinking" | "text";
   signature: string;
   text: string;
-} | null {
+};
+
+function getCompletionsReasoningDeltas(
+  delta: Record<string, unknown>,
+): CompletionsReasoningDelta[] {
+  const deltas: CompletionsReasoningDelta[] = [];
   const reasoningDetails = delta.reasoning_details;
   if (Array.isArray(reasoningDetails)) {
     let thinkingText = "";
@@ -1239,21 +1251,27 @@ function getCompletionsReasoningDelta(delta: Record<string, unknown>): {
         thinkingText += detail.text;
       }
     }
-    if (visibleText) {
-      return { kind: "text", signature: "reasoning_details", text: visibleText };
-    }
+    // Emit thinking before visible text so within-chunk interleaving keeps
+    // the reasoning trace instead of dropping it when both kinds coexist.
     if (thinkingText) {
-      return { kind: "thinking", signature: "reasoning_details", text: thinkingText };
+      deltas.push({ kind: "thinking", signature: "reasoning_details", text: thinkingText });
+    }
+    if (visibleText) {
+      deltas.push({ kind: "text", signature: "reasoning_details", text: visibleText });
+    }
+    if (deltas.length > 0) {
+      return deltas;
     }
   }
   const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"] as const;
   for (const field of reasoningFields) {
     const value = delta[field];
     if (typeof value === "string" && value.length > 0) {
-      return { kind: "thinking", signature: field, text: value };
+      deltas.push({ kind: "thinking", signature: field, text: value });
+      break;
     }
   }
-  return null;
+  return deltas;
 }
 
 function detectCompat(model: OpenAIModeModel) {


### PR DESCRIPTION
## Summary

- Problem: OpenRouter model runs (e.g. `openrouter/google/gemini-2.5-flash`, Grok 4.x, minimax-m2.7) return blank responses with `stopReason=stop payloads=0` and surface `⚠️ Agent couldn't generate a response`.
- Why it matters: Entire classes of OpenRouter-proxied models have been unusable since 2026.4.14/15 despite healthy gateway and successful upstream responses.
- What changed: `getCompletionsReasoningDelta` in `src/agents/openai-transport-stream.ts` now discriminates the OpenRouter `reasoning_details` stream between hidden reasoning (`reasoning.text`) and OpenAI Responses–style visible output (`response.output_text`, `response.text`, `text`). Visible-output items are routed through the same text-block path as `choice.delta.content` instead of being buried in a thinking block.
- What did NOT change (scope boundary): no changes to prompts, auth, sandbox, tool policy, secret handling, provider routing, request assembly, transcript bytes, or prompt-cache order. Previous `reasoning.text` behavior is preserved byte-for-byte.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68261
- Related #67410, #67575, #67698, #67907, #67425, #68030, #68076, #68185
- [x] This PR fixes a bug or regression

## Root Cause

`e0bf756b50` ("fix: handle OpenRouter Qwen3 reasoning_details streams") taught `getCompletionsReasoningDelta` to parse `reasoning_details` items, but it unconditionally classified every matching item as hidden thinking. Some OpenRouter upstreams (Gemini 2.5 Flash via the Responses-style reasoning proxy, xAI Grok 4.x, and related models) deliver the assistant's final answer inside `reasoning_details` using OpenAI Responses content types such as `response.output_text`, `response.text`, and plain `text`, with an empty `choice.delta.content`. Because the parser treated those as thinking, the stream closed with `stopReason=stop`, zero text blocks, and the incomplete-turn detector in `src/agents/pi-embedded-runner/run/incomplete-turn.ts` surfaced the generic error.

- Root cause: `reasoning_details` visible-output types were misclassified as internal reasoning and never emitted as user-visible text.
- Missing detection / guardrail: no regression covered `reasoning_details` streams where the final answer arrives without a separate `content` field.
- Contributing context: OpenRouter's proxy layer for several reasoning models started folding visible output into `reasoning_details` alongside reasoning bytes.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/openai-transport-stream.test.ts`
- Scenario the test should lock in: a mixed `reasoning_details` stream where `reasoning.text` items stay as thinking while `response.output_text`, `response.text`, and `text` items surface as a user-visible text block with `stopReason=stop`.
- Why this is the smallest reliable guardrail: it exercises the exact parser path that decides whether bytes become visible text or hidden thinking.
- Existing test that already covers this: `handles reasoning_details from OpenRouter/Qwen3 in completions stream` only covered `content` + `reasoning.text` mixes, not the visible-text-in-`reasoning_details` case.

## User-visible / Behavior Changes

- OpenRouter models that deliver the final answer inside `reasoning_details` (e.g. Gemini 2.5 Flash, Grok 4.x) now produce visible replies instead of the generic `⚠️ Agent couldn't generate a response` error. No configuration, defaults, or docs change.

## Diagram

```text
Before:
OpenRouter -> reasoning_details[{type:"response.output_text", text:"hello"}]
           -> classified as thinking
           -> stopReason=stop, payloads=0
           -> "⚠️ Agent couldn't generate a response."

After:
OpenRouter -> reasoning_details[{type:"response.output_text", text:"hello"}]
           -> classified as visible text
           -> text block "hello", stopReason=stop, payloads>=1
           -> user sees "hello"
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

Runtime-enforced controls that are explicitly unchanged by this PR: tool policy/allowlist, sandbox, exec approval, subagent policy, secrets plan, owner-only gating, OpenRouter routing, auth profiles, and prompt-cache request assembly. The fix is confined to classification of bytes the upstream already returned over an authenticated, already-policy-gated channel; it does not rely on or modify any prompt text or runtime policy. A malicious upstream that labels reasoning as `type: "text"` cannot leak more than it could by setting `choice.delta.content` directly, which is already the default visible path.

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0)
- Runtime/container: local OpenClaw gateway (loopback)
- Model/provider: `openrouter/google/gemini-2.5-flash`, `openrouter/x-ai/grok-4.1-fast`, `openrouter/minimax/minimax-m2.7`
- Integration/channel: none (direct `openclaw infer model run`) and dashboard
- Relevant config: `agents.defaults.models = { "openrouter/google/gemini-2.5-flash": {} }` (redacted)

### Steps

1. `openclaw infer model run --model openrouter/google/gemini-2.5-flash --prompt "Reply with exactly: hello" --json`
2. Observe response contents and gateway log for `incomplete turn detected ... payloads=0`.
3. Repeat for Grok 4.x / minimax-m2.7.

### Expected

- `outputs[0].text` contains the assistant reply.
- No `payloads=0` / `incomplete turn detected` warning.

### Actual (before fix)

- `outputs[0].text` = `⚠️ Agent couldn't generate a response. Please try again.`
- Gateway log: `incomplete turn detected: ... stopReason=stop payloads=0 — surfacing error to user`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Before: `reasoning_details` visible-text items classified as thinking, zero text blocks, `stopReason=stop payloads=0`.
After: new test `surfaces reasoning_details visible-text as text while keeping reasoning.text as thinking` asserts text block emission alongside the preserved thinking block; existing `reasoning_details`/Qwen3 and tool-call regression tests remain green.

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/agents/openai-transport-stream.test.ts` — 56/56 pass including the new case.
  - `pnpm test src/agents/openai-transport-stream.test.ts -t reasoning_details` — 4/4 `reasoning_details` cases pass.
  - Re-ran `pnpm check` (host-env-policy, tool-display, no-conflict-markers green); remaining `pnpm tsgo`/`pnpm lint` failures are pre-existing in `extensions/qa-lab/src/providers/aimock/server.ts` on `upstream/main` and unrelated to this change (verified by running `pnpm tsgo` on clean `upstream/main`).
- Edge cases checked:
  - `reasoning.text`-only stream still becomes a thinking block (existing Qwen3 test).
  - Mixed `reasoning.text` + visible-text items in the same stream produce both thinking and text blocks in order.
  - `reasoning_details` arriving alongside `tool_calls` still routes through the buffered thinking path and preserves tool-call arguments (existing tests).
  - Non-array or unknown-type `reasoning_details` items are skipped silently.
- What I did not verify:
  - Live OpenRouter run against real keys (no live lane invoked in this change).
  - Parallels smoke / cross-platform onboarding (not in scope for a parser-only fix).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a model intentionally using `type: "text"` inside `reasoning_details` for genuinely-hidden scratchpad content would now surface that content to users.
  - Mitigation: OpenRouter's documented semantics for `response.output_text` / `response.text` / `text` are visible assistant output; the existing `reasoning.text` type still maps to hidden reasoning. If a specific upstream deviates, follow-up can narrow the visible-type set.
- Risk: Qwen3 regression from #66905 returns.
  - Mitigation: the existing Qwen3 regression test and the tool-call + reasoning_details test remain unchanged and still pass.

## Testing notes

- AI-assisted PR, lightly tested (parser unit tests only; no live OpenRouter run).
- Exact tests run:
  - `pnpm test src/agents/openai-transport-stream.test.ts` (56/56 pass)
  - `pnpm test src/agents/openai-transport-stream.test.ts -t reasoning_details` (4/4 pass)
  - `pnpm test src/agents/openai-transport-stream.test.ts -t visible-text` (1/1 pass)
  - `pnpm check` (pre-existing `aimock/server.ts` failures on `upstream/main`; no new failures introduced)


Made with [Cursor](https://cursor.com)