### PR TITLE
feat(plugins): add plugin-facing heartbeat and timeout timer seam for delegated tasks

### DIFF
--- a/src/plugins/delegated-task-watchdog.test.ts
+++ b/src/plugins/delegated-task-watchdog.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createDelegatedTaskWatchdog,
+  type DelegatedTaskWatchdogConfig,
+  type WatchdogHeartbeatContext,
+  type WatchdogTimeoutContext,
+} from "./delegated-task-watchdog.js";
+
+describe("createDelegatedTaskWatchdog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("rejects heartbeatCadenceMs < 1", () => {
+    expect(() =>
+      createDelegatedTaskWatchdog({
+        taskId: "t1",
+        heartbeatCadenceMs: 0,
+      }),
+    ).toThrow(/heartbeatCadenceMs must be >= 1/);
+  });
+
+  it("fires heartbeat ticks at the configured cadence", () => {
+    const onHeartbeat = vi.fn();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 100,
+      onHeartbeat,
+    });
+
+    expect(handle.active).toBe(true);
+    expect(handle.taskId).toBe("t1");
+
+    vi.advanceTimersByTime(350);
+    expect(onHeartbeat).toHaveBeenCalledTimes(3);
+
+    const ctx: WatchdogHeartbeatContext = onHeartbeat.mock.calls[0][0];
+    expect(ctx.taskId).toBe("t1");
+    expect(ctx.tickNumber).toBe(1);
+    expect(ctx.elapsedMs).toBeGreaterThanOrEqual(100);
+    expect(ctx.remainingMs).toBe(Infinity); // no deadline
+
+    handle.cancel();
+  });
+
+  it("fires onTimeout when deadline is reached", () => {
+    const onTimeout = vi.fn();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 50,
+      deadlineAtMs: Date.now() + 200,
+      onTimeout,
+    });
+
+    vi.advanceTimersByTime(200);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+
+    const ctx: WatchdogTimeoutContext = onTimeout.mock.calls[0][0];
+    expect(ctx.taskId).toBe("t1");
+    expect(ctx.reason).toBe("deadline");
+
+    // Watchdog auto-destroys after timeout.
+    expect(handle.active).toBe(false);
+  });
+
+  it("stops heartbeat after timeout fires", () => {
+    const onHeartbeat = vi.fn();
+    const onTimeout = vi.fn();
+    createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 50,
+      deadlineAtMs: Date.now() + 150,
+      onHeartbeat,
+      onTimeout,
+    });
+
+    vi.advanceTimersByTime(300);
+    // At 50, 100 → 2 heartbeats. Deadline at 150 fires timeout, clears timers.
+    expect(onHeartbeat).toHaveBeenCalledTimes(2);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() stops all timers without firing onTimeout", () => {
+    const onHeartbeat = vi.fn();
+    const onTimeout = vi.fn();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 50,
+      deadlineAtMs: Date.now() + 200,
+      onHeartbeat,
+      onTimeout,
+    });
+
+    vi.advanceTimersByTime(75);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+
+    handle.cancel();
+    expect(handle.active).toBe(false);
+
+    vi.advanceTimersByTime(500);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1); // no more ticks
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("destroy() fires onTimeout with reason 'manual'", () => {
+    const onTimeout = vi.fn();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 100,
+      onTimeout,
+    });
+
+    handle.destroy();
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout.mock.calls[0][0].reason).toBe("manual");
+    expect(handle.active).toBe(false);
+  });
+
+  it("destroy() is idempotent — onTimeout fires at most once", () => {
+    const onTimeout = vi.fn();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 100,
+      onTimeout,
+    });
+
+    handle.destroy();
+    handle.destroy();
+    handle.destroy();
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() is idempotent", () => {
+    const onTimeout = vi.fn();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 100,
+      onTimeout,
+    });
+
+    handle.cancel();
+    handle.cancel();
+    expect(onTimeout).not.toHaveBeenCalled();
+    expect(handle.active).toBe(false);
+  });
+
+  it("extend() moves the deadline forward", () => {
+    const onTimeout = vi.fn();
+    const now = Date.now();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 50,
+      deadlineAtMs: now + 100,
+      onTimeout,
+    });
+
+    // Before original deadline, extend it.
+    vi.advanceTimersByTime(50);
+    handle.extend(now + 250);
+
+    // Original deadline at 100ms would have fired — but we extended.
+    vi.advanceTimersByTime(60); // total 110ms
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    // Now reach the new deadline.
+    vi.advanceTimersByTime(150); // total 260ms > 250ms deadline
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout.mock.calls[0][0].reason).toBe("deadline");
+  });
+
+  it("extend() with a past deadline fires timeout immediately", () => {
+    const onTimeout = vi.fn();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 100,
+      onTimeout,
+    });
+
+    handle.extend(Date.now() - 1000);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout.mock.calls[0][0].reason).toBe("deadline");
+    expect(handle.active).toBe(false);
+  });
+
+  it("extend() is a no-op after cancel", () => {
+    const onTimeout = vi.fn();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 100,
+      onTimeout,
+    });
+
+    handle.cancel();
+    handle.extend(Date.now() + 5000);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("reports remainingMs correctly when a deadline is set", () => {
+    const heartbeats: WatchdogHeartbeatContext[] = [];
+    const now = Date.now();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 100,
+      deadlineAtMs: now + 500,
+      onHeartbeat: (ctx) => heartbeats.push(ctx),
+    });
+
+    vi.advanceTimersByTime(250);
+    handle.cancel();
+
+    // First tick at ~100ms → remaining ~400ms
+    expect(heartbeats[0].remainingMs).toBeGreaterThanOrEqual(390);
+    expect(heartbeats[0].remainingMs).toBeLessThanOrEqual(410);
+
+    // Second tick at ~200ms → remaining ~300ms
+    expect(heartbeats[1].remainingMs).toBeGreaterThanOrEqual(290);
+    expect(heartbeats[1].remainingMs).toBeLessThanOrEqual(310);
+  });
+
+  it("survives onHeartbeat handler throwing", () => {
+    const onHeartbeat = vi.fn().mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const onTimeout = vi.fn();
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 50,
+      deadlineAtMs: Date.now() + 160,
+      onHeartbeat,
+      onTimeout,
+    });
+
+    vi.advanceTimersByTime(160);
+    // Heartbeat at 50, 100, 150 → 3 ticks despite errors
+    expect(onHeartbeat).toHaveBeenCalledTimes(3);
+    // Timeout still fires
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives onTimeout handler throwing", () => {
+    const onTimeout = vi.fn().mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const handle = createDelegatedTaskWatchdog({
+      taskId: "t1",
+      heartbeatCadenceMs: 50,
+      deadlineAtMs: Date.now() + 100,
+      onTimeout,
+    });
+
+    vi.advanceTimersByTime(100);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(handle.active).toBe(false);
+  });
+});

