### PR TITLE
fix(agents): stop treating session lock waits as timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,7 @@ Docs: https://docs.openclaw.ai
 - Config/agents: accept `agents.list[].contextTokens` in strict config validation so per-agent overrides survive hot reload, letting `/status` reflect the configured model window instead of the 200k fallback. Fixes #70692. (#71247) Thanks @statxc.
 - Heartbeat: include async exec completion details in heartbeat prompts so command-finished notifications relay the actual output. (#71213) Thanks @GodsBoy.
 - Memory search: apply session visibility and agent-to-agent policy to session transcript hits, and keep `corpus=sessions` ranking scoped to session collections before result limiting. (#70761) Thanks @nefainl.
+- Agents/sessions: stop session write-lock timeouts from entering model failover, so local lock contention surfaces directly instead of cascading across providers. (#68700) Thanks @MonkeyLeeT.
 
 ## 2026.4.23
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -359,6 +359,24 @@ describe("failover-error", () => {
     ).toBe("overloaded");
   });
 
+  it("does not classify session lock wait errors as model timeout failover", () => {
+    const sessionLockMessage =
+      "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock";
+    expect(
+      resolveFailoverReasonFromError({
+        message: sessionLockMessage,
+      }),
+    ).toBeNull();
+    expect(isTimeoutError({ message: sessionLockMessage })).toBe(false);
+
+    const wrappedLockError = Object.assign(new Error("operation timed out"), {
+      name: "AbortError",
+      cause: new Error(sessionLockMessage),
+    });
+    expect(resolveFailoverReasonFromError(wrappedLockError)).toBeNull();
+    expect(isTimeoutError(wrappedLockError)).toBe(false);
+  });
+
   it("classifies provider-scoped generic upstream errors for failover", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -421,6 +421,18 @@ describe("failover-error", () => {
     ).toBeNull();
   });
 
+  it("does not let cause-based failover classification bypass wrapper session lock suppression", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: "wrapper",
+        reason: new Error(
+          "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock",
+        ),
+        cause: new Error("operation timed out"),
+      }),
+    ).toBeNull();
+  });
+
   it("classifies provider-scoped generic upstream errors for failover", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -8,6 +8,7 @@ import {
   resolveFailoverStatus,
 } from "./failover-error.js";
 import { classifyFailoverSignal } from "./pi-embedded-helpers/errors.js";
+import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 
 // OpenAI 429 example shape: https://help.openai.com/en/articles/5955604-how-can-i-solve-429-too-many-requests-errors
 const OPENAI_RATE_LIMIT_MESSAGE =
@@ -360,25 +361,24 @@ describe("failover-error", () => {
   });
 
   it("does not classify session lock wait errors as model timeout failover", () => {
-    const sessionLockMessage =
-      "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock";
-    expect(
-      resolveFailoverReasonFromError({
-        message: sessionLockMessage,
-      }),
-    ).toBeNull();
-    expect(isTimeoutError({ message: sessionLockMessage })).toBe(false);
+    const sessionLockError = new SessionWriteLockTimeoutError({
+      timeoutMs: 10_000,
+      owner: "pid=37121",
+      lockPath: "/tmp/openclaw/session.jsonl.lock",
+    });
+    expect(resolveFailoverReasonFromError(sessionLockError)).toBeNull();
+    expect(isTimeoutError(sessionLockError)).toBe(false);
 
     const wrappedLockError = Object.assign(new Error("operation timed out"), {
       name: "AbortError",
-      cause: new Error(sessionLockMessage),
+      cause: sessionLockError,
     });
     expect(resolveFailoverReasonFromError(wrappedLockError)).toBeNull();
     expect(isTimeoutError(wrappedLockError)).toBe(false);
 
     const abortWrappedLockError = Object.assign(new Error("request was aborted"), {
       name: "AbortError",
-      cause: new Error(sessionLockMessage),
+      cause: sessionLockError,
     });
     expect(resolveFailoverReasonFromError(abortWrappedLockError)).toBeNull();
     expect(isTimeoutError(abortWrappedLockError)).toBe(false);
@@ -390,9 +390,11 @@ describe("failover-error", () => {
         status: 429,
         code: "RESOURCE_EXHAUSTED",
         message: "upstream quota pressure",
-        cause: new Error(
-          "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock",
-        ),
+        cause: new SessionWriteLockTimeoutError({
+          timeoutMs: 10_000,
+          owner: "pid=37121",
+          lockPath: "/tmp/openclaw/session.jsonl.lock",
+        }),
       }),
     ).toBe("rate_limit");
   });
