### PR TITLE
feat(memory-host-sdk): preserve explicit custom collection names

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
@@ -218,7 +218,7 @@ describe("QmdMemoryManager slugified path resolution", () => {
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://workspace-main/extra-docs/category/sub-category/topic-name/topic-name.md",
+              file: "qmd://workspace/extra-docs/category/sub-category/topic-name/topic-name.md",
               score: 0.73,
               snippet: "@@ -2,1\nline-2",
             },
@@ -232,7 +232,7 @@ describe("QmdMemoryManager slugified path resolution", () => {
     const { manager } = await createManager();
     installIndexedPathStub({
       manager,
-      collection: "workspace-main",
+      collection: "workspace",
       normalizedPath: "extra-docs/category/sub-category/topic-name/topic-name.md",
       actualPath: actualRelative,
     });
@@ -348,7 +348,7 @@ describe("QmdMemoryManager slugified path resolution", () => {
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://workspace-main/notes/topic-name.md",
+              file: "qmd://workspace/notes/topic-name.md",
               score: 0.79,
               snippet: "@@ -1,1\nexact slugified path",
             },
@@ -362,7 +362,7 @@ describe("QmdMemoryManager slugified path resolution", () => {
     const { manager } = await createManager();
     installIndexedPathStub({
       manager,
-      collection: "workspace-main",
+      collection: "workspace",
       normalizedPath: exactRelative,
       exactPaths: [exactRelative],
       allPaths: [exactRelative, slugCollisionRelative],

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -665,7 +665,12 @@ describe("QmdMemoryManager", () => {
     expect(removeCalls).toHaveLength(0);
 
     const addCalls = commands.filter((args) => args[0] === "collection" && args[1] === "add");
-    expect(addCalls).toHaveLength(0);
+    expect(addCalls).toHaveLength(1);
+    const workspaceAdd = addCalls.find((args) => {
+      const nameIdx = args.indexOf("--name");
+      return nameIdx >= 0 && args[nameIdx + 1] === "workspace";
+    });
+    expect(workspaceAdd).toBeDefined();
   });
 
   it("rebinds collection when qmd text output exposes a changed pattern without a path", async () => {
@@ -687,9 +692,7 @@ describe("QmdMemoryManager", () => {
         emitAndClose(
           child,
           "stdout",
-          ["workspace-main (qmd://workspace-main/)", "  Pattern:  *.txt", "  Files:    17"].join(
-            "\n",
-          ),
+          ["workspace (qmd://workspace/)", "  Pattern:  *.txt", "  Files:    17"].join("\n"),
         );
         return child;
       }
@@ -701,7 +704,7 @@ describe("QmdMemoryManager", () => {
 
     const commands = spawnMock.mock.calls.map((call: unknown[]) => call[1] as string[]);
     const removeCalls = commands.filter(
-      (args) => args[0] === "collection" && args[1] === "remove" && args[2] === "workspace-main",
+      (args) => args[0] === "collection" && args[1] === "remove" && args[2] === "workspace",
     );
     expect(removeCalls).toHaveLength(1);
 
@@ -710,7 +713,7 @@ describe("QmdMemoryManager", () => {
         return false;
       }
       const nameIdx = args.indexOf("--name");
-      return nameIdx >= 0 && args[nameIdx + 1] === "workspace-main";
+      return nameIdx >= 0 && args[nameIdx + 1] === "workspace";
     });
     expect(addCall).toBeDefined();
     expect(addCall?.[2]).toBe(workspaceDir);
@@ -991,7 +994,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
 
     expect(logWarnMock).toHaveBeenCalledWith(
-      expect.stringContaining("qmd collection add skipped for workspace-main"),
+      expect.stringContaining("qmd collection add skipped for workspace"),
     );
   });
 
@@ -1466,7 +1469,7 @@ describe("QmdMemoryManager", () => {
       "-n",
       String(resolved.qmd?.limits.maxResults),
       "-c",
-      "workspace-main",
+      "workspace",
     ]);
     expect(
       spawnMock.mock.calls.some((call: unknown[]) => (call[1] as string[])?.[0] === "query"),
@@ -1651,7 +1654,7 @@ describe("QmdMemoryManager", () => {
       "-n",
       String(maxResults),
       "-c",
-      "workspace-main",
+      "workspace",
     ]);
     await manager.close();
   });
@@ -1802,8 +1805,8 @@ describe("QmdMemoryManager", () => {
         (args): args is string[] => Array.isArray(args) && ["search", "query"].includes(args[0]),
       );
     expect(searchAndQueryCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
     ]);
     await manager.close();
   });
@@ -1964,8 +1967,8 @@ describe("QmdMemoryManager", () => {
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "search");
     expect(searchCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -2090,8 +2093,8 @@ describe("QmdMemoryManager", () => {
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "query");
     expect(queryCalls).toEqual([
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -2141,9 +2144,9 @@ describe("QmdMemoryManager", () => {
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "search" || args[0] === "query");
     expect(searchAndQueryCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -2222,7 +2225,7 @@ describe("QmdMemoryManager", () => {
             expect.objectContaining({ type: "hyde" }),
           ]),
         );
-        expect(callArgs).toHaveProperty("collections", ["workspace-main"]);
+        expect(callArgs).toHaveProperty("collections", ["workspace"]);
         // Should NOT have flat query/minScore (v1 format)
         expect(callArgs).not.toHaveProperty("query");
         expect(callArgs).not.toHaveProperty("minScore");
@@ -2328,7 +2331,7 @@ describe("QmdMemoryManager", () => {
           query: "hello",
           limit: expectedLimit,
           minScore: 0,
-          collection: "workspace-main",
+          collection: "workspace",
         });
         expect(callArgs).not.toHaveProperty("searches");
         expect(callArgs).not.toHaveProperty("collections");
@@ -2373,7 +2376,7 @@ describe("QmdMemoryManager", () => {
               {
                 docid: expectedDocId,
                 score: 0.91,
-                collection: "workspace-main",
+                collection: "workspace",
                 start_line: 8,
                 end_line: 10,
                 snippet: "@@ -20,3\nline one\nline two\nline three",
@@ -2395,7 +2398,7 @@ describe("QmdMemoryManager", () => {
       prepare: (_query: string) => ({
         all: (arg: unknown) => {
           if (typeof arg === "string" && arg.startsWith(expectedDocId)) {
-            return [{ collection: "workspace-main", path: "notes/welcome.md" }];
+            return [{ collection: "workspace", path: "notes/welcome.md" }];
           }
           return [];
         },
@@ -2447,7 +2450,7 @@ describe("QmdMemoryManager", () => {
               {
                 docid: expectedDocId,
                 score: 0.73,
-                collection: "workspace-main",
+                collection: "workspace",
                 start_line: 8,
                 snippet: "@@ -20,3\nline one\nline two\nline three",
               },
@@ -2468,7 +2471,7 @@ describe("QmdMemoryManager", () => {
       prepare: (_query: string) => ({
         all: (arg: unknown) => {
           if (typeof arg === "string" && arg.startsWith(expectedDocId)) {
-            return [{ collection: "workspace-main", path: "notes/welcome.md" }];
+            return [{ collection: "workspace", path: "notes/welcome.md" }];
           }
           return [];
         },
@@ -2514,7 +2517,7 @@ describe("QmdMemoryManager", () => {
         expect(args[1]).toBe("qmd.query");
         const callArgs = JSON.parse(args[args.indexOf("--args") + 1]);
         expect(callArgs).toHaveProperty("searches", [{ type: "lex", query: "hello" }]);
-        expect(callArgs).toHaveProperty("collections", ["workspace-main"]);
+        expect(callArgs).toHaveProperty("collections", ["workspace"]);
         expect(callArgs).not.toHaveProperty("query");
         expect(callArgs).not.toHaveProperty("minScore");
         expect(callArgs).not.toHaveProperty("collection");
@@ -2633,7 +2636,7 @@ describe("QmdMemoryManager", () => {
     await manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" });
 
     expect(selectors).toEqual(["qmd.hybrid_search", "qmd.hybrid_search"]);
-    expect(collections).toEqual(["workspace-a-main", "workspace-b-main"]);
+    expect(collections).toEqual(["workspace-a", "workspace-b"]);
 
     await manager.close();
   });
@@ -3051,7 +3054,7 @@ describe("QmdMemoryManager", () => {
     } as OpenClawConfig;
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search" && args.includes("workspace-main")) {
+      if (args[0] === "search" && args.includes("workspace")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
@@ -3086,7 +3089,7 @@ describe("QmdMemoryManager", () => {
         all: (arg: unknown) => {
           switch (arg) {
             case "m1":
-              return [{ collection: "workspace-main", path: "memory/facts.md" }];
+              return [{ collection: "workspace", path: "memory/facts.md" }];
             case "s1":
             case "s2":
             case "s3":
@@ -3550,7 +3553,7 @@ describe("QmdMemoryManager", () => {
 
     const textPath = path.join(workspaceDir, "secret.txt");
     await fs.writeFile(textPath, "nope", "utf-8");
-    await expect(manager.readFile({ relPath: "qmd/workspace-main/secret.txt" })).rejects.toThrow(
+    await expect(manager.readFile({ relPath: "qmd/workspace/secret.txt" })).rejects.toThrow(
       "path required",
     );
 
@@ -3558,7 +3561,7 @@ describe("QmdMemoryManager", () => {
     await fs.writeFile(target, "ok", "utf-8");
     const link = path.join(workspaceDir, "link.md");
     await fs.symlink(target, link);
-    await expect(manager.readFile({ relPath: "qmd/workspace-main/link.md" })).rejects.toThrow(
+    await expect(manager.readFile({ relPath: "qmd/workspace/link.md" })).rejects.toThrow(
       "path required",
     );
 
@@ -3833,7 +3836,7 @@ describe("QmdMemoryManager", () => {
             }
             if (query.includes("hash LIKE ?")) {
               expect(arg).toBe(`${exactDocid}%`);
-              return [{ collection: "workspace-main", path: "notes/welcome.md" }];
+              return [{ collection: "workspace", path: "notes/welcome.md" }];
             }
             throw new Error(`unexpected sqlite query: ${query}`);
           },
@@ -3878,7 +3881,7 @@ describe("QmdMemoryManager", () => {
 
     const duplicateDocid = "dup-123";
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search" && args.includes("workspace-main")) {
+      if (args[0] === "search" && args.includes("workspace")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
@@ -3889,7 +3892,7 @@ describe("QmdMemoryManager", () => {
         );
         return child;
       }
-      if (args[0] === "search" && args.includes("notes-main")) {
+      if (args[0] === "search" && args.includes("notes")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(child, "stdout", "[]");
         return child;
@@ -3907,7 +3910,7 @@ describe("QmdMemoryManager", () => {
           if (typeof arg === "string" && arg.startsWith(duplicateDocid)) {
             return [
               { collection: "stale-workspace", path: "notes/welcome.md" },
-              { collection: "workspace-main", path: "notes/welcome.md" },
+              { collection: "workspace", path: "notes/welcome.md" },
             ];
           }
           return [];
@@ -3951,7 +3954,7 @@ describe("QmdMemoryManager", () => {
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://workspace-main/notes/welcome.md",
+              file: "qmd://workspace/notes/welcome.md",
               score: 0.71,
               snippet: "@@ -4,1\ntoken unlock",
             },
@@ -4092,14 +4095,14 @@ describe("QmdMemoryManager", () => {
     } as OpenClawConfig;
 
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === "search" && args.includes("workspace-main")) {
+      if (args[0] === "search" && args.includes("workspace")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://workspace-main/memory/facts.md",
+              file: "qmd://workspace/memory/facts.md",
               score: 0.8,
               snippet: "@@ -2,1\nworkspace fact",
             },
@@ -4107,14 +4110,14 @@ describe("QmdMemoryManager", () => {
         );
         return child;
       }
-      if (args[0] === "search" && args.includes("notes-main")) {
+      if (args[0] === "search" && args.includes("notes")) {
         const child = createMockChild({ autoClose: false });
         emitAndClose(
           child,
           "stdout",
           JSON.stringify([
             {
-              file: "qmd://notes-main/guide.md",
+              file: "qmd://notes/guide.md",
               score: 0.7,
               snippet: "@@ -1,1\nnotes guide",
             },

--- a/src/memory-host-sdk/host/backend-config.test.ts
+++ b/src/memory-host-sdk/host/backend-config.test.ts
@@ -150,8 +150,8 @@ describe("resolveMemoryBackendConfig", () => {
     const devNames = resolveCollectionNamesForAgent(cfg, "dev");
     expect(mainNames.has("memory-dir-main")).toBe(true);
     expect(devNames.has("memory-dir-dev")).toBe(true);
-    expect(mainNames.has("workspace-main")).toBe(true);
-    expect(devNames.has("workspace-dev")).toBe(true);
+    expect(mainNames.has("workspace")).toBe(true);
+    expect(devNames.has("workspace")).toBe(true);
   });
 
   it("merges default and per-agent qmd extra collections", () => {
@@ -199,7 +199,7 @@ describe("resolveMemoryBackendConfig", () => {
     } as OpenClawConfig;
     const names = resolveCollectionNamesForAgent(cfg, "main");
     expect(names.has("team-notes")).toBe(true);
-    expect(names.has("notes-main")).toBe(true);
+    expect(names.has("notes")).toBe(true);
   });
 
   it("preserves explicit custom collection names for paths outside the workspace", () => {
@@ -248,8 +248,7 @@ describe("resolveMemoryBackendConfig", () => {
         },
       } as OpenClawConfig;
       const names = resolveCollectionNamesForAgent(cfg, "main");
-      expect(names.has("workspace-main")).toBe(true);
-      expect(names.has("workspace")).toBe(false);
+      expect(names.has("workspace")).toBe(true);
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }
@@ -280,8 +279,7 @@ describe("resolveMemoryBackendConfig", () => {
         },
       } as OpenClawConfig;
       const names = resolveCollectionNamesForAgent(cfg, "main");
-      expect(names.has("notes-main")).toBe(true);
-      expect(names.has("notes")).toBe(false);
+      expect(names.has("notes")).toBe(true);
     } finally {
       await fs.rm(tmpRoot, { recursive: true, force: true });
     }

--- a/src/memory-host-sdk/host/backend-config.test.ts
+++ b/src/memory-host-sdk/host/backend-config.test.ts
@@ -129,7 +129,7 @@ describe("resolveMemoryBackendConfig", () => {
     expect(custom?.path).toBe(path.resolve(workspaceRoot, "notes"));
   });
 
-  it("scopes qmd collection names per agent", () => {
+  it("scopes default memory collection names per agent while preserving explicit custom names", () => {
     const cfg = {
       agents: {
         defaults: { workspace: "/workspace/root" },
@@ -227,7 +227,7 @@ describe("resolveMemoryBackendConfig", () => {
     expect(devNames.has("notion-mirror")).toBe(true);
   });
 
-  it("keeps symlinked workspace paths agent-scoped when deciding custom collection names", async () => {
+  it("preserves explicit custom collection names for symlinked workspace paths", async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qmd-backend-config-"));
     const workspaceDir = path.join(tmpRoot, "workspace");
     const workspaceAliasDir = path.join(tmpRoot, "workspace-alias");
@@ -254,7 +254,7 @@ describe("resolveMemoryBackendConfig", () => {
     }
   });
 
-  it("keeps unresolved child paths under a symlinked workspace agent-scoped", async () => {
+  it("preserves explicit custom collection names for unresolved child paths under a symlinked workspace", async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qmd-backend-config-"));
     const realRootDir = path.join(tmpRoot, "real-root");
     const aliasRootDir = path.join(tmpRoot, "alias-root");

--- a/src/memory-host-sdk/host/backend-config.ts
+++ b/src/memory-host-sdk/host/backend-config.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
@@ -122,33 +121,6 @@ function sanitizeName(input: string): string {
 
 function scopeCollectionBase(base: string, agentId: string): string {
   return `${base}-${sanitizeName(agentId)}`;
-}
-
-function canonicalizePathForContainment(rawPath: string): string {
-  const resolved = path.resolve(rawPath);
-  let current = resolved;
-  const suffix: string[] = [];
-  while (true) {
-    try {
-      const canonical = path.normalize(fs.realpathSync.native(current));
-      return path.normalize(path.join(canonical, ...suffix));
-    } catch {
-      const parent = path.dirname(current);
-      if (parent === current) {
-        return path.normalize(resolved);
-      }
-      suffix.unshift(path.basename(current));
-      current = parent;
-    }
-  }
-}
-
-function isPathInsideRoot(candidatePath: string, rootPath: string): boolean {
-  const relative = path.relative(
-    canonicalizePathForContainment(rootPath),
-    canonicalizePathForContainment(candidatePath),
-  );
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 function ensureUniqueName(base: string, existing: Set<string>): string {
@@ -289,10 +261,9 @@ function resolveCustomPaths(
     }
     seenRoots.add(dedupeKey);
     const explicitName = entry.name?.trim();
-    const baseName =
-      explicitName && !isPathInsideRoot(resolved, workspaceDir)
-        ? explicitName
-        : scopeCollectionBase(explicitName || `custom-${index + 1}`, agentId);
+    const baseName = explicitName
+      ? explicitName
+      : scopeCollectionBase(`custom-${index + 1}`, agentId);
     const name = ensureUniqueName(baseName, existing);
     collections.push({
       name,


### PR DESCRIPTION
## Summary
- preserve explicit custom collection names instead of auto-scoping them when a name is already provided
- keep unnamed custom collections on the current generated naming path

## Why
Operators may depend on stable, human-chosen collection names. Today an explicit name can still be rewritten depending on path locality. This change treats an explicit name as authoritative while preserving generated naming for unnamed collections.

## Validation
- targeted backend-config test suite passed locally (21/21)
