### PR TITLE
fix: exec tool gateway crash (#68376) and memory-core dreaming bloat (#68379)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -585,7 +585,8 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}-${nowMs}`;
+    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}-2026-04-05`;
+    const expectedIdempotencyKey = `dreaming-narrative-light-${workspaceHash}-${nowMs}`;
 
     await generateAndAppendDreamNarrative({
       subagent,
@@ -601,7 +602,7 @@ describe("generateAndAppendDreamNarrative", () => {
 
     expect(subagent.run).toHaveBeenCalledOnce();
     expect(subagent.run.mock.calls[0][0]).toMatchObject({
-      idempotencyKey: expectedSessionKey,
+      idempotencyKey: expectedIdempotencyKey,
       sessionKey: expectedSessionKey,
       deliver: false,
     });

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -138,6 +138,7 @@ function buildRequestScopedFallbackNarrative(data: NarrativePhaseData): string {
 async function startNarrativeRunOrFallback(params: {
   subagent: SubagentSurface;
   sessionKey: string;
+  idempotencyKey: string;
   message: string;
   data: NarrativePhaseData;
   workspaceDir: string;
@@ -147,7 +148,7 @@ async function startNarrativeRunOrFallback(params: {
 }): Promise<string | null> {
   try {
     const run = await params.subagent.run({
-      idempotencyKey: params.sessionKey,
+      idempotencyKey: params.idempotencyKey,
       sessionKey: params.sessionKey,
       message: params.message,
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
@@ -189,6 +190,18 @@ function buildNarrativeSessionKey(params: {
   // key included millisecond-precision nowMs).
   const dayBucket = new Date(params.nowMs).toISOString().slice(0, 10);
   return `dreaming-narrative-${params.phase}-${workspaceHash}-${dayBucket}`;
+}
+
+function buildNarrativeIdempotencyKey(params: {
+  workspaceDir: string;
+  phase: NarrativePhaseData["phase"];
+  nowMs: number;
+}): string {
+  const workspaceHash = createHash("sha1").update(params.workspaceDir).digest("hex").slice(0, 12);
+  // Idempotency key must be unique per run so the gateway does not cache/dedupe
+  // fresh narrative sweeps within the same day-bucket session (see P1 review on
+  // PR #68437 — day-bucket idempotency caused stale cached narratives).
+  return `dreaming-narrative-${params.phase}-${workspaceHash}-${params.nowMs}`;
 }
 
 // ── Prompt building ────────────────────────────────────────────────────
@@ -855,6 +868,11 @@ export async function generateAndAppendDreamNarrative(params: {
     phase: params.data.phase,
     nowMs,
   });
+  const idempotencyKey = buildNarrativeIdempotencyKey({
+    workspaceDir: params.workspaceDir,
+    phase: params.data.phase,
+    nowMs,
+  });
   const message = buildNarrativePrompt(params.data);
   let runId: string | null = null;
   let waitStatus: string | null = null;
@@ -863,6 +881,7 @@ export async function generateAndAppendDreamNarrative(params: {
     runId = await startNarrativeRunOrFallback({
       subagent: params.subagent,
       sessionKey,
+      idempotencyKey,
       message,
       data: params.data,
       workspaceDir: params.workspaceDir,

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -183,7 +183,12 @@ function buildNarrativeSessionKey(params: {
   nowMs: number;
 }): string {
   const workspaceHash = createHash("sha1").update(params.workspaceDir).digest("hex").slice(0, 12);
-  return `dreaming-narrative-${params.phase}-${workspaceHash}-${params.nowMs}`;
+  // Use a day-based bucket instead of the raw timestamp so that sessions are
+  // reused within the same calendar day, preventing unbounded session growth
+  // (see #68379 — each heartbeat was creating a unique session because the
+  // key included millisecond-precision nowMs).
+  const dayBucket = new Date(params.nowMs).toISOString().slice(0, 10);
+  return `dreaming-narrative-${params.phase}-${workspaceHash}-${dayBucket}`;
 }
 
 // ── Prompt building ────────────────────────────────────────────────────
@@ -932,9 +937,19 @@ export async function generateAndAppendDreamNarrative(params: {
     try {
       await params.subagent.deleteSession({ sessionKey });
     } catch (cleanupErr) {
-      params.logger.warn(
-        `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupErr)}`,
-      );
+      // Permission errors (e.g. "missing scope: operator.admin") should be
+      // logged at info level instead of warning — they are expected when the
+      // plugin lacks admin scope and are not actionable by the user (#68379).
+      const errMsg = formatErrorMessage(cleanupErr);
+      if (errMsg.includes("missing scope")) {
+        params.logger.info(
+          `memory-core: narrative session cleanup skipped for ${params.data.phase} phase (insufficient scope): ${errMsg}`,
+        );
+      } else {
+        params.logger.warn(
+          `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${errMsg}`,
+        );
+      }
     }
 
     await scrubDreamingNarrativeArtifacts(params.logger).catch((scrubErr: unknown) => {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -75,6 +75,10 @@ const SESSION_INGESTION_MAX_MESSAGES_PER_FILE = 80;
 const SESSION_INGESTION_MIN_MESSAGES_PER_FILE = 12;
 const SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION = 4096;
 const SESSION_INGESTION_MAX_TRACKED_SCOPES = 2048;
+// Cap per-day session corpus files to prevent unbounded disk growth (#68379).
+// Once a corpus file exceeds this size, further appends are skipped until the
+// next day bucket rolls over.
+const SESSION_CORPUS_MAX_FILE_BYTES = 2 * 1024 * 1024;
 const GENERIC_DAY_HEADING_RE =
   /^(?:(?:mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|sun|sunday)(?:,\s+)?)?(?:(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4}[/-]\d{2}[/-]\d{2})$/i;
 const MANAGED_DAILY_DREAMING_BLOCKS = [
@@ -636,6 +640,18 @@ async function appendSessionCorpusLines(params: {
     `${params.day}.txt`,
   );
   await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  // Check file size via stat before reading to avoid unnecessary I/O when the
+  // corpus file already exceeds the cap (#68379).
+  try {
+    const { size } = await fs.stat(absolutePath);
+    if (size >= SESSION_CORPUS_MAX_FILE_BYTES) {
+      return [];
+    }
+  } catch (statErr) {
+    if ((statErr as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      throw statErr;
+    }
+  }
   let existing = "";
   try {
     existing = await fs.readFile(absolutePath, "utf-8");

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -32,6 +32,9 @@ const SHORT_TERM_LOCK_RELATIVE_PATH = path.join("memory", ".dreams", "short-term
 const SHORT_TERM_LOCK_WAIT_TIMEOUT_MS = 10_000;
 const SHORT_TERM_LOCK_STALE_MS = 60_000;
 const SHORT_TERM_LOCK_RETRY_DELAY_MS = 40;
+// Maximum entries in the short-term recall store.  Older entries are evicted
+// when the store exceeds this cap, preventing unbounded file growth (#68379).
+const SHORT_TERM_MAX_ENTRIES = 4096;
 // Repeated dreaming revisits should be able to clear the default promotion gate
 // without requiring separate organic recall traffic for the same snippet.
 const PHASE_SIGNAL_LIGHT_BOOST_MAX = 0.06;
@@ -853,10 +856,24 @@ async function writePhaseSignalStore(
 }
 
 async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
+  let entriesToWrite = store.entries;
+  const keys = Object.keys(entriesToWrite);
+  if (keys.length > SHORT_TERM_MAX_ENTRIES) {
+    // Evict oldest (by lastRecalledAt) entries to cap store size (#68379).
+    // Build a new object to avoid mutating the caller's store.entries.
+    const sorted = keys.toSorted(
+      (a, b) =>
+        Date.parse(entriesToWrite[b].lastRecalledAt) -
+        Date.parse(entriesToWrite[a].lastRecalledAt),
+    );
+    const keep = sorted.slice(0, SHORT_TERM_MAX_ENTRIES);
+    entriesToWrite = Object.fromEntries(keep.map((k) => [k, entriesToWrite[k]]));
+  }
+  const storeToWrite = { ...store, entries: entriesToWrite };
   const storePath = resolveStorePath(workspaceDir);
   await ensureShortTermArtifactsDir(workspaceDir);
   const tmpPath = `${storePath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
-  await fs.writeFile(tmpPath, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+  await fs.writeFile(tmpPath, `${JSON.stringify(storeToWrite, null, 2)}\n`, "utf-8");
   await fs.rename(tmpPath, storePath);
 }
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -511,7 +511,7 @@ export async function runExecProcess(opts: {
   sessionKey?: string;
   notifyDeliveryContext?: DeliveryContext;
   timeoutSec: number | null;
-  onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
+  onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void | Promise<void>;
 }): Promise<ExecProcessHandle> {
   const startedAt = Date.now();
   const sessionId = createSessionSlug();
@@ -570,16 +570,15 @@ export async function runExecProcess(opts: {
     }
     const tailText = session.tail || session.aggregated;
     const warningText = opts.warnings.length ? `${opts.warnings.join("\n")}\n\n` : "";
-    // Note: opts.onUpdate() is provided by pi-agent-core's agent-loop and
+    // opts.onUpdate() is provided by pi-agent-core's agent-loop and
     // internally pushes Promise.resolve(emit(event)) into an updateEvents
     // array.  Because emit → processEvents is async, any failure (e.g.
     // activeRun cleared) produces a *rejected Promise*, not a synchronous
-    // throw — so a try-catch here would be ineffective.  Instead we rely
-    // on the `updatesDisabled` flag being set proactively: by the promise
-    // chain on process exit (Layer 1) and by `disableUpdates()` on abort
-    // signal (Layer 2) — both of which prevent this call from ever being
-    // reached after the agent run has ended.
-    opts.onUpdate({
+    // throw.  The `updatesDisabled` flag is set proactively on process exit
+    // and abort signal, but race conditions can still allow a late call to
+    // slip through (see #68376).  Catch the returned Promise to prevent
+    // unhandled rejections from crashing the gateway.
+    const result = opts.onUpdate({
       content: [{ type: "text", text: warningText + (tailText || "") }],
       details: {
         status: "running",
@@ -590,6 +589,13 @@ export async function runExecProcess(opts: {
         tail: session.tail,
       },
     });
+    // Swallow: race between process exit / abort-signal and a late emitUpdate
+    // tick.  See #68376 — a synchronous try/catch cannot catch the rejected
+    // Promise from emit.  Guard with instanceof check because a void callback
+    // may return a non-Promise truthy value (e.g. array.push() returns a number).
+    if (result instanceof Promise) {
+      result.catch(() => {});
+    }
   };
 
   const handleStdout = (data: string) => {


### PR DESCRIPTION
## Summary

- **#68376**: Fix gateway crash caused by unhandled promise rejection in exec tool's `onUpdate` callback. The `emitUpdate()` call could produce a rejected Promise from an async `onUpdate`, but the synchronous call site never caught it, triggering the global unhandled-rejection handler (`process.exit(1)`).
- **#68379**: Fix memory bloat (500MB → 3.7GB) from the dreaming subsystem with four changes:
  1. Day-bucket `sessionKey` to prevent unbounded session growth from per-heartbeat unique keys
  2. Unique-per-run `idempotencyKey` (uses raw `nowMs`) so the gateway does not cache/dedupe fresh narrative sweeps within the same day-bucket session
  3. 2MB corpus file size cap before reading in dream phases
  4. 4096-entry cap on short-term recall store with LRU eviction

## Test plan

- [x] `pnpm check` passes (lint, tsgo, import cycles)
- [x] `extensions/memory-core/src/dreaming-narrative.test.ts` — all 42 tests pass
- [x] Scoped test for the "generates narrative and writes diary entry" case asserts split key format