@@ -401,9 +403,11 @@ describe("failover-error", () => {
     expect(
       resolveFailoverReasonFromError({
         message: "HTTP 429: upstream quota pressure",
-        cause: new Error(
-          "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock",
-        ),
+        cause: new SessionWriteLockTimeoutError({
+          timeoutMs: 10_000,
+          owner: "pid=37121",
+          lockPath: "/tmp/openclaw/session.jsonl.lock",
+        }),
       }),
     ).toBe("rate_limit");
   });
@@ -414,9 +418,11 @@ describe("failover-error", () => {
         name: "AbortError",
         code: "ABORT_ERR",
         message: "The operation was aborted",
-        cause: new Error(
-          "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock",
-        ),
+        cause: new SessionWriteLockTimeoutError({
+          timeoutMs: 10_000,
+          owner: "pid=37121",
+          lockPath: "/tmp/openclaw/session.jsonl.lock",
+        }),
       }),
     ).toBeNull();
   });
@@ -425,9 +431,11 @@ describe("failover-error", () => {
     expect(
       resolveFailoverReasonFromError({
         message: "wrapper",
-        reason: new Error(
-          "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock",
-        ),
+        reason: new SessionWriteLockTimeoutError({
+          timeoutMs: 10_000,
+          owner: "pid=37121",
+          lockPath: "/tmp/openclaw/session.jsonl.lock",
+        }),
         cause: new Error("operation timed out"),
       }),
     ).toBeNull();

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -375,6 +375,13 @@ describe("failover-error", () => {
     });
     expect(resolveFailoverReasonFromError(wrappedLockError)).toBeNull();
     expect(isTimeoutError(wrappedLockError)).toBe(false);
+
+    const abortWrappedLockError = Object.assign(new Error("request was aborted"), {
+      name: "AbortError",
+      cause: new Error(sessionLockMessage),
+    });
+    expect(resolveFailoverReasonFromError(abortWrappedLockError)).toBeNull();
+    expect(isTimeoutError(abortWrappedLockError)).toBe(false);
   });
 
   it("classifies provider-scoped generic upstream errors for failover", () => {

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -384,6 +384,19 @@ describe("failover-error", () => {
     expect(isTimeoutError(abortWrappedLockError)).toBe(false);
   });
 
+  it("keeps explicit provider failover metadata authoritative over nested session lock text", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 429,
+        code: "RESOURCE_EXHAUSTED",
+        message: "upstream quota pressure",
+        cause: new Error(
+          "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock",
+        ),
+      }),
+    ).toBe("rate_limit");
+  });
+
   it("classifies provider-scoped generic upstream errors for failover", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -397,6 +397,17 @@ describe("failover-error", () => {
     ).toBe("rate_limit");
   });
 
+  it("keeps inferred HTTP failover metadata authoritative over nested session lock text", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: "HTTP 429: upstream quota pressure",
+        cause: new Error(
+          "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock",
+        ),
+      }),
+    ).toBe("rate_limit");
+  });
+
   it("classifies provider-scoped generic upstream errors for failover", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -408,6 +408,19 @@ describe("failover-error", () => {
     ).toBe("rate_limit");
   });
 
