### PR TITLE
fix(memory-core): suppress expected dreaming cleanup scope warnings

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -789,6 +789,31 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(subagent.deleteSession).toHaveBeenCalled();
   });
 
+  it("does not warn when dreaming cleanup lacks operator.admin in synthetic scope", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("The repository whispered of forgotten endpoints.");
+    subagent.deleteSession.mockRejectedValue(
+      Object.assign(new Error("missing scope: operator.admin"), {
+        code: "INVALID_REQUEST",
+      }),
+    );
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["memory fragment"] },
+      logger,
+    });
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("The repository whispered of forgotten endpoints.");
+    expect(subagent.deleteSession).toHaveBeenCalledOnce();
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("narrative session cleanup failed for light phase"),
+    );
+  });
+
   it("scrubs stale dreaming entries and orphan transcripts after cleanup", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const stateDir = await createTempWorkspace("openclaw-dreaming-state-");

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -90,6 +90,8 @@ const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
 const DREAMING_TRANSCRIPT_RUN_MARKER = '"runId":"dreaming-narrative-';
 const DREAMING_ORPHAN_MIN_AGE_MS = 300_000;
 const SAFE_SESSION_ID_RE = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
+const GATEWAY_INVALID_REQUEST_ERROR_CODE = "INVALID_REQUEST";
+const MISSING_ADMIN_SCOPE_RE = /\bmissing scope:\s*operator\.admin\b/i;
 const DREAMS_FILENAMES = ["DREAMS.md", "dreams.md"] as const;
 const DIARY_START_MARKER = "<!-- openclaw:dreaming:diary:start -->";
 const DIARY_END_MARKER = "<!-- openclaw:dreaming:diary:end -->";
@@ -110,6 +112,17 @@ function isRequestScopedSubagentRuntimeError(err: unknown): boolean {
       err.name === "RequestScopedSubagentRuntimeError" &&
       extractErrorCode(err) === SUBAGENT_RUNTIME_REQUEST_SCOPE_ERROR_CODE)
   );
+}
+
+function isExpectedNarrativeCleanupScopeError(err: unknown): boolean {
+  const code = extractErrorCode(err);
+  if (code && code !== GATEWAY_INVALID_REQUEST_ERROR_CODE) {
+    return false;
+  }
+  // Gateway scope denials currently surface through the plugin runtime as
+  // INVALID_REQUEST, so keep the message fallback until the gateway exposes a
+  // dedicated scope-denied error code here.
+  return MISSING_ADMIN_SCOPE_RE.test(formatErrorMessage(err));
 }
 
 function formatFallbackWriteFailure(err: unknown): string {
@@ -932,9 +945,11 @@ export async function generateAndAppendDreamNarrative(params: {
     try {
       await params.subagent.deleteSession({ sessionKey });
     } catch (cleanupErr) {
-      params.logger.warn(
-        `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupErr)}`,
-      );
+      if (!isExpectedNarrativeCleanupScopeError(cleanupErr)) {
+        params.logger.warn(
+          `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupErr)}`,
+        );
+      }
     }
 
     await scrubDreamingNarrativeArtifacts(params.logger).catch((scrubErr: unknown) => {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { extractErrorCode } from "../plugin-sdk/error-runtime.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { PluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
@@ -792,12 +793,19 @@ describe("loadGatewayPlugins", () => {
       opts.respond(true, {});
     });
 
-    await expect(
-      runtime.deleteSession({
+    let thrown: unknown;
+    try {
+      await runtime.deleteSession({
         sessionKey: "s-delete",
         deleteTranscript: true,
-      }),
-    ).rejects.toThrow("missing scope: operator.admin");
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("missing scope: operator.admin");
+    expect(extractErrorCode(thrown)).toBe("INVALID_REQUEST");
 
     expect(getLastDispatchedClientScopes()).toEqual(["operator.write"]);
     expect(getLastDispatchedClientScopes()).not.toContain("operator.admin");

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -292,7 +292,10 @@ async function dispatchGatewayMethod<T>(
     throw new Error(`Gateway method "${method}" completed without a response.`);
   }
   if (!result.ok) {
-    throw new Error(result.error?.message ?? `Gateway method "${method}" failed.`);
+    throw Object.assign(
+      new Error(result.error?.message ?? `Gateway method "${method}" failed.`),
+      result.error?.code ? { code: result.error.code } : {},
+    );
   }
   return result.payload as T;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:


- Problem: dreaming narrative cleanup can log `missing scope: operator.admin` during synthetic plugin-runtime cleanup.
- Why it matters: this is expected best-effort cleanup behavior, but it shows up as warning noise and makes dreaming failures look more serious than they are.
- What changed: suppress the expected cleanup warning for `missing scope: operator.admin` and add regression coverage in `dreaming-narrative.test.ts`.
- What did NOT change (scope boundary): this does not change gateway auth, scope minting, or cleanup behavior for other real cleanup failures.:

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:dreaming narrative cleanup always attempted `deleteSession()` and logged any resulting error, even when synthetic plugin runtime scope is intentionally not allowed to perform admin-scoped session deletion.
- Missing detection / guardrail:memory-core did not recognize the expected `missing scope: operator.admin` cleanup path as non-actionable noise.
- Contributing context (if known): the dreaming scrubber already runs afterward as the best-effort cleanup fallback, so the warning was noisy rather than useful.O

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
