### PR TITLE
docs: extend assistant-first framing to feature and help hubs

### DIFF
--- a/docs/concepts/features.md
+++ b/docs/concepts/features.md
@@ -1,5 +1,5 @@
 ---
-summary: "OpenClaw capabilities across channels, routing, media, and UX."
+summary: "OpenClaw assistant capabilities across channels, routing, media, and UX."
 read_when:
   - You want a full list of what OpenClaw supports
 title: "Features"
@@ -11,7 +11,7 @@ title: "Features"
 
 <Columns>
   <Card title="Channels" icon="message-square">
-    Discord, iMessage, Signal, Slack, Telegram, WhatsApp, WebChat, and more with a single Gateway.
+    Message your OpenClaw assistant across Discord, iMessage, Signal, Slack, Telegram, WhatsApp, WebChat, and more.
   </Card>
   <Card title="Plugins" icon="plug">
     Bundled plugins add Matrix, Nextcloud Talk, Nostr, Twitch, Zalo, and more without separate installs in normal current releases.
@@ -23,7 +23,7 @@ title: "Features"
     Images, audio, video, documents, and image/video generation.
   </Card>
   <Card title="Apps and UI" icon="monitor">
-    Web Control UI and macOS companion app.
+    Web Control UI and companion apps for interacting with your assistant.
   </Card>
   <Card title="Mobile nodes" icon="smartphone">
     iOS and Android nodes with pairing, voice/chat, and rich device commands.

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -1,5 +1,5 @@
 ---
-summary: "Help hub: common fixes, install sanity, and where to look when something breaks"
+summary: "Help hub for fixing setup and runtime issues with your OpenClaw assistant"
 read_when:
   - You’re new and want the “what do I click/run” guide
   - Something broke and you want the fastest path to a fix
@@ -8,7 +8,7 @@ title: "Help"
 
 # Help
 
-If you want a quick “get unstuck” flow, start here:
+If you want a quick way to get your assistant working again, start here:
 
 - **Troubleshooting:** [Start here](/help/troubleshooting)
 - **Install sanity (Node/npm/PATH):** [Install](/install/node#troubleshooting)

--- a/docs/start/docs-directory.md
+++ b/docs/start/docs-directory.md
@@ -1,5 +1,5 @@
 ---
-summary: "Curated links to the most used OpenClaw docs."
+summary: "Curated links to the most used docs for setting up and using OpenClaw."
 read_when:
   - You want quick access to key docs pages
 title: "Docs directory"
@@ -8,7 +8,7 @@ title: "Docs directory"
 # Docs Directory
 
 <Note>
-This page is a curated index. If you are new, start with [Getting Started](/start/getting-started).
+This page is a curated index for the docs most people need first. If you are new, start with [Getting Started](/start/getting-started).
 For a complete map of the docs, see [Docs hubs](/start/hubs).
 </Note>
 


### PR DESCRIPTION
## Summary

This follow-up PR extends the assistant-first docs pass to a few additional user-facing docs hubs.

## What changed

Updated:
- docs/concepts/features.md
- docs/help/index.md
- docs/start/docs-directory.md

## Notes

Docs-only change. No functional changes.
