### PR TITLE
fix(discord): enforce guild guards for /new and /reset

### DIFF
--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -322,6 +322,41 @@ async function expectBoundStatusCommandDirectReply(params: {
   expect(statusCall.sessionKey).toMatch(params.expectedPattern);
 }
 
+async function expectConfiguredAcpCommandBlocked(params: {
+  cfg: OpenClawConfig;
+  interaction: MockCommandInteraction;
+  expectedMessage: string;
+  commandName?: "new" | "reset";
+}) {
+  discordNativeCommandTesting.setResolveDiscordNativeInteractionRouteState(async () =>
+    createConfiguredRouteState({
+      sessionKey: "agent:codex:acp:binding:discord:default:blocked-channel",
+      agentId: "codex",
+    }),
+  );
+  runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
+  const dispatchSpy = createDispatchSpy();
+  const command = await createNativeCommand(params.cfg, {
+    name: params.commandName ?? "new",
+    description:
+      params.commandName === "reset" ? "Reset the current session." : "Start a new session.",
+    acceptsArgs: true,
+  });
+  params.interaction.options.getString.mockReturnValue("continue with deployment");
+
+  await (command as { run: (interaction: unknown) => Promise<void> }).run(
+    params.interaction as unknown,
+  );
+
+  expect(dispatchSpy).not.toHaveBeenCalled();
+  expect(params.interaction.followUp).toHaveBeenCalledWith(
+    expect.objectContaining({
+      content: params.expectedMessage,
+    }),
+  );
+  expect(params.interaction.reply).not.toHaveBeenCalled();
+}
+
 describe("Discord native plugin command dispatch", () => {
   beforeAll(async () => {
     ({ createDiscordNativeCommand, __testing: discordNativeCommandTesting } =
@@ -638,6 +673,122 @@ describe("Discord native plugin command dispatch", () => {
     });
   });
 
+  it("blocks /new on disabled guild channels even when an ACP binding exists", async () => {
+    const guildId = "1459246755253325866";
+    const channelId = "1478836151241412759";
+    const cfg = {
+      commands: {
+        useAccessGroups: false,
+      },
+      channels: {
+        discord: {
+          guilds: {
+            [guildId]: {
+              channels: {
+                [channelId]: {
+                  enabled: false,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      bindings: [createConfiguredAcpBinding({ channelId, peerKind: "channel", agentId: "codex" })],
+    } as OpenClawConfig;
+    const interaction = createInteraction({
+      channelType: ChannelType.GuildText,
+      channelId,
+      guildId,
+      guildName: "Ops",
+    });
+
+    await expectConfiguredAcpCommandBlocked({
+      cfg,
+      interaction,
+      expectedMessage: "This channel is disabled.",
+    });
+  });
+
+  it("blocks /new on guild channels outside the allowlist even when an ACP binding exists", async () => {
+    const guildId = "1459246755253325866";
+    const channelId = "1478836151241412760";
+    const cfg = {
+      commands: {
+        useAccessGroups: false,
+      },
+      channels: {
+        discord: {
+          groupPolicy: "allowlist",
+          guilds: {
+            [guildId]: {
+              channels: {
+                "1478836151241419999": {
+                  enabled: true,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      bindings: [createConfiguredAcpBinding({ channelId, peerKind: "channel", agentId: "codex" })],
+    } as OpenClawConfig;
+    const interaction = createInteraction({
+      channelType: ChannelType.GuildText,
+      channelId,
+      guildId,
+      guildName: "Ops",
+    });
+
+    await expectConfiguredAcpCommandBlocked({
+      cfg,
+      interaction,
+      expectedMessage: "This channel is not allowed.",
+    });
+  });
+
+  it("blocks unauthorized /reset senders even when an ACP binding exists", async () => {
+    const guildId = "1459246755253325866";
+    const channelId = "1478836151241412761";
+    const cfg = {
+      commands: {
+        useAccessGroups: false,
+        allowFrom: {
+          discord: ["user:123456789012345678"],
+        },
+      },
+      channels: {
+        discord: {
+          guilds: {
+            [guildId]: {
+              channels: {
+                [channelId]: {
+                  enabled: true,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      bindings: [createConfiguredAcpBinding({ channelId, peerKind: "channel", agentId: "codex" })],
+    } as OpenClawConfig;
+    const interaction = createInteraction({
+      channelType: ChannelType.GuildText,
+      channelId,
+      guildId,
+      guildName: "Ops",
+    });
+
+    await expectConfiguredAcpCommandBlocked({
+      cfg,
+      interaction,
+      expectedMessage: "You are not authorized to use this command.",
+      commandName: "reset",
+    });
+  });
+
   it("falls back to the routed slash and channel session keys when no bound session exists", async () => {
     const guildId = "1459246755253325866";
     const channelId = "1478836151241412759";
@@ -771,7 +922,7 @@ describe("Discord native plugin command dispatch", () => {
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("allows recovery commands through configured ACP bindings even when ensure fails", async () => {
+  it("blocks /new through configured ACP bindings when guild command authorization fails", async () => {
     const { cfg, interaction } = createConfiguredAcpCase({
       channelType: ChannelType.GuildText,
       channelId: "1479098716916023408",
@@ -787,7 +938,6 @@ describe("Discord native plugin command dispatch", () => {
       }),
     );
     runtimeModuleMocks.matchPluginCommand.mockReturnValue(null);
-    const dispatchSpy = createDispatchSpy();
     const command = await createNativeCommand(cfg, {
       name: "new",
       description: "Start a new session.",
@@ -796,18 +946,13 @@ describe("Discord native plugin command dispatch", () => {
 
     await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
 
-    expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    const dispatchCall = dispatchSpy.mock.calls[0]?.[0] as {
-      ctx?: { SessionKey?: string; CommandTargetSessionKey?: string };
-    };
-    expect(dispatchCall.ctx?.SessionKey).toMatch(/^agent:codex:acp:binding:discord:default:/);
-    expect(dispatchCall.ctx?.CommandTargetSessionKey).toMatch(
-      /^agent:codex:acp:binding:discord:default:/,
-    );
-    expect(interaction.reply).not.toHaveBeenCalledWith(
+    expect(runtimeModuleMocks.dispatchReplyWithDispatcher).not.toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: "Configured ACP binding is unavailable right now. Please try again.",
+        content: "You are not authorized to use this command.",
+        ephemeral: true,
       }),
     );
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -326,6 +326,7 @@ async function expectConfiguredAcpCommandBlocked(params: {
   cfg: OpenClawConfig;
   interaction: MockCommandInteraction;
   expectedMessage: string;
+  expectedEphemeral?: boolean;
   commandName?: "new" | "reset";
 }) {
   discordNativeCommandTesting.setResolveDiscordNativeInteractionRouteState(async () =>
@@ -352,6 +353,7 @@ async function expectConfiguredAcpCommandBlocked(params: {
   expect(params.interaction.followUp).toHaveBeenCalledWith(
     expect.objectContaining({
       content: params.expectedMessage,
+      ...(params.expectedEphemeral ? { ephemeral: true } : {}),
     }),
   );
   expect(params.interaction.reply).not.toHaveBeenCalled();
@@ -785,6 +787,7 @@ describe("Discord native plugin command dispatch", () => {
       cfg,
       interaction,
       expectedMessage: "You are not authorized to use this command.",
+      expectedEphemeral: true,
       commandName: "reset",
     });
   });

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -33,7 +33,6 @@ import {
   type ChatCommandDefinition,
   type CommandArgDefinition,
   type CommandArgValues,
-  type CommandArgs,
   type NativeCommandSpec,
 } from "openclaw/plugin-sdk/native-command-registry";
 import * as pluginRuntime from "openclaw/plugin-sdk/plugin-runtime";
@@ -87,6 +86,10 @@ import type { ThreadBindingManager } from "./thread-bindings.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
+type NativeCommandArgs = {
+  raw?: string;
+  values?: CommandArgValues;
+};
 const log = createSubsystemLogger("discord/native-command");
 // Discord application command and option descriptions are limited to 1-100 chars.
 // https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
@@ -360,11 +363,6 @@ function shouldBypassConfiguredAcpEnsure(commandName: string): boolean {
   return normalized === "acp";
 }
 
-function shouldBypassConfiguredAcpGuildGuards(commandName: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(commandName);
-  return normalized === "new" || normalized === "reset";
-}
-
 function resolveDiscordNativeGroupDmAccess(params: {
   isGroupDm: boolean;
   groupEnabled?: boolean;
@@ -558,7 +556,7 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
 function readDiscordCommandArgs(
   interaction: CommandInteraction,
   definitions?: CommandArgDefinition[],
-): CommandArgs | undefined {
+): NativeCommandArgs | undefined {
   if (!definitions || definitions.length === 0) {
     return undefined;
   }
@@ -725,7 +723,7 @@ export function createDiscordNativeCommand(params: {
         ? ({
             ...commandArgs,
             raw: serializeCommandArgs(commandDefinition, commandArgs) ?? commandArgs.raw,
-          } satisfies CommandArgs)
+          } satisfies NativeCommandArgs)
         : undefined;
       const prompt = buildCommandTextFromArgs(commandDefinition, commandArgsWithRaw);
       await dispatchDiscordCommandInteraction({
@@ -750,7 +748,7 @@ async function dispatchDiscordCommandInteraction(params: {
   interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction;
   prompt: string;
   command: ChatCommandDefinition;
-  commandArgs?: CommandArgs;
+  commandArgs?: NativeCommandArgs;
   cfg: ReturnType<typeof loadConfig>;
   discordConfig: DiscordConfig;
   accountId: string;
@@ -889,27 +887,11 @@ async function dispatchDiscordCommandInteraction(params: {
       threadBinding: isThreadChannel ? threadBindings.getByThreadId(rawChannelId) : undefined,
       enforceConfiguredBindingReadiness: !shouldBypassConfiguredAcpEnsure(commandName),
     }));
-  const canBypassConfiguredAcpGuildGuards = async () => {
-    if (!interaction.guild || !shouldBypassConfiguredAcpGuildGuards(commandName)) {
-      return false;
-    }
-    const routeState = await getNativeRouteState();
-    return (
-      routeState.effectiveRoute.matchedBy === "binding.channel" ||
-      routeState.boundSessionKey != null ||
-      routeState.configuredBinding != null ||
-      routeState.configuredRoute != null
-    );
-  };
-  if (channelConfig?.enabled === false && !(await canBypassConfiguredAcpGuildGuards())) {
+  if (channelConfig?.enabled === false) {
     await respond("This channel is disabled.");
     return;
   }
-  if (
-    interaction.guild &&
-    channelConfig?.allowed === false &&
-    !(await canBypassConfiguredAcpGuildGuards())
-  ) {
+  if (interaction.guild && channelConfig?.allowed === false) {
     await respond("This channel is not allowed.");
     return;
   }
@@ -924,7 +906,7 @@ async function dispatchDiscordCommandInteraction(params: {
       guildInfo,
       channelConfig,
     });
-    if (!policyAuthorizer.allowed && !(await canBypassConfiguredAcpGuildGuards())) {
+    if (!policyAuthorizer.allowed) {
       await respond("This channel is not allowed.");
       return;
     }
@@ -1006,7 +988,7 @@ async function dispatchDiscordCommandInteraction(params: {
       ownerAllowListConfigured: ownerAllowList != null,
       ownerAllowed: ownerOk,
     });
-    if (!commandAuthorized && !(await canBypassConfiguredAcpGuildGuards())) {
+    if (!commandAuthorized) {
       await respond("You are not authorized to use this command.", { ephemeral: true });
       return;
     }


### PR DESCRIPTION
## Summary

- Problem: Discord `/new` and `/reset` could bypass guild channel disable/allowlist and command-authorization guards when a configured ACP binding or route was present.
- Why it matters: admins can disable or disallow a channel during incident response, but bound ACP recovery commands could still reopen a session from that channel.
- What changed: removed the Discord-side ACP guard bypass for guild channel gating and guild command authorization, and added regression coverage for disabled channels, allowlist misses, unauthorized senders, and `/reset`.
- What did NOT change (scope boundary): ACP session routing itself and the core ACP command-dispatch path were not changed outside the Discord native command guard layer.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Discord native command handling added a special-case bypass for configured ACP bindings/routes and reused it around channel disabled/allowlist and guild authorization checks.
- Missing detection / guardrail: there was no regression test asserting that ACP-bound `/new` and `/reset` still respect disabled/disallowed guild channels and guild command auth.
- Contributing context (if known): the recovery-flow change was trying to preserve ACP-bound resets, but it expanded beyond binding-readiness handling into authorization checks.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts`
- Scenario the test should lock in: ACP-bound Discord `/new` and `/reset` must still be blocked by disabled channels, guild allowlist misses, and unauthorized sender checks.
- Why this is the smallest reliable guardrail: the bug lives in the Discord native command dispatch seam where route resolution, guild policy, and plugin/dispatcher handoff all meet.
- Existing test that already covers this (if any): existing configured-ACP slash command tests covered successful routing, but not the denied paths.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Discord `/new` and `/reset` now respect disabled guild channels, channel allowlists, and guild command authorization even when a configured ACP binding exists.

## Diagram (if applicable)

```text
Before:
[Discord /new or /reset] -> [ACP binding present] -> [skip guild guards] -> [session dispatch]

After:
[Discord /new or /reset] -> [guild/channel/auth guards] -> [only authorized allowed channels dispatch]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Discord native slash commands with ACP bindings
- Relevant config (redacted): Discord guild channel config + ACP channel binding

### Steps

1. Configure a Discord guild channel ACP binding or route for a channel.
2. Disable or disallow the guild channel, or use an unauthorized guild sender.
3. Invoke `/new` or `/reset` in that channel.

### Expected

- The command is rejected with the existing Discord guard reply and does not dispatch.

### Actual

- Before this fix, ACP-bound `/new` and `/reset` could still dispatch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran the Discord `native-command*` test subset after the fix, including the updated ACP plugin-dispatch coverage.
- Edge cases checked: disabled guild channel, channel allowlist miss, unauthorized sender, and `/reset` coverage in the blocked path.
- What you did **not** verify: live Discord end-to-end interaction against a real bot token/server.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: ACP-bound recovery flows on Discord guild channels that previously relied on the bypass will now be blocked unless the channel and sender are actually authorized.
  - Mitigation: this restores the documented guild guard semantics and is covered by explicit regression tests for both allowed and denied paths.
