### PR TITLE
fix(matrix): strip mention prefix before slash command matching

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -39,7 +39,7 @@ import { resolveMatrixAllowListMatch } from "./allowlist.js";
 import type { MatrixInboundEventDeduper } from "./inbound-dedupe.js";
 import { resolveMatrixLocation, type MatrixLocationPayload } from "./location.js";
 import { downloadMatrixMedia } from "./media.js";
-import { resolveMentions } from "./mentions.js";
+import { resolveMentions, stripMatrixMentionPrefix } from "./mentions.js";
 import { deliverMatrixReplies } from "./replies.js";
 import { createMatrixReplyContextResolver } from "./reply-context.js";
 import { createRoomHistoryTracker } from "./room-history.js";
@@ -850,8 +850,16 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           surface: "matrix",
         });
         const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+        // Strip the bot mention prefix so "@bot:server /new" or "BotName: /new"
+        // is recognized as a slash command, matching the behavior of Slack,
+        // MSTeams, Tlon, Feishu, Mattermost, WhatsApp, and ZaloUser.
+        const commandPrecheckText = stripMatrixMentionPrefix({
+          text: mentionPrecheckText,
+          userId: selfUserId,
+          displayName: selfDisplayName,
+        });
         const hasControlCommandInMessage = core.channel.text.hasControlCommand(
-          mentionPrecheckText,
+          commandPrecheckText,
           cfg,
         );
         const commandGate = resolveControlCommandGate({

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -857,6 +857,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           text: mentionPrecheckText,
           userId: selfUserId,
           displayName: selfDisplayName,
+          mentionRegexes: agentMentionRegexes,
         });
         const hasControlCommandInMessage = core.channel.text.hasControlCommand(
           commandPrecheckText,
@@ -1209,7 +1210,12 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const ctxPayload = core.channel.reply.finalizeInboundContext({
         Body: body,
         RawBody: bodyText,
-        CommandBody: bodyText,
+        CommandBody: stripMatrixMentionPrefix({
+          text: bodyText,
+          userId: selfUserId,
+          displayName: selfDisplayName,
+          mentionRegexes: agentMentionRegexes,
+        }),
         InboundHistory: inboundHistory && inboundHistory.length > 0 ? inboundHistory : undefined,
         From: isDirectMessage ? `matrix:${senderId}` : `matrix:channel:${roomId}`,
         To: `room:${roomId}`,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -1210,12 +1210,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const ctxPayload = core.channel.reply.finalizeInboundContext({
         Body: body,
         RawBody: bodyText,
-        CommandBody: stripMatrixMentionPrefix({
-          text: bodyText,
-          userId: selfUserId,
-          displayName: selfDisplayName,
-          mentionRegexes: agentMentionRegexes,
-        }),
+        CommandBody: bodyText,
         InboundHistory: inboundHistory && inboundHistory.length > 0 ? inboundHistory : undefined,
         From: isDirectMessage ? `matrix:${senderId}` : `matrix:channel:${roomId}`,
         To: `room:${roomId}`,

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -154,10 +154,11 @@ export function stripMatrixMentionPrefix(params: {
   text: string;
   userId?: string | null;
   displayName?: string | null;
+  mentionRegexes?: RegExp[];
 }): string {
-  const text = params.text ?? "";
-  if (!text) {
-    return text;
+  let result = params.text ?? "";
+  if (!result) {
+    return result;
   }
   const candidates: string[] = [];
   const userId = typeof params.userId === "string" ? params.userId.trim() : "";
@@ -170,7 +171,6 @@ export function stripMatrixMentionPrefix(params: {
   }
   const displayName = typeof params.displayName === "string" ? params.displayName.trim() : "";
   if (displayName) {
-    candidates.push(`@${displayName}`);
     candidates.push(displayName);
   }
   for (const candidate of candidates) {
@@ -178,15 +178,25 @@ export function stripMatrixMentionPrefix(params: {
       continue;
     }
     const escaped = candidate.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    // Match the label at the start, allowing an optional ":" or "," separator
-    // before the rest of the message. Requires at least one trailing whitespace
-    // so we don't strip messages like "@bot" with no further content.
     const pattern = new RegExp(`^\\s*${escaped}\\s*[:,]?\\s+`, "i");
-    if (pattern.test(text)) {
-      return text.replace(pattern, "").trimStart();
+    const before = result;
+    result = result.replace(pattern, "");
+    if (result !== before) {
+      return result.trimStart();
     }
   }
-  return text;
+  // Fall back to mentionRegexes (e.g. @botname patterns from config)
+  if (params.mentionRegexes) {
+    for (const re of params.mentionRegexes) {
+      const startRe = new RegExp(`^(?:${re.source})\\s*[:,]?\\s+`, re.flags.replace("g", ""));
+      const before = result;
+      result = result.replace(startRe, "");
+      if (result !== before) {
+        return result.trimStart();
+      }
+    }
+  }
+  return result;
 }
 
 export function resolveMentions(params: {

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -137,6 +137,58 @@ function checkFormattedBodyMention(params: {
   return false;
 }
 
+/**
+ * Strip a leading bot mention from a message body so slash command matching
+ * still recognizes "/cmd" when the user addresses the bot directly. Mirrors
+ * the behavior of other channels (Slack, MSTeams, Tlon, Feishu, Mattermost,
+ * WhatsApp, ZaloUser).
+ *
+ * Examples:
+ *   "@bot:server /new"           -> "/new"
+ *   "@bot:server /new extra"     -> "/new extra"
+ *   "@bot /new"                  -> "/new"
+ *   "BotDisplayName: /new"       -> "/new"  (Element plaintext fallback)
+ *   "/new"                       -> "/new"  (unchanged)
+ */
+export function stripMatrixMentionPrefix(params: {
+  text: string;
+  userId?: string | null;
+  displayName?: string | null;
+}): string {
+  const text = params.text ?? "";
+  if (!text) {
+    return text;
+  }
+  const candidates: string[] = [];
+  const userId = typeof params.userId === "string" ? params.userId.trim() : "";
+  if (userId) {
+    candidates.push(userId);
+    const localpart = resolveMatrixUserLocalpart(userId);
+    if (localpart) {
+      candidates.push(`@${localpart}`);
+    }
+  }
+  const displayName = typeof params.displayName === "string" ? params.displayName.trim() : "";
+  if (displayName) {
+    candidates.push(`@${displayName}`);
+    candidates.push(displayName);
+  }
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+    const escaped = candidate.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Match the label at the start, allowing an optional ":" or "," separator
+    // before the rest of the message. Requires at least one trailing whitespace
+    // so we don't strip messages like "@bot" with no further content.
+    const pattern = new RegExp(`^\\s*${escaped}\\s*[:,]?\\s+`, "i");
+    if (pattern.test(text)) {
+      return text.replace(pattern, "").trimStart();
+    }
+  }
+  return text;
+}
+
 export function resolveMentions(params: {
   content: RoomMessageEventContent;
   userId?: string | null;


### PR DESCRIPTION
## Problem

In Matrix rooms, when a user addresses the bot with a mention before a slash command (e.g., `@bot:server /new` or Element's plaintext fallback `BotName: /new`), the slash command is not recognized because the mention prefix is not stripped before `hasControlCommand` matching. As a result, control commands like `/new`, `/help`, `/focus`, etc. are silently ignored when invoked via mention in a room.

This is the only mainstream channel still missing this behavior. Other channels already handle it:

- Slack — `stripSlackMentionsForCommandDetection` (`extensions/slack/src/monitor/commands.ts`)
- MSTeams — `stripMSTeamsMentionTags` (`extensions/msteams/src/inbound.ts`)
- Tlon — `stripBotMention` (`extensions/tlon/src/monitor/utils.ts`)
- Feishu — `stripBotMention` (bot-content)
- Mattermost — `normalizeMention`
- WhatsApp — `stripMentionsForCommand`
- ZaloUser — `stripOwnMentionsForCommandBody` / `stripLeadingAtMentionForCommand`

## Solution

- Add `stripMatrixMentionPrefix` in `extensions/matrix/src/matrix/monitor/mentions.ts`. It strips a leading bot label (full Matrix user ID `@local:server`, just `@local`, or display name) followed by an optional `:` / `,` separator and whitespace from the start of the message body.
- Apply the helper in `extensions/matrix/src/matrix/monitor/handler.ts` to compute a `commandPrecheckText` that is passed to `hasControlCommand`. The original `mentionPrecheckText` is preserved for mention/history detection so existing mention semantics are unchanged.

The bot's user id comes from `client.getUserId()` (`selfUserId`), and `selfDisplayName` is reused from the existing `formatted_body`-driven lookup.

### Examples

| Input                          | Output           |
| ------------------------------ | ---------------- |
| `@bot:server /new`             | `/new`           |
| `@bot:server /new extra args`  | `/new extra args`|
| `@bot /new`                    | `/new`           |
| `BotDisplayName: /new`         | `/new`           |
| `/new`                         | `/new` (unchanged)|

## Verification

- `oxlint extensions/matrix/src/matrix/monitor/{mentions,handler}.ts` — clean
- `vitest run extensions/matrix/src/matrix/monitor/mentions.test.ts` — 19/19 pass
- `vitest run extensions/matrix/src/matrix/monitor/handler.test.ts handler.body-for-agent.test.ts` — 88/88 pass

## References

- Issue #68547
- Original PR #30679 (item F7)

Made with [Cursor](https://cursor.com)