### PR TITLE
fix(infra/restart): exclude ancestor pids from stale-gateway cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 - Agents/CLI delivery: run the same reply-media path normalizer the auto-reply flow uses before shipping `openclaw agent --deliver` payloads, so relative `MEDIA:./out/photo.png` tokens resolve against the agent workspace instead of being rejected downstream with `LocalMediaAccessError: Local media path is not under an allowed directory`. Thanks @frankekn.
 - Agents/Google: strip `thinkingBudget=0` for the thinking-required `gemini-2.5-pro` model in embedded-runner and native Google payloads, so requests no longer fail with `Budget 0 is invalid. This model only works in thinking mode.` and the API uses its default thinking behavior instead. (#68607) Thanks @josmithiii.
 - Slack/threads: log failed thread starter and history fetches at verbose level while preserving best-effort fallback behavior, so missing Slack thread context is diagnosable without interrupting inbound handling. (#68594) Thanks @martingarramon.
+- Gateway/restart: keep stale-gateway cleanup from terminating the current process's parent or ancestors, so plugin sidecars like WeChat no longer kill the active gateway and trigger an infinite supervisor restart loop. Fixes #68451. (#68517) Thanks @openperf.
 
 ## 2026.4.15
 

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -26,6 +26,29 @@ const mockReadWindowsProcessArgsResult = vi.hoisted(() =>
     (_pid: number, _timeoutMs?: number) => ({ ok: true, args: null }),
   ),
 );
+// Drives the Linux `/proc/<pid>/status` ancestor walk inside
+// `getSelfAndAncestorPidsSync`. The default implementation is installed in
+// `beforeEach` (simulates a restricted /proc via ENOENT) so every test starts
+// from the same baseline; tests that need to simulate deeper ancestor chains
+// override it via `mockImplementation` / `mockImplementationOnce`.
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs", async () => {
+  const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:fs")>("node:fs"),
+    (actual) => ({
+      // `readFileSync` is an overloaded function; a single arrow expression
+      // cannot match every overload (no-encoding → NonSharedBuffer, encoded →
+      // string, etc.), which tsgo flags as TS2322. Assert the wrapper's type
+      // against the actual module's export so TS accepts it as a drop-in.
+      // The test only exercises the string-returning overload (encoded /proc
+      // reads); the cast is a precise retype, not `any`.
+      readFileSync: ((path: unknown, encoding?: unknown) =>
+        mockReadFileSync(path, encoding)) as typeof actual.readFileSync,
+    }),
+  );
+});
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
@@ -143,6 +166,14 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
     mockReadWindowsListeningPidsResult.mockReset();
     mockReadWindowsProcessArgs.mockReset();
     mockReadWindowsProcessArgsResult.mockReset();
+    mockReadFileSync.mockReset();
+    mockReadFileSync.mockImplementation(() => {
+      // Default: simulate /proc unavailable. Walks that reach this mock
+      // degrade silently and return whatever set they collected so far.
+      const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+      error.code = "ENOENT";
+      throw error;
+    });
     mockResolveGatewayPort.mockReturnValue(18789);
     mockReadWindowsListeningPids.mockReturnValue([]);
     mockReadWindowsListeningPidsResult.mockReturnValue({ ok: true, pids: [] });
@@ -156,6 +187,24 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
     __testing.setDateNowOverride(null);
     vi.restoreAllMocks();
   });
+
+  // Temporarily rewrites `process.ppid` for a block of test code. Used by the
+  // ancestor-exclusion tests to drive the real `getSelfAndAncestorPidsSync`
+  // walk without installing a runtime-reachable override on the module. Node
+  // always exposes `process.ppid` as an own property so the captured
+  // descriptor is non-null in practice; the `if (orig)` guard is defensive
+  // against a broken environment, not a reachable branch.
+  function withStubbedPpid<T>(ppid: number, fn: () => T): T {
+    const orig = Object.getOwnPropertyDescriptor(process, "ppid");
+    Object.defineProperty(process, "ppid", { value: ppid, configurable: true });
+    try {
+      return fn();
+    } finally {
+      if (orig) {
+        Object.defineProperty(process, "ppid", orig);
+      }
+    }
+  }
 
   // -------------------------------------------------------------------------
   // findGatewayPidsOnPortSync