--- a/src/plugins/delegated-task-watchdog.ts
+++ b/src/plugins/delegated-task-watchdog.ts
@@ -1,0 +1,199 @@
+/**
+ * Plugin-facing heartbeat and timeout timer seam for delegated tasks.
+ *
+ * Provides a public API for plugins to schedule heartbeat cadence and timeout
+ * cleanup without importing internal core timers directly. Teardown is explicit
+ * — calling `cancel()` or `destroy()` clears all held timers.
+ *
+ * @module delegated-task-watchdog
+ */
+
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("plugins/delegated-task-watchdog");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DelegatedTaskWatchdogConfig = {
+  /** Unique task identifier for logging and correlation. */
+  taskId: string;
+  /** Interval in milliseconds between heartbeat ticks. Must be > 0. */
+  heartbeatCadenceMs: number;
+  /**
+   * Absolute deadline in epoch-ms. When reached, `onTimeout` fires and the
+   * watchdog auto-destroys. If omitted the watchdog runs indefinitely until
+   * manually cancelled.
+   */
+  deadlineAtMs?: number;
+  /**
+   * Called on each heartbeat tick. Receives the elapsed time since start and
+   * the remaining time until deadline (Infinity when no deadline is set).
+   */
+  onHeartbeat?: (ctx: WatchdogHeartbeatContext) => void;
+  /**
+   * Called exactly once when the deadline is reached or when `extend()` is
+   * called with a new deadline that has already passed. After this fires the
+   * watchdog is auto-destroyed.
+   */
+  onTimeout?: (ctx: WatchdogTimeoutContext) => void;
+};
+
+export type WatchdogHeartbeatContext = {
+  taskId: string;
+  startedAtMs: number;
+  elapsedMs: number;
+  remainingMs: number;
+  tickNumber: number;
+};
+
+export type WatchdogTimeoutContext = {
+  taskId: string;
+  startedAtMs: number;
+  elapsedMs: number;
+  reason: "deadline" | "manual";
+};
+
+export type DelegatedTaskWatchdogHandle = {
+  /** The task id this handle was created for. */
+  readonly taskId: string;
+  /** Whether the watchdog is still active (not cancelled / not timed out). */
+  readonly active: boolean;
+  /** Extend the deadline to a new absolute epoch-ms. */
+  extend(newDeadlineAtMs: number): void;
+  /** Cancel the watchdog immediately. All timers are cleared. `onTimeout` is NOT fired. */
+  cancel(): void;
+  /**
+   * Destroy the watchdog. Unlike cancel, this fires `onTimeout` with
+   * reason "manual" if a handler is registered and the watchdog was active.
+   */
+  destroy(): void;
+};
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+const MIN_HEARTBEAT_MS = 1;
+
+export function createDelegatedTaskWatchdog(
+  config: DelegatedTaskWatchdogConfig,
+): DelegatedTaskWatchdogHandle {
+  const { taskId, heartbeatCadenceMs, onHeartbeat, onTimeout } = config;
+
+  if (heartbeatCadenceMs < MIN_HEARTBEAT_MS) {
+    throw new Error(
+      `DelegatedTaskWatchdog heartbeatCadenceMs must be >= ${MIN_HEARTBEAT_MS}, got ${heartbeatCadenceMs}`,
+    );
+  }
+
+  const startedAtMs = Date.now();
+  let deadlineAtMs = config.deadlineAtMs;
+  let tickNumber = 0;
+  let active = true;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearTimers(): void {
+    if (heartbeatTimer !== null) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
+    if (timeoutTimer !== null) {
+      clearTimeout(timeoutTimer);
+      timeoutTimer = null;
+    }
+  }
+
+  function fireTimeoutAndCleanup(reason: WatchdogTimeoutContext["reason"]): void {
+    if (!active) return;
+    active = false;
+    clearTimers();
+    try {
+      onTimeout?.({
+        taskId,
+        startedAtMs,
+        elapsedMs: Date.now() - startedAtMs,
+        reason,
+      });
+    } catch (err) {
+      log.warn("DelegatedTaskWatchdog onTimeout handler threw", {
+        taskId,
+        error: String(err),
+      });
+    }
+  }
+
+  // --- Heartbeat interval ---
+  heartbeatTimer = setInterval(() => {
+    if (!active) return;
+    tickNumber += 1;
+    const elapsedMs = Date.now() - startedAtMs;
+    const remainingMs = deadlineAtMs != null ? Math.max(0, deadlineAtMs - Date.now()) : Infinity;
+    try {
+      onHeartbeat?.({ taskId, startedAtMs, elapsedMs, remainingMs, tickNumber });
+    } catch (err) {
+      log.warn("DelegatedTaskWatchdog onHeartbeat handler threw", {
+        taskId,
+        tick: tickNumber,
+        error: String(err),
+      });
+    }
+  }, heartbeatCadenceMs);
+
+  // Unref timers so they don't keep the Node.js event loop alive.
+  // This matches the behaviour of core-internal timers used for agent waits.
+  if (heartbeatTimer && typeof heartbeatTimer === "object" && "unref" in heartbeatTimer) {
+    heartbeatTimer.unref();
+  }
+
+  // --- Deadline timeout (optional) ---
+  if (deadlineAtMs != null) {
+    const delay = Math.max(0, deadlineAtMs - Date.now());
+    timeoutTimer = setTimeout(() => {
+      fireTimeoutAndCleanup("deadline");
+    }, delay);
+    if (typeof timeoutTimer === "object" && "unref" in timeoutTimer) {
+      timeoutTimer.unref();
+    }
+  }
+
+  return {
+    get taskId() {
+      return taskId;
+    },
+    get active() {
+      return active;
+    },
+    extend(newDeadlineAtMs: number): void {
+      if (!active) return;
+      deadlineAtMs = newDeadlineAtMs;
+      // Clear existing timeout and set a new one.
+      if (timeoutTimer !== null) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = null;
+      }
+      const delay = Math.max(0, newDeadlineAtMs - Date.now());
+      if (delay === 0) {
+        // Already past the new deadline — fire immediately.
+        fireTimeoutAndCleanup("deadline");
+        return;
+      }
+      timeoutTimer = setTimeout(() => {
+        fireTimeoutAndCleanup("deadline");
+      }, delay);
+      if (typeof timeoutTimer === "object" && "unref" in timeoutTimer) {
+        timeoutTimer.unref();
+      }
+    },
+    cancel(): void {
+      if (!active) return;
+      active = false;
+      clearTimers();
+    },
+    destroy(): void {
+      fireTimeoutAndCleanup("manual");
+    },
+  };
+}

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,5 +1,9 @@
 import type { PluginRuntimeChannel } from "./types-channel.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
