### PR TITLE
fix: allow unknown properties in WakeParams schema (#68347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals/display: escape raw control characters (including newline and carriage return) in the shared and macOS approval-prompt command sanitizers, so trailing command payloads no longer render on hidden extra lines in the approval UI. (#68198)
 - OpenAI Codex/OAuth + Pi: keep imported Codex CLI OAuth bootstrap, Pi auth export, and runtime overlay handling aligned so Codex sessions survive refresh and health checks without leaking transient CLI state into saved auth files. Thanks @vincentkoc.
 - Agents/TTS: report failed speech synthesis as a real tool error so unconfigured providers no longer feed successful TTS failure output back into agent loops. (#67980) Thanks @lawrence3699.
+- Gateway/wake: allow unknown properties on wake payloads so external senders like Paperclip can attach opaque metadata without failing schema validation. (#68355) Thanks @kagura-agent.
 
 ## 2026.4.15
 

--- a/src/gateway/protocol/index.test.ts
+++ b/src/gateway/protocol/index.test.ts
@@ -127,8 +127,6 @@ describe("validateWakeParams", () => {
   });
 
   it("accepts unknown properties for forward compatibility", () => {
-    // External tools like Paperclip may add extra properties to wake payloads.
-    // The schema must not reject them (#68347).
     expect(
       validateWakeParams({
         mode: "now",

--- a/src/gateway/protocol/index.test.ts
+++ b/src/gateway/protocol/index.test.ts
@@ -1,7 +1,7 @@
 import type { ErrorObject } from "ajv";
 import { describe, expect, it } from "vitest";
 import { TALK_TEST_PROVIDER_ID } from "../../test-utils/talk-test-provider.js";
-import { formatValidationErrors, validateTalkConfigResult } from "./index.js";
+import { formatValidationErrors, validateTalkConfigResult, validateWakeParams } from "./index.js";
 
 const makeError = (overrides: Partial<ErrorObject>): ErrorObject => ({
   keyword: "type",
@@ -111,5 +111,39 @@ describe("validateTalkConfigResult", () => {
         },
       }),
     ).toBe(false);
+  });
+});
+
+describe("validateWakeParams", () => {
+  it("accepts valid wake params", () => {
+    expect(validateWakeParams({ mode: "now", text: "hello" })).toBe(true);
+    expect(validateWakeParams({ mode: "next-heartbeat", text: "remind me" })).toBe(true);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(validateWakeParams({ mode: "now" })).toBe(false);
+    expect(validateWakeParams({ text: "hello" })).toBe(false);
+    expect(validateWakeParams({})).toBe(false);
+  });
+
+  it("accepts unknown properties for forward compatibility", () => {
+    // External tools like Paperclip may add extra properties to wake payloads.
+    // The schema must not reject them (#68347).
+    expect(
+      validateWakeParams({
+        mode: "now",
+        text: "hello",
+        paperclip: { version: "2026.416.0", source: "wake" },
+      }),
+    ).toBe(true);
+
+    expect(
+      validateWakeParams({
+        mode: "next-heartbeat",
+        text: "check back",
+        unknownFutureField: 42,
+        anotherExtra: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -196,5 +196,5 @@ export const WakeParamsSchema = Type.Object(
     mode: Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),
     text: NonEmptyString,
   },
-  { additionalProperties: true },
+  { additionalProperties: true }, // external wake senders may attach opaque metadata
 );

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -196,5 +196,5 @@ export const WakeParamsSchema = Type.Object(
     mode: Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),
     text: NonEmptyString,
   },
-  { additionalProperties: false },
+  { additionalProperties: true },
 );


### PR DESCRIPTION
Fixes #68347

**Problem:** `WakeParamsSchema` used `additionalProperties: false` (AJV), rejecting unknown properties like `paperclip` injected by Paperclip 2026.416.0 in wake payloads.

**Fix:** Changed to `additionalProperties: true` so unknown properties from external tools/plugins are silently accepted. This improves forward compatibility — new tools may add properties that shouldn't break validation.

**Tests:** Added test verifying unknown properties are accepted without error.