### PR TITLE
fix(matrix): pin event-helpers import to canonical matrix-js-sdk subpath (refs #50477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Docs: https://docs.openclaw.ai
 - Google/Antigravity: resolve forward-compatible Gemini 3.1 Pro custom-tools and Flash variants from the bundled Google plugin templates, so `google-antigravity/gemini-3.1-pro-preview-customtools` no longer falls through to an unknown-model error. Fixes #35512.
 - Active Memory: raise the blocking recall timeout ceiling to 120 seconds and reject larger config values during plugin schema validation. Fixes #68410. (#68480) Thanks @Bartok9.
 - Control UI/chat: keep history-backed user image uploads visible after chat reload while filtering blocked or non-image transcript media paths. (#68415) Thanks @mraleko.
+- Matrix/plugins: keep remaining Matrix event helpers on the canonical `matrix-js-sdk` subpath so build and plugin-load entrypoint checks stay consistent. (#68498) Thanks @masatohoshino.
 
 ## 2026.4.15
 

--- a/extensions/matrix/src/matrix/client/file-sync-store.test.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { ISyncResponse } from "matrix-js-sdk";
+import type { ISyncResponse } from "matrix-js-sdk/lib/matrix.js";
 import * as jsonStore from "openclaw/plugin-sdk/json-store";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FileBackedMatrixSyncStore } from "./file-sync-store.js";

--- a/extensions/matrix/src/matrix/sdk/event-helpers.test.ts
+++ b/extensions/matrix/src/matrix/sdk/event-helpers.test.ts
@@ -1,4 +1,4 @@
-import type { MatrixEvent } from "matrix-js-sdk";
+import type { MatrixEvent } from "matrix-js-sdk/lib/matrix.js";
 import { describe, expect, it } from "vitest";
 import { buildHttpError, matrixEventToRaw, parseMxc } from "./event-helpers.js";
 

--- a/extensions/matrix/src/matrix/sdk/event-helpers.ts
+++ b/extensions/matrix/src/matrix/sdk/event-helpers.ts
@@ -1,4 +1,4 @@
-import type { MatrixEvent } from "matrix-js-sdk";
+import type { MatrixEvent } from "matrix-js-sdk/lib/matrix.js";
 import type { MatrixRawEvent } from "./types.js";
 
 export type MatrixEventContentMode = "current" | "original";


### PR DESCRIPTION
## Summary

- Problem: `event-helpers.ts` imports the `MatrixEvent` type from the bare `matrix-js-sdk` package root, while sibling files in the same extension reach the SDK via a deeper subpath.
- Why it matters: Mixed import paths to the same package can lead to inconsistent module resolution and are one source of the symptom discussed in #50477.
- What changed: Pinned the `MatrixEvent` type import to `matrix-js-sdk/lib/matrix.js`, the path already used by other files in the matrix extension.
- What did NOT change (scope boundary): Type definition itself, runtime behavior, public API. This is a type-only import path change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Refs #50477 (partial — addresses one of the inconsistent import paths)
- Resubmit of a single commit from #68458 (closed; that PR also contained an unrelated dead-code addition).
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `event-helpers.ts` used a bare `matrix-js-sdk` import while sibling files in `extensions/matrix/src/matrix/` reach the SDK via the `matrix-js-sdk/lib/matrix.js` subpath. Mixed import paths to the same package can result in inconsistent module identity and may contribute to the symptom in #50477.
- Missing detection / guardrail: No lint rule enforces a single canonical import path for `matrix-js-sdk` within the extension.
- Contributing context (if known): One of the symptoms surfaced as #50477.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `extensions/matrix` test suite + TypeScript type checking
- Scenario the test should lock in: type imports for `matrix-js-sdk` in this extension resolve through a consistent path.
- Why this is the smallest reliable guardrail: this is a type-only import path change with no runtime behavior delta. The TypeScript compiler validates the import at build time; runtime tests would not exercise an additional code path.
- Existing test that already covers this (if any): `pnpm test -- extensions/matrix` passes on this branch.
- If no new test is added, why not: type-only import path change with no runtime behavior change.

## User-visible / Behavior Changes

None

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Docker
- Model/provider: N/A
- Integration/channel (if any): local multi-channel deployment (Matrix not configured)
- Relevant config (redacted): Matrix homeserver not configured in this environment

### Steps

1. `pnpm build` and `pnpm test -- extensions/matrix` on this branch.
2. Inspect the diff: a single type-only import path change.

### Expected

- Build and tests pass; the matrix extension reaches `matrix-js-sdk` through a single subpath.

### Actual

- Build and tests pass on this branch.
- After this fix: all matrix extension files reach the SDK via the same subpath used elsewhere in the extension.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
$ pnpm test -- extensions/matrix
 Test Files  114 passed (114)
      Tests  1102 passed (1102)
```

## Human Verification (required)

- Verified scenarios: built a docker image from this branch and deployed it locally; the gateway started cleanly, and other active channels handled message exchange normally without runtime errors related to the matrix extension.
- Edge cases checked: container restart with the new build.
- What you did **not** verify: Matrix channel runtime behavior, as the local deployment does not have a Matrix homeserver configured. The change is type-only and the matrix test suite passes (114 test files / 1102 tests).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Future `matrix-js-sdk` releases may reorganize subpath exports, breaking the pinned `matrix-js-sdk/lib/matrix.js` import.
  - Mitigation: TypeScript will fail the build at the import site if the subpath is removed; this is fail-fast rather than a silent breakage.

## AI-assisted

- [x] Drafted with Claude (design decisions) + Codex CLI (implementation)
- [x] Tested locally — `pnpm test -- extensions/matrix` passes
- [x] `codex review --base origin/main` run — no actionable regressions
- [x] Author understands the change
