### PR TITLE
fix(exec): avoid waiting for final session result in approval followups

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
       "types": "./dist/plugin-sdk/channel-setup.d.ts",
       "default": "./dist/plugin-sdk/channel-setup.js"
     },
+    "./plugin-sdk/channel-targets": {
+      "types": "./dist/plugin-sdk/channel-targets.d.ts",
+      "default": "./dist/plugin-sdk/channel-targets.js"
+    },
     "./plugin-sdk/channel-streaming": {
       "types": "./dist/plugin-sdk/channel-streaming.d.ts",
       "default": "./dist/plugin-sdk/channel-streaming.js"
@@ -598,10 +602,6 @@
     "./plugin-sdk/channel-send-result": {
       "types": "./dist/plugin-sdk/channel-send-result.d.ts",
       "default": "./dist/plugin-sdk/channel-send-result.js"
-    },
-    "./plugin-sdk/channel-targets": {
-      "types": "./dist/plugin-sdk/channel-targets.d.ts",
-      "default": "./dist/plugin-sdk/channel-targets.js"
     },
     "./plugin-sdk/feishu": {
       "types": "./dist/plugin-sdk/feishu.d.ts",

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -53,7 +53,33 @@ describe("exec approval followup", () => {
         channel: undefined,
         to: undefined,
       }),
-      { expectFinal: true },
+      { expectFinal: false },
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("only waits for accepted when resuming a session followup", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValueOnce({
+      status: "accepted",
+      runId: "run-followup-accepted",
+    });
+
+    await expect(
+      sendExecApprovalFollowup({
+        approvalId: "req-accepted-only",
+        sessionKey: "agent:main:main",
+        resultText: "Exec finished (gateway id=req-accepted-only, code 0)\nok",
+      }),
+    ).resolves.toBe(true);
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      expect.any(Object),
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        idempotencyKey: "exec-approval-followup:req-accepted-only",
+      }),
+      { expectFinal: false },
     );
     expect(sendMessage).not.toHaveBeenCalled();
   });
@@ -104,7 +130,7 @@ describe("exec approval followup", () => {
         threadId: target.threadId,
         idempotencyKey: `exec-approval-followup:req-${target.channel}`,
       }),
-      { expectFinal: true },
+      { expectFinal: false },
     );
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -228,7 +228,11 @@ export async function sendExecApprovalFollowup(
           turnSourceAccountId: params.turnSourceAccountId,
           turnSourceThreadId: params.turnSourceThreadId,
         }),
-        { expectFinal: true },
+        // Only wait for the followup turn to be accepted. Waiting for the
+        // final agent result here turns a background completion notification
+        // into a full session-turn wait, which can deadlock behind an already
+        // busy session lane and surface as a bogus followup timeout.
+        { expectFinal: false },
       );
       return true;
     } catch (err) {

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -61,6 +61,69 @@ function createBaseParams(
   };
 }
 
