### PR TITLE
fix(webhooks): re-resolve rotated webhook secrets

### DIFF
--- a/extensions/webhooks/src/http.test.ts
+++ b/extensions/webhooks/src/http.test.ts
@@ -160,7 +160,7 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     expect(target.taskFlow.list()).toEqual([]);
   });
 
-  it("caches SecretRef resolution across requests for the same route", async () => {
+  it("re-resolves SecretRef values across requests so rotation takes effect", async () => {
     const runtime = createRuntimeTaskFlow();
     const target: TaskFlowWebhookTarget = {
       routeId: "cached",
@@ -176,7 +176,10 @@ describe("createTaskFlowWebhookRequestHandler", () => {
         sessionKey: "agent:main:webhook-cached",
       }),
     };
-    hoisted.resolveConfiguredSecretInputStringMock.mockResolvedValue({ value: "shared-secret" });
+    hoisted.resolveConfiguredSecretInputStringMock
+      .mockResolvedValueOnce({ value: "shared-secret" })
+      .mockResolvedValueOnce({ value: "rotated-secret" })
+      .mockResolvedValueOnce({ value: "rotated-secret" });
     const handler = createHandlerWithTarget(target);
 
     const first = await dispatchJsonRequest({
@@ -195,10 +198,20 @@ describe("createTaskFlowWebhookRequestHandler", () => {
         action: "list_flows",
       },
     });
+    const third = await dispatchJsonRequest({
+      handler,
+      path: target.path,
+      secret: "rotated-secret",
+      body: {
+        action: "list_flows",
+      },
+    });
 
     expect(first.statusCode).toBe(200);
-    expect(second.statusCode).toBe(200);
-    expect(hoisted.resolveConfiguredSecretInputStringMock).toHaveBeenCalledTimes(1);
+    expect(second.statusCode).toBe(401);
+    expect(second.body).toBe("unauthorized");
+    expect(third.statusCode).toBe(200);
+    expect(hoisted.resolveConfiguredSecretInputStringMock).toHaveBeenCalledTimes(3);
   });
 
   it("creates flows through the bound session and scrubs owner metadata from responses", async () => {

--- a/extensions/webhooks/src/http.ts
+++ b/extensions/webhooks/src/http.ts
@@ -667,7 +667,6 @@ export function createTaskFlowWebhookRequestHandler(params: {
   targetsByPath: Map<string, TaskFlowWebhookTarget[]>;
   inFlightLimiter?: WebhookInFlightLimiter;
 }): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
-  const secretByTarget = new WeakMap<TaskFlowWebhookTarget, Promise<string | undefined>>();
   const rateLimiter = createFixedWindowRateLimiter({
     windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
     maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
@@ -679,20 +678,6 @@ export function createTaskFlowWebhookRequestHandler(params: {
       maxInFlightPerKey: WEBHOOK_IN_FLIGHT_DEFAULTS.maxInFlightPerKey,
       maxTrackedKeys: WEBHOOK_IN_FLIGHT_DEFAULTS.maxTrackedKeys,
     });
-  const resolveTargetSecret = (target: TaskFlowWebhookTarget): Promise<string | undefined> => {
-    const cached = secretByTarget.get(target);
-    if (cached) {
-      return cached;
-    }
-    const pending = resolveConfiguredSecretInputString({
-      config: params.cfg,
-      env: process.env,
-      value: target.secretInput,
-      path: target.secretConfigPath,
-    }).then((resolved) => resolved.value);
-    secretByTarget.set(target, pending);
-    return pending;
-  };
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
     return await withResolvedWebhookRequestPipeline({
@@ -723,7 +708,14 @@ export function createTaskFlowWebhookRequestHandler(params: {
             if (presentedSecret.length === 0) {
               return false;
             }
-            const resolvedSecret = await resolveTargetSecret(candidate);
+            const resolvedSecret = (
+              await resolveConfiguredSecretInputString({
+                config: params.cfg,
+                env: process.env,
+                value: candidate.secretInput,
+                path: candidate.secretConfigPath,
+              })
+            ).value;
             return Boolean(resolvedSecret && timingSafeEquals(resolvedSecret, presentedSecret));
           },
         });


### PR DESCRIPTION
## Summary

- Problem: the webhooks plugin cached the first resolved SecretRef-backed shared secret for each target and kept reusing it across requests.
- Why it matters: rotating a leaked webhook secret in its backing provider did not revoke the old secret until the gateway process restarted.
- What changed: webhook auth now resolves the configured secret on each request, and the regression test now verifies old secrets stop working after rotation while the new secret is accepted.
- What did NOT change (scope boundary): request routing, rate limiting, in-flight limiting, and webhook action execution are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `createTaskFlowWebhookRequestHandler` memoized the first resolved shared secret in a `WeakMap`, so SecretRef-backed webhook auth stopped re-reading rotated values.
- Missing detection / guardrail: the existing test locked in caching across requests instead of rotation behavior.
- Contributing context (if known): introduced as a webhook auth optimization, but it broke runtime secret rotation semantics.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/webhooks/src/http.test.ts`
- Scenario the test should lock in: a request authenticated with the old SecretRef value succeeds before rotation, fails after rotation, and the rotated secret succeeds on the next request.
- Why this is the smallest reliable guardrail: the regression lives entirely in the request handler auth path and can be reproduced with a mocked secret resolver without broader runtime setup.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- SecretRef-backed webhook shared secrets now take effect on the next request after rotation instead of requiring a process restart.

## Diagram (if applicable)

```text
Before:
[request with old secret] -> [handler cache hit] -> [old secret still accepted after rotation]

After:
[request] -> [re-resolve SecretRef] -> [compare current secret] -> [old secret rejected, rotated secret accepted]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: webhook auth now re-resolves SecretRef-backed secrets per request so runtime rotation and revocation take effect immediately.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js via pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): bundled `webhooks` extension
- Relevant config (redacted): webhook route with SecretRef-backed `secret`

### Steps

1. Configure a webhook route whose `secret` is backed by a SecretRef provider.
2. Authenticate one request with the original secret, then rotate the backing secret value without restarting the process.
3. Send another request with the old secret and one with the rotated secret.

### Expected

- The old secret is rejected after rotation, and the rotated secret is accepted.

### Actual

- Verified by test after the fix.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted webhook handler test for SecretRef rotation, repo `build`, repo `check`.
- Edge cases checked: old secret rejected immediately after rotation; rotated secret accepted on the next request.
- What you did **not** verify: live end-to-end webhook traffic against an external SecretRef provider.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: per-request secret resolution adds a small amount of auth overhead for SecretRef-backed webhook routes.
  - Mitigation: the fix keeps the change scoped to the auth read path and only touches webhook secret resolution.

## AI Assistance

- AI-assisted: Codex
- Testing: targeted test + `pnpm build` + `pnpm check`