+  it("does not treat generic abort codes as explicit failover metadata over nested session lock text", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        name: "AbortError",
+        code: "ABORT_ERR",
+        message: "The operation was aborted",
+        cause: new Error(
+          "session file locked (timeout 10000ms): pid=37121 /tmp/openclaw/session.jsonl.lock",
+        ),
+      }),
+    ).toBeNull();
+  });
+
   it("classifies provider-scoped generic upstream errors for failover", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -8,10 +8,10 @@ import {
 } from "./pi-embedded-helpers/errors.js";
 import { isTimeoutErrorMessage } from "./pi-embedded-helpers/errors.js";
 import type { FailoverReason } from "./pi-embedded-helpers/types.js";
+import { isSessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
 const MAX_FAILOVER_CAUSE_DEPTH = 25;
-const SESSION_LOCK_ERROR_RE = /\bsession file locked\b/i;
 
 export class FailoverError extends Error {
   readonly reason: FailoverReason;
@@ -200,9 +200,8 @@ function normalizeDirectErrorSignal(err: unknown): FailoverSignal {
   };
 }
 
-function isSessionLockError(err: unknown, seen: Set<object> = new Set()): boolean {
-  const directMessage = readDirectErrorMessage(err);
-  if (directMessage && SESSION_LOCK_ERROR_RE.test(directMessage)) {
+function hasSessionWriteLockTimeout(err: unknown, seen: Set<object> = new Set()): boolean {
+  if (isSessionWriteLockTimeoutError(err)) {
     return true;
   }
   if (!err || typeof err !== "object") {
@@ -214,9 +213,9 @@ function isSessionLockError(err: unknown, seen: Set<object> = new Set()): boolea
   seen.add(err);
   const candidate = err as { error?: unknown; cause?: unknown; reason?: unknown };
   return (
-    isSessionLockError(candidate.error, seen) ||
-    isSessionLockError(candidate.cause, seen) ||
-    isSessionLockError(candidate.reason, seen)
+    hasSessionWriteLockTimeout(candidate.error, seen) ||
+    hasSessionWriteLockTimeout(candidate.cause, seen) ||
+    hasSessionWriteLockTimeout(candidate.reason, seen)
   );
 }
 
@@ -224,7 +223,7 @@ function hasTimeoutHint(err: unknown): boolean {
   if (!err) {
     return false;
   }
-  if (isSessionLockError(err)) {
+  if (hasSessionWriteLockTimeout(err)) {
     return false;
   }
   if (readErrorName(err) === "TimeoutError") {
@@ -244,7 +243,7 @@ export function isTimeoutError(err: unknown): boolean {
   if (readErrorName(err) !== "AbortError") {
     return false;
   }
-  if (isSessionLockError(err)) {
+  if (hasSessionWriteLockTimeout(err)) {
     return false;
   }
   const message = getErrorMessage(err);
@@ -351,7 +350,7 @@ function resolveFailoverClassificationFromErrorInternal(
   const hasExplicitFailoverMetadata =
     typeof inferSignalStatus(signal) === "number" ||
     (codeReason !== null && codeReason !== "timeout");
-  const hasSessionLock = isSessionLockError(err);
+  const hasSessionLock = hasSessionWriteLockTimeout(err);
 
   const classification = classifyFailoverSignal(signal);
   const nestedCandidates = getNestedErrorCandidates(err);

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -1,6 +1,7 @@
 import { readErrorName } from "../infra/errors.js";
 import {
   classifyFailoverSignal,
+  inferSignalStatus,
   isUnclassifiedNoBodyHttpSignal,
   type FailoverClassification,
   type FailoverSignal,
@@ -345,7 +346,7 @@ function resolveFailoverClassificationFromErrorInternal(
   }
   const signal = normalizeErrorSignal(err);
   const hasExplicitFailoverMetadata =
-    typeof signal.status === "number" || typeof signal.code === "string";
+    typeof inferSignalStatus(signal) === "number" || typeof signal.code === "string";
   const classification = classifyFailoverSignal(signal);
   const nestedCandidates = getNestedErrorCandidates(err);
 

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -343,12 +343,9 @@ function resolveFailoverClassificationFromErrorInternal(
       reason: err.reason,
     };
   }
-  // Session lock contention is local infrastructure pressure, not a provider failure.
-  if (isSessionLockError(err)) {
-    return null;
-  }
-
   const signal = normalizeErrorSignal(err);
+  const hasExplicitFailoverMetadata =
+    typeof signal.status === "number" || typeof signal.code === "string";
   const classification = classifyFailoverSignal(signal);
   const nestedCandidates = getNestedErrorCandidates(err);
 
@@ -383,7 +380,14 @@ function resolveFailoverClassificationFromErrorInternal(
   }
 
   if (classification) {
+    if (isSessionLockError(err) && !hasExplicitFailoverMetadata) {
+      return null;
+    }
     return classification;
+  }
+
+  if (isSessionLockError(err)) {
+    return null;
   }
 
   if (isTimeoutError(err)) {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -351,6 +351,8 @@ function resolveFailoverClassificationFromErrorInternal(
   const hasExplicitFailoverMetadata =
     typeof inferSignalStatus(signal) === "number" ||
     (codeReason !== null && codeReason !== "timeout");
+  const hasSessionLock = isSessionLockError(err);
+
   const classification = classifyFailoverSignal(signal);
   const nestedCandidates = getNestedErrorCandidates(err);
 
@@ -362,6 +364,9 @@ function resolveFailoverClassificationFromErrorInternal(
         depth + 1,
       );
       if (nestedClassification) {
+        if (hasSessionLock && !hasExplicitFailoverMetadata) {
+          return null;
+        }
         return nestedClassification;
       }
     }
@@ -385,13 +390,13 @@ function resolveFailoverClassificationFromErrorInternal(
   }
 
   if (classification) {
-    if (isSessionLockError(err) && !hasExplicitFailoverMetadata) {
+    if (hasSessionLock && !hasExplicitFailoverMetadata) {
       return null;
     }
     return classification;
   }
 
-  if (isSessionLockError(err)) {
+  if (hasSessionLock) {
     return null;
   }
 

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -10,6 +10,7 @@ import type { FailoverReason } from "./pi-embedded-helpers/types.js";
 
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
 const MAX_FAILOVER_CAUSE_DEPTH = 25;
+const SESSION_LOCK_ERROR_RE = /\bsession file locked\b/i;
 
 export class FailoverError extends Error {
   readonly reason: FailoverReason;
@@ -198,8 +199,31 @@ function normalizeDirectErrorSignal(err: unknown): FailoverSignal {
   };
 }
 
+function isSessionLockError(err: unknown, seen: Set<object> = new Set()): boolean {
+  const directMessage = readDirectErrorMessage(err);
+  if (directMessage && SESSION_LOCK_ERROR_RE.test(directMessage)) {
+    return true;
+  }
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  if (seen.has(err)) {
+    return false;
+  }
+  seen.add(err);
+  const candidate = err as { error?: unknown; cause?: unknown; reason?: unknown };
+  return (
+    isSessionLockError(candidate.error, seen) ||
+    isSessionLockError(candidate.cause, seen) ||
+    isSessionLockError(candidate.reason, seen)
+  );
+}
+
 function hasTimeoutHint(err: unknown): boolean {
   if (!err) {
+    return false;
+  }
+  if (isSessionLockError(err)) {
     return false;
   }
   if (readErrorName(err) === "TimeoutError") {
@@ -217,6 +241,9 @@ export function isTimeoutError(err: unknown): boolean {
     return false;
   }
   if (readErrorName(err) !== "AbortError") {
+    return false;
+  }
+  if (isSessionLockError(err)) {
     return false;
   }
   const message = getErrorMessage(err);
@@ -315,6 +342,10 @@ function resolveFailoverClassificationFromErrorInternal(
       kind: "reason",
       reason: err.reason,
     };
+  }
+  // Session lock contention is local infrastructure pressure, not a provider failure.
+  if (isSessionLockError(err)) {
+    return null;
   }
 
   const signal = normalizeErrorSignal(err);

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -345,8 +345,12 @@ function resolveFailoverClassificationFromErrorInternal(
     };
   }
   const signal = normalizeErrorSignal(err);
+  const codeReason = signal.code
+    ? failoverReasonFromClassification(classifyFailoverSignal({ code: signal.code }))
+    : null;
   const hasExplicitFailoverMetadata =
-    typeof inferSignalStatus(signal) === "number" || typeof signal.code === "string";
+    typeof inferSignalStatus(signal) === "number" ||
+    (codeReason !== null && codeReason !== "timeout");
   const classification = classifyFailoverSignal(signal);
   const nestedCandidates = getNestedErrorCandidates(err);
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -337,7 +337,7 @@ function stripErrorPrefix(raw: string): string {
   return raw.replace(/^error:\s*/i, "").trim();
 }
 
-function inferSignalStatus(signal: FailoverSignal): number | undefined {
+export function inferSignalStatus(signal: FailoverSignal): number | undefined {
   if (typeof signal.status === "number" && Number.isFinite(signal.status)) {
     return signal.status;
   }

--- a/src/agents/session-write-lock-error.ts
+++ b/src/agents/session-write-lock-error.ts
@@ -1,0 +1,29 @@
+export const SESSION_WRITE_LOCK_TIMEOUT_CODE = "OPENCLAW_SESSION_WRITE_LOCK_TIMEOUT";
+
+export class SessionWriteLockTimeoutError extends Error {
+  readonly code = SESSION_WRITE_LOCK_TIMEOUT_CODE;
+  readonly timeoutMs: number;
+  readonly owner: string;
+  readonly lockPath: string;
+
+  constructor(params: { timeoutMs: number; owner: string; lockPath: string }) {
+    super(
+      `session file locked (timeout ${params.timeoutMs}ms): ${params.owner} ${params.lockPath}`,
+    );
+    this.name = "SessionWriteLockTimeoutError";
+    this.timeoutMs = params.timeoutMs;
+    this.owner = params.owner;
+    this.lockPath = params.lockPath;
+  }
+}
+
+export function isSessionWriteLockTimeoutError(err: unknown): boolean {
+  return (
+    err instanceof SessionWriteLockTimeoutError ||
+    Boolean(
+      err &&
+      typeof err === "object" &&
+      (err as { code?: unknown }).code === SESSION_WRITE_LOCK_TIMEOUT_CODE,
+    )
+  );
+}

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
+import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 
 type LockFilePayload = {
   pid?: number;
@@ -584,7 +585,7 @@ export async function acquireSessionWriteLock(params: {
 
   const payload = await readLockPayload(lockPath);
   const owner = typeof payload?.pid === "number" ? `pid=${payload.pid}` : "unknown";
-  throw new Error(`session file locked (timeout ${timeoutMs}ms): ${owner} ${lockPath}`);
+  throw new SessionWriteLockTimeoutError({ timeoutMs, owner, lockPath });
 }
 
 export const __testing = {


### PR DESCRIPTION
## Summary

- stop treating session lock wait errors as provider timeout failovers
- keep wrapped `AbortError` session-lock cases out of timeout classification, including `request was aborted`
- add regressions covering direct and wrapped session lock errors

## Root Cause

`session-write-lock` reports local lock contention using the text `session file locked (timeout ...)`.
The failover classifier treated the bare `timeout` substring as a model/provider timeout, and `isTimeoutError()` still treated abort-wrapped lock waits as timeouts when the outer abort message matched `request was aborted`.
That let model fallback continue across candidates for a local file-lock contention issue.

## Impact

Session lock contention now fails fast as infrastructure pressure instead of drifting across fallback models, including abort-wrapped lock waits that previously still looked like timeout. This avoids wasting fallback attempts on the same locked session and keeps model fallback focused on actual provider-side failures.

## Testing

- `pnpm test src/agents/failover-error.test.ts -t "does not classify session lock wait errors as model timeout failover"`
- `pnpm test src/agents/failover-error.test.ts src/agents/session-write-lock.test.ts`
- `pnpm check`
