### PR TITLE
fix(daemon): preserve launchd proxy env on reinstall

### DIFF
--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -28,6 +28,10 @@ Healthy baseline:
 - `RPC probe: ok`
 - Channel probe shows transport connected and, where supported, `works` or `audit ok`
 
+Proxy note:
+
+- On macOS, the LaunchAgent service does not read the system proxy from Network Settings. If OpenClaw needs a proxy, configure the channel/provider proxy directly or install/reinstall the gateway from a shell that exports `HTTP_PROXY` / `HTTPS_PROXY`.
+
 ## WhatsApp
 
 ### WhatsApp failure signatures

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -218,6 +218,14 @@ vi.mock("node:fs/promises", async () => {
       }
       throw new Error(`ENOENT: no such file or directory, chmod '${key}'`);
     }),
+    readFile: vi.fn(async (p: string) => {
+      const key = p;
+      const value = state.files.get(key);
+      if (value !== undefined) {
+        return value;
+      }
+      throw new Error(`ENOENT: no such file or directory, open '${key}'`);
+    }),
     unlink: vi.fn(async (p: string) => {
       state.files.delete(p);
     }),
@@ -455,6 +463,66 @@ describe("launchd install", () => {
     expect(plist).toContain("<key>EnvironmentVariables</key>");
     expect(plist).toContain("<key>TMPDIR</key>");
     expect(plist).toContain(`<string>${tmpDir}</string>`);
+  });
+
+  it("preserves existing proxy environment when reinstalling without proxy vars", async () => {
+    const env = createDefaultLaunchdEnv();
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+      environment: {
+        HTTP_PROXY: "http://127.0.0.1:7890",
+        HTTPS_PROXY: "http://127.0.0.1:7890",
+        NO_PROXY: "127.0.0.1,localhost,::1,.local",
+      },
+    });
+
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+    });
+
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const plist = state.files.get(plistPath) ?? "";
+    expect(plist).toContain("<key>HTTP_PROXY</key>");
+    expect(plist).toContain("<string>http://127.0.0.1:7890</string>");
+    expect(plist).toContain("<key>HTTPS_PROXY</key>");
+    expect(plist).toContain("<key>NO_PROXY</key>");
+    expect(plist).toContain("<string>127.0.0.1,localhost,::1,.local</string>");
+  });
+
+  it("keeps explicit proxy overrides while filling missing proxy vars from the existing plist", async () => {
+    const env = createDefaultLaunchdEnv();
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+      environment: {
+        HTTP_PROXY: "http://127.0.0.1:7890",
+        HTTPS_PROXY: "http://127.0.0.1:7890",
+        NO_PROXY: "127.0.0.1,localhost,::1,.local",
+      },
+    });
+
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+      environment: {
+        HTTP_PROXY: "http://proxy.example:8080",
+      },
+    });
+
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const plist = state.files.get(plistPath) ?? "";
+    expect(plist).toContain("<key>HTTP_PROXY</key>");
+    expect(plist).toContain("<string>http://proxy.example:8080</string>");
+    expect(plist).toContain("<key>HTTPS_PROXY</key>");
+    expect(plist).toContain("<string>http://127.0.0.1:7890</string>");
+    expect(plist).toContain("<key>NO_PROXY</key>");
+    expect(plist).toContain("<string>127.0.0.1,localhost,::1,.local</string>");
   });
 
   it("writes KeepAlive=true policy with restrictive umask", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -35,6 +35,16 @@ import type {
 
 const LAUNCH_AGENT_DIR_MODE = 0o755;
 const LAUNCH_AGENT_PLIST_MODE = 0o644;
+const SERVICE_PROXY_ENV_KEYS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+  "all_proxy",
+] as const;
 
 function assertValidLaunchAgentLabel(label: string): string {
   const trimmed = label.trim();
@@ -58,6 +68,60 @@ function resolveLaunchAgentPlistPathForLabel(
 ): string {
   const home = toPosixPath(resolveHomeDir(env));
   return path.posix.join(home, "Library", "LaunchAgents", `${label}.plist`);
+}
+
+function readProxyEnvironment(
+  env: Record<string, string | undefined> | undefined,
+): Record<string, string> {
+  const proxyEnv: Record<string, string> = {};
+  if (!env) {
+    return proxyEnv;
+  }
+  for (const key of SERVICE_PROXY_ENV_KEYS) {
+    const value = env[key];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      continue;
+    }
+    proxyEnv[key] = trimmed;
+  }
+  return proxyEnv;
+}
+
+async function preserveExistingLaunchAgentProxyEnvironment(params: {
+  env: GatewayServiceEnv;
+  environment?: Record<string, string | undefined>;
+}): Promise<Record<string, string | undefined> | undefined> {
+  // launchd does not inherit the macOS system proxy, so a service refresh that
+  // rewrites the plist from a shell without HTTP(S)_PROXY would silently break
+  // previously working gateway egress. Preserve the existing proxy env unless
+  // the current install explicitly overrides it.
+  const label = resolveLaunchAgentLabel({ env: params.env });
+  const plistPath = resolveLaunchAgentPlistPathForLabel(params.env, label);
+  const existing = await readLaunchAgentProgramArgumentsFromFile(plistPath);
+  const preservedProxyEnv = readProxyEnvironment(existing?.environment);
+  if (Object.keys(preservedProxyEnv).length === 0) {
+    return params.environment;
+  }
+
+  const mergedEnvironment = { ...params.environment };
+  let changed = false;
+  for (const [key, value] of Object.entries(preservedProxyEnv)) {
+    const current = mergedEnvironment[key];
+    if (typeof current === "string" && current.trim()) {
+      continue;
+    }
+    mergedEnvironment[key] = value;
+    changed = true;
+  }
+
+  if (!changed) {
+    return params.environment;
+  }
+  return mergedEnvironment;
 }
 
 export function resolveLaunchAgentPlistPath(env: GatewayServiceEnv): string {
@@ -619,6 +683,10 @@ async function writeLaunchAgentPlist({
   await ensureSecureDirectory(path.dirname(plistPath));
 
   const serviceDescription = resolveGatewayServiceDescription({ env, environment, description });
+  const mergedEnvironment = await preserveExistingLaunchAgentProxyEnvironment({
+    env,
+    environment,
+  });
   const plist = buildLaunchAgentPlist({
     label,
     comment: serviceDescription,
@@ -626,7 +694,7 @@ async function writeLaunchAgentPlist({
     workingDirectory,
     stdoutPath,
     stderrPath,
-    environment,
+    environment: mergedEnvironment,
   });
   await fs.writeFile(plistPath, plist, { encoding: "utf8", mode: LAUNCH_AGENT_PLIST_MODE });
   await fs.chmod(plistPath, LAUNCH_AGENT_PLIST_MODE).catch(() => undefined);


### PR DESCRIPTION
## Summary
- preserve existing launchd proxy environment variables when reinstalling the macOS LaunchAgent without proxy vars in the current shell
- keep explicit proxy overrides while filling missing proxy keys from the existing plist
- document that the macOS LaunchAgent does not inherit the system proxy from Network Settings

## Test Plan
- corepack pnpm test src/daemon/launchd.test.ts src/daemon/service-env.test.ts
- corepack pnpm build