### PR TITLE
security(ci): hoist docker-release manifest run: expressions into step env

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -362,28 +362,36 @@ jobs:
 
       - name: Create and push default manifest
         shell: bash
+        env:
+          TAGS_VALUE: ${{ steps.tags.outputs.value }}
+          AMD64_DIGEST: ${{ needs.build-amd64.outputs.digest }}
+          ARM64_DIGEST: ${{ needs.build-arm64.outputs.digest }}
         run: |
           set -euo pipefail
-          mapfile -t tags <<< "${{ steps.tags.outputs.value }}"
+          mapfile -t tags <<< "${TAGS_VALUE}"
           args=()
           for tag in "${tags[@]}"; do
             [ -z "$tag" ] && continue
             args+=("-t" "$tag")
           done
           docker buildx imagetools create "${args[@]}" \
-            ${{ needs.build-amd64.outputs.digest }} \
-            ${{ needs.build-arm64.outputs.digest }}
+            "${AMD64_DIGEST}" \
+            "${ARM64_DIGEST}"
 
       - name: Create and push slim manifest
         shell: bash
+        env:
+          SLIM_TAGS_VALUE: ${{ steps.tags.outputs.slim }}
+          AMD64_SLIM_DIGEST: ${{ needs.build-amd64.outputs.slim-digest }}
+          ARM64_SLIM_DIGEST: ${{ needs.build-arm64.outputs.slim-digest }}
         run: |
           set -euo pipefail
-          mapfile -t tags <<< "${{ steps.tags.outputs.slim }}"
+          mapfile -t tags <<< "${SLIM_TAGS_VALUE}"
           args=()
           for tag in "${tags[@]}"; do
             [ -z "$tag" ] && continue
             args+=("-t" "$tag")
           done
           docker buildx imagetools create "${args[@]}" \
-            ${{ needs.build-amd64.outputs.slim-digest }} \
-            ${{ needs.build-arm64.outputs.slim-digest }}
+            "${AMD64_SLIM_DIGEST}" \
+            "${ARM64_SLIM_DIGEST}"


### PR DESCRIPTION
## Summary

- Problem: Six `template-injection` findings from `zizmor` in `.github/workflows/docker-release.yml` (lines 367:36, 374:17, 375:17, 381:36, 388:17, 389:17). Each is a `${{ ... }}` GitHub Actions expression interpolated directly into a shell `run:` block inside the `create-manifest` job. If any of the referenced outputs were attacker-influenced, the expression value would be expanded as shell code at YAML-render time.
- Why it matters: Template-injection in release workflows is the canonical path to running attacker-controlled code with release-grade permissions (`packages: write`, `GITHUB_TOKEN`). Part of tracking issue openclaw/openclaw#68428.
- What changed: Hoist every `${{ ... }}` used inside the two `docker buildx imagetools create` `run:` blocks (`Create and push default manifest` and `Create and push slim manifest`) into a step-level `env:` block, and reference the values as quoted `"${VAR}"` from the shell. Pattern matches the adjacent `Resolve manifest tags` step which already uses this exact shape.
- What did NOT change (scope boundary):
  - Only the `create-manifest` job's two final steps are touched.
  - Bash logic is identical: `mapfile` still populates `tags`, the tag loop is unchanged, digests are passed to `imagetools create` as separate positional arguments (word splitting is not needed — docker digests are `sha256:…`, no embedded spaces).
  - Other `zizmor` finding classes in this file (`unpinned-uses`, etc.) are out of scope per the issue.
  - The other files called out in openclaw/openclaw#68428 (`openclaw-cross-os-release-checks-reusable.yml`, `openclaw-npm-release.yml`, `control-ui-locale-refresh.yml`) are out of scope — this PR only covers the 6 unowned sites in `docker-release.yml`.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes part of openclaw/openclaw#68428 (docker-release.yml — 6 sites)
- Related openclaw/openclaw#66884 (the in-flight PR covering the 12 sites in `openclaw-cross-os-release-checks-reusable.yml`)
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — this is preventative hardening, not a regression fix. The template-injection pattern has been present since the `create-manifest` job was introduced; the current shape was simply not refreshed when the rest of the workflow adopted step-level `env:` hoisting.