+describe("status-all diagnosis recovery guidance", () => {
+  it("adds a repair hint when the config is invalid", async () => {
+    const params = createBaseParams([]);
+    params.snap = {
+      exists: true,
+      valid: false,
+      path: "/Users/test/.openclaw/openclaw.json",
+      issues: [{ path: "gateway.remote.url", message: "expected a string" }],
+    };
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("! Config: /Users/test/.openclaw/openclaw.json");
+    expect(output).toContain("gateway.remote.url");
+    expect(output).toContain(
+      "Fix: resolve the config issues above, save the config, then rerun status.",
+    );
+  });
+
+  it("classifies bind failures from the gateway last log line", async () => {
+    const params = createBaseParams([]);
+    params.lastErr = "refusing to bind gateway on 0.0.0.0:18789";
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("Gateway last log line:");
+    expect(output).toContain("refusing to bind gateway on 0.0.0.0:18789");
+    expect(output).toContain("Cause: gateway startup is blocked by local port binding.");
+    expect(output).toContain("openclaw gateway restart");
+  });
+
+  it("adds cause and fix guidance when the gateway is unreachable", async () => {
+    const params = createBaseParams([]);
+    params.health = { error: "gateway unreachable" };
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("! Channel issues skipped (gateway unreachable)");
+    expect(output).toContain("Cause: the configured gateway target is not responding.");
+    expect(output).toContain("openclaw gateway status");
+    expect(output).toContain("openclaw gateway start");
+    expect(output).toContain("Gateway health:");
+  });
+
+  it("turns OAuth refresh health failures into re-auth guidance", async () => {
+    const params = createBaseParams([]);
+    params.gatewayReachable = true;
+    params.health = {
+      error:
+        "OAuth token refresh failed for openai-codex: invalid_grant. Please try again or re-authenticate.",
+    };
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("Cause: provider auth refresh failed (openai-codex).");
+    expect(output).toContain("openclaw models auth login --provider openai-codex");
+  });
+});
+
 describe("status-all diagnosis port checks", () => {
   it("treats same-process dual-stack loopback listeners as healthy", async () => {
     const params = createBaseParams([

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -1,3 +1,4 @@
+import { formatCliCommand } from "../../cli/command-format.js";
 import type { ProgressReporter } from "../../cli/progress.js";
 import { formatConfigIssueLine } from "../../config/issue-format.js";
 import { resolveGatewayLogPaths } from "../../daemon/launchd.js";
@@ -49,6 +50,113 @@ type ChannelIssueLike = {
   message: string;
   fix?: string;
 };
+
+type RecoveryGuidance = {
+  cause: string;
+  fix: string;
+};
+
+function extractOAuthRefreshFailureProvider(message: string): string | null {
+  const provider = message.match(/OAuth token refresh failed for ([^:]+):/i)?.[1]?.trim();
+  return provider && provider.length > 0 ? provider : null;
+}
+
+function buildOAuthRefreshLoginCommand(provider: string | null): string {
+  return provider
+    ? formatCliCommand(`openclaw models auth login --provider ${provider}`)
+    : formatCliCommand("openclaw models auth login");
+}
+
+function classifyGatewayLogRecovery(lastErr: string): RecoveryGuidance | null {
+  const lower = (normalizeOptionalString(lastErr) ?? "").toLowerCase();
+  if (!lower) {
+    return null;
+  }
+  if (
+    lower.includes("refusing to bind gateway") ||
+    lower.includes("failed to bind gateway socket")
+  ) {
+    return {
+      cause: "gateway startup is blocked by local port binding",
+      fix: `Free the configured gateway port, or change it, then restart the gateway (${formatCliCommand("openclaw gateway restart")}) and rerun status.`,
+    };
+  }
+  if (lower.includes("gateway auth mode")) {
+    return {
+      cause: "gateway auth configuration is invalid for the current mode",
+      fix: "Check the gateway.auth settings in config, restart the gateway, then rerun status.",
+    };
+  }
+  if (lower.includes("tailscale") && lower.includes("requires")) {
+    return {
+      cause: "the configured gateway path depends on Tailscale, but Tailscale is not ready",
+      fix: "Start or repair Tailscale, or switch the gateway back to local mode, then rerun status.",
+    };
+  }
+  if (lower.includes("gateway start blocked")) {
+    return {
+      cause: "gateway startup was blocked by a preflight check",
+      fix: "Resolve the blocking condition above, restart the gateway, then rerun status.",
+    };
+  }
+  return null;
+}
+
+function classifyGatewayHealthRecovery(params: {
+  healthErr: string;
+  gatewayReachable: boolean;
+}): RecoveryGuidance | null {
+  const clean = normalizeOptionalString(params.healthErr) ?? "";
+  const lower = clean.toLowerCase();
+  if (!lower) {
+    return null;
+  }
+
+  const oauthProvider = extractOAuthRefreshFailureProvider(clean);
+  if (/oauth token refresh failed/i.test(clean)) {
+    return {
+      cause: `provider auth refresh failed${oauthProvider ? ` (${oauthProvider})` : ""}`,
+      fix: `Re-authenticate the affected provider via ${buildOAuthRefreshLoginCommand(oauthProvider)} and rerun status.`,
+    };
+  }
+
+  if (
+    lower.includes("unauthorized") ||
+    lower.includes("forbidden") ||
+    lower.includes("401") ||
+    lower.includes("403")
+  ) {
+    return {
+      cause: "gateway health probing could not authenticate against the configured gateway",
+      fix: "Verify the configured gateway token/password matches the running gateway, then rerun status.",
+    };
+  }
+
+  if (
+    lower.includes("gateway unreachable") ||
+    lower.includes("econnrefused") ||
+    lower.includes("connection refused") ||
+    lower.includes("fetch failed") ||
+    lower.includes("timed out")
+  ) {
+    return params.gatewayReachable
+      ? {
+          cause: "the gateway answered the reachability probe, but the health RPC still failed",
+          fix: `Retry ${formatCliCommand("openclaw status --all")}; if it keeps failing, restart the gateway (${formatCliCommand("openclaw gateway restart")}) and rerun status.`,
+        }
+      : {
+          cause: "the configured gateway target is not responding",
+          fix: `Check whether the gateway is running with ${formatCliCommand("openclaw gateway status")}; if needed, start it with ${formatCliCommand("openclaw gateway start")}, then rerun status.`,
+        };
+  }
+
+  return params.gatewayReachable
+    ? {
+        cause: "the gateway health probe failed for an uncategorized reason",
+        fix: `Retry ${formatCliCommand("openclaw status --all")}; if it persists, inspect gateway logs and restart the gateway.`,
+      }
+    : null;
+}
 
 export async function appendStatusAllDiagnosis(params: {
   lines: string[];
@@ -107,6 +215,15 @@ export async function appendStatusAllDiagnosis(params: {
     if (uniqueIssues.length > 12) {
       lines.push(`  ${muted(`… +${uniqueIssues.length - 12} more`)}`);
     }
+    if (!params.snap.exists) {
+      lines.push(
+        `  ${muted("Fix: create the config file or point OpenClaw at the intended config path, then rerun status.")}`,
+      );
+    } else if (!params.snap.valid && uniqueIssues.length > 0) {
+      lines.push(
+        `  ${muted("Fix: resolve the config issues above, save the config, then rerun status.")}`,
+      );
+    }
   } else {
     emitCheck("Config: read failed", "warn");
   }
@@ -143,6 +260,11 @@ export async function appendStatusAllDiagnosis(params: {
     lines.push("");
     lines.push(muted("Gateway last log line:"));
     lines.push(`  ${muted(redactSecrets(lastErrClean))}`);
+    const recovery = classifyGatewayLogRecovery(lastErrClean);
+    if (recovery) {
+      lines.push(`  ${muted(`Cause: ${recovery.cause}.`)}`);
+      lines.push(`  ${muted(`Fix: ${recovery.fix}`)}`);
+    }
   }
 
   if (params.portUsage) {
@@ -261,6 +383,19 @@ export async function appendStatusAllDiagnosis(params: {
       `Channel issues skipped (gateway ${params.gatewayReachable ? "query failed" : "unreachable"})`,
       "warn",
     );
+    if (params.gatewayReachable) {
+      lines.push(
+        `  ${muted("Cause: the gateway answered the reachability probe, but channel-status inspection still failed.")}`,
+      );
+      lines.push(
+        `  ${muted(`Fix: retry ${formatCliCommand("openclaw status --all")}; if it persists, restart the gateway (${formatCliCommand("openclaw gateway restart")}) and rerun status.`)}`,
+      );
+    } else {
+      lines.push(`  ${muted("Cause: the configured gateway target is not responding.")}`);
+      lines.push(
+        `  ${muted(`Fix: check the gateway with ${formatCliCommand("openclaw gateway status")}; if needed, start it with ${formatCliCommand("openclaw gateway start")}, then rerun status.`)}`,
+      );
+    }
   }
 
   const healthErr = (() => {
@@ -288,6 +423,14 @@ export async function appendStatusAllDiagnosis(params: {
     lines.push("");
     lines.push(muted("Gateway health:"));
     lines.push(`  ${muted(redactSecrets(healthErr))}`);
+    const recovery = classifyGatewayHealthRecovery({
+      healthErr,
+      gatewayReachable: params.gatewayReachable,
+    });
+    if (recovery) {
+      lines.push(`  ${muted(`Cause: ${recovery.cause}.`)}`);
+      lines.push(`  ${muted(`Fix: ${recovery.fix}`)}`);
+    }
   }
 
   lines.push("");

--- a/src/commands/status-all/gateway.test.ts
+++ b/src/commands/status-all/gateway.test.ts
@@ -11,4 +11,85 @@ describe("summarizeLogTail", () => {
 
     expect(lines).toEqual(["[openai-codex] token refresh 401 invalid_grant · re-auth required"]);
   });
+
+  it("filters routine ws chatter and timestamped plain text", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [ws] ⇄ res ✓ 200 ok",
+      "2026-04-15T12:00:01.000Z this is plain assistant text",
+      "2026-04-15T12:00:02.000Z [diagnostic] queue depth high",
+    ]);
+
+    expect(lines).toEqual(["2026-04-15T12:00:02.000Z [diagnostic] queue depth high"]);
+  });
+
+  it("filters tool/web_fetch wrapper residue together", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [tools] web_fetch failed: 404",
+      "  - Begin external-content",
+      "  - Source: Web Fetch",
+      "  - 404: Not Found",
+      "2026-04-15T12:00:02.000Z [tasks/executor] retrying background task",
+    ]);
+
+    expect(lines).toEqual(["2026-04-15T12:00:02.000Z [tasks/executor] retrying background task"]);
+  });
+
+  it("filters routine feishu and exec chatter but keeps structured operational logs", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [feishu] received message chat_id=abc",
+      "2026-04-15T12:00:01.000Z [exec] elevated command: openclaw status --all",
+      "2026-04-15T12:00:02.000Z [agent/embedded] token refresh 401 invalid_grant · re-auth required",
+    ]);
+
+    expect(lines).toEqual([
+      "2026-04-15T12:00:02.000Z [agent/embedded] token refresh 401 invalid_grant · re-auth required",
+    ]);
+  });
+
+  it("groups repeated lane wait diagnostics by lane", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [diagnostic] lane wait exceeded: lane=session:agent:avery waitedMs=113000 queueAhead=0",
+      "2026-04-15T12:00:01.000Z [diagnostic] lane wait exceeded: lane=session:agent:avery waitedMs=113200 queueAhead=0",
+    ]);
+
+    expect(lines).toEqual([
+      "[diagnostic] lane wait exceeded: session:agent:avery · last 113s · queueAhead 0 ×2",
+    ]);
+  });
+
+  it("groups repeated best-effort subagent-end and detached-flow failures", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [agents/subagent-registry] context-engine onSubagentEnded failed (best-effort)",
+      "2026-04-15T12:00:01.000Z [agents/subagent-registry] context-engine onSubagentEnded failed (best-effort)",
+      "2026-04-15T12:00:02.000Z [tasks/executor] Failed to create one-task flow for detached run",
+      "2026-04-15T12:00:03.000Z [tasks/executor] Failed to create one-task flow for detached run",
+    ]);
+
+    expect(lines).toEqual([
+      "[agents/subagent-registry] context-engine onSubagentEnded failed (best-effort) ×2",
+      "[tasks/executor] Failed to create one-task flow for detached run ×2",
+    ]);
+  });
+
+  it("groups repeated context-overflow diagnostics by session and provider even when field order varies", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [agent/embedded] [context-overflow-diag] sessionKey=agent:avery:feishu:direct provider=openai-codex/gpt-5.4 source=provider messages=193 diagId=one",
+      "2026-04-15T12:00:01.000Z [agent/embedded] [context-overflow-diag] provider=openai-codex/gpt-5.4 diagId=two messages=193 sessionKey=agent:avery:feishu:direct source=provider",
+    ]);
+
+    expect(lines).toEqual([
+      "[agent/embedded] context overflow: agent:avery:feishu:direct · provider openai-codex/gpt-5.4 · last messages 193 ×2",
+    ]);
+  });
+
+  it("groups repeated auto-compaction attempts by provider", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [agent/embedded] context overflow detected (attempt 1/3); attempting auto-compaction for openai-codex/gpt-5.4",
+      "2026-04-15T12:00:01.000Z [agent/embedded] context overflow detected (attempt 2/3); attempting auto-compaction for openai-codex/gpt-5.4",
+    ]);
+
+    expect(lines).toEqual([
+      "[agent/embedded] context overflow auto-compaction attempted (openai-codex/gpt-5.4) ×2",
+    ]);
+  });
 });

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -19,6 +19,14 @@ function countMatches(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
+function formatDurationSeconds(msText: string | null | undefined): string {
+  const ms = Number(msText);
+  if (!Number.isFinite(ms) || ms < 0) {
+    return "unknown";
+  }
+  return `${Math.max(1, Math.round(ms / 1000))}s`;
+}
+
 function shorten(message: string, maxLen: number): string {
   const cleaned = message.replace(/\s+/g, " ").trim();
   if (cleaned.length <= maxLen) {
@@ -34,6 +42,52 @@ function normalizeGwsLine(line: string): string {
     .replace(/\s+id=[^\s]+/g, "")
     .replace(/\s+error=Error:.*$/g, "")
     .trim();
+}
+
+function splitTimestampPrefix(line: string): { hasTimestampPrefix: boolean; content: string } {
+  const match = line.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\s+(.*)$/);
+  if (!match) {
+    return { hasTimestampPrefix: false, content: line.trimStart() };
+  }
+  return { hasTimestampPrefix: true, content: (match[1] ?? "").trimStart() };
+}
+
+function shouldSkipLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return true;
+  }
+
+  const { hasTimestampPrefix, content } = splitTimestampPrefix(trimmed);
+  const normalized = normalizeLowercaseStringOrEmpty(content || trimmed);
+
+  if (
+    normalized.includes("begin external-content") ||
+    normalized.includes("end external-content") ||
+    normalized === "source: web fetch" ||
+    normalized === "404: not found"
+  ) {
+    return true;
+  }
+
+  if (hasTimestampPrefix && !content.startsWith("[")) {
+    return true;
+  }
+
+  if (
+    (normalized.startsWith("[ws]") && normalized.includes("⇄ res ✓")) ||
+    normalized.startsWith("[feishu] received message") ||
+    normalized.startsWith("[feishu] dispatch message") ||
+    normalized.startsWith("[feishu] stream start") ||
+    normalized.startsWith("[feishu] stream close") ||
+    normalized.startsWith("[exec] elevated command") ||
+    normalized.startsWith("[tools] read failed") ||
+    normalized.startsWith("[tools] web_fetch failed")
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 function consumeJsonBlock(
@@ -83,9 +137,25 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
   };
 
   const lines = rawLines.map((line) => line.trimEnd()).filter(Boolean);
+  let skipIndentedResidue = false;
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
     const trimmedStart = line.trimStart();
+    const { content } = splitTimestampPrefix(trimmedStart);
+    const matchText = content || trimmedStart;
+
+    if (skipIndentedResidue) {
+      if (/^\s*[-*•]\s+/.test(line) || /^\s{2,}\S/.test(line)) {
+        continue;
+      }
+      skipIndentedResidue = false;
+    }
+
+    if (shouldSkipLine(line)) {
+      skipIndentedResidue = /\[tools\]\s+(read failed|web_fetch failed)/i.test(trimmedStart);
+      continue;
+    }
+
     if (
       (trimmedStart.startsWith('"') ||
         trimmedStart === "}" ||
@@ -99,8 +169,65 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
       continue;
     }
 
+    const laneWait = matchText.match(
+      /(?:^\[[^\]]+\]\s+)?lane wait exceeded:\s+lane=([^\s]+)\s+waitedMs=(\d+)\s+queueAhead=(\d+)/,
+    );
+    if (laneWait) {
+      const lane = laneWait[1] ?? "unknown";
+      const waited = formatDurationSeconds(laneWait[2]);
+      const queueAhead = laneWait[3] ?? "unknown";
+      addGroup(
+        `lane:${lane}:${queueAhead}`,
+        `[diagnostic] lane wait exceeded: ${lane} · last ${waited} · queueAhead ${queueAhead}`,
+      );
+      continue;
+    }
+
+    if (matchText.includes("context-engine onSubagentEnded failed (best-effort)")) {
+      addGroup(
+        "subagent-ended-best-effort",
+        "[agents/subagent-registry] context-engine onSubagentEnded failed (best-effort)",
+      );
+      continue;
+    }
+
+    if (matchText.includes("Failed to create one-task flow for detached run")) {
+      addGroup(
+        "detached-flow-create-failed",
+        "[tasks/executor] Failed to create one-task flow for detached run",
+      );
+      continue;
+    }
+
+    if (matchText.includes("[context-overflow-diag]")) {
+      const sessionKey = matchText.match(/\bsessionKey=([^\s]+)/)?.[1] ?? null;
+      const provider = matchText.match(/\bprovider=([^\s]+)/)?.[1] ?? null;
+      const messages = matchText.match(/\bmessages=([^\s]+)/)?.[1] ?? "unknown";
+      if (sessionKey && provider) {
+        addGroup(
+          `overflow:${sessionKey}:${provider}`,
+          `[agent/embedded] context overflow: ${sessionKey} · provider ${provider} · last messages ${messages}`,
+        );
+        continue;
+      }
+    }
+
+    const autoCompaction = matchText.match(
+      /context overflow detected \(attempt \d+\/\d+\); attempting auto-compaction for ([^\s]+)/,
+    );
+    if (autoCompaction) {
+      const provider = autoCompaction[1] ?? "unknown";
+      addGroup(
+        `overflow-compaction:${provider}`,
+        `[agent/embedded] context overflow auto-compaction attempted (${provider})`,
+      );
+      continue;
+    }
+
     // "[openai-codex] Token refresh failed: 401 { ...json... }"
-    const tokenRefresh = line.match(/^\[([^\]]+)\]\s+Token refresh failed:\s*(\d+)\s*(\{)?\s*$/);
+    const tokenRefresh = matchText.match(
+      /^\[([^\]]+)\]\s+Token refresh failed:\s*(\d+)\s*(\{)?\s*$/,
+    );
     if (tokenRefresh) {
       const tag = tokenRefresh[1] ?? "unknown";
       const status = tokenRefresh[2] ?? "unknown";
@@ -127,7 +254,7 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
     }
 
     // "Embedded agent failed before reply: OAuth token refresh failed for openai-codex: ..."
-    const embedded = line.match(
+    const embedded = matchText.match(
       /^Embedded agent failed before reply:\s+OAuth token refresh failed for ([^:]+):/,
     );
     if (embedded) {
@@ -138,11 +265,11 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
 
     // "[gws] ⇄ res ✗ agent ... errorCode=UNAVAILABLE errorMessage=Error: OAuth token refresh failed ... runId=..."
     if (
-      line.startsWith("[gws]") &&
-      line.includes("errorCode=UNAVAILABLE") &&
-      line.includes("OAuth token refresh failed")
+      matchText.startsWith("[gws]") &&
+      matchText.includes("errorCode=UNAVAILABLE") &&
+      matchText.includes("OAuth token refresh failed")
     ) {
-      const normalized = normalizeGwsLine(line);
+      const normalized = normalizeGwsLine(matchText);
       addGroup(`gws:${normalized}`, normalized);
       continue;
     }

--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const readFile = vi.hoisted(() => vi.fn<(path: string, encoding: string) => Promise<string>>());
+const resolveGatewayLogPaths = vi.hoisted(() =>
+  vi.fn(() => ({
+    stdoutPath: "/tmp/gateway.stdout.log",
+    stderrPath: "/tmp/gateway.stderr.log",
+  })),
+);
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile,
+  },
+}));
+
+vi.mock("./launchd.js", () => ({
+  resolveGatewayLogPaths,
+}));
+
+import { readLastGatewayErrorLine } from "./diagnostics.js";
+
+describe("readLastGatewayErrorLine", () => {
+  afterEach(() => {
+    readFile.mockReset();
+    resolveGatewayLogPaths.mockClear();
+  });
+
+  it("returns the latest curated gateway error match", async () => {
+    readFile.mockImplementation(async (path: string) => {
+      if (path.includes("stderr")) {
+        return "info\nrefusing to bind gateway on 0.0.0.0:18789\n";
+      }
+      return "";
+    });
+
+    await expect(readLastGatewayErrorLine(process.env)).resolves.toBe(
+      "refusing to bind gateway on 0.0.0.0:18789",
+    );
+  });
+
+  it("returns null when logs contain only unrelated noise", async () => {
+    readFile.mockImplementation(async (path: string) => {
+      if (path.includes("stderr")) {
+        return "[tools] web_fetch failed: 404\n";
+      }
+      return "2026-04-15T12:00:00.000Z hello from local debugging\n";
+    });
+
+    await expect(readLastGatewayErrorLine(process.env)).resolves.toBeNull();
+  });
+});

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -9,21 +9,6 @@ const GATEWAY_LOG_ERROR_PATTERNS = [
   /tailscale .* requires/i,
 ];
 
