### PR TITLE
fix: export cleanupProvisionalSession function (#68398)

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -222,7 +222,7 @@ function sanitizeMountPathHint(value?: string): string | undefined {
   return trimmed;
 }
 
-export export async function cleanupProvisionalSession(
+export async function cleanupProvisionalSession(
   childSessionKey: string,
   options?: {
     emitLifecycleHooks?: boolean;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -222,7 +222,7 @@ function sanitizeMountPathHint(value?: string): string | undefined {
   return trimmed;
 }
 
-export async function cleanupProvisionalSession(
+export export async function cleanupProvisionalSession(
   childSessionKey: string,
   options?: {
     emitLifecycleHooks?: boolean;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -222,7 +222,7 @@ function sanitizeMountPathHint(value?: string): string | undefined {
   return trimmed;
 }
 
-async function cleanupProvisionalSession(
+export async function cleanupProvisionalSession(
   childSessionKey: string,
   options?: {
     emitLifecycleHooks?: boolean;


### PR DESCRIPTION
## Fix for #68398

### Problem
cleanupProvisionalSession was defined in subagent-spawn.ts but not exported, causing "cleanupProvisionalSession is not defined" errors when called from the subagent-registry chunk at runtime.

### Solution
Export the cleanupProvisionalSession function so it can be properly imported by the registry chunk and other future consumers.

### Changes
- src/agents/subagent-spawn.ts: Changed sync function cleanupProvisionalSession( to export async function cleanupProvisionalSession(`n
> **Note**: The consuming module (registry chunk) may need a corresponding import { cleanupProvisionalSession } statement to fully resolve the runtime error. This PR handles the export side; the import will be addressed in a follow-up if needed.

---

_This PR was submitted as part of the GitHub Bounty Automation project._