### PR TITLE
docs: shift user-facing copy toward assistant-first positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@
 </p>
 
 **OpenClaw** is a _personal AI assistant_ you run on your own devices.
-It answers you on the channels you already use. It can speak and listen on macOS/iOS/Android, and can render a live Canvas you control. The Gateway is just the control plane — the product is the assistant.
+It answers you on the channels you already use, keeps context over time, and helps you stay on top of what matters. It can remind you, send useful summaries, alert you when something breaks, and help you take action through one interface. It can also speak and listen on macOS/iOS/Android, and render a live Canvas you control. The Gateway is just the control plane — the product is the assistant.
+
+**One smart assistant instead of dashboards, alerts, and manual routine.**
+
+Reminders, summaries, notifications, and actions — in one interface.
+
+**Less manual checking. More clarity.**
 
 If you want a personal, single-user assistant that feels local, fast, and always-on, this is it.
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1,5 +1,5 @@
 ---
-summary: "Frequently asked questions about OpenClaw setup, configuration, and usage"
+summary: "Frequently asked questions about setting up and using your OpenClaw assistant"
 read_when:
   - Answering common setup, install, onboarding, or runtime support questions
   - Triaging user-reported issues before deeper debugging
@@ -8,7 +8,7 @@ title: "FAQ"
 
 # FAQ
 
-Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS, multi-agent, OAuth/API keys, model failover). For runtime diagnostics, see [Troubleshooting](/gateway/troubleshooting). For the full config reference, see [Configuration](/gateway/configuration).
+Quick answers plus deeper troubleshooting for real-world OpenClaw assistant setups (local dev, VPS, multi-agent, OAuth/API keys, model failover). For runtime diagnostics, see [Troubleshooting](/gateway/troubleshooting). For the full config reference, see [Configuration](/gateway/configuration).
 
 ## First 60 seconds if something is broken
 
@@ -143,7 +143,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
 
   </Accordion>
 
-  <Accordion title="Recommended way to install and set up OpenClaw">
+  <Accordion title="Recommended way to install and set up your OpenClaw assistant">
     The repo recommends running from source and using onboarding:
 
     ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-summary: "OpenClaw is a multi-channel gateway for AI agents that runs on any OS."
+summary: "OpenClaw is a personal AI assistant for your systems, tasks, and routines."
 read_when:
   - Introducing OpenClaw to newcomers
 title: "OpenClaw"
@@ -25,8 +25,8 @@ title: "OpenClaw"
 > _"EXFOLIATE! EXFOLIATE!"_ — A space lobster, probably
 
 <p align="center">
-  <strong>Any OS gateway for AI agents across Discord, Google Chat, iMessage, Matrix, Microsoft Teams, Signal, Slack, Telegram, WhatsApp, Zalo, and more.</strong><br />
-  Send a message, get an agent response from your pocket. Run one Gateway across built-in channels, bundled channel plugins, WebChat, and mobile nodes.
+  <strong>One smart assistant instead of dashboards, alerts, and manual routine.</strong><br />
+  Reminders, summaries, notifications, and actions — in one interface.
 </p>
 
 <Columns>
@@ -43,12 +43,15 @@ title: "OpenClaw"
 
 ## What is OpenClaw?
 
-OpenClaw is a **self-hosted gateway** that connects your favorite chat apps and channel surfaces — built-in channels plus bundled or external channel plugins such as Discord, Google Chat, iMessage, Matrix, Microsoft Teams, Signal, Slack, Telegram, WhatsApp, Zalo, and more — to AI coding agents like Pi. You run a single Gateway process on your own machine (or a server), and it becomes the bridge between your messaging apps and an always-available AI assistant.
+OpenClaw is a **personal AI assistant** you run on your own machine (or server). Under the hood, it uses a self-hosted Gateway that connects your chat apps, channel surfaces, tools, and nodes — but the user-facing product is the assistant.
+
+It helps you remember what matters, stay informed with useful summaries, notice problems early, and react through one interface.
 
 **Who is it for?** Developers and power users who want a personal AI assistant they can message from anywhere — without giving up control of their data or relying on a hosted service.
 
 **What makes it different?**
 
