### PR TITLE
fix(commands): correct dead ternary branch in normalizeTimeout

### DIFF
--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -48,7 +48,7 @@ type ChannelCapabilitiesReport = {
 };
 
 function normalizeTimeout(raw: unknown, fallback = 10_000) {
-  const value = typeof raw === "string" ? Number(raw) : Number(raw);
+  const value = typeof raw === "number" ? raw : Number(raw);
   if (!Number.isFinite(value) || value <= 0) {
     return fallback;
   }


### PR DESCRIPTION
## Summary

- `normalizeTimeout` in `src/commands/channels/capabilities.ts` had a dead ternary: both the `then` and `else` branches evaluated `Number(raw)`, so the `typeof raw === "string"` guard had no effect
- The intended behavior is to pass numeric values through unchanged and coerce everything else via `Number()`; fixed the condition to `typeof raw === "number" ? raw : Number(raw)`
- This matches the correct pattern used in `normalizeTimeoutMs` in `src/infra/push-apns.relay.ts`

## Test plan
- [ ] No behavior change for current callers — `opts.timeout` is typed as `string | undefined`, so both paths produced the same result in practice; the fix makes the code correct for the `unknown` parameter type the function declares
- [ ] TypeScript type-checks cleanly with the corrected condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)