### PR TITLE
fix(auto-reply): commit inbound dedupe on handled exits

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -19,12 +19,13 @@ import {
 } from "./dispatch-from-config.shared.test-harness.js";
 
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
+let claimInboundDedupe: typeof import("./inbound-dedupe.js").claimInboundDedupe;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 
 describe("dispatchReplyFromConfig reply_dispatch hook", () => {
   beforeAll(async () => {
     ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
-    ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
+    ({ claimInboundDedupe, resetInboundDedupe } = await import("./inbound-dedupe.js"));
   });
 
   beforeEach(() => {
@@ -92,9 +93,10 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       queuedFinal: true,
       counts: { tool: 1, block: 2, final: 3 },
     });
+    const ctx = { ...createHookCtx(), MessageSid: "reply-dispatch-handled-1" };
 
     const result = await dispatchReplyFromConfig({
-      ctx: createHookCtx(),
+      ctx,
       cfg: emptyConfig,
       dispatcher: createDispatcher(),
       fastAbortResolver: async () => ({ handled: false, aborted: false }),
@@ -116,6 +118,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       queuedFinal: true,
       counts: { tool: 1, block: 2, final: 3 },
     });
+    expect(claimInboundDedupe(ctx)).toMatchObject({ status: "duplicate" });
   });
   it("still applies send-policy deny after an unhandled plugin dispatch", async () => {
     hookMocks.runner.runReplyDispatch.mockResolvedValue({

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -120,6 +120,48 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
     expect(claimInboundDedupe(ctx)).toMatchObject({ status: "duplicate" });
   });
+
+  it("does not double-record diagnostics when a handled reply_dispatch hook records completion", async () => {
+    const cfg = { diagnostics: { enabled: true } };
+    hookMocks.runner.runReplyDispatch.mockImplementation(async (_event: unknown, ctx: unknown) => {
+      const hookCtx = ctx as {
+        recordProcessed: (
+          outcome: "completed" | "skipped" | "error",
+          opts?: { reason?: string; error?: string },
+        ) => void;
+        markIdle: (reason: string) => void;
+      };
+      hookCtx.recordProcessed("completed", { reason: "hook-handled" });
+      hookCtx.markIdle("message_completed");
+      return {
+        handled: true,
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      };
+    });
+    const ctx = { ...createHookCtx(), MessageSid: "reply-dispatch-diagnostics-1" };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher: createDispatcher(),
+      fastAbortResolver: async () => ({ handled: false, aborted: false }),
+      formatAbortReplyTextResolver: () => "⚙️ Agent was aborted.",
+      replyResolver: async () => ({ text: "model reply" }),
+    });
+
+    expect(
+      diagnosticMocks.logMessageProcessed.mock.calls.filter(
+        ([event]) => (event as { outcome?: string }).outcome === "completed",
+      ),
+    ).toHaveLength(1);
+    expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "completed",
+        reason: "hook-handled",
+      }),
+    );
+  });
   it("still applies send-policy deny after an unhandled plugin dispatch", async () => {
     hookMocks.runner.runReplyDispatch.mockResolvedValue({
       handled: false,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -359,6 +359,7 @@ vi.mock("../../tts/tts-config.js", () => ({
 const noAbortResult = { handled: false, aborted: false } as const;
 const emptyConfig = {} as OpenClawConfig;
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
+let claimInboundDedupe: typeof import("./inbound-dedupe.js").claimInboundDedupe;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tryDispatchAcpReplyHook;
 type DispatchReplyArgs = Parameters<
@@ -371,7 +372,7 @@ beforeAll(async () => {
   await import("./dispatch-acp-command-bypass.js");
   await import("./dispatch-acp-tts.runtime.js");
   await import("./dispatch-acp-session.runtime.js");
-  ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
+  ({ claimInboundDedupe, resetInboundDedupe } = await import("./inbound-dedupe.js"));
   ({ tryDispatchAcpReplyHook } = await import("../../plugin-sdk/acp-runtime.js"));
 });
 
@@ -2391,6 +2392,7 @@ describe("dispatchReplyFromConfig", () => {
     );
     expect(hookMocks.runner.runInboundClaim).not.toHaveBeenCalled();
     expect(replyResolver).not.toHaveBeenCalled();
+    expect(claimInboundDedupe(ctx)).toMatchObject({ status: "duplicate" });
   });
 
   it("routes plugin-owned Discord DM bindings to the owning plugin before generic inbound claim broadcast", async () => {
@@ -2969,6 +2971,7 @@ describe("before_dispatch hook", () => {
       From: "user1",
       Surface: "telegram",
       ChatType: "private",
+      MessageSid: "before-dispatch-hook-message",
       ...overrides,
     });
 
@@ -2993,13 +2996,15 @@ describe("before_dispatch hook", () => {
   it("skips model dispatch when hook returns handled", async () => {
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true, text: "Blocked" });
     const dispatcher = createDispatcher();
+    const ctx = createHookCtx();
     const result = await dispatchReplyFromConfig({
-      ctx: createHookCtx(),
+      ctx,
       cfg: emptyConfig,
       dispatcher,
     });
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Blocked" });
     expect(result.queuedFinal).toBe(true);
+    expect(claimInboundDedupe(ctx)).toMatchObject({ status: "duplicate" });
   });
 
   it("silently short-circuits when hook returns handled without text", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1419,6 +1419,7 @@ describe("dispatchReplyFromConfig", () => {
     const ctx = buildTestCtx({
       Provider: "telegram",
       Body: "/stop",
+      MessageSid: "fast-abort-handled-1",
     });
     const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
 
@@ -1428,6 +1429,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
       text: "⚙️ Agent was aborted.",
     });
+    expect(claimInboundDedupe(ctx)).toMatchObject({ status: "duplicate" });
   });
 
   it("fast-abort reply includes stopped subagent count when provided", async () => {
@@ -3158,6 +3160,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     const ctx = buildTestCtx({
       SessionKey: "test:session",
       AcpDispatchTailAfterReset: true,
+      MessageSid: "tail-reply-dispatch-1",
     });
 
     await dispatchReplyFromConfig({
@@ -3175,6 +3178,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       }),
       expect.any(Object),
     );
+    expect(claimInboundDedupe(ctx)).toMatchObject({ status: "duplicate" });
   });
 
   it("suppresses final reply delivery when sendPolicy is deny", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -271,6 +271,20 @@ export async function dispatchReplyFromConfig(
     recordProcessed("skipped", { reason: "duplicate" });
     return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
   }
+  const completeDispatch = (
+    result: DispatchFromConfigResult,
+    opts?: {
+      reason?: string;
+      idleReason?: string;
+    },
+  ): DispatchFromConfigResult => {
+    if (inboundDedupeClaim.status === "claimed") {
+      commitInboundDedupe(inboundDedupeClaim.key);
+    }
+    recordProcessed("completed", opts?.reason ? { reason: opts.reason } : undefined);
+    markIdle(opts?.idleReason ?? "message_completed");
+    return result;
+  };
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
@@ -515,9 +529,13 @@ export async function dispatchReplyFromConfig(
 
       switch (targetedClaimOutcome.status) {
         case "handled": {
-          markIdle("plugin_binding_dispatch");
-          recordProcessed("completed", { reason: "plugin-bound-handled" });
-          return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+          return completeDispatch(
+            { queuedFinal: false, counts: dispatcher.getQueuedCounts() },
+            {
+              reason: "plugin-bound-handled",
+              idleReason: "plugin_binding_dispatch",
+            },
+          );
         }
         case "missing_plugin":
         case "no_handler": {
@@ -541,9 +559,13 @@ export async function dispatchReplyFromConfig(
             { text: buildPluginBindingDeclinedText(pluginOwnedBinding) },
             "terminal",
           );
-          markIdle("plugin_binding_declined");
-          recordProcessed("completed", { reason: "plugin-bound-declined" });
-          return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+          return completeDispatch(
+            { queuedFinal: false, counts: dispatcher.getQueuedCounts() },
+            {
+              reason: "plugin-bound-declined",
+              idleReason: "plugin_binding_declined",
+            },
+          );
         }
         case "error": {
           logVerbose(
@@ -553,9 +575,13 @@ export async function dispatchReplyFromConfig(
             { text: buildPluginBindingErrorText(pluginOwnedBinding) },
             "terminal",
           );
-          markIdle("plugin_binding_error");
-          recordProcessed("completed", { reason: "plugin-bound-error" });
-          return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+          return completeDispatch(
+            { queuedFinal: false, counts: dispatcher.getQueuedCounts() },
+            {
+              reason: "plugin-bound-error",
+              idleReason: "plugin_binding_error",
+            },
+          );
         }
       }
     }
@@ -624,9 +650,7 @@ export async function dispatchReplyFromConfig(
       }
       const counts = dispatcher.getQueuedCounts();
       counts.final += routedFinalCount;
-      recordProcessed("completed", { reason: "fast_abort" });
-      markIdle("message_completed");
-      return { queuedFinal, counts };
+      return completeDispatch({ queuedFinal, counts }, { reason: "fast_abort" });
     }
 
     const shouldSendToolSummaries = ctx.ChatType !== "group" || ctx.IsForum === true;
@@ -692,9 +716,7 @@ export async function dispatchReplyFromConfig(
         }
         const counts = dispatcher.getQueuedCounts();
         counts.final += routedFinalCount;
-        recordProcessed("completed", { reason: "before_dispatch_handled" });
-        markIdle("message_completed");
-        return { queuedFinal, counts };
+        return completeDispatch({ queuedFinal, counts }, { reason: "before_dispatch_handled" });
       }
     }
 
@@ -724,10 +746,10 @@ export async function dispatchReplyFromConfig(
         },
       );
       if (replyDispatchResult?.handled) {
-        return {
+        return completeDispatch({
           queuedFinal: replyDispatchResult.queuedFinal,
           counts: replyDispatchResult.counts,
-        };
+        });
       }
     }
 
@@ -1025,10 +1047,10 @@ export async function dispatchReplyFromConfig(
           },
         );
         if (tailDispatchResult?.handled) {
-          return {
+          return completeDispatch({
             queuedFinal: tailDispatchResult.queuedFinal,
             counts: tailDispatchResult.counts,
-          };
+          });
         }
       }
     }
