### PR TITLE
fix(plugins): preserve existing capability during plugin cache state restore

### DIFF
--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -274,6 +274,59 @@ describe("memory plugin state", () => {
     expect(getMemoryRuntime()).toBe(runtime);
   });
 
+  it("restoreMemoryPluginState preserves existing capability when cached snapshot lacks it", () => {
+    const runtime = createMemoryRuntime();
+    registerMemoryCapability("memory-core", {
+      promptBuilder: () => ["capability prompt"],
+      flushPlanResolver: () => createMemoryFlushPlan("memory/capability.md"),
+      runtime,
+    });
+
+    // Snapshot taken BEFORE capability was registered (simulates plugin cache)
+    const snapshotWithoutCapability = {
+      capability: undefined,
+      corpusSupplements: [],
+      promptBuilder: undefined,
+      promptSupplements: [],
+      flushPlanResolver: undefined,
+      runtime: undefined,
+    };
+
+    restoreMemoryPluginState(snapshotWithoutCapability);
+
+    // Capability should be preserved, not overwritten with undefined
+    expect(getMemoryCapabilityRegistration()).toMatchObject({
+      pluginId: "memory-core",
+    });
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["capability prompt"]);
+    expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/capability.md");
+    expect(getMemoryRuntime()).toBe(runtime);
+  });
+
+  it("restoreMemoryPluginState overwrites capability when cached snapshot includes it", () => {
+    const runtimeA = createMemoryRuntime();
+    registerMemoryCapability("memory-core", {
+      promptBuilder: () => ["old prompt"],
+      runtime: runtimeA,
+    });
+
+    const runtimeB = createMemoryRuntime();
+    registerMemoryCapability("memory-wiki", {
+      promptBuilder: () => ["new prompt"],
+      runtime: runtimeB,
+    });
+    const snapshot = createMemoryStateSnapshot();
+
+    // Reset and restore from snapshot that HAS capability
+    _resetMemoryPluginState();
+    restoreMemoryPluginState(snapshot);
+
+    expect(getMemoryCapabilityRegistration()).toMatchObject({
+      pluginId: "memory-wiki",
+    });
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["new prompt"]);
+  });
+
   it("clearMemoryPluginState resets both registries", () => {
     registerMemoryState({
       promptSection: ["stale section"],

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -302,17 +302,27 @@ export async function listActiveMemoryPublicArtifacts(params: {
 }
 
 export function restoreMemoryPluginState(state: MemoryPluginState): void {
-  memoryPluginState.capability = state.capability
-    ? {
-        pluginId: state.capability.pluginId,
-        capability: { ...state.capability.capability },
-      }
-    : undefined;
-  memoryPluginState.corpusSupplements = [...state.corpusSupplements];
-  memoryPluginState.promptBuilder = state.promptBuilder;
-  memoryPluginState.promptSupplements = [...state.promptSupplements];
-  memoryPluginState.flushPlanResolver = state.flushPlanResolver;
-  memoryPluginState.runtime = state.runtime;
+  if (state.capability) {
+    memoryPluginState.capability = {
+      pluginId: state.capability.pluginId,
+      capability: { ...state.capability.capability },
+    };
+  }
+  if (state.corpusSupplements.length > 0 || !memoryPluginState.corpusSupplements.length) {
+    memoryPluginState.corpusSupplements = [...state.corpusSupplements];
+  }
+  if (state.promptBuilder !== undefined) {
+    memoryPluginState.promptBuilder = state.promptBuilder;
+  }
+  if (state.promptSupplements.length > 0 || !memoryPluginState.promptSupplements.length) {
+    memoryPluginState.promptSupplements = [...state.promptSupplements];
+  }
+  if (state.flushPlanResolver !== undefined) {
+    memoryPluginState.flushPlanResolver = state.flushPlanResolver;
+  }
+  if (state.runtime !== undefined) {
+    memoryPluginState.runtime = state.runtime;
+  }
 }
 
 export function clearMemoryPluginState(): void {


### PR DESCRIPTION
Fixes #68373

**Problem:** `restoreMemoryPluginState` from plugin cache overwrites memory capability with `undefined` because the cached snapshot was taken before capability registration. This causes wiki bridge import to return 0 artifacts.

**Fix:** Use a merge strategy that preserves existing capability values when the cached state doesn't include them (skip keys with `undefined` values in the cached snapshot).

**Tests:** Added tests verifying existing capability data is preserved during cache restore.