### PR TITLE
fix(feishu): harden Mira clarification card action writebacks

### DIFF
--- a/docs/handoff/current.md
+++ b/docs/handoff/current.md
@@ -1,0 +1,48 @@
+# Current Status
+
+## 当前目标
+
+- 把 `Feishu card-action parser` 的 source-level 修复固定成可续做的 owner-repo 现场，不再依赖运行时 bundle 热修记忆。
+
+## 当前事实
+
+- 仓库路径：`/Users/vincent/Workspace/lab/openclaw-upstream`
+- 当前分支：`codex/feishu-card-action-hotfix`
+- 当前主题：`Feishu card-action malformed payload compatibility fix`
+- 当前涉及文件：
+  - `extensions/feishu/src/card-action.ts`
+  - `extensions/feishu/src/monitor.account.ts`
+  - `extensions/feishu/src/monitor.card-action.lifecycle.test.ts`
+- 这轮修复已经把运行时热修回补到 source clone，兼容以下真实结构：
+  - `header.token`
+  - `event.operator / event.action / event.context`
+  - `context.open_chat_id`
+- 当前最小必要字段策略已收紧为：
+  - `token + operator.open_id + action.tag + action.value + chat_id`
+- 对 Vincent OS 当前 `limited trial` 的结论：
+  - 这条 source 修复已经有明确代码与测试证据，不再是运行 blocker。
+
+## 最新验证
+
+- 已执行：
+
+```bash
+cd /Users/vincent/Workspace/lab/openclaw-upstream
+node scripts/run-vitest.mjs run extensions/feishu/src/monitor.card-action.lifecycle.test.ts
+```
+
+- 结果：
+  - `pass`
+  - `1 file / 3 tests`
+
+## 风险与边界
+
+- 当前改动尚未 `commit / push / PR`，因此仍属于本机 source clone 证据，而不是已上游化结论。
+- 这不影响 Vincent OS 当前 `limited trial`；只影响后续是否要把修复继续提交回正式上游协作链。
+
+## 建议先读
+
+- `/Users/vincent/Workspace/_worktrees/vincent-os-vnext-landing/AI-Org-OS/reports/2026-04-11-openclaw-card-action-source-closeout.md`
+- `/Users/vincent/Workspace/lab/openclaw-upstream/extensions/feishu/src/card-action.ts`
+- `/Users/vincent/Workspace/lab/openclaw-upstream/extensions/feishu/src/monitor.account.ts`
+- `/Users/vincent/Workspace/lab/openclaw-upstream/extensions/feishu/src/monitor.card-action.lifecycle.test.ts`

--- a/docs/handoff/current.md
+++ b/docs/handoff/current.md
@@ -21,6 +21,9 @@
   - `token + operator.open_id + action.tag + action.value + chat_id`
 - 对 Vincent OS 当前 `limited trial` 的结论：
   - 这条 source 修复已经有明确代码与测试证据，不再是运行 blocker。
+- 当前 owner 边界：
+  - `Mira/OpenClaw` 是 Vincent clarification card 的 live sender + callback owner
+  - 这条链直接写回 Vincent OS canonical return / apply，不再经过 `my-claw` relay
 
 ## 最新验证
 
@@ -34,6 +37,10 @@ node scripts/run-vitest.mjs run extensions/feishu/src/monitor.card-action.lifecy
 - 结果：
   - `pass`
   - `1 file / 3 tests`
+- `2026-04-18 22:38 +08:00` 已完成一次真实 owner-check：
+  - `Mira` 发卡，message id 为 `om_x100b510d29120788b2bccbe23ffe523`
+  - Vincent 点击按钮后，Vincent OS canonical repo 生成新的 `RETURN` 与 `APPLY-LOG`
+  - 结果确认：后续所有 Mira clarification 发卡与按钮回传都只走 `Mira/OpenClaw -> Vincent OS`
 
 ## 风险与边界
 