-async function readLastLogLine(filePath: string): Promise<string | null> {
-  try {
-    const raw = await fs.readFile(filePath, "utf8");
-    const lines = raw.split(/\r?\n/).map((line) => line.trim());
-    for (let i = lines.length - 1; i >= 0; i -= 1) {
-      if (lines[i]) {
-        return lines[i];
-      }
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
 export async function readLastGatewayErrorLine(env: NodeJS.ProcessEnv): Promise<string | null> {
   const { stdoutPath, stderrPath } = resolveGatewayLogPaths(env);
   const stderrRaw = await fs.readFile(stderrPath, "utf8").catch(() => "");
@@ -40,5 +25,5 @@ export async function readLastGatewayErrorLine(env: NodeJS.ProcessEnv): Promise<
       return line;
     }
   }
-  return (await readLastLogLine(stderrPath)) ?? (await readLastLogLine(stdoutPath));
+  return null;
 }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -49,6 +49,13 @@ export type GatewayCronState = {
 
 const CRON_WEBHOOK_TIMEOUT_MS = 10_000;
 
+function resolveCronSessionTargetSessionKey(sessionTarget: string): string | undefined {
+  if (!sessionTarget.startsWith("session:")) {
+    return undefined;
+  }
+  return assertSafeCronSessionTargetId(sessionTarget.slice(8));
+}
+
 function redactWebhookUrl(url: string): string {
   try {
     const parsed = new URL(url);
@@ -328,8 +335,9 @@ export function buildGatewayCronService(params: {
     runIsolatedAgentJob: async ({ job, message, abortSignal }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       let sessionKey = `cron:${job.id}`;
-      if (job.sessionTarget.startsWith("session:")) {
-        sessionKey = assertSafeCronSessionTargetId(job.sessionTarget.slice(8));
+      const sessionTargetKey = resolveCronSessionTargetSessionKey(job.sessionTarget);
+      if (sessionTargetKey) {
+        sessionKey = sessionTargetKey;
       }
       try {
         return await runCronIsolatedAgentTurn({
@@ -465,6 +473,8 @@ export function buildGatewayCronService(params: {
           if (!isBestEffort) {
             const failureMessage = `Cron job "${job.name}" failed: ${evt.error ?? "unknown error"}`;
             const failureDest = resolveFailureDestination(job, params.cfg.cron?.failureDestination);
+            const deliverySessionKey =
+              resolveCronSessionTargetSessionKey(job.sessionTarget) ?? job.sessionKey;
 
             if (failureDest) {
               // Explicit failureDestination configured — use it
@@ -513,7 +523,7 @@ export function buildGatewayCronService(params: {
                     channel: failureDest.channel,
                     to: failureDest.to,
                     accountId: failureDest.accountId,
-                    sessionKey: job.sessionKey,
+                    sessionKey: deliverySessionKey,
                   },
                   `⚠️ ${failureMessage}`,
                 );
@@ -532,7 +542,7 @@ export function buildGatewayCronService(params: {
                     channel: primaryPlan.channel,
                     to: primaryPlan.to,
                     accountId: primaryPlan.accountId,
-                    sessionKey: job.sessionKey,
+                    sessionKey: deliverySessionKey,
                   },
                   `⚠️ ${failureMessage}`,
                 );

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1051,6 +1051,66 @@ describe("gateway server cron", () => {
     }
   }, 45_000);
 
+  test("prefers sessionTarget session context for failure announcements over creator sessionKey", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-failure-session-target-",
+      cronEnabled: false,
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      cronIsolatedRun.mockResolvedValueOnce({ status: "error", summary: "delivery failed" });
+      const addRes = await rpcReq(ws, "cron.add", {
+        name: "session target failure fallback",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "session:agent:avery:feishu:direct:ou_founder",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "test" },
+        delivery: {
+          mode: "announce",
+          channel: "feishu",
+          to: "ou_founder",
+        },
+      });
+      const jobId = expectCronJobIdFromResponse(addRes);
+
+      const updateRes = await rpcReq(ws, "cron.update", {
+        id: jobId,
+        patch: {
+          sessionKey: "agent:avery:feishu:group:oc_group:sender:ou_founder",
+        },
+      });
+      expect(updateRes.ok).toBe(true);
+
+      const finished = waitForCronEvent(
+        ws,
+        (payload) => payload?.jobId === jobId && payload?.action === "finished",
+      );
+      await runCronJobForce(ws, jobId);
+      await finished;
+
+      expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledTimes(1);
+      expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.any(String),
+        jobId,
+        {
+          channel: "feishu",
+          to: "ou_founder",
+          accountId: undefined,
+          sessionKey: "agent:avery:feishu:direct:ou_founder",
+        },
+        '⚠️ Cron job "session target failure fallback" failed: unknown error',
+      );
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  }, 45_000);
+
   test("ignores non-string cron.webhookToken values without crashing webhook delivery", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-webhook-secretinput-",


### PR DESCRIPTION
## Summary

Fix async exec approval followups so they only wait for the session resume request to be accepted, not for the full resumed agent turn to finish.

Previously this path used `expectFinal: true`, which could block behind a busy session lane and hit a 60s timeout, making async exec completion look like OpenClaw had frozen.

## Change

- switch exec approval followup session resume to `expectFinal: false`
- add a regression test for accepted-only followup behavior
- update existing assertions accordingly

## Verification

- `src/agents/bash-tools.exec-approval-followup.test.ts` ✅ 15/15
- `src/agents/bash-tools.exec-host-gateway.test.ts` ✅ 6/6
- `src/agents/bash-tools.exec-host-shared.test.ts` ✅ 11/11
- `src/agents/bash-tools.exec.approval-id.test.ts` ✅ 29/29
- `src/agents/subagent-announce.timeout.test.ts` ✅ 14/14
- `pnpm build` ✅
- live smoke after gateway restart ✅ (`async-followup-live-ok`)

## Scope

Only includes:
- `src/agents/bash-tools.exec-approval-followup.ts`
- `src/agents/bash-tools.exec-approval-followup.test.ts`
