### PR TITLE
fix(whatsapp): preserve scoped group activation backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - macOS/gateway: add `screen.snapshot` support for macOS app nodes, including runtime plumbing, default macOS allowlisting, and docs for monitor preview flows. (#67954) Thanks @BunsDev.
+- WhatsApp/inbound: centralize inbound policy resolution and route named-account group sessions through account-scoped keys. Thanks @mcaxtr.
 
 ### Fixes
 
-- WhatsApp/inbound: centralize inbound policy resolution and route named-account group sessions through account-scoped keys. Thanks @mcaxtr.
 - Agents/bootstrap: resolve bootstrap from workspace truth instead of stale session transcript markers, keep embedded bootstrap instructions on a hidden user-context prelude, suppress normal `/new` and `/reset` greetings while `BOOTSTRAP.md` is still pending, and make the embedded runner read the bootstrap ritual before replying normally.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
 - Gateway/hello-ok: always report negotiated auth metadata for successful shared-auth handshakes, including control-ui bypass coverage when no device token is issued. (#67810) Thanks @BunsDev.
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/assistant media: require `operator.read` scope for assistant-media file and metadata requests on identity-bearing HTTP auth paths so callers without a read scope can no longer access assistant media. (#68175) Thanks @eleqtrizit.
 - Exec approvals/display: escape raw control characters (including newline and carriage return) in the shared and macOS approval-prompt command sanitizers, so trailing command payloads no longer render on hidden extra lines in the approval UI. (#68198)
 - OpenAI Codex/OAuth + Pi: keep imported Codex CLI OAuth bootstrap, Pi auth export, and runtime overlay handling aligned so Codex sessions survive refresh and health checks without leaking transient CLI state into saved auth files. Thanks @vincentkoc.
+- WhatsApp/groups: preserve per-account group activation state across scoped-session routing and legacy activation backfill. Thanks @mcaxtr.
 
 ## 2026.4.15
 

--- a/extensions/whatsapp/src/auto-reply/monitor/group-activation.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-activation.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeSessionStore } from "../../auto-reply.test-harness.js";
+import { loadSessionStore } from "../config.runtime.js";
+import { resolveGroupActivationFor } from "./group-activation.js";
+
+describe("resolveGroupActivationFor", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  it("reads legacy named-account group activation and backfills the scoped key", async () => {
+    const sessionKey = "agent:main:whatsapp:group:123@g.us:thread:whatsapp-account-work";
+    const legacySessionKey = "agent:main:whatsapp:group:123@g.us";
+    const { storePath, cleanup } = await makeSessionStore({
+      [legacySessionKey]: {
+        groupActivation: "always",
+        sessionId: "legacy-session",
+        updatedAt: 123,
+      },
+    });
+    cleanups.push(cleanup);
+
+    const activation = await resolveGroupActivationFor({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              work: {},
+            },
+          },
+        },
+        session: { store: storePath },
+      } as never,
+      accountId: "work",
+      agentId: "main",
+      sessionKey,
+      conversationId: "123@g.us",
+    });
+
+    expect(activation).toBe("always");
+    await vi.waitFor(() => {
+      const scopedEntry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(scopedEntry?.groupActivation).toBe("always");
+      expect(scopedEntry?.sessionId).toBeUndefined();
+      expect(scopedEntry?.updatedAt).toBeUndefined();
+    });
+  });
+
+  it("preserves legacy group activation when the scoped entry already exists without activation", async () => {
+    const sessionKey = "agent:main:whatsapp:group:123@g.us:thread:whatsapp-account-work";
+    const legacySessionKey = "agent:main:whatsapp:group:123@g.us";
+    const { storePath, cleanup } = await makeSessionStore({
+      [legacySessionKey]: {
+        groupActivation: "always",
+      },
+      [sessionKey]: {
+        sessionId: "scoped-session",
+      },
+    });
+    cleanups.push(cleanup);
+
+    const activation = await resolveGroupActivationFor({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              work: {},
+            },
+          },
+        },
+        session: { store: storePath },
+      } as never,
+      accountId: "work",
+      agentId: "main",
+      sessionKey,
+      conversationId: "123@g.us",
+    });
+
+    expect(activation).toBe("always");
+    await vi.waitFor(() => {
+      const scopedEntry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+      expect(scopedEntry?.groupActivation).toBe("always");
+      expect(scopedEntry?.sessionId).toBe("scoped-session");
+    });
+  });
+
+  it("does not wake the default account from an activation-only legacy group entry in multi-account setups", async () => {
+    const defaultSessionKey = "agent:main:whatsapp:group:123@g.us";
+    const workSessionKey = "agent:main:whatsapp:group:123@g.us:thread:whatsapp-account-work";
+    const { storePath, cleanup } = await makeSessionStore({
+      [defaultSessionKey]: {
+        groupActivation: "always",
+      },
+    });
+    cleanups.push(cleanup);
+
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groups: {
+            "*": {
+              requireMention: true,
+            },
+          },
+          accounts: {
+            work: {},
+          },
+        },
+      },
+      session: { store: storePath },
+    } as never;
+
+    const workActivation = await resolveGroupActivationFor({
+      cfg,
+      accountId: "work",
+      agentId: "main",
+      sessionKey: workSessionKey,
+      conversationId: "123@g.us",
+    });
+
+    expect(workActivation).toBe("always");
+
+    const defaultActivation = await resolveGroupActivationFor({
+      cfg,
+      accountId: "default",
+      agentId: "main",
+      sessionKey: defaultSessionKey,
+      conversationId: "123@g.us",
+    });
+
+    expect(defaultActivation).toBe("mention");
+    await vi.waitFor(() => {
+      const scopedEntry = loadSessionStore(storePath, { skipCache: true })[workSessionKey];
+      expect(scopedEntry?.groupActivation).toBe("always");
+    });
+  });
+
+  it("does not treat mixed-case default account keys as named accounts", async () => {
+    const defaultSessionKey = "agent:main:whatsapp:group:123@g.us";
+    const { storePath, cleanup } = await makeSessionStore({
+      [defaultSessionKey]: {
+        groupActivation: "always",
+      },
+    });
+    cleanups.push(cleanup);
+
+    const activation = await resolveGroupActivationFor({
+      cfg: {
+        channels: {
+          whatsapp: {
+            groups: {
+              "*": {
+                requireMention: true,
+              },
+            },
+            accounts: {
+              Default: {},
+            },
+          },
+        },
+        session: { store: storePath },
+      } as never,
+      accountId: "default",
+      agentId: "main",
+      sessionKey: defaultSessionKey,
+      conversationId: "123@g.us",
+    });
+
+    expect(activation).toBe("always");
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
@@ -1,52 +1,36 @@
-import {
-  resolveChannelGroupPolicy,
-  resolveChannelGroupRequireMention,
-  loadSessionStore,
-  resolveGroupSessionKey,
-  resolveStorePath,
-} from "../config.runtime.js";
+import { updateSessionStore } from "openclaw/plugin-sdk/config-runtime";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { resolveWhatsAppLegacyGroupSessionKey } from "../../group-session-key.js";
+import { resolveWhatsAppInboundPolicy } from "../../inbound-policy.js";
+import { loadSessionStore, resolveStorePath } from "../config.runtime.js";
 import { normalizeGroupActivation } from "./group-activation.runtime.js";
 
 type LoadConfigFn = typeof import("../config.runtime.js").loadConfig;
 
-export function resolveGroupPolicyFor(cfg: ReturnType<LoadConfigFn>, conversationId: string) {
-  const groupId = resolveGroupSessionKey({
-    From: conversationId,
-    ChatType: "group",
-    Provider: "whatsapp",
-  })?.id;
-  const whatsappCfg = cfg.channels?.whatsapp as
-    | { groupAllowFrom?: string[]; allowFrom?: string[] }
-    | undefined;
-  const hasGroupAllowFrom = Boolean(
-    whatsappCfg?.groupAllowFrom?.length || whatsappCfg?.allowFrom?.length,
-  );
-  return resolveChannelGroupPolicy({
-    cfg,
-    channel: "whatsapp",
-    groupId: groupId ?? conversationId,
-    hasGroupAllowFrom,
-  });
+function hasNamedWhatsAppAccounts(cfg: ReturnType<LoadConfigFn>) {
+  const accountIds = Object.keys(cfg.channels?.whatsapp?.accounts ?? {});
+  return accountIds.some((accountId) => normalizeAccountId(accountId) !== DEFAULT_ACCOUNT_ID);
 }
 
-export function resolveGroupRequireMentionFor(
-  cfg: ReturnType<LoadConfigFn>,
-  conversationId: string,
+function isActivationOnlyEntry(
+  entry:
+    | {
+        groupActivation?: unknown;
+        sessionId?: unknown;
+        updatedAt?: unknown;
+      }
+    | undefined,
 ) {
-  const groupId = resolveGroupSessionKey({
-    From: conversationId,
-    ChatType: "group",
-    Provider: "whatsapp",
-  })?.id;
-  return resolveChannelGroupRequireMention({
-    cfg,
-    channel: "whatsapp",
-    groupId: groupId ?? conversationId,
-  });
+  return (
+    entry?.groupActivation !== undefined &&
+    typeof entry?.sessionId !== "string" &&
+    typeof entry?.updatedAt !== "number"
+  );
 }
 
-export function resolveGroupActivationFor(params: {
+export async function resolveGroupActivationFor(params: {
   cfg: ReturnType<LoadConfigFn>;
+  accountId?: string | null;
   agentId: string;
   sessionKey: string;
   conversationId: string;
@@ -55,8 +39,36 @@ export function resolveGroupActivationFor(params: {
     agentId: params.agentId,
   });
   const store = loadSessionStore(storePath);
-  const entry = store[params.sessionKey];
-  const requireMention = resolveGroupRequireMentionFor(params.cfg, params.conversationId);
+  const legacySessionKey = resolveWhatsAppLegacyGroupSessionKey({
+    sessionKey: params.sessionKey,
+    accountId: params.accountId,
+  });
+  const legacyEntry = legacySessionKey ? store[legacySessionKey] : undefined;
+  const scopedEntry = store[params.sessionKey];
+  const normalizedAccountId = normalizeAccountId(params.accountId);
+  const ignoreScopedActivation =
+    normalizedAccountId === DEFAULT_ACCOUNT_ID &&
+    hasNamedWhatsAppAccounts(params.cfg) &&
+    isActivationOnlyEntry(scopedEntry);
+  const activation =
+    (ignoreScopedActivation ? undefined : scopedEntry?.groupActivation) ??
+    legacyEntry?.groupActivation;
+  if (activation !== undefined && scopedEntry?.groupActivation === undefined) {
+    await updateSessionStore(storePath, (nextStore) => {
+      const nextScopedEntry = nextStore[params.sessionKey];
+      if (nextScopedEntry?.groupActivation !== undefined) {
+        return;
+      }
+      nextStore[params.sessionKey] = {
+        ...nextScopedEntry,
+        groupActivation: activation,
+      };
+    });
+  }
+  const requireMention = resolveWhatsAppInboundPolicy({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  }).resolveConversationRequireMention(params.conversationId);
   const defaultActivation = !requireMention ? "always" : "mention";
-  return normalizeGroupActivation(entry?.groupActivation) ?? defaultActivation;
+  return normalizeGroupActivation(activation) ?? defaultActivation;
 }

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1527,6 +1527,48 @@ describe("initSessionState reset triggers in WhatsApp groups", () => {
       }
     }
   });
+
+  it("starts a fresh session when a scoped WhatsApp group entry only contains activation state", async () => {
+    const sessionKey =
+      "agent:main:whatsapp:group:120363406150318674@g.us:thread:whatsapp-account-work";
+    const storePath = await createStorePath("openclaw-group-activation-backfill-");
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        groupActivation: "always",
+      },
+    });
+    const cfg = makeCfg({
+      storePath,
+      allowFrom: ["+41796666864"],
+    });
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello without mention",
+        RawBody: "hello without mention",
+        CommandBody: "hello without mention",
+        From: "120363406150318674@g.us",
+        To: "+41779241027",
+        ChatType: "group",
+        SessionKey: sessionKey,
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        SenderName: "Peschiño",
+        SenderE164: "+41796666864",
+        SenderId: "41796666864:0@s.whatsapp.net",
+      },
+      cfg,
+      commandAuthorized: false,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(result.sessionEntry.groupActivation).toBe("always");
+    expect(result.sessionEntry.sessionId).toBe(result.sessionId);
+    expect(typeof result.sessionEntry.updatedAt).toBe("number");
+  });
 });
 
 describe("initSessionState reset triggers in Slack channels", () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -451,7 +451,12 @@ export async function initSessionState(params: {
     previousSessionId: previousSessionEntry?.sessionId,
   });
 
-  if (!isNewSession && freshEntry) {
+  const canReuseExistingEntry =
+    Boolean(entry?.sessionId) &&
+    typeof entry?.updatedAt === "number" &&
+    Number.isFinite(entry.updatedAt);
+
+  if (!isNewSession && freshEntry && canReuseExistingEntry) {
     sessionId = entry.sessionId;
     systemSent = entry.systemSent ?? false;
     abortedLastRun = entry.abortedLastRun ?? false;
@@ -608,6 +613,8 @@ export async function initSessionState(params: {
     subject: baseEntry?.subject,
     groupChannel: baseEntry?.groupChannel,
     space: baseEntry?.space,
+    groupActivation: entry?.groupActivation,
+    groupActivationNeedsSystemIntro: entry?.groupActivationNeedsSystemIntro,
     deliveryContext: deliveryFields.deliveryContext,
     // Track originating channel for subagent announce routing.
     lastChannel,


### PR DESCRIPTION
## Summary

- Problem: after introducing account-scoped WhatsApp group session keys, legacy activation state still lived on the old unsuffixed key and activation-only entries could be misread or reused incorrectly.
- Why it matters: named-account group activation must survive the routing change without crashing or waking the wrong account.
- What changed: preserved legacy activation backfill into scoped keys, avoided reusing activation-only entries as full sessions, and kept default-account activation isolated from named-account backfill behavior.
- What did NOT change (scope boundary): this PR does not yet wire `accounts.default` shared config inheritance or schema/runtime monitor alignment.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #68359
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the new scoped WhatsApp group session key model did not yet reconcile legacy activation state stored on unsuffixed keys, and activation-only session records were treated as reusable full sessions.
- Missing detection / guardrail: there was no dedicated coverage for activation-only scoped entries or legacy backfill into named-account keys.
- Contributing context (if known): the account-scoped routing change exposed assumptions in generic session bootstrap and the WhatsApp group-activation path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auto-reply/monitor/group-activation.test.ts`, `src/auto-reply/reply/session.test.ts`
- Scenario the test should lock in: legacy WhatsApp activation state backfills into the scoped named-account key, activation-only scoped entries start a fresh session safely, and default-account activation does not leak in multi-account setups.
- Why this is the smallest reliable guardrail: the issue is entirely in the activation/session seam and does not require the later config inheritance layer.
- Existing test that already covers this (if any): none before this PR
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Legacy WhatsApp group activation now survives the move to scoped named-account session keys.
- Activation-only scoped entries no longer crash session bootstrap or wake the wrong account.

## Diagram (if applicable)

```text
Before:
legacy unsuffixed activation -> scoped named account lookup -> missing/partial session reuse -> crash or wrong-account activation

After:
legacy unsuffixed activation -> scoped named account backfill -> fresh session bootstrap if needed -> correct account activation
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): multi-account WhatsApp config with group activation state in the session store

### Steps

1. Seed legacy WhatsApp group activation on an unsuffixed session key.
2. Resolve activation for a named-account scoped group session.
3. Bootstrap a session from an activation-only scoped entry.

### Expected

- Legacy activation backfills into the scoped key and activation-only entries start a fresh session without cross-account leakage.

### Actual

- Before this change, activation-only entries could be reused as full sessions or the default account could wake from named-account backfill state.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test extensions/whatsapp/src/auto-reply/monitor/group-activation.test.ts src/auto-reply/reply/session.test.ts --reporter=dot`
- Edge cases checked: activation-only scoped entries, legacy backfill into scoped keys, mixed-case default-account detection.
- What you did **not** verify: live WhatsApp traffic; this PR keeps verification at the session/activation seam.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: later stacked changes still need to align runtime config inheritance with the now-correct activation behavior.
  - Mitigation: that contract work is isolated to the next PR in the stack.