@@ -1101,15 +1123,10 @@ export async function dispatchReplyFromConfig(
 
     const counts = dispatcher.getQueuedCounts();
     counts.final += routedFinalCount;
-    if (inboundDedupeClaim.status === "claimed") {
-      commitInboundDedupe(inboundDedupeClaim.key);
-    }
-    recordProcessed(
-      "completed",
+    return completeDispatch(
+      { queuedFinal, counts },
       pluginFallbackReason ? { reason: pluginFallbackReason } : undefined,
     );
-    markIdle("message_completed");
-    return { queuedFinal, counts };
   } catch (err) {
     if (inboundDedupeClaim.status === "claimed") {
       releaseInboundDedupe(inboundDedupeClaim.key);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -276,13 +276,16 @@ export async function dispatchReplyFromConfig(
     opts?: {
       reason?: string;
       idleReason?: string;
+      recordLifecycle?: boolean;
     },
   ): DispatchFromConfigResult => {
     if (inboundDedupeClaim.status === "claimed") {
       commitInboundDedupe(inboundDedupeClaim.key);
     }
-    recordProcessed("completed", opts?.reason ? { reason: opts.reason } : undefined);
-    markIdle(opts?.idleReason ?? "message_completed");
+    if (opts?.recordLifecycle !== false) {
+      recordProcessed("completed", opts?.reason ? { reason: opts.reason } : undefined);
+      markIdle(opts?.idleReason ?? "message_completed");
+    }
     return result;
   };
 
@@ -746,10 +749,13 @@ export async function dispatchReplyFromConfig(
         },
       );
       if (replyDispatchResult?.handled) {
-        return completeDispatch({
-          queuedFinal: replyDispatchResult.queuedFinal,
-          counts: replyDispatchResult.counts,
-        });
+        return completeDispatch(
+          {
+            queuedFinal: replyDispatchResult.queuedFinal,
+            counts: replyDispatchResult.counts,
+          },
+          { recordLifecycle: false },
+        );
       }
     }
 
@@ -1047,10 +1053,13 @@ export async function dispatchReplyFromConfig(
           },
         );
         if (tailDispatchResult?.handled) {
-          return completeDispatch({
-            queuedFinal: tailDispatchResult.queuedFinal,
-            counts: tailDispatchResult.counts,
-          });
+          return completeDispatch(
+            {
+              queuedFinal: tailDispatchResult.queuedFinal,
+              counts: tailDispatchResult.counts,
+            },
+            { recordLifecycle: false },
+          );
         }
       }
     }


