### PR TITLE
anthropic: stop forcing Claude CLI permission bypass

### DIFF
--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -36,8 +36,6 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
         "--verbose",
         "--setting-sources",
         "user",
-        "--permission-mode",
-        "bypassPermissions",
       ],
       resumeArgs: [
         "-p",
@@ -47,8 +45,6 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
         "--verbose",
         "--setting-sources",
         "user",
-        "--permission-mode",
-        "bypassPermissions",
         "--resume",
         "{sessionId}",
       ],

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -8,23 +8,16 @@ import {
 } from "./cli-shared.js";
 
 describe("normalizeClaudePermissionArgs", () => {
-  it("injects bypassPermissions when args omit permission flags", () => {
+  it("leaves args unchanged when permission flags are omitted", () => {
     expect(
       normalizeClaudePermissionArgs(["-p", "--output-format", "stream-json", "--verbose"]),
-    ).toEqual([
-      "-p",
-      "--output-format",
-      "stream-json",
-      "--verbose",
-      "--permission-mode",
-      "bypassPermissions",
-    ]);
+    ).toEqual(["-p", "--output-format", "stream-json", "--verbose"]);
   });
 
-  it("removes legacy skip-permissions and injects bypassPermissions", () => {
+  it("removes legacy skip-permissions without forcing bypassPermissions", () => {
     expect(
       normalizeClaudePermissionArgs(["-p", "--dangerously-skip-permissions", "--verbose"]),
-    ).toEqual(["-p", "--verbose", "--permission-mode", "bypassPermissions"]);
+    ).toEqual(["-p", "--verbose"]);
   });
 
   it("keeps explicit permission-mode overrides", () => {
@@ -39,10 +32,10 @@ describe("normalizeClaudePermissionArgs", () => {
     ]);
   });
 
-  it("treats a bare permission-mode flag as malformed and falls back to bypassPermissions", () => {
+  it("drops malformed bare permission-mode flags", () => {
     expect(
       normalizeClaudePermissionArgs(["-p", "--permission-mode", "--output-format", "stream-json"]),
-    ).toEqual(["-p", "--output-format", "stream-json", "--permission-mode", "bypassPermissions"]);
+    ).toEqual(["-p", "--output-format", "stream-json"]);
   });
 });
 
@@ -92,8 +85,6 @@ describe("normalizeClaudeBackendConfig", () => {
       "--verbose",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
     expect(normalized.resumeArgs).toEqual([
       "-p",
@@ -104,8 +95,6 @@ describe("normalizeClaudeBackendConfig", () => {
       "{sessionId}",
       "--setting-sources",
       "user",
-      "--permission-mode",
-      "bypassPermissions",
     ]);
   });
 
@@ -121,14 +110,25 @@ describe("normalizeClaudeBackendConfig", () => {
       resumeArgs: ["-p", "--output-format", "stream-json", "--verbose", "--resume", "{sessionId}"],
     });
 
-    expect(normalized?.args).toContain("--permission-mode");
-    expect(normalized?.args).toContain("bypassPermissions");
-    expect(normalized?.args).toContain("--setting-sources");
-    expect(normalized?.args).toContain("user");
-    expect(normalized?.resumeArgs).toContain("--permission-mode");
-    expect(normalized?.resumeArgs).toContain("bypassPermissions");
-    expect(normalized?.resumeArgs).toContain("--setting-sources");
-    expect(normalized?.resumeArgs).toContain("user");
+    expect(normalized).toBeDefined();
+    expect(normalized?.args).toBeDefined();
+    expect(normalized?.resumeArgs).toBeDefined();
+
+    const normalizedArgs = normalized!.args!;
+    const normalizedResumeArgs = normalized!.resumeArgs!;
+
+    const argsSettingSourcesIndex = normalizedArgs.indexOf("--setting-sources");
+    expect(argsSettingSourcesIndex).toBeGreaterThanOrEqual(0);
+    expect(normalizedArgs.slice(argsSettingSourcesIndex, argsSettingSourcesIndex + 2)).toEqual([
+      "--setting-sources",
+      "user",
+    ]);
+
+    const resumeArgsSettingSourcesIndex = normalizedResumeArgs.indexOf("--setting-sources");
+    expect(resumeArgsSettingSourcesIndex).toBeGreaterThanOrEqual(0);
+    expect(
+      normalizedResumeArgs.slice(resumeArgsSettingSourcesIndex, resumeArgsSettingSourcesIndex + 2),
+    ).toEqual(["--setting-sources", "user"]);
   });
 
   it("leaves claude cli subscription-managed, restricts setting sources, and clears inherited env overrides", () => {
@@ -137,8 +137,10 @@ describe("normalizeClaudeBackendConfig", () => {
     expect(backend.config.env).toBeUndefined();
     expect(backend.config.args).toContain("--setting-sources");
     expect(backend.config.args).toContain("user");
+    expect(backend.config.args).not.toContain("--permission-mode");
     expect(backend.config.resumeArgs).toContain("--setting-sources");
     expect(backend.config.resumeArgs).toContain("user");
+    expect(backend.config.resumeArgs).not.toContain("--permission-mode");
     expect(backend.config.clearEnv).toEqual([...CLAUDE_CLI_CLEAR_ENV]);
     expect(backend.config.clearEnv).toContain("ANTHROPIC_API_TOKEN");
     expect(backend.config.clearEnv).toContain("ANTHROPIC_BASE_URL");

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -90,7 +90,6 @@ export const CLAUDE_CLI_CLEAR_ENV = [
 
 const CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG = "--dangerously-skip-permissions";
 const CLAUDE_PERMISSION_MODE_ARG = "--permission-mode";
-const CLAUDE_BYPASS_PERMISSIONS_MODE = "bypassPermissions";
 const CLAUDE_SETTING_SOURCES_ARG = "--setting-sources";
 const CLAUDE_SAFE_SETTING_SOURCES = "user";
 
@@ -103,7 +102,6 @@ export function normalizeClaudePermissionArgs(args?: string[]): string[] | undef
     return args;
   }
   const normalized: string[] = [];
-  let hasPermissionMode = false;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG) {
@@ -116,20 +114,13 @@ export function normalizeClaudePermissionArgs(args?: string[]): string[] | undef
         maybeValue.trim().length > 0 &&
         !maybeValue.startsWith("-")
       ) {
-        hasPermissionMode = true;
         normalized.push(arg);
         normalized.push(maybeValue);
         i += 1;
       }
       continue;
     }
-    if (arg.startsWith(`${CLAUDE_PERMISSION_MODE_ARG}=`)) {
-      hasPermissionMode = true;
-    }
     normalized.push(arg);
-  }
-  if (!hasPermissionMode) {
-    normalized.push(CLAUDE_PERMISSION_MODE_ARG, CLAUDE_BYPASS_PERMISSIONS_MODE);
   }
   return normalized;
 }


### PR DESCRIPTION
## Issue
The Anthropic CLI backend currently forces `--permission-mode bypassPermissions` into Claude CLI runs even when the caller did not request it. That weakens the default security posture by suppressing Claude's built-in permission prompts for tool actions.

## Fix
- remove the forced `--permission-mode bypassPermissions` defaults from `extensions/anthropic/cli-backend.ts`
- keep stripping the legacy `--dangerously-skip-permissions` flag in `extensions/anthropic/cli-shared.ts`
- preserve explicit `--permission-mode` overrides, but stop injecting bypass mode when permission flags are omitted or malformed
- tighten the regression coverage in `extensions/anthropic/cli-shared.test.ts`, including adjacency checks for `--setting-sources user`

## How to test
- run: `pnpm test extensions/anthropic/cli-shared.test.ts`
- verify the normalized Claude CLI args no longer grow `--permission-mode bypassPermissions` by default
- verify explicit `--permission-mode` values are still preserved and malformed bare flags are dropped
