### PR TITLE
[Context] Avoid replaying current Slack bot thread context

### DIFF
--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -15,6 +15,7 @@ function createTestContext() {
     app: { client: {} } as App,
     runtime: {} as RuntimeEnv,
     botUserId: "U_BOT",
+    botId: "B_BOT",
     teamId: "T_EXPECTED",
     apiAppId: "A_EXPECTED",
     historyLimit: 0,

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -34,6 +34,7 @@ export type SlackMonitorContext = {
   runtime: RuntimeEnv;
 
   botUserId: string;
+  botId?: string;
   teamId: string;
   apiAppId: string;
 
@@ -102,6 +103,7 @@ export function createSlackMonitorContext(params: {
   runtime: RuntimeEnv;
 
   botUserId: string;
+  botId?: string;
   teamId: string;
   apiAppId: string;
 
@@ -395,6 +397,7 @@ export function createSlackMonitorContext(params: {
     app: params.app,
     runtime: params.runtime,
     botUserId: params.botUserId,
+    botId: params.botId,
     teamId: params.teamId,
     apiAppId: params.apiAppId,
     historyLimit: params.historyLimit,

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -100,8 +100,8 @@ describe("resolveSlackThreadContextData", () => {
 
     expect(result.threadStarterBody).toBeUndefined();
     expect(result.threadLabel).toBe("Slack thread #general");
-    expect(result.threadHistoryBody).toContain("assistant reply");
     expect(result.threadHistoryBody).toContain("allowed follow-up");
+    expect(result.threadHistoryBody).not.toContain("assistant reply");
     expect(result.threadHistoryBody).not.toContain("starter secret");
     expect(result.threadHistoryBody).not.toContain("blocked follow-up");
     expect(result.threadHistoryBody).not.toContain("current message");

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -46,7 +46,7 @@ describe("resolveSlackThreadContextData", () => {
 
   async function resolveAllowlistedThreadContext(params: {
     repliesMessages: Array<Record<string, string>>;
-    threadStarter: { text: string; userId: string; ts: string };
+    threadStarter: { text: string; userId?: string; ts: string; botId?: string };
     allowFromLower: string[];
     allowNameMatching: boolean;
   }) {
@@ -128,5 +128,50 @@ describe("resolveSlackThreadContextData", () => {
     expect(result.threadLabel).toContain("starter from Alice");
     expect(result.threadHistoryBody).toContain("starter from Alice");
     expect(result.threadHistoryBody).not.toContain("blocked follow-up");
+  });
+
+  it("omits bot-authored starter text and history from a new thread session", async () => {
+    const { result } = await resolveAllowlistedThreadContext({
+      repliesMessages: [
+        { text: "bot starter", bot_id: "B1", ts: "100.000" },
+        { text: "allowed follow-up", user: "U1", ts: "100.800" },
+        { text: "current message", user: "U1", ts: "101.000" },
+      ],
+      threadStarter: {
+        text: "bot starter",
+        botId: "B1",
+        ts: "100.000",
+      },
+      allowFromLower: ["u1"],
+      allowNameMatching: false,
+    });
+
+    expect(result.threadStarterBody).toBeUndefined();
+    expect(result.threadLabel).toBe("Slack thread #general");
+    expect(result.threadHistoryBody).toContain("allowed follow-up");
+    expect(result.threadHistoryBody).not.toContain("bot starter");
+    expect(result.threadHistoryBody).not.toContain("current message");
+  });
+
+  it("keeps third-party bot starter text in a new thread session", async () => {
+    const { result } = await resolveAllowlistedThreadContext({
+      repliesMessages: [
+        { text: "other bot starter", bot_id: "B2", ts: "100.000" },
+        { text: "allowed follow-up", user: "U1", ts: "100.800" },
+        { text: "current message", user: "U1", ts: "101.000" },
+      ],
+      threadStarter: {
+        text: "other bot starter",
+        botId: "B2",
+        ts: "100.000",
+      },
+      allowFromLower: ["u1"],
+      allowNameMatching: false,
+    });
+
+    expect(result.threadStarterBody).toBe("other bot starter");
+    expect(result.threadLabel).toContain("other bot starter");
+    expect(result.threadHistoryBody).toContain("other bot starter");
+    expect(result.threadHistoryBody).toContain("allowed follow-up");
   });
 });

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -56,6 +56,8 @@ describe("resolveSlackThreadContextData", () => {
       response_metadata: { next_cursor: "" },
     });
     const ctx = createThreadContext({ replies });
+    ctx.botUserId = "U_BOT";
+    ctx.botId = "B1";
     ctx.resolveUserName = async (id: string) => ({
       name: id === "U1" ? "Alice" : "Mallory",
     });
@@ -173,5 +175,26 @@ describe("resolveSlackThreadContextData", () => {
     expect(result.threadLabel).toContain("other bot starter");
     expect(result.threadHistoryBody).toContain("other bot starter");
     expect(result.threadHistoryBody).toContain("allowed follow-up");
+  });
+
+  it("omits self-authored starter text when identified by bot user id", async () => {
+    const { result } = await resolveAllowlistedThreadContext({
+      repliesMessages: [
+        { text: "self starter", user: "U_BOT", ts: "100.000" },
+        { text: "allowed follow-up", user: "U1", ts: "100.800" },
+        { text: "current message", user: "U1", ts: "101.000" },
+      ],
+      threadStarter: {
+        text: "self starter",
+        userId: "U_BOT",
+        ts: "100.000",
+      },
+      allowFromLower: ["u1"],
+      allowNameMatching: false,
+    });
+
+    expect(result.threadStarterBody).toBeUndefined();
+    expect(result.threadHistoryBody).toContain("allowed follow-up");
+    expect(result.threadHistoryBody).not.toContain("self starter");
   });
 });

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -174,7 +174,9 @@ describe("resolveSlackThreadContextData", () => {
     expect(result.threadStarterBody).toBe("other bot starter");
     expect(result.threadLabel).toContain("other bot starter");
     expect(result.threadHistoryBody).toContain("other bot starter");
+    expect(result.threadHistoryBody).toContain("Bot (B2) (assistant)");
     expect(result.threadHistoryBody).toContain("allowed follow-up");
+    expect(result.threadHistoryBody).not.toContain("Unknown (user)");
   });
 
   it("omits self-authored starter text when identified by bot user id", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -142,9 +142,14 @@ export async function resolveSlackThreadContextData(params: {
     });
 
     if (threadHistory.length > 0) {
+      const threadHistoryWithoutBots = threadHistory.filter((historyMsg) => !historyMsg.botId);
+      const omittedBotHistoryCount = threadHistory.length - threadHistoryWithoutBots.length;
+
       const uniqueUserIds = [
         ...new Set(
-          threadHistory.map((item) => item.userId).filter((id): id is string => Boolean(id)),
+          threadHistoryWithoutBots
+            .map((item) => item.userId)
+            .filter((id): id is string => Boolean(id)),
         ),
       ];
       const userMap = new Map<string, { name?: string }>();
@@ -156,9 +161,6 @@ export async function resolveSlackThreadContextData(params: {
           }
         }),
       );
-
-      const threadHistoryWithoutBots = threadHistory.filter((historyMsg) => !historyMsg.botId);
-      const omittedBotHistoryCount = threadHistory.length - threadHistoryWithoutBots.length;
 
       const { items: filteredThreadHistory, omitted: omittedHistoryCount } =
         filterSupplementalContextItems({
@@ -185,15 +187,12 @@ export async function resolveSlackThreadContextData(params: {
       const historyParts: string[] = [];
       for (const historyMsg of filteredThreadHistory) {
         const msgUser = historyMsg.userId ? userMap.get(historyMsg.userId) : null;
-        const msgSenderName =
-          msgUser?.name ?? (historyMsg.botId ? `Bot (${historyMsg.botId})` : "Unknown");
-        const isBot = Boolean(historyMsg.botId);
-        const role = isBot ? "assistant" : "user";
+        const msgSenderName = msgUser?.name ?? "Unknown";
         const msgWithId = `${historyMsg.text}\n[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${params.message.channel}]`;
         historyParts.push(
           formatInboundEnvelope({
             channel: "Slack",
-            from: `${msgSenderName} (${role})`,
+            from: `${msgSenderName} (user)`,
             timestamp: historyMsg.ts ? Math.round(Number(historyMsg.ts) * 1000) : undefined,
             body: msgWithId,
             chatType: "channel",

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -157,9 +157,12 @@ export async function resolveSlackThreadContextData(params: {
         }),
       );
 
+      const threadHistoryWithoutBots = threadHistory.filter((historyMsg) => !historyMsg.botId);
+      const omittedBotHistoryCount = threadHistory.length - threadHistoryWithoutBots.length;
+
       const { items: filteredThreadHistory, omitted: omittedHistoryCount } =
         filterSupplementalContextItems({
-          items: threadHistory,
+          items: threadHistoryWithoutBots,
           mode: params.contextVisibilityMode,
           kind: "thread",
           isSenderAllowed: (historyMsg) => {
@@ -173,9 +176,9 @@ export async function resolveSlackThreadContextData(params: {
             });
           },
         });
-      if (omittedHistoryCount > 0) {
+      if (omittedHistoryCount > 0 || omittedBotHistoryCount > 0) {
         logVerbose(
-          `slack: omitted ${omittedHistoryCount} thread message(s) from context (mode=${params.contextVisibilityMode})`,
+          `slack: omitted ${omittedHistoryCount + omittedBotHistoryCount} thread message(s) from context (mode=${params.contextVisibilityMode})`,
         );
       }
 

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -85,22 +85,25 @@ export async function resolveSlackThreadContextData(params: {
     params.allowNameMatching && starter?.userId
       ? (await params.ctx.resolveUserName(starter.userId))?.name
       : undefined;
+  const starterIsCurrentBot = Boolean(starter?.botId && starter.botId === params.ctx.botUserId);
   const starterAllowed =
     !starter ||
-    isSlackThreadContextSenderAllowed({
-      allowFromLower: params.allowFromLower,
-      allowNameMatching: params.allowNameMatching,
-      userId: starter.userId,
-      userName: starterSenderName,
-      botId: starter.botId,
-    });
+    (!starterIsCurrentBot &&
+      isSlackThreadContextSenderAllowed({
+        allowFromLower: params.allowFromLower,
+        allowNameMatching: params.allowNameMatching,
+        userId: starter.userId,
+        userName: starterSenderName,
+        botId: starter.botId,
+      }));
   const includeStarterContext =
     !starter ||
-    shouldIncludeSupplementalContext({
-      mode: params.contextVisibilityMode,
-      kind: "thread",
-      senderAllowed: starterAllowed,
-    });
+    (!starterIsCurrentBot &&
+      shouldIncludeSupplementalContext({
+        mode: params.contextVisibilityMode,
+        kind: "thread",
+        senderAllowed: starterAllowed,
+      }));
 
   if (starter?.text && includeStarterContext) {
     threadStarterBody = starter.text;
@@ -120,7 +123,9 @@ export async function resolveSlackThreadContextData(params: {
   } else {
     threadLabel = `Slack thread ${params.roomLabel}`;
   }
-  if (starter?.text && !includeStarterContext) {
+  if (starter?.text && starterIsCurrentBot) {
+    logVerbose("slack: omitted current-bot thread starter from context");
+  } else if (starter?.text && !includeStarterContext) {
     logVerbose(
       `slack: omitted thread starter from context (mode=${params.contextVisibilityMode}, sender_allowed=${starterAllowed ? "yes" : "no"})`,
     );
@@ -142,12 +147,15 @@ export async function resolveSlackThreadContextData(params: {
     });
 
     if (threadHistory.length > 0) {
-      const threadHistoryWithoutBots = threadHistory.filter((historyMsg) => !historyMsg.botId);
-      const omittedBotHistoryCount = threadHistory.length - threadHistoryWithoutBots.length;
+      const threadHistoryWithoutCurrentBot = threadHistory.filter(
+        (historyMsg) => !historyMsg.botId || historyMsg.botId !== params.ctx.botUserId,
+      );
+      const omittedCurrentBotHistoryCount =
+        threadHistory.length - threadHistoryWithoutCurrentBot.length;
 
       const uniqueUserIds = [
         ...new Set(
-          threadHistoryWithoutBots
+          threadHistoryWithoutCurrentBot
             .map((item) => item.userId)
             .filter((id): id is string => Boolean(id)),
         ),
@@ -164,7 +172,7 @@ export async function resolveSlackThreadContextData(params: {
 
       const { items: filteredThreadHistory, omitted: omittedHistoryCount } =
         filterSupplementalContextItems({
-          items: threadHistoryWithoutBots,
+          items: threadHistoryWithoutCurrentBot,
           mode: params.contextVisibilityMode,
           kind: "thread",
           isSenderAllowed: (historyMsg) => {
@@ -178,9 +186,9 @@ export async function resolveSlackThreadContextData(params: {
             });
           },
         });
-      if (omittedHistoryCount > 0 || omittedBotHistoryCount > 0) {
+      if (omittedHistoryCount > 0 || omittedCurrentBotHistoryCount > 0) {
         logVerbose(
-          `slack: omitted ${omittedHistoryCount + omittedBotHistoryCount} thread message(s) from context (mode=${params.contextVisibilityMode})`,
+          `slack: omitted ${omittedHistoryCount + omittedCurrentBotHistoryCount} thread message(s) from context (mode=${params.contextVisibilityMode})`,
         );
       }
 

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -64,6 +64,12 @@ export async function resolveSlackThreadContextData(params: {
   >;
   effectiveDirectMedia: SlackMediaResult[] | null;
 }): Promise<SlackThreadContextData> {
+  const isCurrentBotAuthor = (author: { userId?: string; botId?: string }): boolean =>
+    Boolean(
+      (params.ctx.botUserId && author.userId && author.userId === params.ctx.botUserId) ||
+      (params.ctx.botId && author.botId && author.botId === params.ctx.botId),
+    );
+
   let threadStarterBody: string | undefined;
   let threadHistoryBody: string | undefined;
   let threadSessionPreviousTimestamp: number | undefined;
@@ -85,7 +91,13 @@ export async function resolveSlackThreadContextData(params: {
     params.allowNameMatching && starter?.userId
       ? (await params.ctx.resolveUserName(starter.userId))?.name
       : undefined;
-  const starterIsCurrentBot = Boolean(starter?.botId && starter.botId === params.ctx.botUserId);
+  const starterIsCurrentBot = Boolean(
+    starter &&
+    isCurrentBotAuthor({
+      userId: starter.userId,
+      botId: starter.botId,
+    }),
+  );
   const starterAllowed =
     !starter ||
     (!starterIsCurrentBot &&
@@ -148,7 +160,11 @@ export async function resolveSlackThreadContextData(params: {
 
     if (threadHistory.length > 0) {
       const threadHistoryWithoutCurrentBot = threadHistory.filter(
-        (historyMsg) => !historyMsg.botId || historyMsg.botId !== params.ctx.botUserId,
+        (historyMsg) =>
+          !isCurrentBotAuthor({
+            userId: historyMsg.userId,
+            botId: historyMsg.botId,
+          }),
       );
       const omittedCurrentBotHistoryCount =
         threadHistory.length - threadHistoryWithoutCurrentBot.length;

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -211,12 +211,14 @@ export async function resolveSlackThreadContextData(params: {
       const historyParts: string[] = [];
       for (const historyMsg of filteredThreadHistory) {
         const msgUser = historyMsg.userId ? userMap.get(historyMsg.userId) : null;
-        const msgSenderName = msgUser?.name ?? "Unknown";
+        const isBot = Boolean(historyMsg.botId);
+        const msgSenderName = msgUser?.name ?? (isBot ? `Bot (${historyMsg.botId})` : "Unknown");
+        const role = isBot ? "assistant" : "user";
         const msgWithId = `${historyMsg.text}\n[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${params.message.channel}]`;
         historyParts.push(
           formatInboundEnvelope({
             channel: "Slack",
-            from: `${msgSenderName} (user)`,
+            from: `${msgSenderName} (${role})`,
             timestamp: historyMsg.ts ? Math.round(Number(historyMsg.ts) * 1000) : undefined,
             body: msgWithId,
             chatType: "channel",

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -23,6 +23,7 @@ export function createInboundSlackTestContext(params: {
     app: { client: params.appClient ?? {} } as App,
     runtime: {} as RuntimeEnv,
     botUserId: "B1",
+    botId: "B1",
     teamId: "T1",
     apiAppId: "A1",
     historyLimit: 0,

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -472,8 +472,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     expect(prepared).toBeTruthy();
     expect(prepared!.ctxPayload.IsFirstThreadTurn).toBe(true);
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("follow-up question");
+    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("current message");
     expect(replies).toHaveBeenCalledTimes(2);
   });

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-context-allowlist.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-context-allowlist.test.ts
@@ -140,8 +140,8 @@ describe("prepareSlackMessage thread context allowlists", () => {
     expect(prepared).toBeTruthy();
     expect(prepared!.ctxPayload.ThreadStarterBody).toBe("starter from room user");
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("starter from room user");
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("allowed follow-up");
+    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("current message");
     expect(replies).toHaveBeenCalledTimes(2);
   });
@@ -169,8 +169,8 @@ describe("prepareSlackMessage thread context allowlists", () => {
     expect(prepared).toBeTruthy();
     expect(prepared!.ctxPayload.ThreadStarterBody).toBe("starter from open room");
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("starter from open room");
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("open-room follow-up");
+    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("current message");
     expect(replies).toHaveBeenCalledTimes(2);
   });
@@ -192,8 +192,8 @@ describe("prepareSlackMessage thread context allowlists", () => {
     expect(prepared).toBeTruthy();
     expect(prepared!.ctxPayload.ThreadStarterBody).toBe("starter from open dm");
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("starter from open dm");
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("dm follow-up");
+    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("current message");
     expect(replies).toHaveBeenCalledTimes(2);
   });
@@ -215,8 +215,8 @@ describe("prepareSlackMessage thread context allowlists", () => {
     expect(prepared).toBeTruthy();
     expect(prepared!.ctxPayload.ThreadStarterBody).toBe("starter from mpim");
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("starter from mpim");
-    expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).toContain("mpim follow-up");
+    expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("assistant reply");
     expect(prepared!.ctxPayload.ThreadHistoryBody).not.toContain("current message");
     expect(replies).toHaveBeenCalledTimes(2);
   });

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -113,6 +113,7 @@ const baseParams = () => ({
   app: { client: {} } as App,
   runtime: {} as RuntimeEnv,
   botUserId: "B1",
+  botId: "B1",
   teamId: "T1",
   apiAppId: "A1",
   historyLimit: 0,

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -380,12 +380,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let unregisterHttpHandler: (() => void) | null = null;
 
   let botUserId = "";
+  let botId = "";
   let teamId = "";
   let apiAppId = "";
   const expectedApiAppIdFromAppToken = parseApiAppIdFromAppToken(appToken);
   try {
     const auth = await app.client.auth.test({ token: botToken });
     botUserId = auth.user_id ?? "";
+    botId = (auth as { bot_id?: string }).bot_id ?? "";
     teamId = auth.team_id ?? "";
     apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
   } catch {
@@ -405,6 +407,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     app,
     runtime,
     botUserId,
+    botId,
     teamId,
     apiAppId,
     historyLimit,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -281,6 +281,47 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
   });
 
+  it("does not duplicate thread starter text with a plain-text prelude", async () => {
+    vi.mocked(buildInboundUserContextPrefix).mockReturnValueOnce(
+      [
+        "Thread starter (untrusted, for context):",
+        "```json",
+        '{"body":"starter message"}',
+        "```",
+      ].join("\n"),
+    );
+
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+          ThreadStarterBody: "starter message",
+          OriginatingChannel: "slack",
+          OriginatingTo: "C123",
+          ChatType: "group",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          ThreadStarterBody: "starter message",
+          MediaPath: "/tmp/input.png",
+          Provider: "slack",
+          ChatType: "group",
+          OriginatingChannel: "slack",
+          OriginatingTo: "C123",
+        },
+      }),
+    );
+    expect(result).toEqual({ text: "ok" });
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    expect(call?.followupRun.prompt).toContain("Thread starter (untrusted, for context):");
+    expect(call?.followupRun.prompt).not.toContain("[Thread starter - for context]");
+  });
+
   it("returns the empty-body reply when there is no text and no media", async () => {
     const result = await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -281,6 +281,76 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
   });
 
+  it("falls back to thread starter context on follow-up turns when history is absent", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        isNewSession: false,
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+          ThreadStarterBody: "starter message",
+          ThreadHistoryBody: undefined,
+          OriginatingChannel: "slack",
+          OriginatingTo: "C123",
+          ChatType: "group",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          ThreadStarterBody: "starter message",
+          ThreadHistoryBody: undefined,
+          MediaPath: "/tmp/input.png",
+          Provider: "slack",
+          ChatType: "group",
+          OriginatingChannel: "slack",
+          OriginatingTo: "C123",
+        },
+      }),
+    );
+    expect(result).toEqual({ text: "ok" });
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    expect(call?.followupRun.prompt).toContain("[Thread starter - for context]");
+    expect(call?.followupRun.prompt).toContain("starter message");
+  });
+
+  it("prefers thread history over thread starter on follow-up turns", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        isNewSession: false,
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+          ThreadStarterBody: "starter message",
+          ThreadHistoryBody: "Earlier message in this thread",
+          OriginatingChannel: "slack",
+          OriginatingTo: "C123",
+          ChatType: "group",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          ThreadStarterBody: "starter message",
+          ThreadHistoryBody: "Earlier message in this thread",
+          MediaPath: "/tmp/input.png",
+          Provider: "slack",
+          ChatType: "group",
+          OriginatingChannel: "slack",
+          OriginatingTo: "C123",
+        },
+      }),
+    );
+    expect(result).toEqual({ text: "ok" });
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    expect(call?.followupRun.prompt).toContain("[Thread history - for context]");
+    expect(call?.followupRun.prompt).not.toContain("[Thread starter - for context]");
+  });
+
   it("does not duplicate thread starter text with a plain-text prelude", async () => {
     vi.mocked(buildInboundUserContextPrefix).mockReturnValueOnce(
       [

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -420,13 +420,10 @@ export async function runPreparedReply(
     }
   }
   const prefixedBodyCore = prefixedBodyBase;
-  const threadStarterBody = normalizeOptionalString(ctx.ThreadStarterBody);
   const threadHistoryBody = normalizeOptionalString(ctx.ThreadHistoryBody);
   const threadContextNote = threadHistoryBody
     ? `[Thread history - for context]\n${threadHistoryBody}`
-    : threadStarterBody
-      ? `[Thread starter - for context]\n${threadStarterBody}`
-      : undefined;
+    : undefined;
   const drainedSystemEventBlocks: string[] = [];
   let forceSenderIsOwnerFalseFromSystemEvents = false;
   const rebuildPromptBodies = async (): Promise<{

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -420,10 +420,13 @@ export async function runPreparedReply(
     }
   }
   const prefixedBodyCore = prefixedBodyBase;
+  const threadStarterBody = normalizeOptionalString(ctx.ThreadStarterBody);
   const threadHistoryBody = normalizeOptionalString(ctx.ThreadHistoryBody);
   const threadContextNote = threadHistoryBody
     ? `[Thread history - for context]\n${threadHistoryBody}`
-    : undefined;
+    : !isNewSession && threadStarterBody
+      ? `[Thread starter - for context]\n${threadStarterBody}`
+      : undefined;
   const drainedSystemEventBlocks: string[] = [];
   let forceSenderIsOwnerFalseFromSystemEvents = false;
   const rebuildPromptBodies = async (): Promise<{


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: fresh Slack thread bootstrap could replay OpenClaw's own prior Slack bot turns back into a new session as assistant context, and `runPreparedReply()` could duplicate `ThreadStarterBody` by emitting both the structured untrusted block and a plain-text `[Thread starter - for context]` prelude.
- Why it matters: a restarted or newly-created thread session could inherit low-value self-authored prompt text and duplicate starter content, both of which add noise to the agent prompt.
- What changed: first-turn Slack thread seeding now excludes only the current Slack bot's starter/history entries, preserves human and third-party bot context, and removes the plain-text `ThreadStarterBody` fallback when no `ThreadHistoryBody` exists.
- What did NOT change (scope boundary): allowlist/context-visibility behavior for non-bot senders is unchanged, and third-party bot/integration thread context is still retained.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #69006
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Slack first-turn bootstrap treated prior thread context too broadly, so OpenClaw-authored Slack bot turns could be replayed into the next session as assistant context, and `get-reply-run.ts` independently added a second plain-text starter prelude when only `ThreadStarterBody` existed.
- Missing detection / guardrail: there was no regression coverage distinguishing current-bot thread content from third-party bot context, and no test asserting that starter-only context should appear exactly once.
- Contributing context (if known): the branch originally removed all bot-authored thread history; `codex review --base origin/main` caught that as over-broad, so this update narrows the filter to the current Slack bot identity only.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts`, `extensions/slack/src/monitor/message-handler/prepare.thread-context-allowlist.test.ts`, `extensions/slack/src/monitor/message-handler/prepare.test.ts`, `src/auto-reply/reply/get-reply-run.media-only.test.ts`
- Scenario the test should lock in: fresh Slack thread bootstrap excludes the current bot's prior starter/history, retains third-party bot context, and does not duplicate starter-only prompt context.
- Why this is the smallest reliable guardrail: the bug lives at the Slack thread-context seam plus reply prompt construction, and these tests exercise those exact boundaries without needing a live Slack environment.
- Existing test that already covers this (if any): the Slack extension lane also covers the touched Slack surface via `pnpm test:extension slack`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Fresh Slack thread sessions no longer replay OpenClaw's own earlier Slack bot turns into `ThreadStarterBody` / `ThreadHistoryBody`.
- Third-party bot/integration messages in Slack threads are still preserved as context.
- Starter-only context is no longer duplicated by an extra plain-text `[Thread starter - for context]` prelude.

## Diagram (if applicable)

```text
Before:
[new Slack thread session] -> [seed all prior thread content] -> [self-bot turns and starter-only plain-text fallback can enter prompt]

After:
[new Slack thread session] -> [drop only current Slack bot starter/history] -> [keep human/third-party context] -> [single starter-context representation]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local `pnpm` / Vitest checkout
- Model/provider: Codex local review + edit workflow
- Integration/channel (if any): Slack
- Relevant config (redacted): `channels.slack.replyToMode=all`, `channels.slack.groupPolicy=open`, thread bootstrap enabled with `initialHistoryLimit=20`

### Steps

1. Start a fresh Slack thread session where the thread already contains earlier replies from OpenClaw.
2. Send a new follow-up in that thread after session creation or rehydration.
3. Inspect the seeded prompt context for `ThreadStarterBody` / `ThreadHistoryBody`.

### Expected

- OpenClaw's own earlier Slack bot turns are not replayed into the new session bootstrap.
- Third-party bot or human context remains available when relevant.
- Starter-only context appears once.

### Actual

- With this patch, the above expected behavior is observed in the focused regression suite and the Slack extension test lane.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: current-bot starter/history filtering, third-party bot starter retention, and the duplicate `ThreadStarterBody` prelude regression.
- Edge cases checked: allowlist mode, first-turn thread bootstrap, and media-only reply prompt construction.
- What you did **not** verify: a live Slack workspace/manual end-to-end run.

## AI Assistance

- [x] AI-assisted: Codex was used to implement and review this PR.
- Testing degree: fully tested for the touched surface; full-repo `pnpm build` / `pnpm check` still fail on unrelated existing issues noted below.
- Prompts/session logs: local Codex session history is available on request.
- I understand what the code does and reviewed the final changes before pushing.
- `codex review --base origin/main` was run locally and its actionable finding was addressed before this update.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: filtering by the current Slack bot identity could miss future self-authored payload shapes if Slack changes the relevant author fields.
  - Mitigation: added regression coverage for current-bot vs third-party-bot starter/history behavior; retained existing sender formatting path for all surviving context.
- Risk: full-repo validation is currently noisy due unrelated red checks.
  - Mitigation: ran focused regression coverage plus `pnpm test:extension slack`, and documented the unrelated failures below.

## Validation Notes

Passed locally:
- `codex review --base origin/main`
- `pnpm exec vitest run extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts extensions/slack/src/monitor/message-handler/prepare.thread-context-allowlist.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts`
- `pnpm test:extension slack`

Attempted but currently failing outside this diff:
- `pnpm build`
  - `extensions/lobster/src/lobster-runner.ts`: could not resolve `@clawdbot/lobster/core`
- `pnpm check`
  - `extensions/discord/src/monitor/gateway-plugin*.ts`: `firstHeartbeatTimeout` typing
  - `extensions/qa-lab/src/providers/aimock/server.ts`: `@copilotkit/aimock` / implicit `any`
  - tracked at `#69006` for the Discord / qa-lab failures
