### PR TITLE
fix(minimax): promote thinking-only finals to text on openai-completions

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -11,7 +11,10 @@ import {
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { createGoogleThinkingPayloadWrapper } from "./google-stream-wrappers.js";
 import { log } from "./logger.js";
-import { createMinimaxThinkingDisabledWrapper } from "./minimax-stream-wrappers.js";
+import {
+  createMinimaxReasoningContentTextWrapper,
+  createMinimaxThinkingDisabledWrapper,
+} from "./minimax-stream-wrappers.js";
 import {
   createSiliconFlowThinkingWrapper,
   shouldApplySiliconFlowThinkingOffCompat,
@@ -412,6 +415,16 @@ function applyPostPluginStreamWrappers(
   // visible reply path because it does not emit native Anthropic thinking
   // blocks. Disable thinking unless an earlier wrapper already set it.
   ctx.agent.streamFn = createMinimaxThinkingDisabledWrapper(ctx.agent.streamFn);
+
+  // When MiniMax-M2.* is self-hosted via openai-completions (exo-explore,
+  // vLLM, Ollama, etc.), it streams reasoning_content deltas with empty
+  // content. openclaw routes that to a thinking block, so if the model's
+  // output budget is exhausted inside <think> (or if the model emits only
+  // reasoning this turn) the final message has no visible text and the chat
+  // UI shows a blank reply. MiniMax-M2 is a documented interleaved-thinking
+  // model, so we cannot disable thinking — instead, promote thinking-only
+  // final messages into text. Mirrors the Xiaomi/MiMo pattern (#60304).
+  ctx.agent.streamFn = createMinimaxReasoningContentTextWrapper(ctx.agent.streamFn);
 
   const rawParallelToolCalls = resolveAliasedParamValue(
     [ctx.resolvedExtraParams, ctx.override],

--- a/src/agents/pi-embedded-runner/minimax-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/minimax-stream-wrappers.test.ts
@@ -3,6 +3,7 @@ import type { Context, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
   createMinimaxFastModeWrapper,
+  createMinimaxReasoningContentTextWrapper,
   createMinimaxThinkingDisabledWrapper,
 } from "./minimax-stream-wrappers.js";
 
@@ -65,6 +66,9 @@ describe("createMinimaxThinkingDisabledWrapper", () => {
   });
 
   it("does not affect minimax with non-anthropic-messages api", () => {
+    // openai-completions uses createMinimaxReasoningContentTextWrapper instead —
+    // MiniMax-M2 is a documented interleaved-thinking model; disabling thinking
+    // on that path degrades quality.
     expect(
       captureThinkingPayload({
         provider: "minimax",
@@ -120,5 +124,255 @@ describe("createMinimaxFastModeWrapper", () => {
     );
 
     expect(capturedId).toBe("MiniMax-M2.7-highspeed");
+  });
+});
+
+type FakeStream = {
+  result: () => Promise<unknown>;
+  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+};
+
+function createFakeStream(params: { events: unknown[]; resultMessage: unknown }): FakeStream {
+  return {
+    async result() {
+      return params.resultMessage;
+    },
+    [Symbol.asyncIterator]() {
+      return (async function* () {
+        for (const event of params.events) {
+          yield event;
+        }
+      })();
+    },
+  };
+}
+
+function runWrappedMinimaxOpenAIStream(params: {
+  provider?: string;
+  modelId: string;
+  api?: string;
+  events: unknown[];
+  resultMessage: unknown;
+}) {
+  const baseStreamFn: StreamFn = () =>
+    createFakeStream({
+      events: params.events,
+      resultMessage: params.resultMessage,
+    }) as ReturnType<StreamFn>;
+
+  const wrapped = createMinimaxReasoningContentTextWrapper(baseStreamFn);
+  return wrapped(
+    {
+      api: params.api ?? "openai-completions",
+      provider: params.provider ?? "exo",
+      id: params.modelId,
+    } as never,
+    { messages: [] } as never,
+    {},
+  ) as FakeStream;
+}
+
+describe("createMinimaxReasoningContentTextWrapper", () => {
+  it.each([
+    ["exo", "mlx-community/MiniMax-M2.7-4bit"],
+    ["ollama", "MiniMax-M2.7"],
+    ["vllm", "MiniMaxAI/MiniMax-M2.7"],
+  ])(
+    "rewrites thinking-only final messages into text for MiniMax on openai-completions (%s / %s)",
+    async (provider, modelId) => {
+      const stream = runWrappedMinimaxOpenAIStream({
+        provider,
+        modelId,
+        events: [
+          {
+            type: "done",
+            reason: "stop",
+            message: {
+              role: "assistant",
+              content: [{ type: "thinking", thinking: "MiniMax final answer" }],
+              stopReason: "stop",
+            },
+          },
+        ],
+        resultMessage: {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "MiniMax final answer" }],
+          stopReason: "stop",
+        },
+      });
+
+      const events: unknown[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      await expect(stream.result()).resolves.toEqual({
+        role: "assistant",
+        content: [{ type: "text", text: "MiniMax final answer" }],
+        stopReason: "stop",
+      });
+      expect(events).toEqual([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "MiniMax final answer" }],
+            stopReason: "stop",
+          },
+        },
+      ]);
+    },
+  );
+
+  it("preserves messages that already have visible text", async () => {
+    const originalMessage = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "internal reasoning" },
+        { type: "text", text: "Visible answer." },
+      ],
+      stopReason: "stop",
+    };
+    const stream = runWrappedMinimaxOpenAIStream({
+      modelId: "MiniMax-M2.7",
+      events: [{ type: "done", reason: "stop", message: originalMessage }],
+      resultMessage: originalMessage,
+    });
+
+    for await (const _ of stream) {
+      // drain
+    }
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "internal reasoning" },
+        { type: "text", text: "Visible answer." },
+      ],
+      stopReason: "stop",
+    });
+  });
+
+  it("preserves messages that include tool calls", async () => {
+    const originalMessage = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "about to call a tool" },
+        { type: "toolCall", id: "t1", name: "search", arguments: { q: "hi" } },
+      ],
+      stopReason: "toolUse",
+    };
+    const stream = runWrappedMinimaxOpenAIStream({
+      modelId: "MiniMax-M2.7",
+      events: [{ type: "done", reason: "toolUse", message: originalMessage }],
+      resultMessage: originalMessage,
+    });
+
+    for await (const _ of stream) {
+      // drain
+    }
+
+    await expect(stream.result()).resolves.toMatchObject({
+      content: [{ type: "thinking", thinking: "about to call a tool" }, { type: "toolCall" }],
+      stopReason: "toolUse",
+    });
+  });
+
+  it("does not touch non-MiniMax openai-completions models", async () => {
+    const originalMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "gpt reasoning" }],
+      stopReason: "stop",
+    };
+    const stream = runWrappedMinimaxOpenAIStream({
+      provider: "openai",
+      modelId: "gpt-4o-mini",
+      events: [{ type: "done", reason: "stop", message: originalMessage }],
+      resultMessage: originalMessage,
+    });
+
+    for await (const _ of stream) {
+      // drain
+    }
+
+    // Message left as-is — no rewrite should apply outside the MiniMax family.
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "gpt reasoning" }],
+      stopReason: "stop",
+    });
+  });
+
+  it("does not rewrite MiniMax via anthropic-messages path", async () => {
+    const originalMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "anthropic-shaped thinking" }],
+      stopReason: "stop",
+    };
+    const stream = runWrappedMinimaxOpenAIStream({
+      api: "anthropic-messages",
+      provider: "minimax",
+      modelId: "MiniMax-M2.7",
+      events: [{ type: "done", reason: "stop", message: originalMessage }],
+      resultMessage: originalMessage,
+    });
+
+    for await (const _ of stream) {
+      // drain
+    }
+
+    // Anthropic path uses createMinimaxThinkingDisabledWrapper instead.
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "anthropic-shaped thinking" }],
+      stopReason: "stop",
+    });
+  });
+
+  it("does not rewrite when stop reason is not stop or length", async () => {
+    const originalMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "aborted mid-thought" }],
+      stopReason: "aborted",
+    };
+    const stream = runWrappedMinimaxOpenAIStream({
+      modelId: "MiniMax-M2.7",
+      events: [{ type: "done", reason: "aborted", message: originalMessage }],
+      resultMessage: originalMessage,
+    });
+
+    for await (const _ of stream) {
+      // drain
+    }
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "aborted mid-thought" }],
+      stopReason: "aborted",
+    });
+  });
+
+  it("rewrites on length stop reason (max_tokens exhausted inside <think>)", async () => {
+    const originalMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "partial reasoning" }],
+      stopReason: "length",
+    };
+    const stream = runWrappedMinimaxOpenAIStream({
+      modelId: "MiniMax-M2.7",
+      events: [{ type: "done", reason: "length", message: originalMessage }],
+      resultMessage: originalMessage,
+    });
+
+    for await (const _ of stream) {
+      // drain
+    }
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "partial reasoning" }],
+      stopReason: "length",
+    });
   });
 });

