### PR TITLE
fix(pi-tools): allow empty/whitespace-only content in write tool

### DIFF
--- a/src/agents/pi-tools.params.test.ts
+++ b/src/agents/pi-tools.params.test.ts
@@ -127,3 +127,76 @@ describe("assertRequiredParams", () => {
     ).not.toThrow();
   });
 });
+
+describe("REQUIRED_PARAM_GROUPS.write", () => {
+  // The `write` tool's `content` group sets `allowEmpty: true` so that
+  // writing an empty or whitespace-only file (e.g. initializing an empty
+  // JSONL append-log, creating a sentinel file, truncating an existing
+  // file) is accepted. Without this flag, the model gets the validation
+  // error "Missing required parameter: content (received: content=<empty-string>)"
+  // on `content: ""` or `content: "\n"` and ends up stuck retrying the
+  // same input.
+
+  it('accepts content="" (empty file write)', () => {
+    expect(() =>
+      assertRequiredParams(
+        { path: "/tmp/a.txt", content: "" },
+        REQUIRED_PARAM_GROUPS.write,
+        "write",
+      ),
+    ).not.toThrow();
+  });
+
+  it('accepts content="\\n" (newline-only write)', () => {
+    expect(() =>
+      assertRequiredParams(
+        { path: "/tmp/a.txt", content: "\n" },
+        REQUIRED_PARAM_GROUPS.write,
+        "write",
+      ),
+    ).not.toThrow();
+  });
+
+  it("accepts content with only whitespace", () => {
+    expect(() =>
+      assertRequiredParams(
+        { path: "/tmp/a.txt", content: "   \t\n  " },
+        REQUIRED_PARAM_GROUPS.write,
+        "write",
+      ),
+    ).not.toThrow();
+  });
+
+  it("still rejects when content is entirely missing", () => {
+    expect(() =>
+      assertRequiredParams({ path: "/tmp/a.txt" }, REQUIRED_PARAM_GROUPS.write, "write"),
+    ).toThrow(/Missing required parameter: content/);
+  });
+
+  it("still rejects when content is a non-string type", async () => {
+    const tool = wrapToolParamValidation(
+      {
+        name: "write",
+        label: "write",
+        description: "write a file",
+        parameters: {},
+        execute: vi.fn(),
+      },
+      REQUIRED_PARAM_GROUPS.write,
+    );
+    await expect(
+      tool.execute(
+        "id",
+        { path: "test.txt", content: { unexpected: true } },
+        new AbortController().signal,
+        vi.fn(),
+      ),
+    ).rejects.toThrow(/Missing required parameter: content/);
+  });
+
+  it("still rejects when path is missing", () => {
+    expect(() =>
+      assertRequiredParams({ content: "hello" }, REQUIRED_PARAM_GROUPS.write, "write"),
+    ).toThrow(/Missing required parameter: path/);
+  });
+});

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -76,7 +76,13 @@ export const REQUIRED_PARAM_GROUPS = {
   read: [{ keys: ["path"], label: "path" }],
   write: [
     { keys: ["path"], label: "path" },
-    { keys: ["content"], label: "content" },
+    // `allowEmpty: true` because writing an empty or whitespace-only file is a
+    // legitimate operation — for example, initializing an empty JSONL append-log,
+    // creating a sentinel file, or truncating an existing file. Without this
+    // flag the validator rejects `content: ""` and `content: "\n"` as
+    // "missing required parameter" and the LLM gets stuck retrying with the
+    // same or slightly-different empty strings.
+    { keys: ["content"], label: "content", allowEmpty: true },
   ],
   edit: [
     { keys: ["path"], label: "path" },


### PR DESCRIPTION
Closes #68636

## Summary

The `write` tool's parameter validator currently rejects `content: ""` and any whitespace-only value with the error `"Missing required parameter: content (received: path, content=<empty-string>)"`. This treats a legitimate operation (initializing an empty JSONL append-log, creating a sentinel file, or truncating an existing file) as a missing-parameter error, and because the error hints `"Supply correct parameters before retrying"` the model retries with the same or another empty value, gets the same error, and the turn ends with a user-visible `Write failed` banner without the file ever being created.

See the linked issue for a live reproduction with three model-driven retries in 39s.

## Fix

Single change in `src/agents/pi-tools.params.ts`: add `allowEmpty: true` to the `content` group of `REQUIRED_PARAM_GROUPS.write`.

```diff
   write: [
     { keys: ["path"], label: "path" },
-    { keys: ["content"], label: "content" },
+    { keys: ["content"], label: "content", allowEmpty: true },
   ],
```

This is a one-flag change that uses the existing `allowEmpty` mechanism. The validator still rejects:
- `content` key entirely missing
- `content` as `null` or `undefined`
- `content` as a non-string type (object, array)
- `path` missing

It now accepts:
- `content: ""` (empty write)
- `content: "\n"` (newline-only, e.g. JSONL append-log initialization)
- `content: "   \t\n  "` (all-whitespace)

## Tests

Added a dedicated `describe("REQUIRED_PARAM_GROUPS.write")` block in `src/agents/pi-tools.params.test.ts` with six cases: three accepting (empty, newline, all-whitespace), three still-rejecting (missing content, non-string content, missing path). All pass locally.

## Rationale

The intent of the `.trim().length > 0` check is to catch `content` being *missing* (the model forgot the parameter), but it also catches the legitimate case where the model is intentionally writing an empty file. The existing `allowEmpty` flag exists for exactly this distinction. The write tool's natural semantics (create/truncate) should accept empty content.