### PR TITLE
fix(agents): keep subagent sweeper alive while pendingLifecycleErrorByRunId has entries

### DIFF
--- a/src/agents/subagent-registry.sweeper-self-stop.test.ts
+++ b/src/agents/subagent-registry.sweeper-self-stop.test.ts
@@ -1,0 +1,48 @@
+// Regression: sweeper must not self-stop while pendingLifecycleErrorByRunId
+// still has entries.
+//
+// Bug: the sweep cycle ends with
+//   if (subagentRuns.size === 0) { stopSweeper(); }
+// without also checking the pending-error map that the SAME sweep cycle is
+// responsible for expiring via PENDING_ERROR_TTL_MS. Any entry newer than
+// PENDING_ERROR_TTL_MS (5 min) at the self-stop moment is stranded until a
+// subsequent registerSubagentRun call revives the sweeper, which on an idle
+// workload can be hours to days. The entry holds a NodeJS.Timeout and the
+// cached error payload the entire time.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __testing, resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+describe("sweeper self-stop respects pendingLifecycleErrorByRunId", () => {
+  beforeEach(() => {
+    resetSubagentRegistryForTests({ persist: false });
+  });
+
+  afterEach(() => {
+    resetSubagentRegistryForTests({ persist: false });
+  });
+
+  it("keeps sweeper running while pending lifecycle errors exist", async () => {
+    // Populate pending-error map with an entry that has not yet reached its
+    // PENDING_ERROR_TTL_MS. subagentRuns stays empty — the exact condition
+    // that trips the buggy self-stop.
+    __testing.schedulePendingLifecycleErrorForTest({
+      runId: "sweeper-drain-regression",
+      endedAt: Date.now(),
+      error: "regression fixture",
+    });
+    expect(__testing.getPendingLifecycleErrorCountForTest()).toBe(1);
+    expect(__testing.getSubagentRunsSizeForTest()).toBe(0);
+
+    __testing.startSweeperForTest();
+    expect(__testing.isSweeperActiveForTest()).toBe(true);
+
+    // Run one sweep cycle. Pending TTL is not yet reached, so the cycle leaves
+    // the entry in the map. The self-stop check must observe that the map is
+    // non-empty and keep the sweeper alive so a later cycle can expire it.
+    await __testing.runSweepForTest();
+
+    expect(__testing.getPendingLifecycleErrorCountForTest()).toBe(1);
+    expect(__testing.isSweeperActiveForTest()).toBe(true);
+  });
+});

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -601,7 +601,11 @@ async function sweepSubagentRuns() {
     if (mutated) {
       persistSubagentRuns();
     }
-    if (subagentRuns.size === 0) {
+    // Also require the pending-error map to be drained before stopping. The
+    // same sweep cycle expires those entries via PENDING_ERROR_TTL_MS, so
+    // leaving the sweeper alive is the only way entries scheduled after the
+    // last run was reclaimed can ever be cleaned up on an idle workload.
+    if (subagentRuns.size === 0 && pendingLifecycleErrorByRunId.size === 0) {
       stopSweeper();
     }
   } finally {
@@ -766,6 +770,29 @@ export const __testing = {
           ...overrides,
         }
       : defaultSubagentRegistryDeps;
+  },
+  // Sweeper-drain regression coverage: expose just enough to observe whether the
+  // sweeper self-stops while pendingLifecycleErrorByRunId still has entries.
+  getPendingLifecycleErrorCountForTest(): number {
+    return pendingLifecycleErrorByRunId.size;
+  },
+  getSubagentRunsSizeForTest(): number {
+    return subagentRuns.size;
+  },
+  isSweeperActiveForTest(): boolean {
+    return sweeper !== null;
+  },
+  startSweeperForTest() {
+    startSweeper();
+  },
+  schedulePendingLifecycleErrorForTest(params: { runId: string; endedAt: number; error?: string }) {
+    schedulePendingLifecycleError(params);
+  },
+  async runSweepForTest() {
+    await sweepSubagentRuns();
+  },
+  getPendingErrorTtlMsForTest(): number {
+    return PENDING_ERROR_TTL_MS;
   },
 } as const;
 


### PR DESCRIPTION
## Summary

- **Problem:** The subagent sweeper self-stops the moment `subagentRuns` becomes empty, without checking `pendingLifecycleErrorByRunId`. That same sweeper cycle is the only thing that expires pending-error entries via `PENDING_ERROR_TTL_MS` (5 min), so any entry newer than the TTL at the self-stop moment is stranded until a later `registerSubagentRun` revives the sweeper.
- **Why it matters:** On an idle gateway, stranded entries persist indefinitely instead of ~5 min, each holding a `NodeJS.Timeout` and the cached error payload. Latent leak on long-running processes with sporadic subagent activity.
- **What changed:** Extend the self-stop condition to require both maps drained (`subagentRuns.size === 0 && pendingLifecycleErrorByRunId.size === 0`). Adds a scoped regression test plus minimal `__testing` accessors to observe sweeper state.
- **What did NOT change (scope boundary):** Public API, `stopSweeper`/`startSweeper` bodies, `schedulePendingLifecycleError`, `PENDING_ERROR_TTL_MS`, the 15-second grace-timer retry flow, or any persisted state format. `setInterval(...).unref()` semantics preserved.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #68487
- [x] This PR fixes a bug or regression

