### PR TITLE
fix(docker): enable host.docker.internal for local providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/callbacks: treat permanent callback edit errors as completed updates so stale command pagination buttons no longer wedge the update watermark and block newer Telegram updates. (#68588) Thanks @Lucenx9.
 - Browser/CDP: allow the selected remote CDP profile host for CDP health and control checks without widening browser navigation SSRF policy, so WSL-to-Windows Chrome endpoints no longer appear offline under strict defaults. Fixes #68108. (#68207) Thanks @Mlightsnow.
 - Codex: stop cumulative app-server token totals from being treated as fresh context usage, so session status no longer reports inflated context percentages after long Codex threads. (#64669) Thanks @cyrusaf.
+- Docker/setup: map `host.docker.internal` to the host gateway in the bundled `docker-compose.yml` and document it in the Docker install guide, so local AI providers (LM Studio, Ollama, etc.) running on the host are reachable from the container via `http://host.docker.internal:<port>` on Linux as well as Docker Desktop. Fixes #68684.
 
 ## 2026.4.18
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
       # - /var/run/docker.sock:/var/run/docker.sock
     # group_add:
     #   - "${DOCKER_GID:-999}"
+    # Map host.docker.internal to the host gateway so that local AI providers
+    # (LM Studio, Ollama, etc.) running on the host are reachable from the
+    # container via http://host.docker.internal:<port>. Docker Desktop sets
+    # this automatically; this entry makes the same alias work on Linux.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
       - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -167,6 +167,32 @@ Use bind mode values in `gateway.bind` (`lan` / `loopback` / `custom` /
 `tailnet` / `auto`), not host aliases like `0.0.0.0` or `127.0.0.1`.
 </Note>
 
+### Connecting to host services (LM Studio, Ollama, etc.)
+
+When OpenClaw runs in a container, `127.0.0.1` resolves to the container
+itself, not the host machine. Local AI providers running on the host —
+LM Studio, Ollama, llama.cpp, vLLM, and similar — are not reachable at
+`http://127.0.0.1:<port>` from inside the container.
+
+Use `host.docker.internal` instead when the onboarding wizard prompts for
+a base URL:
+
+| Provider  | Host base URL              | Container base URL                  |
+| --------- | -------------------------- | ----------------------------------- |
+| LM Studio | `http://127.0.0.1:1234`    | `http://host.docker.internal:1234`  |
+| Ollama    | `http://127.0.0.1:11434`   | `http://host.docker.internal:11434` |
+
+The bundled `docker-compose.yml` maps `host.docker.internal` to the host
+gateway via `extra_hosts: ["host.docker.internal:host-gateway"]`, so the
+same URL works on Docker Desktop (macOS, Windows) and Docker Engine on
+Linux. If you run OpenClaw with your own Compose file or `docker run`
+invocation, add the same `--add-host=host.docker.internal:host-gateway`
+flag (or the equivalent `extra_hosts` entry) yourself.
+
+Make sure the host provider is reachable from outside loopback: by
+default LM Studio binds to `0.0.0.0` and Ollama can be configured with
+`OLLAMA_HOST=0.0.0.0:11434`.
+
 ### Storage and persistence
 
 Docker Compose bind-mounts `OPENCLAW_CONFIG_DIR` to `/home/node/.openclaw` and

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -177,10 +177,10 @@ LM Studio, Ollama, llama.cpp, vLLM, and similar — are not reachable at
 Use `host.docker.internal` instead when the onboarding wizard prompts for
 a base URL:
 
-| Provider  | Host base URL              | Container base URL                  |
-| --------- | -------------------------- | ----------------------------------- |
-| LM Studio | `http://127.0.0.1:1234`    | `http://host.docker.internal:1234`  |
-| Ollama    | `http://127.0.0.1:11434`   | `http://host.docker.internal:11434` |
+| Provider  | Host base URL            | Container base URL                  |
+| --------- | ------------------------ | ----------------------------------- |
+| LM Studio | `http://127.0.0.1:1234`  | `http://host.docker.internal:1234`  |
+| Ollama    | `http://127.0.0.1:11434` | `http://host.docker.internal:11434` |
 
 The bundled `docker-compose.yml` maps `host.docker.internal` to the host
 gateway via `extra_hosts: ["host.docker.internal:host-gateway"]`, so the


### PR DESCRIPTION
## Summary

- **Problem:** When OpenClaw runs in a container, the onboarding wizard prompts for a base URL (e.g. for LM Studio or Ollama) and users naturally enter `http://127.0.0.1:1234` / `http://127.0.0.1:11434`. Inside the container that resolves to the container itself, not the host, so every model call silently fails.
- **Why it matters:** Local-provider users on Docker hit a dead end during onboarding with no in-product hint about why.
- **What changed:** Mapped `host.docker.internal` → `host-gateway` in the bundled `docker-compose.yml` (so the alias works on Linux, not just Docker Desktop) and added a "Connecting to host services" subsection to `docs/install/docker.md` documenting the correct base URLs for LM Studio and Ollama.
- **What did NOT change (scope boundary):** No changes to the LM Studio or Ollama setup wizards, no plugin SDK additions, no auto-detection logic. Issue suggested wizard auto-detection as one option; kept this PR docs+compose-only as the smallest defensible fix. Wizard hint can be a follow-up if maintainers want it.

> AI-assisted (Claude). Lightly tested locally — verified `extra_hosts` syntax against existing repo precedent (`extensions/qa-lab/src/docker-harness.ts`); did not stand up a full Docker rebuild on Linux to confirm `host-gateway` resolution end-to-end.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #68684
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `docker-compose.yml` did not declare `extra_hosts: ["host.docker.internal:host-gateway"]`, so on Linux the alias does not resolve (Docker Desktop sets it implicitly; Docker Engine does not). The Docker install docs also did not call out the container-vs-host loopback gotcha for local AI providers, so users entering `127.0.0.1` had no hint why their setup silently failed.
- **Missing detection / guardrail:** The onboarding wizard for LM Studio/Ollama does not detect container environments and warn about loopback. Out of scope here; deferred to a possible follow-up.

## Regression Test Plan (if applicable)

N/A — no runtime/test code is touched. The change is a YAML config addition and a docs section.

## User-visible / Behavior Changes

- Inside the bundled OpenClaw Docker Compose stack, `http://host.docker.internal:<port>` now resolves to the host gateway on Linux (it already worked on Docker Desktop). Users following the docs can now point LM Studio/Ollama setup at the correct URL on any platform.
- Docs gain a new "Connecting to host services (LM Studio, Ollama, etc.)" subsection under `docs/install/docker.md`.

## Diagram (if applicable)

```text
Before (Linux, Docker Engine):
[wizard] -> http://127.0.0.1:11434 -> container loopback (no Ollama) -> silent failure
[wizard] -> http://host.docker.internal:11434 -> name resolution failure

After:
[wizard] -> http://host.docker.internal:11434 -> host gateway -> host Ollama -> 200 OK
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (only adds a name resolution alias inside the container)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

`extra_hosts: ["host.docker.internal:host-gateway"]` only resolves a hostname to the existing host gateway IP; it does not open new ports, expose new services, or grant new privileges. Same alias Docker Desktop already provides implicitly.

## Repro + Verification

### Environment

- OS: Linux Docker Engine host (issue reporter's environment); also Docker Desktop on macOS/Windows
- Runtime/container: bundled `openclaw-gateway` container
- Model/provider: LM Studio, Ollama (host-side)
- Integration/channel (if any): N/A
- Relevant config (redacted): default `docker-compose.yml`

### Steps

1. Run `./scripts/docker/setup.sh` on a Linux Docker Engine host.
2. During onboarding, configure LM Studio (or Ollama) and enter `http://127.0.0.1:1234` (or `http://127.0.0.1:11434`).
3. Send a message via any channel.

### Expected

- After this PR: docs guide users to enter `http://host.docker.internal:<port>` instead, and that hostname resolves correctly on both Docker Desktop and Linux Docker Engine.

### Actual

- Before this PR on Linux: entering `host.docker.internal` gave name resolution errors; entering `127.0.0.1` reached the container loopback (no provider). Either way, model calls silently failed.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Reproduction and root cause are well-documented in #68684 (filed by @safrano9999). No new automated coverage added — this PR is config + docs only.

## Human Verification (required)

- Verified scenarios:
  - Diff review of `docker-compose.yml`, `docs/install/docker.md`, and `CHANGELOG.md`.
  - Confirmed `extra_hosts: ["host.docker.internal:host-gateway"]` matches the syntax already in use elsewhere in this repo (`extensions/qa-lab/src/docker-harness.ts:125`, `src/agents/sandbox/config-hash.test.ts:17`).
  - Confirmed `openclaw-cli` shares the gateway's network namespace (`network_mode: "service:openclaw-gateway"`), so adding `extra_hosts` only on the gateway service is sufficient.
- Edge cases checked:
  - macOS / Windows Docker Desktop: `host.docker.internal` already resolves implicitly; adding `extra_hosts` is a harmless no-op.
  - Linux Docker Engine: `host-gateway` magic value is supported since Docker 20.10 (released 2020-12), which is well below the project's existing Docker baseline.
- What I did **not** verify:
  - Did not stand up a full Linux Docker Engine rebuild end-to-end to confirm name resolution. The compose syntax change is small and matches established repo precedent, so confidence is high but not first-hand validated.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** (no environment variables added)
- Migration needed? **No** — existing users who already entered the working URL keep working; the new `extra_hosts` is additive.

## Risks and Mitigations

- **Risk:** Some unusual Docker setups (e.g. ancient Docker Engine < 20.10 without `host-gateway` magic value) might fail to start the container with the new `extra_hosts`.
  - **Mitigation:** Docker 20.10 was released in Dec 2020; OpenClaw's bundled tooling already assumes a modern Docker. If this becomes an issue, the line can be made conditional via a Compose override.