### PR TITLE
fix(cron): preserve silent tool-result `NO_REPLY` on empty final turn

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -27,6 +27,7 @@ import {
   STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
+  resolveSilentToolResultReplyPayload,
 } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
@@ -67,6 +68,79 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(mockedClassifyFailoverReason).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("verify before retrying");
+  });
+
+  it("synthesizes a silent NO_REPLY payload from the latest cron tool result", () => {
+    const payload = resolveSilentToolResultReplyPayload({
+      isCronTrigger: true,
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "NO_REPLY" }],
+            details: { aggregated: "NO_REPLY" },
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+      }),
+    });
+
+    expect(payload).toEqual({ text: "NO_REPLY" });
+  });
+
+  it("treats exact NO_REPLY tool output as a quiet cron success when the final assistant is empty", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec" }],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "NO_REPLY" }],
+            details: { aggregated: "NO_REPLY" },
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      trigger: "cron",
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-cron-no-reply-empty-final",
+    });
+
+    expect(result.payloads).toEqual([{ text: "NO_REPLY" }]);
+    expect(result.meta.livenessState).toBe("working");
+    expect(mockedLog.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("incomplete turn detected"),
+    );
   });
 
   it("uses explicit agentId without a session key before surfacing the strict-agentic blocked state", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -106,6 +106,7 @@ import {
   resolvePlanningOnlyRetryLimit,
   resolvePlanningOnlyRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
+  resolveSilentToolResultReplyPayload,
   STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
@@ -1691,7 +1692,19 @@ export async function runEmbeddedPiAgent(
             };
           }
 
-          const payloadCount = payloadsWithToolMedia?.length ?? 0;
+          const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
+            isCronTrigger: params.trigger === "cron",
+            payloadCount: payloadsWithToolMedia?.length ?? 0,
+            aborted,
+            timedOut,
+            attempt,
+          });
+          const finalPayloads = payloadsWithToolMedia?.length
+            ? payloadsWithToolMedia
+            : silentToolResultReplyPayload
+              ? [silentToolResultReplyPayload]
+              : payloadsWithToolMedia;
+          const payloadCount = finalPayloads?.length ?? 0;
           const nextPlanningOnlyRetryInstruction = resolvePlanningOnlyRetryInstruction({
             provider,
             modelId,
@@ -1908,7 +1921,7 @@ export async function runEmbeddedPiAgent(
           if (incompleteTurnText) {
             const replayInvalid = resolveReplayInvalidForAttempt(incompleteTurnText);
             const livenessState = resolveRunLivenessState({
-              payloadCount: payloads.length,
+              payloadCount,
               aborted,
               timedOut,
               attempt,
@@ -1921,7 +1934,7 @@ export async function runEmbeddedPiAgent(
             const incompleteStopReason = attempt.lastAssistant?.stopReason;
             log.warn(
               `incomplete turn detected: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `stopReason=${incompleteStopReason} payloads=0 — surfacing error to user`,
+                `stopReason=${incompleteStopReason} payloads=${payloadCount} — surfacing error to user`,
             );
 
             // Mark the failing profile for cooldown so multi-profile setups
@@ -1978,7 +1991,7 @@ export async function runEmbeddedPiAgent(
           }
           const replayInvalid = resolveReplayInvalidForAttempt(null);
           const livenessState = resolveRunLivenessState({
-            payloadCount: payloads.length,
+            payloadCount,
             aborted,
             timedOut,
             attempt,
@@ -1994,7 +2007,7 @@ export async function runEmbeddedPiAgent(
             livenessState,
           });
           return {
-            payloads: payloadsWithToolMedia?.length ? payloadsWithToolMedia : undefined,
+            payloads: finalPayloads?.length ? finalPayloads : undefined,
             meta: {
               durationMs: Date.now() - started,
               agentMeta,

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -1,7 +1,12 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { isSilentReplyText } from "../../../auto-reply/tokens.js";
 import type { EmbeddedPiExecutionContract } from "../../../config/types.agent-defaults.js";
-import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../../../shared/string-coerce.js";
 import { isStrictAgenticSupportedProviderModel } from "../../execution-contract.js";
+import { extractToolResultText } from "../../pi-embedded-subscribe.tools.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 import { assessLastAssistantMessage } from "../thinking.js";
 import type { EmbeddedRunLivenessState } from "../types.js";
@@ -38,6 +43,15 @@ type PlanningOnlyAttempt = Pick<
   | "itemLifecycle"
   | "replayMetadata"
   | "toolMetas"
+>;
+
+type SilentToolResultAttempt = Pick<
+  EmbeddedRunAttemptResult,
+  | "clientToolCall"
+  | "yieldDetected"
+  | "didSendDeterministicApprovalPrompt"
+  | "lastToolError"
+  | "messagesSnapshot"
 >;
 
 type RunLivenessAttempt = Pick<
@@ -197,6 +211,55 @@ export function resolveIncompleteTurnPayloadText(params: {
   return params.attempt.replayMetadata.hadPotentialSideEffects
     ? "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying."
     : "⚠️ Agent couldn't generate a response. Please try again.";
+}
+
+export function resolveSilentToolResultReplyPayload(params: {
+  isCronTrigger: boolean;
+  payloadCount: number;
+  aborted: boolean;
+  timedOut: boolean;
+  attempt: SilentToolResultAttempt;
+}): { text: "NO_REPLY" } | null {
+  if (
+    !params.isCronTrigger ||
+    params.payloadCount !== 0 ||
+    params.aborted ||
+    params.timedOut ||
+    params.attempt.clientToolCall ||
+    params.attempt.yieldDetected ||
+    params.attempt.didSendDeterministicApprovalPrompt ||
+    params.attempt.lastToolError
+  ) {
+    return null;
+  }
+
+  const messages = params.attempt.messagesSnapshot;
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return null;
+  }
+
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i] as AgentMessage & {
+      isError?: boolean;
+      details?: { aggregated?: unknown };
+    };
+    const role = normalizeLowercaseStringOrEmpty(message?.role);
+    if (role !== "toolresult" && role !== "tool_result" && role !== "tool") {
+      continue;
+    }
+    if (message?.isError === true) {
+      return null;
+    }
+    const aggregated =
+      typeof message?.details?.aggregated === "string" ? message.details.aggregated : undefined;
+    const text = normalizeOptionalString(extractToolResultText(message) ?? aggregated);
+    if (!text || !isSilentReplyText(text, "NO_REPLY")) {
+      return null;
+    }
+    return { text: "NO_REPLY" };
+  }
+
+  return null;
 }
 
 export function resolveReplayInvalidFlag(params: {


### PR DESCRIPTION
Fixes #68452.

## Summary

This fixes a cron silent-success bug in embedded runner finalization.

If an isolated cron `agentTurn` receives a successful tool result whose content is exact `NO_REPLY`, but the model then ends with an empty final assistant message (`stopReason=stop`, `content: []`), the runner can currently treat the turn as `payloads=0` and surface the generic incomplete-turn error.

That turns a valid quiet-success path into a false failure.

## Root cause

The finalization path only trusts assistant-derived payloads (plus tool media) when deciding whether the run produced a valid result.

So this sequence is mishandled:

1. tool call succeeds
2. tool result text is exact `NO_REPLY`
3. final assistant message is empty
4. payload count remains zero
5. incomplete-turn logic fires

The runner already has enough information to know the run completed silently; it just drops that information before the incomplete-turn check.

## What changed

### Source changes

- `src/agents/pi-embedded-runner/run/incomplete-turn.ts`
  - add `resolveSilentToolResultReplyPayload(...)`
  - when the trigger is cron and the latest successful tool result is exact `NO_REPLY`, synthesize a silent final payload instead of returning `null`

- `src/agents/pi-embedded-runner/run.ts`
  - use the synthesized silent payload before computing `payloadCount`
  - carry the adjusted payload count into the incomplete-turn / liveness / final-return path
  - log the real payload count in the incomplete-turn warning path

- `src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
  - add focused coverage for the helper
  - add a runner regression test for the exact cron + empty-final-assistant case

## Scope boundary

This is intentionally narrow.

It only changes behavior when all of these are true:

- trigger is cron
- final payload count is still zero
- there is no abort / timeout / tool-error blocker
- the latest successful tool result is exact silent `NO_REPLY`

It does **not** change:

- normal visible replies
- timeout handling
- delivery-time `NO_REPLY` stripping
- non-cron empty-final behavior

## Validation

Passed:

```bash
node scripts/test-projects.mjs src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
node scripts/test-projects.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
```

## Why this matters

Without this fix, a valid unchanged cron run can be turned into:

- `payloads=0`
- `livenessState=abandoned`
- a generic embedded failure payload
- a second cron-layer failure wrapper on announce surfaces

With this patch, the unchanged path stays a real silent success and delivery continues to suppress it correctly.

## Notes

This is adjacent to earlier cron / `NO_REPLY` delivery work, but the seam here is earlier in the pipeline: embedded finalization loses a valid silent tool-result outcome before cron delivery sees it.
