### PR TITLE
fix(telegram): avoid wedging callback updates on permanent edit errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/channels: route cross-agent subagent spawns through the target agent's bound channel account while preserving peer and workspace/role-scoped bindings, so child sessions no longer inherit the caller's account in shared rooms, workspaces, or multi-account setups. (#67508) Thanks @lukeboyett and @gumadeiras.
+- Telegram/callbacks: treat permanent callback edit errors as completed updates so stale command pagination buttons no longer wedge the update watermark and block newer Telegram updates. (#68588) Thanks @Lucenx9.
 
 ## 2026.4.18
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -674,6 +674,12 @@ export const registerTelegramHandlers = ({
     }
   }
 
+  const TELEGRAM_PERMANENT_CALLBACK_EDIT_ERROR_RE =
+    /400:\s*Bad Request:\s*message to edit not found|400:\s*Bad Request:\s*there is no text in the message to edit|MESSAGE_ID_INVALID|message can't be edited/i;
+
+  const isPermanentTelegramCallbackEditError = (err: unknown): boolean =>
+    TELEGRAM_PERMANENT_CALLBACK_EDIT_ERROR_RE.test(String(err));
+
   const resolveTelegramEventAuthorizationContext = async (params: {
     chatId: number;
     isGroup: boolean;
@@ -1672,10 +1678,15 @@ export const registerTelegramHandlers = ({
         messageIdOverride: callback.id,
       });
     } catch (err) {
-      runtime.error?.(danger(`callback handler failed: ${String(err)}`));
       if (err instanceof TelegramRetryableCallbackError) {
+        if (isPermanentTelegramCallbackEditError(err.cause)) {
+          logVerbose(`telegram: swallowing permanent callback edit error: ${String(err.cause)}`);
+          return;
+        }
+        runtime.error?.(danger(`callback handler failed: ${String(err)}`));
         throw err.cause;
       }
+      runtime.error?.(danger(`callback handler failed: ${String(err)}`));
     }
   });
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -675,7 +675,7 @@ export const registerTelegramHandlers = ({
   }
 
   const TELEGRAM_PERMANENT_CALLBACK_EDIT_ERROR_RE =
-    /400:\s*Bad Request:\s*message to edit not found|400:\s*Bad Request:\s*there is no text in the message to edit|MESSAGE_ID_INVALID|message can't be edited/i;
+    /400:\s*Bad Request:\s*message to edit not found|400:\s*Bad Request:\s*there is no text in the message to edit|MESSAGE_ID_INVALID|400:\s*Bad Request:\s*message can't be edited/i;
 
   const isPermanentTelegramCallbackEditError = (err: unknown): boolean =>
     TELEGRAM_PERMANENT_CALLBACK_EDIT_ERROR_RE.test(String(err));

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -3328,6 +3328,62 @@ describe("createTelegramBot", () => {
     expect(editMessageTextSpy.mock.calls.at(-1)?.[2]).toContain("Commands (2/");
   });
 
+  it("treats permanent command pagination edit failures as completed updates", async () => {
+    sequentializeSpy.mockImplementationOnce(
+      () => async (_ctx: unknown, next: () => Promise<void>) => {
+        await next();
+      },
+    );
+
+    const onUpdateId = vi.fn();
+    createTelegramBot({
+      token: "tok",
+      updateOffset: {
+        lastUpdateId: 776,
+        onUpdateId,
+      },
+    });
+
+    const callbackHandler = getOnHandler("callback_query");
+    const ctx = {
+      update: { update_id: 777 },
+      callbackQuery: {
+        id: "cbq-commands-permanent-edit-1",
+        data: "commands_page_2:main",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 20,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    };
+
+    editMessageTextSpy.mockRejectedValueOnce(
+      new Error("400: Bad Request: message can't be edited"),
+    );
+
+    await expect(
+      runTelegramMiddlewareChain({
+        ctx,
+        finalHandler: callbackHandler,
+      }),
+    ).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(onUpdateId).toHaveBeenCalledWith(777);
+    });
+
+    await runTelegramMiddlewareChain({
+      ctx,
+      finalHandler: callbackHandler,
+    });
+
+    expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("retries command pagination callbacks after a bubbled preflight failure", async () => {
     const listSkillCommandsMock = listSkillCommandsForAgents as unknown as ReturnType<typeof vi.fn>;
     listSkillCommandsMock.mockClear();

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -3384,6 +3384,43 @@ describe("createTelegramBot", () => {
     expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("does not swallow unprefixed command pagination edit failures", async () => {
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query");
+
+    const ctx = {
+      update: { update_id: 778 },
+      callbackQuery: {
+        id: "cbq-commands-non-telegram-edit-1",
+        data: "commands_page_2:main",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 21,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    };
+
+    editMessageTextSpy.mockRejectedValueOnce(new Error("message can't be edited"));
+
+    await expect(
+      runTelegramMiddlewareChain({
+        ctx,
+        finalHandler: callbackHandler,
+      }),
+    ).rejects.toThrow("message can't be edited");
+
+    await runTelegramMiddlewareChain({
+      ctx,
+      finalHandler: callbackHandler,
+    });
+
+    expect(editMessageTextSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("retries command pagination callbacks after a bubbled preflight failure", async () => {
     const listSkillCommandsMock = listSkillCommandsForAgents as unknown as ReturnType<typeof vi.fn>;
     listSkillCommandsMock.mockClear();


### PR DESCRIPTION
## Summary

- Problem: Telegram callback pagination treated every edit failure as retryable, including permanent Telegram edit errors.
- Why it matters: a permanently failing callback update stayed in `failedUpdateIds`, so the persisted watermark stopped advancing and newer updates could be replay-blocked.
- What changed: permanent callback edit failures are now treated as completed callback updates instead of being rethrown into the middleware retry path, and a regression test locks that behavior in.
- What did NOT change (scope boundary): retry behavior for genuinely transient callback failures remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: callback edit failures were wrapped as `TelegramRetryableCallbackError` and then always rethrown into the update middleware, even when Telegram had returned a permanent edit error such as `message can't be edited`.
- Missing detection / guardrail: callback handling did not distinguish permanent Telegram edit failures from transient ones before feeding them into the failed-update watermark logic.
- Contributing context (if known): the middleware intentionally blocks watermark advancement across failed updates, so misclassifying a permanent callback edit error wedges later updates behind it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/bot.create-telegram-bot.test.ts`
- Scenario the test should lock in: a commands pagination callback that hits `400: Bad Request: message can't be edited` should complete the update, advance the watermark, and not be retried on the next poll cycle.
- Why this is the smallest reliable guardrail: it exercises the real callback handler plus the update watermark middleware without needing external Telegram infrastructure.
- Existing test that already covers this (if any): the adjacent retry test covers transient bubbled edit failures.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram pagination callbacks from stale or otherwise uneditable messages no longer wedge later Telegram updates behind a permanently failing edit.

## Diagram (if applicable)

```text
Before:
[old callback button] -> [permanent edit error] -> [update marked failed] -> [watermark stalls]

After:
[old callback button] -> [permanent edit error] -> [callback treated as completed] -> [watermark advances]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu Linux
- Runtime/container: Node.js + pnpm workspace checkout
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): default Telegram bot test harness

### Steps

1. Trigger a `commands_page_*` callback for an older Telegram message that can no longer be edited.
2. Let `editMessageText` return a permanent Telegram error such as `400: Bad Request: message can't be edited`.
3. Observe whether the middleware treats the update as failed or completed.

### Expected

- The callback should not wedge the Telegram update watermark on a permanent edit failure.

### Actual

- Before this change, the callback was retried as a failed update and could block later updates.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Telegram bot tests, Telegram extension test suite, full `pnpm build`, and full `pnpm check`.
- Edge cases checked: transient callback edit failures still bubble through the existing retry path; permanent Telegram edit errors are swallowed only for retryable callback edit wrappers.
- What you did **not** verify: live Telegram API behavior against a real bot token.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: swallowing too many callback edit errors could hide a transient Telegram outage.
  - Mitigation: only known permanent edit error strings are swallowed; other retryable callback failures still propagate.

AI-assisted: yes.