### PR TITLE
docs(changelog): deduplicate #67679 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - macOS/gateway: add `screen.snapshot` support for macOS app nodes, including runtime plumbing, default macOS allowlisting, and docs for monitor preview flows. (#67954) Thanks @BunsDev.
-- fix: redact credentials in browser.cdpUrl config paths (#67679). Thanks @Ziy1-Tan
 
 ### Fixes
 


### PR DESCRIPTION
## Summary

- PR #67679 landed a duplicate line under `### Changes` in the Unreleased block in addition to the detailed entry that was already present under `### Fixes`.
- The short `### Changes` line appears to have been auto-generated from the PR title during the merge step, even though a richer `### Fixes` entry already described the same PR.
- That line also mis-categorizes a security redaction fix as a feature change.

This PR removes the duplicate and keeps the `### Fixes` entry, which is in the right section and carries the descriptive text.

## Test plan

- [x] `grep -c "67679" CHANGELOG.md` returns `1`
- [x] The remaining entry is under `## Unreleased / ### Fixes`