### PR TITLE
fix(cli): skip sessions warmup for non-TTY output

### DIFF
--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -216,6 +216,18 @@ describe("lookupContextTokens", () => {
           expectedCalls: 0,
         },
         {
+          argv: ["node", "openclaw", "sessions"],
+          expectedCalls: 0,
+        },
+        {
+          argv: ["node", "openclaw", "sessions", "--json"],
+          expectedCalls: 0,
+        },
+        {
+          argv: ["node", "openclaw", "sessions", "--active", "10"],
+          expectedCalls: 0,
+        },
+        {
           argv: ["node", "scripts/test-built-plugin-singleton.mjs"],
           expectedCalls: 0,
         },

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -97,6 +97,23 @@ async function importResolveContextTokensForModel() {
   return resolveContextTokensForModel;
 }
 
+function setStdoutIsTTY(value: boolean): () => void {
+  const stdout = process.stdout as NodeJS.WriteStream & { isTTY?: boolean };
+  const hadOwnIsTTY = Object.prototype.hasOwnProperty.call(stdout, "isTTY");
+  const previousIsTTYDescriptor = Object.getOwnPropertyDescriptor(stdout, "isTTY");
+  Object.defineProperty(stdout, "isTTY", {
+    value,
+    configurable: true,
+  });
+  return () => {
+    if (hadOwnIsTTY && previousIsTTYDescriptor) {
+      Object.defineProperty(stdout, "isTTY", previousIsTTYDescriptor);
+      return;
+    }
+    delete stdout.isTTY;
+  };
+}
+
 describe("lookupContextTokens", () => {
   beforeAll(async () => {
     contextModule = await import("./context.js");
@@ -216,16 +233,14 @@ describe("lookupContextTokens", () => {
           expectedCalls: 0,
         },
         {
-          argv: ["node", "openclaw", "sessions"],
-          expectedCalls: 0,
+          argv: ["node", "openclaw", "sessions", "--json"],
+          expectedCalls: 1,
+          stdoutIsTTY: true,
         },
         {
           argv: ["node", "openclaw", "sessions", "--json"],
           expectedCalls: 0,
-        },
-        {
-          argv: ["node", "openclaw", "sessions", "--active", "10"],
-          expectedCalls: 0,
+          stdoutIsTTY: false,
         },
         {
           argv: ["node", "scripts/test-built-plugin-singleton.mjs"],
@@ -234,10 +249,21 @@ describe("lookupContextTokens", () => {
       ]) {
         const loadConfigMock = vi.fn(() => ({ models: {} }));
         const { ensureOpenClawModelsJson } = mockContextModuleDeps(loadConfigMock);
+        contextModule.resetContextWindowCacheForTest();
         process.argv = scenario.argv;
-        await importFreshContextModule();
-        expect(loadConfigMock).toHaveBeenCalledTimes(scenario.expectedCalls);
-        expect(ensureOpenClawModelsJson).toHaveBeenCalledTimes(scenario.expectedCalls);
+        const restoreStdoutIsTTY =
+          typeof scenario.stdoutIsTTY === "boolean" ? setStdoutIsTTY(scenario.stdoutIsTTY) : null;
+        try {
+          await importFreshContextModule();
+        } finally {
+          restoreStdoutIsTTY?.();
+        }
+        expect(loadConfigMock, scenario.argv.join(" ")).toHaveBeenCalledTimes(
+          scenario.expectedCalls,
+        );
+        expect(ensureOpenClawModelsJson, scenario.argv.join(" ")).toHaveBeenCalledTimes(
+          scenario.expectedCalls,
+        );
       }
     } finally {
       process.argv = argvSnapshot;

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -24,6 +24,10 @@ vi.mock("./models-config.js", () => ({
   ensureOpenClawModelsJson: contextTestState.ensureOpenClawModelsJson,
 }));
 
+vi.mock("./models-config.runtime.js", () => ({
+  ensureOpenClawModelsJson: contextTestState.ensureOpenClawModelsJson,
+}));
+
 vi.mock("./agent-paths.js", () => ({
   resolveOpenClawAgentDir: () => "/tmp/openclaw-agent",
 }));
@@ -223,12 +227,12 @@ describe("lookupContextTokens", () => {
         },
         {
           argv: ["node", "openclaw", "chat"],
-          expectedCalls: 0,
+          expectedCalls: 1,
           stdoutIsTTY: false,
         },
         {
           argv: ["node", "openclaw", "chat"],
-          expectedCalls: 0,
+          expectedCalls: 1,
           stdoutIsTTY: undefined,
         },
         {
@@ -245,7 +249,7 @@ describe("lookupContextTokens", () => {
         },
         {
           argv: ["node", "openclaw", "sessions"],
-          expectedCalls: 0,
+          expectedCalls: 1,
           stdoutIsTTY: true,
         },
         {
@@ -255,7 +259,7 @@ describe("lookupContextTokens", () => {
         },
         {
           argv: ["node", "openclaw", "sessions", "--json"],
-          expectedCalls: 0,
+          expectedCalls: 1,
           stdoutIsTTY: true,
         },
         {
@@ -265,8 +269,13 @@ describe("lookupContextTokens", () => {
         },
         {
           argv: ["node", "openclaw", "sessions", "cleanup", "--dry-run"],
-          expectedCalls: 0,
+          expectedCalls: 1,
           stdoutIsTTY: true,
+        },
+        {
+          argv: ["node", "openclaw", "sessions", "cleanup", "--dry-run"],
+          expectedCalls: 0,
+          stdoutIsTTY: false,
         },
         {
           argv: ["node", "scripts/test-built-plugin-singleton.mjs"],
@@ -275,12 +284,14 @@ describe("lookupContextTokens", () => {
       ]) {
         const loadConfigMock = vi.fn(() => ({ models: {} }));
         const { ensureOpenClawModelsJson } = mockContextModuleDeps(loadConfigMock);
+        contextModule.resetContextWindowCacheForTest();
         process.argv = scenario.argv;
         const restoreStdoutIsTTY = Object.prototype.hasOwnProperty.call(scenario, "stdoutIsTTY")
           ? setStdoutIsTTY(scenario.stdoutIsTTY)
           : null;
         try {
           await importFreshContextModule();
+          await flushAsyncWarmup();
         } finally {
           restoreStdoutIsTTY?.();
         }

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -110,7 +110,7 @@ function setStdoutIsTTY(value: boolean): () => void {
       Object.defineProperty(stdout, "isTTY", previousIsTTYDescriptor);
       return;
     }
-    delete stdout.isTTY;
+    Reflect.deleteProperty(stdout as { isTTY?: boolean }, "isTTY");
   };
 }
 

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -97,7 +97,7 @@ async function importResolveContextTokensForModel() {
   return resolveContextTokensForModel;
 }
 
-function setStdoutIsTTY(value: boolean): () => void {
+function setStdoutIsTTY(value: boolean | undefined): () => void {
   const stdout = process.stdout as NodeJS.WriteStream & { isTTY?: boolean };
   const hadOwnIsTTY = Object.prototype.hasOwnProperty.call(stdout, "isTTY");
   const previousIsTTYDescriptor = Object.getOwnPropertyDescriptor(stdout, "isTTY");
@@ -219,6 +219,17 @@ describe("lookupContextTokens", () => {
         {
           argv: ["node", "openclaw", "chat"],
           expectedCalls: 1,
+          stdoutIsTTY: true,
+        },
+        {
+          argv: ["node", "openclaw", "chat"],
+          expectedCalls: 0,
+          stdoutIsTTY: false,
+        },
+        {
+          argv: ["node", "openclaw", "chat"],
+          expectedCalls: 0,
+          stdoutIsTTY: undefined,
         },
         {
           argv: ["node", "openclaw", "--profile", "--", "config", "validate"],
@@ -233,8 +244,18 @@ describe("lookupContextTokens", () => {
           expectedCalls: 0,
         },
         {
+          argv: ["node", "openclaw", "sessions"],
+          expectedCalls: 0,
+          stdoutIsTTY: true,
+        },
+        {
+          argv: ["node", "openclaw", "sessions"],
+          expectedCalls: 0,
+          stdoutIsTTY: false,
+        },
+        {
           argv: ["node", "openclaw", "sessions", "--json"],
-          expectedCalls: 1,
+          expectedCalls: 0,
           stdoutIsTTY: true,
         },
         {
@@ -243,16 +264,21 @@ describe("lookupContextTokens", () => {
           stdoutIsTTY: false,
         },
         {
+          argv: ["node", "openclaw", "sessions", "cleanup", "--dry-run"],
+          expectedCalls: 0,
+          stdoutIsTTY: true,
+        },
+        {
           argv: ["node", "scripts/test-built-plugin-singleton.mjs"],
           expectedCalls: 0,
         },
       ]) {
         const loadConfigMock = vi.fn(() => ({ models: {} }));
         const { ensureOpenClawModelsJson } = mockContextModuleDeps(loadConfigMock);
-        contextModule.resetContextWindowCacheForTest();
         process.argv = scenario.argv;
-        const restoreStdoutIsTTY =
-          typeof scenario.stdoutIsTTY === "boolean" ? setStdoutIsTTY(scenario.stdoutIsTTY) : null;
+        const restoreStdoutIsTTY = Object.prototype.hasOwnProperty.call(scenario, "stdoutIsTTY")
+          ? setStdoutIsTTY(scenario.stdoutIsTTY)
+          : null;
         try {
           await importFreshContextModule();
         } finally {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -140,7 +140,6 @@ const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
   "models",
   "plugins",
   "secrets",
-  "sessions",
   "status",
   "update",
   "webhooks",
@@ -161,11 +160,11 @@ function shouldEagerWarmContextWindowCache(argv: string[] = process.argv): boole
   if (!primary || SKIP_EAGER_WARMUP_PRIMARY_COMMANDS.has(primary)) {
     return false;
   }
-  // Non-interactive CLI runs should avoid import-time warmup because bundled
-  // model discovery can leave active AWS SDK credential-provider FS/DNS work
-  // alive after the command has already written its output.
   const stdoutIsTTY = Reflect.get(process.stdout, "isTTY") as boolean | undefined;
-  if (stdoutIsTTY !== true) {
+  // Captured sessions commands can finish writing output while bundled model
+  // discovery still has active AWS SDK credential-provider FS/DNS work alive.
+  // Keep TTY sessions warmup so display paths can still benefit from discovery.
+  if (primary === "sessions" && stdoutIsTTY !== true) {
     return false;
   }
   return true;

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -140,7 +140,6 @@ const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
   "models",
   "plugins",
   "secrets",
-  "sessions",
   "status",
   "update",
   "webhooks",
@@ -158,6 +157,9 @@ function shouldEagerWarmContextWindowCache(argv: string[] = process.argv): boole
     return false;
   }
   const [primary] = getCommandPathFromArgv(argv);
+  if (primary === "sessions" && argv.includes("--json") && !process.stdout.isTTY) {
+    return false;
+  }
   return Boolean(primary) && !SKIP_EAGER_WARMUP_PRIMARY_COMMANDS.has(primary);
 }
 

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -140,6 +140,7 @@ const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
   "models",
   "plugins",
   "secrets",
+  "sessions",
   "status",
   "update",
   "webhooks",

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -140,6 +140,7 @@ const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
   "models",
   "plugins",
   "secrets",
+  "sessions",
   "status",
   "update",
   "webhooks",
@@ -157,10 +158,17 @@ function shouldEagerWarmContextWindowCache(argv: string[] = process.argv): boole
     return false;
   }
   const [primary] = getCommandPathFromArgv(argv);
-  if (primary === "sessions" && argv.includes("--json") && !process.stdout.isTTY) {
+  if (!primary || SKIP_EAGER_WARMUP_PRIMARY_COMMANDS.has(primary)) {
     return false;
   }
-  return Boolean(primary) && !SKIP_EAGER_WARMUP_PRIMARY_COMMANDS.has(primary);
+  // Non-interactive CLI runs should avoid import-time warmup because bundled
+  // model discovery can leave active AWS SDK credential-provider FS/DNS work
+  // alive after the command has already written its output.
+  const stdoutIsTTY = Reflect.get(process.stdout, "isTTY") as boolean | undefined;
+  if (stdoutIsTTY !== true) {
+    return false;
+  }
+  return true;
 }
 
 function primeConfiguredContextWindows(): OpenClawConfig | undefined {


### PR DESCRIPTION
## Summary
Fixes #62076.

This avoids import-time eager context warmup for captured `sessions` command output:
- skip eager warmup for the `sessions` command family when stdout is not a TTY
- keep eager warmup for interactive/TTY `sessions` runs
- keep eager warmup behavior for other startup commands, including non-TTY `chat`

## Why
`openclaw sessions --json` can write valid JSON in redirected/captured runs, but the process can remain alive afterward.

On the PR base, `why-is-node-running` showed active AWS SDK credential-provider work from bundled Amazon Bedrock/Mantle model discovery: `FSREQPROMISE` under `@smithy/shared-ini-file-loader` via `@aws-sdk/credential-provider-ini` / `credential-provider-node`, plus a `DNSCHANNEL`.

The earlier `sessions --json`-only guard was too narrow: plain `sessions` in non-TTY output could also write its output and then remain alive.

The final boundary skips import-time warmup for non-TTY `sessions` command-family runs, while preserving discovery warmup for TTY sessions display paths and for non-sessions automation.

## Scope
This remains focused:
- no global non-TTY warmup gate
- no provider discovery changes
- no `.unref()` changes inside bundled provider code
- no model selection redesign
- no session/cron architecture changes
- no change to TTY eager warmup for `sessions` or other non-skipped startup commands

## Testing
Passed:
- `corepack pnpm run check`
- `corepack pnpm run format:check`
- `corepack pnpm run lint`
- `corepack pnpm run tsgo`
- `node scripts/test-projects.mjs src/agents/context.lookup.test.ts`
- `node scripts/test-projects.mjs src/cli/program/register.status-health-sessions.test.ts src/commands/sessions.test.ts src/commands/sessions.model-resolution.test.ts src/config/io.owner-display-secret.test.ts`
- `node scripts/tsdown-build.mjs`
- `node scripts/runtime-postbuild.mjs`
- isolated source-entry capture checks for `sessions` and `sessions --json`
- isolated built-entry capture checks for `sessions` and `sessions --json`
