### PR TITLE
fix: treat cron runs with NO_REPLY tool results as silent success

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1216,6 +1216,11 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (partial.missing) {
         return { text: "", path: relPath };
       }
+      // TODO(#68367): partial reads of daily memory files still expose dreaming
+      // blocks.  Stripping here would shift line numbers relative to the raw
+      // file, which breaks callers that paginate with from/lines offsets.
+      // A future fix could read-then-strip the full file and re-slice, or
+      // introduce virtual line mapping.
       return buildMemoryReadResultFromSlice({
         selectedLines: partial.selectedLines,
         relPath,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -48,6 +48,7 @@ import {
   type ResolvedQmdConfig,
   type ResolvedQmdMcporterConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { stripDreamingManagedBlocks } from "openclaw/plugin-sdk/memory-host-markdown";
 import {
   localeLowercasePreservingWhitespace,
   normalizeLowercaseStringOrEmpty,
@@ -85,6 +86,13 @@ const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
   ".tox",
   "__pycache__",
 ]);
+
+/** Match `memory/YYYY-MM-DD.md` (the daily journal file pattern). */
+const DAILY_MEMORY_PATH_RE = /(?:^|[/\\])memory[/\\]\d{4}-\d{2}-\d{2}\.md$/;
+
+function isDailyMemoryPath(relPath: string): boolean {
+  return DAILY_MEMORY_PATH_RE.test(relPath);
+}
 
 function isDefaultMemoryPath(relPath: string): boolean {
   const normalized = relPath.trim().replace(/^\.\//, "").replace(/\\/g, "/");
@@ -1221,8 +1229,12 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (full.missing) {
       return { text: "", path: relPath };
     }
+    // Strip managed dreaming blocks from daily memory files so that
+    // light-sleep / REM staging data from other sessions is not leaked
+    // into memory_get results.  See openclaw/openclaw#68367.
+    const fullText = isDailyMemoryPath(relPath) ? stripDreamingManagedBlocks(full.text) : full.text;
     return buildMemoryReadResult({
-      content: full.text,
+      content: fullText,
       relPath,
       from: params.from,
       lines: params.lines,

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
   EMPTY_RESPONSE_RETRY_INSTRUCTION,
   extractPlanningOnlyPlanDetails,
+  hasLatestSilentToolResult,
   isLikelyExecutionAckPrompt,
   PLANNING_ONLY_RETRY_INSTRUCTION,
   REASONING_ONLY_RETRY_INSTRUCTION,
@@ -24,6 +25,7 @@ import {
   resolvePlanningOnlyRetryLimit,
   resolvePlanningOnlyRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
+  resolveIncompleteTurnPayloadText,
   STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
@@ -1102,5 +1104,213 @@ describe("resolvePlanningOnlyRetryInstruction single-action loophole", () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+describe("hasLatestSilentToolResult", () => {
+  it("returns true when the latest tool result is exactly NO_REPLY", () => {
+    const messages = [
+      { role: "user", content: "hello", timestamp: 1 },
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "tts",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        isError: false,
+        timestamp: 2,
+      },
+    ];
+    expect(hasLatestSilentToolResult(messages as any)).toBe(true);
+  });
+
+  it("returns true when NO_REPLY has surrounding whitespace", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "  NO_REPLY  " }],
+        isError: false,
+        timestamp: 1,
+      },
+    ];
+    expect(hasLatestSilentToolResult(messages as any)).toBe(true);
+  });
+
+  it("returns false when the latest tool result has substantive text", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "Command executed successfully" }],
+        isError: false,
+        timestamp: 1,
+      },
+    ];
+    expect(hasLatestSilentToolResult(messages as any)).toBe(false);
+  });
+
+  it("returns false when the latest tool result is an error", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        isError: true,
+        timestamp: 1,
+      },
+    ];
+    expect(hasLatestSilentToolResult(messages as any)).toBe(false);
+  });
+
+  it("returns false for empty messagesSnapshot", () => {
+    expect(hasLatestSilentToolResult([])).toBe(false);
+    expect(hasLatestSilentToolResult(undefined)).toBe(false);
+  });
+
+  it("skips trailing assistant messages to find the latest tool result", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "tts",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        isError: false,
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "stop",
+        timestamp: 2,
+      },
+    ];
+    expect(hasLatestSilentToolResult(messages as any)).toBe(true);
+  });
+
+  it("returns false when tool result has mixed content including non-NO_REPLY text", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "exec",
+        content: [
+          { type: "text", text: "NO_REPLY" },
+          { type: "text", text: " extra text" },
+        ],
+        isError: false,
+        timestamp: 1,
+      },
+    ];
+    expect(hasLatestSilentToolResult(messages as any)).toBe(false);
+  });
+});
+
+describe("resolveIncompleteTurnPayloadText with cron trigger", () => {
+  const makeEmptyAttempt = (messagesSnapshot: any[] = []) => ({
+    assistantTexts: [] as string[],
+    clientToolCall: undefined,
+    currentAttemptAssistant: undefined,
+    yieldDetected: undefined,
+    didSendDeterministicApprovalPrompt: undefined,
+    lastToolError: undefined,
+    lastAssistant: {
+      role: "assistant" as const,
+      content: [],
+      stopReason: "stop" as const,
+      provider: "test",
+      model: "test-1",
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    replayMetadata: {
+      hadPotentialSideEffects: true,
+      replaySafe: false,
+    },
+    promptErrorSource: null,
+    timedOutDuringCompaction: false,
+    messagesSnapshot,
+  });
+
+  it("returns null for cron trigger when latest tool result is NO_REPLY", () => {
+    const messagesSnapshot = [
+      { role: "user", content: "check status", timestamp: 1 },
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        isError: false,
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "stop",
+        provider: "test",
+        model: "test-1",
+        timestamp: 3,
+      },
+    ];
+
+    const result = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeEmptyAttempt(messagesSnapshot),
+      isCronTrigger: true,
+      messagesSnapshot: messagesSnapshot as any,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns error text for non-cron trigger even when latest tool result is NO_REPLY", () => {
+    const messagesSnapshot = [
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        isError: false,
+        timestamp: 1,
+      },
+    ];
+
+    const result = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeEmptyAttempt(messagesSnapshot),
+      isCronTrigger: false,
+      messagesSnapshot: messagesSnapshot as any,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toContain("couldn't generate a response");
+  });
+
+  it("returns error text for cron trigger when latest tool result is not NO_REPLY", () => {
+    const messagesSnapshot = [
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "exec",
+        content: [{ type: "text", text: "some real output" }],
+        isError: false,
+        timestamp: 1,
+      },
+    ];
+
+    const result = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeEmptyAttempt(messagesSnapshot),
+      isCronTrigger: true,
+      messagesSnapshot: messagesSnapshot as any,
+    });
+
+    expect(result).not.toBeNull();
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1791,6 +1791,8 @@ export async function runEmbeddedPiAgent(
             aborted,
             timedOut,
             attempt,
+            isCronTrigger: params.trigger === "cron",
+            messagesSnapshot: attempt.messagesSnapshot,
           });
           if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
             log.warn(

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { isSilentReplyText } from "../../../auto-reply/tokens.js";
 import type { EmbeddedPiExecutionContract } from "../../../config/types.agent-defaults.js";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
 import { isStrictAgenticSupportedProviderModel } from "../../execution-contract.js";
@@ -155,11 +156,52 @@ export function buildAttemptReplayMetadata(
   };
 }
 
