### PR TITLE
onboard (ollama): populate cloud-only model list from ollama.com/api/tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Changes
+
+- Ollama/onboard: populate the cloud-only model list from `ollama.com/api/tags` so `openclaw onboard` reflects the live cloud catalog instead of a static three-model seed; cap the discovered list at 500 and fall back to the previous hardcoded suggestions when ollama.com is unreachable or returns no models. (#68463) Thanks @BruceMacD.
+
 ## 2026.4.20
 
 ### Changes

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -114,6 +114,7 @@ describe("ollama setup", () => {
 
   it("puts suggested cloud model first in cloud mode", async () => {
     const prompter = createCloudPrompter();
+    vi.stubGlobal("fetch", createOllamaFetchMock({ tags: [] }));
     const result = await promptAndConfigureOllama({
       cfg: {},
       env: {},
@@ -130,6 +131,7 @@ describe("ollama setup", () => {
 
   it("uses generic token flags for cloud-only setup", async () => {
     const prompter = createCloudPrompter();
+    vi.stubGlobal("fetch", createOllamaFetchMock({ tags: [] }));
 
     const result = await promptAndConfigureOllama({
       cfg: {},
@@ -189,7 +191,7 @@ describe("ollama setup", () => {
 
   it("cloud mode does not hit local Ollama endpoints", async () => {
     const prompter = createCloudPrompter();
-    const fetchMock = vi.fn();
+    const fetchMock = createOllamaFetchMock({ tags: [] });
     vi.stubGlobal("fetch", fetchMock);
 
     await promptAndConfigureOllama({
@@ -199,7 +201,12 @@ describe("ollama setup", () => {
       allowSecretRefPrompt: false,
     });
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock.mock.calls.some((call) => requestUrl(call[0]).includes("127.0.0.1"))).toBe(
+      false,
+    );
+    expect(fetchMock.mock.calls.some((call) => requestUrl(call[0]).includes("ollama.com"))).toBe(
+      true,
+    );
   });
 
   it("rejects the local marker during cloud-only setup", async () => {
@@ -250,6 +257,7 @@ describe("ollama setup", () => {
       }),
       note: vi.fn(async () => undefined),
     } as unknown as WizardPrompter;
+    vi.stubGlobal("fetch", createOllamaFetchMock({ tags: [] }));
 
     await promptAndConfigureOllama({
       cfg: {},
@@ -315,8 +323,9 @@ describe("ollama setup", () => {
     );
   });
 
-  it("cloud mode seeds the hosted cloud model list", async () => {
+  it("cloud mode falls back to the hardcoded cloud model list when /api/tags is empty", async () => {
     const prompter = createCloudPrompter();
+    vi.stubGlobal("fetch", createOllamaFetchMock({ tags: [] }));
     const result = await promptAndConfigureOllama({
       cfg: {},
       env: {},
@@ -331,6 +340,36 @@ describe("ollama setup", () => {
       "text",
       "image",
     ]);
+  });
+
+  it("cloud mode populates models from ollama.com /api/tags when reachable", async () => {
+    const prompter = createCloudPrompter();
+    const fetchMock = createOllamaFetchMock({
+      tags: ["qwen3-coder:480b-cloud", "gpt-oss:120b-cloud"],
+      show: { "qwen3-coder:480b-cloud": 262144 },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await promptAndConfigureOllama({
+      cfg: {},
+      env: {},
+      prompter,
+      allowSecretRefPrompt: false,
+    });
+    const models = result.config.models?.providers?.ollama?.models;
+    const modelIds = models?.map((m) => m.id);
+
+    expect(modelIds).toEqual([
+      "kimi-k2.5:cloud",
+      "minimax-m2.7:cloud",
+      "glm-5.1:cloud",
+      "qwen3-coder:480b-cloud",
+      "gpt-oss:120b-cloud",
+    ]);
+    expect(models?.find((m) => m.id === "qwen3-coder:480b-cloud")?.contextWindow).toBe(262144);
+    expect(
+      fetchMock.mock.calls.some((call) => requestUrl(call[0]) === "https://ollama.com/api/tags"),
+    ).toBe(true);
   });
 
   it("uses /api/show context windows when building Ollama model configs", async () => {

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -40,6 +40,7 @@ export { buildOllamaProvider };
 const OLLAMA_SUGGESTED_MODELS_LOCAL = [OLLAMA_DEFAULT_MODEL];
 const OLLAMA_SUGGESTED_MODELS_CLOUD = ["kimi-k2.5:cloud", "minimax-m2.7:cloud", "glm-5.1:cloud"];
 const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
+const OLLAMA_CLOUD_MAX_DISCOVERED_MODELS = 500;
 
 type OllamaSetupOptions = {
   customBaseUrl?: string;
@@ -499,14 +500,30 @@ export async function promptAndConfigureOllama(params: {
       secretInputMode: params.secretInputMode,
       allowSecretRefPrompt: params.allowSecretRefPrompt,
     });
+    const { reachable, models: rawDiscoveredModels } =
+      await fetchOllamaModels(OLLAMA_CLOUD_BASE_URL);
+    const discoveredModels = rawDiscoveredModels.slice(0, OLLAMA_CLOUD_MAX_DISCOVERED_MODELS);
+    const enrichedModels =
+      reachable && discoveredModels.length > 0
+        ? await enrichOllamaModelsWithContext(
+            OLLAMA_CLOUD_BASE_URL,
+            discoveredModels.slice(0, OLLAMA_CONTEXT_ENRICH_LIMIT),
+          )
+        : [];
+    const discoveredModelsByName = new Map(enrichedModels.map((model) => [model.name, model]));
+    const discoveredModelNames = discoveredModels.map((model) => model.name);
+    const modelNames =
+      discoveredModelNames.length > 0
+        ? mergeUniqueModelNames(OLLAMA_SUGGESTED_MODELS_CLOUD, discoveredModelNames)
+        : OLLAMA_SUGGESTED_MODELS_CLOUD;
     return {
       credential,
       credentialMode,
       config: applyOllamaProviderConfig(
         params.cfg,
         OLLAMA_CLOUD_BASE_URL,
-        OLLAMA_SUGGESTED_MODELS_CLOUD,
-        undefined,
+        modelNames,
+        discoveredModelsByName,
         credential,
       ),
     };


### PR DESCRIPTION
## Summary

- Problem: `openclaw onboard` in Ollama cloud-only mode populated the provider's model list from a hardcoded, stale array (`kimi-k2.5:cloud`, `minimax-m2.7:cloud`, `glm-5.1:cloud`). The local-only and cloud+local modes already discovered models via `/api/tags` against the local daemon, but the cloud-only branch never talked to `ollama.com`.
- Why it matters: `ollama.com` speaks the Ollama API, so `/api/tags` returns the actual cloud-available model catalog. Onboarding should reflect what users can actually run, not a fixed list that drifts as the cloud catalog changes.
- What changed: in the cloud-only branch of `promptAndConfigureOllama`, fetch `/api/tags` from `OLLAMA_CLOUD_BASE_URL` (unauthenticated, no key needed), enrich with `/api/show` for context windows, and merge the curated suggestions as a stable prefix with the discovered names. Fall back to the existing hardcoded suggestions when the fetch fails or returns no models.
- What did NOT change (scope boundary): local-only and cloud+local modes still hit the configured local Ollama daemon (default `http://127.0.0.1:11434`). The non-interactive `configureOllamaNonInteractive` path, credential collection, and SSRF policy are untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A (this is a feature change, not a bug fix).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/ollama/src/setup.test.ts`
- Scenario the test should lock in:
  - New test `"cloud mode populates models from ollama.com /api/tags when reachable"` verifies the discovered names appear in the config, context windows are enriched from `/api/show`, and the request is issued against `https://ollama.com/api/tags`.
  - Existing `"cloud mode falls back to the hardcoded cloud model list when /api/tags is empty"` locks in the fallback when the endpoint returns no models.
- Why this is the smallest reliable guardrail: the behavior is entirely inside `promptAndConfigureOllama`, so unit tests against the prompter with a stubbed fetch are the most direct coverage.

## User-visible / Behavior Changes

- Ollama cloud-only onboarding now lists the actual set of cloud models returned by `ollama.com/api/tags`, with the curated suggestions still prepended so recommended defaults stay at the top. If `ollama.com` is unreachable or returns no models, the previous hardcoded list is used.

## Diagram (if applicable)

```text
Before (cloud-only onboard):
user picks "Cloud only" -> prompt for OLLAMA_API_KEY -> config.models = [hardcoded 3 names]

After (cloud-only onboard):
user picks "Cloud only" -> prompt for OLLAMA_API_KEY -> GET ollama.com/api/tags
  reachable + models:  config.models = [suggested, ...discovered] (context windows via /api/show)
  unreachable / empty: config.models = [hardcoded 3 names]  (unchanged fallback)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`. The tags fetch is unauthenticated; `OLLAMA_API_KEY` is still collected and stored the same way.
- New/changed network calls? `Yes`. Adds `GET https://ollama.com/api/tags` and per-model `POST https://ollama.com/api/show` during onboarding. Both go through the existing `fetchWithSsrFGuard` with a hostname-scoped allowlist from `buildOllamaBaseUrlSsrFPolicy`.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Mitigation: network calls reuse the existing SSRF guard; no new trust boundary or secret flow.

## Repro + Verification

### Environment

- OS: macOS (darwin 25.2.0)
- Runtime/container: Node 22 + pnpm, local dev
- Model/provider: ollama (cloud-only mode)
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.providers.ollama.baseUrl = https://ollama.com`

### Steps

1. Run `openclaw onboard` and choose Ollama.
2. Pick "Cloud only".
3. Provide any valid `OLLAMA_API_KEY`.

### Expected

- `models.providers.ollama.models` contains entries discovered from `https://ollama.com/api/tags` (with the curated suggestions prepended), with context windows populated where `/api/show` returns them.

### Actual

- Matches expected. When `ollama.com` is unreachable the config falls back to the previous hardcoded list.

## Evidence

- [x] Failing test/log before + passing after

`pnpm test extensions/ollama/src/setup.test.ts`: 22 tests pass, including the two new cloud-mode assertions.
`pnpm check`: clean.

## Human Verification (required)

- Verified scenarios: ran the scoped vitest suite locally (`pnpm test extensions/ollama/src/setup.test.ts` and `extensions/ollama/src/provider-models*.test.ts`), plus `pnpm check`.
- Edge cases checked: empty `/api/tags` response falls back to hardcoded list; `/api/tags` returns models and discovered names appear with context windows from `/api/show`.
- What I did **not** verify: an end-to-end interactive `openclaw onboard` run against live `ollama.com`. That path is exercised by the new unit test with a stubbed fetch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`. When `ollama.com/api/tags` is unreachable or empty, the flow falls back to the previous hardcoded suggestions, so existing onboarding behavior is preserved.
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: `ollama.com/api/tags` could return a very large catalog and slow onboarding.
  - Mitigation: enrichment is capped by `OLLAMA_CONTEXT_ENRICH_LIMIT` (200) and runs with the existing bounded concurrency; on fetch failure the flow falls back to the hardcoded list.