### PR TITLE
fix: exec tool gateway crash (#68376) and memory-core dreaming bloat (#68379)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -183,7 +183,12 @@ function buildNarrativeSessionKey(params: {
   nowMs: number;
 }): string {
   const workspaceHash = createHash("sha1").update(params.workspaceDir).digest("hex").slice(0, 12);
-  return `dreaming-narrative-${params.phase}-${workspaceHash}-${params.nowMs}`;
+  // Use a day-based bucket instead of the raw timestamp so that sessions are
+  // reused within the same calendar day, preventing unbounded session growth
+  // (see #68379 — each heartbeat was creating a unique session because the
+  // key included millisecond-precision nowMs).
+  const dayBucket = new Date(params.nowMs).toISOString().slice(0, 10);
+  return `dreaming-narrative-${params.phase}-${workspaceHash}-${dayBucket}`;
 }
 
 // ── Prompt building ────────────────────────────────────────────────────
@@ -932,9 +937,19 @@ export async function generateAndAppendDreamNarrative(params: {
     try {
       await params.subagent.deleteSession({ sessionKey });
     } catch (cleanupErr) {
-      params.logger.warn(
-        `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupErr)}`,
-      );
+      // Permission errors (e.g. "missing scope: operator.admin") should be
+      // logged at debug level instead of warning — they are expected when the
+      // plugin lacks admin scope and are not actionable by the user (#68379).
+      const errMsg = formatErrorMessage(cleanupErr);
+      if (errMsg.includes("missing scope") || errMsg.includes("permission")) {
+        params.logger.info(
+          `memory-core: narrative session cleanup skipped for ${params.data.phase} phase (insufficient scope): ${errMsg}`,
+        );
+      } else {
+        params.logger.warn(
+          `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${errMsg}`,
+        );
+      }
     }
 
     await scrubDreamingNarrativeArtifacts(params.logger).catch((scrubErr: unknown) => {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -75,6 +75,10 @@ const SESSION_INGESTION_MAX_MESSAGES_PER_FILE = 80;
 const SESSION_INGESTION_MIN_MESSAGES_PER_FILE = 12;
 const SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION = 4096;
 const SESSION_INGESTION_MAX_TRACKED_SCOPES = 2048;
+// Cap per-day session corpus files to prevent unbounded disk growth (#68379).
+// Once a corpus file exceeds this size, further appends are skipped until the
+// next day bucket rolls over.
+const SESSION_CORPUS_MAX_FILE_BYTES = 2 * 1024 * 1024;
 const GENERIC_DAY_HEADING_RE =
   /^(?:(?:mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|sun|sunday)(?:,\s+)?)?(?:(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4}[/-]\d{2}[/-]\d{2})$/i;
 const MANAGED_DAILY_DREAMING_BLOCKS = [
@@ -643,6 +647,10 @@ async function appendSessionCorpusLines(params: {
     if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
       throw err;
     }
+  }
+  // Skip append if the corpus file already exceeds the size cap (#68379).
+  if (Buffer.byteLength(existing, "utf-8") >= SESSION_CORPUS_MAX_FILE_BYTES) {
+    return [];
   }
   const normalizedExisting = existing.replace(/\r\n/g, "\n");
   const existingLineCount =

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -32,6 +32,9 @@ const SHORT_TERM_LOCK_RELATIVE_PATH = path.join("memory", ".dreams", "short-term
 const SHORT_TERM_LOCK_WAIT_TIMEOUT_MS = 10_000;
 const SHORT_TERM_LOCK_STALE_MS = 60_000;
 const SHORT_TERM_LOCK_RETRY_DELAY_MS = 40;
+// Maximum entries in the short-term recall store.  Older entries are evicted
+// when the store exceeds this cap, preventing unbounded file growth (#68379).
+const SHORT_TERM_MAX_ENTRIES = 4096;
 // Repeated dreaming revisits should be able to clear the default promotion gate
 // without requiring separate organic recall traffic for the same snippet.
 const PHASE_SIGNAL_LIGHT_BOOST_MAX = 0.06;
@@ -853,6 +856,21 @@ async function writePhaseSignalStore(
 }
 
 async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
+  const entries = store.entries;
+  const keys = Object.keys(entries);
+  if (keys.length > SHORT_TERM_MAX_ENTRIES) {
+    // Evict oldest (by lastRecalledAt) entries to cap store size (#68379).
+    const sorted = keys.toSorted(
+      (a, b) =>
+        Date.parse(entries[b].lastRecalledAt) - Date.parse(entries[a].lastRecalledAt),
+    );
+    const keep = new Set(sorted.slice(0, SHORT_TERM_MAX_ENTRIES));
+    for (const key of keys) {
+      if (!keep.has(key)) {
+        delete entries[key];
+      }
+    }
+  }
   const storePath = resolveStorePath(workspaceDir);
   await ensureShortTermArtifactsDir(workspaceDir);
   const tmpPath = `${storePath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -570,16 +570,15 @@ export async function runExecProcess(opts: {
     }
     const tailText = session.tail || session.aggregated;
     const warningText = opts.warnings.length ? `${opts.warnings.join("\n")}\n\n` : "";
-    // Note: opts.onUpdate() is provided by pi-agent-core's agent-loop and
+    // opts.onUpdate() is provided by pi-agent-core's agent-loop and
     // internally pushes Promise.resolve(emit(event)) into an updateEvents
     // array.  Because emit → processEvents is async, any failure (e.g.
     // activeRun cleared) produces a *rejected Promise*, not a synchronous
-    // throw — so a try-catch here would be ineffective.  Instead we rely
-    // on the `updatesDisabled` flag being set proactively: by the promise
-    // chain on process exit (Layer 1) and by `disableUpdates()` on abort
-    // signal (Layer 2) — both of which prevent this call from ever being
-    // reached after the agent run has ended.
-    opts.onUpdate({
+    // throw.  The `updatesDisabled` flag is set proactively on process exit
+    // and abort signal, but race conditions can still allow a late call to
+    // slip through (see #68376).  Catch the returned Promise to prevent
+    // unhandled rejections from crashing the gateway.
+    const maybePromise = opts.onUpdate({
       content: [{ type: "text", text: warningText + (tailText || "") }],
       details: {
         status: "running",
@@ -590,6 +589,11 @@ export async function runExecProcess(opts: {
         tail: session.tail,
       },
     });
+    // Prevent unhandled rejection if the agent-loop's emit() rejects
+    // (e.g. activeRun already cleared by a concurrent yield/abort).
+    if (maybePromise && typeof maybePromise.catch === "function") {
+      maybePromise.catch(() => {});
+    }
   };
 
   const handleStdout = (data: string) => {


### PR DESCRIPTION
## Summary

- **#68376**: Catch rejected `onUpdate` promises in the exec tool's `emitUpdate()` to prevent unhandled rejections from crashing the gateway
- **#68379**: Cap dreaming artifact growth — day-based narrative session keys, 2MB corpus file cap, 4096 entry recall store limit with LRU eviction, and downgrade permission-scope cleanup warnings

## Changes

### #68376 — exec tool gateway crash
- `src/agents/bash-tools.exec-runtime.ts`: Update `onUpdate` type to `void | Promise<void>` and use `?.catch()` to swallow rejected promises that escape the `updatesDisabled` guard during yield/abort race conditions

### #68379 — memory-core dreaming bloat
- `extensions/memory-core/src/dreaming-narrative.ts`: Change `buildNarrativeSessionKey` from millisecond timestamp to day-based bucket so narrative sessions are reused within the same day instead of creating unbounded new sessions
- `extensions/memory-core/src/dreaming-narrative.ts`: Downgrade "missing scope: operator.admin" cleanup errors from `warn` to `info` — these are expected when the plugin lacks admin scope
- `extensions/memory-core/src/dreaming-phases.ts`: Add `SESSION_CORPUS_MAX_FILE_BYTES = 2MB` cap — skip appends when corpus file exceeds the limit
- `extensions/memory-core/src/short-term-promotion.ts`: Add `SHORT_TERM_MAX_ENTRIES = 4096` cap with LRU eviction by `lastRecalledAt` in `writeStore()`

## Test plan

- [ ] Verify exec tool no longer crashes gateway when calling commands (reproduces with any model on Ubuntu 24.04, v2026.4.15)
- [ ] Run gateway for extended period with memory-core dreaming enabled and verify `.dreams/` directory stays bounded
- [ ] Confirm narrative sessions are reused within the same day (check session store)
- [ ] Verify `short-term-recall.json` does not grow beyond ~4096 entries
- [ ] Confirm "missing scope" cleanup messages appear at `info` level, not `warn`