### PR TITLE
fix(active-memory): honor timeoutMs values up to 90s

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1068,6 +1068,60 @@ describe("active-memory plugin", () => {
     expect(infoLines.some((line: string) => line.includes(" cached "))).toBe(false);
   });
 
+  it("honors a configured timeoutMs of 90_000ms", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      timeoutMs: 90_000,
+      logging: true,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+
+    await hooks.before_prompt_build(
+      { prompt: "what wings should i order? ninety second timeout", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:ninety-second-timeout",
+        messageProvider: "webchat",
+      },
+    );
+
+    expect(runEmbeddedPiAgent).toHaveBeenCalled();
+    const firstCall = runEmbeddedPiAgent.mock.calls[0]?.[0] as { timeoutMs?: number } | undefined;
+    expect(firstCall?.timeoutMs).toBe(90_000);
+    const infoLines = vi
+      .mocked(api.logger.info)
+      .mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(infoLines.some((line: string) => line.includes(" start timeoutMs=90000"))).toBe(true);
+  });
+
+  it("clamps configured timeoutMs values above 90_000ms down to 90_000ms", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      timeoutMs: 120_000,
+      logging: true,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+
+    await hooks.before_prompt_build(
+      { prompt: "what wings should i order? above cap timeout", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:above-cap-timeout",
+        messageProvider: "webchat",
+      },
+    );
+
+    expect(runEmbeddedPiAgent).toHaveBeenCalled();
+    const firstCall = runEmbeddedPiAgent.mock.calls[0]?.[0] as { timeoutMs?: number } | undefined;
+    expect(firstCall?.timeoutMs).toBe(90_000);
+    const infoLines = vi
+      .mocked(api.logger.info)
+      .mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(infoLines.some((line: string) => line.includes(" start timeoutMs=90000"))).toBe(true);
+  });
+
   it("does not share cached recall results across session-id-only contexts", async () => {
     api.pluginConfig = {
       agents: ["main"],

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -633,7 +633,8 @@ function normalizePluginConfig(pluginConfig: unknown): ResolvedActiveRecallPlugi
       parseOptionalPositiveInt(raw.timeoutMs, DEFAULT_TIMEOUT_MS),
       DEFAULT_TIMEOUT_MS,
       250,
-      60_000,
+      // Keep a bounded reply-path budget, but allow longer explicit operator canaries than 60s.
+      90_000,
     ),
     queryMode:
       raw.queryMode === "message" || raw.queryMode === "recent" || raw.queryMode === "full"


### PR DESCRIPTION
## Summary

- Problem: Active Memory silently clamps configured `timeoutMs` values above `60000` down to `60000`, so a requested `90000` budget never actually reaches runtime.
- Why it matters: operators can believe they are testing a longer Active Memory budget, but the helper still aborts at 60 seconds, which makes timeout tuning misleading and can leave pre-reply failures unresolved. The current behavior is also surprising because repo docs already show timeout examples above 60 seconds (for example `docs/pi.md` uses `timeoutMs: 120_000`).
- What changed: raise the Active Memory normalization ceiling from `60_000` to `90_000`, add an inline rationale comment, and add focused regression coverage for both `90000` pass-through and `120000 -> 90000` clamping.
- What did NOT change (scope boundary): default timeout behavior stays the same, lower configured values are unchanged, and this PR does not alter fail-open behavior, model routing, prompt shape, or any restart/drain behavior. This PR also does not add a warning log when clamping occurs; that can be a separate follow-up if maintainers want it. The choice of `90_000` is the smallest local validated fix for the already-configured 90s canary, not a claim that 90s is the only defensible ceiling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68410
- Related #66849
- Related #66708
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `normalizePluginConfig()` in `extensions/active-memory/index.ts` hard-codes the upper clamp for `timeoutMs` to `60_000`, so larger configured values are normalized down before runtime logging or abort timers are created.
- Missing detection / guardrail: there was no regression coverage asserting either (a) that a configured `timeoutMs = 90000` survives normalization and reaches the embedded recall run or (b) that values above the supported ceiling clamp predictably.
- Contributing context (if known): operators used higher Active Memory budgets as an explicit mitigation path for pre-reply timeouts, and repo docs already imply values above 60 seconds can be legitimate, so the silent clamp made real canary evaluation misleading.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/active-memory/index.test.ts`
- Scenario the test should lock in: configured `timeoutMs = 90000` is passed through to the embedded recall run and values above the supported ceiling (for example `120000`) clamp to `90000` before the embedded recall run is invoked.
- Why this is the smallest reliable guardrail: the bug lives in plugin-local normalization, but the helper is not currently exported as a stand-alone pure function. A plugin-level seam test catches the real contract break without widening PR scope just to export internals for a narrower unit test.
- Existing test that already covers this (if any): None found for this specific upper-bound contract.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Active Memory now honors configured `timeoutMs` values up to `90000` instead of silently capping them at `60000`.
- Configured values above `90000` continue to clamp to `90000`.
- No user-visible change for installs that keep the default timeout or use values below `60000`.

## Diagram (if applicable)

```text
Before:
config timeoutMs=90000 -> normalizePluginConfig clamp max 60000 -> runtime start timeoutMs=60000 -> helper aborts by 60s

After:
config timeoutMs=90000 -> normalizePluginConfig clamp max 90000 -> runtime start timeoutMs=90000 -> real 90s canary is possible
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (arm64)
- Runtime/container: package install
- Model/provider: Active Memory helper on a remote model; exact provider choice does not appear material to the clamp
- Integration/channel (if any): reproduced on a live host, but the bug is plugin-local and not channel-specific
- Relevant config (redacted): Active Memory enabled with `timeoutMs=90000`, `logging=true`

### Steps

1. Set Active Memory `timeoutMs` to `90000` and restart the gateway.
2. Trigger a normal conversation turn that runs Active Memory.
3. Observe runtime logs before this patch showing `start timeoutMs=60000`.
4. Apply this patch and restart.
5. Trigger the same class of conversation turn again.
6. Observe runtime logs showing `start timeoutMs=90000`.

### Expected

- Configured `timeoutMs=90000` should be honored by runtime and visible in the Active Memory start log.
- Configured values above the supported ceiling should clamp predictably to that ceiling rather than silently retaining an older hidden limit.

### Actual

- Before the patch, runtime still started with `timeoutMs=60000` even though config requested `90000`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)
- [x] Fresh focused local extension test run in the prepared clone
- [ ] Fresh clean-checkout CI run

## Human Verification (required)

- Verified scenarios:
  - Config requested `timeoutMs=90000`
  - Runtime logs before patch still showed `start timeoutMs=60000`
  - After the local validation patch, runtime logs showed `start timeoutMs=90000`
  - Subsequent Active Memory runs completed successfully under the new budget
  - Above-cap regression coverage was added for `120000 -> 90000` clamping in the prepared branch
  - Fresh focused test pass in the prepared clone:
    - `PATH=/tmp/openclaw-bin:$PATH node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/active-memory/index.test.ts`
    - Result: `1 file passed, 56 tests passed`
- Edge cases checked:
  - Lower values were not intentionally changed by this patch
  - This PR does not modify prompt shape, chat-type gating, or fallback policy
- What you did **not** verify:
  - Full CI on a clean upstream checkout
  - Cross-platform behavior outside the validated Linux/package-install path
  - Whether maintainers prefer `90_000` specifically versus a different supported ceiling, no ceiling, or warning-only design

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: higher configured Active Memory budgets can increase pre-reply latency when operators explicitly set values above 60 seconds.
  - Mitigation: the change only affects explicitly configured values above `60000`; defaults and lower values are unchanged.
- Risk: a broader timeout budget may allow more slow `status=empty` runs before aborting.
  - Mitigation: this PR does not change defaults; it only makes configured budgets truthful so operators can evaluate the tradeoff honestly.
- Risk: maintainers may prefer a different supported ceiling or an explicit warning path instead of `90_000` specifically.
  - Mitigation: the draft states that `90_000` was the smallest local validated fix for an already-configured canary, not a claim that it is the only valid policy choice.
- Deferred adjacent concern: warning when clamping still happens above the supported ceiling.
  - Mitigation: intentionally left out of this PR to keep the fix narrow and easy to review.
