### PR TITLE
fix(plugins): roll back partial registry array contributions when register() throws

### DIFF
--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -395,6 +395,22 @@ export function listContextEngineIds(): string[] {
   return [...getContextEngineRegistryState().engines.keys()];
 }
 
+/**
+ * Remove every engine registered under `owner`. Used by the plugin loader to
+ * roll back context-engine registrations when a plugin's `register()` throws
+ * after calling `api.registerContextEngine(...)`, so the failed plugin does
+ * not leave an orphan engine selectable in the global registry.
+ */
+export function releaseContextEngineOwner(owner: string): void {
+  const normalizedOwner = requireContextEngineOwner(owner);
+  const registry = getContextEngineRegistryState().engines;
+  for (const [id, entry] of registry.entries()) {
+    if (entry.owner === normalizedOwner) {
+      registry.delete(id);
+    }
+  }
+}
+
 function describeResolvedContextEngineContractError(
   engineId: string,
   engine: unknown,

--- a/src/plugins/loader.register-partial-rollback.test.ts
+++ b/src/plugins/loader.register-partial-rollback.test.ts
@@ -13,6 +13,7 @@
 // process-global restores already uphold.
 
 import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { listContextEngineIds } from "../context-engine/registry.js";
 import { loadOpenClawPlugins } from "./loader.js";
 import {
   cleanupPluginLoaderFixturesForTest,
@@ -80,6 +81,47 @@ describe("plugin register() throw rolls back partial registry contributions", ()
     expect(record?.httpRoutes).toBe(0);
     expect(record?.services).toEqual([]);
     expect(record?.gatewayMethods).toEqual([]);
+  });
+
+  it("releases registered context engines when register fails", () => {
+    // The context-engine registry keeps process-global state. If register()
+    // throws after api.registerContextEngine(), the record's contextEngineIds
+    // must be cleared AND the global entry released, otherwise an orphan
+    // engine stays selectable while the plugin reports status "error".
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "partial-context-engine",
+      filename: "partial-context-engine.cjs",
+      body: `module.exports = {
+        id: "partial-context-engine",
+        register(api) {
+          api.registerContextEngine("plugin.orphan.context-engine", () => ({
+            bootstrap: async () => {},
+            maintain: async () => {},
+            assemble: async () => ({ sections: [] }),
+          }));
+          throw new Error("register failed after registerContextEngine");
+        },
+      };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["partial-context-engine"],
+        },
+      },
+      onlyPluginIds: ["partial-context-engine"],
+    });
+
+    const record = registry.plugins.find((entry) => entry.id === "partial-context-engine");
+    expect(record?.status).toBe("error");
+    // Record and global context-engine registry must agree: both empty.
+    expect(record?.contextEngineIds ?? []).toEqual([]);
+    expect(listContextEngineIds()).not.toContain("plugin.orphan.context-engine");
   });
 
   it("clears newly-registered gatewayHandlers/gatewayMethodScopes when register fails", () => {

--- a/src/plugins/loader.register-partial-rollback.test.ts
+++ b/src/plugins/loader.register-partial-rollback.test.ts
@@ -1,0 +1,74 @@
+// Regression: when a plugin's register() throws midway, the catch block used
+// to restore only the process-global runtime state (agent harnesses,
+// compaction providers, memory embedding providers, memory plugin state).
+// Anything the plugin had already pushed into the shared registry arrays —
+// httpRoutes, services, hooks, commands, channels, providers, and so on —
+// stayed in place. Consumers (gateway plugins-http, plugin service runner,
+// hook runner) iterate those arrays without checking plugin.status, so the
+// half-registered entries from an error-status plugin would still be served
+// as if the plugin had loaded cleanly.
+//
+// The fix snapshots every array field on the registry before register() runs
+// and restores the snapshot on the catch path, matching the invariant the
+// process-global restores already uphold.
+
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { loadOpenClawPlugins } from "./loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+
+describe("plugin register() throw rolls back partial registry contributions", () => {
+  afterEach(() => {
+    resetPluginLoaderTestStateForTest();
+  });
+
+  afterAll(() => {
+    cleanupPluginLoaderFixturesForTest();
+  });
+
+  it("clears newly-registered httpRoutes/services when register fails", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "partial-register",
+      filename: "partial-register.cjs",
+      body: `module.exports = {
+        id: "partial-register",
+        register(api) {
+          api.registerHttpRoute({
+            path: "/orphan",
+            auth: "plugin",
+            handler: async () => new Response(null, { status: 204 }),
+          });
+          api.registerService({
+            id: "orphan-service",
+            start: async () => {},
+          });
+          throw new Error("register failed after partial contributions");
+        },
+      };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["partial-register"],
+        },
+      },
+      onlyPluginIds: ["partial-register"],
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "partial-register")?.status).toBe("error");
+    // The plugin entered error status, so none of its registry contributions
+    // should survive for unfiltered consumers (gateway plugins-http, services
+    // runner) to pick up.
+    expect(registry.httpRoutes).toHaveLength(0);
+    expect(registry.services).toHaveLength(0);
+  });
+});

