### PR TITLE
fix(auto-reply): don't drop URL messages when link-understanding import fails

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -131,12 +131,17 @@ async function applyMediaUnderstandingIfNeeded(params: {
   return true;
 }
 
+let linkUnderstandingDisabled = false;
+
 async function applyLinkUnderstandingIfNeeded(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
 }): Promise<boolean> {
   if (!hasLinkCandidate(params.ctx)) {
     return false;
+  }
+  if (linkUnderstandingDisabled) {
+    return false; // skip retry after prior import/apply failure
   }
   const { applyLinkUnderstanding } = await import("../../link-understanding/apply.runtime.js");
   await applyLinkUnderstanding(params);
@@ -248,9 +253,12 @@ export async function getReplyFromConfig(
       // Non-fatal: link-understanding is an optional enrichment step.
       // After in-place upgrades, the hashed chunk may be missing from disk
       // (ERR_MODULE_NOT_FOUND), which should not silently drop the message.
-      finalized.logger?.warn?.(
-        `[getReply] link-understanding import/apply failed (non-fatal): ${linkErr instanceof Error ? linkErr.message : String(linkErr)}`,
-      );
+      if (!linkUnderstandingDisabled) {
+        finalized.logger?.warn?.(
+          `[getReply] link-understanding import/apply failed (non-fatal): ${linkErr instanceof Error ? linkErr.message : String(linkErr)}`,
+        );
+        linkUnderstandingDisabled = true;
+      }
     }
   }
   emitPreAgentMessageHooks({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -239,10 +239,19 @@ export async function getReplyFromConfig(
       agentDir,
       activeModel: { provider, model },
     });
-    await applyLinkUnderstandingIfNeeded({
-      ctx: finalized,
-      cfg,
-    });
+    try {
+      await applyLinkUnderstandingIfNeeded({
+        ctx: finalized,
+        cfg,
+      });
+    } catch (linkErr) {
+      // Non-fatal: link-understanding is an optional enrichment step.
+      // After in-place upgrades, the hashed chunk may be missing from disk
+      // (ERR_MODULE_NOT_FOUND), which should not silently drop the message.
+      finalized.logger?.warn?.(
+        `[getReply] link-understanding import/apply failed (non-fatal): ${linkErr instanceof Error ? linkErr.message : String(linkErr)}`,
+      );
+    }
   }
   emitPreAgentMessageHooks({
     ctx: finalized,


### PR DESCRIPTION
## Summary

After an in-place npm upgrade, the running process may reference a hashed `link-understanding` chunk that no longer exists on disk (`ERR_MODULE_NOT_FOUND`). Previously this **silently killed message dispatch** for any URL-containing message.

## Fix

Wrap `applyLinkUnderstandingIfNeeded()` in try-catch:
- Import/apply failures are logged as warnings (non-fatal)
- Message delivery continues normally without link enrichment
- Link-understanding is an optional enrichment step — it should never block the primary path

## Reproduction

1. Upgrade OpenClaw in-place to a newer version while the gateway process is still running
2. Send a message containing a URL
3. Message is silently dropped with `ERR_MODULE_NOT_FOUND` for the stale link-understanding chunk

## Testing

- Existing tests should pass (no behavior change for happy path)
- Error path: if the dynamic import fails, the warning is logged and the message proceeds

Fixes #68466