### PR TITLE
fix(web-search): restore SecretRef runtime compatibility for bundled providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram/status reactions: honor `messages.removeAckAfterReply` when lifecycle status reactions are enabled, clearing or restoring the reaction after success/error using the configured hold timings. (#68067) Thanks @poiskgit.
+- Web search/plugins: resolve plugin-scoped SecretRef API keys for bundled Exa, Firecrawl, Gemini, Kimi, Perplexity, Tavily, and Grok web-search providers when they are selected through the shared web-search config. (#68424) Thanks @afurm.
 - Telegram/polling: raise the default polling watchdog threshold from 90s to 120s and add configurable `channels.telegram.pollingStallThresholdMs` (also per-account) so long-running Telegram work gets more room before polling is treated as stalled. (#57737) Thanks @Vitalcheffe.
 - Telegram/polling: bound the persisted-offset confirmation `getUpdates` probe with a client-side timeout so a zombie socket cannot hang polling recovery before the runner watchdog starts. (#50368) Thanks @boticlaw.
 - Agents/Pi runner: retry silent `stopReason=error` turns with no output when no side effects ran, so non-frontier providers that briefly return empty error turns get another chance instead of ending the session early. (#68310) Thanks @Chased1k.

--- a/extensions/exa/openclaw.plugin.json
+++ b/extensions/exa/openclaw.plugin.json
@@ -14,6 +14,9 @@
   "contracts": {
     "webSearchProviders": ["exa"]
   },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -30,6 +30,9 @@
     "webSearchProviders": ["firecrawl"],
     "tools": ["firecrawl_search", "firecrawl_scrape"]
   },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -53,6 +53,9 @@
     "videoGenerationProviders": ["google"],
     "webSearchProviders": ["gemini"]
   },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -52,6 +52,9 @@
     "mediaUnderstandingProviders": ["moonshot"],
     "webSearchProviders": ["kimi"]
   },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/perplexity/openclaw.plugin.json
+++ b/extensions/perplexity/openclaw.plugin.json
@@ -22,6 +22,9 @@
   "contracts": {
     "webSearchProviders": ["perplexity"]
   },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/tavily/openclaw.plugin.json
+++ b/extensions/tavily/openclaw.plugin.json
@@ -20,6 +20,9 @@
     "webSearchProviders": ["tavily"],
     "tools": ["tavily_search", "tavily_extract"]
   },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -87,6 +87,9 @@
     "videoGenerationProviders": ["xai"],
     "tools": ["code_execution", "x_search"]
   },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/plugins/web-provider-public-artifacts.test.ts
