### PR TITLE
fix(minimax): enable image input for M2.7 models in provider catalog (#65424)

### DIFF
--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -1,14 +1,9 @@
-import type {
-  ModelDefinitionConfig,
-  ModelProviderConfig,
-} from "openclaw/plugin-sdk/provider-model-shared";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import {
-  DEFAULT_MINIMAX_CONTEXT_WINDOW,
-  DEFAULT_MINIMAX_MAX_TOKENS,
   MINIMAX_API_BASE_URL,
-  resolveMinimaxApiCost,
+  buildMinimaxApiModelDefinition,
 } from "./model-definitions.js";
-import { MINIMAX_TEXT_MODEL_CATALOG, MINIMAX_TEXT_MODEL_ORDER } from "./provider-models.js";
+import { MINIMAX_TEXT_MODEL_ORDER } from "./provider-models.js";
 
 function resolveMinimaxCatalogBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
   const rawHost = env.MINIMAX_API_HOST?.trim();
@@ -28,43 +23,8 @@ function resolveMinimaxCatalogBaseUrl(env: NodeJS.ProcessEnv = process.env): str
   }
 }
 
-function buildMinimaxModel(params: {
-  id: string;
-  name: string;
-  reasoning: boolean;
-  input: ModelDefinitionConfig["input"];
-  cost: ModelDefinitionConfig["cost"];
-}): ModelDefinitionConfig {
-  return {
-    id: params.id,
-    name: params.name,
-    reasoning: params.reasoning,
-    input: params.input,
-    cost: params.cost,
-    contextWindow: DEFAULT_MINIMAX_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MINIMAX_MAX_TOKENS,
-  };
-}
-
-function buildMinimaxTextModel(params: {
-  id: string;
-  name: string;
-  reasoning: boolean;
-  cost: ModelDefinitionConfig["cost"];
-}): ModelDefinitionConfig {
-  return buildMinimaxModel({ ...params, input: ["text"] });
-}
-
-function buildMinimaxCatalog(): ModelDefinitionConfig[] {
-  return MINIMAX_TEXT_MODEL_ORDER.map((id) => {
-    const model = MINIMAX_TEXT_MODEL_CATALOG[id];
-    return buildMinimaxTextModel({
-      id,
-      name: model.name,
-      reasoning: model.reasoning,
-      cost: resolveMinimaxApiCost(id),
-    });
-  });
+function buildMinimaxCatalog() {
+  return MINIMAX_TEXT_MODEL_ORDER.map((id) => buildMinimaxApiModelDefinition(id));
 }
 
 export function buildMinimaxProvider(env?: NodeJS.ProcessEnv): ModelProviderConfig {


### PR DESCRIPTION
## Summary
MiniMax-M2.7 and M2.7-highspeed image attachments were silently dropped because `buildMinimaxCatalog()` hardcoded `input: ["text"]` via `buildMinimaxTextModel()`, bypassing the correct image-detection logic already present in `buildMinimaxModelDefinition()`.

## Root Cause
`buildMinimaxTextModel()` always passed `input: ["text"]` to `buildMinimaxModel()`, overriding the M2.7 image capability check in `buildMinimaxModelDefinition()` (line 74: `isImageCapable = params.id === "MiniMax-M2.7" || params.id.startsWith("MiniMax-M2.7-")`).

## Changes
- `extensions/minimax/provider-catalog.ts`: Replace `buildMinimaxTextModel()` with `buildMinimaxApiModelDefinition()` which already has the correct image-detection logic. Removed unused `buildMinimaxModel()` and `buildMinimaxTextModel()` helpers.

## Test
All 87 minimax extension tests pass (`pnpm test extensions/minimax/`).

Closes #65424