### PR TITLE
fix: chmod openclaw.json to 0o600 after atomic rename on config write

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1679,8 +1679,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         // Windows doesn't reliably support atomic replace via rename when dest exists.
         if (code === "EPERM" || code === "EEXIST") {
           await deps.fs.promises.copyFile(tmp, configPath);
-          await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
-            // best-effort
+          await deps.fs.promises.chmod(configPath, 0o600).catch((chmodErr) => {
+            deps.logger.warn(
+              `Failed to chmod ${configPath} to 0o600 after config write (copy-fallback) — file may be readable by other users: ${formatErrorMessage(chmodErr)}`,
+            );
           });
           await deps.fs.promises.unlink(tmp).catch(() => {
             // best-effort
@@ -1699,6 +1701,16 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         });
         throw err;
       }
+      // Ensure restrictive permissions after atomic rename. The tmp file is created
+      // with mode 0o600, but the effective mode is subject to the process umask
+      // (e.g. systemd default UMask=0002 is fine, but a permissive umask could
+      // widen it). Belt-and-suspenders chmod ensures openclaw.json — which contains
+      // API keys and security policy — is never group/world-readable. (#68709)
+      await deps.fs.promises.chmod(configPath, 0o600).catch((chmodErr) => {
+        deps.logger.warn(
+          `Failed to chmod ${configPath} to 0o600 after config write — file may be readable by other users: ${formatErrorMessage(chmodErr)}`,
+        );
+      });
       logConfigOverwrite();
       logConfigWriteAnomalies();
       await appendWriteAudit(

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -102,6 +102,36 @@ describe("config io write", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "ensures config file is mode 0o600 after write (#68709)",
+    async () => {
+      await withSuiteHome(async (home) => {
+        const stateDir = path.join(home, ".openclaw");
+        await fs.mkdir(stateDir, { recursive: true });
+
+        const io = createConfigIO({
+          env: {} as NodeJS.ProcessEnv,
+          homedir: () => home,
+          logger: silentLogger,
+        });
+
+        // First write (creates file)
+        await io.writeConfigFile({ gateway: { mode: "local" } });
+        const configPath = path.join(stateDir, "openclaw.json");
+        const stat1 = await fs.stat(configPath);
+        expect(stat1.mode & 0o777).toBe(0o600);
+
+        // Widen permissions to simulate a permissive umask environment
+        await fs.chmod(configPath, 0o664);
+
+        // Second write (overwrites existing file via atomic rename)
+        await io.writeConfigFile({ gateway: { mode: "local", port: 9999 } } as any);
+        const stat2 = await fs.stat(configPath);
+        expect(stat2.mode & 0o777).toBe(0o600);
+      });
+    },
+  );
+
   it("keeps writes inside an OPENCLAW_STATE_DIR override even when the real home config exists", async () => {
     await withSuiteHome(async (home) => {
       const liveConfigPath = path.join(home, ".openclaw", "openclaw.json");


### PR DESCRIPTION
Fixes #68709

## Problem

The main config writer in `src/config/io.ts` writes a tmp file with `mode: 0o600`, then atomically renames it over the target. On the **rename success path** (Linux), no `chmod` was applied afterward. Under a permissive process umask (e.g. systemd default `UMask=0002`), the effective file mode could end up as `0664`, exposing API keys and security policy as group-readable.

The **copy-fallback path** (Windows) already had a `chmod`, but silently swallowed failures.

The **models config writer** (`src/agents/models-config.ts`) already does this correctly.

## Fix

- Add `chmod(configPath, 0o600)` after successful atomic rename (belt-and-suspenders)
- Upgrade both rename and copy-fallback chmod to log a warning on failure instead of silently swallowing
- Add regression test that widens permissions between writes and asserts they are tightened back to `0o600`

## Test

```
npx vitest run src/config/io.write-config.test.ts
# 8 passed (8)
```

The new test:
1. Writes config (verifies 0o600)
2. Manually `chmod 0o664` to simulate permissive umask
3. Writes again (verifies chmod restores 0o600)