### PR TITLE
fix(secret-scanning): remove maintainer @<LOGIN> attribution from replacement comment template

### DIFF
--- a/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/SKILL.md
@@ -127,7 +127,7 @@ The `fetch-content` output for `discussion_comment` includes `comment_node_id` a
 The recreated comment should follow this format:
 
 ```
-> **Note from maintainer (@<LOGIN>):** The original comment by @<AUTHOR> has been removed due to secret leakage. Below is the redacted version of the original content.
+> **Note:** The original comment by @<AUTHOR> has been removed due to secret leakage. Below is the redacted version of the original content.
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove `@<LOGIN>` maintainer attribution from the secret-scanning replacement comment template in SKILL.md
- The person executing the skill is already a maintainer — GitHub's author association badge makes this clear, so a hardcoded `@<LOGIN>` placeholder is unnecessary and error-prone (it got filled with the wrong maintainer name in #67170)
- Changed template from `> **Note from maintainer (@<LOGIN>):** …` to `> **Note:** …`

## Context

In https://github.com/openclaw/openclaw/issues/67170#issuecomment-4258831130, the replacement comment was attributed to `@thewilloftheshadow` instead of the actual maintainer (`@hxy91819`) who processed the alert. Since the comment author is automatically a maintainer and GitHub shows the `MEMBER` badge, there's no need for an explicit `@<LOGIN>` attribution that can be incorrectly filled.