--- a/docs/handoff/next.md
+++ b/docs/handoff/next.md
@@ -1,0 +1,24 @@
+# Next Steps
+
+## 下一步
+
+1. 如果只是跨仓回顾或系统续做：
+   - 认定这条任务已经完成 source-level closeout，不要再从 runtime bundle 逆向定位修复点。
+2. 如果要继续工程化收口：
+   - 先重新运行：
+
+```bash
+cd /Users/vincent/Workspace/lab/openclaw-upstream
+git status --short --branch
+node scripts/run-vitest.mjs run extensions/feishu/src/monitor.card-action.lifecycle.test.ts
+```
+
+3. 只有在明确要把修复正式送回上游时，才继续：
+   - `commit`
+   - `push`
+   - `PR`
+
+## 当前默认判断
+
+- 这条线已经满足 Vincent OS 跨仓任务 `WTL-20260411-04` 的关闭条件。
+- 后续若没有“提交上游”这个新目标，不需要再把它当成待处理 blocker。

--- a/docs/handoff/next.md
+++ b/docs/handoff/next.md
@@ -17,6 +17,9 @@ node scripts/run-vitest.mjs run extensions/feishu/src/monitor.card-action.lifecy
    - `commit`
    - `push`
    - `PR`
+4. 如果后续要排查 Vincent clarification callback：
+   - 默认从 `OpenClaw feishu:main` 的 live owner 视角排查
+   - 不要再把 `my-claw` 当这条链的 receiver 或 fallback
 
 ## 当前默认判断
 

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -1,6 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createRuntimeEnv } from "../../../test/helpers/plugins/runtime-env.js";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
+
+const { existsSyncMock, spawnSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: existsSyncMock,
+    },
+    existsSync: existsSyncMock,
+  };
+});
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawnSync: spawnSyncMock,
+  };
+});
+
 import {
   handleFeishuCardAction,
   resetProcessedFeishuCardActionTokensForTests,
@@ -89,6 +115,8 @@ describe("Feishu Card Action Handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetProcessedFeishuCardActionTokensForTests();
+    existsSyncMock.mockReturnValue(false);
+    spawnSyncMock.mockReset();
   });
 
   it("handles card action with text payload", async () => {
@@ -133,6 +161,102 @@ describe("Feishu Card Action Handler", () => {
         }),
       }),
     );
