### PR TITLE
cron: prefer sessionTarget for failure alerts

### DIFF
--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -49,6 +49,13 @@ export type GatewayCronState = {
 
 const CRON_WEBHOOK_TIMEOUT_MS = 10_000;
 
+function resolveCronSessionTargetSessionKey(sessionTarget: string): string | undefined {
+  if (!sessionTarget.startsWith("session:")) {
+    return undefined;
+  }
+  return assertSafeCronSessionTargetId(sessionTarget.slice(8));
+}
+
 function redactWebhookUrl(url: string): string {
   try {
     const parsed = new URL(url);
@@ -332,8 +339,9 @@ export function buildGatewayCronService(params: {
     runIsolatedAgentJob: async ({ job, message, abortSignal }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       let sessionKey = `cron:${job.id}`;
-      if (job.sessionTarget.startsWith("session:")) {
-        sessionKey = assertSafeCronSessionTargetId(job.sessionTarget.slice(8));
+      const sessionTargetKey = resolveCronSessionTargetSessionKey(job.sessionTarget);
+      if (sessionTargetKey) {
+        sessionKey = sessionTargetKey;
       }
       try {
         return await runCronIsolatedAgentTurn({
@@ -469,6 +477,8 @@ export function buildGatewayCronService(params: {
           if (!isBestEffort) {
             const failureMessage = `Cron job "${job.name}" failed: ${evt.error ?? "unknown error"}`;
             const failureDest = resolveFailureDestination(job, params.cfg.cron?.failureDestination);
+            const deliverySessionKey =
+              resolveCronSessionTargetSessionKey(job.sessionTarget) ?? job.sessionKey;
 
             if (failureDest) {
               // Explicit failureDestination configured — use it
@@ -517,7 +527,7 @@ export function buildGatewayCronService(params: {
                     channel: failureDest.channel,
                     to: failureDest.to,
                     accountId: failureDest.accountId,
-                    sessionKey: job.sessionKey,
+                    sessionKey: deliverySessionKey,
                   },
                   `⚠️ ${failureMessage}`,
                 );
@@ -536,7 +546,7 @@ export function buildGatewayCronService(params: {
                     channel: primaryPlan.channel,
                     to: primaryPlan.to,
                     accountId: primaryPlan.accountId,
-                    sessionKey: job.sessionKey,
+                    sessionKey: deliverySessionKey,
                   },
                   `⚠️ ${failureMessage}`,
                 );

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1054,6 +1054,66 @@ describe("gateway server cron", () => {
     }
   }, 45_000);
 
+  test("prefers sessionTarget session context for failure announcements over creator sessionKey", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-failure-session-target-",
+      cronEnabled: false,
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      cronIsolatedRun.mockResolvedValueOnce({ status: "error", summary: "delivery failed" });
+      const addRes = await rpcReq(ws, "cron.add", {
+        name: "session target failure fallback",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "session:agent:avery:feishu:direct:ou_founder",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "test" },
+        delivery: {
+          mode: "announce",
+          channel: "feishu",
+          to: "ou_founder",
+        },
+      });
+      const jobId = expectCronJobIdFromResponse(addRes);
+
+      const updateRes = await rpcReq(ws, "cron.update", {
+        id: jobId,
+        patch: {
+          sessionKey: "agent:avery:feishu:group:oc_group:sender:ou_founder",
+        },
+      });
+      expect(updateRes.ok).toBe(true);
+
+      const finished = waitForCronEvent(
+        ws,
+        (payload) => payload?.jobId === jobId && payload?.action === "finished",
+      );
+      await runCronJobForce(ws, jobId);
+      await finished;
+
+      expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledTimes(1);
+      expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(String),
+        jobId,
+        {
+          channel: "feishu",
+          to: "ou_founder",
+          accountId: undefined,
+          sessionKey: "agent:avery:feishu:direct:ou_founder",
+        },
+        '⚠️ Cron job "session target failure fallback" failed: unknown error',
+      );
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  }, 45_000);
+
   test("ignores non-string cron.webhookToken values without crashing webhook delivery", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-webhook-secretinput-",


### PR DESCRIPTION
$## Summary
- use `sessionTarget` session context for cron failure announcements when the job targets a specific session
- fall back to creator `sessionKey` only when no `session:` target exists
- add a regression test covering a group-created job that should announce failures back into the founder private session

## Why
A live Feishu failure path was using the creator session context for cron failure alerts. For jobs created from a group context but targeted at the founder private session, that let failure delivery resolve against the wrong app/account identity and triggered `open_id cross app`.

## Verification
- targeted gateway cron test passed on the release-matched verification branch before this clean cherry-pick:
  - `pnpm vitest run src/gateway/server.cron.test.ts`
  - result: `11 passed`
- this PR branch is a clean cherry-pick of that verified change onto `origin/main`
- fresh mainline rerun is expected via CI on this PR
