### PR TITLE
docs: fix broken links and display text consistency (fixes #50828)

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -111,7 +111,7 @@ Fix options:
 Related:
 
 - [/gateway/local-models](/gateway/local-models)
-- [/gateway/configuration](/gateway/configuration)
+- [/gateway/configuration-reference](/gateway/configuration-reference)
 - [/gateway/configuration-reference#openai-compatible-endpoints](/gateway/configuration-reference#openai-compatible-endpoints)
 
 ## No replies
@@ -224,7 +224,7 @@ If `openclaw devices rotate` / `revoke` / `remove` is denied unexpectedly:
 Related:
 
 - [/web/control-ui](/web/control-ui)
-- [/gateway/configuration](/gateway/configuration) (gateway auth modes)
+- [/gateway/configuration-reference](/gateway/configuration-reference) (gateway auth modes)
 - [/gateway/trusted-proxy-auth](/gateway/trusted-proxy-auth)
 - [/gateway/remote](/gateway/remote)
 - [/cli/devices](/cli/devices)
@@ -259,7 +259,7 @@ Common signatures:
 Related:
 
 - [/gateway/background-process](/gateway/background-process)
-- [/gateway/configuration](/gateway/configuration)
+- [/gateway/configuration-reference](/gateway/configuration-reference)
 - [/gateway/doctor](/gateway/doctor)
 
 ## Gateway probe warnings

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -8,7 +8,7 @@ title: "FAQ"
 
 # FAQ
 
-Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS, multi-agent, OAuth/API keys, model failover). For runtime diagnostics, see [Troubleshooting](/gateway/troubleshooting). For the full config reference, see [Configuration](/gateway/configuration).
+Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS, multi-agent, OAuth/API keys, model failover). For runtime diagnostics, see [Troubleshooting](/gateway/troubleshooting). For the full config reference, see [Configuration](/gateway/configuration-reference).
 
 ## First 60 seconds if something is broken
 
@@ -790,7 +790,7 @@ for usage/billing and raise limits as needed.
   </Accordion>
 
   <Accordion title='Can I run a "fast chat" agent and an "Opus for coding" agent?'>
-    Yes. Use multi-agent routing: give each agent its own default model, then bind inbound routes (provider account or specific peers) to each agent. Example config lives in [Multi-Agent Routing](/concepts/multi-agent). See also [Models](/concepts/models) and [Configuration](/gateway/configuration).
+    Yes. Use multi-agent routing: give each agent its own default model, then bind inbound routes (provider account or specific peers) to each agent. Example config lives in [Multi-Agent Routing](/concepts/multi-agent). See also [Models](/concepts/models) and [Configuration](/gateway/configuration-reference).
   </Accordion>
 
   <Accordion title="Does Homebrew work on Linux?">

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -582,7 +582,7 @@ hook instead.
 - If plugin config exists but the plugin is **disabled**, the config is kept and
   a **warning** is surfaced in Doctor + logs.
 
-See [Configuration reference](/gateway/configuration) for the full `plugins.*` schema.
+See [Configuration reference](/gateway/configuration-reference) for the full `plugins.*` schema.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Fix broken internal links and display text consistency reported in issue #50828.

### Changes

- `docs/plugins/manifest.md`: `/configuration` → `/configuration-reference`
- `docs/gateway/troubleshooting.md`: 
  - Link paths: `/gateway/configuration` → `/gateway/configuration-reference`
  - Display text: `[/gateway/configuration]` → `[/gateway/configuration-reference]` (to match URL)
- `docs/help/faq.md`: `/gateway/configuration` → `/gateway/configuration-reference`

### Improvements from previous PR

- Fixed display text inconsistency (Bot review feedback)
- Link display text now matches the URL path

### Issue

Fixes #50828