### PR TITLE
fix(matrix): hot-reload dm.allowFrom and groupAllowFrom on each inbound message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 - Active Memory: raise the blocking recall timeout ceiling to 120 seconds and reject larger config values during plugin schema validation. Fixes #68410. (#68480) Thanks @Bartok9.
 - Control UI/chat: keep history-backed user image uploads visible after chat reload while filtering blocked or non-image transcript media paths. (#68415) Thanks @mraleko.
 - Matrix/plugins: keep remaining Matrix event helpers on the canonical `matrix-js-sdk` subpath so build and plugin-load entrypoint checks stay consistent. (#68498) Thanks @masatohoshino.
+- Matrix/allowlists: hot-reload `dm.allowFrom` and `groupAllowFrom` entries on inbound messages while keeping config removals authoritative, so Matrix allowlist changes no longer require a channel restart to add or revoke a sender. (#68546) Thanks @johnlanni.
 
 ## 2026.4.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Cron/gateway: reject ambiguous announce delivery config at add/update time so invalid multi-channel or target-id provider settings fail early instead of persisting broken cron jobs. (#69015) Thanks @obviyus.
 - Cron/main-session delivery: preserve `heartbeat.target="last"` through deferred wake queuing, gateway wake forwarding, and same-target wake coalescing so queued cron replies still return to the last active chat. (#69021) Thanks @obviyus.
 - Cron/gateway: ignore disabled channels when announce delivery ambiguity is checked, and validate main-session delivery patches against the live cron service default agent so hot-reloaded agent config does not falsely reject valid updates. (#69040) Thanks @obviyus.
+- Matrix/allowlists: hot-reload `dm.allowFrom` and `groupAllowFrom` entries on inbound messages while keeping config removals authoritative, so Matrix allowlist changes no longer require a channel restart to add or revoke a sender. (#68546) Thanks @johnlanni.
 
 ## 2026.4.19-beta.2
 
@@ -116,7 +117,6 @@ Docs: https://docs.openclaw.ai
 - Active Memory: raise the blocking recall timeout ceiling to 120 seconds and reject larger config values during plugin schema validation. Fixes #68410. (#68480) Thanks @Bartok9.
 - Control UI/chat: keep history-backed user image uploads visible after chat reload while filtering blocked or non-image transcript media paths. (#68415) Thanks @mraleko.
 - Matrix/plugins: keep remaining Matrix event helpers on the canonical `matrix-js-sdk` subpath so build and plugin-load entrypoint checks stay consistent. (#68498) Thanks @masatohoshino.
-- Matrix/allowlists: hot-reload `dm.allowFrom` and `groupAllowFrom` entries on inbound messages while keeping config removals authoritative, so Matrix allowlist changes no longer require a channel restart to add or revoke a sender. (#68546) Thanks @johnlanni.
 
 ## 2026.4.15
 

--- a/extensions/matrix/src/matrix/account-config.ts
+++ b/extensions/matrix/src/matrix/account-config.ts
@@ -148,3 +148,28 @@ export function resolveMatrixAccountConfig(params: {
     ...(rooms ? { rooms } : {}),
   };
 }
+
+export function resolveMatrixAccountAllowlistConfig(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+}): {
+  dmAllowFrom?: NonNullable<MatrixConfig["dm"]>["allowFrom"];
+  groupAllowFrom?: MatrixConfig["groupAllowFrom"];
+} {
+  const accountId = normalizeAccountId(params.accountId);
+  const base = resolveMatrixBaseConfig(params.cfg);
+  const accountConfig = findMatrixAccountConfig(params.cfg, accountId);
+  const accountDm = accountConfig?.dm;
+
+  let dmAllowFrom = base.dm?.allowFrom;
+  if (accountDm && Object.hasOwn(accountDm, "allowFrom")) {
+    dmAllowFrom = accountDm.allowFrom;
+  }
+
+  let groupAllowFrom = base.groupAllowFrom;
+  if (accountConfig && Object.hasOwn(accountConfig, "groupAllowFrom")) {
+    groupAllowFrom = accountConfig.groupAllowFrom;
+  }
+
+  return { dmAllowFrom, groupAllowFrom };
+}

--- a/extensions/matrix/src/matrix/monitor/config.ts
+++ b/extensions/matrix/src/matrix/monitor/config.ts
@@ -14,6 +14,16 @@ import {
 type MatrixRoomsConfig = Record<string, MatrixRoomConfig>;
 type ResolveMatrixTargetsFn = typeof resolveMatrixTargets;
 
+export type MatrixResolvedAllowlistEntry = {
+  input: string;
+  id: string;
+};
+
+type MatrixResolvedUserAllowlist = {
+  entries: string[];
+  resolvedEntries: MatrixResolvedAllowlistEntry[];
+};
+
 function normalizeMatrixUserLookupEntry(raw: string): string {
   return raw
     .replace(/^matrix:/i, "")
@@ -39,6 +49,30 @@ function filterResolvedMatrixAllowlistEntries(entries: string[]): string[] {
     }
     return isMatrixQualifiedUserId(normalizeMatrixUserLookupEntry(trimmed));
   });
+}
+
+function listResolvedMatrixAllowlistEntries(params: {
+  entries: Array<string | number>;
+  resolvedMap: Map<string, { resolved: boolean; id?: string }>;
+}): MatrixResolvedAllowlistEntry[] {
+  const resolvedEntries: MatrixResolvedAllowlistEntry[] = [];
+  const seen = new Set<string>();
+  for (const entry of params.entries) {
+    const input = String(entry).trim();
+    if (!input || seen.has(input)) {
+      continue;
+    }
+    seen.add(input);
+    const resolved = params.resolvedMap.get(input);
+    if (!resolved?.resolved || !resolved.id) {
+      continue;
+    }
+    const id = normalizeMatrixUserId(resolved.id);
+    if (isMatrixQualifiedUserId(id)) {
+      resolvedEntries.push({ input, id });
+    }
+  }
+  return resolvedEntries;
 }
 
 function sanitizeMatrixRoomUserAllowlists(entries: MatrixRoomsConfig): MatrixRoomsConfig {
@@ -119,10 +153,10 @@ async function resolveMatrixMonitorUserAllowlist(params: {
   list?: Array<string | number>;
   runtime: RuntimeEnv;
   resolveTargets: ResolveMatrixTargetsFn;
-}): Promise<string[]> {
+}): Promise<MatrixResolvedUserAllowlist> {
   const allowList = (params.list ?? []).map(String);
   if (allowList.length === 0) {
-    return allowList;
+    return { entries: allowList, resolvedEntries: [] };
   }
 
   const resolution = await resolveMatrixMonitorUserEntries({
@@ -144,7 +178,13 @@ async function resolveMatrixMonitorUserAllowlist(params: {
     );
   }
 
-  return filterResolvedMatrixAllowlistEntries(canonicalized);
+  return {
+    entries: filterResolvedMatrixAllowlistEntries(canonicalized),
+    resolvedEntries: listResolvedMatrixAllowlistEntries({
+      entries: allowList,
+      resolvedMap: resolution.resolvedMap,
+    }),
+  };
 }
 
 async function resolveMatrixMonitorRoomsConfig(params: {
@@ -264,7 +304,9 @@ export async function resolveMatrixMonitorConfig(params: {
   resolveTargets?: ResolveMatrixTargetsFn;
 }): Promise<{
   allowFrom: string[];
+  allowFromResolvedEntries: MatrixResolvedAllowlistEntry[];
   groupAllowFrom: string[];
+  groupAllowFromResolvedEntries: MatrixResolvedAllowlistEntry[];
   roomsConfig?: MatrixRoomsConfig;
 }> {
   const resolveTargets = params.resolveTargets ?? resolveMatrixTargets;
@@ -296,8 +338,10 @@ export async function resolveMatrixMonitorConfig(params: {
   ]);
 
   return {
-    allowFrom,
-    groupAllowFrom,
+    allowFrom: allowFrom.entries,
+    allowFromResolvedEntries: allowFrom.resolvedEntries,
+    groupAllowFrom: groupAllowFrom.entries,
+    groupAllowFromResolvedEntries: groupAllowFrom.resolvedEntries,
     roomsConfig,
   };
 }

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -115,6 +115,7 @@ export function createMatrixHandlerTestHarness(
       counts: { final: 0, block: 0, tool: 0 },
     }));
   const enqueueSystemEvent = options.enqueueSystemEvent ?? vi.fn();
+  const cfgForHandler = options.cfg ?? {};
 
   const handler = createMatrixRoomMessageHandler({
     client: {
@@ -123,6 +124,9 @@ export function createMatrixHandlerTestHarness(
       ...options.client,
     } as never,
     core: {
+      config: {
+        loadConfig: () => cfgForHandler,
+      },
       channel: {
         pairing: {
           readAllowFromStore,
@@ -193,7 +197,7 @@ export function createMatrixHandlerTestHarness(
         enqueueSystemEvent,
       },
     } as never,
-    cfg: (options.cfg ?? {}) as never,
+    cfg: cfgForHandler as never,
     accountId: options.accountId ?? "ops",
     runtime:
       options.runtime ??

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -22,7 +22,9 @@ type MatrixHandlerTestHarnessOptions = {
   logger?: RuntimeLogger;
   logVerboseMessage?: (message: string) => void;
   allowFrom?: string[];
+  allowFromResolvedEntries?: MatrixMonitorHandlerParams["allowFromResolvedEntries"];
   groupAllowFrom?: string[];
+  groupAllowFromResolvedEntries?: MatrixMonitorHandlerParams["groupAllowFromResolvedEntries"];
   roomsConfig?: Record<string, MatrixRoomConfig>;
   accountAllowBots?: boolean | "mentions";
   configuredBotUserIds?: Set<string>;
@@ -213,7 +215,9 @@ export function createMatrixHandlerTestHarness(
       } as RuntimeLogger),
     logVerboseMessage: options.logVerboseMessage ?? (() => {}),
     allowFrom: options.allowFrom ?? [],
+    allowFromResolvedEntries: options.allowFromResolvedEntries,
     groupAllowFrom: options.groupAllowFrom ?? [],
+    groupAllowFromResolvedEntries: options.groupAllowFromResolvedEntries,
     roomsConfig: options.roomsConfig,
     accountAllowBots: options.accountAllowBots,
     configuredBotUserIds: options.configuredBotUserIds,

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -1741,6 +1741,190 @@ describe("matrix monitor handler pairing account scope", () => {
   });
 });
 
+describe("matrix monitor handler live allowlist reload", () => {
+  it("accepts a DM sender added to live dm.allowFrom", async () => {
+    const dispatchReplyFromConfig = vi.fn(async () => ({
+      queuedFinal: false,
+      counts: { final: 0, block: 0, tool: 0 },
+    }));
+    const cfg = {
+      channels: {
+        matrix: {
+          dm: { allowFrom: [] as string[] },
+        },
+      },
+    };
+    const { handler } = createMatrixHandlerTestHarness({
+      cfg,
+      dmPolicy: "allowlist",
+      isDirectMessage: true,
+      allowFrom: [],
+      allowFromResolvedEntries: [],
+      dispatchReplyFromConfig,
+    });
+
+    await handler(
+      "!dm:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$dm-add-before",
+        sender: "@alice:example.org",
+        body: "hello",
+      }),
+    );
+    expect(dispatchReplyFromConfig).not.toHaveBeenCalled();
+
+    cfg.channels.matrix.dm.allowFrom = ["@alice:example.org"];
+    await handler(
+      "!dm:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$dm-add-after",
+        sender: "@alice:example.org",
+        body: "hello again",
+      }),
+    );
+
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a DM sender removed from live dm.allowFrom", async () => {
+    const dispatchReplyFromConfig = vi.fn(async () => ({
+      queuedFinal: false,
+      counts: { final: 0, block: 0, tool: 0 },
+    }));
+    const cfg = {
+      channels: {
+        matrix: {
+          dm: { allowFrom: ["@alice:example.org"] },
+        },
+      },
+    };
+    const { handler } = createMatrixHandlerTestHarness({
+      cfg,
+      dmPolicy: "allowlist",
+      isDirectMessage: true,
+      allowFrom: ["@alice:example.org"],
+      allowFromResolvedEntries: [{ input: "@alice:example.org", id: "@alice:example.org" }],
+      dispatchReplyFromConfig,
+    });
+
+    await handler(
+      "!dm:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$dm-remove-before",
+        sender: "@alice:example.org",
+        body: "hello",
+      }),
+    );
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+
+    cfg.channels.matrix.dm.allowFrom = [];
+    await handler(
+      "!dm:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$dm-remove-after",
+        sender: "@alice:example.org",
+        body: "hello again",
+      }),
+    );
+
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps startup-resolved display names only while the raw input remains configured", async () => {
+    const dispatchReplyFromConfig = vi.fn(async () => ({
+      queuedFinal: false,
+      counts: { final: 0, block: 0, tool: 0 },
+    }));
+    const cfg = {
+      channels: {
+        matrix: {
+          dm: { allowFrom: ["Alice"] },
+        },
+      },
+    };
+    const { handler } = createMatrixHandlerTestHarness({
+      cfg,
+      dmPolicy: "allowlist",
+      isDirectMessage: true,
+      allowFrom: ["@alice:example.org"],
+      allowFromResolvedEntries: [{ input: "Alice", id: "@alice:example.org" }],
+      dispatchReplyFromConfig,
+    });
+
+    await handler(
+      "!dm:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$dm-name-before",
+        sender: "@alice:example.org",
+        body: "hello",
+      }),
+    );
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+
+    cfg.channels.matrix.dm.allowFrom = [];
+    await handler(
+      "!dm:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$dm-name-after",
+        sender: "@alice:example.org",
+        body: "hello again",
+      }),
+    );
+
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a room sender removed from live groupAllowFrom while the group list remains configured", async () => {
+    const dispatchReplyFromConfig = vi.fn(async () => ({
+      queuedFinal: false,
+      counts: { final: 0, block: 0, tool: 0 },
+    }));
+    const cfg = {
+      channels: {
+        matrix: {
+          groupAllowFrom: ["@alice:example.org", "@bob:example.org"],
+        },
+      },
+    };
+    const { handler } = createMatrixHandlerTestHarness({
+      cfg,
+      isDirectMessage: false,
+      groupPolicy: "allowlist",
+      roomsConfig: { "*": {} },
+      groupAllowFrom: ["@alice:example.org", "@bob:example.org"],
+      groupAllowFromResolvedEntries: [
+        { input: "@alice:example.org", id: "@alice:example.org" },
+        { input: "@bob:example.org", id: "@bob:example.org" },
+      ],
+      dispatchReplyFromConfig,
+    });
+
+    await handler(
+      "!room:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$group-remove-before",
+        sender: "@alice:example.org",
+        body: "@room hello",
+        mentions: { room: true },
+      }),
+    );
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+
+    cfg.channels.matrix.groupAllowFrom = ["@bob:example.org"];
+    await handler(
+      "!room:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$group-remove-after",
+        sender: "@alice:example.org",
+        body: "@room hello again",
+        mentions: { room: true },
+      }),
+    );
+
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("matrix monitor handler durable inbound dedupe", () => {
   it("skips replayed inbound events before session recording", async () => {
     const inboundDeduper = {

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -1742,11 +1742,37 @@ describe("matrix monitor handler pairing account scope", () => {
 });
 
 describe("matrix monitor handler live allowlist reload", () => {
-  it("accepts a DM sender added to live dm.allowFrom", async () => {
-    const dispatchReplyFromConfig = vi.fn(async () => ({
+  type MatrixHandler = ReturnType<typeof createMatrixHandlerTestHarness>["handler"];
+
+  const createDispatchReplyFromConfig = () =>
+    vi.fn(async () => ({
       queuedFinal: false,
       counts: { final: 0, block: 0, tool: 0 },
     }));
+
+  const sendLiveAllowlistMessage = async (
+    handler: MatrixHandler,
+    params: {
+      eventId: string;
+      sender: string;
+      body: string;
+      roomId?: string;
+      mentions?: MatrixRawEvent["content"]["m.mentions"];
+    },
+  ) => {
+    await handler(
+      params.roomId ?? "!dm:example.org",
+      createMatrixTextMessageEvent({
+        eventId: params.eventId,
+        sender: params.sender,
+        body: params.body,
+        ...(params.mentions ? { mentions: params.mentions } : {}),
+      }),
+    );
+  };
+
+  it("accepts a DM sender added to live dm.allowFrom", async () => {
+    const dispatchReplyFromConfig = createDispatchReplyFromConfig();
     const cfg = {
       channels: {
         matrix: {
@@ -1763,34 +1789,25 @@ describe("matrix monitor handler live allowlist reload", () => {
       dispatchReplyFromConfig,
     });
 
-    await handler(
-      "!dm:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$dm-add-before",
-        sender: "@alice:example.org",
-        body: "hello",
-      }),
-    );
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-add-before",
+      sender: "@alice:example.org",
+      body: "hello",
+    });
     expect(dispatchReplyFromConfig).not.toHaveBeenCalled();
 
     cfg.channels.matrix.dm.allowFrom = ["@alice:example.org"];
-    await handler(
-      "!dm:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$dm-add-after",
-        sender: "@alice:example.org",
-        body: "hello again",
-      }),
-    );
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-add-after",
+      sender: "@alice:example.org",
+      body: "hello again",
+    });
 
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
   it("blocks a DM sender removed from live dm.allowFrom", async () => {
-    const dispatchReplyFromConfig = vi.fn(async () => ({
-      queuedFinal: false,
-      counts: { final: 0, block: 0, tool: 0 },
-    }));
+    const dispatchReplyFromConfig = createDispatchReplyFromConfig();
     const cfg = {
       channels: {
         matrix: {
@@ -1807,34 +1824,25 @@ describe("matrix monitor handler live allowlist reload", () => {
       dispatchReplyFromConfig,
     });
 
-    await handler(
-      "!dm:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$dm-remove-before",
-        sender: "@alice:example.org",
-        body: "hello",
-      }),
-    );
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-remove-before",
+      sender: "@alice:example.org",
+      body: "hello",
+    });
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
 
     cfg.channels.matrix.dm.allowFrom = [];
-    await handler(
-      "!dm:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$dm-remove-after",
-        sender: "@alice:example.org",
-        body: "hello again",
-      }),
-    );
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-remove-after",
+      sender: "@alice:example.org",
+      body: "hello again",
+    });
 
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
   it("keeps startup-resolved display names only while the raw input remains configured", async () => {
-    const dispatchReplyFromConfig = vi.fn(async () => ({
-      queuedFinal: false,
-      counts: { final: 0, block: 0, tool: 0 },
-    }));
+    const dispatchReplyFromConfig = createDispatchReplyFromConfig();
     const cfg = {
       channels: {
         matrix: {
@@ -1851,34 +1859,25 @@ describe("matrix monitor handler live allowlist reload", () => {
       dispatchReplyFromConfig,
     });
 
-    await handler(
-      "!dm:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$dm-name-before",
-        sender: "@alice:example.org",
-        body: "hello",
-      }),
-    );
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-name-before",
+      sender: "@alice:example.org",
+      body: "hello",
+    });
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
 
     cfg.channels.matrix.dm.allowFrom = [];
-    await handler(
-      "!dm:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$dm-name-after",
-        sender: "@alice:example.org",
-        body: "hello again",
-      }),
-    );
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-name-after",
+      sender: "@alice:example.org",
+      body: "hello again",
+    });
 
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
   it("blocks a room sender removed from live groupAllowFrom while the group list remains configured", async () => {
-    const dispatchReplyFromConfig = vi.fn(async () => ({
-      queuedFinal: false,
-      counts: { final: 0, block: 0, tool: 0 },
-    }));
+    const dispatchReplyFromConfig = createDispatchReplyFromConfig();
     const cfg = {
       channels: {
         matrix: {
@@ -1899,27 +1898,23 @@ describe("matrix monitor handler live allowlist reload", () => {
       dispatchReplyFromConfig,
     });
 
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$group-remove-before",
-        sender: "@alice:example.org",
-        body: "@room hello",
-        mentions: { room: true },
-      }),
-    );
+    await sendLiveAllowlistMessage(handler, {
+      roomId: "!room:example.org",
+      eventId: "$group-remove-before",
+      sender: "@alice:example.org",
+      body: "@room hello",
+      mentions: { room: true },
+    });
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
 
     cfg.channels.matrix.groupAllowFrom = ["@bob:example.org"];
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$group-remove-after",
-        sender: "@alice:example.org",
-        body: "@room hello again",
-        mentions: { room: true },
-      }),
-    );
+    await sendLiveAllowlistMessage(handler, {
+      roomId: "!room:example.org",
+      eventId: "$group-remove-after",
+      sender: "@alice:example.org",
+      body: "@room hello again",
+      mentions: { room: true },
+    });
 
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -1841,6 +1841,41 @@ describe("matrix monitor handler live allowlist reload", () => {
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
+  it("blocks a DM sender after live wildcard removal", async () => {
+    const dispatchReplyFromConfig = createDispatchReplyFromConfig();
+    const cfg = {
+      channels: {
+        matrix: {
+          dm: { allowFrom: ["*"] },
+        },
+      },
+    };
+    const { handler } = createMatrixHandlerTestHarness({
+      cfg,
+      dmPolicy: "allowlist",
+      isDirectMessage: true,
+      allowFrom: ["*"],
+      allowFromResolvedEntries: [],
+      dispatchReplyFromConfig,
+    });
+
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-wildcard-before",
+      sender: "@alice:example.org",
+      body: "hello",
+    });
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+
+    cfg.channels.matrix.dm.allowFrom = [];
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-wildcard-after",
+      sender: "@alice:example.org",
+      body: "hello again",
+    });
+
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
   it("uses account-scoped live dm.allowFrom overrides", async () => {
     const dispatchReplyFromConfig = createDispatchReplyFromConfig();
     const cfg = {

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -1841,6 +1841,47 @@ describe("matrix monitor handler live allowlist reload", () => {
     expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
+  it("uses account-scoped live dm.allowFrom overrides", async () => {
+    const dispatchReplyFromConfig = createDispatchReplyFromConfig();
+    const cfg = {
+      channels: {
+        matrix: {
+          dm: { allowFrom: ["@base:example.org"] },
+          accounts: {
+            ops: {
+              dm: { allowFrom: ["@alice:example.org"] },
+            },
+          },
+        },
+      },
+    };
+    const { handler } = createMatrixHandlerTestHarness({
+      cfg,
+      accountId: "ops",
+      dmPolicy: "allowlist",
+      isDirectMessage: true,
+      allowFrom: ["@alice:example.org"],
+      allowFromResolvedEntries: [{ input: "@alice:example.org", id: "@alice:example.org" }],
+      dispatchReplyFromConfig,
+    });
+
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-account-before",
+      sender: "@alice:example.org",
+      body: "hello",
+    });
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+
+    cfg.channels.matrix.accounts.ops.dm.allowFrom = [];
+    await sendLiveAllowlistMessage(handler, {
+      eventId: "$dm-account-after",
+      sender: "@alice:example.org",
+      body: "hello again",
+    });
+
+    expect(dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps startup-resolved display names only while the raw input remains configured", async () => {
     const dispatchReplyFromConfig = createDispatchReplyFromConfig();
     const cfg = {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -34,9 +34,11 @@ import {
 import type { LocationMessageEventContent, MatrixClient } from "../sdk.js";
 import { MATRIX_OPENCLAW_FINALIZED_PREVIEW_KEY } from "../send/types.js";
 import { resolveMatrixStoredSessionMeta } from "../session-store-metadata.js";
+import { isMatrixQualifiedUserId } from "../target-ids.js";
 import { resolveMatrixMonitorAccessState } from "./access-state.js";
 import { resolveMatrixAckReactionConfig } from "./ack-config.js";
-import { resolveMatrixAllowListMatch } from "./allowlist.js";
+import { normalizeMatrixUserId, resolveMatrixAllowListMatch } from "./allowlist.js";
+import type { MatrixResolvedAllowlistEntry } from "./config.js";
 import type { MatrixInboundEventDeduper } from "./inbound-dedupe.js";
 import { resolveMatrixLocation, type MatrixLocationPayload } from "./location.js";
 import { downloadMatrixMedia } from "./media.js";
@@ -152,7 +154,9 @@ export type MatrixMonitorHandlerParams = {
   logger: RuntimeLogger;
   logVerboseMessage: (message: string) => void;
   allowFrom: string[];
+  allowFromResolvedEntries?: readonly MatrixResolvedAllowlistEntry[];
   groupAllowFrom?: string[];
+  groupAllowFromResolvedEntries?: readonly MatrixResolvedAllowlistEntry[];
   roomsConfig?: Record<string, MatrixRoomConfig>;
   accountAllowBots?: boolean | "mentions";
   configuredBotUserIds?: ReadonlySet<string>;
@@ -188,6 +192,67 @@ export type MatrixMonitorHandlerParams = {
   getMemberDisplayName: (roomId: string, userId: string) => Promise<string>;
   needsRoomAliasesForConfig: boolean;
 };
+
+function normalizeConfiguredMatrixAllowlistEntries(
+  entries?: ReadonlyArray<string | number>,
+): string[] {
+  const normalized: string[] = [];
+  for (const entry of entries ?? []) {
+    const trimmed = String(entry).trim();
+    if (trimmed) {
+      normalized.push(trimmed);
+    }
+  }
+  return normalized;
+}
+
+function isMatrixHotReloadAllowlistEntry(entry: string): boolean {
+  if (entry === "*") {
+    return true;
+  }
+  return isMatrixQualifiedUserId(normalizeMatrixUserId(entry));
+}
+
+function resolveEffectiveMatrixLiveAllowlist(params: {
+  liveEntries?: ReadonlyArray<string | number>;
+  startupResolvedEntries?: readonly MatrixResolvedAllowlistEntry[];
+  fallbackEntries?: readonly string[];
+}): string[] {
+  const liveEntries = normalizeConfiguredMatrixAllowlistEntries(params.liveEntries);
+  const startupResolvedEntries = params.startupResolvedEntries ?? [];
+  if (liveEntries.length === 0 && startupResolvedEntries.length === 0) {
+    return [...(params.fallbackEntries ?? [])];
+  }
+
+  const liveInputs = new Set(liveEntries);
+  const effective: string[] = [];
+  const seen = new Set<string>();
+  const add = (entry: string) => {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      return;
+    }
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    effective.push(trimmed);
+  };
+
+  for (const entry of liveEntries) {
+    if (isMatrixHotReloadAllowlistEntry(entry)) {
+      add(entry);
+    }
+  }
+  for (const entry of startupResolvedEntries) {
+    if (liveInputs.has(entry.input)) {
+      add(entry.id);
+    }
+  }
+
+  return effective;
+}
 
 function resolveMatrixMentionPrecheckText(params: {
   eventType: string;
@@ -356,7 +421,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     logger,
     logVerboseMessage,
     allowFrom,
+    allowFromResolvedEntries = [],
     groupAllowFrom = [],
+    groupAllowFromResolvedEntries = [],
     roomsConfig,
     accountAllowBots,
     configuredBotUserIds = new Set<string>(),
@@ -639,22 +706,24 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         };
         const storeAllowFrom = isDirectMessage ? await readStoreAllowFrom() : [];
         const roomUsers = roomConfig?.users ?? [];
-        // Hot-reload: re-read raw allowlist entries from live config on each
-        // inbound message so additions to dm.allowFrom / groupAllowFrom take
-        // effect without restarting the gateway. Display-name resolution still
-        // only runs at startup, so new entries must be full Matrix IDs
-        // (@user:server). Merging with the closure values preserves any
-        // startup-time resolution work.
         const liveAccountCfg = resolveMatrixAccountConfig({
           cfg: core.config.loadConfig() as CoreConfig,
           accountId,
         });
-        const liveDmAllowFrom = (liveAccountCfg.dm?.allowFrom ?? []).map(String);
-        const liveGroupAllowFrom = (liveAccountCfg.groupAllowFrom ?? []).map(String);
+        const liveDmAllowFrom = resolveEffectiveMatrixLiveAllowlist({
+          liveEntries: liveAccountCfg.dm?.allowFrom,
+          startupResolvedEntries: allowFromResolvedEntries,
+          fallbackEntries: allowFrom,
+        });
+        const liveGroupAllowFrom = resolveEffectiveMatrixLiveAllowlist({
+          liveEntries: liveAccountCfg.groupAllowFrom,
+          startupResolvedEntries: groupAllowFromResolvedEntries,
+          fallbackEntries: groupAllowFrom,
+        });
         const accessState = resolveMatrixMonitorAccessState({
-          allowFrom: [...allowFrom, ...liveDmAllowFrom],
+          allowFrom: liveDmAllowFrom,
           storeAllowFrom,
-          groupAllowFrom: [...groupAllowFrom, ...liveGroupAllowFrom],
+          groupAllowFrom: liveGroupAllowFrom,
           roomUsers,
           senderId,
           isRoom,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -216,14 +216,8 @@ function isMatrixHotReloadAllowlistEntry(entry: string): boolean {
 function resolveEffectiveMatrixLiveAllowlist(params: {
   liveEntries?: ReadonlyArray<string | number>;
   startupResolvedEntries?: readonly MatrixResolvedAllowlistEntry[];
-  fallbackEntries?: readonly string[];
 }): string[] {
   const liveEntries = normalizeConfiguredMatrixAllowlistEntries(params.liveEntries);
-  const startupResolvedEntries = params.startupResolvedEntries ?? [];
-  if (liveEntries.length === 0 && startupResolvedEntries.length === 0) {
-    return [...(params.fallbackEntries ?? [])];
-  }
-
   const liveInputs = new Set(liveEntries);
   const effective: string[] = [];
   const seen = new Set<string>();
@@ -245,7 +239,7 @@ function resolveEffectiveMatrixLiveAllowlist(params: {
       add(entry);
     }
   }
-  for (const entry of startupResolvedEntries) {
+  for (const entry of params.startupResolvedEntries ?? []) {
     if (liveInputs.has(entry.input)) {
       add(entry.id);
     }
@@ -420,9 +414,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     runtime,
     logger,
     logVerboseMessage,
-    allowFrom,
     allowFromResolvedEntries = [],
-    groupAllowFrom = [],
     groupAllowFromResolvedEntries = [],
     roomsConfig,
     accountAllowBots,
@@ -713,12 +705,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         const liveDmAllowFrom = resolveEffectiveMatrixLiveAllowlist({
           liveEntries: liveAccountAllowlists.dmAllowFrom,
           startupResolvedEntries: allowFromResolvedEntries,
-          fallbackEntries: allowFrom,
         });
         const liveGroupAllowFrom = resolveEffectiveMatrixLiveAllowlist({
           liveEntries: liveAccountAllowlists.groupAllowFrom,
           startupResolvedEntries: groupAllowFromResolvedEntries,
-          fallbackEntries: groupAllowFrom,
         });
         const accessState = resolveMatrixMonitorAccessState({
           allowFrom: liveDmAllowFrom,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -14,7 +14,7 @@ import type {
   MatrixStreamingMode,
   ReplyToMode,
 } from "../../types.js";
-import { resolveMatrixAccountConfig } from "../account-config.js";
+import { resolveMatrixAccountAllowlistConfig } from "../account-config.js";
 import { formatMatrixErrorMessage } from "../errors.js";
 import { isMatrixMediaSizeLimitError } from "../media-errors.js";
 import {
@@ -706,17 +706,17 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         };
         const storeAllowFrom = isDirectMessage ? await readStoreAllowFrom() : [];
         const roomUsers = roomConfig?.users ?? [];
-        const liveAccountCfg = resolveMatrixAccountConfig({
+        const liveAccountAllowlists = resolveMatrixAccountAllowlistConfig({
           cfg: core.config.loadConfig() as CoreConfig,
           accountId,
         });
         const liveDmAllowFrom = resolveEffectiveMatrixLiveAllowlist({
-          liveEntries: liveAccountCfg.dm?.allowFrom,
+          liveEntries: liveAccountAllowlists.dmAllowFrom,
           startupResolvedEntries: allowFromResolvedEntries,
           fallbackEntries: allowFrom,
         });
         const liveGroupAllowFrom = resolveEffectiveMatrixLiveAllowlist({
-          liveEntries: liveAccountCfg.groupAllowFrom,
+          liveEntries: liveAccountAllowlists.groupAllowFrom,
           startupResolvedEntries: groupAllowFromResolvedEntries,
           fallbackEntries: groupAllowFrom,
         });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -14,6 +14,7 @@ import type {
   MatrixStreamingMode,
   ReplyToMode,
 } from "../../types.js";
+import { resolveMatrixAccountConfig } from "../account-config.js";
 import { formatMatrixErrorMessage } from "../errors.js";
 import { isMatrixMediaSizeLimitError } from "../media-errors.js";
 import {
@@ -638,10 +639,22 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         };
         const storeAllowFrom = isDirectMessage ? await readStoreAllowFrom() : [];
         const roomUsers = roomConfig?.users ?? [];
+        // Hot-reload: re-read raw allowlist entries from live config on each
+        // inbound message so additions to dm.allowFrom / groupAllowFrom take
+        // effect without restarting the gateway. Display-name resolution still
+        // only runs at startup, so new entries must be full Matrix IDs
+        // (@user:server). Merging with the closure values preserves any
+        // startup-time resolution work.
+        const liveAccountCfg = resolveMatrixAccountConfig({
+          cfg: core.config.loadConfig() as CoreConfig,
+          accountId,
+        });
+        const liveDmAllowFrom = (liveAccountCfg.dm?.allowFrom ?? []).map(String);
+        const liveGroupAllowFrom = (liveAccountCfg.groupAllowFrom ?? []).map(String);
         const accessState = resolveMatrixMonitorAccessState({
-          allowFrom,
+          allowFrom: [...allowFrom, ...liveDmAllowFrom],
           storeAllowFrom,
-          groupAllowFrom,
+          groupAllowFrom: [...groupAllowFrom, ...liveGroupAllowFrom],
           roomUsers,
           senderId,
           isRoom,

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -34,7 +34,7 @@ import {
 } from "../sync-state.js";
 import { createMatrixThreadBindingManager } from "../thread-bindings.js";
 import { registerMatrixAutoJoin } from "./auto-join.js";
-import { resolveMatrixMonitorConfig } from "./config.js";
+import { resolveMatrixMonitorConfig, type MatrixResolvedAllowlistEntry } from "./config.js";
 import { createDirectRoomTracker } from "./direct.js";
 import { registerMatrixMonitorEvents } from "./events.js";
 import { createMatrixRoomMessageHandler } from "./handler.js";
@@ -112,6 +112,8 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const accountAllowBots = accountConfig.allowBots;
   let allowFrom: string[] = (accountConfig.dm?.allowFrom ?? []).map(String);
   let groupAllowFrom: string[] = (accountConfig.groupAllowFrom ?? []).map(String);
+  let allowFromResolvedEntries: MatrixResolvedAllowlistEntry[] = [];
+  let groupAllowFromResolvedEntries: MatrixResolvedAllowlistEntry[] = [];
   let roomsConfig = accountConfig.groups ?? accountConfig.rooms;
   let needsRoomAliasesForConfig = false;
   const configuredBotUserIds = resolveConfiguredMatrixBotUserIds({
@@ -119,7 +121,13 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     accountId: effectiveAccountId,
   });
 
-  ({ allowFrom, groupAllowFrom, roomsConfig } = await resolveMatrixMonitorConfig({
+  ({
+    allowFrom,
+    allowFromResolvedEntries,
+    groupAllowFrom,
+    groupAllowFromResolvedEntries,
+    roomsConfig,
+  } = await resolveMatrixMonitorConfig({
     cfg,
     accountId: effectiveAccountId,
     allowFrom,
@@ -320,7 +328,9 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       logger,
       logVerboseMessage,
       allowFrom,
+      allowFromResolvedEntries,
       groupAllowFrom,
+      groupAllowFromResolvedEntries,
       roomsConfig,
       accountAllowBots,
       configuredBotUserIds,


### PR DESCRIPTION
## Summary

Re-read raw allowlist entries from live config on each inbound message, merging with the startup-time resolved values. This allows new entries in `dm.allowFrom` and `groupAllowFrom` to take effect immediately without restarting the gateway.

## Problem

Adding users to `dm.allowFrom` or `groupAllowFrom` in the config file currently requires a full gateway restart. The handler freezes these arrays in a closure at startup time and reuses them for every subsequent inbound message.

## Solution

On each inbound message, call `core.config.loadConfig()` to get the live config, resolve the account-specific config via `resolveMatrixAccountConfig`, extract the raw `dm.allowFrom` and `groupAllowFrom` entries, and merge them with the startup-resolved closure values. `normalizeStringEntries` (called inside `resolveMatrixMonitorAccessState`) deduplicates any overlap.

**Note:** Display-name resolution still only runs at startup, so newly added entries should use full Matrix IDs (`@user:server`) for reliable matching.

## Changes

- `extensions/matrix/src/matrix/monitor/handler.ts` — Import `resolveMatrixAccountConfig`, add live-config re-read + merge before access state resolution
- `extensions/matrix/src/matrix/monitor/handler.test-helpers.ts` — Add `config.loadConfig` mock to test harness

## Testing

- Existing handler tests continue to pass (test harness updated to provide `loadConfig`)
- Manual test: add a new MXID to `dm.allowFrom` → next DM from that user is accepted without restart

Closes #68544

## References

- Original PR with this fix (closed, not merged): #30679 (F5)