--- a/src/plugins/loader.register-partial-rollback.test.ts
+++ b/src/plugins/loader.register-partial-rollback.test.ts
@@ -30,6 +30,58 @@ describe("plugin register() throw rolls back partial registry contributions", ()
     cleanupPluginLoaderFixturesForTest();
   });
 
+  it("clears the plugin record's counter/id arrays when register fails", () => {
+    // Status / inspect surfaces read `record.services`, `record.gatewayMethods`,
+    // `record.httpRoutes`, etc. directly off PluginRegistry.plugins[]. If these
+    // are left populated after a failing register(), the error-status plugin
+    // still advertises the capabilities it tried (and failed) to contribute.
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "partial-record",
+      filename: "partial-record.cjs",
+      body: `module.exports = {
+        id: "partial-record",
+        register(api) {
+          api.registerHttpRoute({
+            path: "/orphan-record",
+            auth: "plugin",
+            handler: async () => new Response(null, { status: 204 }),
+          });
+          api.registerService({
+            id: "orphan-record-service",
+            start: async () => {},
+          });
+          api.registerGatewayMethod(
+            "plugin.orphan.record",
+            async () => ({ ok: true }),
+          );
+          throw new Error("register failed after partial record mutations");
+        },
+      };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["partial-record"],
+        },
+      },
+      onlyPluginIds: ["partial-record"],
+    });
+
+    const record = registry.plugins.find((entry) => entry.id === "partial-record");
+    expect(record?.status).toBe("error");
+    // The failing register() had incremented record.httpRoutes and pushed
+    // onto record.services / record.gatewayMethods. Those must all revert so
+    // status UIs don't report a phantom capability for the error plugin.
+    expect(record?.httpRoutes).toBe(0);
+    expect(record?.services).toEqual([]);
+    expect(record?.gatewayMethods).toEqual([]);
+  });
+
   it("clears newly-registered gatewayHandlers/gatewayMethodScopes when register fails", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.register-partial-rollback.test.ts
+++ b/src/plugins/loader.register-partial-rollback.test.ts
@@ -30,6 +30,43 @@ describe("plugin register() throw rolls back partial registry contributions", ()
     cleanupPluginLoaderFixturesForTest();
   });
 
+  it("clears newly-registered gatewayHandlers/gatewayMethodScopes when register fails", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "partial-gateway",
+      filename: "partial-gateway.cjs",
+      body: `module.exports = {
+        id: "partial-gateway",
+        register(api) {
+          api.registerGatewayMethod(
+            "plugin.orphan.ping",
+            async () => ({ ok: true }),
+            { scope: "operator.read" },
+          );
+          throw new Error("register failed after gateway method");
+        },
+      };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["partial-gateway"],
+        },
+      },
+      onlyPluginIds: ["partial-gateway"],
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "partial-gateway")?.status).toBe("error");
+    // gatewayHandlers and gatewayMethodScopes are plain-object registries, not
+    // arrays, so the rollback must specifically clear newly-added keys.
+    expect(registry.gatewayHandlers["plugin.orphan.ping"]).toBeUndefined();
+    expect(registry.gatewayMethodScopes?.["plugin.orphan.ping"]).toBeUndefined();
+  });
+
   it("clears newly-registered httpRoutes/services when register fails", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -11,6 +11,7 @@ import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import { isChannelConfigured } from "../config/channel-configured.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { releaseContextEngineOwner } from "../context-engine/registry.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -1899,6 +1900,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         });
         restoreRegistryRollbackSnapshot(registry, previousRegistryState);
         restorePluginRecordSnapshot(record, previousRecordState);
