### PR TITLE
fix: prevent unbounded narrative session growth by stabilizing session key (#68354)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -585,7 +585,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}-${nowMs}`;
+    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}`;
 
     await generateAndAppendDreamNarrative({
       subagent,
@@ -601,12 +601,13 @@ describe("generateAndAppendDreamNarrative", () => {
 
     expect(subagent.run).toHaveBeenCalledOnce();
     expect(subagent.run.mock.calls[0][0]).toMatchObject({
-      idempotencyKey: expectedSessionKey,
+      idempotencyKey: `${expectedSessionKey}-${nowMs}`,
       sessionKey: expectedSessionKey,
       deliver: false,
     });
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
+    // deleteSession is called twice: once for pre-run cleanup, once in finally
+    expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
 
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(content).toContain("The repository whispered of forgotten endpoints.");
@@ -721,7 +722,8 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(content).toContain("API endpoints need authentication");
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining(workspaceDir));
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
+    // deleteSession is called twice: once for pre-run cleanup, once in finally
+    expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
   });
 
   it("falls back when the request-scoped runtime error is detected by stable code", async () => {
@@ -880,7 +882,9 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(firstSessionKey).not.toBe(secondSessionKey);
     expect(firstSessionKey).toContain("dreaming-narrative-light-");
     expect(secondSessionKey).toContain("dreaming-narrative-light-");
-    expect(subagent.deleteSession.mock.calls[0]?.[0]?.sessionKey).toBe(firstSessionKey);
-    expect(subagent.deleteSession.mock.calls[1]?.[0]?.sessionKey).toBe(secondSessionKey);
+    // Each workspace triggers deleteSession twice (pre-run cleanup + finally)
+    const deleteKeys = subagent.deleteSession.mock.calls.map((c: unknown[]) => (c[0] as { sessionKey: string })?.sessionKey);
+    expect(deleteKeys.filter((k: string) => k === firstSessionKey)).toHaveLength(2);
+    expect(deleteKeys.filter((k: string) => k === secondSessionKey)).toHaveLength(2);
   });
 });

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -147,7 +147,7 @@ async function startNarrativeRunOrFallback(params: {
 }): Promise<string | null> {
   try {
     const run = await params.subagent.run({
-      idempotencyKey: params.sessionKey,
+      idempotencyKey: `${params.sessionKey}-${params.nowMs}`,
       sessionKey: params.sessionKey,
       message: params.message,
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
@@ -180,10 +180,9 @@ async function startNarrativeRunOrFallback(params: {
 function buildNarrativeSessionKey(params: {
   workspaceDir: string;
   phase: NarrativePhaseData["phase"];
-  nowMs: number;
 }): string {
   const workspaceHash = createHash("sha1").update(params.workspaceDir).digest("hex").slice(0, 12);
-  return `dreaming-narrative-${params.phase}-${workspaceHash}-${params.nowMs}`;
+  return `dreaming-narrative-${params.phase}-${workspaceHash}`;
 }
 
 // ── Prompt building ────────────────────────────────────────────────────
@@ -848,11 +847,18 @@ export async function generateAndAppendDreamNarrative(params: {
   const sessionKey = buildNarrativeSessionKey({
     workspaceDir: params.workspaceDir,
     phase: params.data.phase,
-    nowMs,
   });
   const message = buildNarrativePrompt(params.data);
   let runId: string | null = null;
   let waitStatus: string | null = null;
+
+  // Defensive cleanup: delete any leftover session from a previous failed run
+  // to prevent stale conversation context from polluting the new narrative.
+  try {
+    await params.subagent.deleteSession({ sessionKey });
+  } catch {
+    // Ignore — session may not exist yet.
+  }
 
   try {
     runId = await startNarrativeRunOrFallback({


### PR DESCRIPTION
## Problem

`buildNarrativeSessionKey` includes a millisecond timestamp (`nowMs` from `Date.now()`) in the session key, making it unique per dream run:

```ts
return `dreaming-narrative-${params.phase}-${workspaceHash}-${params.nowMs}`;
```

When `deleteSession` fails in the `finally` block, these uniquely-keyed sessions accumulate indefinitely. As reported in #68354: **251 orphan sessions in 4 days**, consuming ~4.8M tokens.

## Fix

### 1. Stabilize session key (remove `nowMs`)

```ts
return `dreaming-narrative-${params.phase}-${workspaceHash}`;
```

Now each workspace+phase combination reuses the same session key. If `deleteSession` fails, the next run reuses the existing session instead of creating a new orphan. Maximum accumulation: 2-3 sessions (one per phase) instead of unbounded.

### 2. Keep `nowMs` in idempotency key

```ts
idempotencyKey: `${params.sessionKey}-${params.nowMs}`,
```

Prevents deduplication across dream runs — each run is still treated as unique by the subagent runtime.

### 3. Pre-run defensive cleanup

Added a `deleteSession` call before `subagent.run()` to clear any leftover session from a previous failed run. This prevents stale conversation context from polluting the new narrative.

```ts
// Defensive cleanup: delete any leftover session from a previous failed run
try {
  await params.subagent.deleteSession({ sessionKey });
} catch {
  // Ignore — session may not exist yet.
}
```

## Trade-offs considered

- **Stale context**: If `deleteSession` fails in `finally` AND the pre-run cleanup also fails, the next run could see stale messages. This is a minor cosmetic risk (dream diary entries slightly influenced by previous context) vs. the current unbounded resource leak.
- **Concurrent runs**: Dream runs are cron-scheduled, so concurrent same-workspace/phase runs are unlikely. The stable key makes them share a session if they do overlap, which is safer than creating parallel orphans.

## Tests updated

- Updated `deleteSession` call count expectations (now 2 per run: pre-run cleanup + finally)
- Updated workspace isolation test to verify delete keys per workspace
- Updated idempotency key expectations

Closes #68354