## Root Cause

The sweeper owns two TTL-driven maps: `subagentRuns` (session/archive TTL) and `pendingLifecycleErrorByRunId` (`PENDING_ERROR_TTL_MS`). The self-stop predicate only considered the first one, so any pending-error entry added between the last run being reclaimed and the sweep cycle ending was stranded — its timer would fire the 15-second grace retry correctly, but the absolute 5-minute TTL cleanup never got another chance until a future `registerSubagentRun` re-armed the sweeper.

- **Root cause:** Self-stop predicate is asymmetric with the responsibilities of the sweeper body. It only checks one of the two maps that the cycle is supposed to drain.
- **Missing detection / guardrail:** No regression test covered the `subagentRuns empty + pendingLifecycleErrorByRunId non-empty` shape.
- **Contributing context:** `schedulePendingLifecycleError` is reachable from orphan/cleanup paths where `subagentRuns.delete(runId)` fires independently of the pending map's TTL state, so the two maps can legitimately end a sweep cycle in different drain states.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/subagent-registry.sweeper-self-stop.test.ts`
- Scenario the test should lock in: populate `pendingLifecycleErrorByRunId` with an entry newer than `PENDING_ERROR_TTL_MS`, leave `subagentRuns` empty, start the sweeper, run one sweep cycle, assert the sweeper is still active and the pending entry is still queued for TTL cleanup.
- Why this is the smallest reliable guardrail: it directly exercises the self-stop predicate in the exact shape that regresses; does not rely on real timers, gateway calls, or event plumbing.
- Existing test that already covers this: none. `subagent-registry.lifecycle-retry-grace.e2e.test.ts` covers the 15-second grace timer retry but not the absolute 5-minute TTL cleanup path.
- If no new test is added, why not: N/A — new test added.

## User-visible / Behavior Changes

None. Timing of sweeper self-stop shifts by at most a few 60-second cycles on workloads that land in this exact state. No config, CLI output, or persisted format changes.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 25.4.0 (darwin)
- Runtime: Node 22+ / pnpm
- Commit base: `d7cc6f7643` (docs: prepare changelog for 2026.4.14)

### Steps (in this PR's regression test)

1. `__testing.schedulePendingLifecycleErrorForTest({ runId, endedAt: Date.now(), error: "..." })`
2. `__testing.startSweeperForTest()` (subagentRuns stays empty)
3. `await __testing.runSweepForTest()`
4. Assert: `__testing.isSweeperActiveForTest() === true` and `__testing.getPendingLifecycleErrorCountForTest() === 1`

### Expected

Sweeper remains active so the next cycle can expire the entry via `PENDING_ERROR_TTL_MS`.

### Actual (on current main)

`isSweeperActiveForTest()` returns `false`. Sweeper stopped mid-pending; TTL cleanup will not run again until `registerSubagentRun` revives it.

## Evidence

- [x] Failing test on main + passing after patch

Before the one-line predicate change the new test fails with:

```
AssertionError: expected false to be true
 ❯ src/agents/subagent-registry.sweeper-self-stop.test.ts:47:48
```

After the change the same file passes (and all other targeted `subagent-registry*` tests stay green).

## Human Verification (required)

- Verified scenarios:
  - New test fails against the unmodified predicate, passes after the one-line change.
  - Targeted `pnpm test src/agents/subagent-registry*` (minus e2e) — all green (22 tests across the files touched by this change).
  - `pnpm check` — 0 warnings, 0 errors on the staged diff (pre-commit hook output).
  - `pnpm build` — exits 0.
- Edge cases checked:
  - Sweeper is still stopped when both maps are empty (baseline behavior preserved).
  - The 15-second grace timer retry path is unchanged — `schedulePendingLifecycleError`, `clearPendingLifecycleError`, and `clearAllPendingLifecycleErrors` were not touched.
- What I did **not** verify:
  - Full-repo `pnpm test` — `extensions/feishu/**` has 442 unrelated pre-existing lint errors on main, and a broad run is expensive; I relied on the scoped tests plus `pnpm check` on the staged diff.
  - Real multi-minute wall-clock behavior under a live gateway — the test uses direct sweeper invocation, not a real `setInterval`, which is deterministic but not identical to production timing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: The sweeper stays alive for additional 60-second cycles while the pending map drains.
  - Mitigation: `setInterval(...).unref()` is preserved so process exit is unaffected; at most a handful of additional empty sweeps while entries age out.
- Risk: The scope of `__testing` grows.
  - Mitigation: All added members are `ForTest`-suffixed and read-only relative to production state (except the deliberate `schedulePendingLifecycleErrorForTest` which mirrors the internal helper under a test-only name). No production call site uses them.

## AI-assisted

- [x] Drafted with Claude Code assistance.
- Testing level: lightly tested (scoped unit + `pnpm check` + `pnpm build`; full-repo `pnpm test` not run because of unrelated pre-existing failures in `extensions/feishu/**`).
- Failing regression test was written first, the predicate change was the minimal diff that turned it green.
- I understand what the code does; the fix is a one-condition extension of the existing self-stop predicate so the sweeper keeps cycling until both TTL-owned maps are drained.