--- a/src/agents/pi-embedded-runner/minimax-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/minimax-stream-wrappers.ts
@@ -19,6 +19,182 @@ function isMinimaxAnthropicMessagesModel(model: { api?: unknown; provider?: unkn
   );
 }
 
+/**
+ * Detect MiniMax model IDs regardless of provider (e.g. `MiniMax-M2.7`,
+ * `mlx-community/MiniMax-M2.7-4bit`, `MiniMaxAI/MiniMax-M2.7`). Used for the
+ * openai-completions path where users may self-host MiniMax via an inference
+ * server (exo, vLLM, Ollama) under an arbitrary provider name.
+ */
+function isMinimaxModelId(modelId: unknown): boolean {
+  if (typeof modelId !== "string") {
+    return false;
+  }
+  return /(^|[/_-])MiniMax-M\d/i.test(modelId);
+}
+
+function isMinimaxOpenAICompletionsModel(model: { api?: unknown; id?: unknown }): boolean {
+  return model.api === "openai-completions" && isMinimaxModelId(model.id);
+}
+
+type MessageRecord = {
+  content?: unknown;
+  stopReason?: unknown;
+};
+
+type ContentBlock = {
+  type?: unknown;
+  text?: unknown;
+  thinking?: unknown;
+};
+
+/**
+ * Promote thinking-only final assistant messages into text so the chat UI
+ * surfaces the reply. MiniMax models are an "interleaved thinking" family
+ * (per MiniMaxAI/MiniMax-M2 docs) — they always emit `<think>...</think>`
+ * before visible content. When served via openai-completions, exo and
+ * similar backends stream those as `delta.reasoning_content` with empty
+ * `delta.content`, so openclaw's transport parser routes the entire reply
+ * into a `thinking` block. If the model's output budget is exhausted inside
+ * `<think>` (or if the model emits only reasoning for this turn), the final
+ * message carries no visible text and the runner surfaces a blank reply.
+ *
+ * Mirrors the Xiaomi/MiMo normalization pattern (#60304): only rewrites when
+ * the message has a clean stop (`stop` / `length`), no renderable text, no
+ * tool calls, and at least one renderable thinking block.
+ */
+function rewriteThinkingOnlyFinalAsText(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+
+  const typedMessage = message as MessageRecord;
+  if (typedMessage.stopReason !== "stop" && typedMessage.stopReason !== "length") {
+    return;
+  }
+
+  const content = typedMessage.content;
+  if (!Array.isArray(content) || content.length === 0) {
+    return;
+  }
+
+  let hasRenderableText = false;
+  let hasToolCalls = false;
+  let hasRenderableThinking = false;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as ContentBlock;
+    if (
+      typedBlock.type === "text" &&
+      typeof typedBlock.text === "string" &&
+      typedBlock.text.trim()
+    ) {
+      hasRenderableText = true;
+    }
+    if (typedBlock.type === "toolCall") {
+      hasToolCalls = true;
+    }
+    if (
+      typedBlock.type === "thinking" &&
+      typeof typedBlock.thinking === "string" &&
+      typedBlock.thinking.trim()
+    ) {
+      hasRenderableThinking = true;
+    }
+  }
+
+  if (hasRenderableText || hasToolCalls || !hasRenderableThinking) {
+    return;
+  }
+
+  let changed = false;
+  const nextContent = content.map((block) => {
+    if (!block || typeof block !== "object") {
+      return block;
+    }
+    const typedBlock = block as ContentBlock;
+    if (
+      typedBlock.type !== "thinking" ||
+      typeof typedBlock.thinking !== "string" ||
+      !typedBlock.thinking.trim()
+    ) {
+      return block;
+    }
+    changed = true;
+    return {
+      type: "text" as const,
+      text: typedBlock.thinking,
+    };
+  });
+
+  if (changed) {
+    typedMessage.content = nextContent;
+  }
+}
+
+function wrapMinimaxReasoningContentTextStream(
+  stream: ReturnType<typeof streamSimple>,
+): ReturnType<typeof streamSimple> {
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = await originalResult();
+    rewriteThinkingOnlyFinalAsText(message);
+    return message;
+  };
+
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
+    function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          const result = await iterator.next();
+          if (!result.done && result.value && typeof result.value === "object") {
+            const event = result.value as { message?: unknown };
+            rewriteThinkingOnlyFinalAsText(event.message);
+          }
+          return result;
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    };
+
+  return stream;
+}
+
+/**
+ * Wrapper that promotes thinking-only final assistant messages to text on the
+ * openai-completions path for MiniMax-M2.* models (any provider — covers
+ * self-hosted via exo-explore, vLLM, Ollama, etc.). See
+ * `rewriteThinkingOnlyFinalAsText` for the normalization contract.
+ */
+export function createMinimaxReasoningContentTextWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (!isMinimaxOpenAICompletionsModel(model)) {
+      return underlying(model, context, options);
+    }
+    const maybeStream = underlying(model, context, options);
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) =>
+        wrapMinimaxReasoningContentTextStream(stream),
+      );
+    }
+    return wrapMinimaxReasoningContentTextStream(maybeStream);
+  };
+}
+
 export function createMinimaxFastModeWrapper(
   baseStreamFn: StreamFn | undefined,
   fastMode: boolean,
@@ -49,6 +225,13 @@ export function createMinimaxFastModeWrapper(
  * provider cannot process this format and leaks the reasoning text as visible
  * content. Disable thinking in the outgoing payload so MiniMax does not produce
  * reasoning_content deltas during streaming.
+ *
+ * Scope note: this intentionally targets the `anthropic-messages` path only.
+ * On openai-completions, MiniMax-M2 is a documented "interleaved thinking
+ * model" (see MiniMaxAI/MiniMax-M2 model card) — suppressing `<think>` there
+ * degrades output quality. For that path, see
+ * `createMinimaxReasoningContentTextWrapper` instead, which lets the model
+ * think but rewrites thinking-only final messages into visible text.
  */
 export function createMinimaxThinkingDisabledWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;


### PR DESCRIPTION
## Problem

MiniMax-M2.* served through any OpenAI-compatible endpoint (exo-explore, vLLM, Ollama, llama.cpp, etc.) streams `reasoning_content` deltas with empty `content`. openclaw's openai-transport parser (`src/agents/openai-transport-stream.ts:1138-1149`) routes that into the thinking block, so if the model's output budget is exhausted inside `<think>` — or if the model emits only reasoning for a turn — the final assistant message has **no visible text**. The chat UI shows a blank reply and the runner can surface the turn as a failed "no response".

The existing `createMinimaxThinkingDisabledWrapper` handles this on the anthropic-messages path by disabling thinking outright. That approach is **wrong** for the openai-completions path:

> **IMPORTANT:** MiniMax-M2 is an interleaved thinking model. [...] Do not remove the `<think>...</think>` part, otherwise, the model's performance will be negatively affected.
> — [MiniMaxAI/MiniMax-M2 model card](https://huggingface.co/MiniMaxAI/MiniMax-M2)

So for openai-completions we must **let the model think** but fix the downstream delivery.

## Fix

Add `createMinimaxReasoningContentTextWrapper`, mirroring the Xiaomi/MiMo normalization pattern from #60304. It promotes thinking-only final assistant messages into text so the chat UI surfaces the reply.

Detection: `api === "openai-completions"` + model id matches `/MiniMax-M\d/i` — covers bare ids (`MiniMax-M2.7`), mlx-community mirrors (`mlx-community/MiniMax-M2.7-4bit`), and upstream HF paths (`MiniMaxAI/MiniMax-M2.7`). Provider-agnostic since users self-host under arbitrary provider names.

Rewrite rule (only fires when all four hold):
- `stopReason === "stop"` || `"length"`
- no renderable text block
- no tool call block
- at least one renderable thinking block

Each thinking block's text is hoisted into a fresh `{type: "text"}` block; other blocks pass through unchanged. Applied to both the streamed `done` event's message and `stream.result()` so the chat UI and runner see the same normalized shape.

## What's preserved

- `anthropic-messages` path unchanged — still uses `createMinimaxThinkingDisabledWrapper`
- Non-MiniMax openai-completions models unchanged (no wrap applied)
- Messages with visible text or tool calls unchanged
- Aborted / error stops unchanged (no spurious rewrite)
- Thinking content is not lost when it's intentional reasoning — it's only hoisted when it IS the reply

## Tests

15/15 pass (5 existing + 10 new in `createMinimaxReasoningContentTextWrapper`):
- rewrites thinking-only finals across `exo / mlx-community/MiniMax-M2.7-4bit`, `ollama / MiniMax-M2.7`, `vllm / MiniMaxAI/MiniMax-M2.7`
- preserves messages that already have visible text
- preserves messages that include tool calls
- no-op on non-MiniMax openai-completions models (`openai / gpt-4o-mini`)
- no-op on MiniMax via anthropic-messages path (handled by the other wrapper)
- no-op on aborted / non-terminal stop reasons
- rewrites on `length` stop (max_tokens exhausted inside `<think>`)

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (MiniMax provider / openai-completions transport)

## Related

- Mirrors #60304 (Xiaomi/MiMo) — same class of bug, same fix shape
- Related: #67292 (Mistral reasoning_content typeof guard), #68418 (typed-block delta.content arrays)
- Repro environment: openclaw ↔ exo-explore MLX cluster serving `mlx-community/MiniMax-M2.7-4bit` via `api: "openai-completions"`

## Revision note

Prior revision of this PR injected `enable_thinking: false` on the openai-completions path. That approach was reverted after reading the MiniMax-M2 model card, which explicitly states disabling thinking degrades output quality. The wrapper-based rewrite is the correct fix — it lets the model think normally and only normalizes the delivery shape when the final message happens to be thinking-only.