### PR TITLE
Skills: add exec dispatch for slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Skills: add `command-dispatch: exec` with `command-exec: <shell command>` to run a script directly for slash-command invocations, bypassing the LLM. Stdout is returned as the reply.
 - Onboarding: add Cloudflare AI Gateway provider setup and docs. (#7914) Thanks @roerohan.
 - Onboarding: add Moonshot (.cn) auth choice and keep the China base URL when preserving defaults. (#7180) Thanks @waynelwz.
 - Docs: clarify tmux send-keys for TUI by splitting text and Enter. (#7737) Thanks @Wangnov.

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -190,6 +190,42 @@ export function stripDowngradedToolCallText(text: string): string {
 }
 
 /**
+ * Strip generic tool call XML blocks that leak into text content.
+ * Some models (e.g. Kimi K2.5, generic OpenRouter providers) emit tool calls
+ * as raw XML text blocks instead of structured tool calls. This removes:
+ * - <antml_function_calls>...</antml_function_calls>
+ * - <function_calls>...</function_calls>
+ * - <tool_use>...</tool_use> / <tool_call>...</tool_call>
+ *
+ * Note: <invoke> blocks are intentionally excluded here — they are handled
+ * separately by stripMinimaxToolCallXml only when Minimax markers are present,
+ * because plain <invoke> can appear as legitimate doc/code content.
+ */
+export function stripToolCallXml(text: string): string {
+  if (!text) {
+    return text;
+  }
+  if (!/<antml_function_calls|<function_calls|<tool_use\b|<tool_call\b/i.test(text)) {
+    return text;
+  }
+  let cleaned = text;
+  // <antml_function_calls>...</antml_function_calls>
+  cleaned = cleaned.replace(/<antml_function_calls>[\s\S]*?<\/antml_function_calls>/gi, "");
+  // <function_calls>...</function_calls>
+  cleaned = cleaned.replace(/<function_calls>[\s\S]*?<\/function_calls>/gi, "");
+  // <tool_use ...>...</tool_use>
+  cleaned = cleaned.replace(/<tool_use\b[^>]*>[\s\S]*?<\/tool_use>/gi, "");
+  // <tool_call ...>...</tool_call>
+  cleaned = cleaned.replace(/<tool_call\b[^>]*>[\s\S]*?<\/tool_call>/gi, "");
+  // Stray opening/closing tags left behind
+  cleaned = cleaned.replace(
+    /<\/?(antml_function_calls|function_calls|tool_use|tool_call)\b[^>]*>/gi,
+    "",
+  );
+  return cleaned;
+}
+
+/**
  * Strip thinking tags and their content from text.
  * This is a safety net for cases where the model outputs <think> tags
  * that slip through other filtering mechanisms.
@@ -212,7 +248,7 @@ export function extractAssistantText(msg: AssistantMessage): string {
         .filter(isTextBlock)
         .map((c) =>
           stripThinkingTagsFromText(
-            stripDowngradedToolCallText(stripMinimaxToolCallXml(c.text)),
+            stripDowngradedToolCallText(stripMinimaxToolCallXml(stripToolCallXml(c.text))),
           ).trim(),
         )
         .filter(Boolean)

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -129,6 +129,39 @@ describe("buildWorkspaceSkillCommandSpecs", () => {
     const cmd = commands.find((entry) => entry.skillName === "tool-dispatch");
     expect(cmd?.dispatch).toEqual({ kind: "tool", toolName: "sessions_send", argMode: "raw" });
   });
+
+  it("includes exec-dispatch metadata from frontmatter", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillDir = path.join(workspaceDir, "skills", "exec-dispatch");
+    await writeSkill({
+      dir: skillDir,
+      name: "exec-dispatch",
+      description: "Dispatch to a script",
+      frontmatterExtra: "command-dispatch: exec\ncommand-exec: python3 scripts/run.py",
+    });
+
+    const commands = buildWorkspaceSkillCommandSpecs(workspaceDir);
+    const cmd = commands.find((entry) => entry.skillName === "exec-dispatch");
+    expect(cmd?.dispatch).toEqual({
+      kind: "exec",
+      command: "python3 scripts/run.py",
+      cwd: skillDir,
+    });
+  });
+
+  it("ignores exec-dispatch without command-exec", async () => {
+    const workspaceDir = await makeWorkspace();
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "exec-missing"),
+      name: "exec-missing",
+      description: "Missing exec command",
+      frontmatterExtra: "command-dispatch: exec",
+    });
+
+    const commands = buildWorkspaceSkillCommandSpecs(workspaceDir);
+    const cmd = commands.find((entry) => entry.skillName === "exec-missing");
+    expect(cmd?.dispatch).toBeUndefined();
+  });
 });
 
 describe("buildWorkspaceSkillsPrompt", () => {

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -37,16 +37,24 @@ export type SkillInvocationPolicy = {
   disableModelInvocation: boolean;
 };
 
-export type SkillCommandDispatchSpec = {
-  kind: "tool";
-  /** Name of the tool to invoke (AnyAgentTool.name). */
-  toolName: string;
-  /**
-   * How to forward user-provided args to the tool.
-   * - raw: forward the raw args string (no core parsing).
-   */
-  argMode?: "raw";
-};
+export type SkillCommandDispatchSpec =
+  | {
+      kind: "tool";
+      /** Name of the tool to invoke (AnyAgentTool.name). */
+      toolName: string;
+      /**
+       * How to forward user-provided args to the tool.
+       * - raw: forward the raw args string (no core parsing).
+       */
+      argMode?: "raw";
+    }
+  | {
+      kind: "exec";
+      /** Shell command to run. User args are appended verbatim. */
+      command: string;
+      /** Working directory (absolute path, usually the skill's baseDir). */
+      cwd: string;
+    };
 
 export type SkillCommandSpec = {
   name: string;

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -392,6 +392,22 @@ export function buildWorkspaceSkillCommandSpecs(
       if (!kindRaw) {
         return undefined;
       }
+      if (kindRaw === "exec") {
+        const execCmd = (
+          entry.frontmatter?.["command-exec"] ??
+          entry.frontmatter?.["command_exec"] ??
+          ""
+        ).trim();
+        if (!execCmd) {
+          debugSkillCommandOnce(
+            `dispatch:missingExec:${rawName}`,
+            `Skill command "/${unique}" requested exec dispatch but did not provide command-exec. Ignoring dispatch.`,
+            { skillName: rawName, command: unique },
+          );
+          return undefined;
+        }
+        return { kind: "exec", command: execCmd, cwd: entry.skill.baseDir } as const;
+      }
       if (kindRaw !== "tool") {
         return undefined;
       }

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -164,6 +164,26 @@ export async function handleInlineActions(params: {
     }
 
     const dispatch = skillInvocation.command.dispatch;
+    if (dispatch?.kind === "exec") {
+      const rawArgs = (skillInvocation.args ?? "").trim();
+      try {
+        const { execFile } = await import("node:child_process");
+        const { promisify } = await import("node:util");
+        const run = promisify(execFile);
+        const { stdout } = await run(
+          "sh",
+          ["-c", rawArgs ? `${dispatch.command} ${rawArgs}` : dispatch.command],
+          { cwd: dispatch.cwd, timeout: 15_000, maxBuffer: 1_000_000 },
+        );
+        const text = stdout.trim() || "✅ Done.";
+        typing.cleanup();
+        return { kind: "reply", reply: { text } };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        typing.cleanup();
+        return { kind: "reply", reply: { text: `❌ ${message}` } };
+      }
+    }
     if (dispatch?.kind === "tool") {
       const rawArgs = (skillInvocation.args ?? "").trim();
       const channel =

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -147,9 +147,8 @@ export async function deliverReplies(params: {
       const fileName = media.fileName ?? (isGif ? "animation.gif" : "file");
       const file = new InputFile(media.buffer, fileName);
       // Caption only on first item; if text exceeds limit, defer to follow-up message.
-      const { caption, followUpText } = splitTelegramCaption(
-        isFirstMedia ? (reply.text ?? undefined) : undefined,
-      );
+      const rawText = isFirstMedia ? (reply.text ?? undefined) : undefined;
+      const { caption, followUpText } = splitTelegramCaption(rawText);
       const htmlCaption = caption
         ? renderTelegramHtmlText(caption, { tableMode: params.tableMode })
         : undefined;


### PR DESCRIPTION
## Summary

- Add `command-dispatch: exec` (with `command-exec: <shell command>`) to workspace skill frontmatter.
- When a slash command bound to such a skill is invoked, OpenClaw runs the script in the skill's `baseDir` and delivers stdout verbatim, bypassing the LLM. Timeout 15s, 1MB stdout buffer.
- Existing `command-dispatch: tool` behavior unchanged; skills without `command-dispatch` still route through the LLM as before.

Motivates thin script-backed skills (e.g. `/ctx`, `/ping`, `/version`) that should reply with exact, deterministic output and shouldn't pay the token/latency/reformatting cost of an LLM round trip.

### Example

```yaml
---
name: ctx
description: Show current session context usage, model, cost, and duration.
command-dispatch: exec
command-exec: python3 scripts/session-status.py
---
```

## Test plan

- [x] `pnpm exec vitest run src/agents/skills.test.ts` — 11/11 pass (new tests cover exec dispatch parsing + missing-command fallback).
- [x] `pnpm build` — clean.
- [ ] Manual: install locally, invoke `/ctx` on Telegram, confirm stdout is delivered verbatim with no LLM turn.