### PR TITLE
fix(feishu): prevent duplicate message after streaming card close (#67791)

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -364,6 +364,27 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
+
+  it("skips final text already closed by idle streaming", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "```md\nidle streamed reply\n```" });
+    await options.onIdle?.();
+    await options.deliver({ text: "```md\nidle streamed reply\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\nidle streamed reply\n```", {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("suppresses duplicate final text while still sending media", async () => {
     const options = setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "plain final" }, { kind: "final" });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -311,6 +311,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       }
       const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
       await streaming.close(text, { note: finalNote });
+      // Track the raw streamed text so the duplicate-final check in deliver()
+      // can skip the redundant text delivery that arrives after onIdle closes
+      // the streaming card.
+      if (streamText) {
+        deliveredFinalTexts.add(streamText);
+      }
     }
     streaming = null;
     streamingStartPromise = null;


### PR DESCRIPTION
## Summary
Feishu sends a duplicate text/card message after streaming completes because the `onIdle`-triggered `closeStreaming()` does not record the streamed content in `deliveredFinalTexts`. The subsequent `final` delivery bypasses the inactive streaming guard and sends the same content again.

## Root Cause
When `onIdle` fires before the `final` delivery arrives:
1. `closeStreaming()` finalizes the streaming card with the accumulated text
2. `streaming` is set to `null`
3. The `final` delivery arrives, but `streaming?.isActive()` returns `false`
4. The code falls through to the non-streaming path and sends a redundant message
5. `deliveredFinalTexts` does not contain the streamed text (only added at line 419 inside the `isActive()` guard), so the duplicate check passes

## Changes
- `extensions/feishu/src/reply-dispatcher.ts`: Add `streamText` to `deliveredFinalTexts` in `closeStreaming()` before clearing state, so the duplicate-final check in `deliver()` can skip the redundant text delivery.

## Test
All 30 reply-dispatcher tests pass (`pnpm test extensions/feishu/src/reply-dispatcher.test.ts`). 2 pre-existing failures in other Feishu test files (media upload mock, webhook ECONNRESET) are unrelated.

Closes #67791