### PR TITLE
Fix Control UI image history rendering

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -246,8 +246,8 @@ private struct ChatMessageBody: View {
 
     private var inlineAttachments: [OpenClawChatMessageContent] {
         self.message.content.filter { content in
-            switch content.type ?? "text" {
-            case "file", "attachment":
+            switch (content.type ?? "text").lowercased() {
+            case "file", "attachment", "image":
                 true
             default:
                 false
@@ -355,17 +355,71 @@ private struct AttachmentRow: View {
     let isUser: Bool
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "paperclip")
-            Text(self.att.fileName ?? "Attachment")
-                .font(.footnote)
-                .lineLimit(1)
-                .foregroundStyle(self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText)
-            Spacer()
+        VStack(alignment: .leading, spacing: 8) {
+            if let preview = self.previewImage {
+                OpenClawPlatformImageFactory.image(preview)
+                    .resizable()
+                    .scaledToFit()
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+
+            HStack(spacing: 8) {
+                Image(systemName: self.previewImage == nil ? "paperclip" : "photo")
+                Text(self.att.fileName ?? "Attachment")
+                    .font(.footnote)
+                    .lineLimit(1)
+                    .foregroundStyle(self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText)
+                Spacer()
+            }
         }
         .padding(10)
         .background(self.isUser ? Color.white.opacity(0.2) : Color.black.opacity(0.04))
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private var previewImage: OpenClawPlatformImage? {
+        if let data = self.imageData {
+            return OpenClawPlatformImage(data: data)
+        }
+        return nil
+    }
+
+    private var imageData: Data? {
+        if let string = self.att.content?.value as? String {
+            return Self.decodeImageData(from: string)
+        }
+        if let dict = self.att.content?.value as? [String: Any] {
+            if let nested = dict["data"] as? String {
+                return Self.decodeImageData(from: nested)
+            }
+            if let url = dict["url"] as? String {
+                return Self.decodeImageData(from: url)
+            }
+        }
+        if let dict = self.att.content?.value as? [String: AnyCodable] {
+            if let nested = dict["data"]?.value as? String {
+                return Self.decodeImageData(from: nested)
+            }
+            if let url = dict["url"]?.value as? String {
+                return Self.decodeImageData(from: url)
+            }
+        }
+        return nil
+    }
+
+    private static func decodeImageData(from raw: String) -> Data? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let commaIndex = trimmed.range(of: ","), trimmed[..<commaIndex.lowerBound].contains(";base64") {
+            let base64 = String(trimmed[commaIndex.upperBound...])
+            return Data(base64Encoded: base64)
+        }
+        if let base64 = Data(base64Encoded: trimmed) {
+            return base64
+        }
+        let url = URL(fileURLWithPath: trimmed)
+        guard url.isFileURL else { return nil }
+        return try? Data(contentsOf: url)
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -351,8 +351,12 @@ private struct ChatMessageBody: View {
 }
 
 private struct AttachmentRow: View {
+    private static let maxPreviewBytes = 5_000_000
+
     let att: OpenClawChatMessageContent
     let isUser: Bool
+
+    @State private var previewImage: OpenClawPlatformImage?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -375,20 +379,46 @@ private struct AttachmentRow: View {
         .padding(10)
         .background(self.isUser ? Color.white.opacity(0.2) : Color.black.opacity(0.04))
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .task(id: self.previewSourceKey) {
+            self.previewImage = await Self.loadPreviewImage(from: self.att)
+        }
     }
 
-    private var previewImage: OpenClawPlatformImage? {
-        if let data = self.imageData {
-            return OpenClawPlatformImage(data: data)
+    private var previewSourceKey: String {
+        [self.att.type, self.att.fileName, self.att.mimeType, self.contentSourceString].compactMap { $0 }.joined(separator: "|")
+    }
+
+    private var contentSourceString: String? {
+        if let string = self.att.content?.value as? String {
+            return string
+        }
+        if let dict = self.att.content?.value as? [String: Any], let nested = dict["data"] as? String {
+            return nested
+        }
+        if let dict = self.att.content?.value as? [String: Any], let url = dict["url"] as? String {
+            return url
+        }
+        if let dict = self.att.content?.value as? [String: AnyCodable], let nested = dict["data"]?.value as? String {
+            return nested
+        }
+        if let dict = self.att.content?.value as? [String: AnyCodable], let url = dict["url"]?.value as? String {
+            return url
         }
         return nil
     }
 
-    private var imageData: Data? {
-        if let string = self.att.content?.value as? String {
+    nonisolated private static func loadPreviewImage(from att: OpenClawChatMessageContent) async -> OpenClawPlatformImage? {
+        await Task.detached(priority: .utility) {
+            guard let data = Self.imageData(from: att) else { return nil }
+            return OpenClawPlatformImage(data: data)
+        }.value
+    }
+
+    nonisolated private static func imageData(from att: OpenClawChatMessageContent) -> Data? {
+        if let string = att.content?.value as? String {
             return Self.decodeImageData(from: string)
         }
-        if let dict = self.att.content?.value as? [String: Any] {
+        if let dict = att.content?.value as? [String: Any] {
             if let nested = dict["data"] as? String {
                 return Self.decodeImageData(from: nested)
             }
@@ -396,7 +426,7 @@ private struct AttachmentRow: View {
                 return Self.decodeImageData(from: url)
             }
         }
-        if let dict = self.att.content?.value as? [String: AnyCodable] {
+        if let dict = att.content?.value as? [String: AnyCodable] {
             if let nested = dict["data"]?.value as? String {
                 return Self.decodeImageData(from: nested)
             }
@@ -407,19 +437,38 @@ private struct AttachmentRow: View {
         return nil
     }
 
-    private static func decodeImageData(from raw: String) -> Data? {
+    nonisolated private static func decodeImageData(from raw: String) -> Data? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         if let commaIndex = trimmed.range(of: ","), trimmed[..<commaIndex.lowerBound].contains(";base64") {
             let base64 = String(trimmed[commaIndex.upperBound...])
-            return Data(base64Encoded: base64)
+            return Self.decodeBase64ImageData(base64)
         }
-        if let base64 = Data(base64Encoded: trimmed) {
+        if let base64 = Self.decodeBase64ImageData(trimmed) {
             return base64
         }
-        let url = URL(fileURLWithPath: trimmed)
-        guard url.isFileURL else { return nil }
-        return try? Data(contentsOf: url)
+        guard let url = URL(string: trimmed), url.isFileURL else { return nil }
+        return Self.readImageData(from: url)
+    }
+
+    nonisolated private static func decodeBase64ImageData(_ base64: String) -> Data? {
+        let estimatedDecodedLength = (base64.count * 3) / 4
+        guard estimatedDecodedLength <= Self.maxPreviewBytes else { return nil }
+        guard let data = Data(base64Encoded: base64), data.count <= Self.maxPreviewBytes else { return nil }
+        return data
+    }
+
+    nonisolated private static func readImageData(from url: URL) -> Data? {
+        guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+              let fileSize = values.fileSize,
+              fileSize <= Self.maxPreviewBytes
+        else {
+            return nil
+        }
+        guard let data = try? Data(contentsOf: url, options: [.mappedIfSafe]), data.count <= Self.maxPreviewBytes else {
+            return nil
+        }
+        return data
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -351,7 +351,7 @@ private struct ChatMessageBody: View {
 }
 
 private struct AttachmentRow: View {
-    private static let maxPreviewBytes = 5_000_000
+    nonisolated(unsafe) private static let maxPreviewBytes = 5_000_000
 
     let att: OpenClawChatMessageContent
     let isUser: Bool
@@ -385,7 +385,7 @@ private struct AttachmentRow: View {
     }
 
     private var previewSourceKey: String {
-        [self.att.type, self.att.fileName, self.att.mimeType, self.contentSourceString].compactMap { $0 }.joined(separator: "|")
+        [self.att.type, self.att.fileName, self.att.mimeType, self.contentSourceDigest].compactMap { $0 }.joined(separator: "|")
     }
 
     private var contentSourceString: String? {
@@ -405,6 +405,14 @@ private struct AttachmentRow: View {
             return url
         }
         return nil
+    }
+
+    private var contentSourceDigest: String? {
+        guard let source = self.contentSourceString else { return nil }
+        var hasher = Hasher()
+        hasher.combine(source)
+        hasher.combine(source.count)
+        return String(hasher.finalize(), radix: 16)
     }
 
     nonisolated private static func loadPreviewImage(from att: OpenClawChatMessageContent) async -> OpenClawPlatformImage? {
@@ -447,8 +455,10 @@ private struct AttachmentRow: View {
         if let base64 = Self.decodeBase64ImageData(trimmed) {
             return base64
         }
-        guard let url = URL(string: trimmed), url.isFileURL else { return nil }
-        return Self.readImageData(from: url)
+        if let url = URL(string: trimmed), url.isFileURL {
+            return Self.readImageData(from: url)
+        }
+        return Self.readImageData(from: URL(fileURLWithPath: trimmed))
     }
 
     nonisolated private static func decodeBase64ImageData(_ base64: String) -> Data? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -108,6 +108,9 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         case mimeType
         case fileName
         case content
+        case data
+        case source
+        case imageURL = "image_url"
         case id
         case name
         case arguments
@@ -129,9 +132,29 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
             self.content = any
         } else if let str = try container.decodeIfPresent(String.self, forKey: .content) {
             self.content = AnyCodable(str)
+        } else if let data = try container.decodeIfPresent(String.self, forKey: .data) {
+            self.content = AnyCodable(data)
+        } else if let source = try container.decodeIfPresent(AnyCodable.self, forKey: .source) {
+            self.content = source
+        } else if let imageURL = try container.decodeIfPresent(AnyCodable.self, forKey: .imageURL) {
+            self.content = imageURL
         } else {
             self.content = nil
         }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(self.type, forKey: .type)
+        try container.encodeIfPresent(self.text, forKey: .text)
+        try container.encodeIfPresent(self.thinking, forKey: .thinking)
+        try container.encodeIfPresent(self.thinkingSignature, forKey: .thinkingSignature)
+        try container.encodeIfPresent(self.mimeType, forKey: .mimeType)
+        try container.encodeIfPresent(self.fileName, forKey: .fileName)
+        try container.encodeIfPresent(self.content, forKey: .content)
+        try container.encodeIfPresent(self.id, forKey: .id)
+        try container.encodeIfPresent(self.name, forKey: .name)
+        try container.encodeIfPresent(self.arguments, forKey: .arguments)
     }
 }
 
@@ -155,6 +178,10 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
         case tool_name
         case usage
         case stopReason
+        case mediaPath = "MediaPath"
+        case mediaPaths = "MediaPaths"
+        case mediaType = "MediaType"
+        case mediaTypes = "MediaTypes"
     }
 
     public init(
@@ -190,14 +217,11 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
         self.usage = try container.decodeIfPresent(OpenClawChatUsage.self, forKey: .usage)
         self.stopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
 
+        var decodedContent: [OpenClawChatMessageContent] = []
         if let decoded = try? container.decode([OpenClawChatMessageContent].self, forKey: .content) {
-            self.content = decoded
-            return
-        }
-
-        // Some session log formats store `content` as a plain string.
-        if let text = try? container.decode(String.self, forKey: .content) {
-            self.content = [
+            decodedContent = decoded
+        } else if let text = try? container.decode(String.self, forKey: .content) {
+            decodedContent = [
                 OpenClawChatMessageContent(
                     type: "text",
                     text: text,
@@ -210,10 +234,32 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
                     name: nil,
                     arguments: nil),
             ]
-            return
         }
 
-        self.content = []
+        let mediaPaths =
+            (try? container.decodeIfPresent([String].self, forKey: .mediaPaths)) ??
+            ((try? container.decodeIfPresent(String.self, forKey: .mediaPath)).map { [$0] }) ?? []
+        let mediaTypes =
+            (try? container.decodeIfPresent([String].self, forKey: .mediaTypes)) ??
+            ((try? container.decodeIfPresent(String.self, forKey: .mediaType)).map { [$0] }) ?? []
+
+        for (index, path) in mediaPaths.enumerated() {
+            let mimeType = index < mediaTypes.count ? mediaTypes[index] : mediaTypes.first
+            decodedContent.append(
+                OpenClawChatMessageContent(
+                    type: "image",
+                    text: nil,
+                    thinking: nil,
+                    thinkingSignature: nil,
+                    mimeType: mimeType,
+                    fileName: URL(fileURLWithPath: path).lastPathComponent,
+                    content: AnyCodable(path),
+                    id: nil,
+                    name: nil,
+                    arguments: nil))
+        }
+
+        self.content = decodedContent
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -255,7 +255,6 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
                     mimeType: nil,
                     fileName: nil,
                     content: nil,
-                    contentCodingKey: nil,
                     id: nil,
                     name: nil,
                     arguments: nil),

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -63,6 +63,13 @@ public struct OpenClawChatUsage: Codable, Hashable, Sendable {
 }
 
 public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
+    public enum ContentCodingKey: String, Codable, Hashable, Sendable {
+        case content
+        case data
+        case source
+        case imageURL = "image_url"
+    }
+
     public let type: String?
     public let text: String?
     public let thinking: String?
@@ -70,6 +77,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
     public let mimeType: String?
     public let fileName: String?
     public let content: AnyCodable?
+    public let contentCodingKey: ContentCodingKey?
 
     // Tool-call fields (when `type == "toolCall"` or similar)
     public let id: String?
@@ -84,6 +92,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         mimeType: String?,
         fileName: String?,
         content: AnyCodable?,
+        contentCodingKey: ContentCodingKey? = nil,
         id: String? = nil,
         name: String? = nil,
         arguments: AnyCodable? = nil)
@@ -95,6 +104,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         self.mimeType = mimeType
         self.fileName = fileName
         self.content = content
+        self.contentCodingKey = contentCodingKey
         self.id = id
         self.name = name
         self.arguments = arguments
@@ -130,16 +140,22 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
 
         if let any = try container.decodeIfPresent(AnyCodable.self, forKey: .content) {
             self.content = any
+            self.contentCodingKey = .content
         } else if let str = try container.decodeIfPresent(String.self, forKey: .content) {
             self.content = AnyCodable(str)
+            self.contentCodingKey = .content
         } else if let data = try container.decodeIfPresent(String.self, forKey: .data) {
             self.content = AnyCodable(data)
+            self.contentCodingKey = .data
         } else if let source = try container.decodeIfPresent(AnyCodable.self, forKey: .source) {
             self.content = source
+            self.contentCodingKey = .source
         } else if let imageURL = try container.decodeIfPresent(AnyCodable.self, forKey: .imageURL) {
             self.content = imageURL
+            self.contentCodingKey = .imageURL
         } else {
             self.content = nil
+            self.contentCodingKey = nil
         }
     }
 
@@ -151,7 +167,16 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         try container.encodeIfPresent(self.thinkingSignature, forKey: .thinkingSignature)
         try container.encodeIfPresent(self.mimeType, forKey: .mimeType)
         try container.encodeIfPresent(self.fileName, forKey: .fileName)
-        try container.encodeIfPresent(self.content, forKey: .content)
+        switch self.contentCodingKey ?? .content {
+        case .content:
+            try container.encodeIfPresent(self.content, forKey: .content)
+        case .data:
+            try container.encodeIfPresent(self.content?.value as? String, forKey: .data)
+        case .source:
+            try container.encodeIfPresent(self.content, forKey: .source)
+        case .imageURL:
+            try container.encodeIfPresent(self.content, forKey: .imageURL)
+        }
         try container.encodeIfPresent(self.id, forKey: .id)
         try container.encodeIfPresent(self.name, forKey: .name)
         try container.encodeIfPresent(self.arguments, forKey: .arguments)
@@ -230,6 +255,7 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
                     mimeType: nil,
                     fileName: nil,
                     content: nil,
+                    contentCodingKey: nil,
                     id: nil,
                     name: nil,
                     arguments: nil),
@@ -254,6 +280,7 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
                     mimeType: mimeType,
                     fileName: URL(fileURLWithPath: path).lastPathComponent,
                     content: AnyCodable(path),
+                    contentCodingKey: .data,
                     id: nil,
                     name: nil,
                     arguments: nil))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -378,6 +378,7 @@ public struct OpenClawChatView: View {
                     mimeType: nil,
                     fileName: nil,
                     content: nil,
+                    contentCodingKey: nil,
                     id: toolCallId,
                     name: message.toolName,
                     arguments: nil))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -378,7 +378,6 @@ public struct OpenClawChatView: View {
                     mimeType: nil,
                     fileName: nil,
                     content: nil,
-                    contentCodingKey: nil,
                     id: toolCallId,
                     name: message.toolName,
                     arguments: nil))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -513,6 +513,7 @@ public final class OpenClawChatViewModel {
                 mimeType: nil,
                 fileName: nil,
                 content: nil,
+                contentCodingKey: nil,
                 id: nil,
                 name: nil,
                 arguments: nil),
@@ -534,6 +535,7 @@ public final class OpenClawChatViewModel {
                     mimeType: att.mimeType,
                     fileName: att.fileName,
                     content: AnyCodable(att.content),
+                    contentCodingKey: .data,
                     id: nil,
                     name: nil,
                     arguments: nil))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -513,7 +513,6 @@ public final class OpenClawChatViewModel {
                 mimeType: nil,
                 fileName: nil,
                 content: nil,
-                contentCodingKey: nil,
                 id: nil,
                 name: nil,
                 arguments: nil),

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatModelsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatModelsTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import OpenClawProtocol
+import Testing
+@testable import OpenClawChatUI
+
+struct ChatModelsTests {
+    @Test
+    func decodesTranscriptMediaPathsIntoImageContentBlocks() throws {
+        let json = """
+        {
+          "role": "user",
+          "content": "See attached.",
+          "timestamp": 123,
+          "MediaPaths": ["/tmp/test-image.png"],
+          "MediaTypes": ["image/png"]
+        }
+        """
+
+        let message = try JSONDecoder().decode(OpenClawChatMessage.self, from: Data(json.utf8))
+
+        #expect(message.content.count == 2)
+        #expect(message.content[0].text == "See attached.")
+        #expect(message.content[1].type == "image")
+        #expect(message.content[1].mimeType == "image/png")
+        #expect(message.content[1].fileName == "test-image.png")
+        #expect(message.content[1].content?.value as? String == "/tmp/test-image.png")
+    }
+
+    @Test
+    func decodesImageBlockSourceIntoContent() throws {
+        let json = """
+        {
+          "role": "assistant",
+          "content": [
+            {
+              "type": "image",
+              "mimeType": "image/png",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "QUJDRA=="
+              }
+            }
+          ],
+          "timestamp": 123
+        }
+        """
+
+        let message = try JSONDecoder().decode(OpenClawChatMessage.self, from: Data(json.utf8))
+        let content = try #require(message.content.first)
+        let source = try #require(content.content?.value as? [String: AnyCodable])
+
+        #expect(content.type == "image")
+        #expect(source["data"]?.value as? String == "QUJDRA==")
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatModelsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatModelsTests.swift
@@ -24,6 +24,7 @@ struct ChatModelsTests {
         #expect(message.content[1].mimeType == "image/png")
         #expect(message.content[1].fileName == "test-image.png")
         #expect(message.content[1].content?.value as? String == "/tmp/test-image.png")
+        #expect(message.content[1].contentCodingKey == .data)
     }
 
     @Test
@@ -51,6 +52,45 @@ struct ChatModelsTests {
         let source = try #require(content.content?.value as? [String: AnyCodable])
 
         #expect(content.type == "image")
+        #expect(content.contentCodingKey == .source)
         #expect(source["data"]?.value as? String == "QUJDRA==")
+    }
+
+    @Test
+    func preservesOriginalImagePayloadCodingKeyWhenEncoding() throws {
+        let json = """
+        {
+          "role": "assistant",
+          "content": [
+            {
+              "type": "image",
+              "mimeType": "image/png",
+              "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "QUJDRA=="
+              }
+            },
+            {
+              "type": "image",
+              "mimeType": "image/png",
+              "image_url": {
+                "url": "https://example.com/image.png"
+              }
+            }
+          ],
+          "timestamp": 123
+        }
+        """
+
+        let message = try JSONDecoder().decode(OpenClawChatMessage.self, from: Data(json.utf8))
+        let encoded = try JSONEncoder().encode(message)
+        let object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let content = try #require(object?["content"] as? [[String: Any]])
+
+        #expect(content[0]["source"] != nil)
+        #expect(content[0]["content"] == nil)
+        #expect(content[1]["image_url"] != nil)
+        #expect(content[1]["content"] == nil)
     }
 }


### PR DESCRIPTION
## Summary
- decode transcript MediaPath and image payload variants into chat attachment content blocks
- render image attachments in the shared chat UI so sent images stay visible after history refresh
- add coverage for transcript media-path and image-source decoding

## Testing
- swift test --package-path apps/shared/OpenClawKit --filter 'ChatModelsTests'
- pnpm check
- pnpm protocol:check

Closes #68605