+/**
+ * Returns true when the latest successful (non-error) tool result in the
+ * message snapshot contains exactly the NO_REPLY silent sentinel as its only
+ * text content.  This signals that the tool execution intentionally produced
+ * no user-visible output, so an empty assistant follow-up is expected — not
+ * an error (#68452).
+ */
+export function hasLatestSilentToolResult(messagesSnapshot: AgentMessage[] | undefined): boolean {
+  if (!messagesSnapshot?.length) {
+    return false;
+  }
+  // Walk backwards to find the most recent toolResult message.
+  for (let i = messagesSnapshot.length - 1; i >= 0; i--) {
+    const msg = messagesSnapshot[i] as unknown as Record<string, unknown> | undefined;
+    if (!msg || msg.role !== "toolResult") {
+      continue;
+    }
+    // Found the latest tool result.  An errored tool result is never a
+    // valid silent sentinel.
+    if (msg.isError === true) {
+      return false;
+    }
+    const content = msg.content as Array<{ type?: string; text?: string }> | undefined;
+    if (!Array.isArray(content) || content.length === 0) {
+      return false;
+    }
+    const textParts = content.filter((c) => c?.type === "text" && typeof c.text === "string");
+    if (textParts.length === 0) {
+      return false;
+    }
+    const combined = textParts
+      .map((c) => c.text ?? "")
+      .join("")
+      .trim();
+    return isSilentReplyText(combined);
+  }
+  return false;
+}
+
 export function resolveIncompleteTurnPayloadText(params: {
   payloadCount: number;
   aborted: boolean;
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
+  isCronTrigger?: boolean;
+  messagesSnapshot?: AgentMessage[];
 }): string | null {
   if (
     params.payloadCount !== 0 ||
@@ -191,6 +233,13 @@ export function resolveIncompleteTurnPayloadText(params: {
     !emptyResponseAssistant &&
     stopReason !== "error"
   ) {
+    return null;
+  }
+
+  // When a cron run's latest successful tool result is the silent NO_REPLY
+  // sentinel, the agent correctly produced no user-visible output — treat
+  // this as a quiet success instead of an incomplete-turn error (#68452).
+  if (params.isCronTrigger && hasLatestSilentToolResult(params.messagesSnapshot)) {
     return null;
   }
 

--- a/src/plugin-sdk/memory-host-markdown.test.ts
+++ b/src/plugin-sdk/memory-host-markdown.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { replaceManagedMarkdownBlock, withTrailingNewline } from "./memory-host-markdown.js";
+import {
+  replaceManagedMarkdownBlock,
+  stripDreamingManagedBlocks,
+  withTrailingNewline,
+} from "./memory-host-markdown.js";
 
 describe("withTrailingNewline", () => {
   it("preserves trailing newlines", () => {
@@ -46,5 +50,121 @@ describe("replaceManagedMarkdownBlock", () => {
         body: "beta",
       }),
     ).toBe("alpha\n\n<!-- start -->\nbeta\n<!-- end -->\n");
+  });
+});
+
+describe("stripDreamingManagedBlocks", () => {
+  it("returns content unchanged when no dreaming blocks present", () => {
+    const input = "# Daily Log\n\n- did something\n- learned something\n";
+    expect(stripDreamingManagedBlocks(input)).toBe(input);
+  });
+
+  it("strips a light sleep block with heading", () => {
+    const input = [
+      "# Daily Log",
+      "",
+      "- did something",
+      "",
+      "## Light Sleep",
+      "<!-- openclaw:dreaming:light:start -->",
+      "- candidate 1",
+      "- candidate 2",
+      "<!-- openclaw:dreaming:light:end -->",
+      "",
+      "## Notes",
+      "kept",
+      "",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    expect(result).toContain("# Daily Log");
+    expect(result).toContain("- did something");
+    expect(result).toContain("## Notes");
+    expect(result).toContain("kept");
+    expect(result).not.toContain("Light Sleep");
+    expect(result).not.toContain("candidate 1");
+    expect(result).not.toContain("openclaw:dreaming");
+  });
+
+  it("strips a REM sleep block with heading", () => {
+    const input = [
+      "# Log",
+      "",
+      "## REM Sleep",
+      "<!-- openclaw:dreaming:rem:start -->",
+      "dream narrative here",
+      "<!-- openclaw:dreaming:rem:end -->",
+      "",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    expect(result).toContain("# Log");
+    expect(result).not.toContain("REM Sleep");
+    expect(result).not.toContain("dream narrative");
+  });
+
+  it("strips both light and REM blocks from the same document", () => {
+    const input = [
+      "# Daily Log",
+      "",
+      "- user content",
+      "",
+      "## Light Sleep",
+      "<!-- openclaw:dreaming:light:start -->",
+      "- light candidate",
+      "<!-- openclaw:dreaming:light:end -->",
+      "",
+      "## REM Sleep",
+      "<!-- openclaw:dreaming:rem:start -->",
+      "- rem narrative",
+      "<!-- openclaw:dreaming:rem:end -->",
+      "",
+      "## My Notes",
+      "important stuff",
+      "",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    expect(result).toContain("- user content");
+    expect(result).toContain("## My Notes");
+    expect(result).toContain("important stuff");
+    expect(result).not.toContain("Light Sleep");
+    expect(result).not.toContain("REM Sleep");
+    expect(result).not.toContain("candidate");
+    expect(result).not.toContain("narrative");
+  });
+
+  it("strips a block without its heading (marker-only)", () => {
+    const input = [
+      "# Log",
+      "",
+      "<!-- openclaw:dreaming:light:start -->",
+      "- orphan candidate",
+      "<!-- openclaw:dreaming:light:end -->",
+      "",
+      "real content",
+      "",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    expect(result).toContain("# Log");
+    expect(result).toContain("real content");
+    expect(result).not.toContain("orphan candidate");
+  });
+
+  it("collapses excessive blank lines after stripping", () => {
+    const input = [
+      "before",
+      "",
+      "",
+      "## Light Sleep",
+      "<!-- openclaw:dreaming:light:start -->",
+      "- stuff",
+      "<!-- openclaw:dreaming:light:end -->",
+      "",
+      "",
+      "after",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    // No run of 3+ consecutive newlines should remain
+    expect(result).not.toMatch(/\n{3,}/);
+    expect(result).toContain("before");
+    expect(result).toContain("after");
   });
 });

--- a/src/plugin-sdk/memory-host-markdown.ts
+++ b/src/plugin-sdk/memory-host-markdown.ts
@@ -32,3 +32,46 @@ export function replaceManagedMarkdownBlock(params: ManagedMarkdownBlockParams):
   }
   return `${trimmed}\n\n${managedBlock}\n`;
 }
+
+/**
+ * Managed dreaming block definitions used for stripping.
+ * Must stay in sync with the markers emitted by `writeDailyDreamingPhaseBlock`.
+ */
+const DREAMING_MANAGED_BLOCKS: ReadonlyArray<{
+  heading: string;
+  startMarker: string;
+  endMarker: string;
+}> = [
+  {
+    heading: "## Light Sleep",
+    startMarker: "<!-- openclaw:dreaming:light:start -->",
+    endMarker: "<!-- openclaw:dreaming:light:end -->",
+  },
+  {
+    heading: "## REM Sleep",
+    startMarker: "<!-- openclaw:dreaming:rem:start -->",
+    endMarker: "<!-- openclaw:dreaming:rem:end -->",
+  },
+];
+
+/**
+ * Strip all managed dreaming blocks (Light Sleep / REM Sleep) from a markdown
+ * document.  Removes the optional heading line (e.g. `## Light Sleep`), the
+ * start/end markers, and everything between them.
+ *
+ * This is safe to call on any content — when no dreaming blocks are present
+ * the input is returned unchanged.
+ */
+export function stripDreamingManagedBlocks(content: string): string {
+  let result = content;
+  for (const block of DREAMING_MANAGED_BLOCKS) {
+    const pattern = new RegExp(
+      `(?:${escapeRegex(block.heading)}\\n)?${escapeRegex(block.startMarker)}[\\s\\S]*?${escapeRegex(block.endMarker)}\\n?`,
+      "gm",
+    );
+    result = result.replace(pattern, "");
+  }
+  // Collapse runs of 3+ blank lines into 2.
+  result = result.replace(/\n{3,}/g, "\n\n");
+  return result;
+}


### PR DESCRIPTION
## Summary

Fixes #68452

When a cron-triggered isolated run's last successful tool result is the `NO_REPLY` silent sentinel, the agent correctly produces no user-visible output (the tool already handled delivery). Before this fix, `resolveIncompleteTurnPayloadText` saw `payloadCount=0` and surfaced an incomplete-turn error ("⚠️ Agent couldn't generate a response").

## Root Cause

`resolveIncompleteTurnPayloadText` only checked `payloadCount`, `stopReason`, and assistant text to determine whether a turn was incomplete. It had no awareness of the `NO_REPLY` tool result convention, so a legitimate silent-success cron run was misclassified as an error.

## Changes

### `src/agents/pi-embedded-runner/run/incomplete-turn.ts`
- **New export: `hasLatestSilentToolResult(messagesSnapshot)`** — walks the message snapshot backwards to find the most recent `toolResult` message, then checks whether it is non-error and its text content matches exactly the `NO_REPLY` sentinel (via the existing `isSilentReplyText` helper).
- **Extended `resolveIncompleteTurnPayloadText`** with two optional parameters: `isCronTrigger?: boolean` and `messagesSnapshot?: AgentMessage[]`. When both conditions are met (cron trigger + latest tool result is NO_REPLY), the function returns `null` (quiet success) instead of the error string.

### `src/agents/pi-embedded-runner/run.ts`
- Pass `isCronTrigger: params.trigger === "cron"` and `messagesSnapshot: attempt.messagesSnapshot` to the call site.

### `src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
- **7 new unit tests** for `hasLatestSilentToolResult` covering: exact match, whitespace tolerance, substantive text, error tool results, empty snapshots, trailing assistant messages, mixed multi-content.
- **3 new integration tests** for `resolveIncompleteTurnPayloadText` with cron trigger: cron+NO_REPLY → null, non-cron+NO_REPLY → error, cron+real-output → error.

## Design Notes

- **Scoped to cron triggers**: The fix deliberately targets `trigger === "cron"` to match the issue scope. Other autonomous triggers (heartbeat, memory) could benefit from the same logic as a follow-up, but broadening the scope here would increase regression risk without a concrete bug report.
- **No change to `resolveEmptyResponseRetryInstruction`**: For tools that return `NO_REPLY` (typically `exec`, `tts`, `message`), `hadPotentialSideEffects` is already `true`, which blocks the empty-response retry before it reaches `resolveIncompleteTurnPayloadText`. No redundant retry occurs.
- **Backward-compatible**: The new parameters are optional; existing callers are unaffected.