+- **Personal assistant first**: reminders, summaries, notifications, and actions in one interface
 - **Self-hosted**: runs on your hardware, your rules
 - **Multi-channel**: one Gateway serves built-in channels plus bundled or external channel plugins simultaneously
 - **Agent-native**: built for coding agents with tool use, sessions, memory, and multi-agent routing

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -1,5 +1,5 @@
 ---
-summary: "Get OpenClaw installed and run your first chat in minutes."
+summary: "Get OpenClaw installed and start using your personal AI assistant in minutes."
 read_when:
   - First time setup from zero
   - You want the fastest path to a working chat
@@ -8,9 +8,12 @@ title: "Getting Started"
 
 # Getting Started
 
-Install OpenClaw, run onboarding, and chat with your AI assistant — all in
+Install OpenClaw, run onboarding, and start using your AI assistant — all in
 about 5 minutes. By the end you will have a running Gateway, configured auth,
 and a working chat session.
+
+OpenClaw is built to give you one assistant interface for reminders, summaries,
+notifications, and actions.
 
 ## What you need
 

--- a/docs/start/hubs.md
+++ b/docs/start/hubs.md
@@ -1,5 +1,5 @@
 ---
-summary: "Hubs that link to every OpenClaw doc"
+summary: "A complete map of OpenClaw docs for your personal AI assistant setup"
 read_when:
   - You want a complete map of the documentation
 title: "Docs Hubs"
@@ -12,6 +12,8 @@ If you are new to OpenClaw, start with [Getting Started](/start/getting-started)
 </Note>
 
 Use these hubs to discover every page, including deep dives and reference docs that don’t appear in the left nav.
+
+If you are learning OpenClaw from the top down, think of it as a personal AI assistant powered by a self-hosted Gateway underneath.
 
 ## Start here
 

--- a/docs/start/onboarding-overview.md
+++ b/docs/start/onboarding-overview.md
@@ -1,5 +1,5 @@
 ---
-summary: "Overview of OpenClaw onboarding options and flows"
+summary: "Overview of onboarding options and flows for your OpenClaw assistant"
 read_when:
   - Choosing an onboarding path
   - Setting up a new environment
@@ -10,7 +10,7 @@ sidebarTitle: "Onboarding Overview"
 # Onboarding Overview
 
 OpenClaw has two onboarding paths. Both configure auth, the Gateway, and
-optional chat channels — they just differ in how you interact with the setup.
+optional chat channels for your assistant — they just differ in how you interact with the setup.
 
 ## Which path should I use?
 
@@ -23,7 +23,7 @@ optional chat channels — they just differ in how you interact with the setup.
 | **Command**    | `openclaw onboard`                     | Launch the app            |
 
 Most users should start with **CLI onboarding** — it works everywhere and gives
-you the most control.
+you the fastest path to a working assistant with the most control.
 
 ## What onboarding configures
 

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -1,5 +1,5 @@
 ---
-summary: "First-run setup flow for OpenClaw (macOS app)"
+summary: "First-run setup flow for your OpenClaw assistant in the macOS app"
 read_when:
   - Designing the macOS onboarding assistant
   - Implementing auth or identity setup
@@ -10,8 +10,8 @@ sidebarTitle: "Onboarding: macOS App"
 # Onboarding (macOS App)
 
 This doc describes the **current** first‑run setup flow. The goal is a
-smooth “day 0” experience: pick where the Gateway runs, connect auth, run the
-wizard, and let the agent bootstrap itself.
+smooth “day 0” experience: choose where the Gateway runs, connect auth, run the
+wizard, and let your assistant bootstrap itself.
 For a general overview of onboarding paths, see [Onboarding Overview](/start/onboarding-overview).
 
 <Steps>

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -8,7 +8,7 @@ title: "Personal Assistant Setup"
 
 # Building a personal assistant with OpenClaw
 
