### PR TITLE
feat(auth): add --profile to models auth login

### DIFF
--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -1,6 +1,13 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const refreshOpenAICodexTokenMock = vi.hoisted(() => vi.fn());
+const { refreshOpenAICodexTokenMock, loginOpenAICodexOAuthMock } = vi.hoisted(() => ({
+  refreshOpenAICodexTokenMock: vi.fn(),
+  loginOpenAICodexOAuthMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-login", () => ({
+  loginOpenAICodexOAuth: loginOpenAICodexOAuthMock,
+}));
 
 vi.mock("./openai-codex-provider.runtime.js", () => ({
   refreshOpenAICodexToken: refreshOpenAICodexTokenMock,
@@ -15,6 +22,7 @@ describe("openai codex provider", () => {
 
   beforeEach(() => {
     refreshOpenAICodexTokenMock.mockReset();
+    loginOpenAICodexOAuthMock.mockReset();
   });
 
   it("falls back to the cached credential when accountId extraction fails", async () => {
@@ -70,6 +78,27 @@ describe("openai codex provider", () => {
       refresh: "next-refresh",
       expires: expect.any(Number),
     });
+  });
+
+  it("uses the requested auth profile name when provided", async () => {
+    loginOpenAICodexOAuthMock.mockResolvedValue({
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+      email: "user@example.com",
+    });
+    const provider = buildOpenAICodexProviderPlugin();
+    const result = await provider.auth[0]?.run({
+      prompter: {} as never,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as never,
+      isRemote: false,
+      openUrl: async () => {},
+      oauth: { createVpsAwareHandlers: vi.fn() } as never,
+      config: {},
+      opts: { profile: "default" },
+    } as never);
+
+    expect(result?.profiles[0]?.profileId).toBe("openai-codex:default");
   });
 
   it("returns deprecated-profile doctor guidance for legacy Codex CLI ids", () => {

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -271,6 +271,11 @@ async function runOpenAICodexOAuth(ctx: ProviderAuthContext) {
     email: readStringValue(creds.email),
   });
 
+  const requestedProfile =
+    typeof ctx.opts?.profile === "string" && ctx.opts.profile.trim().length > 0
+      ? ctx.opts.profile.trim()
+      : undefined;
+
   return buildOauthProviderAuthResult({
     providerId: PROVIDER_ID,
     defaultModel: OPENAI_CODEX_DEFAULT_MODEL,
@@ -278,7 +283,7 @@ async function runOpenAICodexOAuth(ctx: ProviderAuthContext) {
     refresh: creds.refresh,
     expires: creds.expires,
     email: identity.email,
-    profileName: identity.profileName,
+    profileName: requestedProfile ?? identity.profileName,
   });
 }
 

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -93,6 +93,26 @@ describe("models cli", () => {
     );
   });
 
+  it("passes --profile to models auth login", async () => {
+    await runModelsCommand([
+      "models",
+      "auth",
+      "login",
+      "--provider",
+      "openai-codex",
+      "--profile",
+      "default",
+    ]);
+
+    expect(modelsAuthLoginCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai-codex",
+        profile: "default",
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("shows help for models auth without error exit", async () => {
     const program = new Command();
     program.exitOverride();

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -307,6 +307,7 @@ export function registerModelsCli(program: Command) {
     .description("Run a provider plugin auth flow (OAuth/API key)")
     .option("--provider <id>", "Provider id registered by a plugin")
     .option("--method <id>", "Provider auth method id")
+    .option("--profile <name>", "Target auth profile name to update when supported by the provider")
     .option("--set-default", "Apply the provider's default model recommendation", false)
     .action(async (opts) => {
       await runModelsCommand(async () => {
@@ -314,6 +315,7 @@ export function registerModelsCli(program: Command) {
           {
             provider: opts.provider as string | undefined,
             method: opts.method as string | undefined,
+            profile: opts.profile as string | undefined,
             setDefault: Boolean(opts.setDefault),
           },
           defaultRuntime,

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -352,10 +352,12 @@ describe("modelsAuthLoginCommand", () => {
       }),
       agentDir: "/tmp/openclaw/agents/main",
     });
+    expect(mocks.upsertAuthProfile).toHaveBeenCalledTimes(1);
     expect(lastUpdatedConfig?.auth?.profiles?.["openai-codex:user@example.com"]).toMatchObject({
       provider: "openai-codex",
       mode: "oauth",
     });
+    expect(lastUpdatedConfig?.auth?.profiles?.["openai-codex:default"]).toBeUndefined();
     expect(runtime.log).toHaveBeenCalledWith(
       "Auth profile: openai-codex:user@example.com (openai-codex/oauth)",
     );
@@ -426,6 +428,37 @@ describe("modelsAuthLoginCommand", () => {
       "claude-cli/claude-sonnet-4-6": {},
     });
     expect(runtime.log).toHaveBeenCalledWith("Default model set to claude-cli/claude-sonnet-4-6");
+  });
+
+  it("passes --profile through to provider auth methods", async () => {
+    const runtime = createRuntime();
+    const targetedRun = vi.fn().mockImplementation(async (ctx) => {
+      expect(ctx.opts).toEqual({ profile: "default" });
+      return {
+        profiles: [
+          {
+            profileId: "openai-codex:default",
+            credential: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "access-token",
+              refresh: "refresh-token",
+            },
+          },
+        ],
+      };
+    });
+    mocks.resolvePluginProviders.mockReturnValue([
+      createProvider({
+        id: "openai-codex",
+        label: "OpenAI Codex",
+        run: targetedRun as ProviderPlugin["auth"][number]["run"],
+      }),
+    ]);
+
+    await modelsAuthLoginCommand({ provider: "openai-codex", profile: "default" }, runtime);
+
+    expect(targetedRun).toHaveBeenCalledOnce();
   });
 
   it("runs the requested anthropic cli auth method with the full login context", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -287,6 +287,7 @@ async function runProviderAuthMethod(params: {
   method: ProviderAuthMethod;
   runtime: RuntimeEnv;
   prompter: ReturnType<typeof createClackPrompter>;
+  profile?: string;
   setDefault?: boolean;
 }) {
   await clearStaleProfileLockouts(params.provider.id, params.agentDir);
@@ -298,6 +299,7 @@ async function runProviderAuthMethod(params: {
     workspaceDir: params.workspaceDir,
     prompter: params.prompter,
     runtime: params.runtime,
+    opts: params.profile ? { profile: params.profile } : undefined,
     allowSecretRefPrompt: false,
     isRemote: isRemoteEnvironment(),
     openUrl: async (url) => {
@@ -532,6 +534,7 @@ export async function modelsAuthAddCommand(_opts: Record<string, never>, runtime
 type LoginOptions = {
   provider?: string;
   method?: string;
+  profile?: string;
   setDefault?: boolean;
   yes?: boolean;
 };
@@ -630,6 +633,7 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
     method: chosenMethod,
     runtime,
     prompter,
+    profile: opts.profile,
     setDefault: opts.setDefault,
   });
   maybeLogOpenAICodexNativeSearchTip(runtime, selectedProvider.id);


### PR DESCRIPTION
## Summary
- add `--profile <name>` to `openclaw models auth login`
- pass the requested profile through the login command into provider auth context
- let the OpenAI Codex OAuth provider honor that explicit target profile name

## Why
Today `openclaw models auth login --provider openai-codex` refreshes the provider-owned profile name derived from the authenticated identity. In cases where a user wants to refresh a specific auth profile such as `openai-codex:default`, there is no explicit CLI surface to target it.

This keeps the existing default behavior unchanged and adds an explicit path:

```bash
openclaw models auth login --provider openai-codex --profile default
```

## What changed
- CLI: `models auth login` now accepts `--profile <name>`
- command layer: forwards the requested profile into `ctx.opts`
- OpenAI Codex provider: uses `ctx.opts.profile` as `profileName` when provided, otherwise preserves the existing identity-derived profile naming

## Tests
Targeted tests run locally:
- `src/cli/models-cli.test.ts`
- `src/commands/models/auth.test.ts`
- `extensions/openai/openai-codex-provider.test.ts`

Note: local install needed `npm install --legacy-peer-deps` because a peer dependency conflict (`madge` vs TypeScript 6) blocked plain `npm install` in this environment.
