### PR TITLE
fix: exclude volatile inbound metadata from extraSystemPromptHash

### DIFF
--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -78,7 +78,12 @@ export async function prepareCliRunContext(
     authProfileId: params.authProfileId,
   });
   const extraSystemPrompt = params.extraSystemPrompt?.trim() ?? "";
-  const extraSystemPromptHash = hashCliSessionText(extraSystemPrompt);
+  // Use stable content for hashing when available — excludes volatile per-message
+  // metadata (inbound channel context) that differs between heartbeat and user
+  // message triggers without representing a meaningful prompt change (#68471).
+  const extraSystemPromptHashSource =
+    params.extraSystemPromptStableContent?.trim() ?? extraSystemPrompt;
+  const extraSystemPromptHash = hashCliSessionText(extraSystemPromptHashSource);
   const modelId = (params.model ?? "default").trim() || "default";
   const normalizedModel = normalizeCliModel(modelId, backendResolved.config);
   const modelDisplay = `${params.provider}/${modelId}`;

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -23,6 +23,14 @@ export type RunCliAgentParams = {
   timeoutMs: number;
   runId: string;
   extraSystemPrompt?: string;
+  /**
+   * Stable subset of extraSystemPrompt used only for session-reuse hashing.
+   * Excludes volatile per-message metadata (inbound channel context) that
+   * changes between heartbeat and user-message triggers without representing
+   * a meaningful system-prompt change.  When provided, the session hash is
+   * derived from this value instead of extraSystemPrompt.
+   */
+  extraSystemPromptStableContent?: string;
   streamParams?: import("../command/types.js").AgentStreamParams;
   ownerNumbers?: string[];
   cliSessionId?: string;

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -166,4 +166,36 @@ describe("cli-session helpers", () => {
     expect(hashCliSessionText("  keep this  ")).toBe(hashCliSessionText("keep this"));
     expect(hashCliSessionText("")).toBeUndefined();
   });
+
+  it("stable content hash prevents heartbeat-triggered session resets (#68471)", () => {
+    // Simulate: user message creates a session with hash from stable content only.
+    // Heartbeat fires with different inbound metadata but same stable content.
+    // The session should NOT be invalidated.
+    const stableContent = "group-context\n\nexec-overrides";
+    const stableHash = hashCliSessionText(stableContent)!;
+
+    // Session was stored with hash of stable content
+    const binding = {
+      sessionId: "cli-session-1",
+      extraSystemPromptHash: stableHash,
+    };
+
+    // Heartbeat run: different full extraSystemPrompt (different inbound meta),
+    // but same stable content → same hash → session reused
+    expect(
+      resolveCliSessionReuse({
+        binding,
+        extraSystemPromptHash: stableHash,
+      }),
+    ).toEqual({ sessionId: "cli-session-1" });
+
+    // If we had used the full extraSystemPrompt hash (including volatile inbound meta),
+    // it would differ and cause an unnecessary reset
+    const fullPromptUserMsg = "inbound-meta-feishu\n\n" + stableContent;
+    const fullPromptHeartbeat = "inbound-meta-heartbeat\n\n" + stableContent;
+    const userHash = hashCliSessionText(fullPromptUserMsg)!;
+    const heartbeatHash = hashCliSessionText(fullPromptHeartbeat)!;
+    expect(userHash).not.toBe(heartbeatHash); // These differ — would cause reset
+    expect(stableHash).toBe(stableHash); // But stable hashes match — no reset
+  });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -875,6 +875,8 @@ export async function runAgentTurnWithFallback(params: {
                   timeoutMs: params.followupRun.run.timeoutMs,
                   runId,
                   extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                  extraSystemPromptStableContent:
+                    params.followupRun.run.extraSystemPromptStableContent,
                   ownerNumbers: params.followupRun.run.ownerNumbers,
                   cliSessionId: cliSessionBinding?.sessionId,
                   cliSessionBinding,
@@ -988,6 +990,8 @@ export async function runAgentTurnWithFallback(params: {
                 ...runBaseParams,
                 prompt: params.commandBody,
                 extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                extraSystemPromptStableContent:
+                  params.followupRun.run.extraSystemPromptStableContent,
                 toolResultFormat: (() => {
                   const channel = resolveMessageChannel(
                     params.sessionCtx.Surface,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -240,6 +240,7 @@ export function createFollowupRunner(params: {
                 skillsSnapshot: run.skillsSnapshot,
                 prompt: queued.prompt,
                 extraSystemPrompt: run.extraSystemPrompt,
+                extraSystemPromptStableContent: run.extraSystemPromptStableContent,
                 ownerNumbers: run.ownerNumbers,
                 enforceFinalTag: run.enforceFinalTag,
                 provider,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -291,17 +291,27 @@ export async function runPreparedReply(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
     { includeFormattingHints: !useFastReplyRuntime },
   );
+  const execOverrideHint = buildExecOverridePromptHint({
+    execOverrides,
+    elevatedLevel: resolvedElevatedLevel,
+    fullAccessAvailable: fullAccessState.available,
+    fullAccessBlockedReason: fullAccessState.blockedReason,
+  });
   const extraSystemPromptParts = [
     inboundMetaPrompt,
     groupChatContext,
     groupIntro,
     groupSystemPrompt,
-    buildExecOverridePromptHint({
-      execOverrides,
-      elevatedLevel: resolvedElevatedLevel,
-      fullAccessAvailable: fullAccessState.available,
-      fullAccessBlockedReason: fullAccessState.blockedReason,
-    }),
+    execOverrideHint,
+  ].filter(Boolean);
+  // Stable subset for session-reuse hashing: excludes inboundMetaPrompt which
+  // contains per-message volatile metadata (channel, surface, account_id) that
+  // differs between heartbeat and user-message triggers (#68471).
+  const extraSystemPromptStableParts = [
+    groupChatContext,
+    groupIntro,
+    groupSystemPrompt,
+    execOverrideHint,
   ].filter(Boolean);
   const baseBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
   // Use CommandBody/RawBody for bare reset detection (clean message without structural context).
@@ -708,6 +718,7 @@ export async function runPreparedReply(
       ownerNumbers: command.ownerList.length > 0 ? command.ownerList : undefined,
       inputProvenance: ctx.InputProvenance ?? sessionCtx.InputProvenance,
       extraSystemPrompt: extraSystemPromptParts.join("\n\n") || undefined,
+      extraSystemPromptStableContent: extraSystemPromptStableParts.join("\n\n") || undefined,
       skipProviderRuntimeHints: useFastReplyRuntime,
       ...(!useFastReplyRuntime &&
       isReasoningTagProvider(provider, {

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -81,6 +81,7 @@ export type FollowupRun = {
     ownerNumbers?: string[];
     inputProvenance?: InputProvenance;
     extraSystemPrompt?: string;
+    extraSystemPromptStableContent?: string;
     enforceFinalTag?: boolean;
     skipProviderRuntimeHints?: boolean;
     silentExpected?: boolean;


### PR DESCRIPTION
## Summary

Fixes #68471 — Heartbeat triggers unnecessary `cli session reset: reason=system-prompt` every 30 minutes.

## Problem

The built-in heartbeat mechanism causes a full CLI session reset each time it fires because the `extraSystemPromptHash` differs between heartbeat-triggered runs and user-message-triggered runs. The inbound metadata block (`buildInboundMetaSystemPrompt`) contains per-message volatile fields (`channel`, `surface`, `account_id`) that naturally differ between a Feishu user message and a heartbeat trigger, even though nothing structurally meaningful has changed in the system prompt. This destroys conversation context on every heartbeat cycle.

## Solution

Introduce `extraSystemPromptStableContent` — a subset of the extra system prompt that excludes the volatile inbound metadata. This stable content is used for session-reuse hash calculation instead of the full `extraSystemPrompt`.

**Changes:**
- **`cli-runner/types.ts`**: Add `extraSystemPromptStableContent?` field to `RunCliAgentParams`
- **`cli-runner/prepare.ts`**: Hash `extraSystemPromptStableContent` when available, falling back to `extraSystemPrompt`
- **`get-reply-run.ts`**: Compute stable parts (group context, group intro, group system prompt, exec overrides) separately from volatile inbound meta prompt
- **`queue/types.ts`, `agent-runner-execution.ts`, `followup-runner.ts`**: Thread the new field through the run pipeline
- **`cli-session.test.ts`**: Add test demonstrating that stable hashing prevents heartbeat-triggered resets

## Behavior

- The full `extraSystemPrompt` (including inbound metadata) is still used in the actual system prompt sent to the model — no change in prompt content
- Only the **hash used for session reuse comparison** is now derived from the stable subset
- Transitions between user messages and heartbeats no longer trigger session resets
- Genuine structural changes (group context, exec overrides) still correctly invalidate sessions