### PR DESCRIPTION
## Summary

- Problem: inbound dedupe claims were only committed at the end of the main dispatch path, so handled early returns left keys stuck in the global in-flight set.
- Why it matters: handled inbound messages could accumulate permanent in-flight entries, causing memory growth and making reused message ids look perpetually in-flight.
- What changed: centralized successful dispatch completion through a helper that commits the dedupe claim before every handled return path.
- What did NOT change (scope boundary): duplicate detection semantics, error-path release behavior, and send-policy suppression logic.
- AI-assisted: built with Codex.
- Testing: fully tested with targeted unit tests.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `dispatchReplyFromConfig` claimed the inbound dedupe key up front, but several successful early returns bypassed the only `commitInboundDedupe(...)` call at the bottom of the main try block.
- Missing detection / guardrail: no regression test asserted that handled early-return paths transitioned the dedupe key from `claimed` to cached `duplicate`.
- Contributing context (if known): recent inbound dedupe changes added the global in-flight set, but cleanup stayed coupled to the linear completion path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-from-config.test.ts`, `src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts`
- Scenario the test should lock in: after a plugin-owned handled return, `before_dispatch` handled return, or `reply_dispatch` handled return, re-claiming the same inbound context should report `duplicate` rather than `inflight`.
- Why this is the smallest reliable guardrail: the bug is local to dispatcher control flow and is observable directly through the dedupe claim API without needing channel-level integration setup.
- Existing test that already covers this (if any): `src/auto-reply/reply/dispatch-from-config.test.ts` already covered release-on-error for the same dedupe path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[inbound message] -> [claim dedupe key] -> [handled early return] -> [key stays in in-flight set]

After:
[inbound message] -> [claim dedupe key] -> [handled completion helper] -> [commit key] -> [cached duplicate state]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): auto-reply dispatcher unit tests
- Relevant config (redacted): default test harness config

### Steps

1. Dispatch an inbound message that exits early via plugin-bound handled, `before_dispatch` handled, or `reply_dispatch` handled.
2. Re-claim the same inbound dedupe key.
3. Observe whether the claim resolves as cached `duplicate` or stuck `inflight`.

### Expected

- Successful handled exits commit the dedupe key, so subsequent claims resolve as `duplicate`.

### Actual

- Before this fix, handled early returns skipped commit/release and left the key stuck as `inflight`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted unit tests for plugin-bound handled exit, `before_dispatch` handled exit, `reply_dispatch` handled exit, plus existing `inbound-dedupe` unit tests.
- Edge cases checked: existing release-on-error behavior remains covered; plugin-bound declined/error paths now share the same completion helper.
- What you did **not** verify: full CI matrix and live channel integrations locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: missing another future handled return path could reintroduce the same leak.
  - Mitigation: successful completion now goes through a shared helper, and tests assert dedupe state after multiple handled early exits.