+++ b/src/plugins/web-provider-public-artifacts.test.ts
@@ -11,25 +11,26 @@ import {
   resolveBundledExplicitWebSearchProvidersFromPublicArtifacts,
 } from "./web-provider-public-artifacts.explicit.js";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function supportsSecretRefWebSearchApiKey(
   plugin: ReturnType<typeof loadPluginManifestRegistry>["plugins"][number],
 ): boolean {
-  const webSearch = plugin.configSchema?.properties?.webSearch;
-  if (!webSearch || typeof webSearch !== "object" || Array.isArray(webSearch)) {
+  const configProperties = isRecord(plugin.configSchema?.["properties"])
+    ? plugin.configSchema["properties"]
+    : undefined;
+  const webSearch = configProperties?.["webSearch"];
+  if (!isRecord(webSearch)) {
     return false;
   }
-  const properties =
-    "properties" in webSearch &&
-    webSearch.properties &&
-    typeof webSearch.properties === "object" &&
-    !Array.isArray(webSearch.properties)
-      ? webSearch.properties
-      : undefined;
-  const apiKey = properties?.apiKey;
-  if (!apiKey || typeof apiKey !== "object" || Array.isArray(apiKey)) {
+  const properties = isRecord(webSearch["properties"]) ? webSearch["properties"] : undefined;
+  const apiKey = properties?.["apiKey"];
+  if (!isRecord(apiKey)) {
     return false;
   }
-  const typeValue = "type" in apiKey ? apiKey.type : undefined;
+  const typeValue = apiKey["type"];
   return Array.isArray(typeValue) && typeValue.includes("object");
 }
 

--- a/src/plugins/web-provider-public-artifacts.test.ts
+++ b/src/plugins/web-provider-public-artifacts.test.ts
@@ -1,13 +1,37 @@
 import { describe, expect, it } from "vitest";
 import {
+  loadPluginManifestRegistry,
   resolveManifestContractOwnerPluginId,
   resolveManifestContractPluginIds,
+  resolveManifestContractPluginIdsByCompatibilityRuntimePath,
 } from "./manifest-registry.js";
 import {
   hasBundledWebFetchProviderPublicArtifact,
   hasBundledWebSearchProviderPublicArtifact,
   resolveBundledExplicitWebSearchProvidersFromPublicArtifacts,
 } from "./web-provider-public-artifacts.explicit.js";
+
+function supportsSecretRefWebSearchApiKey(
+  plugin: ReturnType<typeof loadPluginManifestRegistry>["plugins"][number],
+): boolean {
+  const webSearch = plugin.configSchema?.properties?.webSearch;
+  if (!webSearch || typeof webSearch !== "object" || Array.isArray(webSearch)) {
+    return false;
+  }
+  const properties =
+    "properties" in webSearch &&
+    webSearch.properties &&
+    typeof webSearch.properties === "object" &&
+    !Array.isArray(webSearch.properties)
+      ? webSearch.properties
+      : undefined;
+  const apiKey = properties?.apiKey;
+  if (!apiKey || typeof apiKey !== "object" || Array.isArray(apiKey)) {
+    return false;
+  }
+  const typeValue = "type" in apiKey ? apiKey.type : undefined;
+  return Array.isArray(typeValue) && typeValue.includes("object");
+}
 
 describe("web provider public artifacts", () => {
   it("has a public artifact for every bundled web search provider declared in manifests", () => {
@@ -42,6 +66,28 @@ describe("web provider public artifacts", () => {
         }),
       ).toBe(provider.pluginId);
     }
+  });
+
+  it("registers compatibility runtime paths for bundled SecretRef-capable web search providers", () => {
+    const registry = loadPluginManifestRegistry({ cache: false });
+    const expectedPluginIds = registry.plugins
+      .filter(
+        (plugin) =>
+          plugin.origin === "bundled" &&
+          (plugin.contracts?.webSearchProviders?.length ?? 0) > 0 &&
+          supportsSecretRefWebSearchApiKey(plugin),
+      )
+      .map((plugin) => plugin.id)
+      .toSorted((left, right) => left.localeCompare(right));
+
+    expect(expectedPluginIds).not.toHaveLength(0);
+    expect(
+      resolveManifestContractPluginIdsByCompatibilityRuntimePath({
+        contract: "webSearchProviders",
+        path: "tools.web.search.apiKey",
+        origin: "bundled",
+      }),
+    ).toEqual(expectedPluginIds);
   });
 
   it("has a public artifact for every bundled web fetch provider declared in manifests", () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: several bundled web-search plugins accepted `SecretRef` objects for `plugins.entries.<id>.config.webSearch.apiKey`, but runtime compatibility lookup only registered Brave and MiniMax.
- Why it matters: affected providers could validate config successfully and still fail at runtime with `is unresolved in the active runtime snapshot`.
- What changed: added `configContracts.compatibilityRuntimePaths: ["tools.web.search.apiKey"]` to Exa, Firecrawl, Google/Gemini, Moonshot/Kimi, Perplexity, Tavily, and xAI/Grok, and added a manifest invariant test.
- What did NOT change (scope boundary): no new secret surfaces, no runtime secret collector refactor, and no web-fetch compatibility changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68028
- Related #68040
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: affected plugin manifests allowed object-shaped plugin-scoped `webSearch.apiKey` values but did not declare `tools.web.search.apiKey` in `configContracts.compatibilityRuntimePaths`, so runtime compatibility-only resolution could not map the active provider back to those plugin-owned credential paths.
- Missing detection / guardrail: there was no invariant test ensuring every bundled web-search provider with an object-shaped `webSearch.apiKey` config registered the compatibility runtime path.
- Contributing context (if known): Brave and MiniMax already had the metadata, which made the manifest drift easy to miss until users configured the other providers with `SecretRef`.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/web-provider-public-artifacts.test.ts`
- Scenario the test should lock in: bundled web-search providers that declare object-shaped `webSearch.apiKey` config must be returned by `resolveManifestContractPluginIdsByCompatibilityRuntimePath(..., "tools.web.search.apiKey")`.
- Why this is the smallest reliable guardrail: the regression is manifest/registry metadata drift, so loading real bundled manifests is enough to catch it without live provider execution.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- `SecretRef` values configured at `plugins.entries.exa.config.webSearch.apiKey`, `plugins.entries.firecrawl.config.webSearch.apiKey`, `plugins.entries.google.config.webSearch.apiKey`, `plugins.entries.moonshot.config.webSearch.apiKey`, `plugins.entries.perplexity.config.webSearch.apiKey`, `plugins.entries.tavily.config.webSearch.apiKey`, and `plugins.entries.xai.config.webSearch.apiKey` now resolve at runtime when the matching provider is active.
- Brave and MiniMax behavior is unchanged; they already declared the compatibility path.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[plugin manifest accepts SecretRef] -> [runtime asks for compatibility owners of tools.web.search.apiKey] -> [affected plugin missing from registry] -> [unresolved snapshot error]

After:
[plugin manifest accepts SecretRef] -> [runtime asks for compatibility owners of tools.web.search.apiKey] -> [affected plugin is registered] -> [plugin-scoped apiKey resolves]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: this only restores runtime compatibility for already-declared bundled `webSearch.apiKey` secret surfaces. It does not add new secret paths or widen provider access. The added invariant test prevents future manifest drift on this path.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout on Node `22.22.0`
- Model/provider: N/A
- Integration/channel (if any): bundled web-search providers
- Relevant config (redacted): env secret provider allowlisting the provider key, `tools.web.search.provider=<provider>`, and `plugins.entries.<plugin>.config.webSearch.apiKey=<SecretRef>`

### Steps

1. Configure `plugins.entries.<plugin>.config.webSearch.apiKey` as a `SecretRef` for an affected bundled web-search provider.
2. Set `tools.web.search.provider` to the matching provider and refresh the runtime snapshot (for example via gateway restart).
3. Trigger a web-search path using that provider.

### Expected

- The plugin-scoped API key resolves from the active runtime snapshot and web search proceeds.

### Actual

- Before this fix, affected providers could fail with `plugins.entries.<plugin>.config.webSearch.apiKey is unresolved in the active runtime snapshot`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Issue `#68028` includes the runtime error logs. Focused regression coverage now passes locally.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test src/plugins/web-provider-public-artifacts.test.ts` and `pnpm test src/config/config.web-search-provider.test.ts`; confirmed affected bundled manifests now register `tools.web.search.apiKey` compatibility ownership.
- Edge cases checked: DuckDuckGo, SearXNG, and Ollama stay out of the compatibility set because they do not expose object-shaped `webSearch.apiKey`; Brave and MiniMax remain included.
- What you did **not** verify: live end-to-end gateway restart and provider calls for each affected provider; full `pnpm build` completion in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: manifest-only compatibility registration could accidentally over-include providers that should not participate in `tools.web.search.apiKey` fallback.
  - Mitigation: the regression test derives the expected set from real bundled manifests that explicitly accept object-shaped `webSearch.apiKey` values, so providers without that surface remain excluded.
- Risk: full build was not completed in this environment.
  - Mitigation: focused tests covering the touched manifest/config path passed, and the build blocker is documented as an unrelated environment issue (`amazon-bedrock-mantle` staging, then `sharp` postinstall requiring `node-gyp`).