### PR TITLE
fix(codex): default app-server approvals to on-request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Memory-core/dreaming: normalize sweep timestamps and reuse hashed narrative session keys for fallback cleanup so Dreaming narrative sub-sessions stop leaking. (#67023) Thanks @chiyouYCH.
 - Gateway/startup: delay HTTP bind until websocket handlers are attached, so immediate post-startup websocket health/connect probes no longer hit the startup race window. (#43392) Thanks @dalefrieswthat.
 - Codex/app-server: release the session lane when a downstream consumer throws while draining the `turn/completed` notification, so follow-up messages after a Codex plugin reply stop queueing behind a stale lane lock. Fixes #67996. (#69072) Thanks @ayeshakhalid192007-dev.
+- Codex/app-server: default approval handling to `on-request` so Codex harness sessions do not start with overly permissive tool approvals. (#68721) Thanks @Lucenx9.
 
 ## 2026.4.20
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -263,7 +263,8 @@ By default, the plugin starts Codex locally with:
 codex app-server --listen stdio://
 ```
 
-You can keep that default and only tune Codex native policy:
+By default, OpenClaw asks Codex to request native approvals. You can tune that
+policy further:
 
 ```json5
 {
@@ -317,7 +318,7 @@ Supported `appServer` fields:
 | `authToken`         | unset                                    | Bearer token for WebSocket transport.                                    |
 | `headers`           | `{}`                                     | Extra WebSocket headers.                                                 |
 | `requestTimeoutMs`  | `60000`                                  | Timeout for app-server control-plane calls.                              |
-| `approvalPolicy`    | `"never"`                                | Native Codex approval policy sent to thread start/resume/turn.           |
+| `approvalPolicy`    | `"on-request"`                           | Native Codex approval policy sent to thread start/resume/turn.           |
 | `sandbox`           | `"workspace-write"`                      | Native Codex sandbox mode sent to thread start/resume.                   |
 | `approvalsReviewer` | `"user"`                                 | Use `"guardian_subagent"` to let Codex guardian review native approvals. |
 | `serviceTier`       | unset                                    | Optional Codex service tier, for example `"priority"`.                   |

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -264,7 +264,8 @@ codex app-server --listen stdio://
 ```
 
 By default, OpenClaw asks Codex to request native approvals. You can tune that
-policy further:
+policy further, for example by tightening it and routing reviews through the
+guardian:
 
 ```json5
 {
@@ -274,7 +275,8 @@ policy further:
         enabled: true,
         config: {
           appServer: {
-            approvalPolicy: "on-request",
+            approvalPolicy: "untrusted",
+            approvalsReviewer: "guardian_subagent",
             sandbox: "workspace-write",
             serviceTier: "priority",
           },

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -65,7 +65,7 @@
           "approvalPolicy": {
             "type": "string",
             "enum": ["never", "on-request", "on-failure", "untrusted"],
-            "default": "never"
+            "default": "on-request"
           },
           "sandbox": {
             "type": "string",

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -60,6 +60,21 @@ describe("Codex app-server config", () => {
     ).toThrow("appServer.url is required");
   });
 
+  it("defaults native Codex approvals to on-request", () => {
+    const runtime = resolveCodexAppServerRuntimeOptions({
+      pluginConfig: {},
+      env: {},
+    });
+
+    expect(runtime).toEqual(
+      expect.objectContaining({
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+        approvalsReviewer: "user",
+      }),
+    );
+  });
+
   it("keeps runtime config keys aligned with manifest schema and UI hints", async () => {
     const manifest = JSON.parse(
       await fs.readFile(new URL("../../openclaw.plugin.json", import.meta.url), "utf8"),

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -136,7 +136,7 @@ export function resolveCodexAppServerRuntimeOptions(
     approvalPolicy:
       resolveApprovalPolicy(config.approvalPolicy) ??
       resolveApprovalPolicy(env.OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY) ??
-      "never",
+      "on-request",
     sandbox:
       resolveSandbox(config.sandbox) ??
       resolveSandbox(env.OPENCLAW_CODEX_APP_SERVER_SANDBOX) ??

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -435,7 +435,7 @@ describe("runCodexAppServerAttempt", () => {
       threadId: "thread-existing",
       model: "gpt-5.4-codex",
       modelProvider: "openai",
-      approvalPolicy: "never",
+      approvalPolicy: "on-request",
       approvalsReviewer: "user",
       sandbox: "workspace-write",
       persistExtendedHistory: true,


### PR DESCRIPTION
## Summary

- Problem: the Codex app-server harness defaulted native sessions to `approvalPolicy: "never"`.
- Why it matters: command-execution and file-change actions could proceed without surfacing the native approval bridge unless operators opted in manually.
- What changed: changed the default app-server approval policy to `on-request`, kept explicit operator overrides intact, and updated tests plus plugin docs to match the secure-by-default behavior.
- What did NOT change (scope boundary): explicit env/config overrides, sandbox selection, and the underlying approval bridge wiring outside the default-policy path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Codex harness already had an approval bridge, but `resolveAppServerApprovalPolicy()` defaulted to `"never"`, which suppressed approval requests by default.
- Missing detection / guardrail: there was no regression test asserting that the default harness configuration requests approvals instead of disabling them.
- Contributing context (if known): the harness exposed an override env var for operators, but the documented and configured default chose the most permissive behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/config.test.ts`, `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: when operators do not override the setting, new Codex app-server sessions start with `approvalPolicy: "on-request"`; explicit overrides still pass through unchanged.
- Why this is the smallest reliable guardrail: the regression is in the harness configuration and request payload assembly, which is fully observable in unit tests.
- Existing test that already covers this (if any): none prior to this fix.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Codex app-server sessions now request approvals by default for native command/file actions instead of silently disabling the approval path.

## Diagram (if applicable)

```text
Before:
[thread/start or turn/start] -> [approvalPolicy: never] -> [native action proceeds without approval request]

After:
[thread/start or turn/start] -> [approvalPolicy: on-request] -> [approval bridge can prompt]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: the default native action surface is now narrower because the harness requests approvals unless an operator explicitly opts out.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: Codex app-server harness tests
- Integration/channel (if any): Codex extension app-server path
- Relevant config (redacted): default Codex harness config with no `OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY` override

### Steps

1. Start a Codex app-server thread or turn without setting the approval-policy override env var.
2. Inspect the request payload sent by the harness.
3. Repeat with an explicit override to verify it is preserved.

### Expected

- Default requests use `approvalPolicy: "on-request"`, while explicit overrides still pass through.

### Actual

- Before this fix, the default requests used `approvalPolicy: "never"`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Codex app-server config/run-attempt tests, plus full `pnpm check` through the commit hook.
- Edge cases checked: explicit operator overrides for the approval policy remain unchanged.
- What you did **not** verify: a live Codex app-server session end-to-end against a running backend.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: set `OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY=never` if you intentionally want the previous approval-free default.

## Risks and Mitigations

- Risk: installs that depended on approval-free Codex native actions by default will now see approval prompts unless they opt out explicitly.
  - Mitigation: the override path is preserved unchanged, and the docs/tests now make the default explicit.

## AI Assistance

- AI-assisted: Codex
- Testing degree: fully tested
- I understand what the code does: Yes
