### PR TITLE
fix(cron): keep message tool when delivery is none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - Agents/TTS: report failed speech synthesis as a real tool error so unconfigured providers no longer feed successful TTS failure output back into agent loops. (#67980) Thanks @lawrence3699.
 - Gateway/wake: allow unknown properties on wake payloads so external senders like Paperclip can attach opaque metadata without failing schema validation. (#68355) Thanks @kagura-agent.
 - Matrix: honor `channels.matrix.network.dangerouslyAllowPrivateNetwork` when creating clients for private-network homeservers. (#68332) Thanks @kagura-agent.
+- Cron/message tool: keep cron-owned runs with `delivery.mode: "none"` on the normal message-tool path so they can still send explicit messages, create threads, and route conditionally when no runner-owned delivery target is active. (#68482) Thanks @obviyus.
 
 ## 2026.4.15
 

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CronDeliveryMode } from "../types.js";
 import {
   clearFastTestEnv,
   dispatchCronDeliveryMock,
@@ -36,7 +37,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
 
   async function expectMessageToolDisabledForPlan(plan: {
     requested: boolean;
-    mode: "none" | "announce";
+    mode: CronDeliveryMode;
     channel?: string;
     to?: string;
   }) {
@@ -49,7 +50,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
 
   async function expectMessageToolEnabledForPlan(plan: {
     requested: boolean;
-    mode: "none" | "announce";
+    mode: CronDeliveryMode;
     channel?: string;
     to?: string;
   }) {

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -47,6 +47,19 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.disableMessageTool).toBe(true);
   }
 
+  async function expectMessageToolEnabledForPlan(plan: {
+    requested: boolean;
+    mode: "none" | "announce";
+    channel?: string;
+    to?: string;
+  }) {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(plan);
+    await runCronIsolatedAgentTurn(makeParams());
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.disableMessageTool).toBe(false);
+  }
+
   beforeEach(() => {
     previousFastTestEnv = clearFastTestEnv();
     resetRunCronIsolatedAgentTurnHarness();
@@ -63,8 +76,8 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     restoreFastTestEnv(previousFastTestEnv);
   });
 
-  it('disables the message tool when delivery.mode is "none"', async () => {
-    await expectMessageToolDisabledForPlan({
+  it('keeps the message tool enabled when delivery.mode is "none"', async () => {
+    await expectMessageToolEnabledForPlan({
       requested: false,
       mode: "none",
     });

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -92,6 +92,14 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
+  it("disables the message tool when webhook delivery is active", async () => {
+    await expectMessageToolDisabledForPlan({
+      requested: false,
+      mode: "webhook",
+      to: "https://example.invalid/cron",
+    });
+  });
+
   it("keeps the message tool enabled for shared callers when delivery is not requested", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -124,17 +124,13 @@ type IsolatedDeliveryContract = "cron-owned" | "shared";
 function resolveCronToolPolicy(params: {
   deliveryRequested: boolean;
   resolvedDelivery: ResolvedCronDeliveryTarget;
-  deliveryContract: IsolatedDeliveryContract;
 }) {
   return {
     // Only enforce an explicit message target when the cron delivery target
     // was successfully resolved. When resolution fails the agent should not
     // be blocked by a target it cannot satisfy (#27898).
     requireExplicitMessageTarget: params.deliveryRequested && params.resolvedDelivery.ok,
-    // Cron-owned runs always route user-facing delivery through the runner
-    // itself. Shared callers keep the previous behavior so non-cron paths do
-    // not silently lose the message tool when no explicit delivery is active.
-    disableMessageTool: params.deliveryContract === "cron-owned" ? true : params.deliveryRequested,
+    disableMessageTool: params.deliveryRequested,
   };
 }
 
@@ -162,7 +158,6 @@ async function resolveCronDeliveryContext(params: {
       toolPolicy: resolveCronToolPolicy({
         deliveryRequested: false,
         resolvedDelivery,
-        deliveryContract: params.deliveryContract,
       }),
     };
   }
@@ -181,7 +176,6 @@ async function resolveCronDeliveryContext(params: {
     toolPolicy: resolveCronToolPolicy({
       deliveryRequested: deliveryPlan.requested,
       resolvedDelivery,
-      deliveryContract: params.deliveryContract,
     }),
   };
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -124,13 +124,14 @@ type IsolatedDeliveryContract = "cron-owned" | "shared";
 function resolveCronToolPolicy(params: {
   deliveryRequested: boolean;
   resolvedDelivery: ResolvedCronDeliveryTarget;
+  deliveryMode: "announce" | "webhook" | "none";
 }) {
   return {
     // Only enforce an explicit message target when the cron delivery target
     // was successfully resolved. When resolution fails the agent should not
     // be blocked by a target it cannot satisfy (#27898).
     requireExplicitMessageTarget: params.deliveryRequested && params.resolvedDelivery.ok,
-    disableMessageTool: params.deliveryRequested,
+    disableMessageTool: params.deliveryMode !== "none",
   };
 }
 
@@ -158,6 +159,7 @@ async function resolveCronDeliveryContext(params: {
       toolPolicy: resolveCronToolPolicy({
         deliveryRequested: false,
         resolvedDelivery,
+        deliveryMode: deliveryPlan.mode,
       }),
     };
   }
@@ -176,6 +178,7 @@ async function resolveCronDeliveryContext(params: {
     toolPolicy: resolveCronToolPolicy({
       deliveryRequested: deliveryPlan.requested,
       resolvedDelivery,
+      deliveryMode: deliveryPlan.mode,
     }),
   };
 }


### PR DESCRIPTION
## Summary
- keep the message tool enabled for cron-owned runs when `delivery.mode` is `none`
- preserve explicit message routing and thread creation when no runner-owned delivery target is active
- add regression coverage for the no-delivery cron path

## Testing
- `pnpm test src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `pnpm test src/cron/isolated-agent/run.ts`

Fixes #68479.