### PR TITLE
fix(sessions_spawn): silently strip ACP-only fields for runtime=subagent

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -328,7 +328,7 @@ describe("sessions_spawn tool", () => {
     );
   });
 
-  it("rejects resumeSessionId without runtime=acp", async () => {
+  it("silently drops resumeSessionId for runtime=subagent", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -338,9 +338,13 @@ describe("sessions_spawn tool", () => {
       resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
     });
 
-    expect(JSON.stringify(result)).toContain("resumeSessionId is only supported for runtime=acp");
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain("resumeSessionId is only supported");
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    const [spawnArgs] = hoisted.spawnSubagentDirectMock.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(spawnArgs).not.toHaveProperty("resumeSessionId");
   });
 
   it("rejects attachments for ACP runtime", async () => {
@@ -367,7 +371,7 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamTo when runtime is not "acp"', async () => {
+  it('silently drops streamTo when runtime is not "acp"', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -378,13 +382,13 @@ describe("sessions_spawn tool", () => {
       streamTo: "parent",
     });
 
-    expect(result.details).toMatchObject({
-      status: "error",
-    });
-    const details = result.details as { error?: string };
-    expect(details.error).toContain("streamTo is only supported for runtime=acp");
+    expect(JSON.stringify(result)).not.toContain("streamTo is only supported");
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    const [spawnArgs] = hoisted.spawnSubagentDirectMock.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(spawnArgs).not.toHaveProperty("streamTo");
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -101,7 +101,7 @@ const SessionsSpawnToolSchema = Type.Object({
   resumeSessionId: Type.Optional(
     Type.String({
       description:
-        'Resume an existing agent session by its ID (e.g. a Codex session UUID from ~/.codex/sessions/). Requires runtime="acp". The agent replays conversation history via session/load instead of starting fresh.',
+        'Resume an existing agent session by its ID (e.g. a Codex session UUID from ~/.codex/sessions/). Only applies when runtime="acp"; silently ignored for runtime="subagent". The agent replays conversation history via session/load instead of starting fresh.',
     }),
   ),
   model: Type.Optional(Type.String()),
@@ -176,7 +176,13 @@ export function createSessionsSpawnTool(
       const label = readStringParam(params, "label") ?? "";
       const runtime = params.runtime === "acp" ? "acp" : "subagent";
       const requestedAgentId = readStringParam(params, "agentId");
-      const resumeSessionId = readStringParam(params, "resumeSessionId");
+      // ACP-only fields: schema-strict LLMs (e.g. gpt-5.4) auto-fill these on
+      // every call regardless of the runtime they also set. The subagent code
+      // path never consumes either field, so silently drop them when
+      // runtime!=="acp" instead of failing the whole spawn. ACP semantics are
+      // preserved: fields still flow through unchanged when runtime==="acp".
+      const resumeSessionId =
+        runtime === "acp" ? readStringParam(params, "resumeSessionId") : undefined;
       const modelOverride = readStringParam(params, "model");
       const thinkingOverrideRaw = readStringParam(params, "thinking");
       const cwd = readStringParam(params, "cwd");
@@ -185,7 +191,8 @@ export function createSessionsSpawnTool(
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const expectsCompletionMessage = params.expectsCompletionMessage !== false;
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const streamTo =
+        runtime === "acp" && params.streamTo === "parent" ? "parent" : undefined;
       const lightContext = params.lightContext === true;
       if (runtime === "acp" && lightContext) {
         throw new Error("lightContext is only supported for runtime='subagent'.");
@@ -212,22 +219,6 @@ export function createSessionsSpawnTool(
         : undefined;
 
       const roleContext = requestedAgentId ? { role: requestedAgentId } : {};
-
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-          ...roleContext,
-        });
-      }
-
-      if (resumeSessionId && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `resumeSessionId is only supported for runtime=acp; got runtime=${runtime}`,
-          ...roleContext,
-        });
-      }
 
       if (runtime === "acp") {
         const { isSpawnAcpAcceptedResult, spawnAcpDirect } = await loadAcpSpawnModule();


### PR DESCRIPTION
## Summary

`sessions_spawn` currently hard-errors when `runtime="subagent"` receives `streamTo` or `resumeSessionId`, even though the subagent code path never consumes either field. Schema-strict providers (most notably `gpt-5.4` via the OpenAI bridge) auto-fill every advertised tool parameter on every call regardless of the runtime value the model also picks, which makes subagent spawns fail 90%+ of the time for those models.

This PR switches the two ACP-only fields from "reject with error" to "silently drop when `runtime!=='acp'`". ACP semantics are unchanged — when `runtime==='acp'` the fields flow through unmodified and the existing ACP spawn logic validates them.

## Why the silent-drop approach

- The subagent branch never reads `streamTo` / `resumeSessionId`, so dropping them has no observable effect on the subagent code path.
- Schema filtering per-runtime would be the cleaner long-term fix but requires reworking the shared tool-schema pipeline (tracked in #59225, #66719). Silent-drop unblocks affected users today without that churn.
- Hard-erroring loses to a predictable failure mode that many downstream models cannot avoid — the model doesn't know the field is ACP-only because the schema doesn't tell it.

## Related issues

Addresses (non-exhaustive):
- #68275 — sessions_spawn auto-injects `streamTo:"parent"` for `runtime="subagent"`
- #67248 — sessions_spawn(runtime="subagent") fails on 2026.4.14 with ACP-only streamTo under GPT-5.4
- #64714 — sessions_spawn rejects subagent runtime when streamTo is auto-filled by strict-mode providers
- #63120 — LLMs pass streamTo for subagent runtime causing 100% spawn failures
- #61724 — sessions_spawn(runtime="subagent") fails with "streamTo is only supported for runtime=acp"
- #60965 — sessions_spawn schema allows streamTo for runtime=subagent but execute rejects it
- #59390 — unified schema exposes ACP-only streamTo to subagent spawns
- #56193 — sessions_spawn(runtime="subagent") can receive ACP-only streamTo from tool-call bridge
- #56326 — sessions_spawn exposes ACP-only fields and breaks runtime=subagent with schema-following models
- #53370 — Make sessions_spawn more forgiving for ACP-only fields in subagent runtime
- #43556 — Bug: streamTo in sessions_spawn breaks subagent runtime

## Test plan

- [x] Updated existing `rejects resumeSessionId without runtime=acp` and `rejects streamTo when runtime is not "acp"` cases to assert the new silent-drop contract: the tool forwards to `spawnSubagentDirect` without the ACP-only keys and returns no error.
- [x] Unchanged: `runtime=acp` path still passes `streamTo` / `resumeSessionId` through to `spawnAcpDirect` (existing tests at lines 177, 226 still cover this).
- [ ] Suggested: add an integration test that round-trips a `runtime="subagent"` call with `streamTo="parent"` through the tool-call bridge to catch future regressions at the schema layer.