-OpenClaw is a self-hosted gateway that connects Discord, Google Chat, iMessage, Matrix, Microsoft Teams, Signal, Slack, Telegram, WhatsApp, Zalo, and more to AI agents. This guide covers the "personal assistant" setup: a dedicated WhatsApp number that behaves like your always-on AI assistant.
+OpenClaw is a personal AI assistant that you run through a self-hosted gateway connecting Discord, Google Chat, iMessage, Matrix, Microsoft Teams, Signal, Slack, Telegram, WhatsApp, Zalo, and more. This guide covers the "personal assistant" setup: a dedicated WhatsApp number that behaves like your always-on AI assistant.
 
 ## ⚠️ Safety first
 
@@ -103,7 +103,7 @@ If you already ship your own workspace files from a repo, you can disable bootst
 }
 ```
 
-## The config that turns it into "an assistant"
+## The config that turns it into your assistant
 
 OpenClaw defaults to a good assistant setup, but you’ll usually want to tune:
 

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -1,5 +1,5 @@
 ---
-summary: "Quick start has moved to Getting Started."
+summary: "Quick start has moved to Getting Started for the fastest path to your OpenClaw assistant."
 read_when:
   - You are looking for the fastest setup steps
   - You were sent here from an older link
@@ -14,7 +14,7 @@ Quick start is now part of [Getting Started](/start/getting-started).
 
 <Columns>
   <Card title="Getting Started" href="/start/getting-started">
-    Install OpenClaw and run your first chat in minutes.
+    Install OpenClaw and start using your assistant in minutes.
   </Card>
   <Card title="Onboarding (CLI)" href="/start/wizard">
     Full CLI onboarding reference and advanced options.

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -1,5 +1,5 @@
 ---
-summary: "Advanced setup and development workflows for OpenClaw"
+summary: "Advanced setup and development workflows for your OpenClaw assistant"
 read_when:
   - Setting up a new machine
   - You want “latest + greatest” without breaking your personal setup
@@ -16,7 +16,7 @@ For onboarding details, see [Onboarding (CLI)](/start/wizard).
 ## TL;DR
 
 - **Tailoring lives outside the repo:** `~/.openclaw/workspace` (workspace) + `~/.openclaw/openclaw.json` (config).
-- **Stable workflow:** install the macOS app; let it run the bundled Gateway.
+- **Stable workflow:** install the macOS app; let it run the bundled Gateway behind your assistant.
 - **Bleeding edge workflow:** run the Gateway yourself via `pnpm gateway:watch`, then let the macOS app attach in Local mode.
 
 ## Prereqs (from source)

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -14,8 +14,9 @@ read_when:
 <div className="showcase-hero">
   <p className="showcase-kicker">Built in chats, terminals, browsers, and living rooms</p>
   <p className="showcase-lead">
-    OpenClaw projects are not toy demos. People are shipping PR review loops, mobile apps, home automation,
-    voice systems, devtools, and memory-heavy workflows from the channels they already use.
+    OpenClaw projects are not toy demos. People are building personal assistant workflows around reminders,
+    summaries, alerts, actions, PR review loops, mobile apps, home automation, voice systems, devtools,
+    and memory-heavy workflows from the channels they already use.
   </p>
   <div className="showcase-actions">
     <a href="#videos">Watch demos</a>


### PR DESCRIPTION
## Summary

This PR reframes key user-facing docs around OpenClaw as a personal AI assistant.

The main change is positioning:
- assistant first
- gateway/control plane second

It makes the top-of-funnel story clearer without changing the underlying technical model.

## What changed

Updated:
- README intro
- docs index
- getting started / quickstart
- onboarding docs
- personal assistant setup docs
- hubs / showcase / setup
- FAQ

## Notes

Docs-only change. No functional changes.