### PR TITLE
[codex] Guard browser route continue race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser/Playwright: ignore the benign `route.continue: Route is already handled!` race during guarded navigation so browser-page tasks no longer crash the gateway when Playwright tears down a route mid-flight.
 - Agents/channels: route cross-agent subagent spawns through the target agent's bound channel account while preserving peer and workspace/role-scoped bindings, so child sessions no longer inherit the caller's account in shared rooms, workspaces, or multi-account setups. (#67508) Thanks @lukeboyett and @gumadeiras.
 - Telegram/callbacks: treat permanent callback edit errors as completed updates so stale command pagination buttons no longer wedge the update watermark and block newer Telegram updates. (#68588) Thanks @Lucenx9.
 - Browser/CDP: allow the selected remote CDP profile host for CDP health and control checks without widening browser navigation SSRF policy, so WSL-to-Windows Chrome endpoints no longer appear offline under strict defaults. Fixes #68108. (#68207) Thanks @Mlightsnow.

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -681,4 +681,49 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
       }),
     ).rejects.toBeInstanceOf(BlockedBrowserTargetError);
   });
+
+  it("ignores already-handled route races during guarded navigation", async () => {
+    const { pageGoto, pageClose, getRouteHandler, mainFrame } = installBrowserMocks();
+
+    await createPageViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "about:blank",
+    });
+    const page = await getPageForTargetId({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "TARGET_1",
+    });
+
+    pageGoto.mockImplementationOnce(async () => {
+      await dispatchMockNavigation({
+        getRouteHandler,
+        mainFrame,
+        url: "https://example.com/static/app.js",
+        isNavigationRequest: false,
+        route: {
+          continue: vi.fn(async () => {
+            throw new Error("route.continue: Route is already handled!");
+          }),
+        },
+      });
+      return {
+        request: () => ({
+          url: () => "https://example.com",
+          redirectedFrom: () => null,
+        }),
+      };
+    });
+
+    await expect(
+      gotoPageWithNavigationGuard({
+        cdpUrl: "http://127.0.0.1:18792",
+        page,
+        url: "https://example.com",
+        timeoutMs: 1000,
+        targetId: "TARGET_1",
+      }),
+    ).resolves.not.toBeNull();
+
+    expect(pageClose).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -783,6 +783,26 @@ export async function assertPageNavigationCompletedSafely(opts: {
   }
 }
 
+async function continueRouteSafely(route: Route): Promise<void> {
+  try {
+    // Playwright can surface a handled-route race when page navigation and teardown
+    // interleave. Swallow only that known benign case so browser tasks do not crash
+    // the whole gateway while preserving every other route failure.
+    await route.continue();
+  } catch (err) {
+    const message =
+      err instanceof Error
+        ? err.message
+        : typeof err === "object" && err && "message" in err && typeof err.message === "string"
+          ? err.message
+          : "";
+    if (message.includes("Route is already handled")) {
+      return;
+    }
+    throw err;
+  }
+}
+
 export async function gotoPageWithNavigationGuard(opts: {
   cdpUrl: string;
   page: Page;
@@ -803,7 +823,7 @@ export async function gotoPageWithNavigationGuard(opts: {
     const isSubframeDocument =
       !isTopLevel && isSubframeDocumentNavigationRequest(opts.page, request);
     if (!isTopLevel && !isSubframeDocument) {
-      await route.continue();
+      await continueRouteSafely(route);
       return;
     }
     try {
@@ -821,7 +841,7 @@ export async function gotoPageWithNavigationGuard(opts: {
       }
       throw err;
     }
-    await route.continue();
+    await continueRouteSafely(route);
   };
 
   await opts.page.route("**", handler);


### PR DESCRIPTION
## Summary

- guard route.continue() inside guarded browser navigation so the known Playwright handled-route race does not unwind browser tasks
- route both guarded continue() call sites through the same helper instead of duplicating the error handling
- add a regression test that reproduces the Route is already handled error during guarded navigation and proves the page flow stays alive
- add an Unreleased changelog note for the browser fix

## Root cause

gotoPageWithNavigationGuard() installs a Playwright route handler around page navigation. When navigation teardown and request handling interleave, Playwright can surface the benign error Route is already handled for a request that has already been resolved internally.

Before this change, that error propagated out of guarded navigation exactly like a real route failure. In practice, that could abort browser page work and take down the surrounding browser workflow even though the underlying request race was already settled.

## Fix

This change adds continueRouteSafely() and uses it for the guarded route.continue() paths. The helper only swallows the specific already-handled race and still rethrows every other route error.

That keeps the browser path resilient to the known Playwright race without masking unrelated navigation or policy failures.

## Validation

- corepack pnpm test extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
- corepack pnpm exec oxlint extensions/browser/src/browser/pw-session.ts extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
- corepack pnpm exec oxfmt --check extensions/browser/src/browser/pw-session.ts extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts CHANGELOG.md
