### PR TITLE
fix(cron): loud error when payload.model silently falls back to wrong provider (#67756)

### DIFF
--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -113,11 +113,14 @@ export async function resolveCronModelSelection(
     });
     if ("error" in resolvedOverride) {
       if (resolvedOverride.error.startsWith("model not allowed:")) {
+        getLog().error(
+          `[cron] payload.model '${modelOverride}' is not in the allowlist — explicitly configured model was rejected. ` +
+            `Refusing silent fallback to defaults (${resolvedDefault.provider}/${resolvedDefault.model}). ` +
+            `Either add '${modelOverride}' to the model allowlist or remove model from cron payload.`,
+        );
         return {
-          ok: true,
-          provider,
-          model,
-          warning: `cron: payload.model '${modelOverride}' not allowed, falling back to agent defaults`,
+          ok: false,
+          error: `cron: payload.model '${modelOverride}' not in allowlist (refusing silent fallback to ${resolvedDefault.provider}/${resolvedDefault.model})`,
         };
       }
       return { ok: false, error: resolvedOverride.error };

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -113,7 +113,7 @@ export async function resolveCronModelSelection(
     });
     if ("error" in resolvedOverride) {
       if (resolvedOverride.error.startsWith("model not allowed:")) {
-        getLog().error(
+        console.error(
           `[cron] payload.model '${modelOverride}' is not in the allowlist — explicitly configured model was rejected. ` +
             `Refusing silent fallback to defaults (${resolvedDefault.provider}/${resolvedDefault.model}). ` +
             `Either add '${modelOverride}' to the model allowlist or remove model from cron payload.`,


### PR DESCRIPTION
## Problem

When a cron job payload explicitly declares `"model": "ollama/llama3.2:3b"`, the gateway **silently** falls back to the default provider/model (`openai/gpt-4o-mini`) if the model is not in the allowlist. There is a `warning` field returned, but it does not include enough detail to diagnose the issue.

**Impact**: User configures cron job to use ollama, job actually hits OpenAI, user has no idea without deep debugging.

## Root Cause

In `resolveCronModelSelection()` (`src/cron/isolated-agent/model-selection.ts`), when `resolveAllowedModelRef()` returns "model not allowed" for an explicit `payload.model`, the code returns `ok: true` with defaults and only a vague warning — effectively hiding the misconfiguration.

## Fix

1. Added `getLog().error()` with full diagnostics (intended provider/model, actual fallback, remediation steps)
2. Changed return value from `ok: true` (with warning) to `ok: false` (with error) so callers know the model was rejected
3. No more silent fallback — if you ask for ollama and it is not allowed, you get a loud error instead of quietly hitting openai

## Notes

- This is a clean rebuild of #67765 (closed by barnacle bot due to dirty history from .orig file fix)
- Single-file change, no unrelated modifications
- Cross-references: #57094 and #58992 address related root causes in other PRs