### PR TITLE
fix(infra): revert sigusr1 authorization when emitGatewayRestart emission throws

### DIFF
--- a/src/infra/restart.emit-authorization-leak.test.ts
+++ b/src/infra/restart.emit-authorization-leak.test.ts
@@ -1,0 +1,50 @@
+// Regression: emitGatewayRestart's catch block rolls back only
+// emittedRestartToken and leaves the sigusr1 authorization count incremented.
+//
+// Sequence:
+//   1. emitGatewayRestart() calls authorizeGatewaySigusr1Restart(), which
+//      increments sigusr1AuthorizedCount.
+//   2. process.emit / process.kill throws.
+//   3. The catch block rolls back emittedRestartToken but not the
+//      authorization count.
+//   4. consumeGatewaySigusr1RestartAuthorization() returns true for a stray
+//      (already-failed) restart cycle, until SIGUSR1_AUTH_GRACE_MS (5 s)
+//      self-expires the bucket.
+//
+// Expected after fix: the catch path reverses the authorization increment so
+// the leak window closes immediately instead of ~5 s later.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  consumeGatewaySigusr1RestartAuthorization,
+  emitGatewayRestart,
+} from "./restart.js";
+
+describe("emitGatewayRestart rolls back authorization when emission throws", () => {
+  beforeEach(() => {
+    __testing.resetSigusr1State();
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    __testing.resetSigusr1State();
+  });
+
+  it("does not leave an unconsumed authorization when process.kill throws", () => {
+    // No SIGUSR1 listener, so emitGatewayRestart falls through to process.kill.
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("simulated kill failure");
+    });
+
+    expect(emitGatewayRestart()).toBe(false);
+    expect(killSpy).toHaveBeenCalledTimes(1);
+
+    // The emission failed, so nothing should be able to claim a "valid"
+    // sigusr1 authorization from that aborted cycle.
+    expect(consumeGatewaySigusr1RestartAuthorization()).toBe(false);
+  });
+});

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -133,6 +133,10 @@ export function emitGatewayRestart(): boolean {
   } catch {
     // Roll back the cycle marker so future restart requests can still proceed.
     emittedRestartToken = consumedRestartToken;
+    // Also revert the authorization that was granted for this failed cycle,
+    // otherwise a stray SIGUSR1 arriving within SIGUSR1_AUTH_GRACE_MS can
+    // consume it and trigger an unsanctioned restart path.
+    revertGatewaySigusr1RestartAuthorization();
     return false;
   }
   lastRestartEmittedAt = Date.now();
