### PR TITLE
fix(ui): filter system event messages from chat transcript (#68508)

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -621,6 +621,63 @@ describe("loadChatHistory", () => {
 
     expect(state.chatMessages).toEqual(messages);
   });
+
+  it("filters system-event-only user messages from history", async () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "System: [2026-04-18 10:00:00] Exec completed.\nSystem: [2026-04-18 10:00:00] Node: gateway",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "Got it" }] },
+      {
+        role: "user",
+        content: [{ type: "text", text: "System (untrusted): [2026-04-18 10:01:00] cron fired" }],
+      },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    // Only the real user message and the assistant reply should remain
+    expect(state.chatMessages).toEqual([messages[0], messages[2]]);
+  });
+
+  it("keeps user messages that mix system event lines with real content", async () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "System: [2026-04-18 10:00:00] Node connected.\n\nWhat is the weather?",
+          },
+        ],
+      },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual(messages);
+  });
 });
 
 describe("sendChatMessage", () => {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -11,6 +11,12 @@ import {
 } from "./scope-errors.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+/**
+ * Matches lines that are purely system event signals injected by the runtime
+ * (e.g. "System: [timestamp] Exec completed", "System (untrusted): ...").
+ * These are agent-only signals and should not be visible in the chat transcript.
+ */
+const SYSTEM_EVENT_LINE_RE = /^System(?:\s*\(untrusted\))?:\s/;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
@@ -71,8 +77,37 @@ function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
   return typeof text === "string" && text.trim() === SYNTHETIC_TRANSCRIPT_REPAIR_RESULT;
 }
 
+/**
+ * Detect user messages whose visible content consists entirely of system event
+ * lines (e.g. cron/exec completion notifications). These are internal signals
+ * for the agent and should not appear in the user-facing chat transcript.
+ */
+function isSystemEventOnlyMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = normalizeLowercaseStringOrEmpty(entry.role);
+  if (role !== "user") {
+    return false;
+  }
+  const text = extractText(message);
+  if (typeof text !== "string" || !text.trim()) {
+    return false;
+  }
+  const lines = text.split("\n");
+  return lines.every((line) => {
+    const trimmed = line.trim();
+    return trimmed === "" || SYSTEM_EVENT_LINE_RE.test(trimmed);
+  });
+}
+
 function shouldHideHistoryMessage(message: unknown): boolean {
-  return isAssistantSilentReply(message) || isSyntheticTranscriptRepairToolResult(message);
+  return (
+    isAssistantSilentReply(message) ||
+    isSyntheticTranscriptRepairToolResult(message) ||
+    isSystemEventOnlyMessage(message)
+  );
 }
 
 function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {


### PR DESCRIPTION
## Summary

Fixes #68508 — System event messages (async exec completion notifications with `System:` and `System (untrusted):` prefixes) were leaking into the visible WebChat/Control UI chat transcript. These are internal agent-only signals and should not be shown to users.

## Changes

- **`ui/src/ui/controllers/chat.ts`**: Updated `shouldHideHistoryMessage` to filter out system event messages (matching `System:` and `System (untrusted):` prefixes) from the rendered chat history
- **`ui/src/ui/controllers/chat.test.ts`**: Added tests verifying system event messages are hidden while normal messages remain visible

## How it works

Messages are filtered at the UI rendering layer only — they remain in the underlying message history so the agent can still access them, but they are excluded from what users see in WebChat/Control UI.