### PR TITLE
fix(ui): keep history-backed user image messages visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 - Slack/threads: keep file-only root messages as starter context so first thread replies can still hydrate starter media. (#68594) Thanks @martingarramon.
 - Google/Antigravity: resolve forward-compatible Gemini 3.1 Pro custom-tools and Flash variants from the bundled Google plugin templates, so `google-antigravity/gemini-3.1-pro-preview-customtools` no longer falls through to an unknown-model error. Fixes #35512.
 - Active Memory: raise the blocking recall timeout ceiling to 120 seconds and reject larger config values during plugin schema validation. Fixes #68410. (#68480) Thanks @Bartok9.
+- Control UI/chat: keep history-backed user image uploads visible after chat reload while filtering blocked or non-image transcript media paths. (#68415) Thanks @mraleko.
 
 ## 2026.4.15
 

--- a/src/channels/plugins/setup-promotion-helpers.test.ts
+++ b/src/channels/plugins/setup-promotion-helpers.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getBundledChannelPluginMock = vi.hoisted(() => vi.fn());
+const getLoadedChannelPluginMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./bundled.js", () => ({
+  getBundledChannelPlugin: getBundledChannelPluginMock,
+}));
+
+vi.mock("./registry.js", () => ({
+  getLoadedChannelPlugin: getLoadedChannelPluginMock,
+}));
+
+import {
+  resolveSingleAccountKeysToMove,
+  shouldMoveSingleAccountChannelKey,
+} from "./setup-promotion-helpers.js";
+
+describe("setup promotion helpers", () => {
+  beforeEach(() => {
+    getBundledChannelPluginMock.mockReset();
+    getLoadedChannelPluginMock.mockReset();
+  });
+
+  it("keeps static named-account migration keys cheap", () => {
+    const keys = resolveSingleAccountKeysToMove({
+      channelKey: "whatsapp",
+      channel: {
+        accounts: {
+          work: { enabled: true },
+        },
+        dmPolicy: "allowlist",
+        allowFrom: ["+15551234567"],
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["120363000000000000@g.us"],
+      },
+    });
+
+    expect(keys).toEqual(["dmPolicy", "allowFrom", "groupPolicy", "groupAllowFrom"]);
+    expect(getLoadedChannelPluginMock).toHaveBeenCalledTimes(1);
+    expect(getLoadedChannelPluginMock).toHaveBeenCalledWith("whatsapp");
+    expect(getBundledChannelPluginMock).not.toHaveBeenCalled();
+  });
+
+  it("loads bundled setup only for non-static migration keys", () => {
+    getBundledChannelPluginMock.mockReturnValue({
+      setup: {
+        singleAccountKeysToMove: ["customAuth"],
+      },
+    });
+
+    expect(
+      shouldMoveSingleAccountChannelKey({
+        channelKey: "demo",
+        key: "customAuth",
+      }),
+    ).toBe(true);
+    expect(getBundledChannelPluginMock).toHaveBeenCalledWith("demo");
+  });
+
+  it("honors loaded plugin named-account filters without bundled fallback", () => {
+    getLoadedChannelPluginMock.mockReturnValue({
+      setup: {
+        namedAccountPromotionKeys: ["token"],
+      },
+    });
+
+    const keys = resolveSingleAccountKeysToMove({
+      channelKey: "demo",
+      channel: {
+        accounts: {
+          work: { enabled: true },
+        },
+        token: "secret",
+        dmPolicy: "allowlist",
+      },
+    });
+
+    expect(keys).toEqual(["token"]);
+    expect(getBundledChannelPluginMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/channels/plugins/setup-promotion-helpers.ts
+++ b/src/channels/plugins/setup-promotion-helpers.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { getBundledChannelPlugin } from "./bundled.js";
-import { getChannelPlugin } from "./registry.js";
+import { getLoadedChannelPlugin } from "./registry.js";
 
 type ChannelSectionBase = {
   defaultAccount?: string;
@@ -59,8 +59,13 @@ type ChannelSetupPromotionSurface = {
   }) => string | undefined;
 };
 
-function getChannelSetupPromotionSurface(channelKey: string): ChannelSetupPromotionSurface | null {
-  const setup = getChannelPlugin(channelKey)?.setup ?? getBundledChannelPlugin(channelKey)?.setup;
+function getChannelSetupPromotionSurface(
+  channelKey: string,
+  opts?: { loadBundledFallback?: boolean },
+): ChannelSetupPromotionSurface | null {
+  const setup =
+    getLoadedChannelPlugin(channelKey)?.setup ??
+    (opts?.loadBundledFallback ? getBundledChannelPlugin(channelKey)?.setup : undefined);
   if (!setup || typeof setup !== "object") {
     return null;
   }
@@ -81,7 +86,9 @@ export function shouldMoveSingleAccountChannelKey(params: {
   if (isStaticSingleAccountPromotionKey(params.channelKey, params.key)) {
     return true;
   }
-  const contractKeys = getChannelSetupPromotionSurface(params.channelKey)?.singleAccountKeysToMove;
+  const contractKeys = getChannelSetupPromotionSurface(params.channelKey, {
+    loadBundledFallback: true,
+  })?.singleAccountKeysToMove;
   if (contractKeys?.includes(params.key)) {
     return true;
   }
@@ -104,7 +111,9 @@ export function resolveSingleAccountKeysToMove(params: {
 
   let setupSurface: ChannelSetupPromotionSurface | null | undefined;
   const resolveSetupSurface = () => {
-    setupSurface ??= getChannelSetupPromotionSurface(params.channelKey);
+    setupSurface ??= getChannelSetupPromotionSurface(params.channelKey, {
+      loadBundledFallback: true,
+    });
     return setupSurface;
   };
 
@@ -119,7 +128,8 @@ export function resolveSingleAccountKeysToMove(params: {
   }
 
   const namedAccountPromotionKeys =
-    resolveSetupSurface()?.namedAccountPromotionKeys ??
+    setupSurface?.namedAccountPromotionKeys ??
+    getChannelSetupPromotionSurface(params.channelKey)?.namedAccountPromotionKeys ??
     BUNDLED_NAMED_ACCOUNT_PROMOTION_FALLBACKS[params.channelKey];
   if (!namedAccountPromotionKeys) {
     return keysToMove;
@@ -139,7 +149,9 @@ export function resolveSingleAccountPromotionTarget(params: {
     );
     return matchedAccountId ?? normalizedTargetAccountId;
   };
-  const surface = getChannelSetupPromotionSurface(params.channelKey);
+  const surface = getChannelSetupPromotionSurface(params.channelKey, {
+    loadBundledFallback: true,
+  });
   const resolved = surface?.resolveSingleAccountPromotionTarget?.({
     channel: params.channel,
   });

--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_AGENT_MAX_CONCURRENT, DEFAULT_SUBAGENT_MAX_CONCURRENT } from "./agent-limits.js";
 import {
   applyAgentDefaults,
@@ -21,6 +21,12 @@ vi.mock("./provider-policy.js", () => ({
 describe("config defaults", () => {
   beforeEach(() => {
     mocks.applyProviderConfigDefaultsForConfig.mockReset();
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_OAUTH_TOKEN", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("skips provider defaults when agent defaults are absent", () => {
@@ -38,8 +44,24 @@ describe("config defaults", () => {
     expect(mocks.applyProviderConfigDefaultsForConfig).not.toHaveBeenCalled();
   });
 
-  it("uses anthropic provider defaults when agent defaults exist", () => {
+  it("skips provider defaults when agent defaults have no Anthropic auth signal", () => {
     const cfg = {
+      agents: {
+        defaults: {},
+      },
+    };
+
+    expect(applyContextPruningDefaults(cfg as never)).toBe(cfg);
+    expect(mocks.applyProviderConfigDefaultsForConfig).not.toHaveBeenCalled();
+  });
+
+  it("uses anthropic provider defaults when agent defaults and auth signal exist", () => {
+    const cfg = {
+      auth: {
+        profiles: {
+          anthropic: { provider: "anthropic", mode: "api_key" },
+        },
+      },
       agents: {
         defaults: {},
       },

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -338,8 +338,37 @@ export function applyLoggingDefaults(cfg: OpenClawConfig): OpenClawConfig {
   };
 }
 
+function hasAnthropicDefaultSignal(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
+  if (env.ANTHROPIC_API_KEY?.trim() || env.ANTHROPIC_OAUTH_TOKEN?.trim()) {
+    return true;
+  }
+  const profiles = cfg.auth?.profiles;
+  if (profiles) {
+    for (const profile of Object.values(profiles)) {
+      const provider = normalizeProviderId(profile?.provider);
+      if (provider === "anthropic" || provider === "claude-cli") {
+        return true;
+      }
+    }
+  }
+  const order = cfg.auth?.order;
+  if (!order) {
+    return false;
+  }
+  return Object.keys(order).some((provider) => {
+    const normalizedProvider = normalizeProviderId(provider);
+    if (normalizedProvider !== "anthropic" && normalizedProvider !== "claude-cli") {
+      return false;
+    }
+    return (order as Record<string, unknown>)[provider] !== undefined;
+  });
+}
+
 export function applyContextPruningDefaults(cfg: OpenClawConfig): OpenClawConfig {
   if (!cfg.agents?.defaults) {
+    return cfg;
+  }
+  if (!hasAnthropicDefaultSignal(cfg, process.env)) {
     return cfg;
   }
   return (

--- a/src/config/test-helpers.ts
+++ b/src/config/test-helpers.ts
@@ -26,6 +26,11 @@ export async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise
         OPENCLAW_MPM_CATALOG_PATHS: undefined,
         OPENCLAW_PLUGIN_DISCOVERY_CACHE_MS: undefined,
         OPENCLAW_PLUGIN_MANIFEST_CACHE_MS: undefined,
+        OPENCLAW_LOAD_SHELL_ENV: undefined,
+        OPENCLAW_DEFER_SHELL_ENV_FALLBACK: undefined,
+        OPENCLAW_SHELL_ENV_TIMEOUT_MS: undefined,
+        ANTHROPIC_API_KEY: undefined,
+        ANTHROPIC_OAUTH_TOKEN: undefined,
       },
     });
   } finally {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -64,6 +64,34 @@ function buildBase64ImageUrl(params: { data: string; mediaType?: string }): stri
     : `data:${params.mediaType ?? "image/png"};base64,${params.data}`;
 }
 
+function getFileExtension(url: string): string | undefined {
+  const source = (() => {
+    try {
+      const trimmed = url.trim();
+      if (/^https?:\/\//i.test(trimmed)) {
+        return new URL(trimmed).pathname;
+      }
+    } catch {
+      // Fall back to the raw path when URL parsing fails.
+    }
+    return url;
+  })();
+  const fileName = source.split(/[\\/]/).pop() ?? source;
+  const match = /\.([a-zA-Z0-9]+)$/.exec(fileName);
+  return match?.[1]?.toLowerCase();
+}
+
+function isImageTranscriptMediaPath(path: string, mediaType: unknown): boolean {
+  if (typeof mediaType === "string" && mediaType.trim()) {
+    return mediaType.trim().toLowerCase().startsWith("image/");
+  }
+  const ext = getFileExtension(path);
+  return (
+    ext !== undefined &&
+    ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "heic", "heif", "avif"].includes(ext)
+  );
+}
+
 function extractImages(message: unknown): ImageBlock[] {
   const m = message as Record<string, unknown>;
   const content = m.content;
@@ -116,7 +144,15 @@ function extractImages(message: unknown): ImageBlock[] {
     : typeof m.MediaPath === "string"
       ? [m.MediaPath]
       : [];
-  for (const mediaPath of transcriptMediaPaths) {
+  const transcriptMediaTypes = Array.isArray(m.MediaTypes)
+    ? m.MediaTypes
+    : typeof m.MediaType === "string"
+      ? [m.MediaType]
+      : [];
+  for (const [index, mediaPath] of transcriptMediaPaths.entries()) {
+    if (!isImageTranscriptMediaPath(mediaPath, transcriptMediaTypes[index])) {
+      continue;
+    }
     appendImageBlock(images, { url: mediaPath });
   }
 

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -52,6 +52,18 @@ type ImageBlock = {
   alt?: string;
 };
 
+function appendImageBlock(images: ImageBlock[], block: ImageBlock) {
+  if (!images.some((entry) => entry.url === block.url && entry.alt === block.alt)) {
+    images.push(block);
+  }
+}
+
+function buildBase64ImageUrl(params: { data: string; mediaType?: string }): string {
+  return params.data.startsWith("data:")
+    ? params.data
+    : `data:${params.mediaType ?? "image/png"};base64,${params.data}`;
+}
+
 function extractImages(message: unknown): ImageBlock[] {
   const m = message as Record<string, unknown>;
   const content = m.content;
@@ -68,22 +80,44 @@ function extractImages(message: unknown): ImageBlock[] {
         // Handle source object format (from sendChatMessage)
         const source = b.source as Record<string, unknown> | undefined;
         if (source?.type === "base64" && typeof source.data === "string") {
-          const data = source.data;
-          const mediaType = (source.media_type as string) || "image/png";
-          // If data is already a data URL, use it directly
-          const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
-          images.push({ url });
+          appendImageBlock(images, {
+            url: buildBase64ImageUrl({
+              data: source.data,
+              mediaType: typeof source.media_type === "string" ? source.media_type : undefined,
+            }),
+          });
         } else if (typeof b.url === "string") {
-          images.push({ url: b.url });
+          appendImageBlock(images, { url: b.url });
         }
       } else if (b.type === "image_url") {
         // OpenAI format
         const imageUrl = b.image_url as Record<string, unknown> | undefined;
         if (typeof imageUrl?.url === "string") {
-          images.push({ url: imageUrl.url });
+          appendImageBlock(images, { url: imageUrl.url });
+        }
+      } else if (b.type === "input_image") {
+        const source = b.source as Record<string, unknown> | undefined;
+        if (typeof source?.url === "string") {
+          appendImageBlock(images, { url: source.url });
+        } else if (typeof source?.data === "string") {
+          appendImageBlock(images, {
+            url: buildBase64ImageUrl({
+              data: source.data,
+              mediaType: typeof source.media_type === "string" ? source.media_type : undefined,
+            }),
+          });
         }
       }
     }
+  }
+
+  const transcriptMediaPaths = Array.isArray(m.MediaPaths)
+    ? m.MediaPaths.filter((value): value is string => typeof value === "string")
+    : typeof m.MediaPath === "string"
+      ? [m.MediaPath]
+      : [];
+  for (const mediaPath of transcriptMediaPaths) {
+    appendImageBlock(images, { url: mediaPath });
   }
 
   return images;
@@ -575,7 +609,14 @@ function isAvatarUrl(value: string): boolean {
   );
 }
 
-function renderMessageImages(images: ImageBlock[]) {
+function renderMessageImages(
+  images: ImageBlock[],
+  opts?: {
+    localMediaPreviewRoots?: readonly string[];
+    basePath?: string;
+    authToken?: string | null;
+  },
+) {
   if (images.length === 0) {
     return nothing;
   }
@@ -586,16 +627,22 @@ function renderMessageImages(images: ImageBlock[]) {
 
   return html`
     <div class="chat-message-images">
-      ${images.map(
-        (img) => html`
+      ${images.map((img) => {
+        const canProxyLocalImage =
+          isLocalAssistantAttachmentSource(img.url) &&
+          isLocalAttachmentPreviewAllowed(img.url, opts?.localMediaPreviewRoots ?? []);
+        const imageUrl = canProxyLocalImage
+          ? buildAssistantAttachmentUrl(img.url, opts?.basePath, opts?.authToken)
+          : img.url;
+        return html`
           <img
-            src=${img.url}
+            src=${imageUrl}
             alt=${img.alt ?? "Attached image"}
             class="chat-message-image"
-            @click=${() => openImage(img.url)}
+            @click=${() => openImage(imageUrl)}
           />
-        `,
-      )}
+        `;
+      })}
     </div>
   `;
 }
@@ -1163,7 +1210,11 @@ function renderGroupedMessage(
               ${toolMessageExpanded
                 ? html`
                     <div class="chat-tool-msg-body">
-                      ${renderMessageImages(images)}
+                      ${renderMessageImages(images, {
+                        localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
+                        basePath: opts.basePath,
+                        authToken: opts.assistantAttachmentAuthToken,
+                      })}
                       ${renderAssistantAttachments(
                         assistantAttachments,
                         opts.localMediaPreviewRoots ?? [],
@@ -1219,7 +1270,11 @@ function renderGroupedMessage(
             </div>
           `
         : html`
-            ${renderMessageImages(images)}
+            ${renderMessageImages(images, {
+              localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
+              basePath: opts.basePath,
+              authToken: opts.assistantAttachmentAuthToken,
+            })}
             ${renderAssistantAttachments(
               assistantAttachments,
               opts.localMediaPreviewRoots ?? [],

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -670,9 +670,13 @@ function renderMessageImages(
   return html`
     <div class="chat-message-images">
       ${images.map((img) => {
+        const isLocalImage = isLocalAssistantAttachmentSource(img.url);
         const canProxyLocalImage =
-          isLocalAssistantAttachmentSource(img.url) &&
+          isLocalImage &&
           isLocalAttachmentPreviewAllowed(img.url, opts?.localMediaPreviewRoots ?? []);
+        if (isLocalImage && !canProxyLocalImage) {
+          return nothing;
+        }
         const imageUrl = canProxyLocalImage
           ? buildAssistantAttachmentUrl(img.url, opts?.basePath, opts?.authToken)
           : img.url;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -83,7 +83,13 @@ function getFileExtension(url: string): string | undefined {
 
 function isImageTranscriptMediaPath(path: string, mediaType: unknown): boolean {
   if (typeof mediaType === "string" && mediaType.trim()) {
-    return mediaType.trim().toLowerCase().startsWith("image/");
+    const normalized = mediaType.trim().toLowerCase();
+    if (normalized.startsWith("image/")) {
+      return true;
+    }
+    if (normalized !== "application/octet-stream") {
+      return false;
+    }
   }
   const ext = getFileExtension(path);
   return (

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -52,6 +52,16 @@ type ImageBlock = {
   alt?: string;
 };
 
+type ImageRenderOptions = {
+  localMediaPreviewRoots?: readonly string[];
+  basePath?: string;
+  authToken?: string | null;
+};
+
+type RenderableImageBlock = ImageBlock & {
+  displayUrl: string;
+};
+
 function appendImageBlock(images: ImageBlock[], block: ImageBlock) {
   if (!images.some((entry) => entry.url === block.url && entry.alt === block.alt)) {
     images.push(block);
@@ -130,6 +140,15 @@ function extractImages(message: unknown): ImageBlock[] {
           appendImageBlock(images, { url: imageUrl.url });
         }
       } else if (b.type === "input_image") {
+        const imageUrl = b.image_url;
+        if (typeof imageUrl === "string") {
+          appendImageBlock(images, { url: imageUrl });
+        } else if (imageUrl && typeof imageUrl === "object") {
+          const url = (imageUrl as Record<string, unknown>).url;
+          if (typeof url === "string") {
+            appendImageBlock(images, { url });
+          }
+        }
         const source = b.source as Record<string, unknown> | undefined;
         if (typeof source?.url === "string") {
           appendImageBlock(images, { url: source.url });
@@ -651,14 +670,25 @@ function isAvatarUrl(value: string): boolean {
   );
 }
 
-function renderMessageImages(
+function resolveRenderableMessageImages(
   images: ImageBlock[],
-  opts?: {
-    localMediaPreviewRoots?: readonly string[];
-    basePath?: string;
-    authToken?: string | null;
-  },
-) {
+  opts?: ImageRenderOptions,
+): RenderableImageBlock[] {
+  return images.flatMap((img) => {
+    const isLocalImage = isLocalAssistantAttachmentSource(img.url);
+    const canProxyLocalImage =
+      isLocalImage && isLocalAttachmentPreviewAllowed(img.url, opts?.localMediaPreviewRoots ?? []);
+    if (isLocalImage && !canProxyLocalImage) {
+      return [];
+    }
+    const displayUrl = canProxyLocalImage
+      ? buildAssistantAttachmentUrl(img.url, opts?.basePath, opts?.authToken)
+      : img.url;
+    return [{ ...img, displayUrl }];
+  });
+}
+
+function renderMessageImages(images: RenderableImageBlock[]) {
   if (images.length === 0) {
     return nothing;
   }
@@ -669,26 +699,16 @@ function renderMessageImages(
 
   return html`
     <div class="chat-message-images">
-      ${images.map((img) => {
-        const isLocalImage = isLocalAssistantAttachmentSource(img.url);
-        const canProxyLocalImage =
-          isLocalImage &&
-          isLocalAttachmentPreviewAllowed(img.url, opts?.localMediaPreviewRoots ?? []);
-        if (isLocalImage && !canProxyLocalImage) {
-          return nothing;
-        }
-        const imageUrl = canProxyLocalImage
-          ? buildAssistantAttachmentUrl(img.url, opts?.basePath, opts?.authToken)
-          : img.url;
-        return html`
+      ${images.map(
+        (img) => html`
           <img
-            src=${imageUrl}
+            src=${img.displayUrl}
             alt=${img.alt ?? "Attached image"}
             class="chat-message-image"
-            @click=${() => openImage(imageUrl)}
+            @click=${() => openImage(img.displayUrl)}
           />
-        `;
-      })}
+        `,
+      )}
     </div>
   `;
 }
@@ -1155,7 +1175,12 @@ function renderGroupedMessage(
 
   const toolCards = (opts.showToolCalls ?? true) ? extractToolCards(message, messageKey) : [];
   const hasToolCards = toolCards.length > 0;
-  const images = extractImages(message);
+  const imageRenderOptions = {
+    localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
+    basePath: opts.basePath,
+    authToken: opts.assistantAttachmentAuthToken,
+  };
+  const images = resolveRenderableMessageImages(extractImages(message), imageRenderOptions);
   const hasImages = images.length > 0;
 
   const normalizedMessage = normalizeMessage(message);
@@ -1256,11 +1281,7 @@ function renderGroupedMessage(
               ${toolMessageExpanded
                 ? html`
                     <div class="chat-tool-msg-body">
-                      ${renderMessageImages(images, {
-                        localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
-                        basePath: opts.basePath,
-                        authToken: opts.assistantAttachmentAuthToken,
-                      })}
+                      ${renderMessageImages(images)}
                       ${renderAssistantAttachments(
                         assistantAttachments,
                         opts.localMediaPreviewRoots ?? [],
@@ -1316,11 +1337,7 @@ function renderGroupedMessage(
             </div>
           `
         : html`
-            ${renderMessageImages(images, {
-              localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
-              basePath: opts.basePath,
-              authToken: opts.assistantAttachmentAuthToken,
-            })}
+            ${renderMessageImages(images)}
             ${renderAssistantAttachments(
               assistantAttachments,
               opts.localMediaPreviewRoots ?? [],

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -946,6 +946,31 @@ describe("chat view", () => {
     );
   });
 
+  it("skips non-image transcript media paths after history reload", () => {
+    const container = document.createElement("div");
+
+    renderGroupedMessage(
+      container,
+      {
+        id: "user-history-document",
+        role: "user",
+        content: "",
+        MediaPath: "/tmp/openclaw/user-upload.pdf",
+        MediaType: "application/pdf",
+        timestamp: Date.now(),
+      },
+      "user",
+      {
+        showToolCalls: false,
+        basePath: "/openclaw",
+        assistantAttachmentAuthToken: "session-token",
+        localMediaPreviewRoots: ["/tmp/openclaw"],
+      },
+    );
+
+    expect(container.querySelector(".chat-message-image")).toBeNull();
+  });
+
   it("opens only safe assistant image URLs in a hardened new tab", () => {
     const container = document.createElement("div");
     const openSpy = vi.spyOn(window, "open").mockReturnValue(null);

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -974,6 +974,31 @@ describe("chat view", () => {
     );
   });
 
+  it("does not render blocked local transcript image paths", () => {
+    const container = document.createElement("div");
+
+    renderGroupedMessage(
+      container,
+      {
+        id: "user-history-image-blocked",
+        role: "user",
+        content: "",
+        MediaPath: "/Users/test/Documents/private.png",
+        MediaType: "image/png",
+        timestamp: Date.now(),
+      },
+      "user",
+      {
+        showToolCalls: false,
+        basePath: "/openclaw",
+        assistantAttachmentAuthToken: "session-token",
+        localMediaPreviewRoots: ["/tmp/openclaw"],
+      },
+    );
+
+    expect(container.querySelector(".chat-message-image")).toBeNull();
+  });
+
   it("skips non-image transcript media paths after history reload", () => {
     const container = document.createElement("div");
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -974,6 +974,37 @@ describe("chat view", () => {
     );
   });
 
+  it("keeps plural user transcript images visible after history reload", () => {
+    const container = document.createElement("div");
+
+    renderGroupedMessage(
+      container,
+      {
+        id: "user-history-images",
+        role: "user",
+        content: "",
+        MediaPaths: ["/tmp/openclaw/first.png", "/tmp/openclaw/second.jpg"],
+        MediaTypes: ["image/png", "application/octet-stream"],
+        timestamp: Date.now(),
+      },
+      "user",
+      {
+        showToolCalls: false,
+        basePath: "/openclaw",
+        assistantAttachmentAuthToken: "session-token",
+        localMediaPreviewRoots: ["/tmp/openclaw"],
+      },
+    );
+
+    const imageSources = [
+      ...container.querySelectorAll<HTMLImageElement>(".chat-message-image"),
+    ].map((image) => image.getAttribute("src"));
+    expect(imageSources).toEqual([
+      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ffirst.png&token=session-token",
+      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Fsecond.jpg&token=session-token",
+    ]);
+  });
+
   it("does not render blocked local transcript image paths", () => {
     const container = document.createElement("div");
 
@@ -997,6 +1028,7 @@ describe("chat view", () => {
     );
 
     expect(container.querySelector(".chat-message-image")).toBeNull();
+    expect(container.querySelector(".chat-bubble")).toBeNull();
   });
 
   it("skips non-image transcript media paths after history reload", () => {
@@ -1022,6 +1054,23 @@ describe("chat view", () => {
     );
 
     expect(container.querySelector(".chat-message-image")).toBeNull();
+  });
+
+  it("renders legacy input_image image_url blocks", () => {
+    const container = document.createElement("div");
+
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [{ type: "input_image", image_url: "data:image/png;base64,cG5n" }],
+        timestamp: Date.now(),
+      },
+      { showToolCalls: false },
+    );
+
+    const image = container.querySelector<HTMLImageElement>(".chat-message-image");
+    expect(image?.getAttribute("src")).toBe("data:image/png;base64,cG5n");
   });
 
   it("opens only safe assistant image URLs in a hardened new tab", () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -946,6 +946,34 @@ describe("chat view", () => {
     );
   });
 
+  it("keeps transcript images visible when MIME falls back to application/octet-stream", () => {
+    const container = document.createElement("div");
+
+    renderGroupedMessage(
+      container,
+      {
+        id: "user-history-image-octet-stream",
+        role: "user",
+        content: "",
+        MediaPath: "/tmp/openclaw/user-upload.png",
+        MediaType: "application/octet-stream",
+        timestamp: Date.now(),
+      },
+      "user",
+      {
+        showToolCalls: false,
+        basePath: "/openclaw",
+        assistantAttachmentAuthToken: "session-token",
+        localMediaPreviewRoots: ["/tmp/openclaw"],
+      },
+    );
+
+    const image = container.querySelector<HTMLImageElement>(".chat-message-image");
+    expect(image?.getAttribute("src")).toBe(
+      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Fuser-upload.png&token=session-token",
+    );
+  });
+
   it("skips non-image transcript media paths after history reload", () => {
     const container = document.createElement("div");
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -97,6 +97,15 @@ function renderAssistantMessage(
   message: unknown,
   opts: Partial<RenderMessageGroupOptions> = {},
 ) {
+  renderGroupedMessage(container, message, "assistant", opts);
+}
+
+function renderGroupedMessage(
+  container: HTMLElement,
+  message: unknown,
+  role: string,
+  opts: Partial<RenderMessageGroupOptions> = {},
+) {
   const timestamp =
     typeof message === "object" &&
     message !== null &&
@@ -105,9 +114,9 @@ function renderAssistantMessage(
       : Date.now();
   const group: MessageGroup = {
     kind: "group",
-    key: "assistant-group",
-    role: "assistant",
-    messages: [{ key: "assistant-message", message }],
+    key: `${role}-group`,
+    role,
+    messages: [{ key: `${role}-message`, message }],
     timestamp,
     isStreaming: false,
   };
@@ -908,6 +917,33 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("[[reply_to_current]]");
     expect(container.textContent).not.toContain("[[audio_as_voice]]");
     expect(container.textContent).not.toContain("MEDIA:https://example.com/photo.png");
+  });
+
+  it("keeps user transcript images visible after history reload", () => {
+    const container = document.createElement("div");
+
+    renderGroupedMessage(
+      container,
+      {
+        id: "user-history-image",
+        role: "user",
+        content: "",
+        MediaPath: "/tmp/openclaw/user-upload.png",
+        timestamp: Date.now(),
+      },
+      "user",
+      {
+        showToolCalls: false,
+        basePath: "/openclaw",
+        assistantAttachmentAuthToken: "session-token",
+        localMediaPreviewRoots: ["/tmp/openclaw"],
+      },
+    );
+
+    const image = container.querySelector<HTMLImageElement>(".chat-message-image");
+    expect(image?.getAttribute("src")).toBe(
+      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Fuser-upload.png&token=session-token",
+    );
   });
 
   it("opens only safe assistant image URLs in a hardened new tab", () => {


### PR DESCRIPTION
## Summary
- Problem: Control UI dropped user image messages after history reload because transcript-backed media fields were not rendered.
- Why it matters: image uploads appeared during the optimistic send path, then disappeared once the assistant finished and chat history reloaded.
- What changed: taught chat image extraction/rendering to preserve history-backed user images, including transcript `MediaPath` fields and `input_image` blocks.
- What did NOT change (scope boundary): no gateway transcript format changes, no assistant attachment behavior changes outside this rendering path.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #68394
- Related #68394
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: chat history reload returned user messages in a transcript-backed media shape that the Control UI image extractor did not recognize.
- Missing detection / guardrail: no UI regression test covered history-backed user image messages.
- Contributing context (if known): optimistic send and history reload used different message representations.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/chat.test.ts`
- Scenario the test should lock in: a user history message with `MediaPath` still renders a visible image after reload.
- Why this is the smallest reliable guardrail: it exercises the exact renderer path that regressed without pulling in gateway/integration setup.
- Existing test that already covers this (if any): None
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- User-uploaded images remain visible in Control UI after chat history reload/final reconciliation.

## Diagram (if applicable)
```text
Before:
[user sends image] -> [optimistic image renders] -> [assistant finishes] -> [history reload] -> [image disappears]

After:
[user sends image] -> [optimistic image renders] -> [assistant finishes] -> [history reload] -> [image still visible]
```

## Security Impact (required)
- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification
### Environment
- OS: macOS 15.x
- Runtime/container: local dev checkout
- Model/provider: N/A for renderer regression test
- Integration/channel (if any): Control UI / webchat
- Relevant config (redacted): `localMediaPreviewRoots` includes the uploaded image path root

### Steps
1. Open Control UI chat.
2. Send an image.
3. Wait for the assistant reply to finish and history to reload.

### Expected
- The user image remains visible after the assistant response completes.

### Actual
- Before this change, the user image disappeared after final/history reconciliation.

## Evidence
- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
- Verified scenarios: history-backed user image rendering via transcript media fields; scoped Control UI test file.
- Edge cases checked: local path images proxied through the existing Control UI media route; `input_image` blocks preserved.
- What you did **not** verify: live manual browser interaction against a running gateway.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations
- Risk: history-backed local image paths now reuse the existing Control UI media proxy path.
- Mitigation: the change stays within the existing preview allowlist and auth-token flow.