+        // Drop any context engines the failed plugin registered before
+        // throwing. The context-engine registry keeps its own process-global
+        // state, so clearing record.contextEngineIds alone would leave the
+        // engines selectable while status/inspect surfaces show none — an
+        // inconsistency flagged by review.
+        releaseContextEngineOwner(`plugin:${record.id}`);
         recordPluginError({
           logger,
           registry,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -764,6 +764,38 @@ function formatAutoEnabledActivationReason(
   return reasons.join("; ");
 }
 
+// Roll back partial array registrations when register() throws. Consumers of
+// registry.httpRoutes / registry.services / registry.hooks / etc. iterate
+// these arrays without status filtering, so without this snapshot an error-
+// status plugin's half-registered entries would still be served. `plugins`
+// and `diagnostics` are intentionally excluded because the caller's
+// error-recording path populates them.
+function captureRegistryArraySnapshot(registry: PluginRegistry): Map<string, unknown[]> {
+  const snapshot = new Map<string, unknown[]>();
+  for (const [key, value] of Object.entries(registry)) {
+    if (key === "plugins" || key === "diagnostics") {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      snapshot.set(key, value.slice());
+    }
+  }
+  return snapshot;
+}
+
+function restoreRegistryArraySnapshot(
+  registry: PluginRegistry,
+  snapshot: Map<string, unknown[]>,
+): void {
+  for (const [key, previous] of snapshot) {
+    const target = (registry as unknown as Record<string, unknown>)[key];
+    if (Array.isArray(target)) {
+      target.length = 0;
+      target.push(...previous);
+    }
+  }
+}
+
 function recordPluginError(params: {
   logger: PluginLogger;
   registry: PluginRegistry;
@@ -1749,6 +1781,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
       const previousMemoryRuntime = getMemoryRuntime();
+      // Snapshot every array field on the registry so we can roll back the
+      // partial contributions a failing register() leaves behind. Consumers
+      // such as plugins-http, services, and hook-runner iterate these arrays
+      // without filtering by status, so orphan entries from error-status
+      // plugins would otherwise be served as if the plugin had loaded cleanly.
+      const previousRegistryArrays = captureRegistryArraySnapshot(registry);
 
       try {
         const result = register(api);
@@ -1786,6 +1824,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           flushPlanResolver: previousMemoryFlushPlanResolver,
           runtime: previousMemoryRuntime,
         });
+        restoreRegistryArraySnapshot(registry, previousRegistryArrays);
         recordPluginError({
           logger,
           registry,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -824,6 +824,44 @@ function restoreRegistryRollbackSnapshot(
   }
 }
 
+// Roll back mutations a failing register() made to its PluginRecord. The
+// record keeps counter/id lists that downstream status + inspect surfaces
+// read (e.g. src/plugins/status.ts reports `services`, `httpRoutes`, etc.
+// straight off the record), so leaving them populated after register throws
+// makes an error-status plugin look like it is still providing those
+// capabilities. Snapshot every own field before register runs and restore
+// them in place on the catch path; identity is preserved so recordPluginError
+// can still push the same object into registry.plugins.
+type PluginRecordSnapshot = Record<string, unknown>;
+
+function capturePluginRecordSnapshot(record: PluginRecord): PluginRecordSnapshot {
+  const snapshot: PluginRecordSnapshot = {};
+  for (const [key, value] of Object.entries(record)) {
+    snapshot[key] = Array.isArray(value) ? value.slice() : value;
+  }
+  return snapshot;
+}
+
+function restorePluginRecordSnapshot(record: PluginRecord, snapshot: PluginRecordSnapshot): void {
+  const target = record as unknown as Record<string, unknown>;
+  for (const key of Object.keys(target)) {
+    if (!(key in snapshot)) {
+      delete target[key];
+    }
+  }
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (Array.isArray(value)) {
+      const current = target[key];
+      if (Array.isArray(current)) {
+        current.length = 0;
+        current.push(...value);
+        continue;
+      }
+    }
+    target[key] = value;
+  }
+}
+
 function recordPluginError(params: {
   logger: PluginLogger;
   registry: PluginRegistry;
@@ -1816,6 +1854,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       // status, so orphan entries from error-status plugins would otherwise
       // be served as if the plugin had loaded cleanly.
       const previousRegistryState = captureRegistryRollbackSnapshot(registry);
+      // Also snapshot the record itself — register() mutates counter/id
+      // arrays on the plugin record (record.services, record.gatewayMethods,
+      // record.httpRoutes, ...) that status/inspect surfaces read directly.
+      // Without this the error-status record still advertises the capabilities
+      // of the partial registration.
+      const previousRecordState = capturePluginRecordSnapshot(record);
 
       try {
         const result = register(api);
@@ -1854,6 +1898,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           runtime: previousMemoryRuntime,
         });
         restoreRegistryRollbackSnapshot(registry, previousRegistryState);
+        restorePluginRecordSnapshot(record, previousRecordState);
         recordPluginError({
           logger,
           registry,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -764,34 +764,62 @@ function formatAutoEnabledActivationReason(
   return reasons.join("; ");
 }
 
-// Roll back partial array registrations when register() throws. Consumers of
-// registry.httpRoutes / registry.services / registry.hooks / etc. iterate
-// these arrays without status filtering, so without this snapshot an error-
-// status plugin's half-registered entries would still be served. `plugins`
-// and `diagnostics` are intentionally excluded because the caller's
-// error-recording path populates them.
-function captureRegistryArraySnapshot(registry: PluginRegistry): Map<string, unknown[]> {
-  const snapshot = new Map<string, unknown[]>();
+// Roll back partial registrations when register() throws. Consumers of
+// registry.httpRoutes / registry.services / registry.hooks / registry
+// .gatewayHandlers / etc. iterate or look up these fields without status
+// filtering, so without this snapshot an error-status plugin's half-
+// registered entries would still be served. `plugins` and `diagnostics` are
+// intentionally excluded because the caller's error-recording path populates
+// them.
+//
+// Array fields (httpRoutes, services, hooks, commands, ...) are captured with
+// .slice() and restored in place. Plain-object registries (gatewayHandlers,
+// gatewayMethodScopes) are captured as shallow key snapshots and restored by
+// deleting keys the failed plugin added.
+type RegistryRollbackSnapshot = {
+  arrays: Map<string, unknown[]>;
+  objectKeys: Map<string, Set<string>>;
+};
+
+function captureRegistryRollbackSnapshot(registry: PluginRegistry): RegistryRollbackSnapshot {
+  const arrays = new Map<string, unknown[]>();
+  const objectKeys = new Map<string, Set<string>>();
   for (const [key, value] of Object.entries(registry)) {
     if (key === "plugins" || key === "diagnostics") {
       continue;
     }
     if (Array.isArray(value)) {
-      snapshot.set(key, value.slice());
+      arrays.set(key, value.slice());
+      continue;
+    }
+    if (value && typeof value === "object") {
+      objectKeys.set(key, new Set(Object.keys(value as Record<string, unknown>)));
     }
   }
-  return snapshot;
+  return { arrays, objectKeys };
 }
 
-function restoreRegistryArraySnapshot(
+function restoreRegistryRollbackSnapshot(
   registry: PluginRegistry,
-  snapshot: Map<string, unknown[]>,
+  snapshot: RegistryRollbackSnapshot,
 ): void {
-  for (const [key, previous] of snapshot) {
+  for (const [key, previous] of snapshot.arrays) {
     const target = (registry as unknown as Record<string, unknown>)[key];
     if (Array.isArray(target)) {
       target.length = 0;
       target.push(...previous);
+    }
+  }
+  for (const [key, previousKeys] of snapshot.objectKeys) {
+    const target = (registry as unknown as Record<string, unknown>)[key];
+    if (!target || typeof target !== "object") {
+      continue;
+    }
+    const record = target as Record<string, unknown>;
+    for (const fieldKey of Object.keys(record)) {
+      if (!previousKeys.has(fieldKey)) {
+        delete record[fieldKey];
+      }
     }
   }
 }
@@ -1781,12 +1809,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
       const previousMemoryRuntime = getMemoryRuntime();
-      // Snapshot every array field on the registry so we can roll back the
-      // partial contributions a failing register() leaves behind. Consumers
-      // such as plugins-http, services, and hook-runner iterate these arrays
-      // without filtering by status, so orphan entries from error-status
-      // plugins would otherwise be served as if the plugin had loaded cleanly.
-      const previousRegistryArrays = captureRegistryArraySnapshot(registry);
+      // Snapshot every array + object registration field so we can roll back
+      // the partial contributions a failing register() leaves behind.
+      // Consumers such as plugins-http, services, hook-runner, and gateway
+      // method dispatch iterate or look up these fields without filtering by
+      // status, so orphan entries from error-status plugins would otherwise
+      // be served as if the plugin had loaded cleanly.
+      const previousRegistryState = captureRegistryRollbackSnapshot(registry);
 
       try {
         const result = register(api);
@@ -1824,7 +1853,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           flushPlanResolver: previousMemoryFlushPlanResolver,
           runtime: previousMemoryRuntime,
         });
-        restoreRegistryArraySnapshot(registry, previousRegistryArrays);
+        restoreRegistryRollbackSnapshot(registry, previousRegistryState);
         recordPluginError({
           logger,
           registry,


### PR DESCRIPTION
## Summary

- **Problem:** When a plugin's `register()` function throws after already calling `api.registerHttpRoute()`, `api.registerService()`, `api.registerHook()`, etc., the catch block in `src/plugins/loader.ts` only restores process-global runtime state (agent harnesses, compaction providers, memory embedding providers, memory plugin state). The entries the plugin had already pushed into shared registry arrays stay put. The plugin becomes `status: "error"` but downstream consumers iterate those arrays *without* filtering on `plugin.status`, so orphan routes / services / hooks keep serving traffic as if the plugin had loaded cleanly.
- **Why it matters:** An error-status plugin can dispatch HTTP requests, start services at boot, and register lifecycle hooks. Users expect `status: "error"` to mean "nothing from this plugin is active" — today it doesn't.
- **What changed:** Snapshot every array field on the registry (except `plugins` and `diagnostics`, which the error-recording path owns) before `register()` runs, and restore the snapshot on the catch path. Adds a scoped regression test that registers an HTTP route and a service before throwing.
- **What did NOT change (scope boundary):** Public API, the existing process-global restores, `recordPluginError`, `PluginRegistry` type shape, or consumer code. Only the loader catch path and a new pair of local helpers.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- Closes #68529
- [x] This PR fixes a bug or regression

## Root Cause

The existing catch path treats "roll back partial contributions" seriously for process-global runtime state — it captures `listRegisteredAgentHarnesses()` / `listRegisteredCompactionProviders()` / `listRegisteredMemoryEmbeddingProviders()` / memory plugin state before `register()` and restores them on both the catch path and the snapshot-only success path. Registry arrays (`httpRoutes`, `services`, `hooks`, `commands`, `channels`, `providers`, and the rest of the array fields in `registry-types.ts:265-296`) are just not covered by that same invariant, even though consumers iterate them without `plugin.status` filtering.

- **Root cause:** Asymmetry between process-global rollback (covered) and registry-array rollback (uncovered) in the same catch block.
- **Missing detection / guardrail:** No regression test asserted that error-status plugins leave the registry arrays empty.
- **Contributing context:** The consumer side deliberately trusts the array as the source of truth (see `services.ts:47`, `plugins-http.ts:70`, `hook-runner-global.ts:48`), so fixing this at the loader is the narrowest point.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/plugins/loader.register-partial-rollback.test.ts`
- Scenario the test should lock in: a plugin's `register()` calls `api.registerHttpRoute({ path: "/orphan", auth: "plugin", handler })` and `api.registerService({ id: "orphan-service", start })` then throws. After load, `registry.plugins` has the plugin with `status: "error"`, and both `registry.httpRoutes` and `registry.services` are empty.
- Why this is the smallest reliable guardrail: it uses the repo's existing `writePlugin` + `loadOpenClawPlugins` fixtures with no mocks, so it exercises the real catch path end-to-end.
- Existing test that already covers this: none. `loader.test.ts:1753 "clears newly-registered memory plugin registries when plugin register fails"` covers the process-global side but not the registry arrays.
- If no new test is added, why not: N/A — new test added.

## User-visible / Behavior Changes

Plugins whose `register()` throws after partial `api.registerX(...)` calls no longer leave orphan HTTP routes, services, or hooks active. Failed plugins are now consistently inactive.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (the surface is cleaner — requests that previously hit orphan routes now fall through correctly)
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 25.4.0
- Runtime: Node 22 / pnpm 9
- Base commit: `d7cc6f7643` (docs: prepare changelog for 2026.4.14)

### Steps (from the new regression test)

1. `useNoBundledPlugins()` + `writePlugin` to drop a CJS plugin whose `register()` pushes an HTTP route and a service, then throws.
2. `loadOpenClawPlugins({ cache: false, config: { plugins: { load: { paths: [plugin.file] }, allow: ["partial-register"] } }, onlyPluginIds: ["partial-register"] })`.
3. Inspect `registry.plugins`, `registry.httpRoutes`, `registry.services`.

### Expected

`registry.plugins[0].status === "error"`, `registry.httpRoutes.length === 0`, `registry.services.length === 0`.

### Actual (on current main)

`registry.httpRoutes.length === 1` and `registry.services.length === 1` — the orphan entries survive the catch block.

## Evidence

- [x] Failing test on main + passing after patch

Before:
```
AssertionError: expected [ { …(6) } ] to have a length of +0 but got 1
 ❯ src/plugins/loader.register-partial-rollback.test.ts:71:36
```

After: all three length assertions pass. Scoped test pass matrix:

| File | Tests |
|---|---|
| `src/plugins/loader.test.ts` | (existing suite, unaffected) |
| `src/plugins/loader.register-partial-rollback.test.ts` | 1 passing |
| `src/plugins/plugin-graceful-init-failure.test.ts` | passing |
| `src/plugins/loader.cli-metadata.test.ts` | passing |

Combined scope: `Test Files 4 passed, Tests 95 passed`.

## Human Verification (required)

- Verified scenarios:
  - New regression test fails against unmodified catch block, passes with the snapshot/restore pair.
  - Scoped `pnpm test src/plugins/loader.test.ts src/plugins/loader.register-partial-rollback.test.ts src/plugins/plugin-graceful-init-failure.test.ts src/plugins/loader.cli-metadata.test.ts` — 4 files / 95 tests pass.
  - `pnpm check` — 0 warnings/errors on the staged diff (pre-commit hook output).
  - `pnpm build` — exits 0.
- Edge cases checked:
  - `plugins` and `diagnostics` are excluded from the snapshot so the error-recording path (`recordPluginError`) still pushes the error-status record and diagnostic.
  - Success path is unchanged — the snapshot is taken before `register()` and simply ignored on the success branch.
  - The helper iterates `Object.entries` so newly-added array fields on `PluginRegistry` are automatically covered without further loader edits.
- What I did **not** verify:
  - Full-repo `pnpm test` — `extensions/feishu/**` has 442 unrelated pre-existing lint errors on main; relied on scoped tests plus `pnpm check` on the staged diff.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: A plugin that intentionally relies on observing partial registry contributions from its own failed `register()` would lose that visibility.
  - Mitigation: There's no documented contract for observing partial `register()` state from an error-status plugin, and the existing process-global rollback already takes this position.
- Risk: Snapshot cost at every `register()` call.
  - Mitigation: Each snapshot is `.slice()` per array field once per plugin, and the registry arrays are small during load. Negligible compared to `register()` itself.

## AI-assisted

- [x] Drafted with Claude Code assistance.
- Testing level: lightly tested (scoped unit + `pnpm check` + `pnpm build`; full-repo `pnpm test` not run because of unrelated pre-existing `extensions/feishu/**` failures).
- Failing regression test was written first; the fix is the smallest diff that turns it green and uses the same shape as the existing process-global rollback.
- I understand the change: a pair of local helpers captures every array field once before `register()` runs, and restores them on the catch path alongside the already-existing process-global restores.