## Regression Test Plan (if applicable)

N/A — workflow YAML has no unit-test surface. The canonical guardrail is `zizmor` running in CI / pre-commit (`.pre-commit-config.yaml` already pins `zizmor` v1.22.0). After this change, the `template-injection` count under `.github/workflows/docker-release.yml` drops from 6 to 0.

## User-visible / Behavior Changes

None. Workflow behavior is identical — the `mapfile` read and the `docker buildx imagetools create` invocations produce the same commands. The expression substitution now happens at shell-expansion time (via env vars) instead of at YAML-render time (via `${{ }}`), which is the whole point of the hardening but is not user-visible.

## Diagram (if applicable)

```text
Before (template-injection site):
  run: |
    mapfile -t tags <<< "${{ steps.tags.outputs.value }}"   # expression expanded by YAML renderer
    docker buildx imagetools create "${args[@]}" \
      ${{ needs.build-amd64.outputs.digest }} \              # expression expanded by YAML renderer
      ${{ needs.build-arm64.outputs.digest }}

After (env-var hoist):
  env:
    TAGS_VALUE: ${{ steps.tags.outputs.value }}
    AMD64_DIGEST: ${{ needs.build-amd64.outputs.digest }}
    ARM64_DIGEST: ${{ needs.build-arm64.outputs.digest }}
  run: |
    mapfile -t tags <<< "${TAGS_VALUE}"                      # shell reads env var
    docker buildx imagetools create "${args[@]}" \
      "${AMD64_DIGEST}" \                                    # shell reads env var
      "${ARM64_DIGEST}"
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — same `docker buildx imagetools create` invocation with the same arguments.
- Data access scope changed? No

This PR only changes *how* the expression values reach the shell (env-var vs YAML-render), not *what* values are used. It closes the template-injection audit findings but is otherwise a no-op at runtime.

## Repro + Verification

### Environment

- OS: Linux x86_64
- Runtime/container: GitHub Actions `ubuntu-24.04`
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config (redacted): `.github/workflows/docker-release.yml`

### Steps

1. `actionlint .github/workflows/docker-release.yml` — clean (0 findings).
2. `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker-release.yml'))"` — parses successfully.
3. `git diff main -- .github/workflows/docker-release.yml` — only the two `create-manifest` steps' `env:` blocks and `run:` bodies change; nothing else.
4. Manual read of the diff vs. the adjacent `Resolve manifest tags` step confirms the pattern matches the in-file convention (SHOUT_CASE env keys, quoted `"${VAR}"` in shell).

### Expected

Zero `template-injection` findings from `zizmor` for `.github/workflows/docker-release.yml`, and the release workflow continues to build + push multi-arch manifests exactly as before.

### Actual

`actionlint` clean locally. `zizmor` was not available in the sandbox; the `zizmor` run happens in CI / pre-commit where it is already pinned.

## Evidence

- [x] Local `actionlint` pass on the edited file (no output = no findings).
- [ ] Failing test/log before + passing after — N/A, there is no test harness for CI workflows.
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `actionlint` clean on the modified workflow.
  - The diff only touches the two steps in the `create-manifest` job and does not alter the bash logic.
  - The env-var names match the existing SHOUT_CASE convention used by the `Resolve manifest tags` step (`IMAGE`, `SOURCE_REF`, `IS_MANUAL_BACKFILL`).
  - Docker digests (`sha256:…`) have no embedded whitespace, so losing the raw-YAML interpolation does not change docker CLI argv shape.
- Edge cases checked:
  - Empty / missing digest: `imagetools create` already fails loudly on a bad ref whether it arrives via YAML-render or env-var — no new failure mode.
  - Manual workflow_dispatch path: unaffected, those inputs flow through `Resolve manifest tags`' existing env block.
- What I did **not** verify:
  - An end-to-end release run. The canonical guardrail is the next release push exercising this job; the change is structural and does not reshape docker semantics.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No — env vars are internal to the step.
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A future contributor copies a new `${{ ... }}` expression into these `run:` blocks without adding it to the step `env:` and reintroduces a finding.
  - Mitigation: `zizmor` pre-commit + CI keeps catching the pattern; this PR does not weaken that guardrail.
