### PR TITLE
fix(cli): normalize reply-media paths for agent --deliver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - Cron/message tool: keep cron-owned runs with `delivery.mode: "none"` on the normal message-tool path so they can still send explicit messages, create threads, and route conditionally when no runner-owned delivery target is active. (#68482) Thanks @obviyus.
 - Agents/failover: avoid treating bare leading `402 ...` prose as billing errors while still recognizing proxy subscription failures. (#45827) Thanks @junyuc25.
 - Config/$schema: preserve root-authored `$schema` during partial config rewrites without injecting include-only schema URLs into the root config. (#47322) Thanks @EfeDurmaz16.
+- Agents/CLI delivery: run the same reply-media path normalizer the auto-reply flow uses before shipping `openclaw agent --deliver` payloads, so relative `MEDIA:./out/photo.png` tokens resolve against the agent workspace instead of being rejected downstream with `LocalMediaAccessError: Local media path is not under an allowed directory`. Thanks @frankekn.
 
 ## 2026.4.15
 

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -6,6 +7,24 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { deliverAgentCommandResult, normalizeAgentCommandReplyPayloads } from "./delivery.js";
 import type { AgentCommandOpts } from "./types.js";
+
+const deliverOutboundPayloadsMock = vi.hoisted(() =>
+  vi.fn(async (..._args: unknown[]) => [] as unknown[]),
+);
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: deliverOutboundPayloadsMock,
+}));
+
+const createReplyMediaPathNormalizerMock = vi.hoisted(() =>
+  vi.fn(
+    (..._args: unknown[]) =>
+      (payload: ReplyPayload) =>
+        Promise.resolve(payload),
+  ),
+);
+vi.mock("../../auto-reply/reply/reply-media-paths.runtime.js", () => ({
+  createReplyMediaPathNormalizer: createReplyMediaPathNormalizerMock,
+}));
 
 type NormalizeParams = Parameters<typeof normalizeAgentCommandReplyPayloads>[0];
 type RunResult = NormalizeParams["result"];
@@ -135,6 +154,94 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     expect(runtime.log).toHaveBeenCalledTimes(1);
     expect(runtime.log).toHaveBeenCalledWith("Options: on, off.");
     expect(delivered.payloads).toMatchObject([{ text: "Options: on, off." }]);
