### PR TITLE
fix(agents): forward-compat adaptive thinking for Claude 4.7+ models

### DIFF
--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -278,6 +278,16 @@ describe("anthropic provider replay hooks", () => {
     ).toBe(false);
   });
 
+  it("forward-compat: adaptive thinking default for future sonnet-4-8", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    expect(
+      provider.resolveDefaultThinkingLevel?.({
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-8",
+      } as never),
+    ).toBe("adaptive");
+  });
+
   it("does not return adaptive default for date-stamped model IDs", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
     expect(

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -220,6 +220,54 @@ describe("anthropic provider replay hooks", () => {
     ).toBe(false);
   });
 
+  it("resolves claude-sonnet-4-7 refs from the 4.6 template family", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-7",
+      modelRegistry: createModelRegistry([
+        {
+          id: "claude-sonnet-4-6",
+          name: "Claude Sonnet 4.6",
+          provider: "anthropic",
+          api: "anthropic-messages",
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200_000,
+          maxTokens: 32_000,
+        } as ProviderRuntimeModel,
+      ]),
+    } as ProviderResolveDynamicModelContext);
+
+    expect(resolved).toMatchObject({
+      provider: "anthropic",
+      id: "claude-sonnet-4-7",
+      api: "anthropic-messages",
+      reasoning: true,
+    });
+  });
+
+  it("forward-compat: supportsXHighThinking matches future opus-4-8 model", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    expect(
+      provider.supportsXHighThinking?.({
+        provider: "anthropic",
+        modelId: "claude-opus-4-8",
+      } as never),
+    ).toBe(true);
+  });
+
+  it("forward-compat: adaptive thinking default for sonnet-4-7", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    expect(
+      provider.resolveDefaultThinkingLevel?.({
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-7",
+      } as never),
+    ).toBe("adaptive");
+  });
+
   it("resolves claude-cli synthetic oauth auth", async () => {
     readClaudeCliCredentialsForRuntimeMock.mockReset();
     readClaudeCliCredentialsForRuntimeMock.mockReturnValue({

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -268,7 +268,7 @@ describe("anthropic provider replay hooks", () => {
     ).toBe("adaptive");
   });
 
-  it("does not match date-stamped model IDs as xhigh-capable", async () => {
+  it("does not match date-stamped model IDs for xhigh or adaptive defaults", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
     expect(
       provider.supportsXHighThinking?.({
@@ -276,20 +276,6 @@ describe("anthropic provider replay hooks", () => {
         modelId: "claude-opus-4-20250918",
       } as never),
     ).toBe(false);
-  });
-
-  it("forward-compat: adaptive thinking default for future sonnet-4-8", async () => {
-    const provider = await registerSingleProviderPlugin(anthropicPlugin);
-    expect(
-      provider.resolveDefaultThinkingLevel?.({
-        provider: "anthropic",
-        modelId: "claude-sonnet-4-8",
-      } as never),
-    ).toBe("adaptive");
-  });
-
-  it("does not return adaptive default for date-stamped model IDs", async () => {
-    const provider = await registerSingleProviderPlugin(anthropicPlugin);
     expect(
       provider.resolveDefaultThinkingLevel?.({
         provider: "anthropic",

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -268,6 +268,26 @@ describe("anthropic provider replay hooks", () => {
     ).toBe("adaptive");
   });
 
+  it("does not match date-stamped model IDs as xhigh-capable", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    expect(
+      provider.supportsXHighThinking?.({
+        provider: "anthropic",
+        modelId: "claude-opus-4-20250918",
+      } as never),
+    ).toBe(false);
+  });
+
+  it("does not return adaptive default for date-stamped model IDs", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    expect(
+      provider.resolveDefaultThinkingLevel?.({
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-20250514",
+      } as never),
+    ).toBeUndefined();
+  });
+
   it("resolves claude-cli synthetic oauth auth", async () => {
     readClaudeCliCredentialsForRuntimeMock.mockReset();
     readClaudeCliCredentialsForRuntimeMock.mockReturnValue({

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -514,7 +514,7 @@ export function buildAnthropicProvider(): ProviderPlugin {
     resolveDefaultThinkingLevel: ({ modelId }) =>
       isAnthropicOpusXHighModel(modelId)
         ? "off"
-        : matchesAnthropicModernModel(modelId) && shouldUseAnthropicAdaptiveThinkingDefault(modelId)
+        : shouldUseAnthropicAdaptiveThinkingDefault(modelId)
           ? "adaptive"
           : undefined,
     resolveUsageAuth: async (ctx) => await ctx.resolveOAuthToken(),

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -53,16 +53,32 @@ const ANTHROPIC_OPUS_47_TEMPLATE_MODEL_IDS = [
   "claude-opus-4.5",
 ] as const;
 const ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS = ["claude-opus-4-5", "claude-opus-4.5"] as const;
+const ANTHROPIC_SONNET_47_MODEL_ID = "claude-sonnet-4-7";
+const ANTHROPIC_SONNET_47_DOT_MODEL_ID = "claude-sonnet-4.7";
+const ANTHROPIC_SONNET_47_TEMPLATE_MODEL_IDS = [
+  "claude-sonnet-4-6",
+  "claude-sonnet-4.6",
+  "claude-sonnet-4-5",
+  "claude-sonnet-4.5",
+] as const;
 const ANTHROPIC_SONNET_46_MODEL_ID = "claude-sonnet-4-6";
 const ANTHROPIC_SONNET_46_DOT_MODEL_ID = "claude-sonnet-4.6";
 const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet-4.5"] as const;
 const ANTHROPIC_MODERN_MODEL_PREFIXES = [
   "claude-opus-4-7",
+  "claude-opus-4.7",
+  "claude-sonnet-4-7",
+  "claude-sonnet-4.7",
   "claude-opus-4-6",
+  "claude-opus-4.6",
   "claude-sonnet-4-6",
+  "claude-sonnet-4.6",
   "claude-opus-4-5",
+  "claude-opus-4.5",
   "claude-sonnet-4-5",
+  "claude-sonnet-4.5",
   "claude-haiku-4-5",
+  "claude-haiku-4.5",
 ] as const;
 const ANTHROPIC_SETUP_TOKEN_NOTE_LINES = [
   "Anthropic setup-token auth is supported in OpenClaw.",
@@ -251,6 +267,14 @@ function resolveAnthropicForwardCompatModel(
     }) ??
     resolveAnthropic46ForwardCompatModel({
       ctx,
+      dashModelId: ANTHROPIC_SONNET_47_MODEL_ID,
+      dotModelId: ANTHROPIC_SONNET_47_DOT_MODEL_ID,
+      dashTemplateId: ANTHROPIC_SONNET_46_MODEL_ID,
+      dotTemplateId: ANTHROPIC_SONNET_46_DOT_MODEL_ID,
+      fallbackTemplateIds: ANTHROPIC_SONNET_47_TEMPLATE_MODEL_IDS,
+    }) ??
+    resolveAnthropic46ForwardCompatModel({
+      ctx,
       dashModelId: ANTHROPIC_SONNET_46_MODEL_ID,
       dotModelId: ANTHROPIC_SONNET_46_DOT_MODEL_ID,
       dashTemplateId: "claude-sonnet-4-5",
@@ -260,22 +284,18 @@ function resolveAnthropicForwardCompatModel(
   );
 }
 
+// All Claude Opus/Sonnet 4.6+ default to adaptive thinking.
+const ADAPTIVE_DEFAULT_PATTERN = /(opus|sonnet)-4[.-]([6-9]|\d{2,})/;
+
 function shouldUseAnthropicAdaptiveThinkingDefault(modelId: string): boolean {
-  const lowerModelId = normalizeLowercaseStringOrEmpty(modelId);
-  return (
-    lowerModelId.startsWith(ANTHROPIC_OPUS_46_MODEL_ID) ||
-    lowerModelId.startsWith(ANTHROPIC_OPUS_46_DOT_MODEL_ID) ||
-    lowerModelId.startsWith(ANTHROPIC_SONNET_46_MODEL_ID) ||
-    lowerModelId.startsWith(ANTHROPIC_SONNET_46_DOT_MODEL_ID)
-  );
+  return ADAPTIVE_DEFAULT_PATTERN.test(normalizeLowercaseStringOrEmpty(modelId));
 }
 
-function isAnthropicOpus47Model(modelId: string): boolean {
-  const lowerModelId = normalizeLowercaseStringOrEmpty(modelId);
-  return (
-    lowerModelId.startsWith(ANTHROPIC_OPUS_47_MODEL_ID) ||
-    lowerModelId.startsWith(ANTHROPIC_OPUS_47_DOT_MODEL_ID)
-  );
+// Opus 4.7+ supports the native "xhigh" effort level.
+const OPUS_XHIGH_PATTERN = /opus-4[.-]([7-9]|\d{2,})/;
+
+function isAnthropicOpusXHighModel(modelId: string): boolean {
+  return OPUS_XHIGH_PATTERN.test(normalizeLowercaseStringOrEmpty(modelId));
 }
 
 function matchesAnthropicModernModel(modelId: string): boolean {
@@ -489,10 +509,10 @@ export function buildAnthropicProvider(): ProviderPlugin {
     buildReplayPolicy: buildAnthropicReplayPolicy,
     isModernModelRef: ({ modelId }) => matchesAnthropicModernModel(modelId),
     resolveReasoningOutputMode: () => "native",
-    supportsXHighThinking: ({ modelId }) => isAnthropicOpus47Model(modelId),
+    supportsXHighThinking: ({ modelId }) => isAnthropicOpusXHighModel(modelId),
     wrapStreamFn: wrapAnthropicProviderStream,
     resolveDefaultThinkingLevel: ({ modelId }) =>
-      isAnthropicOpus47Model(modelId)
+      isAnthropicOpusXHighModel(modelId)
         ? "off"
         : matchesAnthropicModernModel(modelId) && shouldUseAnthropicAdaptiveThinkingDefault(modelId)
           ? "adaptive"

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -285,14 +285,14 @@ function resolveAnthropicForwardCompatModel(
 }
 
 // All Claude Opus/Sonnet 4.6+ default to adaptive thinking.
-const ADAPTIVE_DEFAULT_PATTERN = /(opus|sonnet)-4[.-]([6-9]|\d{2,})/;
+const ADAPTIVE_DEFAULT_PATTERN = /(opus|sonnet)-4[.-]([6-9]|[1-9]\d)(?!\d)/;
 
 function shouldUseAnthropicAdaptiveThinkingDefault(modelId: string): boolean {
   return ADAPTIVE_DEFAULT_PATTERN.test(normalizeLowercaseStringOrEmpty(modelId));
 }
 
 // Opus 4.7+ supports the native "xhigh" effort level.
-const OPUS_XHIGH_PATTERN = /opus-4[.-]([7-9]|\d{2,})/;
+const OPUS_XHIGH_PATTERN = /opus-4[.-]([7-9]|[1-9]\d)(?!\d)/;
 
 function isAnthropicOpusXHighModel(modelId: string): boolean {
   return OPUS_XHIGH_PATTERN.test(normalizeLowercaseStringOrEmpty(modelId));

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -516,4 +516,94 @@ describe("anthropic transport stream", () => {
       undefined,
     );
   });
+
+  it("uses adaptive thinking for Claude Sonnet 4.7 transport runs", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-sonnet-4-7",
+        name: "Claude Sonnet 4.7",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Think about this." }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+          reasoning: "high",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(anthropicMessagesStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thinking: { type: "adaptive" },
+        output_config: { effort: "high" },
+      }),
+      undefined,
+    );
+  });
+
+  it("forward-compat: uses adaptive thinking for future Claude opus-4-8 model", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-opus-4-8",
+        name: "Claude Opus 4.8",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Think about the future." }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+          reasoning: "xhigh",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(anthropicMessagesStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thinking: { type: "adaptive" },
+        output_config: { effort: "xhigh" },
+      }),
+      undefined,
+    );
+  });
 });

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -606,4 +606,48 @@ describe("anthropic transport stream", () => {
       undefined,
     );
   });
+
+  it("does not use adaptive thinking for date-stamped model IDs", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-sonnet-4-20250514",
+        name: "Claude Sonnet 4 (20250514)",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      {
+        proxy: {
+          mode: "env-proxy",
+        },
+      },
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Test date-stamped model." }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+          reasoning: "high",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(anthropicMessagesStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thinking: { type: "enabled", budget_tokens: expect.any(Number) },
+      }),
+      undefined,
+    );
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -106,6 +106,8 @@ function isClaudeOpus46Model(modelId: string): boolean {
 // All Claude Opus/Sonnet 4.6+ use adaptive thinking (type: "adaptive" + output_config.effort)
 // instead of budget-based thinking (type: "enabled" + budget_tokens).
 const ADAPTIVE_THINKING_PATTERN = /(opus|sonnet)-4[.-]([6-9]|[1-9]\d)(?!\d)/;
+// Opus 4.7+ supports the native "xhigh" effort level.
+const OPUS_XHIGH_PATTERN = /opus-4[.-]([7-9]|[1-9]\d)(?!\d)/;
 
 function supportsAdaptiveThinking(modelId: string): boolean {
   return ADAPTIVE_THINKING_PATTERN.test(modelId);
@@ -124,7 +126,7 @@ function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): Anthro
         return "max";
       }
       // Opus 4.7+ supports native xhigh effort.
-      return /opus-4[.-]([7-9]|[1-9]\d)(?!\d)/.test(modelId) ? "xhigh" : "high";
+      return OPUS_XHIGH_PATTERN.test(modelId) ? "xhigh" : "high";
     default:
       return "high";
   }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -99,21 +99,16 @@ type MutableAssistantOutput = {
   errorMessage?: string;
 };
 
-function isClaudeOpus47Model(modelId: string): boolean {
-  return modelId.includes("opus-4-7") || modelId.includes("opus-4.7");
-}
-
 function isClaudeOpus46Model(modelId: string): boolean {
   return modelId.includes("opus-4-6") || modelId.includes("opus-4.6");
 }
 
+// All Claude Opus/Sonnet 4.6+ use adaptive thinking (type: "adaptive" + output_config.effort)
+// instead of budget-based thinking (type: "enabled" + budget_tokens).
+const ADAPTIVE_THINKING_PATTERN = /(opus|sonnet)-4[.-]([6-9]|\d{2,})/;
+
 function supportsAdaptiveThinking(modelId: string): boolean {
-  return (
-    isClaudeOpus47Model(modelId) ||
-    isClaudeOpus46Model(modelId) ||
-    modelId.includes("sonnet-4-6") ||
-    modelId.includes("sonnet-4.6")
-  );
+  return ADAPTIVE_THINKING_PATTERN.test(modelId);
 }
 
 function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): AnthropicAdaptiveEffort {
@@ -124,10 +119,12 @@ function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): Anthro
     case "medium":
       return "medium";
     case "xhigh":
-      if (isClaudeOpus47Model(modelId)) {
-        return "xhigh";
+      // Opus 4.6 predates native xhigh effort; map to "max" instead.
+      if (isClaudeOpus46Model(modelId)) {
+        return "max";
       }
-      return isClaudeOpus46Model(modelId) ? "max" : "high";
+      // Opus 4.7+ supports native xhigh effort.
+      return /opus-4[.-]([7-9]|\d{2,})/.test(modelId) ? "xhigh" : "high";
     default:
       return "high";
   }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -105,7 +105,7 @@ function isClaudeOpus46Model(modelId: string): boolean {
 
 // All Claude Opus/Sonnet 4.6+ use adaptive thinking (type: "adaptive" + output_config.effort)
 // instead of budget-based thinking (type: "enabled" + budget_tokens).
-const ADAPTIVE_THINKING_PATTERN = /(opus|sonnet)-4[.-]([6-9]|\d{2,})/;
+const ADAPTIVE_THINKING_PATTERN = /(opus|sonnet)-4[.-]([6-9]|[1-9]\d)(?!\d)/;
 
 function supportsAdaptiveThinking(modelId: string): boolean {
   return ADAPTIVE_THINKING_PATTERN.test(modelId);
@@ -124,7 +124,7 @@ function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): Anthro
         return "max";
       }
       // Opus 4.7+ supports native xhigh effort.
-      return /opus-4[.-]([7-9]|\d{2,})/.test(modelId) ? "xhigh" : "high";
+      return /opus-4[.-]([7-9]|[1-9]\d)(?!\d)/.test(modelId) ? "xhigh" : "high";
     default:
       return "high";
   }


### PR DESCRIPTION
## Summary

- Problem: `supportsAdaptiveThinking()` in `anthropic-transport-stream.ts` and `shouldUseAnthropicAdaptiveThinkingDefault()` in `register.runtime.ts` use hardcoded model-ID checks that omit Opus 4.7, Sonnet 4.7, and all future 4.8+ models. This causes Anthropic to reject requests with 400 (`"thinking.type.enabled" is not supported`) and silently fall back to `thinking=off`.
- Why it matters: Users configuring `thinkingDefault: "xhigh"` on Opus 4.7 silently lose all extended thinking on every first-turn request.
- What changed: Replaced hardcoded `includes()`/`startsWith()` checks with regex-based forward-compatible patterns (`/(opus|sonnet)-4[.-]([6-9]|\d{2,})/`) so future Claude model versions automatically get correct adaptive thinking and effort mapping. Added Sonnet 4.7 model constants and resolution chain. Fixed `resolveDefaultThinkingLevel` to use forward-compat regex for the `"off"` branch (addresses Greptile review feedback from #68068).
- What did NOT change (scope boundary): No changes to budget-based thinking path for pre-4.6 models, no changes to non-Anthropic providers, no changes to plugin SDK surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67888
- Related #68068 (predecessor PR, closed for resubmission with proper template)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `supportsAdaptiveThinking()` at `src/agents/anthropic-transport-stream.ts:110-117` used hardcoded `modelId.includes()` checks that only covered `opus-4-6`, `opus-4.6`, `sonnet-4-6`, `sonnet-4.6` — missing `opus-4-7` and all future versions. Same pattern repeated in `shouldUseAnthropicAdaptiveThinkingDefault()` at `extensions/anthropic/register.runtime.ts:287-294`.
- Missing detection / guardrail: No forward-compatible pattern for new model versions; each new model required a manual code update.
- Contributing context (if known): Opus 4.7 catalog was added in #67710 (2026.4.15) but the adapter's thinking-mode checks were not updated at the same time.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/anthropic-transport-stream.test.ts`, `extensions/anthropic/index.test.ts`
- Scenario the test should lock in: Sonnet 4.7 and future Opus 4.8 must receive `thinking: { type: "adaptive" }` with correct effort mapping, not `thinking: { type: "enabled", budget_tokens: N }`.
- Why this is the smallest reliable guardrail: Unit tests on the transport stream function and provider registration hooks directly verify the request payload shape without requiring a live API call.
- Existing test that already covers this (if any): Existing tests only covered Opus 4.6/4.7 and Sonnet 4.6.

## User-visible / Behavior Changes

- Opus 4.7 and Sonnet 4.7 now correctly use adaptive thinking mode instead of silently falling back to `thinking=off`.
- `xhigh` thinking level on Opus 4.7+ now maps to native `effort: "xhigh"` instead of `"high"`.
- Future Opus/Sonnet 4.8+ models will automatically receive correct adaptive thinking without code changes.

## Diagram (if applicable)

```text
Before:
[opus-4-7 request] -> supportsAdaptiveThinking()=false -> thinking: {type: "enabled"} -> 400 error -> fallback to thinking=off

After:
[opus-4-7 request] -> supportsAdaptiveThinking()=true -> thinking: {type: "adaptive"} + output_config: {effort} -> success
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node 22+ / Bun
- Model/provider: anthropic/claude-opus-4-7, anthropic/claude-sonnet-4-7
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.thinkingDefault: "xhigh"`

### Steps

1. Configure `claude-opus-4-7` as primary model with `thinkingDefault: "xhigh"`
2. Send a message via `openclaw agent --message "/think:xhigh hi"`
3. Observe request payload

### Expected

- Request contains `thinking: { type: "adaptive" }` and `output_config: { effort: "xhigh" }`

### Actual

- Before fix: Request contains `thinking: { type: "enabled", budget_tokens: N }` causing 400 error
- After fix: Request contains `thinking: { type: "adaptive" }` with correct effort level

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

TDD verification:
- RED: 5 new tests failed as expected (Sonnet 4.7 adaptive thinking, Opus 4.8 forward-compat, Sonnet 4.7 model resolution, Opus 4.8 supportsXHighThinking, Sonnet 4.7 adaptive default)
- GREEN: All 23 tests pass (10 transport stream + 13 extension)

## Human Verification (required)

- Verified scenarios: All 5 new test cases pass; all 18 existing tests remain green
- Edge cases checked: Future Opus 4.8 model gets xhigh effort; Opus 4.6 still maps xhigh to "max"; non-Opus models map xhigh to "high"
- What you did **not** verify: Live API call against real Anthropic endpoint (tested via mocked transport stream)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Regex pattern could match unintended model IDs
  - Mitigation: Pattern anchored to `(opus|sonnet)-4[.-]([6-9]|\d{2,})` — only matches Opus/Sonnet 4.6+ with dash or dot separators. Tested with explicit model ID assertions.