### PR TITLE
build: enable legacy-peer-deps for npm installs (madge@8 vs TS 6)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,9 @@
 # TS 7 native-preview fails to resolve packages reliably from pnpm's isolated linker.
 # Keep the workspace on a hoisted layout so pnpm check/build stay stable.
 node-linker=hoisted
+
+# npm (not pnpm) strict peer resolution fails on madge@8 + typescript@^6:
+# madge's latest release (8.0.0) declares peerOptional typescript@^5.4.4, and
+# no newer madge exists. Without this, plain `npm install` ERESOLVEs and users
+# must remember `--legacy-peer-deps`. pnpm ignores this key and is unaffected.
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- Adds `legacy-peer-deps=true` to `.npmrc` so plain `npm install` works without the `--legacy-peer-deps` flag.
- madge@8.0.0 (latest on registry) declares `peerOptional typescript@^5.4.4`, but this repo is on `typescript@^6.0.2`. No newer madge release exists that accepts TS 6, so the conflict is unavoidable on the npm side.
- pnpm is unaffected (pnpm does not consume the `legacy-peer-deps` key and already handles this peer conflict fine), so the primary `pnpm install` install path is unchanged. This is purely a quality-of-life fix for the minority of users / ops tooling that install with npm (for example `npm link` deployments of the gateway on a server).

## Rationale
Without this change, a freshly-cloned repo fails `npm install` with ERESOLVE and requires the caller to remember `--legacy-peer-deps`. That's a foot-gun for any ops path that rebuilds `node_modules` via npm (for example when a Mac Mini gateway's `node_modules` was blown away and the recovery script used `npm install`). Codifying the behavior in `.npmrc` makes the fix discoverable and self-documenting.

## Alternatives considered
- **Bump madge** to a version that allows TS 6 — not possible; 8.0.0 is the latest release and its peer pins TS ≤5.
- **Downgrade typescript to 5.x** — high-risk; the repo uses `@typescript/native-preview` 7.0-dev alongside TS 6 and downgrading would ripple through the typecheck surface.
- **Add an npm `overrides` entry** mapping madge's typescript peer to `$typescript` — works, but introduces a version-aware override just to silence a `peerOptional` warning. The `.npmrc` approach is narrower and doesn't touch `package.json`.

## Test plan
- [x] `npm install` (with the committed `.npmrc`) succeeds cleanly, no `--legacy-peer-deps` flag required.
- [x] `pnpm install` still succeeds.
- [x] `pnpm check` passes after install.
- [x] Gateway `launchctl kickstart` restart cycle serves `/health` `{ok:true,status:"live"}` within ~1s on the Mac Mini deployment (where this was discovered).