### PR TITLE
security(media): anchor sanitizeMimeType regex to reject malformed input

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -6,6 +6,7 @@ import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { sanitizeMimeType } from "./apply.js";
 import { createSafeAudioFixtureBuffer } from "./runner.test-utils.js";
 import type { MediaUnderstandingProvider } from "./types.js";
 
@@ -1417,5 +1418,43 @@ describe("applyMediaUnderstanding", () => {
     expect(result.appliedFile).toBe(true);
     expect(ctx.Body).toContain("<file");
     expect(ctx.Body).toContain("vendor-json");
+  });
+});
+
+describe("sanitizeMimeType", () => {
+  it("accepts a plain MIME type", () => {
+    expect(sanitizeMimeType("image/png")).toBe("image/png");
+    expect(sanitizeMimeType("application/vnd.api+json")).toBe("application/vnd.api+json");
+  });
+
+  it("strips standard parameters", () => {
+    expect(sanitizeMimeType("text/plain; charset=utf-8")).toBe("text/plain");
+    expect(sanitizeMimeType("text/csv;charset=UTF-8")).toBe("text/csv");
+  });
+
+  it("lowercases mixed-case input", () => {
+    expect(sanitizeMimeType("Image/PNG")).toBe("image/png");
+  });
+
+  it("returns undefined for empty or missing input", () => {
+    expect(sanitizeMimeType(undefined)).toBeUndefined();
+    expect(sanitizeMimeType("")).toBeUndefined();
+    expect(sanitizeMimeType("   ")).toBeUndefined();
+  });
+
+  it("rejects malformed input with trailing junk instead of truncating", () => {
+    expect(sanitizeMimeType("image/png junk")).toBeUndefined();
+    expect(sanitizeMimeType("image/png\nextra")).toBeUndefined();
+  });
+
+  it("rejects path-like inputs that previously captured an allowlisted prefix", () => {
+    expect(sanitizeMimeType("image/png/../etc/passwd")).toBeUndefined();
+    expect(sanitizeMimeType("image/png/evil")).toBeUndefined();
+  });
+
+  it("rejects inputs without a type/subtype separator", () => {
+    expect(sanitizeMimeType("imagepng")).toBeUndefined();
+    expect(sanitizeMimeType("/png")).toBeUndefined();
+    expect(sanitizeMimeType("image/")).toBeUndefined();
   });
 });

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -74,12 +74,15 @@ const TEXT_EXT_MIME = new Map<string, string>([
   [".xml", "application/xml"],
 ]);
 
-function sanitizeMimeType(value?: string): string | undefined {
+// End-anchored so malformed input ("image/png junk", "image/png..etc")
+// returns undefined instead of silently truncating to a prefix that could
+// then pass the downstream allowlist check.
+export function sanitizeMimeType(value?: string): string | undefined {
   const trimmed = normalizeOptionalLowercaseString(value);
   if (!trimmed) {
     return undefined;
   }
-  const match = trimmed.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)/);
+  const match = trimmed.match(/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)(?:;.*)?$/);
   return match?.[1];
 }
 


### PR DESCRIPTION
## Summary

- Problem: `sanitizeMimeType` in `src/media-understanding/apply.ts` matches MIME types with an **unanchored** regex, so malformed input silently truncates to a valid-looking prefix. Example: `"image/png junk"` → `"image/png"`; `"image/png..etc/passwd"` → `"image/png..etc"` (the char class includes `.`, `-`, `_`).
- Why it matters: the returned prefix is then checked against `allowedMimes` at `apply.ts:427`. Malformed input can coerce to a known-good MIME and pass the allowlist, defeating the intent of strict validation at the media-ingest boundary. Maintainers labeled this `security`.
- What changed: anchor the regex at end-of-string and accept standard MIME parameters (`(?:;.*)?$`). Export the helper for focused unit tests.
- What did NOT change: callers, callsite, allowlist semantics, or any other MIME normalizer.

## Change Type

- [x] Security hardening

## Scope

- [x] Skills / tool execution (media-understanding inbound path)

## Linked Issue/PR

- Closes #9795
- Related #10257 (prior combined fix was closed; this PR narrows scope to #9795 only)
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: the regex `/^([a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+)/` had no end anchor. On malformed input, the first-match-wins behavior captured the leading valid-looking substring and discarded the rest, producing a MIME string that the downstream allowlist could accept.
- Missing detection / guardrail: strict end-anchor on the MIME regex at an input boundary.
- Contributing context: the helper is called on values already normalized by `normalizeMimeType` (`src/media/mime.ts` strips `;` and lowercases), so valid inputs are unaffected. Only malformed inputs change behavior.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/media-understanding/apply.test.ts` (new `describe("sanitizeMimeType")` block)
- Scenario the test should lock in: anchor rejects `"image/png junk"`, `"image/png\nextra"`, `"image/png/../etc/passwd"`, `"image/png/evil"`; still accepts plain MIMEs and standard `; param` parameters; still lowercases mixed case; still returns `undefined` on empty/whitespace/missing input.
- Why this is the smallest reliable guardrail: the function is pure and self-contained; unit tests pin its exact behavior without needing the full media pipeline.

## User-visible / Behavior Changes

Malformed MIME hints that previously silently truncated now produce `undefined`, which the existing code path at `apply.ts:412-416` already handles by skipping the attachment with a `"file attachment skipped (unknown mime)"` verbose-log line. No config change required; no user-facing surface touched.

## Security Impact

- New permissions/capabilities? No
- Change in trust boundary? No (tightens an existing input-validation check)
- Secrets/credentials touched? No

## Verification

Gates run locally on macOS Darwin 24.6.0:

- `pnpm test src/media-understanding/apply.test.ts -t sanitizeMimeType` — 7 passed
- `pnpm test src/media-understanding/apply.test.ts` — 48 passed
- `pnpm test 'src/media-understanding/**/*.test.ts'` — 138 passed across 20 files
- `pnpm check` — formatter, oxlint (0 warnings / 0 errors across 11710 files), tsgo, import-cycle + madge checks all green
- `pnpm build` — clean (touches an exported surface, so build is run as a hard gate per CLAUDE.md)

## Human Verification

- Verified scenarios: round-tripped representative inputs against both the old and new regex to confirm the anchor is the only behavioral delta; confirmed current callsite at `apply.ts:405` already handles `undefined` return.
- Edge cases checked: trailing whitespace/newlines, path-like suffixes sharing the allowed char class (`.`, `-`, `_`), vendor-suffix MIMEs (`application/vnd.api+json`), `; charset=` parameters.
- What I did not verify: no changes to `src/media/mime.ts::normalizeMimeType` or `src/media/input-files.ts::normalizeMimeType`; those are out of scope for #9795.

## Review Conversations

- [x] I will reply to or resolve every bot review conversation I address in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a benign input the existing allowlist accepted (via prefix truncation) now returns `undefined` and the attachment is skipped.
  - Mitigation: the truncation-to-allowed path only matters when input does not already match the strict shape; valid MIMEs (including `; param`) and internal hint constants all still match. Existing tests covering real MIMEs still pass (138 tests green).