+  });
+
+  it("normalizes reply-media paths before outbound delivery", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn() };
+    const normalizerFn = vi.fn(
+      async (payload: ReplyPayload): Promise<ReplyPayload> => ({
+        ...payload,
+        mediaUrl: "/tmp/agent-workspace/out/photo.png",
+        mediaUrls: ["/tmp/agent-workspace/out/photo.png"],
+      }),
+    );
+    createReplyMediaPathNormalizerMock.mockReturnValue(normalizerFn);
+    deliverOutboundPayloadsMock.mockResolvedValue([]);
+
+    await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: runtime as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "#general",
+      } as AgentCommandOpts,
+      outboundSession: {
+        key: "agent:tester:slack:direct:alice",
+        agentId: "tester",
+      } as never,
+      sessionEntry: undefined,
+      payloads: [{ text: "here you go", mediaUrls: ["./out/photo.png"] }],
+      result: createResult(),
+    });
+
+    expect(createReplyMediaPathNormalizerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:tester:slack:direct:alice",
+        agentId: "tester",
+        workspaceDir: "/tmp/agent-workspace",
+        messageProvider: "slack",
+      }),
+    );
+    expect(normalizerFn).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaUrls: ["./out/photo.png"] }),
+    );
+    expect(deliverOutboundPayloadsMock).toHaveBeenCalledTimes(1);
+    const [firstCallArg] = deliverOutboundPayloadsMock.mock.calls[0] ?? [];
+    const deliverArgs = firstCallArg as { payloads: ReplyPayload[] } | undefined;
+    expect(deliverArgs?.payloads[0]).toMatchObject({
+      mediaUrls: ["/tmp/agent-workspace/out/photo.png"],
+    });
+  });
+
+  it("threads agentId into the normalizer when sessionKey is unresolved", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn() };
+    createReplyMediaPathNormalizerMock.mockReturnValue(async (payload: ReplyPayload) => payload);
+    deliverOutboundPayloadsMock.mockResolvedValue([]);
+
+    await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: runtime as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        replyChannel: "slack",
+        replyTo: "#general",
+      } as AgentCommandOpts,
+      outboundSession: { agentId: "tester" } as never,
+      sessionEntry: undefined,
+      payloads: [{ text: "here you go", mediaUrls: ["./out/photo.png"] }],
+      result: createResult(),
+    });
+
+    expect(createReplyMediaPathNormalizerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "tester",
+        sessionKey: undefined,
+        workspaceDir: "/tmp/agent-workspace",
+      }),
+    );
   });
 
   it("keeps LINE directive-only replies intact for local preview when delivery is disabled", async () => {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -1,6 +1,8 @@
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope-config.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { normalizeReplyPayload } from "../../auto-reply/reply/normalize-reply.js";
+import { createReplyMediaPathNormalizer } from "../../auto-reply/reply/reply-media-paths.runtime.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { createReplyPrefixContext } from "../../channels/reply-prefix.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
@@ -65,6 +67,39 @@ function logNestedOutput(
     }
     runtime.log(`${prefix} ${line}`);
   }
+}
+
+async function normalizeReplyMediaPathsForDelivery(params: {
+  cfg: OpenClawConfig;
+  payloads: ReplyPayload[];
+  sessionKey?: string;
+  outboundSession: OutboundSessionContext | undefined;
+  deliveryChannel: string;
+  accountId?: string;
+}): Promise<ReplyPayload[]> {
+  if (params.payloads.length === 0) {
+    return params.payloads;
+  }
+  const agentId =
+    params.outboundSession?.agentId ??
+    resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg });
+  const workspaceDir = agentId ? resolveAgentWorkspaceDir(params.cfg, agentId) : undefined;
+  if (!workspaceDir) {
+    return params.payloads;
+  }
+  const normalizeMediaPaths = createReplyMediaPathNormalizer({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    agentId,
+    workspaceDir,
+    messageProvider: params.deliveryChannel,
+    accountId: params.accountId,
+  });
+  const result: ReplyPayload[] = [];
+  for (const payload of params.payloads) {
+    result.push(await normalizeMediaPaths(payload));
+  }
+  return result;
 }
 
 export function normalizeAgentCommandReplyPayloads(params: {
@@ -268,7 +303,23 @@ export async function deliverAgentCommandResult(params: {
     accountId: resolvedAccountId,
     applyChannelTransforms: deliver,
   });
-  const outboundPayloadPlan = createOutboundPayloadPlan(normalizedReplyPayloads);
+  // Auto-reply-style media-path normalization must also run for the CLI
+  // `--deliver` path. Without it, relative `MEDIA:./out/photo.png` tokens
+  // reach the outbound loader unresolved and `assertLocalMediaAllowed` fails
+  // with "Local media path is not under an allowed directory". Mirrors the
+  // normalizer wiring in `src/auto-reply/reply/agent-runner.ts`.
+  const mediaNormalizedReplyPayloads =
+    deliver && !isInternalMessageChannel(deliveryChannel)
+      ? await normalizeReplyMediaPathsForDelivery({
+          cfg,
+          payloads: normalizedReplyPayloads,
+          sessionKey: effectiveSessionKey,
+          outboundSession,
+          deliveryChannel,
+          accountId: resolvedAccountId,
+        })
+      : normalizedReplyPayloads;
+  const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads);
   const normalizedPayloads = projectOutboundPayloadPlanForJson(outboundPayloadPlan);
   if (opts.json) {
     runtime.log(

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -82,6 +82,7 @@ function resolveReplyMediaMaxBytes(params: {
 export function createReplyMediaPathNormalizer(params: {
   cfg: OpenClawConfig;
   sessionKey?: string;
+  agentId?: string;
   workspaceDir: string;
   messageProvider?: string;
   accountId?: string;
@@ -93,9 +94,14 @@ export function createReplyMediaPathNormalizer(params: {
   requesterSenderUsername?: string;
   requesterSenderE164?: string;
 }): (payload: ReplyPayload) => Promise<ReplyPayload> {
-  const agentId = params.sessionKey
-    ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
-    : undefined;
+  // Prefer an explicit agentId so callers without a resolved sessionKey (e.g.
+  // `openclaw agent --deliver` with `--reply-channel/--reply-to`) still get
+  // the stricter agent-scoped file-read policy applied during staging.
+  const agentId =
+    params.agentId ??
+    (params.sessionKey
+      ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
+      : undefined);
   const maxBytes = resolveReplyMediaMaxBytes({
     cfg: params.cfg,
     channel: params.messageProvider,


### PR DESCRIPTION
## Summary

- Problem: `openclaw agent --deliver` drops outbound replies that contain relative `MEDIA:./out/photo.png` tokens. The raw relative path reaches the outbound media loader, which rejects it with `LocalMediaAccessError: Local media path is not under an allowed directory: ./out/photo.png`. Nothing ships to Telegram/Slack/etc, and `logVerbose` suppresses the root cause at the default log level.
- Why it matters: any agent that produces a `MEDIA:` reply through the CLI delivery path (for example image-generation skills whose SKILL/TOOLS docs tell the model to use `MEDIA:./output/<name>.jpg`) silently fails to deliver. Auto-reply already normalizes these via `createReplyMediaPathNormalizer`; the CLI deliver path does not.
- What changed: in `src/agents/command/delivery.ts`, run the same `createReplyMediaPathNormalizer` (sourced through `reply-media-paths.runtime.js`) on the already channel-normalized payloads before `createOutboundPayloadPlan`, but only when `deliver` is true and the channel is external. The helper resolves the agent id / workspace dir the same way the existing code does, then awaits the normalizer per payload. JSON-only / non-deliver previews keep their current raw media paths.
- What did NOT change (scope boundary): auto-reply agent-runner wiring, `normalizeAgentCommandReplyPayloads` signature (still sync), the media parser, and `resolveAgentScopedOutboundMediaAccess`. The deliver path inherits the same normalizer the auto-reply runner uses; no new resolver logic was introduced.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #66689 (`fix: allow workspace-rooted absolute media paths in auto-reply`)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `deliverAgentCommandResult` calls `normalizeAgentCommandReplyPayloads` (channel text transforms) and then jumps straight to `createOutboundPayloadPlan` + `deliverOutboundPayloads`. It never wires in `createReplyMediaPathNormalizer`, so `./out/photo.png` stays relative. Downstream, `loadWebMedia` asks `assertLocalMediaAllowed` to check the still-relative path against absolute `localRoots` and fails closed.
- Missing detection / guardrail: `delivery.test.ts` did not exercise the `deliver: true` + relative-media pairing. The auto-reply tests in `reply-media-paths.test.ts` cover the normalizer directly but not the CLI deliver call site.
- Contributing context (if known): the auto-reply media normalizer was expanded in #66689 to handle workspace-rooted absolute paths. The CLI deliver path appears to have been written before that normalizer existed and was never wired up.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: colocated unit test at `src/agents/command/delivery.test.ts`.
- New test `normalizes reply-media paths before outbound delivery` mocks `deliverOutboundPayloads` and `createReplyMediaPathNormalizer`, runs `deliverAgentCommandResult` with `deliver: true`, `replyChannel: "slack"`, and a payload carrying `mediaUrls: ["./out/photo.png"]`, then asserts the normalizer is constructed with the expected session key / workspace dir / `messageProvider`, invoked with the relative URL, and that the outbound sender receives the absolute rewritten path.
- Verified that the new test fails on current `origin/main` (before this fix, the `createReplyMediaPathNormalizer` mock is never called) and passes with the fix applied.

## Repro Steps

1. Have an agent workspace under `~/.openclaw/workspace-<agent>/` with an image at `output/example.jpg`.
2. Run:

   ```
   openclaw agent --agent <agent> \
     --reply-channel telegram --reply-account <account> --reply-to <group_id> \
     --deliver \
     --message "reply with 'MEDIA:./output/example.jpg' and nothing else"
   ```

### Expected

- Telegram `sendPhoto` is attempted and the image is delivered to the group.

### Actual (before this fix)

- Gateway log shows `Delivery failed (telegram to <group_id>): LocalMediaAccessError: Local media path is not under an allowed directory: ./output/example.jpg`.
- No Telegram outbound request is issued; `~/.openclaw/media/outbound/` stays empty.

## Evidence

- [x] Failing test/log before + passing after: `pnpm test src/agents/command/delivery.test.ts` — 5 tests pass; reverting just the `delivery.ts` change makes the new test fail with `createReplyMediaPathNormalizerMock` never called.
- [x] Trace/log snippets: gateway debug log before fix:

  ```
  MEDIA:./output/pepper-shrimp-self-portrait.jpg
  Delivery failed (telegram to -100XXXXXXXXXX):
  LocalMediaAccessError: Local media path is not under an allowed directory:
  ./output/pepper-shrimp-self-portrait.jpg
  ```
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Reproduced the failure locally against `v2026.4.15` gateway with `OPENCLAW_LOG_LEVEL=debug` and captured the `LocalMediaAccessError` line quoted above.
  - Ran the standalone `createReplyMediaPathNormalizer` against the same workspace+relative URL and confirmed it persists to `~/.openclaw/media/outbound/<uuid>.jpg` — the auto-reply normalizer itself is healthy. The bug is purely that the CLI deliver path never invokes it.
  - Ran `pnpm tsgo`, `pnpm check`, and `pnpm test src/agents/command/delivery.test.ts` in the PR branch; all green.
- Edge cases checked:
  - `deliver: false` (JSON/preview) path keeps raw payloads unchanged; covered by the existing preview tests.
  - `isInternalMessageChannel(deliveryChannel)` branches skip the extra normalization, so nested/internal message-tool deliveries retain their current behavior.
  - No agent id resolvable → helper returns payloads as-is and downstream behavior matches pre-fix.
- What you did **not** verify:
  - Non-Slack/Telegram channels end-to-end (Discord/Matrix/Line etc). The fix lives in the shared delivery path, and the existing auto-reply tests already exercise sandbox/host-local resolution in that normalizer.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: an extra per-payload `await` in the CLI deliver path.
  - Mitigation: the normalizer short-circuits on empty payload lists and no-op sources, and it is only wired in when `deliver && !isInternalMessageChannel(deliveryChannel)`. Preview flows are unchanged.
- Risk: persisting media to `~/.openclaw/media/outbound/` from a CLI-triggered turn that never before created those files.
  - Mitigation: this matches the existing auto-reply behavior for the same payload shapes; cleanup is handled by the existing media-store hygiene.