### PR TITLE
fix(memory-core): resolve runtime artifacts before wiki bridge status

### DIFF
--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -5,6 +5,8 @@ const resolveRuntimePluginRegistryMock =
 const applyPluginAutoEnableMock =
   vi.fn<typeof import("../config/plugin-auto-enable.js").applyPluginAutoEnable>();
 const getMemoryRuntimeMock = vi.fn<typeof import("./memory-state.js").getMemoryRuntime>();
+const registerMemoryCapabilityLoaderMock =
+  vi.fn<typeof import("./memory-state.js").registerMemoryCapabilityLoader>();
 const resolveAgentWorkspaceDirMock =
   vi.fn<typeof import("../agents/agent-scope.js").resolveAgentWorkspaceDir>();
 const resolveDefaultAgentIdMock = vi.fn<
@@ -26,6 +28,7 @@ vi.mock("./loader.js", () => ({
 
 vi.mock("./memory-state.js", () => ({
   getMemoryRuntime: () => getMemoryRuntimeMock(),
+  registerMemoryCapabilityLoader: registerMemoryCapabilityLoaderMock,
 }));
 
 let getActiveMemorySearchManager: typeof import("./memory-runtime.js").getActiveMemorySearchManager;
@@ -126,6 +129,7 @@ describe("memory runtime auto-enable loading", () => {
     resolveRuntimePluginRegistryMock.mockReset();
     applyPluginAutoEnableMock.mockReset();
     getMemoryRuntimeMock.mockReset();
+    registerMemoryCapabilityLoaderMock.mockReset();
     resolveAgentWorkspaceDirMock.mockReset();
     resolveDefaultAgentIdMock.mockClear();
     applyPluginAutoEnableMock.mockImplementation((params) => ({

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveRuntimePluginRegistry } from "./loader.js";
-import { getMemoryRuntime } from "./memory-state.js";
+import { getMemoryRuntime, registerMemoryCapabilityLoader } from "./memory-state.js";
 import {
   buildPluginRuntimeLoadOptions,
   resolvePluginRuntimeLoadContext,
@@ -16,6 +16,10 @@ function ensureMemoryRuntime(cfg?: OpenClawConfig) {
   );
   return getMemoryRuntime();
 }
+
+registerMemoryCapabilityLoader((cfg) => {
+  ensureMemoryRuntime(cfg);
+});
 
 export async function getActiveMemorySearchManager(params: {
   cfg: OpenClawConfig;

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -12,6 +12,7 @@ import {
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
   listActiveMemoryPublicArtifacts,
+  registerMemoryCapabilityLoader,
   registerMemoryCapability,
   registerMemoryCorpusSupplement,
   registerMemoryFlushPlanResolver,
@@ -85,8 +86,7 @@ describe("memory plugin state", () => {
   });
 
   it("lazy-loads plugins when listActiveMemoryPublicArtifacts is called without registered capability", async () => {
-    const loader = await import("./loader.js");
-    const loadSpy = vi.spyOn(loader, "resolveRuntimePluginRegistry").mockImplementation(() => {
+    const loadSpy = vi.fn(() => {
       registerMemoryCapability("memory-core", {
         publicArtifacts: {
           async listArtifacts() {
@@ -103,8 +103,8 @@ describe("memory plugin state", () => {
           },
         },
       });
-      return {} as never;
     });
+    registerMemoryCapabilityLoader(loadSpy);
 
     const cfg = { plugins: {} } as unknown as OpenClawConfig;
     const artifacts = await listActiveMemoryPublicArtifacts({ cfg });
@@ -112,8 +112,6 @@ describe("memory plugin state", () => {
     expect(loadSpy).toHaveBeenCalled();
     expect(artifacts).toHaveLength(1);
     expect(artifacts[0]?.kind).toBe("memory-root");
-
-    loadSpy.mockRestore();
   });
 
   it("returns empty defaults when no memory plugin state is registered", () => {

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   _resetMemoryPluginState,
   buildMemoryPromptSection,
@@ -81,6 +82,38 @@ function registerMemoryState(params: {
 describe("memory plugin state", () => {
   afterEach(() => {
     clearMemoryPluginState();
+  });
+
+  it("lazy-loads plugins when listActiveMemoryPublicArtifacts is called without registered capability", async () => {
+    const loader = await import("./loader.js");
+    const loadSpy = vi.spyOn(loader, "resolveRuntimePluginRegistry").mockImplementation(() => {
+      registerMemoryCapability("memory-core", {
+        publicArtifacts: {
+          async listArtifacts() {
+            return [
+              {
+                kind: "memory-root",
+                workspaceDir: "/tmp/workspace-a",
+                relativePath: "MEMORY.md",
+                absolutePath: "/tmp/workspace-a/MEMORY.md",
+                agentIds: ["main"],
+                contentType: "markdown" as const,
+              },
+            ];
+          },
+        },
+      });
+      return {} as never;
+    });
+
+    const cfg = { plugins: {} } as unknown as OpenClawConfig;
+    const artifacts = await listActiveMemoryPublicArtifacts({ cfg });
+
+    expect(loadSpy).toHaveBeenCalled();
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.kind).toBe("memory-root");
+
+    loadSpy.mockRestore();
   });
 
   it("returns empty defaults when no memory plugin state is registered", () => {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -274,6 +274,16 @@ function cloneMemoryPublicArtifact(
 export async function listActiveMemoryPublicArtifacts(params: {
   cfg: OpenClawConfig;
 }): Promise<MemoryPluginPublicArtifact[]> {
+  if (!memoryPluginState.capability && params.cfg) {
+    const { resolveRuntimePluginRegistry } = await import("./loader.js");
+    const { buildPluginRuntimeLoadOptions, resolvePluginRuntimeLoadContext } =
+      await import("./runtime/load-context.js");
+    if (!memoryPluginState.capability) {
+      resolveRuntimePluginRegistry(
+        buildPluginRuntimeLoadOptions(resolvePluginRuntimeLoadContext({ config: params.cfg })),
+      );
+    }
+  }
   const artifacts =
     (await memoryPluginState.capability?.capability.publicArtifacts?.listArtifacts(params)) ?? [];
   return artifacts.map(cloneMemoryPublicArtifact).toSorted((left, right) => {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -151,10 +151,18 @@ type MemoryPluginState = {
   runtime?: MemoryPluginRuntime;
 };
 
+type MemoryCapabilityLoader = (cfg: OpenClawConfig) => void;
+
 const memoryPluginState: MemoryPluginState = {
   corpusSupplements: [],
   promptSupplements: [],
 };
+
+let memoryCapabilityLoader: MemoryCapabilityLoader | undefined;
+
+export function registerMemoryCapabilityLoader(loader?: MemoryCapabilityLoader): void {
+  memoryCapabilityLoader = loader;
+}
 
 export function registerMemoryCorpusSupplement(
   pluginId: string,
@@ -275,13 +283,9 @@ export async function listActiveMemoryPublicArtifacts(params: {
   cfg: OpenClawConfig;
 }): Promise<MemoryPluginPublicArtifact[]> {
   if (!memoryPluginState.capability && params.cfg) {
-    const { resolveRuntimePluginRegistry } = await import("./loader.js");
-    const { buildPluginRuntimeLoadOptions, resolvePluginRuntimeLoadContext } =
-      await import("./runtime/load-context.js");
+    memoryCapabilityLoader?.(params.cfg);
     if (!memoryPluginState.capability) {
-      resolveRuntimePluginRegistry(
-        buildPluginRuntimeLoadOptions(resolvePluginRuntimeLoadContext({ config: params.cfg })),
-      );
+      memoryCapabilityLoader?.(params.cfg);
     }
   }
   const artifacts =
@@ -332,6 +336,7 @@ export function clearMemoryPluginState(): void {
   memoryPluginState.promptSupplements = [];
   memoryPluginState.flushPlanResolver = undefined;
   memoryPluginState.runtime = undefined;
+  memoryCapabilityLoader = undefined;
 }
 
 export const _resetMemoryPluginState = clearMemoryPluginState;


### PR DESCRIPTION
## Summary
- ensure active memory runtime artifacts are loaded before bridge-based wiki status/import paths query public artifacts
- make the runtime bridge path self-heal from config instead of depending on prior runtime registry state

## Why
The local deployment carried a bundle-level patch so wiki bridge status/import commands would see active memory public artifacts reliably. The root issue is broader than the memory-wiki CLI: the helper that lists active memory public artifacts should ensure the memory runtime is loaded when cfg is available.

## Validation
- focused memory-wiki gateway/status tests passed locally (14/14)
