### PR TITLE
fix: prioritize explicit provider config over model ID prefix parsing

### DIFF
--- a/src/agents/model-selection-resolve.ts
+++ b/src/agents/model-selection-resolve.ts
@@ -296,15 +296,20 @@ export function resolveConfiguredModelRef(params: {
       if (aliasMatch) {
         return aliasMatch.ref;
       }
+    }
 
-      const inferredProvider = inferUniqueProviderFromConfiguredModels({
-        cfg: params.cfg,
-        model: trimmed,
-      });
-      if (inferredProvider) {
-        return { provider: inferredProvider, model: trimmed };
-      }
+    // Try to infer the provider from configured models/providers before
+    // splitting on "/". This ensures explicit provider config (e.g. LM Studio
+    // with a baseURL) takes precedence over model ID prefix parsing (#68447).
+    const inferredProvider = inferUniqueProviderFromConfiguredModels({
+      cfg: params.cfg,
+      model: trimmed,
+    });
+    if (inferredProvider) {
+      return { provider: inferredProvider, model: trimmed };
+    }
 
+    if (!trimmed.includes("/")) {
       const safeTrimmed = sanitizeModelWarningValue(trimmed);
       const safeResolved = sanitizeForLog(`${params.defaultProvider}/${safeTrimmed}`);
       getLog().warn(
@@ -517,16 +522,28 @@ export function resolveAllowedModelRef(params: {
     defaultProvider: params.defaultProvider,
   });
 
-  const effectiveDefaultProvider = !trimmed.includes("/")
-    ? (inferUniqueProviderFromConfiguredModels({ cfg: params.cfg, model: trimmed }) ??
-      params.defaultProvider)
-    : params.defaultProvider;
-
-  const resolved = resolveModelRefFromString({
-    raw: trimmed,
-    defaultProvider: effectiveDefaultProvider,
-    aliasIndex,
+  // Try to infer the correct provider from the configured models/providers
+  // before splitting on "/". This ensures explicit provider config (e.g. LM
+  // Studio with a baseURL) takes precedence over model ID prefix parsing
+  // (#68447).
+  const inferredProvider = inferUniqueProviderFromConfiguredModels({
+    cfg: params.cfg,
+    model: trimmed,
   });
+
+  let resolved: { ref: ModelRef; alias?: string } | null;
+  if (inferredProvider && trimmed.includes("/")) {
+    // The full model ID (e.g. "google/gemma-4-26b-a4b") is configured under
+    // a specific provider — use it directly without splitting on "/".
+    resolved = { ref: { provider: inferredProvider, model: trimmed } };
+  } else {
+    const effectiveDefaultProvider = inferredProvider ?? params.defaultProvider;
+    resolved = resolveModelRefFromString({
+      raw: trimmed,
+      defaultProvider: effectiveDefaultProvider,
+      aliasIndex,
+    });
+  }
   if (!resolved) {
     return { error: `invalid model: ${trimmed}` };
   }

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -548,6 +548,25 @@ describe("model-selection", () => {
         }),
       ).toBeUndefined();
     });
+
+    it("infers provider from provider catalog for slash-containing model id (#68447)", () => {
+      const cfg = {
+        models: {
+          providers: {
+            lmstudio: {
+              models: [{ id: "google/gemma-4-26b-a4b" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      expect(
+        inferUniqueProviderFromConfiguredModels({
+          cfg,
+          model: "google/gemma-4-26b-a4b",
+        }),
+      ).toBe("lmstudio");
+    });
   });
 
   describe("buildModelAliasIndex", () => {
@@ -807,6 +826,37 @@ describe("model-selection", () => {
         ref: { provider: "opencode-go", model: "kimi-k2.5" },
       });
     });
+
+    it("routes slash-containing model id to explicitly configured provider instead of splitting on slash (#68447)", () => {
+      const cfg = {
+        models: {
+          providers: {
+            lmstudio: {
+              models: [{ id: "google/gemma-4-26b-a4b" }],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "lmstudio/google/gemma-4-26b-a4b": {},
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "google/gemma-4-26b-a4b",
+        defaultProvider: "anthropic",
+      });
+
+      expect(result).toEqual({
+        key: "lmstudio/google/gemma-4-26b-a4b",
+        ref: { provider: "lmstudio", model: "google/gemma-4-26b-a4b" },
+      });
+    });
   });
 
   describe("resolveModelRefFromString", () => {
@@ -929,6 +979,34 @@ describe("model-selection", () => {
       });
 
       expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+    });
+
+    it("routes slash-containing default model to explicitly configured provider (#68447)", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "google/gemma-4-26b-a4b" },
+          },
+        },
+        models: {
+          providers: {
+            lmstudio: {
+              models: [{ id: "google/gemma-4-26b-a4b" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg: cfg,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+      });
+
+      expect(result).toEqual({
+        provider: "lmstudio",
+        model: "google/gemma-4-26b-a4b",
+      });
     });
 
     it("should fall back to the configured default provider and warn if provider is missing for non-alias", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -424,15 +424,20 @@ export function resolveConfiguredModelRef(params: {
       if (aliasMatch) {
         return aliasMatch.ref;
       }
+    }
 
-      const inferredProvider = inferUniqueProviderFromConfiguredModels({
-        cfg: params.cfg,
-        model: trimmed,
-      });
-      if (inferredProvider) {
-        return { provider: inferredProvider, model: trimmed };
-      }
+    // Try to infer the provider from configured models/providers before
+    // splitting on "/". This ensures explicit provider config (e.g. LM Studio
+    // with a baseURL) takes precedence over model ID prefix parsing (#68447).
+    const inferredProvider = inferUniqueProviderFromConfiguredModels({
+      cfg: params.cfg,
+      model: trimmed,
+    });
+    if (inferredProvider) {
+      return { provider: inferredProvider, model: trimmed };
+    }
 
+    if (!trimmed.includes("/")) {
       // Default to the configured provider if no provider is specified, but warn as this is deprecated.
       const safeTrimmed = sanitizeModelWarningValue(trimmed);
       const safeResolved = sanitizeForLog(`${params.defaultProvider}/${safeTrimmed}`);
@@ -728,20 +733,30 @@ export function resolveAllowedModelRef(params: {
     defaultProvider: params.defaultProvider,
   });
 
-  // When the model string has no provider prefix ("/"), try to infer the
-  // correct provider from the configured allowlist before falling back to the
-  // session's current default provider. This prevents provider prefix drift
-  // when switching models across different providers (see #48369).
-  const effectiveDefaultProvider = !trimmed.includes("/")
-    ? (inferUniqueProviderFromConfiguredModels({ cfg: params.cfg, model: trimmed }) ??
-      params.defaultProvider)
-    : params.defaultProvider;
-
-  const resolved = resolveModelRefFromString({
-    raw: trimmed,
-    defaultProvider: effectiveDefaultProvider,
-    aliasIndex,
+  // Try to infer the correct provider from the configured models/providers
+  // before falling back to the session's current default provider or splitting
+  // on "/". This prevents provider prefix drift when switching models across
+  // different providers (see #48369) and ensures that explicitly configured
+  // providers (e.g. LM Studio with a baseURL) take precedence over provider
+  // inference from model ID prefixes like "google/" (see #68447).
+  const inferredProvider = inferUniqueProviderFromConfiguredModels({
+    cfg: params.cfg,
+    model: trimmed,
   });
+
+  let resolved: { ref: ModelRef; alias?: string } | null;
+  if (inferredProvider && trimmed.includes("/")) {
+    // The full model ID (e.g. "google/gemma-4-26b-a4b") is configured under
+    // a specific provider — use it directly without splitting on "/".
+    resolved = { ref: { provider: inferredProvider, model: trimmed } };
+  } else {
+    const effectiveDefaultProvider = inferredProvider ?? params.defaultProvider;
+    resolved = resolveModelRefFromString({
+      raw: trimmed,
+      defaultProvider: effectiveDefaultProvider,
+      aliasIndex,
+    });
+  }
   if (!resolved) {
     return { error: `invalid model: ${trimmed}` };
   }


### PR DESCRIPTION
## Problem

When a model ID contains a provider prefix like `google/gemma-4-26b-a4b`, OpenClaw splits on `/` and treats `google` as the provider identifier, routing to Google's remote API instead of the configured local LM Studio backend.

## Fix

Move the `inferUniqueProviderFromConfiguredModels()` call **before** the `/` split in both `resolveConfiguredModelRef()` and `resolveAllowedModelRef()`. When a model is explicitly listed under a provider (e.g. `lmstudio`), that provider now takes precedence over the inferred provider from the model ID prefix.

### Changes
- `src/agents/model-selection.ts`: Restructured provider inference to run before slash splitting
- `src/agents/model-selection-resolve.ts`: Same fix applied to the resolve variant  
- `src/agents/model-selection.test.ts`: Added 3 test cases covering the routing fix

## Testing

All 86 tests in `model-selection.test.ts` pass.

Fixes #68447