### PR TITLE
fix(memory-wiki): forward sessionKey to shared memory search

### DIFF
--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -340,6 +340,40 @@ describe("searchMemoryWiki", () => {
     });
   });
 
+  it("forwards agentSessionKey to shared memory search", async () => {
+    const { config } = await createQueryVault({
+      initialize: true,
+      config: {
+        search: { backend: "shared", corpus: "memory" },
+      },
+    });
+    const manager = createMemoryManager({
+      searchResults: [
+        {
+          path: "MEMORY.md",
+          startLine: 1,
+          endLine: 2,
+          score: 1,
+          snippet: "session key test",
+          source: "memory",
+        },
+      ],
+    });
+    getActiveMemorySearchManagerMock.mockResolvedValue({ manager });
+
+    await searchMemoryWiki({
+      config,
+      appConfig: createAppConfig(),
+      agentSessionKey: "agent:secondary:thread",
+      query: "session",
+    });
+
+    expect(manager.search).toHaveBeenCalledWith("session", {
+      maxResults: expect.any(Number),
+      sessionKey: "agent:secondary:thread",
+    });
+  });
+
   it("allows per-call corpus overrides without changing config defaults", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -665,7 +665,7 @@ export async function searchMemoryWiki(params: {
       })
     : null;
   const memoryResults = sharedMemoryManager
-    ? (await sharedMemoryManager.search(params.query, { maxResults })).map((result) =>
+    ? (await sharedMemoryManager.search(params.query, { maxResults, sessionKey: params.agentSessionKey })).map((result) =>
         toMemoryWikiSearchResult(result),
       )
     : [];


### PR DESCRIPTION
### What

Forward `agentSessionKey` to the shared memory manager's `search()` call in `searchMemoryWiki()`.

### Why

When `memory-wiki` uses the `shared` search backend with QMD, the search call at `query.ts:668` passes `{ maxResults }` but omits `sessionKey`. QMD's scope check requires a session key to resolve the chat type and apply scope rules. Without it, the request is denied:

```
qmd search denied by scope (channel=unknown, chatType=unknown, session=<none>)
```

This causes `wiki_search` to silently return empty results whenever QMD is the shared backend, even though `memory_search` works correctly (it does forward the session key).

### Prior art

The same pattern was fixed for the CLI path in #57493. This PR applies the equivalent fix to the memory-wiki plugin's query path.

Related issues: #43517, #10191, #53231

### Testing

Tested locally on OpenClaw 2026.4.14 with QMD 2.1.0:
- Before fix: `wiki_search` returns empty, gateway logs show
  `qmd search denied by scope (channel=unknown, chatType=unknown, session=<none>)`
- Applied scope workaround (`memory.qmd.scope.default: "allow"`) confirms
  the scope check is the only blocker — results return correctly
- `memory_search corpus=all` with the same query returns results
  (session key forwarded correctly in memory-core path)

### Environment

- OpenClaw: 2026.4.14 (323493f)
- QMD: 2.1.0
- Node: v22.22.2
- memory-wiki plugin: 2026.4.12 (bundled)
- memory-core plugin: bundled
- QMD scope config: default (deny, allow chatType: "direct")
- OS: Ubuntu 24.04 (Azure)

---
🤖 AI-assisted: Authored by Claude Opus 4.6 (1M context), reviewed by GPT-5.4. Human in the loop.
