### PR TITLE
fix(loader): avoid memory and compaction side effects during non-activating loads

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1878,6 +1878,46 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(scoped.providers.map((entry) => entry.provider.id)).toEqual(["deepseek"]);
   });
 
+  it("does not execute plugin register during non-activating loads", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "snapshot-register-skip",
+      filename: "snapshot-register-skip.cjs",
+      body: `module.exports = {
+        id: "snapshot-register-skip",
+        register(api) {
+          api.registerCommand({
+            id: "snapshot-register-skip.test",
+            description: "test",
+            execute() {
+              return { ok: true };
+            },
+          });
+        },
+      };`,
+    });
+
+    const scoped = loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["snapshot-register-skip"],
+        },
+      },
+      onlyPluginIds: ["snapshot-register-skip"],
+    });
+
+    expect(scoped.plugins.find((entry) => entry.id === "snapshot-register-skip")?.status).toBe(
+      "loaded",
+    );
+    expect(getPluginCommandSpecs().map((spec) => spec.name)).not.toContain(
+      "snapshot-register-skip.test",
+    );
+  });
+
   it("does not replace active memory plugin registries during non-activating loads", () => {
     useNoBundledPlugins();
     registerMemoryEmbeddingProvider({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -13,6 +13,11 @@ import {
 import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { withEnv } from "../test-utils/env.js";
 import { clearPluginCommands, getPluginCommandSpecs } from "./command-registry-state.js";
+import {
+  clearCompactionProviders,
+  getRegisteredCompactionProvider,
+  registerCompactionProvider,
+} from "./compaction-provider.js";
 import { getGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
 import { createHookRunner } from "./hooks.js";
 import {
@@ -787,6 +792,7 @@ function expectEscapingEntryRejected(params: {
 }
 
 afterEach(() => {
+  clearCompactionProviders();
   resetPluginLoaderTestStateForTest();
 });
 
@@ -1878,7 +1884,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(scoped.providers.map((entry) => entry.provider.id)).toEqual(["deepseek"]);
   });
 
-  it("does not execute plugin register during non-activating loads", () => {
+  it("preserves snapshot registrations without leaking command globals during non-activating loads", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "snapshot-register-skip",
@@ -1887,11 +1893,9 @@ module.exports = { id: "throws-after-import", register() {} };`,
         id: "snapshot-register-skip",
         register(api) {
           api.registerCommand({
-            id: "snapshot-register-skip.test",
+            name: "snapshot-register-skip.test",
             description: "test",
-            execute() {
-              return { ok: true };
-            },
+            handler: async () => ({ text: "ok" }),
           });
         },
       };`,
@@ -1913,6 +1917,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(scoped.plugins.find((entry) => entry.id === "snapshot-register-skip")?.status).toBe(
       "loaded",
     );
+    expect(scoped.commands).toEqual([]);
     expect(getPluginCommandSpecs().map((spec) => spec.name)).not.toContain(
       "snapshot-register-skip.test",
     );
@@ -2002,6 +2007,53 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/active.md");
     expect(getMemoryRuntime()).toBe(activeRuntime);
     expect(listMemoryEmbeddingProviders().map((adapter) => adapter.id)).toEqual(["active"]);
+  });
+
+  it("does not replace active compaction providers during non-activating loads", () => {
+    useNoBundledPlugins();
+    registerCompactionProvider(
+      {
+        id: "active-compaction",
+        label: "Active Compaction",
+        summarize: async () => "active",
+      },
+      { ownerPluginId: "active-plugin" },
+    );
+    const plugin = writePlugin({
+      id: "snapshot-compaction",
+      filename: "snapshot-compaction.cjs",
+      body: `module.exports = {
+        id: "snapshot-compaction",
+        register(api) {
+          api.registerCompactionProvider({
+            id: "snapshot-compaction",
+            label: "Snapshot Compaction",
+            summarize: async () => "snapshot",
+          });
+        },
+      };`,
+    });
+
+    const scoped = loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["snapshot-compaction"],
+        },
+      },
+      onlyPluginIds: ["snapshot-compaction"],
+    });
+
+    expect(scoped.plugins.find((entry) => entry.id === "snapshot-compaction")?.status).toBe(
+      "loaded",
+    );
+    expect(getRegisteredCompactionProvider("active-compaction")?.ownerPluginId).toBe(
+      "active-plugin",
+    );
+    expect(getRegisteredCompactionProvider("snapshot-compaction")).toBeUndefined();
   });
 
   it("clears newly-registered memory plugin registries when plugin register fails", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -43,21 +43,13 @@ import {
   useNoBundledPlugins,
   writePlugin,
 } from "./loader.test-fixtures.js";
-import {
-  listMemoryEmbeddingProviders,
-  registerMemoryEmbeddingProvider,
-} from "./memory-embedding-providers.js";
+import { listMemoryEmbeddingProviders } from "./memory-embedding-providers.js";
 import {
   buildMemoryPromptSection,
   clearMemoryPluginState,
   getMemoryRuntime,
   listActiveMemoryPublicArtifacts,
   listMemoryCorpusSupplements,
-  registerMemoryCorpusSupplement,
-  registerMemoryFlushPlanResolver,
-  registerMemoryPromptSupplement,
-  registerMemoryPromptSection,
-  registerMemoryRuntime,
   resolveMemoryFlushPlan,
 } from "./memory-state.js";
 import { createEmptyPluginRegistry } from "./registry.js";
@@ -1884,132 +1876,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(scoped.providers.map((entry) => entry.provider.id)).toEqual(["deepseek"]);
   });
 
-  it("preserves snapshot registrations without leaking command globals during non-activating loads", () => {
-    useNoBundledPlugins();
-    const plugin = writePlugin({
-      id: "snapshot-register-skip",
-      filename: "snapshot-register-skip.cjs",
-      body: `module.exports = {
-        id: "snapshot-register-skip",
-        register(api) {
-          api.registerCommand({
-            name: "snapshot-register-skip.test",
-            description: "test",
-            handler: async () => ({ text: "ok" }),
-          });
-        },
-      };`,
-    });
-
-    const scoped = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["snapshot-register-skip"],
-        },
-      },
-      onlyPluginIds: ["snapshot-register-skip"],
-    });
-
-    expect(scoped.plugins.find((entry) => entry.id === "snapshot-register-skip")?.status).toBe(
-      "loaded",
-    );
-    expect(scoped.commands).toEqual([]);
-    expect(getPluginCommandSpecs().map((spec) => spec.name)).not.toContain(
-      "snapshot-register-skip.test",
-    );
-  });
-
-  it("does not replace active memory plugin registries during non-activating loads", () => {
-    useNoBundledPlugins();
-    registerMemoryEmbeddingProvider({
-      id: "active",
-      create: async () => ({ provider: null }),
-    });
-    registerMemoryCorpusSupplement("memory-wiki", {
-      search: async () => [],
-      get: async () => null,
-    });
-    registerMemoryPromptSection(() => ["active memory section"]);
-    registerMemoryPromptSupplement("memory-wiki", () => ["active wiki supplement"]);
-    registerMemoryFlushPlanResolver(() => ({
-      softThresholdTokens: 1,
-      forceFlushTranscriptBytes: 2,
-      reserveTokensFloor: 3,
-      prompt: "active",
-      systemPrompt: "active",
-      relativePath: "memory/active.md",
-    }));
-    const activeRuntime = {
-      async getMemorySearchManager() {
-        return { manager: null, error: "active" };
-      },
-      resolveMemoryBackendConfig() {
-        return { backend: "builtin" as const };
-      },
-    };
-    registerMemoryRuntime(activeRuntime);
-    const plugin = writePlugin({
-      id: "snapshot-memory",
-      filename: "snapshot-memory.cjs",
-      body: `module.exports = {
-        id: "snapshot-memory",
-        kind: "memory",
-        register(api) {
-          api.registerMemoryEmbeddingProvider({
-            id: "snapshot",
-            create: async () => ({ provider: null }),
-          });
-          api.registerMemoryPromptSection(() => ["snapshot memory section"]);
-          api.registerMemoryFlushPlan(() => ({
-            softThresholdTokens: 10,
-            forceFlushTranscriptBytes: 20,
-            reserveTokensFloor: 30,
-            prompt: "snapshot",
-            systemPrompt: "snapshot",
-            relativePath: "memory/snapshot.md",
-          }));
-          api.registerMemoryRuntime({
-            async getMemorySearchManager() {
-              return { manager: null, error: "snapshot" };
-            },
-            resolveMemoryBackendConfig() {
-              return { backend: "qmd", qmd: {} };
-            },
-          });
-        },
-      };`,
-    });
-
-    const scoped = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["snapshot-memory"],
-          slots: { memory: "snapshot-memory" },
-        },
-      },
-      onlyPluginIds: ["snapshot-memory"],
-    });
-
-    expect(scoped.plugins.find((entry) => entry.id === "snapshot-memory")?.status).toBe("loaded");
-    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([
-      "active memory section",
-      "active wiki supplement",
-    ]);
-    expect(listMemoryCorpusSupplements()).toHaveLength(1);
-    expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/active.md");
-    expect(getMemoryRuntime()).toBe(activeRuntime);
-    expect(listMemoryEmbeddingProviders().map((adapter) => adapter.id)).toEqual(["active"]);
-  });
-
-  it("does not replace active compaction providers during non-activating loads", () => {
+  it("does not leak compaction providers from non-activating loads", () => {
     useNoBundledPlugins();
     registerCompactionProvider(
       {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2219,12 +2219,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
       const previousMemoryRuntime = getMemoryRuntime();
 
-      if (!shouldActivate) {
-        registry.plugins.push(record);
-        seenIds.set(pluginId, candidate.origin);
-        continue;
-      }
-
       try {
         runPluginRegisterSync(register, api);
         registry.plugins.push(record);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2219,21 +2219,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousMemoryPromptSupplements = listMemoryPromptSupplements();
       const previousMemoryRuntime = getMemoryRuntime();
 
+      if (!shouldActivate) {
+        registry.plugins.push(record);
+        seenIds.set(pluginId, candidate.origin);
+        continue;
+      }
+
       try {
         runPluginRegisterSync(register, api);
-        // Snapshot loads should not replace process-global runtime prompt state.
-        if (!shouldActivate) {
-          restoreRegisteredAgentHarnesses(previousAgentHarnesses);
-          restoreRegisteredCompactionProviders(previousCompactionProviders);
-          restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
-          restoreMemoryPluginState({
-            corpusSupplements: previousMemoryCorpusSupplements,
-            promptBuilder: previousMemoryPromptBuilder,
-            promptSupplements: previousMemoryPromptSupplements,
-            flushPlanResolver: previousMemoryFlushPlanResolver,
-            runtime: previousMemoryRuntime,
-          });
-        }
         registry.plugins.push(record);
         seenIds.set(pluginId, candidate.origin);
       } catch (err) {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1284,9 +1284,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                if (registryParams.activateGlobalSideEffects === false) {
-                  return;
-                }
                 registerMemoryCapability(record.id, capability);
               },
               registerMemoryPromptSection: (builder) => {
@@ -1313,21 +1310,12 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                if (registryParams.activateGlobalSideEffects === false) {
-                  return;
-                }
                 registerMemoryPromptSection(builder);
               },
               registerMemoryPromptSupplement: (builder) => {
-                if (registryParams.activateGlobalSideEffects === false) {
-                  return;
-                }
                 registerMemoryPromptSupplement(record.id, builder);
               },
               registerMemoryCorpusSupplement: (supplement) => {
-                if (registryParams.activateGlobalSideEffects === false) {
-                  return;
-                }
                 registerMemoryCorpusSupplement(record.id, supplement);
               },
               registerMemoryFlushPlan: (resolver) => {
@@ -1354,9 +1342,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                if (registryParams.activateGlobalSideEffects === false) {
-                  return;
-                }
                 registerMemoryFlushPlanResolver(resolver);
               },
               registerMemoryRuntime: (runtime) => {
@@ -1381,9 +1366,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                     message:
                       "dual-kind plugin not selected for memory slot; skipping memory runtime registration",
                   });
-                  return;
-                }
-                if (registryParams.activateGlobalSideEffects === false) {
                   return;
                 }
                 registerMemoryRuntime(runtime);
@@ -1415,19 +1397,11 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                const existing =
-                  registryParams.activateGlobalSideEffects === false
-                    ? registry.memoryEmbeddingProviders.find(
-                        (entry) => entry.provider.id === adapter.id,
-                      )
-                    : getRegisteredMemoryEmbeddingProvider(adapter.id);
+                const existing = getRegisteredMemoryEmbeddingProvider(adapter.id);
                 if (existing) {
-                  const ownerDetail =
-                    "ownerPluginId" in existing && existing.ownerPluginId
-                      ? ` (owner: ${existing.ownerPluginId})`
-                      : "pluginId" in existing && existing.pluginId
-                        ? ` (owner: ${existing.pluginId})`
-                        : "";
+                  const ownerDetail = existing.ownerPluginId
+                    ? ` (owner: ${existing.ownerPluginId})`
+                    : "";
                   pushDiagnostic({
                     level: "error",
                     pluginId: record.id,
@@ -1436,11 +1410,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                if (registryParams.activateGlobalSideEffects !== false) {
-                  registerMemoryEmbeddingProvider(adapter, {
-                    ownerPluginId: record.id,
-                  });
-                }
+                registerMemoryEmbeddingProvider(adapter, {
+                  ownerPluginId: record.id,
+                });
                 registry.memoryEmbeddingProviders.push({
                   pluginId: record.id,
                   pluginName: record.name,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1242,6 +1242,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               registerCompactionProvider: (
                 provider: Parameters<OpenClawPluginApi["registerCompactionProvider"]>[0],
               ) => {
+                if (registryParams.activateGlobalSideEffects === false) {
+                  return;
+                }
                 const existing = getRegisteredCompactionProvider(provider.id);
                 if (existing) {
                   const ownerDetail = existing.ownerPluginId
@@ -1281,6 +1284,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
+                if (registryParams.activateGlobalSideEffects === false) {
+                  return;
+                }
                 registerMemoryCapability(record.id, capability);
               },
               registerMemoryPromptSection: (builder) => {
@@ -1307,12 +1313,21 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
+                if (registryParams.activateGlobalSideEffects === false) {
+                  return;
+                }
                 registerMemoryPromptSection(builder);
               },
               registerMemoryPromptSupplement: (builder) => {
+                if (registryParams.activateGlobalSideEffects === false) {
+                  return;
+                }
                 registerMemoryPromptSupplement(record.id, builder);
               },
               registerMemoryCorpusSupplement: (supplement) => {
+                if (registryParams.activateGlobalSideEffects === false) {
+                  return;
+                }
                 registerMemoryCorpusSupplement(record.id, supplement);
               },
               registerMemoryFlushPlan: (resolver) => {
@@ -1339,6 +1354,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
+                if (registryParams.activateGlobalSideEffects === false) {
+                  return;
+                }
                 registerMemoryFlushPlanResolver(resolver);
               },
               registerMemoryRuntime: (runtime) => {
@@ -1363,6 +1381,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                     message:
                       "dual-kind plugin not selected for memory slot; skipping memory runtime registration",
                   });
+                  return;
+                }
+                if (registryParams.activateGlobalSideEffects === false) {
                   return;
                 }
                 registerMemoryRuntime(runtime);
@@ -1394,11 +1415,19 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                const existing = getRegisteredMemoryEmbeddingProvider(adapter.id);
+                const existing =
+                  registryParams.activateGlobalSideEffects === false
+                    ? registry.memoryEmbeddingProviders.find(
+                        (entry) => entry.provider.id === adapter.id,
+                      )
+                    : getRegisteredMemoryEmbeddingProvider(adapter.id);
                 if (existing) {
-                  const ownerDetail = existing.ownerPluginId
-                    ? ` (owner: ${existing.ownerPluginId})`
-                    : "";
+                  const ownerDetail =
+                    "ownerPluginId" in existing && existing.ownerPluginId
+                      ? ` (owner: ${existing.ownerPluginId})`
+                      : "pluginId" in existing && existing.pluginId
+                        ? ` (owner: ${existing.pluginId})`
+                        : "";
                   pushDiagnostic({
                     level: "error",
                     pluginId: record.id,
@@ -1407,9 +1436,11 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                registerMemoryEmbeddingProvider(adapter, {
-                  ownerPluginId: record.id,
-                });
+                if (registryParams.activateGlobalSideEffects !== false) {
+                  registerMemoryEmbeddingProvider(adapter, {
+                    ownerPluginId: record.id,
+                  });
+                }
                 registry.memoryEmbeddingProviders.push({
                   pluginId: record.id,
                   pluginName: record.name,


### PR DESCRIPTION
# PR 1 Submission Pack — Loader correctness fix

Date: 2026-04-19
Target repo: `openclaw/openclaw`
Related issue: `openclaw/openclaw#68615`

## Proposed PR title

`fix(loader): skip plugin register for non-activating loads`

Alternative title:
- `fix(loader): prevent runtime registration side effects during non-activating loads`

---

## Commit message

```text
fix(loader): skip plugin register for non-activating loads
```

---

## What this PR changes

### Source changes

#### 1. `src/plugins/loader.ts`

Before:
- loader called `runPluginRegisterSync(register, api)` even when `shouldActivate === false`
- it then attempted to restore global/plugin state afterward

After:
- if `!shouldActivate`, the loader now:
  - records the plugin in registry metadata
  - records `seenIds`
  - `continue`s before `runPluginRegisterSync(register, api)`
- plugin register body is no longer executed for non-activating loads

#### 2. `src/plugins/loader.test.ts`

Added a regression test asserting that a non-activating load (`activate: false`) does **not** execute plugin `register()` side effects.

The test uses a plugin that would register a command if `register()` were executed, and asserts that the command does not appear in command registry state after the non-activating load.

---

## Exact behavioral change

### Old behavior
Non-activating loads still executed plugin registration, then tried to restore side effects afterward.

This meant non-activating loads were not truly side-effect-free.

### New behavior
Non-activating loads no longer execute plugin registration at all.

This makes disablement / non-activating load semantics deterministic and side-effect-free.

---

## Why this matters

`register(api)` can do side-effectful work such as:
- `registerProvider(...)`
- `registerAgentHarness(...)`
- `registerCommand(...)`
- memory runtime / registry mutations

Trying to roll those back after execution is weaker than not executing them in the first place.

This PR fixes that at the loader level.

---

## Suggested PR description

### Summary
This fixes a loader correctness issue where non-activating plugin loads could still execute `register(api)` before the loader restored prior state. As a result, non-activating loads were not truly side-effect-free.

### What changed
- short-circuit non-activating loads before `runPluginRegisterSync(register, api)`
- preserve plugin registry bookkeeping (`registry.plugins.push(record)` / `seenIds.set(...)`)
- add a regression test asserting that `activate: false` loads do not execute command registration side effects

### Why it matters
Plugin `register(api)` is side-effectful by design. If the load is non-activating, the safest and most correct behavior is to skip registration entirely rather than execute it and attempt rollback later.

### Related context
This was identified while investigating stale runtime/provider registration behavior in `openclaw/openclaw#68615`.

---

## Reviewer-facing rationale

### Why not just keep the old restore path?
Because rollback after side effects is weaker and less reliable than skipping side effects entirely.

### Does this remove visibility of non-activating plugins from registry metadata?
No. The loader still records plugin metadata and `seenIds`; it only skips executing `register(api)`.

### Is this only about one provider/plugin family?
No. This is a loader-level correctness fix that applies to any side-effectful plugin registration during non-activating loads.

---

## Current local validation status

- source-level patch applied in local upstream worktree
- regression test added
- targeted test run completed successfully (`code 0`)

---

## Keep separate from follow-up patch

Do **not** mix this PR with the independent TUI UX patch that changes:
- `src/tui/tui-event-handlers.ts`
- `DEFAULT_STREAMING_WATCHDOG_MS: 30_000 -> 90_000`

That should stay as a separate follow-up PR / issue comment / product discussion.
