### PR TITLE
feat: add session-persistence truncation cap for tool results

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -19,6 +19,7 @@ let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncatio
 let estimateToolResultReductionPotential: typeof import("./tool-result-truncation.js").estimateToolResultReductionPotential;
 let DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 let HARD_MAX_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").HARD_MAX_TOOL_RESULT_CHARS;
+let SESSION_MAX_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").SESSION_MAX_TOOL_RESULT_CHARS;
 let resolveLiveToolResultMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultMaxChars;
 let tmpDir: string | undefined;
 
@@ -36,6 +37,7 @@ async function loadFreshToolResultTruncationModuleForTest() {
     estimateToolResultReductionPotential,
     DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     HARD_MAX_TOOL_RESULT_CHARS,
+    SESSION_MAX_TOOL_RESULT_CHARS,
     resolveLiveToolResultMaxChars,
   } = await import("./tool-result-truncation.js"));
 }
@@ -200,6 +202,12 @@ describe("calculateMaxToolResultChars", () => {
   it("exports the live cap through both constant names", () => {
     expect(DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS).toBe(16_000);
     expect(HARD_MAX_TOOL_RESULT_CHARS).toBe(DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS);
+  });
+
+  it("exports SESSION_MAX_TOOL_RESULT_CHARS at 50KB", () => {
+    expect(SESSION_MAX_TOOL_RESULT_CHARS).toBe(51_200);
+    // Should be larger than the live cap to avoid double-truncation in session writes
+    expect(SESSION_MAX_TOOL_RESULT_CHARS).toBeGreaterThan(DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS);
   });
 
   it("caps at HARD_MAX_TOOL_RESULT_CHARS for very large windows", () => {

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -28,6 +28,14 @@ const MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3;
 export const DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS = 16_000;
 
 /**
+ * Session-write limit for tool results persisted to the session JSONL.
+ * Tool output beyond this is truncated before storage to prevent large exec
+ * or file-read results from consuming the entire context window across turns.
+ * ~50KB in characters (1 char ≈ 1 byte for typical ASCII/UTF-8 output).
+ */
+export const SESSION_MAX_TOOL_RESULT_CHARS = 51_200;
+
+/**
  * Backwards-compatible alias for older call sites/tests.
  */
 export const HARD_MAX_TOOL_RESULT_CHARS = DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -388,6 +388,20 @@ describe("installSessionToolResultGuard", () => {
     expect(text).toContain("truncated");
   });
 
+  it("caps tool result persistence at SESSION_MAX_TOOL_RESULT_CHARS (50KB)", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    // 80KB tool result – larger than the 50KB session cap
+    appendToolResultText(sm, "x".repeat(80_000));
+
+    const text = getToolResultText(getPersistedMessages(sm));
+    // Should be truncated to approximately 50KB (51 200 chars) plus truncation notice
+    expect(text.length).toBeLessThanOrEqual(51_200 + 200); // 200 chars headroom for truncation notice
+    expect(text.length).toBeGreaterThan(2_000); // but still keeps meaningful content
+    expect(text).toContain("truncated");
+  });
+
   it("does not truncate tool results under the limit", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -9,6 +9,7 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { formatContextLimitTruncationNotice } from "./pi-embedded-runner/tool-result-context-guard.js";
 import {
   DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
+  SESSION_MAX_TOOL_RESULT_CHARS,
   truncateToolResultMessage,
 } from "./pi-embedded-runner/tool-result-truncation.js";
 import {
@@ -34,8 +35,23 @@ function capToolResultSize(msg: AgentMessage, maxChars: number): AgentMessage {
   });
 }
 
+/**
+ * Maximum characters persisted per tool result in the session JSONL.
+ * Kept well below the model's context window to prevent session file inflation.
+ * 50KB ≈ 51 200 chars — large enough for typical command output, small enough
+ * to prevent runaway sessions from single large exec/read/web_fetch results.
+ */
+const PERSISTENCE_MAX_TOOL_RESULT_CHARS = SESSION_MAX_TOOL_RESULT_CHARS;
+
 function resolveMaxToolResultChars(opts?: { maxToolResultChars?: number }): number {
   return Math.max(1, opts?.maxToolResultChars ?? DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS);
+}
+
+function resolvePersistenceMaxToolResultChars(opts?: { maxToolResultChars?: number }): number {
+  return Math.min(
+    resolveMaxToolResultChars(opts),
+    opts?.maxToolResultChars != null ? opts.maxToolResultChars : PERSISTENCE_MAX_TOOL_RESULT_CHARS,
+  );
 }
 
 function normalizePersistedToolResultName(
@@ -200,7 +216,11 @@ export function installSessionToolResultGuard(
       const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
-      const capped = capToolResultSize(persistMessage(normalizedToolResult), maxToolResultChars);
+      // Persistence cap: tool results stored to the session JSONL are truncated
+      // at SESSION_MAX_TOOL_RESULT_CHARS (50KB) to prevent session file inflation
+      // from oversized exec/read/web_fetch output.
+      const persistenceCap = resolvePersistenceMaxToolResultChars(opts);
+      const capped = capToolResultSize(persistMessage(normalizedToolResult), persistenceCap);
       const persisted = applyBeforeWriteHook(
         persistToolResult(capped, {
           toolCallId: id ?? undefined,
@@ -211,7 +231,7 @@ export function installSessionToolResultGuard(
       if (!persisted) {
         return undefined;
       }
-      return originalAppend(capToolResultSize(persisted, maxToolResultChars) as never);
+      return originalAppend(capToolResultSize(persisted, persistenceCap) as never);
     }
 
     // Skip tool call extraction for aborted/errored assistant messages.


### PR DESCRIPTION
## Summary

Tool results written to the session JSONL are now capped at `SESSION_MAX_TOOL_RESULT_CHARS` (50KB / 51,200 chars) to prevent oversized `exec`/`read`/`web_fetch` output from inflating session files and consuming the entire context window across turns.

### Changes
- **`tool-result-truncation.ts`**: Export `SESSION_MAX_TOOL_RESULT_CHARS = 51_200` — a session-write limit for tool results persisted to the session JSONL.
- **`session-tool-result-guard.ts`**: 
  - Add `PERSISTENCE_MAX_TOOL_RESULT_CHARS` and `resolvePersistenceMaxToolResultChars()` that caps at `min(live cap, persistence cap)` to avoid double-truncation.
  - Apply the persistence cap in `installSessionToolResultGuard` for both the initial persist path and the `originalAppend` return path.
- **Tests**: 
  - `SESSION_MAX_TOOL_RESULT_CHARS` export value test (51,200 > live cap).
  - Session persistence cap test confirming an 80KB tool result is truncated to ≤ 51,200 + overhead.

### Motivation
Without this cap, a single large `exec` or `read` result (hundreds of KB) gets persisted in full to the session JSONL, inflating context consumption on every subsequent turn. The live cap alone (16KB) was applied during session recovery, but the persistence path had no truncation — tool results were stored verbatim then truncated on re-read, which is wasteful and leads to degraded session performance.

### Testing
- 62 tests pass (2 new: persistence cap + SESSION_MAX export value)
- All existing truncation and guard tests continue to pass

Refs AGE-4963