### PR TITLE
feat(hooks): allow prompt hooks to dynamically narrow tool surface

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -311,6 +311,11 @@ export async function runEmbeddedPiAgent(
       modelId = hookSelection.modelId;
       const legacyBeforeAgentStartResult = hookSelection.legacyBeforeAgentStartResult;
 
+      // If a plugin set toolsAllow via before_prompt_build or before_agent_start,
+      // merge it with any cron-provided toolsAllow. Cron (params) takes precedence;
+      // hook-derived toolsAllow only applies when params.toolsAllow is not set.
+      const effectiveToolsAllow = params.toolsAllow ?? hookSelection.hookToolsAllow;
+
       const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
         provider,
         modelId,
@@ -763,7 +768,7 @@ export async function runEmbeddedPiAgent(
             silentExpected: params.silentExpected,
             bootstrapContextMode: params.bootstrapContextMode,
             bootstrapContextRunKind: params.bootstrapContextRunKind,
-            toolsAllow: params.toolsAllow,
+            toolsAllow: effectiveToolsAllow,
             disableMessageTool: params.disableMessageTool,
             requireExplicitMessageTarget: params.requireExplicitMessageTarget,
             internalEvents: params.internalEvents,

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -24,7 +24,7 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 export type PromptBuildHookRunner = {
   hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
   runBeforePromptBuild: (
-    event: { prompt: string; messages: unknown[] },
+    event: { prompt: string; messages: unknown[]; availableTools?: string[] },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
   runBeforeAgentStart: (
@@ -36,6 +36,7 @@ export type PromptBuildHookRunner = {
 export async function resolvePromptBuildHookResult(params: {
   prompt: string;
   messages: unknown[];
+  availableTools?: string[];
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
@@ -46,6 +47,7 @@ export async function resolvePromptBuildHookResult(params: {
           {
             prompt: params.prompt,
             messages: params.messages,
+            availableTools: params.availableTools,
           },
           params.hookCtx,
         )
@@ -86,6 +88,8 @@ export async function resolvePromptBuildHookResult(params: {
       promptBuildResult?.appendSystemContext,
       legacyResult?.appendSystemContext,
     ]),
+    // First defined toolsAllow wins (before_prompt_build takes precedence over legacy hook).
+    toolsAllow: promptBuildResult?.toolsAllow ?? legacyResult?.toolsAllow,
   };
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -89,6 +89,7 @@ describe("resolvePromptBuildHookResult", () => {
       systemPrompt: "legacy-system",
       prependSystemContext: undefined,
       appendSystemContext: undefined,
+      toolsAllow: undefined,
     });
   });
 
@@ -132,6 +133,28 @@ describe("resolvePromptBuildHookResult", () => {
     expect(result.prependContext).toBe("prompt context\n\nlegacy context");
     expect(result.prependSystemContext).toBe("prompt prepend\n\nlegacy prepend");
     expect(result.appendSystemContext).toBe("prompt append\n\nlegacy append");
+    expect(result.toolsAllow).toBeUndefined();
+  });
+
+  it("prefers prompt-build toolsAllow over legacy hook toolsAllow", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(() => true),
+      runBeforePromptBuild: vi.fn(async () => ({
+        toolsAllow: ["read", "exec"],
+      })),
+      runBeforeAgentStart: vi.fn(async () => ({
+        toolsAllow: ["write"],
+      })),
+    };
+
+    const result = await resolvePromptBuildHookResult({
+      prompt: "hello",
+      messages: [],
+      hookCtx: {},
+      hookRunner,
+    });
+
+    expect(result.toolsAllow).toEqual(["read", "exec"]);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -688,7 +688,7 @@ export async function runEmbeddedAttempt(
       senderIsOwner: params.senderIsOwner,
       warn: (message) => log.warn(message),
     });
-    const effectiveTools = [...tools, ...filteredBundledTools];
+    let effectiveTools = [...tools, ...filteredBundledTools];
     const allowedToolNames = collectAllowedToolNames({
       tools: effectiveTools,
       clientTools,
@@ -1833,6 +1833,7 @@ export async function runEmbeddedAttempt(
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,
           messages: activeSession.messages,
+          availableTools: toolsRaw.map((tool) => tool.name),
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
@@ -1866,6 +1867,18 @@ export async function runEmbeddedAttempt(
             systemPromptText = prependedOrAppendedSystemPrompt;
             log.debug(
               `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
+            );
+          }
+
+          // Apply toolsAllow from the full before_prompt_build hook to narrow the tool surface.
+          // This is the load-bearing call for dynamic tool resolution — plugins have access to
+          // availableTools here and can make informed classification decisions.
+          if (hookResult?.toolsAllow && hookResult.toolsAllow.length > 0) {
+            const originalLength = effectiveTools.length;
+            const allowSet = new Set(hookResult.toolsAllow);
+            effectiveTools = effectiveTools.filter((t) => allowSet.has(t.name));
+            log.debug(
+              `hooks: toolsAllow narrowed tools ${originalLength} → ${effectiveTools.length}`,
             );
           }
         }

--- a/src/agents/pi-embedded-runner/run/setup.test.ts
+++ b/src/agents/pi-embedded-runner/run/setup.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveHookModelSelection } from "./setup.js";
+
+describe("resolveHookModelSelection", () => {
+  it("does not call before_prompt_build for early toolsAllow (moved to attempt phase)", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) =>
+        ["before_model_resolve", "before_prompt_build", "before_agent_start"].includes(hookName),
+      ),
+      runBeforeModelResolve: vi.fn(async () => undefined),
+      runBeforePromptBuild: vi.fn(async () => ({ toolsAllow: ["read", "exec"] })),
+      runBeforeAgentStart: vi.fn(async () => ({ toolsAllow: ["write"] })),
+    };
+
+    const result = await resolveHookModelSelection({
+      prompt: "hello",
+      provider: "openai",
+      modelId: "gpt-5",
+      hookRunner: hookRunner as never,
+      hookContext: { sessionId: "test-session", workspaceDir: "/tmp/test" },
+    });
+
+    // before_prompt_build is no longer called in setup — toolsAllow extraction
+    // happens in attempt.ts where availableTools is populated
+    expect(hookRunner.runBeforePromptBuild).not.toHaveBeenCalled();
+    // Legacy before_agent_start toolsAllow still flows through
+    expect(result.hookToolsAllow).toEqual(["write"]);
+    expect(result.legacyBeforeAgentStartResult?.toolsAllow).toEqual(["write"]);
+  });
+
+  it("falls back to legacy before_agent_start toolsAllow", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) =>
+        ["before_prompt_build", "before_agent_start"].includes(hookName),
+      ),
+      runBeforePromptBuild: vi.fn(async () => ({ prependContext: "ctx" })),
+      runBeforeAgentStart: vi.fn(async () => ({ toolsAllow: ["read"] })),
+    };
+
+    const result = await resolveHookModelSelection({
+      prompt: "hello",
+      provider: "openai",
+      modelId: "gpt-5",
+      hookRunner: hookRunner as never,
+      hookContext: { sessionId: "test-session", workspaceDir: "/tmp/test" },
+    });
+
+    expect(result.hookToolsAllow).toEqual(["read"]);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/setup.ts
+++ b/src/agents/pi-embedded-runner/run/setup.ts
@@ -35,6 +35,10 @@ type HookRunnerLike = {
     input: { prompt: string },
     context: HookContext,
   ): Promise<PluginHookBeforeAgentStartResult | undefined>;
+  runBeforePromptBuild(
+    input: { prompt: string; messages: unknown[]; availableTools?: string[] },
+    context: HookContext,
+  ): Promise<{ toolsAllow?: string[] } | undefined>;
 };
 
 export async function resolveHookModelSelection(params: {
@@ -96,6 +100,10 @@ export async function resolveHookModelSelection(params: {
     provider,
     modelId,
     legacyBeforeAgentStartResult,
+    // toolsAllow is now consumed from the full before_prompt_build call in attempt.ts,
+    // where availableTools is populated and plugins can make informed decisions.
+    // Legacy before_agent_start toolsAllow is still supported here for backwards compat.
+    hookToolsAllow: legacyBeforeAgentStartResult?.toolsAllow,
   };
 }
 

--- a/src/plugins/hook-before-agent-start.types.ts
+++ b/src/plugins/hook-before-agent-start.types.ts
@@ -16,6 +16,18 @@ export type PluginHookBeforePromptBuildEvent = {
   prompt: string;
   /** Session messages prepared for this run. */
   messages: unknown[];
+  /**
+   * Names of tools available for this turn (after policy pipeline filtering).
+   * Populated on the full prompt-build call in the attempt phase.
+   * Plugins should use this to dynamically select which tools to include via
+   * `toolsAllow` — no hardcoded tool lists needed.
+   *
+   * When `availableTools` is undefined or empty, the plugin is being called in a
+   * context where tool information is not yet available. Return `undefined` for
+   * `toolsAllow` in this case; the full call with populated `availableTools` will
+   * follow.
+   */
+  availableTools?: string[];
 };
 
 export type PluginHookBeforePromptBuildResult = {
@@ -31,6 +43,23 @@ export type PluginHookBeforePromptBuildResult = {
    * Use for static plugin guidance instead of prependContext to avoid per-turn token cost.
    */
   appendSystemContext?: string;
+  /**
+   * Optional tool allow-list for this turn. When set, only the listed tools are
+   * sent to the model — the same filtering that `toolsAllow` on cron payloads
+   * already applies (intersection with the owner's static policy, never additive).
+   *
+   * Plugins can use this to dynamically narrow the tool surface per-turn based
+   * on task classification, reducing token overhead and model confusion.
+   *
+   * Applied from the full `before_prompt_build` call in attempt.ts, where
+   * `availableTools` is populated. Plugins that need to inspect available tools
+   * before deciding which to allow should check `event.availableTools`.
+   *
+   * Safety guarantee: this list is intersected with the tools that survive the
+   * existing policy pipeline — it can only *remove* tools, never grant access
+   * to tools the owner denied.
+   */
+  toolsAllow?: string[];
 };
 
 export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
@@ -38,6 +67,7 @@ export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
   "prependContext",
   "prependSystemContext",
   "appendSystemContext",
+  "toolsAllow",
 ] as const satisfies readonly (keyof PluginHookBeforePromptBuildResult)[];
 
 type MissingPluginPromptMutationResultFields = Exclude<

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -246,6 +246,8 @@ export function createHookRunner(
       left: acc?.appendSystemContext,
       right: next.appendSystemContext,
     }),
+    // First plugin to set toolsAllow wins (higher priority).
+    toolsAllow: firstDefined(acc?.toolsAllow, next.toolsAllow),
   });
 
   const mergeSubagentSpawningResult = (


### PR DESCRIPTION
## Summary

Extends the `before_prompt_build` hook so plugins can dynamically narrow the tool surface per-turn.

## Changes

- Exposes `availableTools: string[]` on `PluginHookBeforePromptBuildEvent` so plugins can see which tools survived the static policy pipeline
- Accepts `toolsAllow: string[]` in the hook result — intersected with available tools (can only remove, never add)
- Merges cleanly with existing `toolsAllow` from cron payloads (cron takes precedence)
- Consumes `toolsAllow` in `attempt.ts` where the full tool list exists (not in `setup.ts` where `availableTools` is empty)

## Use case

Classifier plugins that use a faster/cheaper model to pre-screen the prompt and drop irrelevant tools from the main context window. Reduces token usage and improves accuracy when 40+ tools are registered.

## Safety guarantee

`toolsAllow` is intersected with tools that survive the existing policy pipeline — it can only *narrow* the surface, never grant access to tools the owner denied.

## Files changed

- `src/plugins/hook-before-agent-start.types.ts` — new hook event fields + result type
- `src/plugins/hooks.ts` — `runBeforePromptBuild` on `HookRunnerLike`
- `src/agents/pi-embedded-runner/run.ts` — pass `availableTools` to hook
- `src/agents/pi-embedded-runner/run/setup.ts` — declare `runBeforePromptBuild` interface
- `src/agents/pi-embedded-runner/run/attempt.ts` — consume `toolsAllow` from hook result
- `src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts` — minimal prompt mode when `toolsAllow` active
- `src/agents/pi-embedded-runner/run/attempt.test.ts` — test coverage for `toolsAllow` filtering
- `src/agents/pi-embedded-runner/run/setup.test.ts` — test coverage for hook interface