### PR TITLE
fix: omit thinkingConfig for Gemini 3 Pro disabled case (fixes #62470)

### DIFF
--- a/src/agents/google-transport-stream.ts
+++ b/src/agents/google-transport-stream.ts
@@ -210,9 +210,12 @@ function resolveThinkingLevel(level: ThinkingLevel, modelId: string): GoogleThin
   }
 }
 
-function getDisabledThinkingConfig(modelId: string): Record<string, unknown> {
+function getDisabledThinkingConfig(modelId: string): Record<string, unknown> | undefined {
   if (isGemini3ProModel(modelId)) {
-    return { thinkingLevel: "LOW" };
+    // Gemini 3/3.1 Pro cannot disable thinking (MINIMAL not supported, LOW
+    // still thinks and burns tokens causing empty replies). Omit thinkingConfig
+    // entirely so the model falls back to its default dynamic thinking.
+    return undefined;
   }
   if (isGemini3FlashModel(modelId)) {
     return { thinkingLevel: "MINIMAL" };


### PR DESCRIPTION
## Summary

Fix Gemini 3/3.1 Pro returning empty replies when thinking is disabled. The root cause is `getDisabledThinkingConfig()` sending `thinkingLevel: "LOW"` — which still thinks and burns tokens, leaving no budget for visible output. Fixes #62470.

## Root cause analysis

The [Google Gemini API docs](https://ai.google.dev/gemini-api/docs/thinking#thinking-levels) explicitly state:

> **"You cannot disable thinking for Gemini 3.1 Pro."**

The `thinkingLevel` support matrix for Gemini 3.1 Pro:

| Level | Supported |
|-------|-----------|
| `minimal` | ❌ Not supported |
| `low` | ✅ (but still thinks) |
| `medium` | ✅ |
| `high` | ✅ (Default, Dynamic) |

When openclaw sends `thinkingLevel: "LOW"` to "disable" thinking on 3.1 Pro, the model still allocates tokens for internal reasoning. With a small output budget, this consumes all available tokens before any visible text is emitted → `finishReason: "MAX_TOKENS"` with empty `parts[].text`.

## The fix

Return `undefined` (omit `thinkingConfig` entirely) for Gemini 3 Pro models in the disabled case, letting the model use its default dynamic thinking.

```diff
-function getDisabledThinkingConfig(modelId: string): Record<string, unknown> {
+function getDisabledThinkingConfig(modelId: string): Record<string, unknown> | undefined {
   if (isGemini3ProModel(modelId)) {
-    return { thinkingLevel: "LOW" };
+    // Gemini 3/3.1 Pro cannot disable thinking (MINIMAL not supported, LOW
+    // still thinks and burns tokens causing empty replies). Omit thinkingConfig
+    // entirely so the model falls back to its default dynamic thinking.
+    return undefined;
   }
```

## Why this approach (multi-angle validation)

### 1. Google API docs confirm it
- Gemini 3.1 Pro: thinking **cannot** be disabled
- `thinkingBudget` on Gemini 3 is backward-compat only and "may result in unexpected performance"
- `thinkingLevel` is the correct parameter for Gemini 3+

### 2. Maintainer direction aligns
steipete's [comment on #62473](https://github.com/openclaw/openclaw/pull/62473#issuecomment-4274194174):
> "The correct direction is to keep Gemini 2.5 Pro protected from invalid zero budgets, and map Gemini 3 / Gemini 3.1 / gemini-*-latest reasoning controls to thinkingLevel instead of forcing thinkingBudget: 0."

He live-tested `gemini-pro-latest` without `thinkingBudget` and it "returned OK".

### 3. Original bug report confirms it
Issue #62470 reporter traced the code and found:
> "gemini-3.1-pro-preview with small output budget and thinkingLevel: LOW can return no visible parts[].text, finishReason: MAX_TOKENS, nonzero thought-token usage"

### 4. Alternatives considered and rejected

| Approach | Why rejected |
|----------|-------------|
| `thinkingBudget: 0` for all models | Explicitly rejected by steipete. Google says it causes "unexpected performance" on Gemini 3. |
| `thinkingLevel: "MINIMAL"` for Pro | Not supported on Gemini 3.1 Pro per API docs. |
| Keep `thinkingLevel: "LOW"` (status quo) | **This IS the bug.** LOW still thinks and burns tokens. |
| `thinkingLevel: "NONE"` | Does not exist in the Gemini API enum. |

## What's unchanged

- **Gemini 2.5 Pro**: Still protected from `thinkingBudget: 0` via `stripInvalidGoogleThinkingBudget()`
- **Gemini 3 Flash**: Still uses `thinkingLevel: "MINIMAL"` (correct — Flash supports it and it "matches the no thinking setting for most queries")
- **All other models**: Untouched

## Behavioral change

"Thinking off" on Gemini 3.x Pro now uses model defaults (dynamic thinking) instead of LOW. Users get actual visible output instead of empty replies. This is strictly better — the previous behavior was broken.

## AI-assisted

This PR was developed with AI assistance (Kiro CLI). All changes have been reviewed and validated against the official Google Gemini API documentation.