### PR TITLE
ci(security): harden workflow steps against template-injection

### DIFF
--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -140,7 +140,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCLAW_CONTROL_UI_I18N_MODEL: gpt-5.4
           OPENCLAW_CONTROL_UI_I18N_THINKING: low
-        run: node --import tsx scripts/control-ui-i18n.ts sync --locale "${{ matrix.locale }}" --write
+          LOCALE: ${{ matrix.locale }}
+        run: node --import tsx scripts/control-ui-i18n.ts sync --locale "${LOCALE}" --write
 
       - name: Commit and push locale updates
         env:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -362,28 +362,36 @@ jobs:
 
       - name: Create and push default manifest
         shell: bash
+        env:
+          TAGS: ${{ steps.tags.outputs.value }}
+          AMD64_DIGEST: ${{ needs.build-amd64.outputs.digest }}
+          ARM64_DIGEST: ${{ needs.build-arm64.outputs.digest }}
         run: |
           set -euo pipefail
-          mapfile -t tags <<< "${{ steps.tags.outputs.value }}"
+          mapfile -t tags <<< "${TAGS}"
           args=()
           for tag in "${tags[@]}"; do
             [ -z "$tag" ] && continue
             args+=("-t" "$tag")
           done
           docker buildx imagetools create "${args[@]}" \
-            ${{ needs.build-amd64.outputs.digest }} \
-            ${{ needs.build-arm64.outputs.digest }}
+            "${AMD64_DIGEST}" \
+            "${ARM64_DIGEST}"
 
       - name: Create and push slim manifest
         shell: bash
+        env:
+          SLIM_TAGS: ${{ steps.tags.outputs.slim }}
+          AMD64_SLIM_DIGEST: ${{ needs.build-amd64.outputs.slim-digest }}
+          ARM64_SLIM_DIGEST: ${{ needs.build-arm64.outputs.slim-digest }}
         run: |
           set -euo pipefail
-          mapfile -t tags <<< "${{ steps.tags.outputs.slim }}"
+          mapfile -t tags <<< "${SLIM_TAGS}"
           args=()
           for tag in "${tags[@]}"; do
             [ -z "$tag" ] && continue
             args+=("-t" "$tag")
           done
           docker buildx imagetools create "${args[@]}" \
-            ${{ needs.build-amd64.outputs.slim-digest }} \
-            ${{ needs.build-arm64.outputs.slim-digest }}
+            "${AMD64_SLIM_DIGEST}" \
+            "${ARM64_SLIM_DIGEST}"

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -397,9 +397,10 @@ jobs:
         env:
           OPENCLAW_PREPACK_PREPARED: "1"
           OPENCLAW_NPM_PUBLISH_TAG: ${{ inputs.npm_dist_tag }}
+          PUBLISH_TARBALL_PATH: ${{ steps.publish_tarball.outputs.path }}
         run: |
           set -euo pipefail
-          publish_target="${{ steps.publish_tarball.outputs.path }}"
+          publish_target="${PUBLISH_TARBALL_PATH}"
           if [[ -n "${publish_target}" ]]; then
             publish_target="./${publish_target}"
           fi


### PR DESCRIPTION
## Summary

Harden three CI workflow files against `template-injection` findings reported by zizmor (v1.24.1), using the canonical fix pattern: hoist every dynamic `${{ … }}` expression out of the `run:` block into a step-level `env:` dictionary, then reference it as `"${VAR}"` from the script.

Covers the 8 template-injection sites that are **not** addressed by #66884 (which handles the remaining 12 sites in `openclaw-cross-os-release-checks-reusable.yml`).

## Files and sites fixed

### `.github/workflows/control-ui-locale-refresh.yml` (1 site)

- Line 143 — `matrix.locale` lifted into env as `LOCALE`.

### `.github/workflows/docker-release.yml` (6 sites)

Both `Create and push default manifest` and `Create and push slim manifest` steps in the `create-manifest` job:

- `steps.tags.outputs.value` → `TAGS`
- `steps.tags.outputs.slim` → `SLIM_TAGS`
- `needs.build-amd64.outputs.digest` → `AMD64_DIGEST`
- `needs.build-arm64.outputs.digest` → `ARM64_DIGEST`
- `needs.build-amd64.outputs.slim-digest` → `AMD64_SLIM_DIGEST`
- `needs.build-arm64.outputs.slim-digest` → `ARM64_SLIM_DIGEST`

### `.github/workflows/openclaw-npm-release.yml` (1 site)

- Line 402 — `steps.publish_tarball.outputs.path` lifted into env as `PUBLISH_TARBALL_PATH` in the `Publish` step.

## Verification

```
$ zizmor --persona regular \
    .github/workflows/control-ui-locale-refresh.yml \
    .github/workflows/docker-release.yml \
    .github/workflows/openclaw-npm-release.yml

No findings to report. Good job! (20 suppressed)
```

- `pnpm format:check` — clean across 12,852 files.
- `pnpm lint` — 0 warnings, 0 errors.
- YAML parses cleanly for all three files via the project's own `yaml` package.

## Behavioural impact

None. The substitution is mechanical — GitHub Actions expands the expressions into environment variables at the same evaluation point as before, and the shell reads them via `${VAR}` instead of having them baked into the script at render time.

## Relationship to other PRs / issues

- Refs #68428 — tracking issue enumerating all 22 template-injection findings.
- Complements #66884 — covers the remaining 12 sites in `openclaw-cross-os-release-checks-reusable.yml`. Together, #66884 + this PR resolve all 22 findings in the tracking issue.
- #67920 has overlapping env-var changes for `openclaw-cross-os-release-checks-reusable.yml` plus an unrelated script refactor; recommended to rebase on main once #66884 lands and keep only the script refactor.