@@ -164,6 +168,20 @@ function authorizeGatewaySigusr1Restart(delayMs = 0) {
   sigusr1AuthorizedCount += 1;
   if (expiresAt > sigusr1AuthorizedUntil) {
     sigusr1AuthorizedUntil = expiresAt;
+  }
+}
+
+// Reverses a prior authorizeGatewaySigusr1Restart() call when the matching
+// emission aborts before the SIGUSR1 actually reaches a handler. Unlike
+// consumeGatewaySigusr1RestartAuthorization(), this does not advertise that
+// the authorization was "used" — it simply undoes the increment.
+function revertGatewaySigusr1RestartAuthorization() {
+  if (sigusr1AuthorizedCount <= 0) {
+    return;
+  }
+  sigusr1AuthorizedCount -= 1;
+  if (sigusr1AuthorizedCount <= 0) {
+    sigusr1AuthorizedUntil = 0;
   }
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** `emitGatewayRestart()` increments `sigusr1AuthorizedCount` via `authorizeGatewaySigusr1Restart()` before emitting SIGUSR1. If the emit throws (e.g. `process.kill(pid, "SIGUSR1")` raises under a sandboxed runtime), the catch block rolls back only `emittedRestartToken` — the authorization increment stays live for up to `SIGUSR1_AUTH_GRACE_MS` (~5 s), during which a stray SIGUSR1 can call `consumeGatewaySigusr1RestartAuthorization()` and get a truthy result for a cycle that never actually emitted.
- **Why it matters:** A failed restart emission can still authorize an unrelated SIGUSR1 consumer for up to 5 seconds. The leak closes on its own via the `sigusr1AuthorizedUntil` timer, so it is bounded, but the authorization semantics leak across a failed cycle.
- **What changed:** The catch path now also reverts the authorization increment via a new `revertGatewaySigusr1RestartAuthorization()` helper that mirrors the decrement path of `consumeGatewaySigusr1RestartAuthorization()` without signaling a "used" authorization. Adds a scoped regression test that throws from `process.kill`.
- **What did NOT change (scope boundary):** Public API, `authorizeGatewaySigusr1Restart`, `consumeGatewaySigusr1RestartAuthorization`, `resetSigusr1AuthorizationIfExpired`, `SIGUSR1_AUTH_GRACE_MS`, the success path of `emitGatewayRestart`, or the `__testing.resetSigusr1State()` helper.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #68510
- [x] This PR fixes a bug or regression

## Root Cause

`emitGatewayRestart()` treats its authorization increment and its emit call as two separate steps, but only the token half is reversible. The catch block restores `emittedRestartToken` (so future restart requests can proceed) yet leaves `sigusr1AuthorizedCount` incremented, because the only public decrementer is `consumeGatewaySigusr1RestartAuthorization()` which reports the authorization as consumed. What was needed is a non-consuming revert — "undo the increment because the emission aborted."

- **Root cause:** The catch path is an asymmetric rollback of the pre-emit side effects.
- **Missing detection / guardrail:** No regression test covered the `process.emit`/`process.kill` failure branch; the existing `infra-runtime.test.ts` mocks `process.kill` with a success stub.
- **Contributing context:** `authorizeGatewaySigusr1Restart()` is only meant to be paired with a successful SIGUSR1 delivery, but the current structure grants the authorization before delivery is attempted.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/infra/restart.emit-authorization-leak.test.ts`
- Scenario the test should lock in: stub `process.kill` to throw, call `emitGatewayRestart()` (returns `false`), then assert `consumeGatewaySigusr1RestartAuthorization()` also returns `false`.
- Why this is the smallest reliable guardrail: it uses the existing `__testing.resetSigusr1State()` seam and fake timers, with a single `vi.spyOn(process, "kill")` to exercise the catch branch.
- Existing test that already covers this: none. `infra-runtime.test.ts` only exercises the success path.
- If no new test is added, why not: N/A — new test added.

## User-visible / Behavior Changes

None. The failed-emit path now correctly cleans up internal authorization state instead of relying on the 5-second grace timer.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 25.4.0
- Runtime: Node 22 / pnpm 9
- Base commit: `d7cc6f7643` (docs: prepare changelog for 2026.4.14)

### Steps (from the new regression test)

1. `__testing.resetSigusr1State()`
2. `vi.spyOn(process, "kill").mockImplementation(() => { throw new Error("simulated kill failure"); })`
3. `expect(emitGatewayRestart()).toBe(false)`
4. `expect(consumeGatewaySigusr1RestartAuthorization()).toBe(false)`

### Expected

`consumeGatewaySigusr1RestartAuthorization()` returns `false` because the authorization granted for the failed cycle is reverted.

### Actual (on current main)

`consumeGatewaySigusr1RestartAuthorization()` returns `true` until ~5 s later when `resetSigusr1AuthorizationIfExpired` clears the bucket.

## Evidence

- [x] Failing test on main + passing after patch

Before:
```
AssertionError: expected true to be false
 ❯ src/infra/restart.emit-authorization-leak.test.ts:51:56
```

After: test passes; the surrounding 6 restart-related test files (78 tests) all stay green.

## Human Verification (required)

- Verified scenarios:
  - New test fails without the fix, passes with it.
  - Scoped `pnpm test src/infra/restart.test.ts src/infra/restart.emit-authorization-leak.test.ts src/infra/restart.deferral-timeout.test.ts src/infra/restart-sentinel.test.ts src/infra/restart-stale-pids.test.ts src/infra/infra-runtime.test.ts` → 6 files / 78 tests all pass.
  - `pnpm check` — 0 warnings/errors on the diff (pre-commit hook output). Unrelated `extensions/feishu/**` errors on main are pre-existing.
  - `pnpm build` — exits 0.
- Edge cases checked:
  - `sigusr1AuthorizedCount === 0` guard before decrement (no negative drift).
  - `sigusr1AuthorizedUntil` reset when the count drops to zero.
  - Success path unchanged — increment stays and is consumed on the real SIGUSR1 handler.
- What I did **not** verify:
  - Full-repo `pnpm test` — `extensions/feishu/**` has 442 unrelated pre-existing lint errors on main; relied on scoped tests plus `pnpm check` on the staged diff.
  - Real sandboxed runtime where `process.kill` naturally raises `EPERM` — the test uses a spy to simulate that failure mode.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: The new `revertGatewaySigusr1RestartAuthorization()` could be called in a state where the count is already zero.
  - Mitigation: The first statement guards `sigusr1AuthorizedCount <= 0` and returns, mirroring `resetSigusr1AuthorizationIfExpired`.
- Risk: Consumers might rely on the current 5-second leak window.
  - Mitigation: The leak is a bug, not documented behavior. The only caller of `consumeGatewaySigusr1RestartAuthorization` checks its return value, and a spurious true was the bug being fixed.

## AI-assisted

- [x] Drafted with Claude Code assistance.
- Testing level: lightly tested (scoped unit tests + `pnpm check` + `pnpm build`; full-repo `pnpm test` not run because of pre-existing failures in `extensions/feishu/**`).
- Regression test written before the fix; minimal diff that turns it green.
- I understand the change: the catch block pairs the authorization rollback with the existing token rollback, symmetrizing the pre-emit side effects.
