### PR TITLE
fix(lmstudio): bound preload cooldown state

### DIFF
--- a/extensions/lmstudio/src/stream.test.ts
+++ b/extensions/lmstudio/src/stream.test.ts
@@ -1,7 +1,11 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { __resetLmstudioPreloadCooldownForTest, wrapLmstudioInferencePreload } from "./stream.js";
+import {
+  __getLmstudioPreloadCooldownSizeForTest,
+  __resetLmstudioPreloadCooldownForTest,
+  wrapLmstudioInferencePreload,
+} from "./stream.js";
 
 const ensureLmstudioModelLoadedMock = vi.hoisted(() => vi.fn());
 const resolveLmstudioProviderHeadersMock = vi.hoisted(() =>
@@ -352,6 +356,95 @@ describe("lmstudio stream wrapper", () => {
       ),
     );
     expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
+  });
+
+  it("prunes expired cooldown entries when unrelated preload failures arrive later", async () => {
+    ensureLmstudioModelLoadedMock.mockRejectedValue(new Error("out of memory"));
+    const baseStream = buildDoneStreamFn();
+    const wrapped = wrapLmstudioInferencePreload({
+      provider: "lmstudio",
+      modelId: "qwen3-8b-instruct",
+      config: {
+        models: {
+          providers: {
+            lmstudio: {
+              baseUrl: "http://localhost:1234",
+              models: [],
+            },
+          },
+        },
+      },
+      streamFn: baseStream,
+    } as never);
+
+    const baseTime = 1_000_000;
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(baseTime);
+    await collectEvents(
+      wrapped(
+        {
+          provider: "lmstudio",
+          api: "openai-completions",
+          id: "qwen3-8b-instruct",
+        } as never,
+        { messages: [] } as never,
+        undefined as never,
+      ),
+    );
+    expect(__getLmstudioPreloadCooldownSizeForTest()).toBe(1);
+
+    nowSpy.mockReturnValue(baseTime + 6_000);
+    await collectEvents(
+      wrapped(
+        {
+          provider: "lmstudio",
+          api: "openai-completions",
+          id: "qwen3-14b-instruct",
+        } as never,
+        { messages: [] } as never,
+        undefined as never,
+      ),
+    );
+    expect(__getLmstudioPreloadCooldownSizeForTest()).toBe(1);
+    nowSpy.mockRestore();
+  });
+
+  it("bounds cooldown state across many unique failing preload keys", async () => {
+    ensureLmstudioModelLoadedMock.mockRejectedValue(new Error("out of memory"));
+    const baseStream = buildDoneStreamFn();
+    const wrapped = wrapLmstudioInferencePreload({
+      provider: "lmstudio",
+      modelId: "qwen3-8b-instruct",
+      config: {
+        models: {
+          providers: {
+            lmstudio: {
+              baseUrl: "http://localhost:1234",
+              models: [],
+            },
+          },
+        },
+      },
+      streamFn: baseStream,
+    } as never);
+
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    for (let index = 0; index < 1_100; index += 1) {
+      await collectEvents(
+        wrapped(
+          {
+            provider: "lmstudio",
+            api: "openai-completions",
+            id: `qwen3-unique-${index}`,
+          } as never,
+          { messages: [] } as never,
+          undefined as never,
+        ),
+      );
+    }
+
+    expect(__getLmstudioPreloadCooldownSizeForTest()).toBeLessThanOrEqual(1024);
     nowSpy.mockRestore();
   });
 

--- a/extensions/lmstudio/src/stream.ts
+++ b/extensions/lmstudio/src/stream.ts
@@ -37,6 +37,7 @@ const preloadCooldown = new Map<string, PreloadCooldownEntry>();
 
 const PRELOAD_BACKOFF_BASE_MS = 5_000;
 const PRELOAD_BACKOFF_MAX_MS = 300_000;
