### PR TITLE
fix(config): openclaw.json written with 0664 mode instead of 0600 after hot-save

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1674,7 +1674,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
       try {
         await deps.fs.promises.rename(tmp, configPath);
-        // Ensure restrictive permissions after rename (temp file inherits umask 0664)
+        // Ensure restrictive permissions after rename: on Linux, rename() to an
+        // existing target preserves target's permissions, so if configPath
+        // previously had mode 0664 it stays 0664 after the atomic swap.
         await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
           // best-effort; some filesystems don't support chmod
         });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1674,6 +1674,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
       try {
         await deps.fs.promises.rename(tmp, configPath);
+        // Ensure restrictive permissions after rename (temp file inherits umask 0664)
+        await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
+          // best-effort; some filesystems don't support chmod
+        });
       } catch (err) {
         const code = (err as { code?: string }).code;
         // Windows doesn't reliably support atomic replace via rename when dest exists.


### PR DESCRIPTION
## Problem

On Linux systemd deployments, `openclaw.json` ends up with mode `0664` (group-writable, world-readable) after gateway runtime hot-saves (e.g. `openclaw config set` or internal config API mutations).

Since `openclaw.json` contains API keys, exec security policies, and model routing config, group-readable/writable defeats the security model.

## Root Cause

The config write path uses atomic write (write temp → rename). The temp file is created with `mode: 0o600`, but after `rename()` the resulting file could retain umask-derived permissions (`0664`) on some systems.

The Windows fallback path (`copyFile` + `chmod 0o600`) already handles this correctly — but the happy-path `rename` was missing the chmod.

## Fix

Add `chmod(configPath, 0o600)` after successful `rename()`, matching the existing pattern in the copyFile fallback. Best-effort catch for filesystems that do not support chmod.

## Impact

- Single file, 4 lines added
- No behavior change for configs that already had correct permissions
- Fixes security gap for all future hot-saves on Linux/systemd deployments