### PR TITLE
Prefer API audio providers before local fallback

### DIFF
--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { runCapability } from "./runner.js";
+import { clearMediaUnderstandingBinaryCacheForTests, runCapability } from "./runner.js";
 import { withAudioFixture } from "./runner.test-utils.js";
 import type { AudioTranscriptionRequest, MediaUnderstandingProvider } from "./types.js";
 
@@ -52,6 +52,13 @@ function createOpenAiAudioCfg(extra?: Partial<OpenClawConfig>): OpenClawConfig {
   } as unknown as OpenClawConfig;
 }
 
+async function createMockExecutable(dir: string, name: string) {
+  const filePath = path.join(dir, name);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(filePath, "#!/bin/sh\necho local audio fallback\n");
+  await fs.chmod(filePath, 0o755);
+}
+
 async function runAutoAudioCase(params: {
   transcribeAudio: (req: AudioTranscriptionRequest) => Promise<{ text: string; model: string }>;
   cfgExtra?: Partial<OpenClawConfig>;
@@ -87,6 +94,31 @@ describe("runCapability auto audio entries", () => {
     expect(result.outputs[0]?.text).toBe("ok");
     expect(seenModel).toBe("gpt-4o-transcribe");
     expect(result.decision.outcome).toBe("success");
+  });
+
+  it("prefers provider keys over auto-detected local audio binaries", async () => {
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audio-bin-"));
+    await createMockExecutable(binDir, "whisper");
+    clearMediaUnderstandingBinaryCacheForTests();
+
+    try {
+      let seenModel: string | undefined;
+      const result = await withEnvAsync({ PATH: binDir }, () =>
+        runAutoAudioCase({
+          transcribeAudio: async (req) => {
+            seenModel = req.model;
+            return { text: "provider ok", model: req.model ?? "unknown" };
+          },
+        }),
+      );
+
+      expect(result.outputs[0]?.text).toBe("provider ok");
+      expect(seenModel).toBe("gpt-4o-transcribe");
+      expect(result.decision.outcome).toBe("success");
+    } finally {
+      await fs.rm(binDir, { recursive: true, force: true });
+      clearMediaUnderstandingBinaryCacheForTests();
+    }
   });
 
   it("skips auto audio when disabled", async () => {

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -568,9 +568,11 @@ export async function runProviderEntry(params: {
     throw new Error(`Media provider not available: ${providerId}`);
   }
 
-  // Resolve proxy-aware fetch from env vars (HTTPS_PROXY, HTTP_PROXY, etc.)
-  // so provider HTTP calls are routed through the proxy when configured.
-  const fetchFn = resolveProxyFetchFromEnv();
+  // Audio providers go through the shared provider HTTP helpers, which already
+  // handle proxy env vars and NO_PROXY at the request URL boundary. Passing an
+  // EnvHttpProxyAgent fetchFn here can force proxy handling before that layer
+  // and has broken multipart audio uploads for OpenAI-compatible providers.
+  const fetchFn = capability === "audio" ? undefined : resolveProxyFetchFromEnv();
 
   if (capability === "audio") {
     if (!provider.transcribeAudio) {

--- a/src/media-understanding/runner.proxy.test.ts
+++ b/src/media-understanding/runner.proxy.test.ts
@@ -101,13 +101,14 @@ describe("runCapability proxy fetch passthrough", () => {
   });
   afterEach(() => vi.unstubAllEnvs());
 
-  it("passes fetchFn to audio provider when HTTPS_PROXY is set", async () => {
+  it("lets audio providers use their shared proxy-aware HTTP helper when HTTPS_PROXY is set", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
     const seenFetchFn = await runAudioCapabilityWithFetchCapture({
       fixturePrefix: "openclaw-audio-proxy",
       outputText: "transcribed",
     });
-    expect(seenFetchFn).toBe(proxyFetchMocks.proxyFetch);
+    expect(seenFetchFn).toBeUndefined();
+    expect(proxyFetchMocks.resolveProxyFetchFromEnv).not.toHaveBeenCalled();
   });
 
   it("passes fetchFn to video provider when HTTPS_PROXY is set", async () => {

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -525,6 +525,10 @@ async function resolveAutoEntries(params: {
     return [activeEntry];
   }
   if (params.capability === "audio") {
+    const keys = await resolveKeyEntry(params);
+    if (keys) {
+      return [keys];
+    }
     const localAudio = await resolveLocalAudioEntry();
     if (localAudio) {
       return [localAudio];


### PR DESCRIPTION
## Summary

Fixes #68727.

This changes audio media-understanding fallback behavior so API-provider audio transcription wins before local CLI auto-detection, and avoids passing a pre-wrapped proxy fetch into audio providers. Audio providers already route requests through the shared provider HTTP helpers, which handle proxy env vars and NO_PROXY at the request URL boundary.

## Why

A gateway with `GROQ_API_KEY`/Groq audio configured and a local `/opt/homebrew/bin/whisper` could still take the local audio path in auto mode. When the Groq provider path was selected, passing `resolveProxyFetchFromEnv()` into OpenAI-compatible audio transcription could break multipart uploads with Groq returning `request Content-Type isn't multipart/form-data`.

## Changes

- Prefer `resolveKeyEntry()` before local audio CLI fallback in audio auto mode.
- Do not pass a direct proxy-wrapped `fetchFn` into audio providers; leave audio proxy handling to the shared provider HTTP layer.
- Add regression coverage for provider-key priority when a local `whisper` executable exists.
- Update proxy passthrough coverage for the audio path.

## Validation

- `pnpm exec vitest run src/media-understanding/runner.auto-audio.test.ts src/media-understanding/runner.proxy.test.ts`
- pre-commit `pnpm check` passed locally during commit.