+const PRELOAD_COOLDOWN_MAX_ENTRIES = 1024;
 
 function computePreloadBackoffMs(consecutiveFailures: number): number {
   const exponent = Math.max(0, consecutiveFailures - 1);
@@ -48,14 +49,37 @@ function recordPreloadSuccess(preloadKey: string): void {
   preloadCooldown.delete(preloadKey);
 }
 
+function pruneExpiredPreloadCooldownEntries(now: number): void {
+  for (const [key, entry] of preloadCooldown) {
+    if (entry.untilMs <= now) {
+      preloadCooldown.delete(key);
+    }
+  }
+}
+
+function prunePreloadCooldownToLimit(limit: number): void {
+  while (preloadCooldown.size > limit) {
+    const oldestKey = preloadCooldown.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    preloadCooldown.delete(oldestKey);
+  }
+}
+
 function recordPreloadFailure(preloadKey: string, now: number): PreloadCooldownEntry {
+  pruneExpiredPreloadCooldownEntries(now);
   const existing = preloadCooldown.get(preloadKey);
   const consecutiveFailures = (existing?.consecutiveFailures ?? 0) + 1;
+  if (existing) {
+    preloadCooldown.delete(preloadKey);
+  }
   const entry: PreloadCooldownEntry = {
     consecutiveFailures,
     untilMs: now + computePreloadBackoffMs(consecutiveFailures),
   };
   preloadCooldown.set(preloadKey, entry);
+  prunePreloadCooldownToLimit(PRELOAD_COOLDOWN_MAX_ENTRIES);
   return entry;
 }
 
@@ -75,6 +99,11 @@ function isPreloadCoolingDown(preloadKey: string, now: number): PreloadCooldownE
 export function __resetLmstudioPreloadCooldownForTest(): void {
   preloadCooldown.clear();
   preloadInFlight.clear();
+}
+
+/** Test-only hook for asserting cooldown cleanup behavior. */
+export function __getLmstudioPreloadCooldownSizeForTest(): number {
+  return preloadCooldown.size;
 }
 
 function normalizeLmstudioModelKey(modelId: string): string {
@@ -194,7 +223,9 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
       requestedContextLength,
     });
 
-    const cooldownEntry = isPreloadCoolingDown(preloadKey, Date.now());
+    const now = Date.now();
+    pruneExpiredPreloadCooldownEntries(now);
+    const cooldownEntry = isPreloadCoolingDown(preloadKey, now);
     const existing = preloadInFlight.get(preloadKey);
     const preloadPromise: Promise<void> | undefined =
       existing ??


### PR DESCRIPTION
## Summary

- Problem: LM Studio preload failures stored cooldown entries in a global map that only self-cleaned on same-key retry or success.
- Why it matters: many unique failing model ids could accumulate stale cooldown state and grow process memory unnecessarily.
- What changed: prune expired cooldown entries on every LM Studio request and cap retained cooldown keys to a bounded maximum.
- What did NOT change (scope boundary): preload backoff semantics, model-selection allowAny behavior, and successful inference fallback behavior.
- AI-assisted: built with Codex.
- Testing: fully tested with targeted LM Studio extension tests.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/lmstudio/src/stream.ts` kept failed preload cooldowns in a global `Map` with per-key expiry, but stale entries were only deleted when the same key was checked again or later succeeded.
- Missing detection / guardrail: tests covered same-key cooldown behavior, but nothing asserted cleanup for expired entries tied to unrelated keys or overall bounded state under many unique failures.
- Contributing context (if known): the cooldown was added to suppress repeated preload warnings, but the global state did not get an opportunistic prune path for unrelated requests.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/lmstudio/src/stream.test.ts`
- Scenario the test should lock in: expired cooldown entries are pruned when later unrelated preload failures occur, and many unique failing preload keys do not grow retained cooldown state beyond the configured cap.
- Why this is the smallest reliable guardrail: the bug is fully local to the LM Studio preload wrapper and observable through the wrapper’s in-memory cooldown state.
- Existing test that already covers this (if any): existing tests already covered same-key backoff and retry-after-expiry behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None in normal use. Under repeated LM Studio preload failures, stale cooldown state is now cleaned opportunistically and retained cooldown keys are bounded.

## Diagram (if applicable)

```text
Before:
[failing preload for unique model ids] -> [global cooldown map only grows] -> [stale entries linger]

After:
[failing preload for unique model ids] -> [prune expired entries + cap retained keys] -> [bounded cooldown state]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: LM Studio extension unit tests
- Integration/channel (if any): LM Studio preload wrapper
- Relevant config (redacted): test harness config with `lmstudio` provider base URL

### Steps

1. Trigger a preload failure for one LM Studio model id to create cooldown state.
2. Advance time past the first cooldown window and trigger a failure for a different model id.
3. Repeat across many unique model ids and inspect retained cooldown state.

### Expected

- Expired cooldown entries are pruned even when the next request is for a different model id.
- Retained cooldown state stays bounded under many unique failing preload keys.

### Actual

- Before this fix, unrelated requests left stale keys in the map indefinitely, and unique failing preload keys could accumulate without a bound.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted `extensions/lmstudio/src/stream.test.ts` plus full `extensions/lmstudio/src` test suite.
- Edge cases checked: existing same-key cooldown skip, retry-after-expiry, and concurrent preload dedupe behavior still pass.
- What you did **not** verify: live LM Studio process behavior under real network failures or end-to-end gateway auth/rate-limit scenarios.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: evicting very old cooldown entries under extreme cardinality could cause an old failing model id to retry preload sooner than before.
  - Mitigation: the cap is intentionally large relative to realistic LM Studio model sets, and normal same-key backoff behavior remains unchanged.