+  });
+
+  it("applies Vincent clarification callbacks directly without routing through chat fallback", async () => {
+    const repoRoot = "/tmp/vincent-os";
+    existsSyncMock.mockImplementation(
+      (candidate: unknown) =>
+        typeof candidate === "string" &&
+        (candidate === `${repoRoot}/AI-Org-OS/scripts/write_vincent_clarification_return.py` ||
+          candidate === `${repoRoot}/AI-Org-OS/scripts/apply_vincent_decision_writeback.py`),
+    );
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: "writeback ok\n",
+      stderr: "",
+    });
+    const runtime = createRuntimeEnv();
+    const batchPath =
+      "/tmp/vincent-os/AI-Org-OS/tasks/escalations/vincent-decisions/VINCENT-CLARIFICATION-BATCH.md";
+    const reviewRef =
+      "/tmp/vincent-os/AI-Org-OS/tasks/escalations/vincent-decisions/test-artifacts/AMBIGUITY-REVIEW.md";
+    const event = createCardActionEvent({
+      token: "tok-vc-1",
+      actionValue: {
+        kind: "vincent-clarification",
+        batch_path: batchPath,
+        review_ref: reviewRef,
+        selected_option: "A",
+      },
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "python3",
+      expect.arrayContaining([
+        "/tmp/vincent-os/AI-Org-OS/scripts/write_vincent_clarification_return.py",
+        "--repo-root",
+        repoRoot,
+        "--batch-path",
+        batchPath,
+        "--review-ref",
+        reviewRef,
+        "--selected-option",
+        "A",
+        "--response-channel",
+        "feishu:mira",
+        "--write",
+        "--apply",
+      ]),
+      { encoding: "utf-8" },
+    );
+    const args = (spawnSyncMock.mock.calls as unknown[][]).at(0)?.[1] as string[] | undefined;
+    expect(args).toBeDefined();
+    expect(args).not.toContain("--item-index");
+    expect(handleFeishuMessage).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("applied vincent clarification option A"),
+    );
+  });
+
+  it("notifies the callback target when Vincent clarification writeback fails", async () => {
+    const repoRoot = "/tmp/vincent-os";
+    existsSyncMock.mockImplementation(
+      (candidate: unknown) =>
+        typeof candidate === "string" &&
+        (candidate === `${repoRoot}/AI-Org-OS/scripts/write_vincent_clarification_return.py` ||
+          candidate === `${repoRoot}/AI-Org-OS/scripts/apply_vincent_decision_writeback.py`),
+    );
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "boom",
+    });
+    const runtime = createRuntimeEnv();
+    const event = createCardActionEvent({
+      token: "tok-vc-2",
+      actionValue: {
+        kind: "vincent-clarification",
+        batch_path:
+          "/tmp/vincent-os/AI-Org-OS/tasks/escalations/vincent-decisions/VINCENT-CLARIFICATION-BATCH.md",
+        review_ref:
+          "/tmp/vincent-os/AI-Org-OS/tasks/escalations/vincent-decisions/test-artifacts/AMBIGUITY-REVIEW.md",
+        selected_option: "B",
+      },
+    });
+
+    await expect(handleFeishuCardAction({ cfg, event, runtime })).rejects.toThrow("boom");
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:chat1",
+        text: "Confirmation received, but writeback failed. Please contact the maintainer.",
+      }),
+    );
+    expect(handleFeishuMessage).not.toHaveBeenCalled();
   });
 
   it("routes quick command actions with operator and conversation context", async () => {

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -13,8 +13,8 @@ import { sendCardFeishu, sendMessageFeishu } from "./send.js";
 export type FeishuCardActionEvent = {
   operator: {
     open_id: string;
-    user_id: string;
-    union_id: string;
+    user_id?: string;
+    union_id?: string;
   };
   token: string;
   action: {
@@ -22,8 +22,8 @@ export type FeishuCardActionEvent = {
     tag: string;
   };
   context: {
-    open_id: string;
-    user_id: string;
+    open_id?: string;
+    user_id?: string;
     chat_id: string;
   };
 };

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -1,3 +1,6 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
@@ -123,6 +126,134 @@ function resolveCallbackTarget(event: FeishuCardActionEvent): string {
     return `chat:${chatId}`;
   }
   return `user:${event.operator.open_id}`;
+}
+
+function readTrimmedClarificationString(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return "";
+}
+
+function parseVincentClarificationActionValue(text: string): Record<string, unknown> | null {
+  if (!text.trim()) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed.kind === "vincent-clarification" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveVincentClarificationWritebackPaths(batchPathRaw: unknown): {
+  repoRoot: string;
+  writerScriptPath: string;
+  applyScriptPath: string;
+  batchPath: string;
+} | null {
+  const batchPath = readTrimmedClarificationString(batchPathRaw);
+  if (!batchPath) {
+    return null;
+  }
+
+  let probeDir = path.dirname(path.resolve(batchPath));
+  while (true) {
+    const writerScriptPath = path.join(
+      probeDir,
+      "AI-Org-OS",
+      "scripts",
+      "write_vincent_clarification_return.py",
+    );
+    const applyScriptPath = path.join(
+      probeDir,
+      "AI-Org-OS",
+      "scripts",
+      "apply_vincent_decision_writeback.py",
+    );
+    if (fs.existsSync(writerScriptPath) && fs.existsSync(applyScriptPath)) {
+      return {
+        repoRoot: probeDir,
+        writerScriptPath,
+        applyScriptPath,
+        batchPath,
+      };
+    }
+    const parent = path.dirname(probeDir);
+    if (parent === probeDir) {
+      return null;
+    }
+    probeDir = parent;
+  }
+}
+
+function applyVincentClarificationAction(actionValue: Record<string, unknown>): {
+  selectedOption: string;
+  reviewRef: string;
+  detail: string;
+  paths: {
+    repoRoot: string;
+    writerScriptPath: string;
+    applyScriptPath: string;
+    batchPath: string;
+  };
+} {
+  const selectedOption = readTrimmedClarificationString(actionValue.selected_option).toUpperCase();
+  const reviewRef = readTrimmedClarificationString(actionValue.review_ref);
+  const itemIndex = readTrimmedClarificationString(actionValue.item_index);
+  if (!selectedOption || !reviewRef) {
+    throw new Error("missing clarification callback payload");
+  }
+
+  const paths = resolveVincentClarificationWritebackPaths(actionValue.batch_path);
+  if (!paths) {
+    throw new Error("unable to resolve Vincent clarification writeback paths");
+  }
+
+  const args = [
+    paths.writerScriptPath,
+    "--repo-root",
+    paths.repoRoot,
+    "--batch-path",
+    paths.batchPath,
+    ...(itemIndex ? ["--item-index", itemIndex] : []),
+    "--review-ref",
+    reviewRef,
+    "--selected-option",
+    selectedOption,
+    "--resolved-at",
+    new Date().toISOString(),
+    "--response-channel",
+    "feishu:mira",
+    "--write",
+    "--apply",
+  ];
+  const result = spawnSync("python3", args, {
+    encoding: "utf-8",
+  });
+  if (result.error) {
+    throw new Error(`failed to execute clarification writer: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(
+      detail || `clarification writeback failed with status ${String(result.status)}`,
+    );
+  }
+
+  return {
+    selectedOption,
+    reviewRef,
+    detail: result.stdout.trim(),
+    paths,
+  };
 }
 
 async function dispatchSyntheticCommand(params: {
@@ -293,6 +424,26 @@ export async function handleFeishuCardAction(params: {
     log(
       `feishu[${account.accountId}]: handling card action from ${event.operator.open_id}: ${content}`,
     );
+
+    const vincentClarificationAction = parseVincentClarificationActionValue(content);
+    if (vincentClarificationAction) {
+      try {
+        const writeback = applyVincentClarificationAction(vincentClarificationAction);
+        log(
+          `feishu[${account.accountId}]: applied vincent clarification option ${writeback.selectedOption} for ${writeback.reviewRef}`,
+        );
+        completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+        return;
+      } catch (err) {
+        await sendMessageFeishu({
+          cfg,
+          to: resolveCallbackTarget(event),
+          text: "Confirmation received, but writeback failed. Please contact the maintainer.",
+          accountId,
+        });
+        throw err;
+      }
+    }
 
     await dispatchSyntheticCommand({
       cfg,

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -245,32 +245,25 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
   if (!isRecord(value)) {
     return null;
   }
-  const operator = value.operator;
-  const action = value.action;
-  const context = value.context;
+  const header = isRecord(value.header) ? value.header : undefined;
+  const event = isRecord(value.event) ? value.event : value;
+  const operator = event.operator;
+  const action = event.action;
+  const context = event.context;
   if (!isRecord(operator) || !isRecord(action) || !isRecord(context)) {
     return null;
   }
-  const token = readString(value.token);
-  const openId = readString(operator.open_id);
-  const userId = readString(operator.user_id);
-  const unionId = readString(operator.union_id);
+  const operatorId = isRecord(operator.operator_id) ? operator.operator_id : undefined;
+  const token = readString(value.token) ?? readString(header?.token);
+  const openId = readString(operator.open_id) ?? readString(operatorId?.open_id);
+  const userId = readString(operator.user_id) ?? readString(operatorId?.user_id);
+  const unionId = readString(operator.union_id) ?? readString(operatorId?.union_id);
   const tag = readString(action.tag);
   const actionValue = action.value;
   const contextOpenId = readString(context.open_id);
   const contextUserId = readString(context.user_id);
-  const chatId = readString(context.chat_id);
-  if (
-    !token ||
-    !openId ||
-    !userId ||
-    !unionId ||
-    !tag ||
-    !isRecord(actionValue) ||
-    !contextOpenId ||
-    !contextUserId ||
-    !chatId
-  ) {
+  const chatId = readString(context.chat_id) ?? readString(context.open_chat_id);
+  if (!token || !openId || !tag || !isRecord(actionValue) || !chatId) {
     return null;
   }
   return {

--- a/extensions/feishu/src/monitor.card-action.lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.card-action.lifecycle.test.ts
@@ -94,6 +94,47 @@ function createCardActionEvent(params: {
   };
 }
 
+function createNestedCardActionEvent(params: {
+  token: string;
+  action: string;
+  command: string;
+  chatId?: string;
+  chatType?: "group" | "p2p";
+}) {
+  const openId = "ou_user1";
+  const chatId = params.chatId ?? "p2p:ou_user1";
+  const chatType = params.chatType ?? "p2p";
+  return {
+    header: {
+      token: params.token,
+    },
+    event: {
+      operator: {
+        operator_id: {
+          open_id: openId,
+        },
+      },
+      action: {
+        tag: "button",
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: params.action,
+          q: params.command,
+          c: {
+            u: openId,
+            h: chatId,
+            t: chatType,
+            e: Date.now() + 60_000,
+          },
+        }),
+      },
+      context: {
+        open_chat_id: chatId,
+      },
+    },
+  };
+}
+
 async function setupLifecycleMonitor() {
   lastRuntime = createRuntimeEnv();
   return setupFeishuLifecycleHandler({
@@ -217,6 +258,40 @@ describe("Feishu card-action lifecycle", () => {
 
     expect(lastRuntime?.error).toHaveBeenCalledTimes(1);
     expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+    expectFeishuReplyDispatcherSentFinalReplyOnce({ createFeishuReplyDispatcherMock });
+  });
+
+  it("accepts nested card-action payloads that only provide header token and open_chat_id", async () => {
+    const onCardAction = await setupLifecycleMonitor();
+    const event = createNestedCardActionEvent({
+      token: "tok-card-nested",
+      action: "feishu.quick_actions.help",
+      command: "/help",
+    });
+
+    await expectFeishuReplyPipelineDedupedAcrossReplay({
+      handler: onCardAction,
+      event,
+      dispatchReplyFromConfigMock,
+      createFeishuReplyDispatcherMock,
+    });
+
+    expect(lastRuntime?.error).not.toHaveBeenCalled();
+    expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+    expect(createFeishuReplyDispatcherMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "acct-card",
+        chatId: "p2p:ou_user1",
+        replyToMessageId: "card-action-tok-card-nested",
+      }),
+    );
+    expect(finalizeInboundContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        AccountId: "acct-card",
+        SessionKey: "agent:bound-agent:feishu:direct:ou_user1",
+        MessageSid: "card-action-tok-card-nested",
+      }),
+    );
     expectFeishuReplyDispatcherSentFinalReplyOnce({ createFeishuReplyDispatcherMock });
   });
 });


### PR DESCRIPTION
## Summary
- accept nested Feishu card action payloads that Mira clarification cards send in practice
- handle direct Mira clarification writebacks inside the Feishu extension instead of relying on an external relay
- document OpenClaw as the live sender and callback owner for Mira clarification cards

## Verification
- `pnpm exec vitest run extensions/feishu/src/bot.card-action.test.ts extensions/feishu/src/monitor.card-action.lifecycle.test.ts`
- live owner-check card click successfully wrote back to Vincent OS after this path was enabled
