### PR TITLE
fix(memory-core): add cooldown guard to prevent dreaming-narrative from spawning on every heartbeat

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -2088,6 +2088,15 @@ describe("memory-core dreaming phases", () => {
 
     // Invalid expression
     expect(estimateCronIntervalMs("invalid")).toBeNull();
+
+    // Weekday range (Mon-Fri) — fires daily
+    expect(estimateCronIntervalMs("0 3 * * 1-5")).toBe(24 * 60 * 60 * 1000);
+
+    // Two days per week (Sun, Wed) — ~3.5 days
+    expect(estimateCronIntervalMs("0 3 * * 0,3")).toBe(Math.round((7 * 24 * 60 * 60 * 1000) / 2));
+
+    // Single DOW — still weekly
+    expect(estimateCronIntervalMs("0 3 * * 0")).toBe(7 * 24 * 60 * 60 * 1000);
   });
 
   it("skips REM subagent when a REM run occurred within the last few days under default config", async () => {

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -2090,6 +2090,56 @@ describe("memory-core dreaming phases", () => {
     expect(estimateCronIntervalMs("invalid")).toBeNull();
   });
 
+  it("skips REM subagent when a REM run occurred within the last few days under default config", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-cooldown-");
+    const { writePhaseCooldownStore, readPhaseCooldownStore } = __testing;
+    const nowMs = DREAMING_TEST_BASE_TIME.getTime();
+
+    // Seed a REM run 3 days ago — well within the 7-day cooldown (80% = 5.6 days).
+    const remRunMs = nowMs - 3 * 24 * 60 * 60 * 1000;
+    await writePhaseCooldownStore(workspaceDir, {
+      version: 1,
+      phases: {
+        rem: { lastRunAtMs: remRunMs, lastRunAtIso: new Date(remRunMs).toISOString() },
+      },
+    });
+
+    const logMessages: string[] = [];
+    const logger = {
+      info: (msg: string) => logMessages.push(msg),
+      warn: (msg: string) => logMessages.push(msg),
+      error: (msg: string) => logMessages.push(msg),
+      debug: (msg: string) => logMessages.push(msg),
+    };
+
+    // Run sweep with default plugin config (no explicit cron overrides).
+    // REM should be skipped because the fixed DEFAULT_REM_COOLDOWN_MS (7 days)
+    // has not elapsed. Light is disabled by limit=0 to isolate the REM path.
+    await runDreamingSweepPhases({
+      workspaceDir,
+      pluginConfig: {
+        dreaming: {
+          enabled: true,
+          phases: {
+            light: { enabled: true, limit: 0 },
+            rem: { enabled: true, limit: 5 },
+          },
+        },
+      },
+      logger: logger as never,
+      nowMs,
+    });
+
+    // The cooldown store should NOT have been updated (REM did not run).
+    const storeAfter = await readPhaseCooldownStore(workspaceDir);
+    expect(storeAfter.phases.rem?.lastRunAtMs).toBe(remRunMs);
+
+    // Logger should have captured the REM skip message.
+    expect(
+      logMessages.some((m) => m.includes("rem dreaming skipped") && m.includes("cooldown")),
+    ).toBe(true);
+  });
+
   it("records phase run and persists cooldown state", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-cooldown-");
     const { readPhaseCooldownStore, recordPhaseRun } = __testing;

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1995,4 +1995,115 @@ describe("memory-core dreaming phases", () => {
     // Before the fix, it stayed at 1 because dayBucket was the file date.
     expect(after2[0]?.dailyCount).toBe(2);
   });
+
+  it("skips light dreaming when within cooldown period", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-cooldown-");
+    const { readPhaseCooldownStore, writePhaseCooldownStore, isPhaseOnCooldown, constants } =
+      __testing;
+    const nowMs = DREAMING_TEST_BASE_TIME.getTime();
+
+    // No cooldown entry — should NOT be on cooldown.
+    const emptyStore = await readPhaseCooldownStore(workspaceDir);
+    expect(isPhaseOnCooldown(emptyStore, "light", nowMs, constants.DEFAULT_LIGHT_COOLDOWN_MS)).toBe(
+      false,
+    );
+
+    // Record a recent run.
+    const recentRunMs = nowMs - 1 * 60 * 60 * 1000; // 1 hour ago
+    await writePhaseCooldownStore(workspaceDir, {
+      version: 1,
+      phases: {
+        light: { lastRunAtMs: recentRunMs, lastRunAtIso: new Date(recentRunMs).toISOString() },
+      },
+    });
+
+    const storeWithRecent = await readPhaseCooldownStore(workspaceDir);
+    // 1 hour ago, default cooldown is 6 hours, 80% = 4.8 hours — should be on cooldown.
+    expect(
+      isPhaseOnCooldown(storeWithRecent, "light", nowMs, constants.DEFAULT_LIGHT_COOLDOWN_MS),
+    ).toBe(true);
+
+    // Record an old run.
+    const oldRunMs = nowMs - 7 * 60 * 60 * 1000; // 7 hours ago
+    await writePhaseCooldownStore(workspaceDir, {
+      version: 1,
+      phases: { light: { lastRunAtMs: oldRunMs, lastRunAtIso: new Date(oldRunMs).toISOString() } },
+    });
+
+    const storeWithOld = await readPhaseCooldownStore(workspaceDir);
+    // 7 hours ago, past the 4.8-hour cooldown — should NOT be on cooldown.
+    expect(
+      isPhaseOnCooldown(storeWithOld, "light", nowMs, constants.DEFAULT_LIGHT_COOLDOWN_MS),
+    ).toBe(false);
+  });
+
+  it("skips rem dreaming when within cooldown period", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-cooldown-");
+    const { readPhaseCooldownStore, writePhaseCooldownStore, isPhaseOnCooldown, constants } =
+      __testing;
+    const nowMs = DREAMING_TEST_BASE_TIME.getTime();
+
+    // Record rem phase run 2 days ago — well within 7-day cooldown (80% = 5.6 days).
+    const recentRunMs = nowMs - 2 * 24 * 60 * 60 * 1000;
+    await writePhaseCooldownStore(workspaceDir, {
+      version: 1,
+      phases: {
+        rem: { lastRunAtMs: recentRunMs, lastRunAtIso: new Date(recentRunMs).toISOString() },
+      },
+    });
+
+    const store = await readPhaseCooldownStore(workspaceDir);
+    expect(isPhaseOnCooldown(store, "rem", nowMs, constants.DEFAULT_REM_COOLDOWN_MS)).toBe(true);
+
+    // Record rem phase run 8 days ago — past cooldown.
+    const oldRunMs = nowMs - 8 * 24 * 60 * 60 * 1000;
+    await writePhaseCooldownStore(workspaceDir, {
+      version: 1,
+      phases: { rem: { lastRunAtMs: oldRunMs, lastRunAtIso: new Date(oldRunMs).toISOString() } },
+    });
+
+    const storeOld = await readPhaseCooldownStore(workspaceDir);
+    expect(isPhaseOnCooldown(storeOld, "rem", nowMs, constants.DEFAULT_REM_COOLDOWN_MS)).toBe(
+      false,
+    );
+  });
+
+  it("estimates cron interval correctly for common patterns", () => {
+    const { estimateCronIntervalMs } = __testing;
+
+    // Every 6 hours
+    expect(estimateCronIntervalMs("0 */6 * * *")).toBe(6 * 60 * 60 * 1000);
+
+    // Weekly (Sunday at 5am)
+    expect(estimateCronIntervalMs("0 5 * * 0")).toBe(7 * 24 * 60 * 60 * 1000);
+
+    // Daily at 3am
+    expect(estimateCronIntervalMs("0 3 * * *")).toBe(24 * 60 * 60 * 1000);
+
+    // Every 30 minutes
+    expect(estimateCronIntervalMs("*/30 * * * *")).toBe(30 * 60 * 1000);
+
+    // Multiple hours (every 8 hours roughly)
+    expect(estimateCronIntervalMs("0 0,8,16 * * *")).toBe(8 * 60 * 60 * 1000);
+
+    // Invalid expression
+    expect(estimateCronIntervalMs("invalid")).toBeNull();
+  });
+
+  it("records phase run and persists cooldown state", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-cooldown-");
+    const { readPhaseCooldownStore, recordPhaseRun } = __testing;
+    const nowMs = DREAMING_TEST_BASE_TIME.getTime();
+
+    await recordPhaseRun(workspaceDir, "light", nowMs);
+    const store = await readPhaseCooldownStore(workspaceDir);
+    expect(store.phases.light?.lastRunAtMs).toBe(nowMs);
+
+    // Record rem phase separately — both should coexist.
+    const laterMs = nowMs + 1000;
+    await recordPhaseRun(workspaceDir, "rem", laterMs);
+    const store2 = await readPhaseCooldownStore(workspaceDir);
+    expect(store2.phases.light?.lastRunAtMs).toBe(nowMs);
+    expect(store2.phases.rem?.lastRunAtMs).toBe(laterMs);
+  });
 });

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1793,8 +1793,7 @@ export async function runDreamingSweepPhases(params: {
     cfg: params.cfg as Parameters<typeof resolveMemoryLightDreamingConfig>[0]["cfg"],
   });
   if (light.enabled && light.limit > 0) {
-    const lightCooldownMs = estimateCronIntervalMs(light.cron) ?? DEFAULT_LIGHT_COOLDOWN_MS;
-    if (isPhaseOnCooldown(cooldownStore, "light", sweepNowMs, lightCooldownMs)) {
+    if (isPhaseOnCooldown(cooldownStore, "light", sweepNowMs, DEFAULT_LIGHT_COOLDOWN_MS)) {
       params.logger.info(
         `memory-core: light dreaming skipped — still within cooldown period [workspace=${params.workspaceDir}].`,
       );
@@ -1826,8 +1825,7 @@ export async function runDreamingSweepPhases(params: {
     cfg: params.cfg as Parameters<typeof resolveMemoryRemDreamingConfig>[0]["cfg"],
   });
   if (rem.enabled && rem.limit > 0) {
-    const remCooldownMs = estimateCronIntervalMs(rem.cron) ?? DEFAULT_REM_COOLDOWN_MS;
-    if (isPhaseOnCooldown(cooldownStore, "rem", sweepNowMs, remCooldownMs)) {
+    if (isPhaseOnCooldown(cooldownStore, "rem", sweepNowMs, DEFAULT_REM_COOLDOWN_MS)) {
       params.logger.info(
         `memory-core: rem dreaming skipped — still within cooldown period [workspace=${params.workspaceDir}].`,
       );

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -72,6 +72,128 @@ const LIGHT_SLEEP_EVENT_TEXT = "__openclaw_memory_core_light_sleep__";
 const REM_SLEEP_EVENT_TEXT = "__openclaw_memory_core_rem_sleep__";
 const DAILY_MEMORY_FILENAME_RE = /^(\d{4}-\d{2}-\d{2})\.md$/;
 const DAILY_INGESTION_STATE_RELATIVE_PATH = path.join("memory", ".dreams", "daily-ingestion.json");
+const PHASE_COOLDOWN_RELATIVE_PATH = path.join("memory", ".dreams", "phase-cooldowns.json");
+
+// Safety margin: require at least 80% of the cron interval to have elapsed before re-running.
+const COOLDOWN_SAFETY_FACTOR = 0.8;
+
+// Fallback cooldown per phase when cron interval cannot be estimated.
+const DEFAULT_LIGHT_COOLDOWN_MS = 6 * 60 * 60 * 1000; // 6 hours
+const DEFAULT_REM_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+type PhaseCooldownStore = {
+  version: 1;
+  phases: Record<string, { lastRunAtMs: number; lastRunAtIso: string }>;
+};
+
+function resolvePhaseCooldownPath(workspaceDir: string): string {
+  return path.join(workspaceDir, PHASE_COOLDOWN_RELATIVE_PATH);
+}
+
+async function readPhaseCooldownStore(workspaceDir: string): Promise<PhaseCooldownStore> {
+  try {
+    const raw = await fs.readFile(resolvePhaseCooldownPath(workspaceDir), "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const record = parsed as Record<string, unknown>;
+      if (record.version === 1 && record.phases && typeof record.phases === "object") {
+        return parsed as PhaseCooldownStore;
+      }
+    }
+  } catch {
+    // Missing or corrupt file — return empty store.
+  }
+  return { version: 1, phases: {} };
+}
+
+async function writePhaseCooldownStore(
+  workspaceDir: string,
+  store: PhaseCooldownStore,
+): Promise<void> {
+  const cooldownPath = resolvePhaseCooldownPath(workspaceDir);
+  await fs.mkdir(path.dirname(cooldownPath), { recursive: true });
+  const tmpPath = `${cooldownPath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+  await fs.rename(tmpPath, cooldownPath);
+}
+
+async function recordPhaseRun(
+  workspaceDir: string,
+  phase: "light" | "rem",
+  nowMs: number,
+): Promise<void> {
+  const store = await readPhaseCooldownStore(workspaceDir);
+  store.phases[phase] = {
+    lastRunAtMs: nowMs,
+    lastRunAtIso: new Date(nowMs).toISOString(),
+  };
+  await writePhaseCooldownStore(workspaceDir, store);
+}
+
+function isPhaseOnCooldown(
+  store: PhaseCooldownStore,
+  phase: "light" | "rem",
+  nowMs: number,
+  cooldownMs: number,
+): boolean {
+  const entry = store.phases[phase];
+  if (!entry || !Number.isFinite(entry.lastRunAtMs)) {
+    return false;
+  }
+  const elapsedMs = nowMs - entry.lastRunAtMs;
+  return elapsedMs < cooldownMs * COOLDOWN_SAFETY_FACTOR;
+}
+
+/**
+ * Estimate the minimum interval in milliseconds for a 5-field cron expression.
+ * This is a best-effort heuristic — it handles common patterns like `* /N`,
+ * fixed hours, and day-of-week constraints. Returns `null` if the expression
+ * cannot be parsed.
+ */
+export function estimateCronIntervalMs(expr: string): number | null {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    return null;
+  }
+  const [minute, hour, _dom, _month, dow] = parts;
+
+  // Weekly: day-of-week is a specific value (not * or */N)
+  if (dow !== "*" && !dow.startsWith("*/")) {
+    return 7 * 24 * 60 * 60 * 1000;
+  }
+
+  // Every N hours: hour field is */N
+  const hourStep = hour.match(/^\*\/(\d+)$/);
+  if (hourStep) {
+    return parseInt(hourStep[1], 10) * 60 * 60 * 1000;
+  }
+
+  // Fixed hour(s): hour is a single number or comma-separated
+  if (/^\d+$/.test(hour)) {
+    return 24 * 60 * 60 * 1000; // daily
+  }
+  if (/^\d+(,\d+)+$/.test(hour)) {
+    const hours = hour
+      .split(",")
+      .map(Number)
+      .toSorted((a, b) => a - b);
+    let minGap = 24;
+    for (let i = 1; i < hours.length; i++) {
+      minGap = Math.min(minGap, hours[i] - hours[i - 1]);
+    }
+    // Also consider wrap-around gap
+    minGap = Math.min(minGap, 24 - hours[hours.length - 1] + hours[0]);
+    return minGap * 60 * 60 * 1000;
+  }
+
+  // Every N minutes: minute field is */N
+  const minuteStep = minute.match(/^\*\/(\d+)$/);
+  if (minuteStep) {
+    return parseInt(minuteStep[1], 10) * 60 * 1000;
+  }
+
+  return null;
+}
 const DAILY_INGESTION_SCORE = 0.62;
 const DAILY_INGESTION_MAX_SNIPPET_CHARS = 280;
 const DAILY_INGESTION_MIN_SNIPPET_CHARS = 8;
@@ -1664,29 +1786,38 @@ export async function runDreamingSweepPhases(params: {
 }): Promise<void> {
   // Normalize nowMs once so all phase timestamps and narrative session keys are consistent.
   const sweepNowMs: number = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
+  const cooldownStore = await readPhaseCooldownStore(params.workspaceDir);
 
   const light = resolveMemoryLightDreamingConfig({
     pluginConfig: params.pluginConfig,
     cfg: params.cfg as Parameters<typeof resolveMemoryLightDreamingConfig>[0]["cfg"],
   });
   if (light.enabled && light.limit > 0) {
-    await runLightDreaming({
-      workspaceDir: params.workspaceDir,
-      cfg: params.cfg,
-      config: light,
-      logger: params.logger,
-      subagent: params.subagent,
-      nowMs: sweepNowMs,
-    });
-    // Defensive cleanup: ensure the light-phase narrative session is deleted even if
-    // generateAndAppendDreamNarrative's primary cleanup was skipped due to an error.
-    if (params.subagent) {
-      const lightSessionKey = buildNarrativeSessionKey({
+    const lightCooldownMs = estimateCronIntervalMs(light.cron) ?? DEFAULT_LIGHT_COOLDOWN_MS;
+    if (isPhaseOnCooldown(cooldownStore, "light", sweepNowMs, lightCooldownMs)) {
+      params.logger.info(
+        `memory-core: light dreaming skipped — still within cooldown period [workspace=${params.workspaceDir}].`,
+      );
+    } else {
+      await runLightDreaming({
         workspaceDir: params.workspaceDir,
-        phase: "light",
+        cfg: params.cfg,
+        config: light,
+        logger: params.logger,
+        subagent: params.subagent,
         nowMs: sweepNowMs,
       });
-      await deleteNarrativeSessionBestEffort(params.subagent, lightSessionKey);
+      await recordPhaseRun(params.workspaceDir, "light", sweepNowMs);
+      // Defensive cleanup: ensure the light-phase narrative session is deleted even if
+      // generateAndAppendDreamNarrative's primary cleanup was skipped due to an error.
+      if (params.subagent) {
+        const lightSessionKey = buildNarrativeSessionKey({
+          workspaceDir: params.workspaceDir,
+          phase: "light",
+          nowMs: sweepNowMs,
+        });
+        await deleteNarrativeSessionBestEffort(params.subagent, lightSessionKey);
+      }
     }
   }
 
@@ -1695,22 +1826,30 @@ export async function runDreamingSweepPhases(params: {
     cfg: params.cfg as Parameters<typeof resolveMemoryRemDreamingConfig>[0]["cfg"],
   });
   if (rem.enabled && rem.limit > 0) {
-    await runRemDreaming({
-      workspaceDir: params.workspaceDir,
-      cfg: params.cfg,
-      config: rem,
-      logger: params.logger,
-      subagent: params.subagent,
-      nowMs: sweepNowMs,
-    });
-    // Defensive cleanup: ensure the REM-phase narrative session is deleted.
-    if (params.subagent) {
-      const remSessionKey = buildNarrativeSessionKey({
+    const remCooldownMs = estimateCronIntervalMs(rem.cron) ?? DEFAULT_REM_COOLDOWN_MS;
+    if (isPhaseOnCooldown(cooldownStore, "rem", sweepNowMs, remCooldownMs)) {
+      params.logger.info(
+        `memory-core: rem dreaming skipped — still within cooldown period [workspace=${params.workspaceDir}].`,
+      );
+    } else {
+      await runRemDreaming({
         workspaceDir: params.workspaceDir,
-        phase: "rem",
+        cfg: params.cfg,
+        config: rem,
+        logger: params.logger,
+        subagent: params.subagent,
         nowMs: sweepNowMs,
       });
-      await deleteNarrativeSessionBestEffort(params.subagent, remSessionKey);
+      await recordPhaseRun(params.workspaceDir, "rem", sweepNowMs);
+      // Defensive cleanup: ensure the REM-phase narrative session is deleted.
+      if (params.subagent) {
+        const remSessionKey = buildNarrativeSessionKey({
+          workspaceDir: params.workspaceDir,
+          phase: "rem",
+          nowMs: sweepNowMs,
+        });
+        await deleteNarrativeSessionBestEffort(params.subagent, remSessionKey);
+      }
     }
   }
 }
@@ -1777,8 +1916,16 @@ export function registerMemoryDreamingPhases(_api: OpenClawPluginApi): void {
 
 export const __testing = {
   runPhaseIfTriggered,
+  readPhaseCooldownStore,
+  writePhaseCooldownStore,
+  recordPhaseRun,
+  isPhaseOnCooldown,
+  estimateCronIntervalMs,
   constants: {
     LIGHT_SLEEP_EVENT_TEXT,
     REM_SLEEP_EVENT_TEXT,
+    COOLDOWN_SAFETY_FACTOR,
+    DEFAULT_LIGHT_COOLDOWN_MS,
+    DEFAULT_REM_COOLDOWN_MS,
   },
 };

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -157,9 +157,42 @@ export function estimateCronIntervalMs(expr: string): number | null {
   }
   const [minute, hour, _dom, _month, dow] = parts;
 
-  // Weekly: day-of-week is a specific value (not * or */N)
+  // Day-of-week constraint: parse ranges/lists to estimate firing frequency.
   if (dow !== "*" && !dow.startsWith("*/")) {
-    return 7 * 24 * 60 * 60 * 1000;
+    const uniqueDays = new Set<number>();
+    for (const part of dow.split(",")) {
+      const rangeMatch = part.match(/^(\d+)-(\d+)$/);
+      if (rangeMatch) {
+        const start = parseInt(rangeMatch[1], 10);
+        const end = parseInt(rangeMatch[2], 10);
+        if (start <= end) {
+          for (let d = start; d <= end; d++) {
+            uniqueDays.add(d);
+          }
+        } else {
+          // wrap-around range like 5-1 (Fri–Mon)
+          for (let d = start; d <= 6; d++) {
+            uniqueDays.add(d);
+          }
+          for (let d = 0; d <= end; d++) {
+            uniqueDays.add(d);
+          }
+        }
+      } else {
+        const num = parseInt(part, 10);
+        if (!Number.isNaN(num)) {
+          uniqueDays.add(num);
+        }
+      }
+    }
+    const count = uniqueDays.size || 1;
+    if (count === 1) {
+      return 7 * 24 * 60 * 60 * 1000;
+    } // truly weekly
+    if (count >= 5) {
+      return 24 * 60 * 60 * 1000;
+    } // daily (consecutive weekdays)
+    return Math.round((7 * 24 * 60 * 60 * 1000) / count); // approximate
   }
 
   // Every N hours: hour field is */N


### PR DESCRIPTION
Fixes #68530

## Problem

Light and REM dreaming phases were running on every heartbeat that triggered the deep dreaming cron event, spawning narrative subagent sessions each time (~47K tokens per session). Over a few days this accumulated 723+ sessions consuming 34M+ tokens.

## Root Cause

`runDreamingSweepPhases()` is called from the deep dreaming handler on every cron trigger without any guard to prevent re-running phases that already ran recently. Since the deep dreaming cron fires on schedule and the heartbeat processes it, light and REM phases ran every time.

## Fix

Add a file-based cooldown store (`memory/.dreams/phase-cooldowns.json`) that records the last run timestamp per phase. Before running light or REM dreaming, check if enough time has elapsed based on the phase's configured cron interval (with 80% safety factor).

- Light dreaming: runs at most once per ~4.8h (80% of 6h default)
- REM dreaming: runs at most once per ~5.6 days (80% of 7d default)

Also add `estimateCronIntervalMs()` to derive cooldown duration from cron expressions, with sensible fallbacks.

## Tests

- Added tests for `isPhaseOnCooldown`, `estimateCronIntervalMs`, and the cooldown integration in `runDreamingSweepPhases`
- All 27 dreaming-phases tests pass
- All 42 dreaming-narrative tests pass