@@ -202,6 +251,142 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(pids).toContain(stalePid);
       expect(pids).not.toContain(process.pid);
     });
+
+    it("excludes ancestor pids so a sidecar cannot kill its parent gateway — regression for #68451", () => {
+      // Regression: openclaw-weixin sidecar (child of the gateway) invoked
+      // cleanStaleGatewayProcessesSync during init. lsof reported the parent
+      // gateway on port 18789, its PID was not process.pid, so the cleanup
+      // SIGTERM'd it — the supervisor restarted the gateway, re-spawned the
+      // sidecar, the cleanup ran again: infinite restart loop.
+      //
+      // Fix: parsePidsFromLsofOutput now excludes process.pid AND its
+      // ancestor chain (see getSelfAndAncestorPidsSync). This test stubs
+      // process.ppid to the synthetic parent gateway pid so the real walk
+      // adds it to the exclusion set; the default /proc mock throws ENOENT
+      // so the walk stops after the direct parent.
+      const parentGatewayPid = process.pid + 2001;
+      const unrelatedStalePid = process.pid + 2002;
+      mockSpawnSync.mockReturnValue({
+        error: null,
+        status: 0,
+        stdout: lsofOutput([
+          { pid: parentGatewayPid, cmd: "openclaw-gateway" },
+          { pid: unrelatedStalePid, cmd: "openclaw-gateway" },
+        ]),
+        stderr: "",
+      });
+      const pids = withStubbedPpid(parentGatewayPid, () => findGatewayPidsOnPortSync(18789));
+      // Parent gateway must be excluded; an unrelated stale PID must still be
+      // reported so the supervisor-path cleanup continues to work.
+      expect(pids).not.toContain(parentGatewayPid);
+      expect(pids).toContain(unrelatedStalePid);
+    });
+
+    it.skipIf(process.platform !== "linux")(
+      "excludes the full ancestor chain, not just the direct parent — deeper nesting",
+      () => {
+        // The ancestor-exclusion invariant is transitive: killing any
+        // ancestor cascades to the caller the same way killing the direct
+        // parent does. Drive the real Linux /proc walk by stubbing
+        // process.ppid to the direct parent and mocking readFileSync to
+        // return synthetic PPid lines for each ancestor hop; the mock ends
+        // the chain with "PPid: 0" so the walk terminates without touching
+        // the real /proc.
+        const directParentPid = process.pid + 2003;
+        const grandparentPid = process.pid + 2004;
+        const benignStalePid = process.pid + 2005;
+        mockReadFileSync.mockImplementation((path: unknown): string => {
+          if (path === `/proc/${directParentPid}/status`) {
+            return `Name:\topenclaw-gateway\nPid:\t${directParentPid}\nPPid:\t${grandparentPid}\n`;
+          }
+          if (path === `/proc/${grandparentPid}/status`) {
+            return `Name:\tsystemd\nPid:\t${grandparentPid}\nPPid:\t0\n`;
+          }
+          const error: NodeJS.ErrnoException = new Error("ENOENT");
+          error.code = "ENOENT";
+          throw error;
+        });
+        mockSpawnSync.mockReturnValue({
+          error: null,
+          status: 0,
+          stdout: lsofOutput([
+            { pid: directParentPid, cmd: "openclaw-gateway" },
+            { pid: grandparentPid, cmd: "openclaw-gateway" },
+            { pid: benignStalePid, cmd: "openclaw-gateway" },
+          ]),
+          stderr: "",
+        });
+        const pids = withStubbedPpid(directParentPid, () => findGatewayPidsOnPortSync(18789));
+        expect(pids).not.toContain(directParentPid);
+        expect(pids).not.toContain(grandparentPid);
+        expect(pids).toContain(benignStalePid);
+      },
+    );
+
+    it("excludes PID 1 when the direct parent gateway is the container entrypoint — container topology", () => {
+      // Codex P1: in container deployments the gateway is the container
+      // entrypoint and therefore runs as PID 1 of its namespace. A sidecar
+      // spawned by that gateway has process.ppid === 1. An earlier revision
+      // guarded the exclusion with `immediateParent > 1`, which dropped PID 1
+      // and reopened the #68451 restart loop on every containerised install.
+      // The current `> 0` check admits PID 1 into the exclusion set; this
+      // test exercises the real walk by stubbing process.ppid to 1.
+      const benignStalePid = process.pid + 2050;
+      mockSpawnSync.mockReturnValue({
+        error: null,
+        status: 0,
+        stdout: lsofOutput([
+          { pid: 1, cmd: "openclaw-gateway" },
+          { pid: benignStalePid, cmd: "openclaw-gateway" },
+        ]),
+        stderr: "",
+      });
+      const pids = withStubbedPpid(1, () => findGatewayPidsOnPortSync(18789));
+      expect(pids).not.toContain(1);
+      expect(pids).toContain(benignStalePid);
+    });
+
+    it.skipIf(process.platform !== "linux")(
+      "leaves the gateway grandparent in the kill list when /proc truncates the walk — documented degradation on hidepid/gVisor hosts",
+      () => {
+        // Pins the known-partial coverage the PR description and the
+        // `readParentPidFromProc` comment call out: in hardened Linux
+        // containers (hidepid=2, gVisor, AppArmor-locked namespaces) the
+        // ancestor walk cannot traverse /proc/<other_pid>/status beyond
+        // the caller, so it stops at `process.ppid`. For the direct-child
+        // topology #68451 reports (gateway→sidecar), this is fine — ppid
+        // is captured unconditionally via Node's syscall. For a 3-level
+        // chain (gateway→plugin-host→sidecar), the gateway grandparent
+        // falls outside the exclusion set and is still killable.
+        //
+        // This test locks that degraded outcome in place so a future
+        // refactor cannot silently regress further (for example, by
+        // skipping `process.ppid` as well) without at least failing this
+        // assertion first. A fuller fix (macOS/Windows ancestor walk,
+        // pidfd-based Linux walk, or privileged cmdline probe) belongs
+        // in a separate change.
+        const pluginHostPid = process.pid + 3001;
+        const gatewayGrandparentPid = process.pid + 3002;
+        // Default mockReadFileSync throws ENOENT for every /proc path —
+        // the same view a non-privileged process has under hidepid=2.
+        mockSpawnSync.mockReturnValue({
+          error: null,
+          status: 0,
+          stdout: lsofOutput([
+            { pid: pluginHostPid, cmd: "openclaw-gateway" },
+            { pid: gatewayGrandparentPid, cmd: "openclaw-gateway" },
+          ]),
+          stderr: "",
+        });
+        const pids = withStubbedPpid(pluginHostPid, () => findGatewayPidsOnPortSync(18789));
+        // Direct parent (plugin-host) must still be excluded — process.ppid
+        // is captured with no /proc dependency, so hidepid cannot mask it.
+        expect(pids).not.toContain(pluginHostPid);
+        // Grandparent IS returned — documented partial coverage, tracked
+        // separately from #68451.
+        expect(pids).toContain(gatewayGrandparentPid);
+      },
+    );
 
     it("excludes pids whose command does not include 'openclaw'", () => {
       const otherPid = process.pid + 2;
@@ -262,6 +447,33 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
         expect(findGatewayPidsOnPortSync(18789)).toEqual([stalePid]);
         expect(mockReadWindowsListeningPids).toHaveBeenCalledWith(18789, undefined);
         expect(mockReadWindowsProcessArgs).toHaveBeenCalledWith(stalePid, undefined);
+      } finally {
+        if (origDescriptor) {
+          Object.defineProperty(process, "platform", origDescriptor);
+        }
+      }
+    });
+
+    it("excludes ancestor pids on Windows too — #68451 regression mirror for the win32 path", () => {
+      // The #68451 invariant must hold on every code path the cleanup can take.
+      // The Windows filter (filterVerifiedWindowsGatewayPids) shares the same
+      // exclusion source, so the direct-parent gateway PID must be dropped
+      // before the argv-verification step runs. Drive the real walk on the
+      // win32 branch (which stops at process.ppid — no /proc lookup) by
+      // stubbing process.ppid to the synthetic parent pid.
+      const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+      const parentGatewayPid = process.pid + 2101;
+      const unrelatedStalePid = process.pid + 2102;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        mockReadWindowsListeningPids.mockReturnValue([parentGatewayPid, unrelatedStalePid]);
+        mockReadWindowsProcessArgs.mockReturnValue(["openclaw", "gateway"]);
+        const pids = withStubbedPpid(parentGatewayPid, () => findGatewayPidsOnPortSync(18789));
+        expect(pids).not.toContain(parentGatewayPid);
+        expect(pids).toContain(unrelatedStalePid);
+        // argv verification must never have been asked about the parent, because
+        // exclusion happens before the per-PID inspection step.
+        expect(mockReadWindowsProcessArgs).not.toHaveBeenCalledWith(parentGatewayPid, undefined);
       } finally {
         if (origDescriptor) {
           Object.defineProperty(process, "platform", origDescriptor);

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { resolveGatewayPort } from "../config/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -33,6 +34,14 @@ const PORT_FREE_POLL_INTERVAL_MS = 50;
 const PORT_FREE_TIMEOUT_MS = 2000;
 const POLL_SPAWN_TIMEOUT_MS = 400;
 
+/**
+ * Upper bound on the ancestor-PID walk. A real-world chain is shallow
+ * (pid1 → systemd → gateway → plugin-host → sidecar ≈ 5); 32 generously covers
+ * nested-supervisor setups (k8s pod → containerd-shim → runc → …) while still
+ * providing a hard stop against corrupted process tables or ppid cycles.
+ */
+const MAX_ANCESTOR_WALK_DEPTH = 32;
+
 const restartLog = createSubsystemLogger("restart");
 let sleepSyncOverride: ((ms: number) => void) | null = null;
 let dateNowOverride: (() => number) | null = null;
@@ -62,8 +71,102 @@ function sleepSync(ms: number): void {
 }
 
 /**
- * Parse openclaw gateway PIDs from lsof -Fpc stdout.
- * Pure function — no I/O. Excludes the current process.
+ * Read a single ancestor PID from `/proc/<pid>/status` on Linux.
+ * Returns null on any failure (non-Linux platform, restricted /proc, race
+ * where the target pid exited between the walk step and the read); callers
+ * treat a null return as "stop walking" and proceed with the ancestor set
+ * collected so far.
+ */
+function readParentPidFromProc(pid: number): number | null {
+  try {
+    const status = readFileSync(`/proc/${pid}/status`, "utf8");
+    const match = status.match(/^PPid:\s*(\d+)/m);
+    if (!match) {
+      return null;
+    }
+    const parsed = Number.parseInt(match[1] ?? "", 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    // Null truncates the walk at this hop. In hardened Linux (hidepid=2,
+    // gVisor, AppArmor-locked namespaces) /proc is unreadable beyond the
+    // caller, so the walk can stop at `process.ppid`. #68451's direct
+    // gateway→sidecar topology is covered (ppid is captured without a
+    // /proc read); 3-level chains (gateway→plugin-host→sidecar) are not
+    // — pinned by the "grandparent stays killable when /proc truncates
+    // the walk" regression test.
+    return null;
+  }
+}
+
+/**
+ * Collect the set of PIDs whose termination would cascade-kill the caller:
+ * the current process, its direct parent, and — where the platform permits
+ * — the full ancestor chain up to the top of the pid namespace.
+ *
+ * Rationale: `cleanStaleGatewayProcessesSync` already refuses to kill
+ * `process.pid` (see `parsePidsFromLsofOutput`), acknowledging the invariant
+ * "a cleanup step must never destroy its own caller." That invariant was
+ * applied only to the caller itself, not to its ancestors — which is how
+ * issue #68451 arises: a plugin sidecar calls the cleanup, `lsof` reports
+ * the parent gateway listening on 18789, the parent's PID passes the
+ * `pid !== process.pid` filter, it is SIGTERM'd, the sidecar is then reaped
+ * by the supervisor, the supervisor restarts the gateway, which re-spawns
+ * the sidecar, which runs the cleanup again — infinite restart loop.
+ *
+ * Completing the invariant here removes the loop at its source: killing any
+ * ancestor is exactly as fatal to the caller as killing itself, so ancestors
+ * must receive the same exclusion treatment. The check admits any positive
+ * ancestor PID (including 1), because inside a container — a first-class
+ * deployment target for this project — the gateway is frequently the
+ * entrypoint and therefore runs as PID 1 of its own namespace; excluding 1
+ * unconditionally would recreate the #68451 loop on every containerised
+ * install where the gateway spawns a direct-child sidecar.
+ *
+ * The walk is best-effort. `process.ppid` is provided by Node via a direct
+ * syscall and is always available; transitive ancestors are only read on
+ * Linux via `/proc`. macOS/Windows stop at ppid, which is sufficient for
+ * the direct-child sidecar topology this bug describes; extending those
+ * platforms can be done without touching the call sites.
+ *
+ * The function takes no parameters and exposes no hooks. Tests exercise
+ * the real walk by stubbing `process.ppid` (and, on Linux, by mocking
+ * `node:fs` to inject `/proc/<pid>/status` payloads) — there is no
+ * reachable override for runtime callers to mutate.
+ */
+function getSelfAndAncestorPidsSync(): Set<number> {
+  const pids = new Set<number>([process.pid]);
+  const immediateParent = process.ppid;
+  if (!Number.isFinite(immediateParent) || immediateParent <= 0) {
+    return pids;
+  }
+  pids.add(immediateParent);
+  if (process.platform !== "linux") {
+    return pids;
+  }
+  // Transitive ancestor walk. Each hop's validity (positive pid, not already
+  // seen) is enforced by the per-iteration `parent` check below; the entry
+  // invariant `current > 0` is established above and preserved by `current =
+  // parent` after the same check, so no separate top-of-loop guard is needed.
+  let current = immediateParent;
+  for (let depth = 0; depth < MAX_ANCESTOR_WALK_DEPTH; depth++) {
+    const parent = readParentPidFromProc(current);
+    if (parent == null || parent <= 0 || pids.has(parent)) {
+      break;
+    }
+    pids.add(parent);
+    current = parent;
+  }
+  return pids;
+}
+
+/**
+ * Parse openclaw gateway PIDs from lsof -Fpc stdout, excluding the current
+ * process and its ancestors (see `getSelfAndAncestorPidsSync` for the full
+ * rationale). On Linux the ancestor lookup reads up to
+ * `MAX_ANCESTOR_WALK_DEPTH` entries from `/proc/<pid>/status`; each read is
+ * a virtual-filesystem access (no disk I/O, no external process), wrapped
+ * in try/catch and degrades silently. On macOS/Windows the lookup is
+ * in-memory via `process.ppid` only.
  */
 function parsePidsFromLsofOutput(stdout: string): number[] {
   const pids: number[] = [];
@@ -94,16 +197,22 @@ function parsePidsFromLsofOutput(stdout: string): number[] {
   }
   // Deduplicate: dual-stack listeners (IPv4 + IPv6) cause lsof to emit the
   // same PID twice. Return each PID at most once to avoid double-killing.
-  return [...new Set(pids)].filter((pid) => pid !== process.pid);
+  // Exclude self and ancestors — terminating any ancestor cascade-kills the
+  // caller via the supervisor, recreating the #68451 restart loop.
+  const excluded = getSelfAndAncestorPidsSync();
+  return [...new Set(pids)].filter((pid) => !excluded.has(pid));
 }
 
 /**
  * Windows: find listening PIDs on the port, then verify each is an openclaw
- * gateway process via command-line inspection. Excludes the current process.
+ * gateway process via command-line inspection. Excludes the current process
+ * and its ancestors (same invariant as the lsof path — see
+ * `getSelfAndAncestorPidsSync`).
  */
 function filterVerifiedWindowsGatewayPids(rawPids: number[]): number[] {
+  const excluded = getSelfAndAncestorPidsSync();
   return Array.from(new Set(rawPids))
-    .filter((pid) => Number.isFinite(pid) && pid > 0 && pid !== process.pid)
+    .filter((pid) => Number.isFinite(pid) && pid > 0 && !excluded.has(pid))
     .filter((pid) => {
       const args = readWindowsProcessArgsSync(pid);
       return args != null && isGatewayArgv(args, { allowGatewayBinary: true });
@@ -114,9 +223,10 @@ function filterVerifiedWindowsGatewayPidsResult(
   rawPids: number[],
   processArgsResult: (pid: number) => WindowsProcessArgsResult,
 ): WindowsListeningPidsResult {
+  const excluded = getSelfAndAncestorPidsSync();
   const verified: number[] = [];
   for (const pid of Array.from(new Set(rawPids))) {
-    if (!Number.isFinite(pid) || pid <= 0 || pid === process.pid) {
+    if (!Number.isFinite(pid) || pid <= 0 || excluded.has(pid)) {
       continue;
     }
     const argsResult = processArgsResult(pid);


### PR DESCRIPTION
### Summary

- **Problem**: The `openclaw-weixin` sidecar invokes `cleanStaleGatewayProcessesSync()` during its init path. The Unix filter in `src/infra/restart-stale-pids.ts` excluded only `process.pid`, and the two Windows filters did the same. Because the sidecar and its parent gateway share the `openclaw` command-name signature and the parent is listening on the configured gateway port, the parent's PID passed the filter and was SIGTERM'd. The supervisor restarted the gateway, the gateway re-spawned the sidecar, the cleanup ran again — an unbounded restart loop on ~45 s cadence, 100 % reproducible on `main` (2026.4.14 and 2026.4.15).

- **Root Cause**: The `pid !== process.pid` filter encodes an invariant: "stale-gateway cleanup must never terminate a process whose death cascades into the caller." That invariant was applied only to the caller itself. Killing a **direct ancestor** is functionally identical to killing the caller — cgroup cleanup reaps the child, the supervisor (systemd / launchctl) respawns the ancestor, and the child re-enters the same cleanup call site. The same applies transitively to any ancestor whose death propagates via the supervisor. The existing guard was therefore not wrong, merely incomplete: it protected one node of the lineage where it needed to protect the whole chain.

- **Fix**: Complete the self-exclusion invariant at the filter layer so the cleanup primitive is safe regardless of caller context. A new helper `getSelfAndAncestorPidsSync()` returns the set of PIDs comprising the current process, its `process.ppid` (always via Node's syscall — no spawn, cross-platform), and on Linux the transitive ancestor chain read from `/proc/<pid>/status`. `parsePidsFromLsofOutput` (Unix) and `filterVerifiedWindowsGatewayPids` / `filterVerifiedWindowsGatewayPidsResult` (Windows) both consult this set. The walk is bounded (`MAX_ANCESTOR_WALK_DEPTH = 32`), cycle-safe (early break on `pids.has(parent)`), and degrades silently on any `/proc` read failure — a deliberate product decision for hardened containers (hidepid=2 / gVisor / AppArmor), documented in the `readParentPidFromProc` catch-branch comment and locked by the "leaves the gateway grandparent in the kill list when /proc truncates the walk" regression test so the degraded outcome is explicit, not accidental. The fix is chosen over "detect misuse and refuse to run" or "patch the third-party sidecar call site" because (a) it repairs a design-level invariant rather than adding a detector, (b) it protects every present and future caller of the exported function, and (c) it has zero behavioural effect on the three legitimate supervisor-context callers (`launchd.ts`, `restart.ts`, `gateway-cli/run.ts`) whose ancestor chains are systemd/launchctl/shell and never listen on the gateway port.

- **What changed**:
  - `src/infra/restart-stale-pids.ts`:
    - New import `readFileSync` from `node:fs`.
    - New constant `MAX_ANCESTOR_WALK_DEPTH = 32`.
    - New helper `readParentPidFromProc(pid)` — Linux `/proc/<pid>/status` parse, returns `number | null`. The catch branch carries a comment documenting that a null return truncates the ancestor walk at the current hop; for the direct `gateway → sidecar` topology this is safe because `process.ppid` is captured unconditionally without a `/proc` read, but a deeper `gateway → plugin-host → sidecar` chain on hidepid=2 / gVisor / AppArmor-locked namespaces leaves the gateway grandparent in the kill list. The degraded outcome is pinned by a regression test rather than silently allowed.
    - New helper `getSelfAndAncestorPidsSync()` — returns `Set<number>` of self + direct parent + transitive ancestors (Linux). The check admits any positive ancestor PID including **1**, because a containerised gateway is frequently the namespace entrypoint (PID 1); excluding 1 unconditionally would recreate the #68451 loop on every containerised install. Written in early-return style (no dead inner guards).
    - `parsePidsFromLsofOutput` replaces the `pid !== process.pid` filter with `!excluded.has(pid)` where `excluded = getSelfAndAncestorPidsSync()`. Its JSDoc is updated to describe the Linux `/proc` behaviour (no more "pure function — no I/O" claim).
    - `filterVerifiedWindowsGatewayPids` and `filterVerifiedWindowsGatewayPidsResult` apply the same exclusion set before argv verification, so the parent gateway PID is dropped before `readWindowsProcessArgsSync` is even asked about it.
    - `__testing` export is **unchanged** — the existing `setSleepSyncOverride` / `setDateNowOverride` / `callSleepSyncRaw` remain; no new hooks were added. The ancestor walk is exercised by test-only stubbing of `process.ppid` and `vi.mock('node:fs')`, keeping the runtime-reachable mutation surface at zero.
  - `src/infra/restart-stale-pids.test.ts`:
    - `vi.mock('node:fs')` intercepts `readFileSync` so the `/proc` ancestor lookup can be driven deterministically. A precise `as typeof actual.readFileSync` cast satisfies `tsgo`'s overload check without reaching for `any`.
    - `mockReadFileSync` hoisted mock + `beforeEach` that installs an ENOENT default (simulating a restricted `/proc` — the view a non-privileged process has under hidepid=2). Tests that need a specific `/proc` payload override with `mockImplementation`.
    - `withStubbedPpid(ppid, fn)` helper — `Object.defineProperty(process, 'ppid', ...)` + descriptor restore in `finally`, matching the pattern already used for `process.platform` stubbing in this file. No `__testing` mutation surface is introduced.
    - **Five new regression tests**:
      1. "excludes ancestor pids so a sidecar cannot kill its parent gateway — regression for #68451" — the reported direct-parent topology on the Unix lsof path.
      2. "excludes the full ancestor chain, not just the direct parent — deeper nesting" — `it.skipIf(platform !== 'linux')`, drives the real `/proc` walk with a mocked two-hop chain terminated by `PPid:\t0`.
      3. "excludes PID 1 when the direct parent gateway is the container entrypoint — container topology" — pins the `> 0` guard (an earlier `> 1` draft would have reopened the loop for containerised installs).
      4. "leaves the gateway grandparent in the kill list when /proc truncates the walk — documented degradation on hidepid/gVisor hosts" — `it.skipIf(platform !== 'linux')`, pins the degraded behaviour so a future refactor cannot silently regress further.
      5. "excludes ancestor pids on Windows too — #68451 regression mirror for the win32 path" — Windows filter via `process.platform` stub, asserting parent exclusion happens before the argv-verification step.

- **What did NOT change (scope boundary)**:
  - No change to the three existing call sites (`launchd.ts`, `restart.ts`, `gateway-cli/run.ts`) — the fix lives at the filter layer.
  - No change to `lsof` spawn logic, `terminateStaleProcessesSync`, `waitForPortFreeSync`, `pollPortOnce`, or any port/poll-budget timing constant.
  - No change to `isGatewayArgv` or the Windows argv-verification step; ancestor exclusion happens **before** that inspection, so argv lookups are never issued against caller-lineage PIDs.
  - No change to the `__testing` surface. No new runtime-reachable override — in particular, no `setAncestorPidProviderOverride` (an earlier iteration proposed one and it was removed per review feedback so no in-process module can neutralise ancestor exclusion at runtime).
  - No change to public API signatures. `cleanStaleGatewayProcessesSync(portOverride?)` keeps its exact contract.
  - No new dependencies. `readFileSync` is a Node built-in already transitively present in the module graph.
  - No `any` types introduced — new surfaces are typed (`number | null`, `Set<number>`, helpers) and the one unavoidable cast (`as typeof actual.readFileSync`) is a precise retype against the real module export, not a widening to `any`.

### Reproduction

1. Deploy openclaw `2026.4.14` or `2026.4.15` behind a supervisor (systemd, launchd, or equivalent with `Restart=always`).
2. Install `@tencent-weixin/openclaw-weixin` v2.1.3 or v2.1.8 and enable it in `plugins.allow`.
3. Start the gateway via the supervisor.
4. Observe the gateway crash-loop at ~45 s cadence: `systemd-cgls` shows the gateway and sidecar in a tight respawn cycle; `journalctl -u openclaw` shows repeated EADDRINUSE / SIGTERM / exit-1 entries.
5. Disable the plugin to confirm the loop stops.

With this patch applied, step 4 no longer loops: the sidecar's cleanup filter drops the parent gateway PID before any SIGTERM is sent, and the gateway remains stable.

### Risk / Mitigation

- **Risk**: The new `getSelfAndAncestorPidsSync()` is called from `parsePidsFromLsofOutput`, which executes once per `lsof` poll inside `waitForPortFreeSync` (up to ~40 calls per cleanup budget). On Linux each call may read up to 32 `/proc/<pid>/status` files; on macOS/Windows it is in-memory only.
- **Mitigation**: `/proc` reads are `readFileSync` against a virtual filesystem — no disk I/O, no syscalls to external binaries. Worst-case arithmetic: 40 polls × ≤ 32 reads × few hundred bytes each ≈ well under 10 ms per cleanup, within noise of the existing `spawnSync("lsof", …)` overhead. Every read is wrapped in `try/catch` returning `null`; the walk also breaks on any `null` result, so a restricted `/proc` (user namespace, AppArmor, seccomp) degrades to "only self + ppid excluded" rather than failing. Existing tests pass unchanged because their synthetic `stalePid = process.pid + N` values are never in the caller's real ancestor chain; new tests drive the walk deterministically via `withStubbedPpid` and `vi.mock('node:fs')`.
- **Risk**: Path-based file read (`/proc/${pid}/status`) could be flagged by a security review for path injection.
- **Mitigation**: `pid` is always an integer produced by `process.ppid` or by `Number.parseInt` of a `/proc`-sourced decimal field, filtered by `Number.isFinite(parsed) && parsed > 0`. No user input, no string concatenation from untrusted data, no shell — the value is always a positive integer interpolated into a fixed path shape.
- **Risk**: Hardened-container topologies (hidepid=2, gVisor, AppArmor-locked namespaces) restrict `/proc` so the walk truncates at `process.ppid`, leaving a 3-level `gateway → plugin-host → sidecar` chain with the gateway grandparent outside the exclusion set.
- **Mitigation**: Documented in code on the `readParentPidFromProc` catch branch and pinned by the "leaves the gateway grandparent in the kill list when /proc truncates the walk" regression test. The reported #68451 case is direct-parent (gateway → sidecar) and is fully covered on every platform via `process.ppid` without depending on `/proc`. A fuller fix for deeper chains on hardened hosts (macOS/Windows ancestor walk, pidfd-based Linux walk, or privileged cmdline probe) is tracked out of band.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Supervisor / restart logic (`src/infra/restart-stale-pids.ts`)
- [x] Cross-platform port cleanup (Unix lsof + Windows PowerShell/netstat)
- [x] Tests (`src/infra/restart-stale-pids.test.ts`)

### Linked Issue/PR

Fixes #68451