### PR TITLE
fix(whatsapp): keep typing active through inbound acceptance and debounce

### DIFF
--- a/extensions/whatsapp/src/auto-reply.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.test-harness.ts
@@ -189,12 +189,22 @@ export function createWebListenerFactoryCapture(): AnyExport {
         onMessage: (msg: WebInboundMessage) => Promise<void>;
         debounceMs?: number;
         selfChatMode?: boolean;
+        shouldStartDebounceTyping?: (
+          msg: WebInboundMessage,
+        ) =>
+          | boolean
+          | Promise<boolean>
+          | { shouldStart: boolean }
+          | Promise<{ shouldStart: boolean }>;
       }
     | undefined;
   const listenerFactory = async (opts: {
     onMessage: (msg: WebInboundMessage) => Promise<void>;
     debounceMs?: number;
     selfChatMode?: boolean;
+    shouldStartDebounceTyping?: (
+      msg: WebInboundMessage,
+    ) => boolean | Promise<boolean> | { shouldStart: boolean } | Promise<{ shouldStart: boolean }>;
   }) => {
     capturedOnMessage = opts.onMessage;
     capturedOptions = opts;

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -2,6 +2,7 @@ import "./test-helpers.js";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
 import { withEnvAsync } from "openclaw/plugin-sdk/testing";
 import { beforeAll, describe, expect, it, vi } from "vitest";
@@ -62,6 +63,20 @@ async function startWatchdogScenario(params: {
   });
 
   return { scripted, sleep, spies, ...started };
+}
+
+function readDebounceTypingDecision(
+  decision:
+    | boolean
+    | {
+        shouldStart: boolean;
+      }
+    | undefined,
+): boolean | undefined {
+  if (typeof decision === "object" && decision !== null) {
+    return decision.shouldStart;
+  }
+  return decision;
 }
 
 describe("web auto-reply connection", () => {
@@ -399,6 +414,276 @@ describe("web auto-reply connection", () => {
     expect(capture.getLastOptions()?.debounceMs).toBe(250);
   });
 
+  it("suppresses debounce typing when send policy denies delivery", async () => {
+    const capture = createWebListenerFactoryCapture();
+
+    setLoadConfigMock({
+      session: {
+        sendPolicy: {
+          default: "deny",
+        },
+      },
+      channels: {
+        whatsapp: {
+          debounceMs: 250,
+          allowFrom: ["*"],
+        },
+      },
+    } as OpenClawConfig);
+
+    await monitorWebChannel(false, capture.listenerFactory as never, false, async () => ({
+      text: "ok",
+    }));
+
+    const shouldStartDebounceTyping = capture.getLastOptions()?.shouldStartDebounceTyping;
+    expect(shouldStartDebounceTyping).toBeTypeOf("function");
+    await expect(
+      Promise.resolve(
+        shouldStartDebounceTyping?.({
+          body: "hello",
+          from: "+15550001111",
+          conversationId: "+15550001111",
+          to: "+15550009999",
+          accountId: "default",
+          chatType: "direct",
+          chatId: "direct:+15550001111",
+          id: "m1",
+          sendComposing: vi.fn(),
+          reply: vi.fn(),
+          sendMedia: vi.fn(),
+        } as never),
+      ).then(readDebounceTypingDecision),
+    ).resolves.toBe(false);
+
+    resetLoadConfigMock();
+  });
+
+  it("suppresses debounce typing for silent unauthorized whole-message commands", async () => {
+    const capture = createWebListenerFactoryCapture();
+
+    setLoadConfigMock({
+      channels: {
+        whatsapp: {
+          debounceMs: 250,
+          dmPolicy: "open",
+        },
+      },
+    } as OpenClawConfig);
+
+    await monitorWebChannel(false, capture.listenerFactory as never, false, async () => ({
+      text: "ok",
+    }));
+
+    const shouldStartDebounceTyping = capture.getLastOptions()?.shouldStartDebounceTyping;
+    expect(shouldStartDebounceTyping).toBeTypeOf("function");
+    await expect(
+      Promise.resolve(
+        shouldStartDebounceTyping?.({
+          body: "/reset",
+          from: "+15550001111",
+          conversationId: "+15550001111",
+          to: "+15550009999",
+          accountId: "default",
+          chatType: "direct",
+          chatId: "direct:+15550001111",
+          id: "m1",
+          sendComposing: vi.fn(),
+          reply: vi.fn(),
+          sendMedia: vi.fn(),
+        } as never),
+      ).then(readDebounceTypingDecision),
+    ).resolves.toBe(false);
+
+    resetLoadConfigMock();
+  });
+
+  it("suppresses debounce typing for owner-gated commands from non-owners", async () => {
+    const capture = createWebListenerFactoryCapture();
+
+    setLoadConfigMock({
+      commands: {
+        config: true,
+        ownerAllowFrom: ["whatsapp:+15550009999"],
+      },
+      channels: {
+        whatsapp: {
+          debounceMs: 250,
+          allowFrom: ["*"],
+        },
+      },
+    } as OpenClawConfig);
+
+    await monitorWebChannel(false, capture.listenerFactory as never, false, async () => ({
+      text: "ok",
+    }));
+
+    const shouldStartDebounceTyping = capture.getLastOptions()?.shouldStartDebounceTyping;
+    expect(shouldStartDebounceTyping).toBeTypeOf("function");
+    await expect(
+      Promise.resolve(
+        shouldStartDebounceTyping?.({
+          body: "/config show",
+          from: "+15550001111",
+          conversationId: "+15550001111",
+          to: "+15550009999",
+          accountId: "default",
+          chatType: "direct",
+          chatId: "direct:+15550001111",
+          id: "m1",
+          sendComposing: vi.fn(),
+          reply: vi.fn(),
+          sendMedia: vi.fn(),
+        } as never),
+      ).then(readDebounceTypingDecision),
+    ).resolves.toBe(false);
+
+    resetLoadConfigMock();
+  });
+
+  it("suppresses debounce typing for echo-filtered inbound text", async () => {
+    const capture = createWebListenerFactoryCapture();
+    const replyResolver = vi.fn(async () => ({ text: "echo me" }));
+
+    setLoadConfigMock({
+      channels: {
+        whatsapp: {
+          debounceMs: 250,
+          allowFrom: ["*"],
+        },
+      },
+    } as OpenClawConfig);
+
+    await monitorWebChannel(false, capture.listenerFactory as never, false, replyResolver);
+
+    const capturedOnMessage = capture.getOnMessage();
+    expect(capturedOnMessage).toBeTypeOf("function");
+    await sendWebDirectInboundMessage({
+      onMessage: capturedOnMessage!,
+      body: "hello",
+      from: "+15550001111",
+      to: "+15550009999",
+      id: "seed-echo",
+      spies: {
+        sendMedia: vi.fn(),
+        reply: vi.fn().mockResolvedValue(undefined),
+        sendComposing: vi.fn(),
+      },
+    });
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+
+    const shouldStartDebounceTyping = capture.getLastOptions()?.shouldStartDebounceTyping;
+    expect(shouldStartDebounceTyping).toBeTypeOf("function");
+    await expect(
+      Promise.resolve(
+        shouldStartDebounceTyping?.({
+          body: "echo me",
+          from: "+15550001111",
+          conversationId: "+15550001111",
+          to: "+15550009999",
+          accountId: "default",
+          chatType: "direct",
+          chatId: "direct:+15550001111",
+          id: "m1",
+          sendComposing: vi.fn(),
+          reply: vi.fn(),
+          sendMedia: vi.fn(),
+        } as never),
+      ).then(readDebounceTypingDecision),
+    ).resolves.toBe(false);
+
+    resetLoadConfigMock();
+  });
+
+  it("suppresses debounce typing for combined-echo duplicate direct turns", async () => {
+    const capture = createWebListenerFactoryCapture();
+    const replyResolver = vi.fn(async () => ({ text: "ok" }));
+    const timestamp = Date.UTC(2026, 3, 20, 12, 0, 0);
+    const cfg = {
+      session: {
+        store: "",
+      },
+      channels: {
+        whatsapp: {
+          debounceMs: 250,
+          allowFrom: ["*"],
+        },
+      },
+    } satisfies OpenClawConfig;
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: "default",
+      peer: {
+        kind: "direct",
+        id: "+15550001111",
+      },
+    });
+    const store = await makeSessionStore({
+      [route.sessionKey]: {
+        sessionId: "sid",
+        updatedAt: timestamp,
+      },
+    });
+    cfg.session.store = store.storePath;
+
+    try {
+      setLoadConfigMock(cfg);
+
+      await monitorWebChannel(false, capture.listenerFactory as never, false, replyResolver);
+
+      const capturedOnMessage = capture.getOnMessage();
+      expect(capturedOnMessage).toBeTypeOf("function");
+      await sendWebDirectInboundMessage({
+        onMessage: capturedOnMessage!,
+        body: "hello",
+        from: "+15550001111",
+        to: "+15550009999",
+        id: "seed-combined-echo",
+        timestamp,
+        spies: {
+          sendMedia: vi.fn(),
+          reply: vi.fn().mockResolvedValue(undefined),
+          sendComposing: vi.fn(),
+        },
+      });
+      expect(replyResolver).toHaveBeenCalledTimes(1);
+
+      await fs.writeFile(
+        store.storePath,
+        JSON.stringify({
+          [route.sessionKey]: {
+            sessionId: "sid",
+            updatedAt: timestamp,
+          },
+        }),
+      );
+
+      const shouldStartDebounceTyping = capture.getLastOptions()?.shouldStartDebounceTyping;
+      expect(shouldStartDebounceTyping).toBeTypeOf("function");
+      await expect(
+        Promise.resolve(
+          shouldStartDebounceTyping?.({
+            body: "hello",
+            from: "+15550001111",
+            conversationId: "+15550001111",
+            to: "+15550009999",
+            accountId: "default",
+            chatType: "direct",
+            chatId: "direct:+15550001111",
+            id: "dup-combined-echo",
+            timestamp,
+            sendComposing: vi.fn(),
+            reply: vi.fn(),
+            sendMedia: vi.fn(),
+          } as never),
+        ).then(readDebounceTypingDecision),
+      ).resolves.toBe(false);
+    } finally {
+      await store.cleanup();
+      resetLoadConfigMock();
+    }
+  });
+
   it("processes inbound messages without batching and preserves timestamps", async () => {
     await withEnvAsync({ TZ: "Europe/Vienna" }, async () => {
       const originalMax = process.getMaxListeners();
@@ -600,5 +885,45 @@ describe("web auto-reply connection", () => {
     resetLoadConfigMock();
 
     expect(markDispatchIdle).toHaveBeenCalled();
+  });
+
+  it("starts composing before reply resolution begins for accepted direct messages", async () => {
+    const sendComposing = vi.fn(async () => undefined);
+    const replyResolver = vi.fn(async () => {
+      expect(sendComposing).toHaveBeenCalledTimes(1);
+      return undefined;
+    });
+
+    setLoadConfigMock({
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } satisfies OpenClawConfig);
+
+    await monitorWebChannel(
+      false,
+      async ({ onMessage }) => {
+        await onMessage({
+          id: "typing-early",
+          from: "+1000",
+          conversationId: "+1000",
+          to: "+2000",
+          body: "hello",
+          timestamp: Date.now(),
+          chatType: "direct",
+          chatId: "direct:+1000",
+          accountId: "default",
+          sendComposing,
+          reply: vi.fn(async () => undefined),
+          sendMedia: vi.fn(async () => undefined),
+        });
+        return createMockWebListener();
+      },
+      false,
+      replyResolver,
+    );
+
+    resetLoadConfigMock();
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(sendComposing).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -32,6 +32,7 @@ import { getRuntimeConfigSourceSnapshot, loadConfig } from "./config.runtime.js"
 import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
 import { createWebChannelStatusController } from "./monitor-state.js";
+import { resolveWhatsAppDirectReplyAdmission } from "./monitor/direct-reply-admission.js";
 import { createEchoTracker } from "./monitor/echo.js";
 import { createWebOnMessageHandler } from "./monitor/on-message.js";
 import type { WebInboundMsg, WebMonitorTuning } from "./types.js";
@@ -94,6 +95,21 @@ function isRetryableAuthUnstableError(error: unknown): error is WhatsAppAuthUnst
       "code" in error &&
       (error as { code?: unknown }).code === WHATSAPP_AUTH_UNSTABLE_CODE)
   );
+}
+
+async function shouldStartWhatsAppDebounceTyping(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  msg: WebInboundMsg & { chatType: "direct" };
+  echoHas: (key: string) => boolean;
+  buildCombinedEchoKey: (params: { sessionKey: string; combinedBody: string }) => string;
+}): Promise<boolean> {
+  const admission = await resolveWhatsAppDirectReplyAdmission({
+    cfg: params.cfg,
+    msg: params.msg,
+    echoHas: params.echoHas,
+    buildCombinedEchoKey: params.buildCombinedEchoKey,
+  });
+  return admission.replyAdmission.shouldStartEarlyTyping;
 }
 
 export async function monitorWebChannel(
@@ -255,6 +271,18 @@ export async function monitorWebChannel(
               sendReadReceipts: account.sendReadReceipts,
               debounceMs: inboundDebounceMs,
               shouldDebounce,
+              shouldStartDebounceTyping: async (msg: WebInboundMsg) => {
+                if (msg.chatType !== "direct") {
+                  return false;
+                }
+                const directMsg = msg as WebInboundMsg & { chatType: "direct" };
+                return shouldStartWhatsAppDebounceTyping({
+                  cfg: loadConfig(),
+                  msg: directMsg,
+                  echoHas: echoTracker.has,
+                  buildCombinedEchoKey: echoTracker.buildCombinedKey,
+                });
+              },
               socketRef: controller.socketRef,
               shouldRetryDisconnect: () => !sigintStop && controller.shouldRetryDisconnect(),
               disconnectRetryPolicy: reconnectPolicy,

--- a/extensions/whatsapp/src/auto-reply/monitor/direct-reply-admission.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/direct-reply-admission.ts
@@ -1,0 +1,120 @@
+import { shouldHandleTextCommands } from "openclaw/plugin-sdk/command-auth";
+import { shouldComputeCommandAuthorized } from "openclaw/plugin-sdk/command-detection";
+import {
+  loadSessionStoreAsync,
+  resolveSendPolicy,
+  resolveSessionStoreEntry,
+  resolveStorePath,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/config-runtime";
+import {
+  resolveInboundReplyAdmission,
+  type InboundReplyAdmission,
+} from "openclaw/plugin-sdk/reply-runtime";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { getPrimaryIdentityId, getSenderIdentity } from "../../identity.js";
+import {
+  resolveWhatsAppCommandAuthorized,
+  resolveWhatsAppInboundPolicy,
+} from "../../inbound-policy.js";
+import type { WhatsAppDirectInboundMessageContract } from "./inbound-message-contract.js";
+import { buildInboundLine } from "./message-line.js";
+import { resolvePeerId } from "./peer.js";
+import { resolveInboundSessionEnvelopeContext } from "./runtime-api.js";
+
+export type WhatsAppDirectReplyAdmission = {
+  replyAdmission: InboundReplyAdmission;
+};
+
+export async function resolveWhatsAppDirectReplyAdmission(params: {
+  cfg: OpenClawConfig;
+  msg: WhatsAppDirectInboundMessageContract;
+  buildCombinedEchoKey: (params: { sessionKey: string; combinedBody: string }) => string;
+  echoHas: (key: string) => boolean;
+}): Promise<WhatsAppDirectReplyAdmission> {
+  const route = resolveAgentRoute({
+    cfg: params.cfg,
+    channel: "whatsapp",
+    accountId: params.msg.accountId,
+    peer: {
+      kind: "direct",
+      id: resolvePeerId(params.msg),
+    },
+  });
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: route.agentId,
+  });
+  const store = await loadSessionStoreAsync(storePath);
+  const sessionStoreEntry = resolveSessionStoreEntry({
+    store,
+    sessionKey: route.sessionKey,
+  });
+  const sendPolicy = resolveSendPolicy({
+    cfg: params.cfg,
+    entry: sessionStoreEntry.existing,
+    sessionKey: route.sessionKey,
+    channel: sessionStoreEntry.existing?.channel ?? "whatsapp",
+    chatType: sessionStoreEntry.existing?.chatType ?? "direct",
+  });
+  const inboundPolicy = resolveWhatsAppInboundPolicy({
+    cfg: params.cfg,
+    accountId: route.accountId ?? params.msg.accountId,
+    selfE164: params.msg.selfE164 ?? null,
+  });
+  const shouldComputeAuth = shouldComputeCommandAuthorized(params.msg.body, params.cfg);
+  const commandAuthorized = shouldComputeAuth
+    ? await resolveWhatsAppCommandAuthorized({
+        cfg: params.cfg,
+        msg: params.msg,
+        policy: inboundPolicy,
+      })
+    : undefined;
+  const { envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
+    cfg: params.cfg,
+    agentId: route.agentId,
+    sessionKey: route.sessionKey,
+  });
+  const combinedBody = buildInboundLine({
+    cfg: params.cfg,
+    msg: params.msg,
+    agentId: route.agentId,
+    previousTimestamp,
+    envelope: envelopeOptions,
+  });
+  const combinedEchoKey = params.buildCombinedEchoKey({
+    sessionKey: route.sessionKey,
+    combinedBody,
+  });
+  const sender = getSenderIdentity(params.msg);
+  const replyAdmission = resolveInboundReplyAdmission({
+    ctx: {
+      AccountId: route.accountId,
+      Body: params.msg.body,
+      RawBody: params.msg.body,
+      CommandBody: params.msg.body,
+      From: params.msg.from,
+      To: params.msg.to,
+      ChatType: "direct",
+      SenderId: getPrimaryIdentityId(sender) ?? sender.e164 ?? params.msg.from,
+      SenderE164: sender.e164 ?? params.msg.senderE164,
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: params.msg.from,
+    },
+    cfg: params.cfg,
+    sendPolicy,
+    allowTextCommands: shouldHandleTextCommands({
+      cfg: params.cfg,
+      surface: "whatsapp",
+    }),
+    commandAuthorized: commandAuthorized ?? true,
+    agentId: route.agentId,
+    echoDetected: params.echoHas(params.msg.body) || params.echoHas(combinedEchoKey),
+    includeDisabledCommands: true,
+  });
+
+  return {
+    replyAdmission,
+  };
+}

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -53,6 +53,12 @@ function resolveWhatsAppDisableBlockStreaming(cfg: ReturnType<LoadConfigFn>): bo
   return !cfg.channels.whatsapp.blockStreaming;
 }
 
+function resolveWhatsAppTypingIntervalSeconds(cfg: ReturnType<LoadConfigFn>): number | undefined {
+  const configuredTypingSeconds =
+    cfg.agents?.defaults?.typingIntervalSeconds ?? cfg.session?.typingIntervalSeconds;
+  return typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : undefined;
+}
+
 function shouldSuppressWhatsAppPayload(
   payload: ReplyPayload,
   info: { kind: ReplyLifecycleKind },
@@ -236,7 +242,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
   maxMediaBytes: number;
   maxMediaTextChunkLimit?: number;
   msg: WebInboundMsg;
-  onModelSelected?: ChannelReplyOnModelSelected | undefined;
+  onModelSelected?: ChannelReplyOnModelSelected;
   rememberSentText: (
     text: string | undefined,
     opts: {
@@ -262,52 +268,59 @@ export async function dispatchWhatsAppBufferedReply(params: {
   const disableBlockStreaming = resolveWhatsAppDisableBlockStreaming(params.cfg);
   let didSendReply = false;
   let didLogHeartbeatStrip = false;
+  const dispatcherOptions = {
+    ...params.replyPipeline,
+    // WhatsApp UX is especially sensitive to cold-start silence. Start
+    // composing as soon as this inbound message has passed channel gating.
+    earlyTyping: {
+      start: "accepted_inbound" as const,
+      typingIntervalSeconds: resolveWhatsAppTypingIntervalSeconds(params.cfg),
+    },
+    onHeartbeatStrip: () => {
+      if (!didLogHeartbeatStrip) {
+        didLogHeartbeatStrip = true;
+        logVerbose("Stripped stray HEARTBEAT_OK token from web reply");
+      }
+    },
+    deliver: async (payload: ReplyPayload, info: { kind: ReplyLifecycleKind }) => {
+      if (shouldSuppressWhatsAppPayload(payload, info)) {
+        return;
+      }
+      await params.deliverReply({
+        replyResult: payload,
+        msg: params.msg,
+        mediaLocalRoots,
+        maxMediaBytes: params.maxMediaBytes,
+        textLimit,
+        chunkMode,
+        replyLogger: params.replyLogger,
+        connectionId: params.connectionId,
+        skipLog: false,
+        tableMode,
+      });
+      didSendReply = true;
+      const shouldLog = payload.text ? true : undefined;
+      params.rememberSentText(payload.text, {
+        combinedBody: params.context.Body as string | undefined,
+        combinedBodySessionKey: params.route.sessionKey,
+        logVerboseMessage: shouldLog,
+      });
+      const fromDisplay =
+        params.msg.chatType === "group" ? params.conversationId : (params.msg.from ?? "unknown");
+      const reply = resolveSendableOutboundReplyParts(payload);
+      if (shouldLogVerbose()) {
+        const preview = payload.text != null ? reply.text : "<media>";
+        logVerbose(`Reply body: ${preview}${reply.hasMedia ? " (media)" : ""} -> ${fromDisplay}`);
+      }
+    },
+    onReplyStart: params.msg.sendComposing,
+  };
 
   const { queuedFinal, counts } = await dispatchReplyWithBufferedBlockDispatcher({
     ctx: params.context,
     cfg: params.cfg,
     replyResolver: params.replyResolver,
-    dispatcherOptions: {
-      ...params.replyPipeline,
-      onHeartbeatStrip: () => {
-        if (!didLogHeartbeatStrip) {
-          didLogHeartbeatStrip = true;
-          logVerbose("Stripped stray HEARTBEAT_OK token from web reply");
-        }
-      },
-      deliver: async (payload: ReplyPayload, info: { kind: ReplyLifecycleKind }) => {
-        if (shouldSuppressWhatsAppPayload(payload, info)) {
-          return;
-        }
-        await params.deliverReply({
-          replyResult: payload,
-          msg: params.msg,
-          mediaLocalRoots,
-          maxMediaBytes: params.maxMediaBytes,
-          textLimit,
-          chunkMode,
-          replyLogger: params.replyLogger,
-          connectionId: params.connectionId,
-          skipLog: false,
-          tableMode,
-        });
-        didSendReply = true;
-        const shouldLog = payload.text ? true : undefined;
-        params.rememberSentText(payload.text, {
-          combinedBody: params.context.Body as string | undefined,
-          combinedBodySessionKey: params.route.sessionKey,
-          logVerboseMessage: shouldLog,
-        });
-        const fromDisplay =
-          params.msg.chatType === "group" ? params.conversationId : (params.msg.from ?? "unknown");
-        const reply = resolveSendableOutboundReplyParts(payload);
-        if (shouldLogVerbose()) {
-          const preview = payload.text != null ? reply.text : "<media>";
-          logVerbose(`Reply body: ${preview}${reply.hasMedia ? " (media)" : ""} -> ${fromDisplay}`);
-        }
-      },
-      onReplyStart: params.msg.sendComposing,
-    },
+    dispatcherOptions,
     replyOptions: {
       disableBlockStreaming,
       onModelSelected: params.onModelSelected,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-message-contract.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-message-contract.ts
@@ -1,0 +1,34 @@
+import type {
+  WhatsAppIdentity,
+  WhatsAppReplyContext,
+  WhatsAppSelfIdentity,
+} from "../../identity.js";
+
+export type WhatsAppInboundMessageContract = {
+  body: string;
+  from: string;
+  to: string;
+  accountId: string;
+  chatType: "direct" | "group";
+  conversationId?: string;
+  timestamp?: number;
+  sender?: WhatsAppIdentity;
+  senderJid?: string;
+  senderE164?: string;
+  senderName?: string;
+  replyTo?: WhatsAppReplyContext;
+  replyToId?: string;
+  replyToBody?: string;
+  replyToSender?: string;
+  replyToSenderJid?: string;
+  replyToSenderE164?: string;
+  self?: WhatsAppSelfIdentity;
+  selfJid?: string | null;
+  selfLid?: string | null;
+  selfE164?: string | null;
+  fromMe?: boolean;
+};
+
+export type WhatsAppDirectInboundMessageContract = WhatsAppInboundMessageContract & {
+  chatType: "direct";
+};

--- a/extensions/whatsapp/src/auto-reply/monitor/message-line.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/message-line.ts
@@ -1,13 +1,13 @@
 import type { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import { getPrimaryIdentityId, getReplyContext, getSenderIdentity } from "../../identity.js";
-import type { WebInboundMsg } from "../types.js";
+import type { WhatsAppInboundMessageContract } from "./inbound-message-contract.js";
 import {
   formatInboundEnvelope,
   resolveMessagePrefix,
   type EnvelopeFormatOptions,
 } from "./message-line.runtime.js";
 
-export function formatReplyContext(msg: WebInboundMsg) {
+export function formatReplyContext(msg: WhatsAppInboundMessageContract) {
   const replyTo = getReplyContext(msg);
   if (!replyTo?.body) {
     return null;
@@ -19,7 +19,7 @@ export function formatReplyContext(msg: WebInboundMsg) {
 
 export function buildInboundLine(params: {
   cfg: ReturnType<typeof loadConfig>;
-  msg: WebInboundMsg;
+  msg: WhatsAppInboundMessageContract;
   agentId: string;
   previousTimestamp?: number;
   envelope?: EnvelopeFormatOptions;

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  applyGroupGating: vi.fn(async () => ({ shouldProcess: false })),
+  maybeBroadcastMessage: vi.fn(async () => false),
+  processMessage: vi.fn(async () => true),
+  updateLastRouteInBackground: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({}));
+vi.mock("openclaw/plugin-sdk/routing", () => ({
+  buildGroupHistoryKey: () => "whatsapp:default:group:123@g.us",
+  resolveAgentRoute: () => ({
+    agentId: "main",
+    accountId: "default",
+    sessionKey: "agent:main:whatsapp:group:123@g.us",
+    mainSessionKey: "agent:main:whatsapp:direct:+2000",
+    channel: "whatsapp",
+    lastRoutePolicy: "main",
+    matchedBy: "default",
+  }),
+}));
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  logVerbose: vi.fn(),
+}));
+vi.mock("../../group-session-key.js", () => ({
+  resolveWhatsAppGroupSessionRoute: (route: unknown) => route,
+}));
+vi.mock("../../identity.js", () => ({
+  getPrimaryIdentityId: (sender: { e164?: string; name?: string }) => sender.e164 ?? sender.name,
+  getSenderIdentity: (msg: { senderE164?: string; senderName?: string }) => ({
+    e164: msg.senderE164,
+    name: msg.senderName,
+  }),
+}));
+vi.mock("../../text-runtime.js", () => ({
+  normalizeE164: (value: string) => value,
+}));
+vi.mock("../config.runtime.js", () => ({
+  loadConfig: () => ({}),
+}));
+vi.mock("./broadcast.js", () => ({
+  maybeBroadcastMessage: mocks.maybeBroadcastMessage,
+}));
+vi.mock("./group-gating.js", () => ({
+  applyGroupGating: mocks.applyGroupGating,
+}));
+vi.mock("./last-route.js", () => ({
+  updateLastRouteInBackground: mocks.updateLastRouteInBackground,
+}));
+vi.mock("./peer.js", () => ({
+  resolvePeerId: () => "123@g.us",
+}));
+vi.mock("./process-message.js", () => ({
+  processMessage: mocks.processMessage,
+}));
+
+const { createWebOnMessageHandler } = await import("./on-message.js");
+
+function makeReplyLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as Parameters<typeof createWebOnMessageHandler>[0]["replyLogger"];
+}
+
+describe("web on-message gating", () => {
+  beforeEach(() => {
+    mocks.applyGroupGating.mockClear();
+    mocks.maybeBroadcastMessage.mockClear();
+    mocks.processMessage.mockClear();
+    mocks.updateLastRouteInBackground.mockClear();
+  });
+
+  it("does not start composing for group messages rejected by gating", async () => {
+    const sendComposing = vi.fn(async () => undefined);
+    const handler = createWebOnMessageHandler({
+      cfg: {} as never,
+      verbose: false,
+      connectionId: "test",
+      maxMediaBytes: 1024,
+      groupHistoryLimit: 5,
+      groupHistories: new Map(),
+      groupMemberNames: new Map(),
+      echoTracker: {
+        has: () => false,
+        forget: () => undefined,
+        buildCombinedKey: () => "group-key",
+        rememberText: () => undefined,
+      },
+      backgroundTasks: new Set(),
+      replyResolver: vi.fn() as never,
+      replyLogger: makeReplyLogger(),
+      baseMentionConfig: {} as never,
+      account: {},
+    });
+
+    await handler({
+      id: "g1",
+      from: "123@g.us",
+      conversationId: "123@g.us",
+      to: "+2000",
+      body: "hello everyone",
+      timestamp: Date.now(),
+      chatType: "group",
+      chatId: "123@g.us",
+      accountId: "default",
+      senderE164: "+15550001111",
+      senderName: "Alice",
+      selfE164: "+15550002222",
+      sendComposing,
+      reply: vi.fn(async () => undefined),
+      sendMedia: vi.fn(async () => undefined),
+    });
+
+    expect(mocks.applyGroupGating).toHaveBeenCalledTimes(1);
+    expect(mocks.processMessage).not.toHaveBeenCalled();
+    expect(sendComposing).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/peer.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/peer.ts
@@ -1,8 +1,8 @@
 import { getSenderIdentity } from "../../identity.js";
 import { jidToE164, normalizeE164 } from "../../text-runtime.js";
-import type { WebInboundMsg } from "../types.js";
+import type { WhatsAppInboundMessageContract } from "./inbound-message-contract.js";
 
-export function resolvePeerId(msg: WebInboundMsg) {
+export function resolvePeerId(msg: WhatsAppInboundMessageContract) {
   if (msg.chatType === "group") {
     return msg.conversationId ?? msg.from;
   }

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -96,16 +96,18 @@ export async function processMessage(params: {
     channel: "whatsapp",
     accountId: account.accountId,
   });
-  const { storePath, envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
+  const sessionEnvelope = resolveInboundSessionEnvelopeContext({
     cfg: params.cfg,
     agentId: params.route.agentId,
     sessionKey: params.route.sessionKey,
   });
+  const storePath = sessionEnvelope.storePath;
+  const envelopeOptions = sessionEnvelope?.envelopeOptions;
   let combinedBody = buildInboundLine({
     cfg: params.cfg,
     msg: params.msg,
     agentId: params.route.agentId,
-    previousTimestamp,
+    previousTimestamp: sessionEnvelope?.previousTimestamp,
     envelope: envelopeOptions,
   });
   let shouldClearGroupHistory = false;

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -14,8 +14,8 @@ import {
   resolveDmGroupAccessWithCommandGate,
 } from "openclaw/plugin-sdk/security-runtime";
 import { resolveWhatsAppAccount, type ResolvedWhatsAppAccount } from "./accounts.js";
+import type { WhatsAppInboundMessageContract } from "./auto-reply/monitor/inbound-message-contract.js";
 import { getSelfIdentity, getSenderIdentity } from "./identity.js";
-import type { WebInboundMessage } from "./inbound/types.js";
 import { resolveWhatsAppRuntimeGroupPolicy } from "./runtime-group-policy.js";
 import { isSelfChatMode, normalizeE164 } from "./text-runtime.js";
 
@@ -141,7 +141,7 @@ export function resolveWhatsAppInboundPolicy(params: {
 
 export async function resolveWhatsAppCommandAuthorized(params: {
   cfg: OpenClawConfig;
-  msg: WebInboundMessage;
+  msg: WhatsAppInboundMessageContract;
   policy?: ResolvedWhatsAppInboundPolicy;
 }): Promise<boolean> {
   const useAccessGroups = params.cfg.commands?.useAccessGroups !== false;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -34,6 +34,12 @@ import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
 const RECONNECT_IN_PROGRESS_ERROR = "no active socket - reconnection in progress";
 
+type DebounceTypingDecision =
+  | boolean
+  | {
+      shouldStart: boolean;
+    };
+
 function logWhatsAppVerbose(enabled: boolean | undefined, message: string) {
   if (!enabled) {
     return;
@@ -57,6 +63,8 @@ function isNonEmptyString(value: string | undefined): value is string {
   return Boolean(value);
 }
 
+const DEBOUNCE_TYPING_REFRESH_MS = 5_000;
+
 export type MonitorWebInboxOptions = {
   verbose: boolean;
   accountId: string;
@@ -71,6 +79,10 @@ export type MonitorWebInboxOptions = {
   debounceMs?: number;
   /** Optional debounce gating predicate. */
   shouldDebounce?: (msg: WebInboundMessage) => boolean;
+  /** Optional guard for starting debounce-window typing before normal reply handling. */
+  shouldStartDebounceTyping?: (
+    msg: WebInboundMessage,
+  ) => DebounceTypingDecision | Promise<DebounceTypingDecision>;
   /** Optional shared socket reference so reply closures can follow reconnects. */
   socketRef?: { current: WASocket | null };
   /** Whether send retries should wait for a reconnect. */
@@ -144,6 +156,81 @@ export async function attachWebInboxToSocket(
   type QueuedInboundMessage = WebInboundMessage & {
     dedupeKey?: string;
   };
+  type DebounceKeyMessage = Pick<
+    QueuedInboundMessage,
+    | "accountId"
+    | "chatType"
+    | "chatId"
+    | "from"
+    | "sender"
+    | "senderJid"
+    | "senderE164"
+    | "senderName"
+  >;
+
+  const buildDebounceKey = (msg: DebounceKeyMessage): string | null => {
+    const sender = msg.sender;
+    const senderKey =
+      msg.chatType === "group"
+        ? (getPrimaryIdentityId(sender ?? null) ??
+          msg.senderJid ??
+          msg.senderE164 ??
+          msg.senderName ??
+          msg.from)
+        : msg.from;
+    if (!senderKey) {
+      return null;
+    }
+    const conversationKey = msg.chatType === "group" ? msg.chatId : msg.from;
+    return `${msg.accountId}:${conversationKey}:${senderKey}`;
+  };
+  const pendingDebounceTyping = new Map<
+    string,
+    { timeout: ReturnType<typeof setTimeout> | null }
+  >();
+
+  const stopPendingDebounceTyping = (key: string | null | undefined) => {
+    if (!key) {
+      return;
+    }
+    const pending = pendingDebounceTyping.get(key);
+    if (!pending) {
+      return;
+    }
+    if (pending.timeout) {
+      clearTimeout(pending.timeout);
+    }
+    pendingDebounceTyping.delete(key);
+  };
+
+  const startPendingDebounceTyping = (key: string, sendComposing: () => Promise<void>) => {
+    if (pendingDebounceTyping.has(key)) {
+      return;
+    }
+    const pending = { timeout: null as ReturnType<typeof setTimeout> | null };
+    pendingDebounceTyping.set(key, pending);
+
+    const tick = async () => {
+      if (pendingDebounceTyping.get(key) !== pending) {
+        return;
+      }
+      await sendComposing();
+      if (pendingDebounceTyping.get(key) !== pending) {
+        return;
+      }
+      pending.timeout = setTimeout(() => {
+        void tick();
+      }, DEBOUNCE_TYPING_REFRESH_MS);
+    };
+
+    void tick();
+  };
+
+  const stopAllPendingDebounceTyping = () => {
+    for (const key of pendingDebounceTyping.keys()) {
+      stopPendingDebounceTyping(key);
+    }
+  };
 
   const finalizeInboundDedupe = async (
     entries: QueuedInboundMessage[],
@@ -164,28 +251,14 @@ export async function attachWebInboxToSocket(
 
   const debouncer = createInboundDebouncer<QueuedInboundMessage>({
     debounceMs: options.debounceMs ?? 0,
-    buildKey: (msg) => {
-      const sender = msg.sender;
-      const senderKey =
-        msg.chatType === "group"
-          ? (getPrimaryIdentityId(sender ?? null) ??
-            msg.senderJid ??
-            msg.senderE164 ??
-            msg.senderName ??
-            msg.from)
-          : msg.from;
-      if (!senderKey) {
-        return null;
-      }
-      const conversationKey = msg.chatType === "group" ? msg.chatId : msg.from;
-      return `${msg.accountId}:${conversationKey}:${senderKey}`;
-    },
+    buildKey: buildDebounceKey,
     shouldDebounce: options.shouldDebounce,
     onFlush: async (entries) => {
       const last = entries.at(-1);
       if (!last) {
         return;
       }
+      stopPendingDebounceTyping(buildDebounceKey(last));
       try {
         if (entries.length === 1) {
           await options.onMessage(last);
@@ -577,13 +650,42 @@ export async function attachWebInboxToSocket(
       mediaFileName: enriched.mediaFileName,
       dedupeKey: inbound.id ? `${options.accountId}:${inbound.remoteJid}:${inbound.id}` : undefined,
     };
+    const debounceKey = buildDebounceKey(inboundMessage);
+    const shouldDebounceInbound =
+      (options.debounceMs ?? 0) > 0 && (options.shouldDebounce?.(inboundMessage) ?? true);
+    if (
+      shouldDebounceInbound &&
+      inboundMessage.chatType === "direct" &&
+      !inbound.access.isSelfChat
+    ) {
+      let shouldStartDebounceTyping = true;
+      if (options.shouldStartDebounceTyping) {
+        try {
+          const decision = await options.shouldStartDebounceTyping(inboundMessage);
+          if (typeof decision === "object" && decision !== null) {
+            shouldStartDebounceTyping = decision.shouldStart;
+          } else {
+            shouldStartDebounceTyping = decision;
+          }
+        } catch (err) {
+          shouldStartDebounceTyping = false;
+          logWhatsAppVerbose(options.verbose, `Debounce typing precheck failed: ${String(err)}`);
+        }
+      }
+      if (debounceKey && shouldStartDebounceTyping) {
+        // Keep a visible typing indicator alive while DMs are intentionally buffered.
+        startPendingDebounceTyping(debounceKey, sendComposing);
+      }
+    }
     try {
       const task = Promise.resolve(debouncer.enqueue(inboundMessage));
       void task.catch((err) => {
+        stopPendingDebounceTyping(debounceKey);
         inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
         inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
       });
     } catch (err) {
+      stopPendingDebounceTyping(debounceKey);
       inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
       inboundConsoleLog.error(`Failed handling inbound web message: ${String(err)}`);
     }
@@ -704,6 +806,7 @@ export async function attachWebInboxToSocket(
   return {
     close: async () => {
       try {
+        stopAllPendingDebounceTyping();
         detachMessagesUpsert();
         detachConnectionUpdate();
         closeInboundMonitorSocket(sock);

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -10,6 +10,7 @@ import {
   getAuthDir,
   getSock,
   installWebMonitorInboxUnitTestHooks,
+  mockLoadConfig,
   startInboxMonitor,
   waitForMessageCalls,
 } from "./monitor-inbox.test-harness.js";
@@ -31,6 +32,11 @@ let nextMessageSequence = 0;
 function nextMessageId(label: string): string {
   nextMessageSequence += 1;
   return `${label}-${nextMessageSequence}`;
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 function createSocketRef(): NonNullable<InboxMonitorOptions["socketRef"]> {
@@ -370,6 +376,121 @@ describe("web monitor inbox", () => {
           body: "first\nsecond",
         }),
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("starts composing before a debounced direct message flushes", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+      });
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-typing-direct"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "hello",
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }),
+      );
+
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(onMessage).not.toHaveBeenCalled();
+      expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("composing", "999@s.whatsapp.net");
+
+      await vi.advanceTimersByTimeAsync(50);
+      await waitForMessageCalls(onMessage, 1);
+
+      await listener.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not start debounce typing for self-chat direct messages", async () => {
+    vi.useFakeTimers();
+    try {
+      mockLoadConfig.mockReturnValue({
+        channels: {
+          whatsapp: {
+            allowFrom: ["*"],
+            selfChatMode: true,
+          },
+        },
+      });
+
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+        selfChatMode: true,
+      });
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-typing-self-chat"),
+          remoteJid: "123@s.whatsapp.net",
+          text: "hello self",
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }),
+      );
+
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(onMessage).not.toHaveBeenCalled();
+      expect(sock.sendPresenceUpdate).not.toHaveBeenCalledWith("composing", "123@s.whatsapp.net");
+
+      await vi.advanceTimersByTimeAsync(50);
+      await waitForMessageCalls(onMessage, 1);
+
+      await listener.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not start debounce typing when the precheck suppresses it", async () => {
+    vi.useFakeTimers();
+    try {
+      const shouldStartDebounceTyping = vi.fn(async () => false);
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 50,
+        shouldStartDebounceTyping,
+      });
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-typing-suppressed"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "hello",
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }),
+      );
+
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(onMessage).not.toHaveBeenCalled();
+      expect(shouldStartDebounceTyping).toHaveBeenCalledTimes(1);
+      expect(sock.sendPresenceUpdate).not.toHaveBeenCalledWith("composing", "999@s.whatsapp.net");
+
+      await vi.advanceTimersByTimeAsync(50);
+      await waitForMessageCalls(onMessage, 1);
+
+      await listener.close();
     } finally {
       vi.useRealTimers();
     }

--- a/src/auto-reply/dispatch.early-typing.test.ts
+++ b/src/auto-reply/dispatch.early-typing.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createReplyDispatcherWithTyping } from "./reply/reply-dispatcher.js";
+
+describe("reply dispatcher early typing", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("creates an eager typing controller only for opt-in paths", () => {
+    const optedIn = createReplyDispatcherWithTyping({
+      deliver: async () => undefined,
+      onReplyStart: async () => undefined,
+      earlyTyping: {
+        start: "accepted_inbound",
+        typingIntervalSeconds: 1,
+      },
+    });
+    const defaultPath = createReplyDispatcherWithTyping({
+      deliver: async () => undefined,
+      onReplyStart: async () => undefined,
+    });
+
+    expect(optedIn.replyOptions.earlyTyping?.controller).toBeDefined();
+    expect(optedIn.replyOptions.earlyTyping?.start).toBe("accepted_inbound");
+    expect(defaultPath.replyOptions.earlyTyping).toBeUndefined();
+  });
+
+  it("uses the configured typing interval for eager early-typing controllers", async () => {
+    vi.useFakeTimers();
+    const onReplyStart = vi.fn(async () => undefined);
+    const { replyOptions, markRunComplete, markDispatchIdle } = createReplyDispatcherWithTyping({
+      deliver: async () => undefined,
+      onReplyStart,
+      earlyTyping: {
+        start: "accepted_inbound",
+        typingIntervalSeconds: 1,
+      },
+    });
+
+    const typing = replyOptions.earlyTyping?.controller;
+    expect(typing).toBeDefined();
+
+    await typing?.startTypingLoop();
+    expect(onReplyStart).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onReplyStart).toHaveBeenCalledTimes(2);
+
+    markRunComplete();
+    markDispatchIdle();
+  });
+});

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -29,6 +29,18 @@ export type ReplyThreadingPolicy = {
   implicitCurrentMessage?: "default" | "allow" | "deny";
 };
 
+export type EarlyTypingStartPhase = "accepted_inbound";
+
+export type EarlyTypingBinding = {
+  /**
+   * Start typing before the reply run begins, once the inbound turn has been
+   * accepted for reply processing.
+   */
+  start: EarlyTypingStartPhase;
+  /** Shared typing controller reused across early-start and normal run-start phases. */
+  controller?: TypingController;
+};
+
 export type GetReplyOptions = {
   /** Override run id for agent events (defaults to random UUID). */
   runId?: string;
@@ -44,6 +56,8 @@ export type GetReplyOptions = {
   /** Called when the typing controller cleans up (e.g., run ended with NO_REPLY). */
   onTypingCleanup?: () => void;
   onTypingController?: (typing: TypingController) => void;
+  /** Optional early-typing handoff for channels that start composing before run start. */
+  earlyTyping?: EarlyTypingBinding;
   isHeartbeat?: boolean;
   /** Policy-level typing control for run classes (user/system/internal/heartbeat). */
   typingPolicy?: TypingPolicy;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -834,6 +834,116 @@ describe("dispatchReplyFromConfig", () => {
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
   });
 
+  it("starts eager typing before reply resolution when allowed", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const startTypingLoop = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: "+15550001111",
+    });
+
+    const replyResolver = async (_ctx: MsgContext) => {
+      expect(startTypingLoop).toHaveBeenCalledTimes(1);
+      return { text: "hi" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        earlyTyping: {
+          start: "accepted_inbound",
+          controller: {
+            startTypingLoop,
+          } as never,
+        },
+      } as GetReplyOptions,
+    });
+  });
+
+  it("does not start eager typing for silent unauthorized whole-message commands", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const startTypingLoop = vi.fn(async () => undefined);
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      CommandAuthorized: false,
+      CommandBody: "/reset",
+      RawBody: "/reset",
+      Body: "/reset",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: "+15550001111",
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        earlyTyping: {
+          start: "accepted_inbound",
+          controller: {
+            startTypingLoop,
+          } as never,
+        },
+      } as GetReplyOptions,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(startTypingLoop).not.toHaveBeenCalled();
+  });
+
+  it("does not start eager typing for disabled privileged commands from unauthorized senders", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const startTypingLoop = vi.fn(async () => undefined);
+    const replyResolver = vi.fn(async () => undefined);
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      ChatType: "direct",
+      CommandAuthorized: false,
+      CommandBody: "/config show",
+      RawBody: "/config show",
+      Body: "/config show",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: "+15550001111",
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        commands: {
+          config: false,
+          text: true,
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        earlyTyping: {
+          start: "accepted_inbound",
+          controller: {
+            startTypingLoop,
+          } as never,
+        },
+      } as GetReplyOptions,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(startTypingLoop).not.toHaveBeenCalled();
+  });
+
   it("routes when provider is webchat but surface carries originating channel metadata", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();
@@ -3193,6 +3303,37 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     // Delivery MUST be suppressed
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
     expect(result.queuedFinal).toBe(false);
+  });
+
+  it("does not start eager typing when sendPolicy is deny", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "deny",
+    };
+    const dispatcher = createDispatcher();
+    const startTypingLoop = vi.fn(async () => undefined);
+    const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
+    const ctx = buildTestCtx({ SessionKey: "test:session" });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        earlyTyping: {
+          start: "accepted_inbound",
+          controller: {
+            startTypingLoop,
+          } as never,
+        },
+      } as GetReplyOptions,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(startTypingLoop).not.toHaveBeenCalled();
   });
 
   it("suppresses tool result delivery when sendPolicy is deny", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -52,6 +52,7 @@ import {
   shouldAttemptTtsPayload,
 } from "../../tts/tts-config.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
+import { shouldHandleTextCommands } from "../commands-text-routing.js";
 import type { BlockReplyContext } from "../get-reply-options.types.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
 import type { FinalizedMsgContext } from "../templating.js";
@@ -68,6 +69,7 @@ import type {
   DispatchFromConfigResult,
 } from "./dispatch-from-config.types.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
+import { resolveInboundReplyAdmission } from "./inbound-reply-admission.js";
 import { resolveReplyRoutingDecision } from "./routing-policy.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 
@@ -879,6 +881,27 @@ export async function dispatchReplyFromConfig(
       originatingChannel,
       systemEvent: shouldRouteToOriginating,
     });
+    const commandAuthorized = ctx.CommandAuthorized;
+    const inboundAdmission = resolveInboundReplyAdmission({
+      ctx,
+      cfg,
+      sendPolicy,
+      allowTextCommands: shouldHandleTextCommands({
+        cfg,
+        surface: normalizeLowercaseStringOrEmpty(ctx.Surface ?? ctx.Provider),
+        commandSource: ctx.CommandSource,
+      }),
+      commandAuthorized,
+      agentId: sessionAgentId,
+      includeDisabledCommands: true,
+    });
+    if (
+      params.replyOptions?.earlyTyping?.start === "accepted_inbound" &&
+      !typing.suppressTyping &&
+      inboundAdmission.shouldStartEarlyTyping
+    ) {
+      await params.replyOptions.earlyTyping.controller?.startTypingLoop();
+    }
 
     const replyResolver =
       params.replyResolver ?? (await loadGetReplyFromConfigRuntime()).getReplyFromConfig;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -22,7 +22,6 @@ import {
 } from "../../routing/session-key.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
-import { hasControlCommand } from "../command-detection.js";
 import { resolveEnvelopeFormatOptions } from "../envelope.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import {
@@ -55,6 +54,7 @@ import { buildSessionStartupContextPrelude, shouldApplyStartupContext } from "./
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 import type { TypingController } from "./typing.js";
+import { isSilentUnauthorizedWholeMessageControlCommand } from "./unauthorized-control-command.js";
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
@@ -308,15 +308,16 @@ export async function runPreparedReply(
   const rawBodyTrimmed = (ctx.CommandBody ?? ctx.RawBody ?? ctx.Body ?? "").trim();
   const baseBodyTrimmedRaw = baseBody.trim();
   const normalizedCommandBody = command.commandBodyNormalized.trim();
-  const isWholeMessageCommand =
-    normalizedCommandBody === rawBodyTrimmed ||
-    normalizedCommandBody === rawBodyTrimmed.toLowerCase();
-  const isResetOrNewCommand = /^\/(new|reset)(?:\s|$)/.test(normalizedCommandBody);
   if (
-    allowTextCommands &&
-    (!commandAuthorized || !command.isAuthorizedSender) &&
-    isWholeMessageCommand &&
-    (hasControlCommand(rawBodyTrimmed, cfg) || isResetOrNewCommand)
+    isSilentUnauthorizedWholeMessageControlCommand({
+      ctx,
+      cfg,
+      allowTextCommands,
+      commandAuthorized,
+      agentId,
+      commandBodyNormalized: normalizedCommandBody,
+      isAuthorizedSender: command.isAuthorizedSender,
+    })
   ) {
     typing.cleanup();
     return undefined;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -232,13 +232,15 @@ export async function getReplyFromConfig(
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
-  const typing = createTypingController({
-    onReplyStart: opts?.onReplyStart,
-    onCleanup: opts?.onTypingCleanup,
-    typingIntervalSeconds,
-    silentToken: SILENT_REPLY_TOKEN,
-    log: defaultRuntime.log,
-  });
+  const typing =
+    opts?.earlyTyping?.controller ??
+    createTypingController({
+      onReplyStart: opts?.onReplyStart,
+      onCleanup: opts?.onTypingCleanup,
+      typingIntervalSeconds,
+      silentToken: SILENT_REPLY_TOKEN,
+      log: defaultRuntime.log,
+    });
   opts?.onTypingController?.(typing);
 
   const finalized = finalizeInboundContext(ctx);

--- a/src/auto-reply/reply/inbound-reply-admission.test.ts
+++ b/src/auto-reply/reply/inbound-reply-admission.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveInboundReplyAdmission } from "./inbound-reply-admission.js";
+
+describe("resolveInboundReplyAdmission", () => {
+  const cfg = {} as OpenClawConfig;
+  const baseCtx = {
+    Body: "hello",
+    RawBody: "hello",
+    CommandBody: "hello",
+    ChatType: "direct",
+    From: "+15550001111",
+    To: "+15550002222",
+    Provider: "whatsapp",
+    Surface: "whatsapp",
+    OriginatingChannel: "whatsapp",
+    OriginatingTo: "+15550001111",
+  };
+
+  it("allows early typing for accepted turns", () => {
+    expect(
+      resolveInboundReplyAdmission({
+        ctx: baseCtx as never,
+        cfg,
+        sendPolicy: "allow",
+        allowTextCommands: true,
+        commandAuthorized: true,
+      }),
+    ).toEqual({
+      sendPolicy: "allow",
+      shouldStartEarlyTyping: true,
+    });
+  });
+
+  it("suppresses early typing when send policy denies delivery", () => {
+    expect(
+      resolveInboundReplyAdmission({
+        ctx: baseCtx as never,
+        cfg,
+        sendPolicy: "deny",
+        allowTextCommands: true,
+        commandAuthorized: true,
+      }),
+    ).toEqual({
+      sendPolicy: "deny",
+      shouldStartEarlyTyping: false,
+      silentReason: "send_policy_deny",
+    });
+  });
+
+  it("suppresses early typing for silent unauthorized commands", () => {
+    expect(
+      resolveInboundReplyAdmission({
+        ctx: {
+          ...baseCtx,
+          Body: "/reset",
+          RawBody: "/reset",
+          CommandBody: "/reset",
+        } as never,
+        cfg,
+        sendPolicy: "allow",
+        allowTextCommands: true,
+        commandAuthorized: false,
+      }),
+    ).toEqual({
+      sendPolicy: "allow",
+      shouldStartEarlyTyping: false,
+      silentReason: "unauthorized_command",
+    });
+  });
+
+  it("suppresses early typing for echo-filtered turns", () => {
+    expect(
+      resolveInboundReplyAdmission({
+        ctx: baseCtx as never,
+        cfg,
+        sendPolicy: "allow",
+        allowTextCommands: true,
+        commandAuthorized: true,
+        echoDetected: true,
+      }),
+    ).toEqual({
+      sendPolicy: "allow",
+      shouldStartEarlyTyping: false,
+      silentReason: "echo_filtered",
+    });
+  });
+});

--- a/src/auto-reply/reply/inbound-reply-admission.ts
+++ b/src/auto-reply/reply/inbound-reply-admission.ts
@@ -1,0 +1,68 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { SessionSendPolicyDecision } from "../../sessions/send-policy.js";
+import type { MsgContext } from "../templating.js";
+import { isSilentUnauthorizedWholeMessageControlCommand } from "./unauthorized-control-command.js";
+
+export type InboundReplySilentReason =
+  | "send_policy_deny"
+  | "unauthorized_command"
+  | "echo_filtered";
+
+export type InboundReplyAdmission = {
+  sendPolicy: SessionSendPolicyDecision;
+  shouldStartEarlyTyping: boolean;
+  silentReason?: InboundReplySilentReason;
+};
+
+export function resolveInboundReplyAdmission(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  sendPolicy: SessionSendPolicyDecision;
+  allowTextCommands: boolean;
+  commandAuthorized: boolean;
+  agentId?: string;
+  commandBodyNormalized?: string;
+  echoDetected?: boolean;
+  includeDisabledCommands?: boolean;
+  isAuthorizedSender?: boolean;
+}): InboundReplyAdmission {
+  if (params.echoDetected) {
+    return {
+      sendPolicy: params.sendPolicy,
+      shouldStartEarlyTyping: false,
+      silentReason: "echo_filtered",
+    };
+  }
+
+  if (params.sendPolicy === "deny") {
+    return {
+      sendPolicy: params.sendPolicy,
+      shouldStartEarlyTyping: false,
+      silentReason: "send_policy_deny",
+    };
+  }
+
+  if (
+    isSilentUnauthorizedWholeMessageControlCommand({
+      ctx: params.ctx,
+      cfg: params.cfg,
+      allowTextCommands: params.allowTextCommands,
+      commandAuthorized: params.commandAuthorized,
+      agentId: params.agentId,
+      commandBodyNormalized: params.commandBodyNormalized,
+      includeDisabledCommands: params.includeDisabledCommands,
+      isAuthorizedSender: params.isAuthorizedSender,
+    })
+  ) {
+    return {
+      sendPolicy: params.sendPolicy,
+      shouldStartEarlyTyping: false,
+      silentReason: "unauthorized_command",
+    };
+  }
+
+  return {
+    sendPolicy: params.sendPolicy,
+    shouldStartEarlyTyping: true,
+  };
+}

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,13 +1,14 @@
 import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
 import { generateSecureInt } from "../../infra/secure-random.js";
+import { defaultRuntime } from "../../runtime.js";
 import { sleep } from "../../utils.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { registerDispatcher } from "./dispatcher-registry.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
 import type { ResponsePrefixContext } from "./response-prefix-template.js";
-import type { TypingController } from "./typing.js";
+import { createTypingController, type TypingController } from "./typing.js";
 
 export type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
 
@@ -66,11 +67,27 @@ export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onI
   onIdle?: () => void;
   /** Called when the typing controller is cleaned up (e.g., on NO_REPLY). */
   onCleanup?: () => void;
+  /** Optional early-typing policy for accepted inbound turns. */
+  earlyTyping?: ReplyDispatcherEarlyTypingOptions;
 };
+
+export type ReplyDispatcherEarlyTypingOptions = {
+  /**
+   * Start typing as soon as the inbound message is accepted for reply
+   * processing, before reply hooks and lazy runtime bootstrap.
+   */
+  start: "accepted_inbound";
+  typingIntervalSeconds?: number;
+};
+
+type TypingReplyOptions = Pick<
+  GetReplyOptions,
+  "onReplyStart" | "onTypingController" | "onTypingCleanup" | "earlyTyping"
+>;
 
 type ReplyDispatcherWithTypingResult = {
   dispatcher: ReplyDispatcher;
-  replyOptions: Pick<GetReplyOptions, "onReplyStart" | "onTypingController" | "onTypingCleanup">;
+  replyOptions: TypingReplyOptions;
   markDispatchIdle: () => void;
   /** Signal that the model run is complete so the typing controller can stop. */
   markRunComplete: () => void;
@@ -220,11 +237,20 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
 export function createReplyDispatcherWithTyping(
   options: ReplyDispatcherWithTypingOptions,
 ): ReplyDispatcherWithTypingResult {
-  const { typingCallbacks, onReplyStart, onIdle, onCleanup, ...dispatcherOptions } = options;
+  const { typingCallbacks, onReplyStart, onIdle, onCleanup, earlyTyping, ...dispatcherOptions } =
+    options;
   const resolvedOnReplyStart = onReplyStart ?? typingCallbacks?.onReplyStart;
   const resolvedOnIdle = onIdle ?? typingCallbacks?.onIdle;
   const resolvedOnCleanup = onCleanup ?? typingCallbacks?.onCleanup;
-  let typingController: TypingController | undefined;
+  const shouldStartTypingOnAccept = earlyTyping?.start === "accepted_inbound";
+  let typingController: TypingController | undefined = shouldStartTypingOnAccept
+    ? createTypingController({
+        onReplyStart: resolvedOnReplyStart,
+        onCleanup: resolvedOnCleanup,
+        typingIntervalSeconds: earlyTyping?.typingIntervalSeconds,
+        log: defaultRuntime.log,
+      })
+    : undefined;
   const dispatcher = createReplyDispatcher({
     ...dispatcherOptions,
     onIdle: () => {
@@ -236,11 +262,25 @@ export function createReplyDispatcherWithTyping(
   return {
     dispatcher,
     replyOptions: {
-      onReplyStart: resolvedOnReplyStart,
+      onReplyStart: typingController?.onReplyStart ?? resolvedOnReplyStart,
       onTypingCleanup: resolvedOnCleanup,
       onTypingController: (typing) => {
-        typingController = typing;
+        if (!typingController) {
+          typingController = typing;
+          return;
+        }
+        if (typing !== typingController) {
+          // Reuse the eagerly-started controller so late run-start hooks don't
+          // spin up a second composing lifecycle for the same inbound turn.
+          return;
+        }
       },
+      earlyTyping: typingController
+        ? {
+            start: "accepted_inbound",
+            controller: typingController,
+          }
+        : undefined,
     },
     markDispatchIdle: () => {
       typingController?.markDispatchIdle();

--- a/src/auto-reply/reply/unauthorized-control-command.test.ts
+++ b/src/auto-reply/reply/unauthorized-control-command.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { buildTestCtx } from "./test-ctx.js";
+import { isSilentUnauthorizedWholeMessageControlCommand } from "./unauthorized-control-command.js";
+
+describe("isSilentUnauthorizedWholeMessageControlCommand", () => {
+  it("keeps disabled privileged commands config-aware by default", () => {
+    const ctx = buildTestCtx({
+      CommandBody: "/config show",
+      RawBody: "/config show",
+      Body: "/config show",
+      CommandSource: "native",
+      Provider: "telegram",
+      Surface: "telegram",
+    });
+
+    expect(
+      isSilentUnauthorizedWholeMessageControlCommand({
+        ctx,
+        cfg: {
+          commands: {
+            config: false,
+            text: true,
+          },
+        } as OpenClawConfig,
+        allowTextCommands: true,
+        commandAuthorized: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("can opt into disabled privileged commands for eager typing suppression", () => {
+    const ctx = buildTestCtx({
+      CommandBody: "/config show",
+      RawBody: "/config show",
+      Body: "/config show",
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+    });
+
+    expect(
+      isSilentUnauthorizedWholeMessageControlCommand({
+        ctx,
+        cfg: {
+          commands: {
+            config: false,
+            text: true,
+          },
+        } as OpenClawConfig,
+        allowTextCommands: true,
+        commandAuthorized: false,
+        includeDisabledCommands: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/unauthorized-control-command.ts
+++ b/src/auto-reply/reply/unauthorized-control-command.ts
@@ -1,0 +1,60 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveCommandAuthorization } from "../command-auth.js";
+import { hasControlCommand } from "../command-detection.js";
+import { normalizeCommandBody } from "../commands-registry-normalize.js";
+import type { MsgContext } from "../templating.js";
+import { stripMentions } from "./mentions.js";
+
+export function isSilentUnauthorizedWholeMessageControlCommand(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  allowTextCommands: boolean;
+  commandAuthorized: boolean;
+  agentId?: string;
+  commandBodyNormalized?: string;
+  isAuthorizedSender?: boolean;
+  includeDisabledCommands?: boolean;
+}): boolean {
+  if (!params.allowTextCommands) {
+    return false;
+  }
+
+  const rawBodyTrimmed = (
+    params.ctx.CommandBody ??
+    params.ctx.RawBody ??
+    params.ctx.Body ??
+    ""
+  ).trim();
+  if (rawBodyTrimmed.length === 0) {
+    return false;
+  }
+
+  const normalizedCommandBody =
+    params.commandBodyNormalized?.trim() ??
+    normalizeCommandBody(
+      params.ctx.ChatType === "group"
+        ? stripMentions(rawBodyTrimmed, params.ctx, params.cfg, params.agentId)
+        : rawBodyTrimmed,
+      { botUsername: params.ctx.BotUsername },
+    ).trim();
+  const isAuthorizedSender =
+    params.isAuthorizedSender ??
+    resolveCommandAuthorization({
+      ctx: params.ctx,
+      cfg: params.cfg,
+      commandAuthorized: params.commandAuthorized,
+    }).isAuthorizedSender;
+  const isWholeMessageCommand =
+    normalizedCommandBody === rawBodyTrimmed ||
+    normalizedCommandBody === rawBodyTrimmed.toLowerCase();
+  const isResetOrNewCommand = /^\/(new|reset)(?:\s|$)/.test(normalizedCommandBody);
+  const isRecognizedControlCommand = params.includeDisabledCommands
+    ? hasControlCommand(rawBodyTrimmed)
+    : hasControlCommand(rawBodyTrimmed, params.cfg);
+
+  return (
+    (!params.commandAuthorized || !isAuthorizedSender) &&
+    isWholeMessageCommand &&
+    (isRecognizedControlCommand || isResetOrNewCommand)
+  );
+}

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -1,5 +1,7 @@
 export type {
   BlockReplyContext,
+  EarlyTypingBinding,
+  EarlyTypingStartPhase,
   GetReplyOptions,
   ModelSelectedContext,
   ReplyThreadingPolicy,

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.shared.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import {
@@ -12,6 +13,12 @@ import { normalizeSessionRuntimeModelFields, type SessionEntry } from "./types.j
 
 export type LoadSessionStoreOptions = {
   skipCache?: boolean;
+};
+
+type SessionStoreReadSnapshot = {
+  store: Record<string, SessionEntry>;
+  fileStat?: ReturnType<typeof getFileStatSnapshot>;
+  serializedFromDisk?: string;
 };
 
 function isSessionStoreRecord(value: unknown): value is Record<string, SessionEntry> {
@@ -63,6 +70,104 @@ export function normalizeSessionStore(store: Record<string, SessionEntry>): void
   }
 }
 
+function finalizeLoadedSessionStore(params: {
+  storePath: string;
+  snapshot: SessionStoreReadSnapshot;
+  opts: LoadSessionStoreOptions;
+}): Record<string, SessionEntry> {
+  if (params.snapshot.serializedFromDisk !== undefined) {
+    setSerializedSessionStore(params.storePath, params.snapshot.serializedFromDisk);
+  } else {
+    setSerializedSessionStore(params.storePath, undefined);
+  }
+
+  applySessionStoreMigrations(params.snapshot.store);
+  normalizeSessionStore(params.snapshot.store);
+
+  if (!params.opts.skipCache && isSessionStoreCacheEnabled()) {
+    writeSessionStoreCache({
+      storePath: params.storePath,
+      store: params.snapshot.store,
+      mtimeMs: params.snapshot.fileStat?.mtimeMs,
+      sizeBytes: params.snapshot.fileStat?.sizeBytes,
+      serialized: params.snapshot.serializedFromDisk,
+    });
+  }
+
+  return structuredClone(params.snapshot.store);
+}
+
+function loadSessionStoreFromDisk(storePath: string): SessionStoreReadSnapshot {
+  // Retry a few times on Windows because readers can briefly observe empty or
+  // transiently invalid content while another process is swapping the file.
+  const snapshot: SessionStoreReadSnapshot = {
+    store: {},
+    fileStat: getFileStatSnapshot(storePath),
+  };
+  const maxReadAttempts = resolveSessionStoreMaxReadAttempts();
+  const retryBuf = maxReadAttempts > 1 ? new Int32Array(new SharedArrayBuffer(4)) : undefined;
+  for (let attempt = 0; attempt < maxReadAttempts; attempt += 1) {
+    try {
+      const raw = fs.readFileSync(storePath, "utf-8");
+      if (raw.length === 0 && attempt < maxReadAttempts - 1) {
+        Atomics.wait(retryBuf!, 0, 0, 50);
+        continue;
+      }
+      const parsed = JSON.parse(raw);
+      if (isSessionStoreRecord(parsed)) {
+        snapshot.store = parsed;
+        snapshot.serializedFromDisk = raw;
+      }
+      snapshot.fileStat = getFileStatSnapshot(storePath) ?? snapshot.fileStat;
+      break;
+    } catch {
+      if (attempt < maxReadAttempts - 1) {
+        Atomics.wait(retryBuf!, 0, 0, 50);
+        continue;
+      }
+    }
+  }
+  return snapshot;
+}
+
+function resolveSessionStoreMaxReadAttempts(): number {
+  return process.platform === "win32" ? 3 : 1;
+}
+
+async function waitForSessionStoreReadRetry(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function loadSessionStoreFromDiskAsync(storePath: string): Promise<SessionStoreReadSnapshot> {
+  const snapshot: SessionStoreReadSnapshot = {
+    store: {},
+    fileStat: getFileStatSnapshot(storePath),
+  };
+  const maxReadAttempts = resolveSessionStoreMaxReadAttempts();
+  for (let attempt = 0; attempt < maxReadAttempts; attempt += 1) {
+    try {
+      const raw = await fsp.readFile(storePath, "utf-8");
+      if (raw.length === 0 && attempt < maxReadAttempts - 1) {
+        await waitForSessionStoreReadRetry(50);
+        continue;
+      }
+      const parsed = JSON.parse(raw);
+      if (isSessionStoreRecord(parsed)) {
+        snapshot.store = parsed;
+        snapshot.serializedFromDisk = raw;
+      }
+      snapshot.fileStat = getFileStatSnapshot(storePath) ?? snapshot.fileStat;
+      break;
+    } catch {
+      if (attempt < maxReadAttempts - 1) {
+        await waitForSessionStoreReadRetry(50);
+        continue;
+      }
+    }
+  }
+  return snapshot;
+}
+
 export function loadSessionStore(
   storePath: string,
   opts: LoadSessionStoreOptions = {},
@@ -79,55 +184,32 @@ export function loadSessionStore(
     }
   }
 
-  // Retry a few times on Windows because readers can briefly observe empty or
-  // transiently invalid content while another process is swapping the file.
-  let store: Record<string, SessionEntry> = {};
-  let fileStat = getFileStatSnapshot(storePath);
-  let mtimeMs = fileStat?.mtimeMs;
-  let serializedFromDisk: string | undefined;
-  const maxReadAttempts = process.platform === "win32" ? 3 : 1;
-  const retryBuf = maxReadAttempts > 1 ? new Int32Array(new SharedArrayBuffer(4)) : undefined;
-  for (let attempt = 0; attempt < maxReadAttempts; attempt += 1) {
-    try {
-      const raw = fs.readFileSync(storePath, "utf-8");
-      if (raw.length === 0 && attempt < maxReadAttempts - 1) {
-        Atomics.wait(retryBuf!, 0, 0, 50);
-        continue;
-      }
-      const parsed = JSON.parse(raw);
-      if (isSessionStoreRecord(parsed)) {
-        store = parsed;
-        serializedFromDisk = raw;
-      }
-      fileStat = getFileStatSnapshot(storePath) ?? fileStat;
-      mtimeMs = fileStat?.mtimeMs;
-      break;
-    } catch {
-      if (attempt < maxReadAttempts - 1) {
-        Atomics.wait(retryBuf!, 0, 0, 50);
-        continue;
-      }
+  return finalizeLoadedSessionStore({
+    storePath,
+    snapshot: loadSessionStoreFromDisk(storePath),
+    opts,
+  });
+}
+
+export async function loadSessionStoreAsync(
+  storePath: string,
+  opts: LoadSessionStoreOptions = {},
+): Promise<Record<string, SessionEntry>> {
+  if (!opts.skipCache && isSessionStoreCacheEnabled()) {
+    const currentFileStat = getFileStatSnapshot(storePath);
+    const cached = readSessionStoreCache({
+      storePath,
+      mtimeMs: currentFileStat?.mtimeMs,
+      sizeBytes: currentFileStat?.sizeBytes,
+    });
+    if (cached) {
+      return cached;
     }
   }
 
-  if (serializedFromDisk !== undefined) {
-    setSerializedSessionStore(storePath, serializedFromDisk);
-  } else {
-    setSerializedSessionStore(storePath, undefined);
-  }
-
-  applySessionStoreMigrations(store);
-  normalizeSessionStore(store);
-
-  if (!opts.skipCache && isSessionStoreCacheEnabled()) {
-    writeSessionStoreCache({
-      storePath,
-      store,
-      mtimeMs,
-      sizeBytes: fileStat?.sizeBytes,
-      serialized: serializedFromDisk,
-    });
-  }
-
-  return structuredClone(store);
+  return finalizeLoadedSessionStore({
+    storePath,
+    snapshot: await loadSessionStoreFromDiskAsync(storePath),
+    opts,
+  });
 }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -54,7 +54,7 @@ export {
   drainSessionStoreLockQueuesForTest,
   getSessionStoreLockQueueSizeForTest,
 } from "./store-lock-state.js";
-export { loadSessionStore } from "./store-load.js";
+export { loadSessionStore, loadSessionStoreAsync } from "./store-load.js";
 export { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
 
 const log = createSubsystemLogger("sessions/store");

--- a/src/plugin-sdk/config-runtime.ts
+++ b/src/plugin-sdk/config-runtime.ts
@@ -49,6 +49,7 @@ export { resolveActiveTalkProviderConfig } from "../config/talk.js";
 export { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 export { loadCronStore, resolveCronStorePath, saveCronStore } from "../cron/store.js";
 export { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+export { resolveSendPolicy } from "../sessions/send-policy.js";
 export { coerceSecretRef } from "../config/types.secrets.js";
 export {
   resolveConfiguredSecretInputString,
@@ -98,6 +99,7 @@ export type {
 export {
   clearSessionStoreCacheForTest,
   loadSessionStore,
+  loadSessionStoreAsync,
   readSessionUpdatedAt,
   recordSessionMetaFromInbound,
   saveSessionStore,

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -48,12 +48,23 @@ export type {
   ReplyDispatchKind,
   ReplyDispatcher,
 } from "../auto-reply/reply/reply-dispatcher.types.js";
+export { resolveInboundReplyAdmission } from "../auto-reply/reply/inbound-reply-admission.js";
 export type {
+  InboundReplyAdmission,
+  InboundReplySilentReason,
+} from "../auto-reply/reply/inbound-reply-admission.js";
+export type {
+  ReplyDispatcherEarlyTypingOptions,
   ReplyDispatcherOptions,
   ReplyDispatcherWithTypingOptions,
 } from "../auto-reply/reply/reply-dispatcher.js";
 export { createReplyReferencePlanner } from "../auto-reply/reply/reply-reference.js";
-export type { GetReplyOptions, BlockReplyContext } from "../auto-reply/get-reply-options.types.js";
+export type {
+  GetReplyOptions,
+  BlockReplyContext,
+  EarlyTypingBinding,
+  EarlyTypingStartPhase,
+} from "../auto-reply/get-reply-options.types.js";
 export type { ReplyPayload } from "../auto-reply/reply-payload.js";
 export type { FinalizedMsgContext, MsgContext } from "../auto-reply/templating.js";
 export { generateConversationLabel } from "../auto-reply/reply/conversation-label-generator.js";


### PR DESCRIPTION
## Summary

- Problem: WhatsApp could stay visibly silent for too long in two places:
  - after an inbound DM was accepted but before the reply run reached `onReplyStart`
  - while inbound DMs were intentionally buffered by `debounceMs`
- Why it matters: the user-visible latency was mostly in pre-reply work, not in the final model call, so even simple messages felt unresponsive.
- What changed:
  - added shared reply-layer early-typing plumbing so a channel can start typing at accepted-inbound time
  - kept that early typing suppressed for silent/no-reply turns in the shared reply path
  - opted WhatsApp into that earlier typing lifecycle
  - kept WhatsApp typing active during DM debounce windows
  - centralized WhatsApp debounce admission so debounce typing and flush-time processing follow the same policy more cleanly
- What did NOT change:
  - this does not try to reduce the actual cold-start/bootstrap latency itself
  - this does not enable accepted-inbound early typing for other channels

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None provided.
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause:
  - WhatsApp only started composing from the later reply-run lifecycle instead of at accepted inbound time
  - WhatsApp debounce buffering had no matching typing lifecycle, so buffered DMs could sit silent before flush
- Missing detection / guardrail:
  - no coverage proving typing starts before reply resolution for accepted WhatsApp inbound turns
  - no guardrails ensuring early typing stays silent for deny/no-reply paths
  - no coverage for debounce-window typing staying aligned with later no-reply suppression
- Contributing context:
  - the slowest observed latency was in dispatch/bootstrap/hooks and debounce holding, not just the model call

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/dispatch.early-typing.test.ts`
  - `src/auto-reply/reply/dispatch-from-config.test.ts`
  - `src/auto-reply/reply/inbound-reply-admission.test.ts`
  - `extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts`
  - `extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
- Scenario the test should lock in:
  - accepted WhatsApp inbound messages start typing before reply resolution
  - debounced WhatsApp DMs keep typing visible during the buffer window
  - silent/no-reply turns stay silent, including `sendPolicy: deny`, unauthorized whole-message commands, and echo-dropped turns
- Why this is the smallest reliable guardrail:
  - the shared reply lifecycle needs a narrow core proof
  - the WhatsApp debounce path needs an end-to-end proof from inbound receipt through flush

## User-visible / Behavior Changes

- WhatsApp direct messages now show composing as soon as an inbound message is accepted for reply processing.
- Debounced WhatsApp direct messages now keep showing composing during the debounce hold instead of waiting until flush.
- WhatsApp still stays silent for blocked/rejected turns and no-reply turns such as:
  - `sendPolicy: deny`
  - unauthorized whole-message control commands
  - echo-dropped inbound text
- Other channels do not opt into this earlier accepted-inbound typing behavior.

## Diagram (if applicable)

```text
Before:
[accepted WhatsApp inbound] -> [debounce hold] -> [dispatch/bootstrap/before_agent_reply] -> [reply run starts] -> [typing begins]

After:
[accepted WhatsApp inbound] -> [typing begins]
                                   -> [debounce hold keeps typing alive]
                                   -> [dispatch/bootstrap/before_agent_reply]
                                   -> [reply run continues]
                                   -> [reply or silent cleanup]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo worktree
- Model/provider: N/A for the regression guard itself; the issue is mostly pre-model latency
- Integration/channel (if any): WhatsApp
- Relevant config (redacted):
  - `channels.whatsapp.allowFrom=["*"]`
  - tested both `debounceMs=0` and debounced DM flows

### Steps

1. Receive an accepted WhatsApp inbound direct message.
2. Optionally hold that DM in a debounce window.
3. Let the reply pipeline hit normal pre-run work such as dispatch/bootstrap/hooks before reply resolution.
4. Observe when `sendComposing` begins relative to debounce, reply resolution, and silent/no-reply cases.

### Expected

- Accepted inbound WhatsApp DMs begin composing before reply resolution starts.
- Debounced accepted WhatsApp DMs show composing during the debounce window.
- Blocked/rejected and no-reply turns do not emit composing.

### Actual

- Verified by targeted tests after this patch.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/auto-reply/dispatch.early-typing.test.ts`
`pnpm test src/auto-reply/reply/dispatch-from-config.test.ts`
`pnpm test src/auto-reply/reply/inbound-reply-admission.test.ts`
`pnpm test extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts`
`pnpm test extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
`pnpm tsgo`

## Human Verification (required)

- Verified scenarios:
  - accepted WhatsApp DM starts composing before reply resolution
  - debounced WhatsApp DM starts composing before flush and stays active through the buffer window
  - rejected/group-gated turn does not compose
  - `sendPolicy: deny` does not compose
  - unauthorized whole-message commands do not leak typing
  - echo-dropped inbound text does not leak typing
- What you did **not** verify:
  - live device/real WhatsApp network behavior outside the repo test harness

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk: shared reply typing lifecycle changed in core, even though behavior opt-in is WhatsApp-only.
  - Mitigation: core unit/seam coverage around early typing and silent-turn suppression.
- Risk: debounce typing could leak on no-reply paths after batching or policy changes.
  - Mitigation: centralized admission, flush-time live recomputation where needed, and WhatsApp e2e coverage for silent-turn cases.
- Risk: typing could become more responsive without improving real latency, making underlying cold-start cost easier to notice in logs.
  - Mitigation: this PR is intentionally scoped to perceived responsiveness, not latency reduction itself.