### PR TITLE
fix(ui): include cache tokens in ctx% badge and cache-hit-rate

### DIFF
--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:42:32.375Z",
+  "generatedAt": "2026-04-18T13:16:39.636Z",
   "locale": "de",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:43:59.297Z",
+  "generatedAt": "2026-04-18T13:16:39.953Z",
   "locale": "es",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:43:57.183Z",
+  "generatedAt": "2026-04-18T13:16:40.906Z",
   "locale": "fr",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:45:17.357Z",
+  "generatedAt": "2026-04-18T13:16:41.873Z",
   "locale": "id",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:43:53.593Z",
+  "generatedAt": "2026-04-18T13:16:40.269Z",
   "locale": "ja-JP",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:43:57.102Z",
+  "generatedAt": "2026-04-18T13:16:40.589Z",
   "locale": "ko",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:45:13.142Z",
+  "generatedAt": "2026-04-18T13:16:42.194Z",
   "locale": "pl",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:42:32.376Z",
+  "generatedAt": "2026-04-18T13:16:39.322Z",
   "locale": "pt-BR",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:45:07.081Z",
+  "generatedAt": "2026-04-18T13:16:41.224Z",
   "locale": "tr",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:45:16.672Z",
+  "generatedAt": "2026-04-18T13:16:41.548Z",
   "locale": "uk",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:42:37.997Z",
+  "generatedAt": "2026-04-18T13:16:38.682Z",
   "locale": "zh-CN",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,10 +1,10 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-15T05:42:35.056Z",
+  "generatedAt": "2026-04-18T13:16:39.001Z",
   "locale": "zh-TW",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "34089e99b81e81139add4dca8eb47a80da365bd90534ac5e5e042474f3816ad6",
+  "sourceHash": "6446f44746db079094280a1aecd10721f5877361e34f05eb434a824ff05ecb50",
   "totalKeys": 706,
   "translatedKeys": 706,
   "workflow": 1

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -511,7 +511,7 @@ export const en: TranslationMap = {
       errorHint: "Error rate = errors / total messages. Lower is better.",
       avgSession: "avg session",
       cacheHitRate: "Cache Hit Rate",
-      cacheHint: "Cache hit rate = cache read / (input + cache read). Higher is better.",
+      cacheHint: "Cache hit rate = cache read / (input + cache read + cache write). Higher is better.",
       cached: "cached",
       prompt: "prompt",
       calls: "calls",

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -286,8 +286,11 @@ function extractGroupMeta(group: MessageGroup, contextWindow: number | null): Gr
     return null;
   }
 
+  const promptTokens = input + cacheRead + cacheWrite;
   const contextPercent =
-    contextWindow && input > 0 ? Math.min(Math.round((input / contextWindow) * 100), 100) : null;
+    contextWindow && promptTokens > 0
+      ? Math.min(Math.round((promptTokens / contextWindow) * 100), 100)
+      : null;
 
   return { input, output, cacheRead, cacheWrite, cost, model, contextPercent };
 }

--- a/ui/src/ui/views/usage-render-overview.ts
+++ b/ui/src/ui/views/usage-render-overview.ts
@@ -496,7 +496,7 @@ function renderUsageInsights(
     ? Math.round(totals.totalTokens / aggregates.messages.total)
     : 0;
   const avgCost = aggregates.messages.total ? totals.totalCost / aggregates.messages.total : 0;
-  const cacheBase = totals.input + totals.cacheRead;
+  const cacheBase = totals.input + totals.cacheRead + totals.cacheWrite;
   const cacheHitRate = cacheBase > 0 ? totals.cacheRead / cacheBase : 0;
   const cacheHitLabel =
     cacheBase > 0 ? `${(cacheHitRate * 100).toFixed(1)}%` : t("usage.common.emptyValue");


### PR DESCRIPTION
## Summary

- **Problem**: The Control UI's ctx% badge and cache-hit-rate metric both ignore prompt cache tokens, so any session using Anthropic prompt caching (where most of the prompt lives in \`cacheRead\`/\`cacheWrite\`) renders a ~0% context badge and an inflated cache-hit-rate.
- **Why it matters**: Operators rely on the badge to know when a session is approaching its context window; today it stays near 0% even when the cached prompt is at 300k/1M. The cache-hit-rate metric is a KPI in the usage overview.
- **What changed**: Include cache-read + cache-write in the prompt-size sum for the ctx% badge, and in the cache-hit-rate denominator. Update the matching tooltip string.
- **What did NOT change**: No API/contract changes, no data shape changes. Pure presentational fix.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

Both call sites were written when Anthropic prompt caching wasn't a first-class concept and only the \`input\` counter mattered. Once caching landed, the bulk of the prompt tokens shifted into \`cacheRead\`/\`cacheWrite\` but the two math expressions weren't updated:

- \`grouped-render.ts:288\` computed \`input / contextWindow\` → near-zero ratio when caching is warm.
- \`usage-render-overview.ts:499\` computed \`cacheRead / (input + cacheRead)\` → excludes cache writes from the base, inflating the ratio.

## Evidence

- [x] Observed wrong behavior: on Opus 4.7 1M-context sessions, ctx% badge stays at 0% while actual prompt caching is at 200-400k tokens per turn. After the fix the badge correctly reflects utilization.
- [x] Ran locally against a production OpenClaw deployment; badge and cache-hit-rate now match what you'd compute by hand from the raw Anthropic usage payload.

## Human Verification (required)

- Verified scenarios:
  - Warm cached prompt on Opus 4.7 1M → badge now shows a meaningful percent instead of sticking at 0%.
  - Cache-hit-rate recomputed on a full-day usage window — lower (more honest) value after the fix.
- Edge cases checked:
  - Cold session (no cache) — behavior unchanged.
  - \`contextWindow\` null — still returns null (no division).
  - \`cacheBase = 0\` — still returns the empty-value fallback.
- What I did **not** verify: i18n strings in non-English locales. Only \`en.ts\` is touched; other locales still reference the old formula in their own copies of the tooltip and may want the same treatment in a follow-up.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Existing dashboards/alerts calibrated against the old cache-hit-rate will show lower values after this lands.
  - Mitigation: Lower values are closer to truth; worth the one-time recalibration. Tooltip text in this PR documents the new formula.