### PR TITLE
fix(whatsapp): centralize inbound policy and scoped group routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WhatsApp/inbound: centralize inbound policy resolution and route named-account group sessions through account-scoped keys. Thanks @mcaxtr.
 - Agents/bootstrap: resolve bootstrap from workspace truth instead of stale session transcript markers, keep embedded bootstrap instructions on a hidden user-context prelude, suppress normal `/new` and `/reset` greetings while `BOOTSTRAP.md` is still pending, and make the embedded runner read the bootstrap ritual before replying normally.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
 - Gateway/hello-ok: always report negotiated auth metadata for successful shared-auth handshakes, including control-ui bypass coverage when no device token is issued. (#67810) Thanks @BunsDev.

--- a/extensions/whatsapp/session-key-api.ts
+++ b/extensions/whatsapp/session-key-api.ts
@@ -1,0 +1,1 @@
+export { resolveWhatsAppSessionConversation as resolveSessionConversation } from "./src/session-conversation.js";

--- a/extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts
+++ b/extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts
@@ -138,6 +138,57 @@ describe("broadcast groups", () => {
     resetLoadConfigMock();
   });
 
+  it("keeps named-account group broadcast routes on the scoped session key", async () => {
+    setLoadConfigMock({
+      channels: {
+        whatsapp: {
+          allowFrom: ["*"],
+          accounts: {
+            work: {
+              allowFrom: ["*"],
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: { maxConcurrent: 10 },
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        strategy: "sequential",
+        "123@g.us": ["alfred", "baerbel"],
+      },
+    } satisfies OpenClawConfig);
+
+    const seen: string[] = [];
+    const resolver = vi.fn(async (ctx: { SessionKey?: unknown }) => {
+      seen.push(String(ctx.SessionKey));
+      return { text: "ok" };
+    });
+
+    const { spies, onMessage } = await monitorWebChannelWithCapture(resolver);
+
+    await sendWebGroupInboundMessage({
+      onMessage,
+      spies,
+      body: "@bot ping",
+      id: "g-work-1",
+      senderE164: "+111",
+      senderName: "Alice",
+      mentionedJids: ["999@s.whatsapp.net"],
+      selfE164: "+999",
+      selfJid: "999@s.whatsapp.net",
+      accountId: "work",
+    });
+
+    expect(resolver).toHaveBeenCalledTimes(2);
+    expect(seen).toEqual([
+      "agent:alfred:whatsapp:group:123@g.us:thread:whatsapp-account-work",
+      "agent:baerbel:whatsapp:group:123@g.us:thread:whatsapp-account-work",
+    ]);
+    resetLoadConfigMock();
+  });
+
   it("broadcasts in parallel by default", async () => {
     setLoadConfigMock({
       channels: { whatsapp: { allowFrom: ["*"] } },

--- a/extensions/whatsapp/src/auto-reply/mentions.ts
+++ b/extensions/whatsapp/src/auto-reply/mentions.ts
@@ -13,6 +13,7 @@ import type { WebInboundMsg } from "./types.js";
 export type MentionConfig = {
   mentionRegexes: RegExp[];
   allowFrom?: Array<string | number>;
+  isSelfChat?: boolean;
 };
 
 export type MentionTargets = {
@@ -43,7 +44,10 @@ export function isBotMentionedFromTargets(
     // Remove zero-width and directionality markers WhatsApp injects around display names
     normalizeMentionText(text);
 
-  const isSelfChat = isSelfChatMode(targets.self.e164, mentionCfg.allowFrom);
+  const isSelfChat =
+    typeof mentionCfg.isSelfChat === "boolean"
+      ? mentionCfg.isSelfChat
+      : isSelfChatMode(targets.self.e164, mentionCfg.allowFrom);
 
   const hasMentions = targets.normalizedMentions.length > 0;
   if (hasMentions && !isSelfChat) {

--- a/extensions/whatsapp/src/auto-reply/monitor/broadcast.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/broadcast.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_MAIN_KEY,
   normalizeAgentId,
 } from "openclaw/plugin-sdk/routing";
+import { resolveWhatsAppGroupSessionRoute } from "../../group-session-key.js";
 import { formatError } from "../../session.js";
 import { whatsappInboundLog } from "../loggers.js";
 import type { WebInboundMsg } from "../types.js";
@@ -92,11 +93,15 @@ export async function maybeBroadcastMessage(params: {
       peerId: params.peerId,
       agentId: normalizedAgentId,
     });
-    const agentRoute = {
+    const baseAgentRoute = {
       ...params.route,
       agentId: normalizedAgentId,
       ...routeKeys,
     };
+    const agentRoute =
+      params.msg.chatType === "group"
+        ? resolveWhatsAppGroupSessionRoute(baseAgentRoute)
+        : baseAgentRoute;
 
     try {
       return await params.processMessage(params.msg, agentRoute, params.groupHistoryKey, {

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -3,6 +3,7 @@ import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { buildGroupHistoryKey } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveWhatsAppGroupSessionRoute } from "../../group-session-key.js";
 import { getPrimaryIdentityId, getSenderIdentity } from "../../identity.js";
 import { normalizeE164 } from "../../text-runtime.js";
 import { loadConfig } from "../config.runtime.js";
@@ -65,7 +66,7 @@ export function createWebOnMessageHandler(params: {
     const conversationId = msg.conversationId ?? msg.from;
     const peerId = resolvePeerId(msg);
     // Fresh config for bindings lookup; other routing inputs are payload-derived.
-    const route = resolveAgentRoute({
+    const baseRoute = resolveAgentRoute({
       cfg: loadConfig(),
       channel: "whatsapp",
       accountId: msg.accountId,
@@ -74,6 +75,8 @@ export function createWebOnMessageHandler(params: {
         id: peerId,
       },
     });
+    const route =
+      msg.chatType === "group" ? resolveWhatsAppGroupSessionRoute(baseRoute) : baseRoute;
     const groupHistoryKey =
       msg.chatType === "group"
         ? buildGroupHistoryKey({

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -1,5 +1,9 @@
-import { resolveWhatsAppAccount } from "../../accounts.js";
 import { getPrimaryIdentityId, getSelfIdentity, getSenderIdentity } from "../../identity.js";
+import {
+  resolveWhatsAppCommandAuthorized,
+  resolveWhatsAppInboundPolicy,
+  type ResolvedWhatsAppInboundPolicy,
+} from "../../inbound-policy.js";
 import { newConnectionId } from "../../reconnect.js";
 import { formatError } from "../../session.js";
 import { deliverWebReply } from "../deliver-reply.js";
@@ -27,12 +31,10 @@ import {
   formatInboundEnvelope,
   logVerbose,
   normalizeE164,
-  readStoreAllowFromForDmPolicy,
   recordSessionMetaFromInbound,
   resolveChannelContextVisibilityMode,
   resolveInboundSessionEnvelopeContext,
   resolvePinnedMainDmOwnerFromAllowlist,
-  resolveDmGroupAccessWithCommandGate,
   shouldComputeCommandAuthorized,
   shouldLogVerbose,
   type getChildLogger,
@@ -42,74 +44,13 @@ import {
   type resolveAgentRoute,
 } from "./runtime-api.js";
 
-async function resolveWhatsAppCommandAuthorized(params: {
-  cfg: ReturnType<LoadConfigFn>;
-  msg: WebInboundMsg;
-}): Promise<boolean> {
-  const useAccessGroups = params.cfg.commands?.useAccessGroups !== false;
-  if (!useAccessGroups) {
-    return true;
-  }
-
-  const isGroup = params.msg.chatType === "group";
-  const sender = getSenderIdentity(params.msg);
-  const self = getSelfIdentity(params.msg);
-  const senderE164 = normalizeE164(
-    isGroup ? (sender.e164 ?? "") : (sender.e164 ?? params.msg.from ?? ""),
-  );
-  if (!senderE164) {
-    return false;
-  }
-
-  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
-  const dmPolicy = account.dmPolicy ?? "pairing";
-  const groupPolicy = account.groupPolicy ?? "allowlist";
-  const configuredAllowFrom = account.allowFrom ?? [];
-  const configuredGroupAllowFrom =
-    account.groupAllowFrom ?? (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
-
-  const storeAllowFrom = isGroup
-    ? []
-    : await readStoreAllowFromForDmPolicy({
-        provider: "whatsapp",
-        accountId: params.msg.accountId,
-        dmPolicy,
-      });
-  const dmAllowFrom =
-    configuredAllowFrom.length > 0 ? configuredAllowFrom : self.e164 ? [self.e164] : [];
-  const access = resolveDmGroupAccessWithCommandGate({
-    isGroup,
-    dmPolicy,
-    groupPolicy,
-    allowFrom: dmAllowFrom,
-    groupAllowFrom: configuredGroupAllowFrom,
-    storeAllowFrom,
-    isSenderAllowed: (allowEntries) => {
-      if (allowEntries.includes("*")) {
-        return true;
-      }
-      const normalizedEntries = allowEntries
-        .map((entry) => normalizeE164(entry))
-        .filter((entry): entry is string => Boolean(entry));
-      return normalizedEntries.includes(senderE164);
-    },
-    command: {
-      useAccessGroups,
-      allowTextCommands: true,
-      hasControlCommand: true,
-    },
-  });
-  return access.commandAuthorized;
-}
-
 function resolvePinnedMainDmRecipient(params: {
   cfg: ReturnType<LoadConfigFn>;
-  msg: WebInboundMsg;
+  allowFrom?: string[];
 }): string | null {
-  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.msg.accountId });
   return resolvePinnedMainDmOwnerFromAllowlist({
     dmScope: params.cfg.session?.dmScope,
-    allowFrom: account.allowFrom,
+    allowFrom: params.allowFrom,
     normalizeEntry: (entry) => normalizeE164(entry),
   });
 }
@@ -143,20 +84,18 @@ export async function processMessage(params: {
   suppressGroupHistoryClear?: boolean;
 }) {
   const conversationId = params.msg.conversationId ?? params.msg.from;
-  const account = resolveWhatsAppAccount({
+  const self = getSelfIdentity(params.msg);
+  const inboundPolicy = resolveWhatsAppInboundPolicy({
     cfg: params.cfg,
     accountId: params.route.accountId ?? params.msg.accountId,
+    selfE164: self.e164 ?? null,
   });
+  const account = inboundPolicy.account;
   const contextVisibilityMode = resolveChannelContextVisibilityMode({
     cfg: params.cfg,
     channel: "whatsapp",
     accountId: account.accountId,
   });
-  const configuredAllowFrom = account.allowFrom ?? [];
-  const configuredGroupAllowFrom =
-    account.groupAllowFrom ?? (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
-  const groupAllowFrom = configuredGroupAllowFrom ?? [];
-  const groupPolicy = account.groupPolicy ?? "allowlist";
   const { storePath, envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
     cfg: params.cfg,
     agentId: params.route.agentId,
@@ -175,8 +114,8 @@ export async function processMessage(params: {
       ? resolveVisibleWhatsAppGroupHistory({
           history: params.groupHistory ?? params.groupHistories.get(params.groupHistoryKey) ?? [],
           mode: contextVisibilityMode,
-          groupPolicy,
-          groupAllowFrom,
+          groupPolicy: inboundPolicy.groupPolicy,
+          groupAllowFrom: inboundPolicy.groupAllowFrom,
         })
       : undefined;
 
@@ -256,13 +195,12 @@ export async function processMessage(params: {
   }
 
   const sender = getSenderIdentity(params.msg);
-  const self = getSelfIdentity(params.msg);
   const visibleReplyTo = resolveVisibleWhatsAppReplyContext({
     msg: params.msg,
     authDir: account.authDir,
     mode: contextVisibilityMode,
-    groupPolicy,
-    groupAllowFrom,
+    groupPolicy: inboundPolicy.groupPolicy,
+    groupAllowFrom: inboundPolicy.groupAllowFrom,
   });
   const dmRouteTarget = resolveWhatsAppDmRouteTarget({
     msg: params.msg,
@@ -270,7 +208,11 @@ export async function processMessage(params: {
     normalizeE164,
   });
   const commandAuthorized = shouldComputeCommandAuthorized(params.msg.body, params.cfg)
-    ? await resolveWhatsAppCommandAuthorized({ cfg: params.cfg, msg: params.msg })
+    ? await resolveWhatsAppCommandAuthorized({
+        cfg: params.cfg,
+        msg: params.msg,
+        policy: inboundPolicy,
+      })
     : undefined;
   const { onModelSelected, ...replyPipeline } = createChannelReplyPipeline({
     cfg: params.cfg,
@@ -278,14 +220,10 @@ export async function processMessage(params: {
     channel: "whatsapp",
     accountId: params.route.accountId,
   });
-  const isSelfChat =
-    params.msg.chatType !== "group" &&
-    Boolean(self.e164) &&
-    normalizeE164(params.msg.from) === normalizeE164(self.e164 ?? "");
   const responsePrefix = resolveWhatsAppResponsePrefix({
     cfg: params.cfg,
     agentId: params.route.agentId,
-    isSelfChat,
+    isSelfChat: params.msg.chatType !== "group" && inboundPolicy.isSelfChat,
     pipelineResponsePrefix: replyPipeline.responsePrefix,
   });
 
@@ -307,7 +245,7 @@ export async function processMessage(params: {
 
   const pinnedMainDmRecipient = resolvePinnedMainDmRecipient({
     cfg: params.cfg,
-    msg: params.msg,
+    allowFrom: inboundPolicy.configuredAllowFrom,
   });
   updateWhatsAppMainLastRoute({
     backgroundTasks: params.backgroundTasks,
@@ -359,3 +297,10 @@ export async function processMessage(params: {
     shouldClearGroupHistory,
   });
 }
+
+export const __testing = {
+  resolveWhatsAppCommandAuthorized,
+  resolveWhatsAppInboundPolicy: (
+    params: Parameters<typeof resolveWhatsAppInboundPolicy>[0],
+  ): ResolvedWhatsAppInboundPolicy => resolveWhatsAppInboundPolicy(params),
+};

--- a/extensions/whatsapp/src/auto-reply/types.ts
+++ b/extensions/whatsapp/src/auto-reply/types.ts
@@ -1,4 +1,4 @@
-import type { monitorWebInbox } from "../inbound.js";
+import type { WebInboundMessage } from "../inbound/types.js";
 import type { ReconnectPolicy } from "../reconnect.js";
 
 export type WebChannelHealthState =
@@ -10,11 +10,7 @@ export type WebChannelHealthState =
   | "logged-out"
   | "stopped";
 
-export type WebInboundMsg = Parameters<typeof monitorWebInbox>[0]["onMessage"] extends (
-  msg: infer M,
-) => unknown
-  ? M
-  : never;
+export type WebInboundMsg = WebInboundMessage;
 
 export type WebChannelStatus = {
   running: boolean;

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -34,6 +34,7 @@ import {
   normalizeWhatsAppTarget,
 } from "./normalize.js";
 import { getWhatsAppRuntime } from "./runtime.js";
+import { resolveWhatsAppSessionConversation } from "./session-conversation.js";
 import { resolveWhatsAppOutboundSessionRoute } from "./session-route.js";
 import { whatsappSetupAdapter } from "./setup-core.js";
 import {
@@ -103,6 +104,8 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
       },
       messaging: {
         normalizeTarget: normalizeWhatsAppMessagingTarget,
+        resolveSessionConversation: ({ kind, rawId }) =>
+          resolveWhatsAppSessionConversation({ kind, rawId }),
         resolveOutboundSessionRoute: (params) => resolveWhatsAppOutboundSessionRoute(params),
         parseExplicitTarget: ({ raw }) => parseWhatsAppExplicitTarget(raw),
         inferTargetChatType: ({ to }) => parseWhatsAppExplicitTarget(to)?.chatType,

--- a/extensions/whatsapp/src/group-session-key.test.ts
+++ b/extensions/whatsapp/src/group-session-key.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { resolveWhatsAppGroupSessionRoute, __testing } from "./group-session-key.js";
+
+describe("resolveWhatsAppGroupSessionRoute", () => {
+  it("keeps default-account group routes unchanged", () => {
+    const route = {
+      agentId: "main",
+      channel: "whatsapp",
+      accountId: "default",
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      mainSessionKey: "agent:main:main",
+      lastRoutePolicy: "session",
+      matchedBy: "default",
+    } as const;
+
+    expect(resolveWhatsAppGroupSessionRoute(route)).toEqual(route);
+  });
+
+  it("scopes named-account group routes through an account-specific thread suffix", () => {
+    const route = {
+      agentId: "main",
+      channel: "whatsapp",
+      accountId: "work",
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      mainSessionKey: "agent:main:main",
+      lastRoutePolicy: "session",
+      matchedBy: "default",
+    } as const;
+
+    expect(resolveWhatsAppGroupSessionRoute(route)).toEqual({
+      ...route,
+      sessionKey: "agent:main:whatsapp:group:123@g.us:thread:whatsapp-account-work",
+    });
+  });
+
+  it("derives the legacy group session key from a named-account scoped group route", () => {
+    expect(
+      __testing.resolveWhatsAppLegacyGroupSessionKey({
+        accountId: "work",
+        sessionKey: "agent:main:whatsapp:group:123@g.us:thread:whatsapp-account-work",
+      }),
+    ).toBe("agent:main:whatsapp:group:123@g.us");
+  });
+
+  it("normalizes mixed-case account ids when resolving legacy scoped group keys", () => {
+    expect(
+      __testing.resolveWhatsAppLegacyGroupSessionKey({
+        accountId: "Work",
+        sessionKey: "agent:main:whatsapp:group:123@g.us:thread:whatsapp-account-work",
+      }),
+    ).toBe("agent:main:whatsapp:group:123@g.us");
+  });
+});

--- a/extensions/whatsapp/src/group-session-key.ts
+++ b/extensions/whatsapp/src/group-session-key.ts
@@ -1,0 +1,41 @@
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  resolveThreadSessionKeys,
+  type ResolvedAgentRoute,
+} from "openclaw/plugin-sdk/routing";
+
+function resolveWhatsAppGroupAccountThreadId(accountId: string): string {
+  return `whatsapp-account-${normalizeAccountId(accountId)}`;
+}
+
+export function resolveWhatsAppLegacyGroupSessionKey(params: {
+  sessionKey: string;
+  accountId?: string | null;
+}): string | null {
+  const accountId = normalizeAccountId(params.accountId);
+  if (!accountId || accountId === DEFAULT_ACCOUNT_ID || !params.sessionKey.includes(":group:")) {
+    return null;
+  }
+  const suffix = `:thread:${resolveWhatsAppGroupAccountThreadId(accountId)}`;
+  return params.sessionKey.endsWith(suffix) ? params.sessionKey.slice(0, -suffix.length) : null;
+}
+
+export function resolveWhatsAppGroupSessionRoute(route: ResolvedAgentRoute): ResolvedAgentRoute {
+  if (route.accountId === DEFAULT_ACCOUNT_ID || !route.sessionKey.includes(":group:")) {
+    return route;
+  }
+  const scopedSession = resolveThreadSessionKeys({
+    baseSessionKey: route.sessionKey,
+    threadId: resolveWhatsAppGroupAccountThreadId(route.accountId),
+  });
+  return {
+    ...route,
+    sessionKey: scopedSession.sessionKey,
+  };
+}
+
+export const __testing = {
+  resolveWhatsAppGroupAccountThreadId,
+  resolveWhatsAppLegacyGroupSessionKey,
+};

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -1,0 +1,191 @@
+import {
+  resolveChannelGroupPolicy,
+  resolveChannelGroupRequireMention,
+  resolveDefaultGroupPolicy,
+  resolveGroupSessionKey,
+  type ChannelGroupPolicy,
+  type DmPolicy,
+  type GroupPolicy,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/config-runtime";
+import {
+  readStoreAllowFromForDmPolicy,
+  resolveDmGroupAccessWithCommandGate,
+} from "openclaw/plugin-sdk/security-runtime";
+import { resolveWhatsAppAccount, type ResolvedWhatsAppAccount } from "./accounts.js";
+import { getSelfIdentity, getSenderIdentity } from "./identity.js";
+import type { WebInboundMessage } from "./inbound/types.js";
+import { resolveWhatsAppRuntimeGroupPolicy } from "./runtime-group-policy.js";
+import { isSelfChatMode, normalizeE164 } from "./text-runtime.js";
+
+export type ResolvedWhatsAppInboundPolicy = {
+  account: ResolvedWhatsAppAccount;
+  dmPolicy: DmPolicy;
+  groupPolicy: GroupPolicy;
+  configuredAllowFrom: string[];
+  dmAllowFrom: string[];
+  groupAllowFrom: string[];
+  isSelfChat: boolean;
+  providerMissingFallbackApplied: boolean;
+  shouldReadStorePairingApprovals: boolean;
+  isSamePhone: (value?: string | null) => boolean;
+  isDmSenderAllowed: (allowEntries: string[], sender?: string | null) => boolean;
+  isGroupSenderAllowed: (allowEntries: string[], sender?: string | null) => boolean;
+  resolveConversationGroupPolicy: (conversationId: string) => ChannelGroupPolicy;
+  resolveConversationRequireMention: (conversationId: string) => boolean;
+};
+
+function resolveGroupConversationId(conversationId: string): string {
+  return (
+    resolveGroupSessionKey({
+      From: conversationId,
+      ChatType: "group",
+      Provider: "whatsapp",
+    })?.id ?? conversationId
+  );
+}
+
+function isNormalizedSenderAllowed(allowEntries: string[], sender?: string | null): boolean {
+  if (allowEntries.includes("*")) {
+    return true;
+  }
+  const normalizedSender = normalizeE164(sender ?? "");
+  if (!normalizedSender) {
+    return false;
+  }
+  const normalizedEntrySet = new Set(
+    allowEntries
+      .map((entry) => normalizeE164(entry))
+      .filter((entry): entry is string => Boolean(entry)),
+  );
+  return normalizedEntrySet.has(normalizedSender);
+}
+
+function buildResolvedWhatsAppGroupConfig(params: {
+  groupPolicy: GroupPolicy;
+  groups: ResolvedWhatsAppAccount["groups"];
+}): OpenClawConfig {
+  return {
+    channels: {
+      whatsapp: {
+        groupPolicy: params.groupPolicy,
+        groups: params.groups,
+      },
+    },
+  } as OpenClawConfig;
+}
+
+export function resolveWhatsAppInboundPolicy(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  selfE164?: string | null;
+}): ResolvedWhatsAppInboundPolicy {
+  const account = resolveWhatsAppAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const configuredAllowFrom = account.allowFrom ?? [];
+  const dmPolicy = account.dmPolicy ?? "pairing";
+  const dmAllowFrom =
+    configuredAllowFrom.length > 0 ? configuredAllowFrom : params.selfE164 ? [params.selfE164] : [];
+  const groupAllowFrom =
+    account.groupAllowFrom ??
+    (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined) ??
+    [];
+  const defaultGroupPolicy = resolveDefaultGroupPolicy(params.cfg);
+  const { groupPolicy, providerMissingFallbackApplied } = resolveWhatsAppRuntimeGroupPolicy({
+    providerConfigPresent: params.cfg.channels?.whatsapp !== undefined,
+    groupPolicy: account.groupPolicy,
+    defaultGroupPolicy,
+  });
+  const resolvedGroupCfg = buildResolvedWhatsAppGroupConfig({
+    groupPolicy,
+    groups: account.groups,
+  });
+  const isSamePhone = (value?: string | null) =>
+    typeof value === "string" && typeof params.selfE164 === "string" && value === params.selfE164;
+  return {
+    account,
+    dmPolicy,
+    groupPolicy,
+    configuredAllowFrom,
+    dmAllowFrom,
+    groupAllowFrom,
+    isSelfChat: account.selfChatMode ?? isSelfChatMode(params.selfE164, configuredAllowFrom),
+    providerMissingFallbackApplied,
+    shouldReadStorePairingApprovals: dmPolicy !== "allowlist",
+    isSamePhone,
+    isDmSenderAllowed: (allowEntries, sender) =>
+      isSamePhone(sender) || isNormalizedSenderAllowed(allowEntries, sender),
+    isGroupSenderAllowed: (allowEntries, sender) => isNormalizedSenderAllowed(allowEntries, sender),
+    resolveConversationGroupPolicy: (conversationId) =>
+      resolveChannelGroupPolicy({
+        cfg: resolvedGroupCfg,
+        channel: "whatsapp",
+        groupId: resolveGroupConversationId(conversationId),
+        hasGroupAllowFrom: groupAllowFrom.length > 0,
+      }),
+    resolveConversationRequireMention: (conversationId) =>
+      resolveChannelGroupRequireMention({
+        cfg: resolvedGroupCfg,
+        channel: "whatsapp",
+        groupId: resolveGroupConversationId(conversationId),
+      }),
+  };
+}
+
+export async function resolveWhatsAppCommandAuthorized(params: {
+  cfg: OpenClawConfig;
+  msg: WebInboundMessage;
+  policy?: ResolvedWhatsAppInboundPolicy;
+}): Promise<boolean> {
+  const useAccessGroups = params.cfg.commands?.useAccessGroups !== false;
+  if (!useAccessGroups) {
+    return true;
+  }
+
+  const self = getSelfIdentity(params.msg);
+  const policy =
+    params.policy ??
+    resolveWhatsAppInboundPolicy({
+      cfg: params.cfg,
+      accountId: params.msg.accountId,
+      selfE164: self.e164 ?? null,
+    });
+  const isGroup = params.msg.chatType === "group";
+  const sender = getSenderIdentity(params.msg);
+  const dmSender = sender.e164 ?? params.msg.from ?? "";
+  const groupSender = sender.e164 ?? "";
+  const normalizedSender = normalizeE164(isGroup ? groupSender : dmSender);
+  if (!normalizedSender) {
+    return false;
+  }
+
+  const storeAllowFrom =
+    isGroup || !policy.shouldReadStorePairingApprovals
+      ? []
+      : await readStoreAllowFromForDmPolicy({
+          provider: "whatsapp",
+          accountId: policy.account.accountId,
+          dmPolicy: policy.dmPolicy,
+          shouldRead: policy.shouldReadStorePairingApprovals,
+        });
+  const access = resolveDmGroupAccessWithCommandGate({
+    isGroup,
+    dmPolicy: policy.dmPolicy,
+    groupPolicy: policy.groupPolicy,
+    allowFrom: policy.dmAllowFrom,
+    groupAllowFrom: policy.groupAllowFrom,
+    storeAllowFrom,
+    isSenderAllowed: (allowEntries) =>
+      isGroup
+        ? policy.isGroupSenderAllowed(allowEntries, groupSender)
+        : policy.isDmSenderAllowed(allowEntries, dmSender),
+    command: {
+      useAccessGroups,
+      allowTextCommands: true,
+      hasControlCommand: true,
+    },
+  });
+  return access.commandAuthorized;
+}

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -9,9 +9,11 @@ import {
 
 setupAccessControlTestHarness();
 let checkInboundAccessControl: typeof import("./access-control.js").checkInboundAccessControl;
+let resolveWhatsAppCommandAuthorized: typeof import("../inbound-policy.js").resolveWhatsAppCommandAuthorized;
 
 beforeAll(async () => {
   ({ checkInboundAccessControl } = await import("./access-control.js"));
+  ({ resolveWhatsAppCommandAuthorized } = await import("../inbound-policy.js"));
 });
 
 async function checkUnauthorizedWorkDmSender() {
@@ -32,6 +34,27 @@ function expectSilentlyBlocked(result: { allowed: boolean }) {
   expect(result.allowed).toBe(false);
   expect(upsertPairingRequestMock).not.toHaveBeenCalled();
   expect(sendMessageMock).not.toHaveBeenCalled();
+}
+
+async function checkCommandAuthorizedForDm(params: {
+  cfg: Record<string, unknown>;
+  accountId?: string;
+  from?: string;
+  senderE164?: string;
+  selfE164?: string;
+}) {
+  return await resolveWhatsAppCommandAuthorized({
+    cfg: params.cfg as never,
+    msg: {
+      accountId: params.accountId ?? "work",
+      chatType: "direct",
+      from: params.from ?? "+15550001111",
+      senderE164: params.senderE164 ?? params.from ?? "+15550001111",
+      selfE164: params.selfE164 ?? "+15550009999",
+      body: "/status",
+      to: params.selfE164 ?? "+15550009999",
+    } as never,
+  });
 }
 
 describe("checkInboundAccessControl pairing grace", () => {
@@ -75,7 +98,7 @@ describe("WhatsApp dmPolicy precedence", () => {
     // Channel-level says "pairing" but the account-level says "allowlist".
     // The account-level override should take precedence, so an unauthorized
     // sender should be blocked silently (no pairing reply).
-    setAccessControlTestConfig({
+    const cfg = {
       channels: {
         whatsapp: {
           dmPolicy: "pairing",
@@ -87,16 +110,19 @@ describe("WhatsApp dmPolicy precedence", () => {
           },
         },
       },
-    });
+    };
+    setAccessControlTestConfig(cfg);
 
     const result = await checkUnauthorizedWorkDmSender();
+    const commandAuthorized = await checkCommandAuthorizedForDm({ cfg });
     expectSilentlyBlocked(result);
+    expect(commandAuthorized).toBe(false);
   });
 
   it("inherits channel-level dmPolicy when account-level dmPolicy is unset", async () => {
     // Account has allowFrom set, but no dmPolicy override. Should inherit the channel default.
     // With dmPolicy=allowlist, unauthorized senders are silently blocked.
-    setAccessControlTestConfig({
+    const cfg = {
       channels: {
         whatsapp: {
           dmPolicy: "allowlist",
@@ -107,14 +133,17 @@ describe("WhatsApp dmPolicy precedence", () => {
           },
         },
       },
-    });
+    };
+    setAccessControlTestConfig(cfg);
 
     const result = await checkUnauthorizedWorkDmSender();
+    const commandAuthorized = await checkCommandAuthorizedForDm({ cfg });
     expectSilentlyBlocked(result);
+    expect(commandAuthorized).toBe(false);
   });
 
   it("does not merge persisted pairing approvals in allowlist mode", async () => {
-    setAccessControlTestConfig({
+    const cfg = {
       channels: {
         whatsapp: {
           dmPolicy: "allowlist",
@@ -125,24 +154,91 @@ describe("WhatsApp dmPolicy precedence", () => {
           },
         },
       },
-    });
+    };
+    setAccessControlTestConfig(cfg);
     readAllowFromStoreMock.mockResolvedValue(["+15550001111"]);
 
     const result = await checkUnauthorizedWorkDmSender();
+    const commandAuthorized = await checkCommandAuthorizedForDm({ cfg });
 
     expectSilentlyBlocked(result);
+    expect(commandAuthorized).toBe(false);
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
   });
 
   it("always allows same-phone DMs even when allowFrom is restrictive", async () => {
-    setAccessControlTestConfig({
+    const cfg = {
       channels: {
         whatsapp: {
           dmPolicy: "pairing",
           allowFrom: ["+15550001111"],
         },
       },
+    };
+    setAccessControlTestConfig(cfg);
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Owner",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550009999@s.whatsapp.net",
     });
+    const commandAuthorized = await checkCommandAuthorizedForDm({
+      cfg,
+      accountId: "default",
+      from: "+15550009999",
+      senderE164: "+15550009999",
+      selfE164: "+15550009999",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(commandAuthorized).toBe(true);
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("does not broaden self-chat mode to every paired DM when allowFrom is empty", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+        },
+      },
+    };
+    setAccessControlTestConfig(cfg);
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      pushName: "Sam",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.isSelfChat).toBe(false);
+  });
+
+  it("treats same-phone DMs as self-chat only when explicitly configured", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          dmPolicy: "pairing",
+          allowFrom: ["+15550009999"],
+        },
+      },
+    };
+    setAccessControlTestConfig(cfg);
 
     const result = await checkInboundAccessControl({
       accountId: "default",
@@ -157,7 +253,6 @@ describe("WhatsApp dmPolicy precedence", () => {
     });
 
     expect(result.allowed).toBe(true);
-    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
-    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(result.isSelfChat).toBe(true);
   });
 });

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -1,18 +1,13 @@
 import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel-pairing";
 import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import {
-  resolveDefaultGroupPolicy,
-  warnMissingProviderGroupPolicyFallbackOnce,
-} from "openclaw/plugin-sdk/config-runtime";
+import { warnMissingProviderGroupPolicyFallbackOnce } from "openclaw/plugin-sdk/config-runtime";
 import { upsertChannelPairingRequest } from "openclaw/plugin-sdk/conversation-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
   readStoreAllowFromForDmPolicy,
   resolveDmGroupAccessWithLists,
 } from "openclaw/plugin-sdk/security-runtime";
-import { resolveWhatsAppAccount } from "../accounts.js";
-import { resolveWhatsAppRuntimeGroupPolicy } from "../runtime-group-policy.js";
-import { isSelfChatMode, normalizeE164 } from "../text-runtime.js";
+import { resolveWhatsAppInboundPolicy } from "../inbound-policy.js";
 
 export type InboundAccessControlResult = {
   allowed: boolean;
@@ -40,25 +35,17 @@ export async function checkInboundAccessControl(params: {
   remoteJid: string;
 }): Promise<InboundAccessControlResult> {
   const cfg = loadConfig();
-  const account = resolveWhatsAppAccount({
+  const policy = resolveWhatsAppInboundPolicy({
     cfg,
     accountId: params.accountId,
+    selfE164: params.selfE164,
   });
-  const dmPolicy = account.dmPolicy ?? "pairing";
-  const configuredAllowFrom = account.allowFrom ?? [];
   const storeAllowFrom = await readStoreAllowFromForDmPolicy({
     provider: "whatsapp",
-    accountId: account.accountId,
-    dmPolicy,
+    accountId: policy.account.accountId,
+    dmPolicy: policy.dmPolicy,
+    shouldRead: policy.shouldReadStorePairingApprovals,
   });
-  // Without user config, default to self-only DM access so the owner can talk to themselves.
-  const defaultAllowFrom =
-    configuredAllowFrom.length === 0 && params.selfE164 ? [params.selfE164] : [];
-  const dmAllowFrom = configuredAllowFrom.length > 0 ? configuredAllowFrom : defaultAllowFrom;
-  const groupAllowFrom =
-    account.groupAllowFrom ?? (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
-  const isSamePhone = params.from === params.selfE164;
-  const isSelfChat = account.selfChatMode ?? isSelfChatMode(params.selfE164, configuredAllowFrom);
   const pairingGraceMs =
     typeof params.pairingGraceMs === "number" && params.pairingGraceMs > 0
       ? params.pairingGraceMs
@@ -72,45 +59,23 @@ export async function checkInboundAccessControl(params: {
   // - "open": groups bypass allowFrom, only mention-gating applies
   // - "disabled": block all group messages entirely
   // - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
-  const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
-  const { groupPolicy, providerMissingFallbackApplied } = resolveWhatsAppRuntimeGroupPolicy({
-    providerConfigPresent: cfg.channels?.whatsapp !== undefined,
-    groupPolicy: account.groupPolicy,
-    defaultGroupPolicy,
-  });
   warnMissingProviderGroupPolicyFallbackOnce({
-    providerMissingFallbackApplied,
+    providerMissingFallbackApplied: policy.providerMissingFallbackApplied,
     providerKey: "whatsapp",
-    accountId: account.accountId,
+    accountId: policy.account.accountId,
     log: (message) => logVerbose(message),
   });
-  const normalizedDmSender = normalizeE164(params.from);
-  const normalizedGroupSender =
-    typeof params.senderE164 === "string" ? normalizeE164(params.senderE164) : null;
   const access = resolveDmGroupAccessWithLists({
     isGroup: params.group,
-    dmPolicy,
-    groupPolicy,
-    // Groups intentionally fall back to configured allowFrom only (not DM self-chat fallback).
-    allowFrom: params.group ? configuredAllowFrom : dmAllowFrom,
-    groupAllowFrom,
+    dmPolicy: policy.dmPolicy,
+    groupPolicy: policy.groupPolicy,
+    allowFrom: params.group ? policy.configuredAllowFrom : policy.dmAllowFrom,
+    groupAllowFrom: policy.groupAllowFrom,
     storeAllowFrom,
     isSenderAllowed: (allowEntries) => {
-      const hasWildcard = allowEntries.includes("*");
-      if (hasWildcard) {
-        return true;
-      }
-      const normalizedEntrySet = new Set(
-        allowEntries
-          .map((entry) => normalizeE164(entry))
-          .filter((entry): entry is string => Boolean(entry)),
-      );
-      if (!params.group && isSamePhone) {
-        return true;
-      }
       return params.group
-        ? Boolean(normalizedGroupSender && normalizedEntrySet.has(normalizedGroupSender))
-        : normalizedEntrySet.has(normalizedDmSender);
+        ? policy.isGroupSenderAllowed(allowEntries, params.senderE164)
+        : policy.isDmSenderAllowed(allowEntries, params.from);
     },
   });
   if (params.group && access.decision !== "allow") {
@@ -126,20 +91,20 @@ export async function checkInboundAccessControl(params: {
     return {
       allowed: false,
       shouldMarkRead: false,
-      isSelfChat,
-      resolvedAccountId: account.accountId,
+      isSelfChat: policy.isSelfChat,
+      resolvedAccountId: policy.account.accountId,
     };
   }
 
   // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled".
   if (!params.group) {
-    if (params.isFromMe && !isSamePhone) {
+    if (params.isFromMe && !policy.isSamePhone(params.from)) {
       logVerbose("Skipping outbound DM (fromMe); no pairing reply needed.");
       return {
         allowed: false,
         shouldMarkRead: false,
-        isSelfChat,
-        resolvedAccountId: account.accountId,
+        isSelfChat: policy.isSelfChat,
+        resolvedAccountId: policy.account.accountId,
       };
     }
     if (access.decision === "block" && access.reason === "dmPolicy=disabled") {
@@ -147,11 +112,11 @@ export async function checkInboundAccessControl(params: {
       return {
         allowed: false,
         shouldMarkRead: false,
-        isSelfChat,
-        resolvedAccountId: account.accountId,
+        isSelfChat: policy.isSelfChat,
+        resolvedAccountId: policy.account.accountId,
       };
     }
-    if (access.decision === "pairing" && !isSamePhone) {
+    if (access.decision === "pairing" && !policy.isSamePhone(params.from)) {
       const candidate = params.from;
       if (suppressPairingReply) {
         logVerbose(`Skipping pairing reply for historical DM from ${candidate}.`);
@@ -162,7 +127,7 @@ export async function checkInboundAccessControl(params: {
             await upsertChannelPairingRequest({
               channel: "whatsapp",
               id,
-              accountId: account.accountId,
+              accountId: policy.account.accountId,
               meta,
             }),
         })({
@@ -185,17 +150,17 @@ export async function checkInboundAccessControl(params: {
       return {
         allowed: false,
         shouldMarkRead: false,
-        isSelfChat,
-        resolvedAccountId: account.accountId,
+        isSelfChat: policy.isSelfChat,
+        resolvedAccountId: policy.account.accountId,
       };
     }
     if (access.decision !== "allow") {
-      logVerbose(`Blocked unauthorized sender ${params.from} (dmPolicy=${dmPolicy})`);
+      logVerbose(`Blocked unauthorized sender ${params.from} (dmPolicy=${policy.dmPolicy})`);
       return {
         allowed: false,
         shouldMarkRead: false,
-        isSelfChat,
-        resolvedAccountId: account.accountId,
+        isSelfChat: policy.isSelfChat,
+        resolvedAccountId: policy.account.accountId,
       };
     }
   }
@@ -203,11 +168,11 @@ export async function checkInboundAccessControl(params: {
   return {
     allowed: true,
     shouldMarkRead: true,
-    isSelfChat,
-    resolvedAccountId: account.accountId,
+    isSelfChat: policy.isSelfChat,
+    resolvedAccountId: policy.account.accountId,
   };
 }
 
 export const __testing = {
-  resolveWhatsAppRuntimeGroupPolicy,
+  resolveWhatsAppInboundPolicy,
 };

--- a/extensions/whatsapp/src/pairing-security.test-harness.ts
+++ b/extensions/whatsapp/src/pairing-security.test-harness.ts
@@ -1,8 +1,3 @@
-import {
-  resolveDefaultGroupPolicy,
-  resolveOpenProviderRuntimeGroupPolicy,
-  warnMissingProviderGroupPolicyFallbackOnce,
-} from "openclaw/plugin-sdk/runtime-group-policy";
 import { vi, type Mock } from "vitest";
 
 export type AsyncMock<TArgs extends unknown[] = unknown[], TResult = unknown> = {
@@ -23,12 +18,13 @@ export function resetPairingSecurityMocks(config: Record<string, unknown>) {
   upsertPairingRequestMock.mockReset().mockResolvedValue({ code: "PAIRCODE", created: true });
 }
 
-vi.mock("openclaw/plugin-sdk/config-runtime", () => {
+vi.mock("openclaw/plugin-sdk/config-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/config-runtime")>(
+    "openclaw/plugin-sdk/config-runtime",
+  );
   return {
+    ...actual,
     loadConfig: (...args: unknown[]) => loadConfigMock(...args),
-    resolveDefaultGroupPolicy,
-    resolveOpenProviderRuntimeGroupPolicy,
-    warnMissingProviderGroupPolicyFallbackOnce,
   };
 });
 

--- a/extensions/whatsapp/src/session-conversation.test.ts
+++ b/extensions/whatsapp/src/session-conversation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveWhatsAppSessionConversation } from "./session-conversation.js";
+
+describe("resolveWhatsAppSessionConversation", () => {
+  it("treats scoped group account suffixes as group-local routing state, not threads", () => {
+    expect(
+      resolveWhatsAppSessionConversation({
+        kind: "group",
+        rawId: "120363407398133622@g.us:thread:whatsapp-account-work",
+      }),
+    ).toEqual({
+      id: "120363407398133622@g.us",
+      baseConversationId: "120363407398133622@g.us",
+      parentConversationCandidates: ["120363407398133622@g.us"],
+    });
+  });
+
+  it("ignores non-group or unrelated session ids", () => {
+    expect(
+      resolveWhatsAppSessionConversation({
+        kind: "channel",
+        rawId: "120363407398133622@g.us:thread:whatsapp-account-work",
+      }),
+    ).toBeNull();
+    expect(
+      resolveWhatsAppSessionConversation({
+        kind: "group",
+        rawId: "120363407398133622@g.us:thread:77",
+      }),
+    ).toBeNull();
+  });
+});

--- a/extensions/whatsapp/src/session-conversation.ts
+++ b/extensions/whatsapp/src/session-conversation.ts
@@ -1,0 +1,36 @@
+import { isWhatsAppGroupJid } from "./normalize.js";
+
+const WHATSAPP_ACCOUNT_SCOPE_THREAD_MARKER = ":thread:whatsapp-account-";
+
+export function resolveWhatsAppSessionConversation(params: {
+  kind: "group" | "channel";
+  rawId: string;
+}) {
+  if (params.kind !== "group") {
+    return null;
+  }
+
+  const rawId = params.rawId.trim();
+  if (!rawId) {
+    return null;
+  }
+
+  const markerIndex = rawId.lastIndexOf(WHATSAPP_ACCOUNT_SCOPE_THREAD_MARKER);
+  if (markerIndex <= 0) {
+    return null;
+  }
+
+  const groupId = rawId.slice(0, markerIndex).trim();
+  const accountScopeId = rawId
+    .slice(markerIndex + WHATSAPP_ACCOUNT_SCOPE_THREAD_MARKER.length)
+    .trim();
+  if (!groupId || !accountScopeId || !isWhatsAppGroupJid(groupId)) {
+    return null;
+  }
+
+  return {
+    id: groupId,
+    baseConversationId: groupId,
+    parentConversationCandidates: [groupId],
+  };
+}

--- a/src/config/sessions/reset.test.ts
+++ b/src/config/sessions/reset.test.ts
@@ -20,4 +20,11 @@ describe("session reset thread detection", () => {
     expect(isThreadSessionKey(sessionKey)).toBe(true);
     expect(resolveSessionResetType({ sessionKey })).toBe("thread");
   });
+
+  it("keeps WhatsApp account-scoped group sessions on the group reset type", () => {
+    const sessionKey =
+      "agent:main:whatsapp:group:120363407398133622@g.us:thread:whatsapp-account-work";
+    expect(isThreadSessionKey(sessionKey)).toBe(false);
+    expect(resolveSessionResetType({ sessionKey })).toBe("group");
+  });
 });

--- a/src/test-utils/session-conversation-registry.ts
+++ b/src/test-utils/session-conversation-registry.ts
@@ -49,6 +49,21 @@ function resolveFeishuSessionConversation(params: { kind: "group" | "channel"; r
   };
 }
 
+function resolveWhatsAppSessionConversation(params: { kind: "group" | "channel"; rawId: string }) {
+  if (params.kind !== "group") {
+    return null;
+  }
+  const match = params.rawId.match(/^(?<groupId>.+):thread:whatsapp-account-(?<accountId>[^:]+)$/u);
+  if (!match?.groups?.groupId || !match.groups.accountId) {
+    return null;
+  }
+  return {
+    id: match.groups.groupId,
+    baseConversationId: match.groups.groupId,
+    parentConversationCandidates: [match.groups.groupId],
+  };
+}
+
 export function createSessionConversationTestRegistry() {
   return createTestRegistry([
     {
@@ -113,6 +128,29 @@ export function createSessionConversationTestRegistry() {
         messaging: {
           resolveSessionConversation: resolveGenericSessionConversation,
           resolveSessionTarget: ({ id }: { id: string }) => `channel:${id}`,
+        },
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({}),
+        },
+      },
+    },
+    {
+      pluginId: "whatsapp",
+      source: "test",
+      plugin: {
+        id: "whatsapp",
+        meta: {
+          id: "whatsapp",
+          label: "WhatsApp",
+          selectionLabel: "WhatsApp",
+          docsPath: "/channels/whatsapp",
+          blurb: "WhatsApp test stub.",
+        },
+        capabilities: { chatTypes: ["direct", "group"] },
+        messaging: {
+          normalizeTarget: (raw: string) => raw.replace(/^group:/, ""),
+          resolveSessionConversation: resolveWhatsAppSessionConversation,
         },
         config: {
           listAccountIds: () => ["default"],


### PR DESCRIPTION
## Summary

- Problem: WhatsApp inbound policy and group-session routing for named accounts were spread across multiple monitor paths, making later multi-account fixes hard to apply consistently.
- Why it matters: named accounts need an account-scoped group session route before activation, backfill, and default-account semantics can be fixed safely.
- What changed: centralized WhatsApp inbound policy resolution and introduced account-scoped group session keys for named-account group traffic.
- What did NOT change (scope boundary): this PR does not yet change legacy activation backfill, `accounts.default` inheritance, or schema/runtime compat behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: WhatsApp inbound policy and group-route decisions were duplicated across the monitor path, and named-account group traffic still reused shared group-session routing semantics.
- Missing detection / guardrail: there was no focused test coverage locking in account-scoped group session routing for named WhatsApp accounts.
- Contributing context (if known): later multi-account fixes needed a single policy seam and stable scoped keys first.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/group-session-key.test.ts`, `extensions/whatsapp/src/inbound/access-control.test.ts`, `extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts`
- Scenario the test should lock in: named-account WhatsApp group routing uses account-scoped session keys and the centralized inbound policy path stays consistent.
- Why this is the smallest reliable guardrail: these tests cover the new routing/policy seam directly without needing the later activation or compat layers.
- Existing test that already covers this (if any): `extensions/whatsapp/src/inbound/access-control.test.ts`
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Named WhatsApp accounts now route group session state through account-scoped keys instead of sharing the unsuffixed group route.
- WhatsApp inbound policy decisions now resolve through a single runtime path.

## Diagram (if applicable)

```text
Before:
[group inbound on work] -> shared group route -> policy/routing decisions split across monitor helpers

After:
[group inbound on work] -> scoped work group route -> centralized inbound policy -> consistent downstream handling
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): multi-account WhatsApp config with a named `work` account

### Steps

1. Route a WhatsApp group inbound message through a named account.
2. Resolve the group session key and inbound policy.
3. Verify the named account uses a scoped `:thread:whatsapp-account-<id>` session key.

### Expected

- Named-account group traffic resolves through an account-scoped session route with consistent inbound policy decisions.

### Actual

- Before this change, named-account group traffic still depended on shared route behavior and split policy helpers.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test extensions/whatsapp/src/group-session-key.test.ts extensions/whatsapp/src/inbound/access-control.test.ts extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts --reporter=dot`
- Edge cases checked: named-account group session suffixing and centralized inbound policy coverage.
- What you did **not** verify: live WhatsApp scenarios; those come in later stacked PRs.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: downstream slices still need to wire activation backfill and shared default-account behavior on top of the new scoped route.
  - Mitigation: those changes are split into the next stacked PRs instead of being mixed into this one.
