### PR TITLE
fix(whatsapp): wire shared defaults through accounts.default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - macOS/gateway: add `screen.snapshot` support for macOS app nodes, including runtime plumbing, default macOS allowlisting, and docs for monitor preview flows. (#67954) Thanks @BunsDev.
 - WhatsApp/inbound: centralize inbound policy resolution and route named-account group sessions through account-scoped keys. Thanks @mcaxtr.
+- WhatsApp/accounts: honor `accounts.default` shared defaults across runtime account resolution, setup writes, and security path guidance. Thanks @mcaxtr.
 
 ### Fixes
 

--- a/extensions/whatsapp/src/account-config.ts
+++ b/extensions/whatsapp/src/account-config.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_ACCOUNT_ID,
+  mergeAccountConfig,
   resolveAccountEntry,
   resolveMergedAccountConfig,
   type OpenClawConfig,
@@ -10,25 +11,58 @@ import {
 } from "openclaw/plugin-sdk/channel-streaming";
 import type { WhatsAppAccountConfig } from "./account-types.js";
 
-function _resolveWhatsAppAccountConfig(
-  cfg: OpenClawConfig,
-  accountId: string,
-): WhatsAppAccountConfig | undefined {
+function resolveWhatsAppDefaultAccountSharedConfig(cfg: OpenClawConfig) {
+  const defaultAccount = resolveAccountEntry(cfg.channels?.whatsapp?.accounts, DEFAULT_ACCOUNT_ID);
+  if (!defaultAccount) {
+    return undefined;
+  }
+  const {
+    enabled: _ignoredEnabled,
+    name: _ignoredName,
+    authDir: _ignoredAuthDir,
+    selfChatMode: _ignoredSelfChatMode,
+    ...sharedDefaults
+  } = defaultAccount;
+  return sharedDefaults;
+}
+
+function _resolveWhatsAppAccountConfig(cfg: OpenClawConfig, accountId: string) {
   return resolveAccountEntry(cfg.channels?.whatsapp?.accounts, accountId);
+}
+
+function resolveMergedNamedWhatsAppAccountConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+}): WhatsAppAccountConfig {
+  const rootCfg = params.cfg.channels?.whatsapp;
+  const accountConfig = _resolveWhatsAppAccountConfig(params.cfg, params.accountId);
+  return {
+    ...mergeAccountConfig<WhatsAppAccountConfig>({
+      channelConfig: rootCfg,
+      accountConfig: undefined,
+      omitKeys: ["defaultAccount"],
+    }),
+    ...resolveWhatsAppDefaultAccountSharedConfig(params.cfg),
+    ...accountConfig,
+  };
 }
 
 export function resolveMergedWhatsAppAccountConfig(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
-}): WhatsAppAccountConfig & { accountId: string } {
+}) {
   const rootCfg = params.cfg.channels?.whatsapp;
   const accountId = params.accountId?.trim() || rootCfg?.defaultAccount || DEFAULT_ACCOUNT_ID;
-  const merged = resolveMergedAccountConfig<WhatsAppAccountConfig>({
-    channelConfig: rootCfg as WhatsAppAccountConfig | undefined,
-    accounts: rootCfg?.accounts as Record<string, Partial<WhatsAppAccountConfig>> | undefined,
+  const base = resolveMergedAccountConfig<WhatsAppAccountConfig>({
+    channelConfig: rootCfg,
+    accounts: rootCfg?.accounts,
     accountId,
     omitKeys: ["defaultAccount"],
   });
+  const merged =
+    accountId === DEFAULT_ACCOUNT_ID
+      ? base
+      : resolveMergedNamedWhatsAppAccountConfig({ cfg: params.cfg, accountId });
   return {
     accountId,
     ...merged,

--- a/extensions/whatsapp/src/accounts.test.ts
+++ b/extensions/whatsapp/src/accounts.test.ts
@@ -71,4 +71,112 @@ describe("resolveWhatsAppAuthDir", () => {
     expect(resolved.messagePrefix).toBe("[root]");
     expect(resolved.debounceMs).toBe(250);
   });
+
+  it("inherits shared defaults from accounts.default for named accounts", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: {
+                dmPolicy: "allowlist",
+                allowFrom: ["+15550001111"],
+                groupPolicy: "open",
+                groupAllowFrom: ["+15550002222"],
+                defaultTo: "+15550003333",
+                reactionLevel: "extensive",
+                historyLimit: 42,
+                mediaMaxMb: 12,
+              },
+              work: {
+                authDir: "/tmp/work",
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolved.dmPolicy).toBe("allowlist");
+    expect(resolved.allowFrom).toEqual(["+15550001111"]);
+    expect(resolved.groupPolicy).toBe("open");
+    expect(resolved.groupAllowFrom).toEqual(["+15550002222"]);
+    expect(resolved.defaultTo).toBe("+15550003333");
+    expect(resolved.reactionLevel).toBe("extensive");
+    expect(resolved.historyLimit).toBe(42);
+    expect(resolved.mediaMaxMb).toBe(12);
+  });
+
+  it("prefers account overrides and accounts.default over root defaults", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupPolicy: "disabled",
+            accounts: {
+              default: {
+                dmPolicy: "allowlist",
+                allowFrom: ["+15550001111"],
+                groupPolicy: "open",
+              },
+              work: {
+                authDir: "/tmp/work",
+                dmPolicy: "pairing",
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolved.dmPolicy).toBe("pairing");
+    expect(resolved.allowFrom).toEqual(["+15550001111"]);
+    expect(resolved.groupPolicy).toBe("open");
+  });
+
+  it("does not inherit default-account authDir for named accounts", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: {
+                authDir: "/tmp/default-auth",
+                name: "Personal",
+              },
+              work: {},
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolved.authDir).toMatch(/whatsapp[/\\]work$/);
+    expect(resolved.name).toBeUndefined();
+  });
+
+  it("does not inherit default-account selfChatMode for named accounts", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: {
+                selfChatMode: true,
+              },
+              work: {},
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolved.selfChatMode).toBeUndefined();
+  });
 });

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -28,6 +28,7 @@ export type ResolvedWhatsAppAccount = {
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
+  historyLimit?: number;
   textChunkLimit?: number;
   chunkMode?: "length" | "newline";
   mediaMaxMb?: number;
@@ -141,6 +142,7 @@ export function resolveWhatsAppAccount(params: {
     allowFrom: merged.allowFrom,
     groupAllowFrom: merged.groupAllowFrom,
     groupPolicy: merged.groupPolicy,
+    historyLimit: merged.historyLimit,
     textChunkLimit: merged.textChunkLimit,
     chunkMode: merged.chunkMode,
     mediaMaxMb: merged.mediaMaxMb,

--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "./runtime-api.js";
 import { finalizeWhatsAppSetup } from "./setup-finalize.js";
 import {
   createWhatsAppAllowlistModeInput,
+  expectWhatsAppDefaultAccountAccessNote,
   createWhatsAppLinkingHarness,
   createWhatsAppOwnerAllowlistHarness,
   createWhatsAppPersonalPhoneHarness,
@@ -217,6 +218,66 @@ describe("whatsapp setup wizard", () => {
     });
 
     expectWhatsAppOpenPolicySetup(result.cfg, harness);
+  });
+
+  it("surfaces accounts.default group warning paths for named accounts", () => {
+    const warnings = whatsappPlugin.security?.collectWarnings?.({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: {
+                groupPolicy: "open",
+              },
+              work: {
+                authDir: "/tmp/work",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "work",
+      account: {
+        accountId: "work",
+        enabled: true,
+        sendReadReceipts: true,
+        authDir: "/tmp/work",
+        isLegacyAuthDir: false,
+        groupPolicy: "open",
+      },
+    });
+
+    expect(warnings).toEqual([
+      '- WhatsApp groups: groupPolicy="open" with no channels.whatsapp.accounts.default.groups allowlist; any group can add + ping (mention-gated). Set channels.whatsapp.accounts.default.groupPolicy="allowlist" + channels.whatsapp.accounts.default.groupAllowFrom or configure channels.whatsapp.accounts.default.groups.',
+    ]);
+  });
+
+  it("writes default-account DM config into accounts.default for multi-account setups", async () => {
+    hoisted.pathExists.mockResolvedValue(true);
+    const harness = createSeparatePhoneHarness({
+      selectValues: ["separate", "open"],
+    });
+
+    const result = await runConfigureWithHarness({
+      harness,
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              work: {
+                authDir: "/tmp/work",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(result.cfg.channels?.whatsapp?.dmPolicy).toBeUndefined();
+    expect(result.cfg.channels?.whatsapp?.allowFrom).toBeUndefined();
+    expect(result.cfg.channels?.whatsapp?.accounts?.default?.dmPolicy).toBe("open");
+    expect(result.cfg.channels?.whatsapp?.accounts?.default?.allowFrom).toEqual(["*"]);
+    expectWhatsAppDefaultAccountAccessNote(harness);
   });
 
   it("runs WhatsApp login when not linked and user confirms linking", async () => {

--- a/extensions/whatsapp/src/setup-finalize.ts
+++ b/extensions/whatsapp/src/setup-finalize.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import {
   DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
   normalizeAllowFromEntries,
   normalizeE164,
   pathExists,
@@ -27,6 +28,31 @@ function trimPromptText(value: string | null | undefined): string {
   return value?.trim() ?? "";
 }
 
+function shouldWriteDefaultWhatsAppAccountConfigAtAccountScope(cfg: OpenClawConfig): boolean {
+  const accounts = cfg.channels?.whatsapp?.accounts;
+  if (!accounts) {
+    return false;
+  }
+  if (accounts.default) {
+    return true;
+  }
+  return Object.keys(accounts).some(
+    (accountId) => normalizeAccountId(accountId) !== DEFAULT_ACCOUNT_ID,
+  );
+}
+
+function resolveWhatsAppConfigPathPrefix(cfg: OpenClawConfig, accountId: string): string {
+  if (
+    accountId === DEFAULT_ACCOUNT_ID &&
+    shouldWriteDefaultWhatsAppAccountConfigAtAccountScope(cfg)
+  ) {
+    return "channels.whatsapp.accounts.default";
+  }
+  return accountId === DEFAULT_ACCOUNT_ID
+    ? "channels.whatsapp"
+    : `channels.whatsapp.accounts.${accountId}`;
+}
+
 function mergeWhatsAppConfig(
   cfg: OpenClawConfig,
   accountId: string,
@@ -35,7 +61,8 @@ function mergeWhatsAppConfig(
 ): OpenClawConfig {
   const channelConfig: WhatsAppConfig = { ...cfg.channels?.whatsapp };
   const mutableChannelConfig = channelConfig as Record<string, unknown>;
-  if (accountId === DEFAULT_ACCOUNT_ID) {
+  const targetPathPrefix = resolveWhatsAppConfigPathPrefix(cfg, accountId);
+  if (targetPathPrefix === "channels.whatsapp") {
     for (const [key, value] of Object.entries(patch)) {
       if (value === undefined) {
         if (options?.unsetOnUndefined?.includes(key)) {
@@ -56,7 +83,9 @@ function mergeWhatsAppConfig(
   const accounts = {
     ...(channelConfig.accounts as Record<string, WhatsAppAccountConfig> | undefined),
   };
-  const nextAccount: WhatsAppAccountConfig = { ...accounts[accountId] };
+  const targetAccountId =
+    targetPathPrefix === "channels.whatsapp.accounts.default" ? DEFAULT_ACCOUNT_ID : accountId;
+  const nextAccount: WhatsAppAccountConfig = { ...accounts[targetAccountId] };
   const mutableNextAccount = nextAccount as Record<string, unknown>;
   for (const [key, value] of Object.entries(patch)) {
     if (value === undefined) {
@@ -67,7 +96,7 @@ function mergeWhatsAppConfig(
     }
     mutableNextAccount[key] = value;
   }
-  accounts[accountId] = nextAccount;
+  accounts[targetAccountId] = nextAccount;
   return {
     ...cfg,
     channels: {
@@ -204,14 +233,9 @@ async function promptWhatsAppDmAccess(params: {
   const existingPolicy = account.dmPolicy ?? "pairing";
   const existingAllowFrom = account.allowFrom ?? [];
   const existingLabel = existingAllowFrom.length > 0 ? existingAllowFrom.join(", ") : "unset";
-  const policyKey =
-    accountId === DEFAULT_ACCOUNT_ID
-      ? "channels.whatsapp.dmPolicy"
-      : `channels.whatsapp.accounts.${accountId}.dmPolicy`;
-  const allowFromKey =
-    accountId === DEFAULT_ACCOUNT_ID
-      ? "channels.whatsapp.allowFrom"
-      : `channels.whatsapp.accounts.${accountId}.allowFrom`;
+  const configPathPrefix = resolveWhatsAppConfigPathPrefix(params.cfg, accountId);
+  const policyKey = `${configPathPrefix}.dmPolicy`;
+  const allowFromKey = `${configPathPrefix}.allowFrom`;
 
   if (params.forceAllowFrom) {
     return await applyWhatsAppOwnerAllowlist({

--- a/extensions/whatsapp/src/setup-test-helpers.ts
+++ b/extensions/whatsapp/src/setup-test-helpers.ts
@@ -205,3 +205,12 @@ export function expectWhatsAppWorkAccountAccessNote(harness: WizardPromptHarness
     WHATSAPP_ACCESS_NOTE_TITLE,
   );
 }
+
+export function expectWhatsAppDefaultAccountAccessNote(harness: WizardPromptHarness): void {
+  expect(harness.note).toHaveBeenCalledWith(
+    expect.stringContaining(
+      "`channels.whatsapp.accounts.default.dmPolicy` + `channels.whatsapp.accounts.default.allowFrom`",
+    ),
+    WHATSAPP_ACCESS_NOTE_TITLE,
+  );
+}

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-core";
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
 import {
@@ -5,7 +6,10 @@ import {
   createScopedChannelConfigAdapter,
   createScopedDmSecurityResolver,
 } from "openclaw/plugin-sdk/channel-config-helpers";
-import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import {
+  collectOpenGroupPolicyRouteAllowlistWarnings,
+  createAllowlistProviderGroupPolicyWarningCollector,
+} from "openclaw/plugin-sdk/channel-policy";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { createChannelPluginBase, getChatChannelMeta } from "openclaw/plugin-sdk/core";
 import {
@@ -31,6 +35,40 @@ import { applyWhatsAppSecurityConfigFixes } from "./security-fix.js";
 import { canonicalizeLegacySessionKey, isLegacyGroupSessionKey } from "./session-contract.js";
 
 export const WHATSAPP_CHANNEL = "whatsapp" as const;
+
+const WHATSAPP_GROUP_SCOPE_FIELDS = ["groupPolicy", "groupAllowFrom", "groups"] as const;
+
+type WhatsAppGroupScopeField = (typeof WHATSAPP_GROUP_SCOPE_FIELDS)[number];
+
+function resolveWhatsAppGroupScopeBasePath(params: {
+  cfg: Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
+  accountId?: string | null;
+}): string {
+  const accountId =
+    typeof params.accountId === "string"
+      ? params.accountId.trim() || DEFAULT_ACCOUNT_ID
+      : DEFAULT_ACCOUNT_ID;
+  const accounts = params.cfg.channels?.whatsapp?.accounts;
+  const accountConfig = accounts?.[accountId];
+  const defaultAccountConfig = accounts?.default;
+  const matchesAnyGroupScopeField = (config: Record<string, unknown> | undefined): boolean =>
+    WHATSAPP_GROUP_SCOPE_FIELDS.some((field) => config?.[field] !== undefined);
+  if (matchesAnyGroupScopeField(accountConfig)) {
+    return `channels.whatsapp.accounts.${accountId}`;
+  }
+  if (accountId !== DEFAULT_ACCOUNT_ID && matchesAnyGroupScopeField(defaultAccountConfig)) {
+    return "channels.whatsapp.accounts.default";
+  }
+  return "channels.whatsapp";
+}
+
+function resolveWhatsAppConfigPath(params: {
+  cfg: Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
+  accountId?: string | null;
+  field: WhatsAppGroupScopeField;
+}): string {
+  return `${resolveWhatsAppGroupScopeBasePath(params)}.${params.field}`;
+}
 
 export async function loadWhatsAppChannelRuntime() {
   return await import("./channel.runtime.js");
@@ -58,6 +96,7 @@ const whatsappResolveDmPolicy = createScopedDmSecurityResolver<ResolvedWhatsAppA
   resolveAllowFrom: (account) => account.allowFrom,
   policyPathSuffix: "dmPolicy",
   normalizeEntry: (raw) => normalizeE164(raw),
+  inheritSharedDefaultsFromDefaultAccount: true,
 });
 
 export function createWhatsAppSetupWizardProxy(
@@ -99,26 +138,41 @@ export function createWhatsAppPluginBase(params: {
   setup: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["setup"]>;
   isConfigured: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["config"]>["isConfigured"];
 }) {
-  const collectWhatsAppSecurityWarnings =
-    createAllowlistProviderRouteAllowlistWarningCollector<ResolvedWhatsAppAccount>({
-      providerConfigPresent: (cfg) => cfg.channels?.whatsapp !== undefined,
-      resolveGroupPolicy: (account) => account.groupPolicy,
-      resolveRouteAllowlistConfigured: (account) =>
-        Boolean(account.groups) && Object.keys(account.groups ?? {}).length > 0,
-      restrictSenders: {
-        surface: "WhatsApp groups",
-        openScope: "any member in allowed groups",
-        groupPolicyPath: "channels.whatsapp.groupPolicy",
-        groupAllowFromPath: "channels.whatsapp.groupAllowFrom",
-      },
-      noRouteAllowlist: {
-        surface: "WhatsApp groups",
-        routeAllowlistPath: "channels.whatsapp.groups",
-        routeScope: "group",
-        groupPolicyPath: "channels.whatsapp.groupPolicy",
-        groupAllowFromPath: "channels.whatsapp.groupAllowFrom",
-      },
-    });
+  const collectWhatsAppSecurityWarnings = createAllowlistProviderGroupPolicyWarningCollector<{
+    account: ResolvedWhatsAppAccount;
+    cfg: Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
+    accountId?: string | null;
+  }>({
+    providerConfigPresent: (cfg) => cfg.channels?.whatsapp !== undefined,
+    resolveGroupPolicy: ({ account }) => account.groupPolicy,
+    collect: ({ account, accountId, cfg, groupPolicy }) =>
+      collectOpenGroupPolicyRouteAllowlistWarnings({
+        groupPolicy,
+        routeAllowlistConfigured:
+          Boolean(account.groups) && Object.keys(account.groups ?? {}).length > 0,
+        restrictSenders: {
+          surface: "WhatsApp groups",
+          openScope: "any member in allowed groups",
+          groupPolicyPath: resolveWhatsAppConfigPath({ cfg, accountId, field: "groupPolicy" }),
+          groupAllowFromPath: resolveWhatsAppConfigPath({
+            cfg,
+            accountId,
+            field: "groupAllowFrom",
+          }),
+        },
+        noRouteAllowlist: {
+          surface: "WhatsApp groups",
+          routeAllowlistPath: resolveWhatsAppConfigPath({ cfg, accountId, field: "groups" }),
+          routeScope: "group",
+          groupPolicyPath: resolveWhatsAppConfigPath({ cfg, accountId, field: "groupPolicy" }),
+          groupAllowFromPath: resolveWhatsAppConfigPath({
+            cfg,
+            accountId,
+            field: "groupAllowFrom",
+          }),
+        },
+      }),
+  });
   const base = createChannelPluginBase({
     id: WHATSAPP_CHANNEL,
     meta: {

--- a/src/channels/plugins/helpers.test.ts
+++ b/src/channels/plugins/helpers.test.ts
@@ -75,6 +75,67 @@ describe("buildAccountScopedDmSecurityPolicy", () => {
       },
     },
     {
+      name: "uses accounts.default paths when shared defaults are inherited",
+      input: {
+        cfg: cfgWithChannel("demo-default-account", {
+          default: {
+            dmPolicy: "allowlist",
+            allowFrom: ["+15550001111"],
+          },
+          work: {},
+        }),
+        channelKey: "demo-default-account",
+        accountId: "work",
+        fallbackAccountId: "default",
+        policy: "allowlist",
+        allowFrom: ["+15550001111"],
+        policyPathSuffix: "dmPolicy",
+        inheritSharedDefaultsFromDefaultAccount: true,
+      },
+      expected: {
+        policy: "allowlist",
+        allowFrom: ["+15550001111"],
+        policyPath: "channels.demo-default-account.accounts.default.dmPolicy",
+        allowFromPath: "channels.demo-default-account.accounts.default.",
+        approveHint: formatPairingApproveHint("demo-default-account"),
+        normalizeEntry: undefined,
+      },
+    },
+    {
+      name: "ignores accounts.default paths unless the channel opts into shared default-account inheritance",
+      input: {
+        cfg: {
+          channels: {
+            "demo-root": {
+              dmPolicy: "pairing",
+              allowFrom: ["*"],
+              accounts: {
+                default: {
+                  dmPolicy: "allowlist",
+                  allowFrom: ["+15550001111"],
+                },
+                work: {},
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        channelKey: "demo-root",
+        accountId: "work",
+        fallbackAccountId: "default",
+        policy: "pairing",
+        allowFrom: ["*"],
+        policyPathSuffix: "dmPolicy",
+      },
+      expected: {
+        policy: "pairing",
+        allowFrom: ["*"],
+        policyPath: "channels.demo-root.dmPolicy",
+        allowFromPath: "channels.demo-root.",
+        approveHint: formatPairingApproveHint("demo-root"),
+        normalizeEntry: undefined,
+      },
+    },
+    {
       name: "supports custom defaults and approve hints",
       input: {
         cfg: cfgWithChannel("demo-default"),

--- a/src/channels/plugins/helpers.ts
+++ b/src/channels/plugins/helpers.ts
@@ -44,15 +44,49 @@ export function buildAccountScopedDmSecurityPolicy(params: {
   approveChannelId?: string;
   approveHint?: string;
   normalizeEntry?: (raw: string) => string;
+  inheritSharedDefaultsFromDefaultAccount?: boolean;
 }): ChannelSecurityDmPolicy {
   const resolvedAccountId = params.accountId ?? params.fallbackAccountId ?? DEFAULT_ACCOUNT_ID;
   const channelConfig = (params.cfg.channels as Record<string, unknown> | undefined)?.[
     params.channelKey
-  ] as { accounts?: Record<string, unknown> } | undefined;
-  const useAccountPath = Boolean(channelConfig?.accounts?.[resolvedAccountId]);
-  const basePath = useAccountPath
-    ? `channels.${params.channelKey}.accounts.${resolvedAccountId}.`
-    : `channels.${params.channelKey}.`;
+  ] as { accounts?: Record<string, Record<string, unknown>> } | undefined;
+  const rootBasePath = `channels.${params.channelKey}.`;
+  const accountBasePath = `channels.${params.channelKey}.accounts.${resolvedAccountId}.`;
+  const defaultBasePath = `channels.${params.channelKey}.accounts.${DEFAULT_ACCOUNT_ID}.`;
+  const accountConfig = channelConfig?.accounts?.[resolvedAccountId];
+  const defaultAccountConfig =
+    params.inheritSharedDefaultsFromDefaultAccount && resolvedAccountId !== DEFAULT_ACCOUNT_ID
+      ? channelConfig?.accounts?.[DEFAULT_ACCOUNT_ID]
+      : undefined;
+  const resolveFieldName = (suffix: string | undefined, fallbackField: string): string | null =>
+    suffix == null || suffix === ""
+      ? fallbackField
+      : /^[A-Za-z0-9_-]+$/.test(suffix)
+        ? suffix
+        : null;
+  const simplePolicyField = resolveFieldName(params.policyPathSuffix, "dmPolicy");
+  const simpleAllowFromField = resolveFieldName(params.allowFromPathSuffix, "allowFrom");
+  const matchesAnyField = (
+    config: Record<string, unknown> | undefined,
+    fields: Array<string | null>,
+  ) => fields.some((field) => field != null && config?.[field] !== undefined);
+  const basePath =
+    simplePolicyField || simpleAllowFromField
+      ? matchesAnyField(accountConfig, [simplePolicyField, simpleAllowFromField])
+        ? accountBasePath
+        : matchesAnyField(defaultAccountConfig, [simplePolicyField, simpleAllowFromField])
+          ? defaultBasePath
+          : matchesAnyField(channelConfig as Record<string, unknown> | undefined, [
+                simplePolicyField,
+                simpleAllowFromField,
+              ])
+            ? rootBasePath
+            : accountConfig
+              ? accountBasePath
+              : rootBasePath
+      : accountConfig
+        ? accountBasePath
+        : rootBasePath;
   const allowFromPath = `${basePath}${params.allowFromPathSuffix ?? ""}`;
   const policyPath =
     params.policyPathSuffix != null ? `${basePath}${params.policyPathSuffix}` : undefined;

--- a/src/plugin-sdk/channel-config-helpers.test.ts
+++ b/src/plugin-sdk/channel-config-helpers.test.ts
@@ -350,6 +350,99 @@ describe("createScopedDmSecurityResolver", () => {
       normalizeEntry: expect.any(Function),
     });
   });
+
+  it("uses accounts.default paths when named accounts inherit shared defaults", () => {
+    const resolveDmPolicy = createScopedDmSecurityResolver<{
+      accountId?: string | null;
+      dmPolicy?: string;
+      allowFrom?: string[];
+    }>({
+      channelKey: "demo",
+      resolvePolicy: (account) => account.dmPolicy,
+      resolveAllowFrom: (account) => account.allowFrom,
+      policyPathSuffix: "dmPolicy",
+      normalizeEntry: (raw) => raw.toLowerCase(),
+      inheritSharedDefaultsFromDefaultAccount: true,
+    });
+
+    expect(
+      resolveDmPolicy({
+        cfg: {
+          channels: {
+            demo: {
+              accounts: {
+                default: {
+                  dmPolicy: "allowlist",
+                  allowFrom: ["Owner"],
+                },
+                alt: {},
+              },
+            },
+          },
+        },
+        accountId: "alt",
+        account: {
+          accountId: "alt",
+          dmPolicy: "allowlist",
+          allowFrom: ["Owner"],
+        },
+      }),
+    ).toEqual({
+      policy: "allowlist",
+      allowFrom: ["Owner"],
+      policyPath: "channels.demo.accounts.default.dmPolicy",
+      allowFromPath: "channels.demo.accounts.default.",
+      approveHint: formatPairingApproveHint("demo"),
+      normalizeEntry: expect.any(Function),
+    });
+  });
+
+  it("ignores accounts.default paths unless the channel opts into shared default-account inheritance", () => {
+    const resolveDmPolicy = createScopedDmSecurityResolver<{
+      accountId?: string | null;
+      dmPolicy?: string;
+      allowFrom?: string[];
+    }>({
+      channelKey: "demo",
+      resolvePolicy: (account) => account.dmPolicy,
+      resolveAllowFrom: (account) => account.allowFrom,
+      policyPathSuffix: "dmPolicy",
+      normalizeEntry: (raw) => raw.toLowerCase(),
+    });
+
+    expect(
+      resolveDmPolicy({
+        cfg: {
+          channels: {
+            demo: {
+              dmPolicy: "pairing",
+              allowFrom: ["*"],
+              accounts: {
+                default: {
+                  dmPolicy: "allowlist",
+                  allowFrom: ["Owner"],
+                },
+                alt: {},
+              },
+            },
+          },
+        },
+        accountId: "alt",
+        account: {
+          accountId: "alt",
+          dmPolicy: "pairing",
+          allowFrom: ["*"],
+        },
+      }),
+    ).toEqual({
+      policy: "pairing",
+      allowFrom: ["*"],
+      policyPath: "channels.demo.dmPolicy",
+      allowFromPath: "channels.demo.",
+      approveHint: formatPairingApproveHint("demo"),
+      normalizeEntry: expect.any(Function),
+    });
+  });
 });
 
 describe("createTopLevelChannelConfigBase", () => {

--- a/src/plugin-sdk/channel-config-helpers.ts
+++ b/src/plugin-sdk/channel-config-helpers.ts
@@ -66,15 +66,49 @@ function buildAccountScopedDmSecurityPolicy(params: {
   approveChannelId?: string;
   approveHint?: string;
   normalizeEntry?: (raw: string) => string;
+  inheritSharedDefaultsFromDefaultAccount?: boolean;
 }) {
   const resolvedAccountId = params.accountId ?? params.fallbackAccountId ?? DEFAULT_ACCOUNT_ID;
   const channelConfig = (params.cfg.channels as Record<string, unknown> | undefined)?.[
     params.channelKey
-  ] as { accounts?: Record<string, unknown> } | undefined;
-  const useAccountPath = Boolean(channelConfig?.accounts?.[resolvedAccountId]);
-  const basePath = useAccountPath
-    ? `channels.${params.channelKey}.accounts.${resolvedAccountId}.`
-    : `channels.${params.channelKey}.`;
+  ] as { accounts?: Record<string, Record<string, unknown>> } | undefined;
+  const rootBasePath = `channels.${params.channelKey}.`;
+  const accountBasePath = `channels.${params.channelKey}.accounts.${resolvedAccountId}.`;
+  const defaultBasePath = `channels.${params.channelKey}.accounts.${DEFAULT_ACCOUNT_ID}.`;
+  const accountConfig = channelConfig?.accounts?.[resolvedAccountId];
+  const defaultAccountConfig =
+    params.inheritSharedDefaultsFromDefaultAccount && resolvedAccountId !== DEFAULT_ACCOUNT_ID
+      ? channelConfig?.accounts?.[DEFAULT_ACCOUNT_ID]
+      : undefined;
+  const resolveFieldName = (suffix: string | undefined, fallbackField: string): string | null =>
+    suffix == null || suffix === ""
+      ? fallbackField
+      : /^[A-Za-z0-9_-]+$/.test(suffix)
+        ? suffix
+        : null;
+  const simplePolicyField = resolveFieldName(params.policyPathSuffix, "dmPolicy");
+  const simpleAllowFromField = resolveFieldName(params.allowFromPathSuffix, "allowFrom");
+  const matchesAnyField = (
+    config: Record<string, unknown> | undefined,
+    fields: Array<string | null>,
+  ) => fields.some((field) => field != null && config?.[field] !== undefined);
+  const basePath =
+    simplePolicyField || simpleAllowFromField
+      ? matchesAnyField(accountConfig, [simplePolicyField, simpleAllowFromField])
+        ? accountBasePath
+        : matchesAnyField(defaultAccountConfig, [simplePolicyField, simpleAllowFromField])
+          ? defaultBasePath
+          : matchesAnyField(channelConfig as Record<string, unknown> | undefined, [
+                simplePolicyField,
+                simpleAllowFromField,
+              ])
+            ? rootBasePath
+            : accountConfig
+              ? accountBasePath
+              : rootBasePath
+      : accountConfig
+        ? accountBasePath
+        : rootBasePath;
   const allowFromPath = `${basePath}${params.allowFromPathSuffix ?? ""}`;
   const policyPath =
     params.policyPathSuffix != null ? `${basePath}${params.policyPathSuffix}` : undefined;
@@ -655,6 +689,7 @@ export function createScopedDmSecurityResolver<
   approveChannelId?: string;
   approveHint?: string;
   normalizeEntry?: (raw: string) => string;
+  inheritSharedDefaultsFromDefaultAccount?: boolean;
 }) {
   return ({
     cfg,
@@ -678,6 +713,7 @@ export function createScopedDmSecurityResolver<
       approveChannelId: params.approveChannelId,
       approveHint: params.approveHint,
       normalizeEntry: params.normalizeEntry,
+      inheritSharedDefaultsFromDefaultAccount: params.inheritSharedDefaultsFromDefaultAccount,
     });
 }
 

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -160,6 +160,7 @@ export function createRestrictSendersChannelSecurity<
   approveChannelId?: string;
   approveHint?: string;
   normalizeDmEntry?: (raw: string) => string;
+  inheritSharedDefaultsFromDefaultAccount?: boolean;
 }): ChannelSecurityAdapter<ResolvedAccount> {
   return {
     resolveDmPolicy: createScopedDmSecurityResolver<ResolvedAccount>({
@@ -173,6 +174,7 @@ export function createRestrictSendersChannelSecurity<
       approveChannelId: params.approveChannelId,
       approveHint: params.approveHint,
       normalizeEntry: params.normalizeDmEntry,
+      inheritSharedDefaultsFromDefaultAccount: params.inheritSharedDefaultsFromDefaultAccount,
     }),
     collectWarnings: createAllowlistProviderRestrictSendersWarningCollector<ResolvedAccount>({
       providerConfigPresent:

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -435,6 +435,7 @@ type ChatChannelSecurityOptions<TResolvedAccount extends { accountId?: string | 
     approveChannelId?: string;
     approveHint?: string;
     normalizeEntry?: (raw: string) => string;
+    inheritSharedDefaultsFromDefaultAccount?: boolean;
   };
   collectWarnings?: ChannelSecurityAdapter<TResolvedAccount>["collectWarnings"];
   collectAuditFindings?: ChannelSecurityAdapter<TResolvedAccount>["collectAuditFindings"];
@@ -543,6 +544,8 @@ function resolveChatChannelSecurity<TResolvedAccount extends { accountId?: strin
         approveChannelId: security.dm.approveChannelId,
         approveHint: security.dm.approveHint,
         normalizeEntry: security.dm.normalizeEntry,
+        inheritSharedDefaultsFromDefaultAccount:
+          security.dm.inheritSharedDefaultsFromDefaultAccount,
       }),
     ...(security.collectWarnings ? { collectWarnings: security.collectWarnings } : {}),
     ...(security.collectAuditFindings


### PR DESCRIPTION
## Summary

- Problem: WhatsApp runtime, setup output, and security path guidance still disagreed on whether shared multi-account defaults live at channel root or under `channels.whatsapp.accounts.default`.
- Why it matters: runtime compat and setup flows were already producing `accounts.default` state in practice, but named-account resolution and user guidance did not consistently honor it.
- What changed: wired WhatsApp named accounts to inherit shared defaults from `accounts.default`, updated setup/finalize writes, and taught DM/group security path helpers to point at the effective shared default-account config.
- What did NOT change (scope boundary): this PR does not yet change schema validation, runtime compat tests, or live monitor debounce/self-chat follow-up behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #68360
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: WhatsApp’s effective multi-account contract had drifted across runtime resolution, setup writes, and operator-facing config guidance after `accounts.default` became part of the persisted shape.
- Missing detection / guardrail: named-account resolution and config-path helper coverage did not assert `root -> accounts.default -> account` semantics.
- Contributing context (if known): runtime compat and setup flows were already generating `accounts.default`, but WhatsApp runtime was still reading only root plus the named account.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/accounts.test.ts`, `extensions/whatsapp/src/channel.setup.test.ts`, `src/channels/plugins/helpers.test.ts`, `src/plugin-sdk/channel-config-helpers.test.ts`
- Scenario the test should lock in: named WhatsApp accounts inherit shared defaults from `accounts.default`, setup writes default-account config to the right scope, and operator guidance points at the effective config path.
- Why this is the smallest reliable guardrail: the contract drift lives in runtime resolution and helper path selection, which these tests cover directly.
- Existing test that already covers this (if any): none before this PR
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Named WhatsApp accounts now honor shared defaults from `channels.whatsapp.accounts.default`.
- Multi-account WhatsApp setup writes default-account DM/group config to `channels.whatsapp.accounts.default` when that is the effective shared scope.
- DM/group security messages now point at the effective `accounts.default` path when WhatsApp is inheriting shared defaults there.

## Diagram (if applicable)

```text
Before:
root config + named account override -> runtime behavior
setup/runtime compat -> accounts.default
operator guidance -> mixed root/account paths

After:
root config -> accounts.default -> named account override -> runtime behavior and guidance agree
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): multi-account WhatsApp config using `channels.whatsapp.accounts.default`

### Steps

1. Configure a named WhatsApp account with shared defaults under `channels.whatsapp.accounts.default`.
2. Resolve the effective account config and setup warning paths.
3. Confirm setup/finalize writes target `accounts.default` for the default account in multi-account mode.

### Expected

- Runtime account resolution, setup writes, and operator guidance all agree on `accounts.default` as the shared default-account source.

### Actual

- Before this change, runtime and helper paths still partially treated root config as the shared source even when persisted state lived under `accounts.default`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test extensions/whatsapp/src/accounts.test.ts extensions/whatsapp/src/channel.setup.test.ts src/channels/plugins/helpers.test.ts src/plugin-sdk/channel-config-helpers.test.ts --reporter=dot`
- Edge cases checked: named-account inheritance, `selfChatMode`/`authDir` not leaking from `accounts.default`, setup path guidance for the default account.
- What you did **not** verify: schema/runtime compat alignment; that follow-up is isolated to the next stacked PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: runtime/schema/monitor surfaces still need to be aligned with the new shared-default contract.
  - Mitigation: those follow-ups are isolated to the next stacked PR and covered by dedicated compat/monitor tests there.