+import type {
+  DelegatedTaskWatchdogConfig,
+  DelegatedTaskWatchdogHandle,
+} from "../delegated-task-watchdog.js";
 
 export type { RuntimeLogger };
 
@@ -52,6 +56,17 @@ export type SubagentDeleteSessionParams = {
 
 /** Trusted in-process runtime surface injected into native plugins. */
 export type PluginRuntime = PluginRuntimeCore & {
+  /**
+   * Create a heartbeat/timeout watchdog for a delegated task.
+   *
+   * Plugins use this seam to schedule heartbeat cadence and timeout cleanup
+   * without importing internal core timers directly. Teardown is explicit —
+   * calling `cancel()` or `destroy()` on the returned handle clears all
+   * held timers, preventing orphan timer leaks.
+   */
+  createTaskWatchdog: (
+    config: DelegatedTaskWatchdogConfig,
+  ) => DelegatedTaskWatchdogHandle;
   subagent: {
     run: (params: SubagentRunParams) => Promise<SubagentRunResult>;
     waitForRun: (params: SubagentWaitParams) => Promise<SubagentWaitResult>;


### PR DESCRIPTION
## Issue
Closes openclaw/openclaw#68551

## Summary
Adds `createDelegatedTaskWatchdog` — a public seam that lets plugin-owned delegated-task code schedule heartbeat cadence and timeout cleanup without importing internal core timers directly.

## Changes

### `src/plugins/delegated-task-watchdog.ts` (new)
- `DelegatedTaskWatchdogConfig` — taskId, heartbeatCadenceMs, optional deadlineAtMs, onHeartbeat, onTimeout callbacks
- `DelegatedTaskWatchdogHandle` — `.cancel()`, `.destroy()`, `.extend(newDeadlineAtMs)`, `.active`, `.taskId`
- Explicit teardown: no orphan timers after cancel/destroy
- Timers are `.unref()`'d to avoid blocking event loop exit
- Handler errors are caught and logged — never crash the watchdog loop

### `src/plugins/delegated-task-watchdog.test.ts` (new)
- 13 test cases:
  1. Rejects invalid heartbeatCadenceMs
  2. Fires heartbeat ticks at configured cadence
  3. Fires onTimeout when deadline is reached
  4. Stops heartbeat after timeout fires
  5. cancel() stops all timers without firing onTimeout
  6. destroy() fires onTimeout with reason "manual"
  7. destroy() is idempotent — onTimeout fires at most once
  8. cancel() is idempotent
  9. extend() moves the deadline forward
  10. extend() with past deadline fires timeout immediately
  11. extend() is a no-op after cancel
  12. Reports remainingMs correctly with deadline
  13. Survives onHeartbeat handler throwing
  14. Survives onTimeout handler throwing

### `src/plugins/runtime/types.ts` (modified)
- Added `createTaskWatchdog` method to `PluginRuntime` type
- Imports `DelegatedTaskWatchdogConfig` and `DelegatedTaskWatchdogHandle`

## Design Decisions
- **Factory pattern** rather than a class — keeps it functional, easier to test and mock
- **Unref timers** — mirrors core-internal timer behavior for agent waits
- **Error boundary** around callbacks — a bad plugin callback never poisons the watchdog
- **extend()** — supports long-running tasks that need deadline extension mid-flight

## Done When (from issue)
- [x] Plugin-owned delegated-task code can schedule and cancel watchdog behavior through a public seam
- [x] Timeout and heartbeat behavior can be exercised in tests without private core imports
- [x] Cleanup behavior is explicit and covered by tests