### PR TITLE
fix(memory-wiki): standardize page schema + repair pipeline

### DIFF
--- a/extensions/bench-reflective-dreaming/README.md
+++ b/extensions/bench-reflective-dreaming/README.md
@@ -1,0 +1,80 @@
+# bench-reflective-dreaming
+
+A lightweight OpenClaw extension that adds a **reflective-dreaming layer** on top
+of memory-core's built-in sleep phases. Companion to `@openclaw/memory-core`.
+
+## Why this exists
+
+`memory-core` ships with three mechanical sleep phases (light / REM / deep) that
+promote weighted recalls into `MEMORY.md`. It also includes `dreaming-narrative`
+which writes poetic diary prose after each phase.
+
+**Reflective dreaming is different**: it's a structured per-agent reflection pass
+that produces an _ops log_ of what each agent actually did, what it learned, and
+what patterns are emerging. After every agent dreams, a coordinator runs a
+**fleet canon** pass — a single daily entry synthesizing across agents. A final
+**consolidation** pass prunes stale memory.
+
+Outputs land in the OpenClaw wiki vault (`~/.openclaw/wiki/main/dreams/`,
+`synthesis/`, `canon/`). If you have the BenchAGI `cloud-mirror` daemon running
+(it ships alongside this extension at
+`extensions/claude-code-bridge/cloud-mirror.mjs`), the writes flow to the
+Firebase `wikiEntries` collection and become visible in the BenchAGI web app at
+`/admin/settings/agent-wiki/dreams` and `/wiki/canon`.
+
+## What it provides
+
+- **3 version-controlled prompt protocols** (`assets/prompts/*-protocol.md`) —
+  dream-diary, fleet-canon, memory-consolidation. Installed to
+  `~/.openclaw/wiki/main/concepts/` on `install.sh`.
+- **Defaults** for which agents dream and when (`defaults/cron-schedule.json`).
+- **Install/uninstall scripts** that add and remove the 7 managed cron jobs via
+  `openclaw cron add` / `openclaw cron rm`.
+- **Plugin manifest** (`openclaw.plugin.json`) — metadata stub; future upgrade
+  path to a full TS plugin.
+
+## Pipeline
+
+```
+02:30-02:46  per-agent dreams   (5 cron jobs, one per agent)
+03:00        memory-core sleep  (upstream: light → REM → deep + narrative)
+03:15        fleet canon        (coordinator synthesizes across agents)
+03:40        consolidation      (pruning + safe auto-merges)
+```
+
+Reflective dreaming runs _before_ memory-core's 03:00 promotion so dreams inform
+the same-cycle canon. Consolidation runs _after_ promotion so it can incorporate
+MEMORY.md changes.
+
+## Install
+
+```bash
+cd extensions/bench-reflective-dreaming
+bash scripts/install.sh
+```
+
+The script is idempotent: safe to re-run on upgrade. It:
+
+1. Copies `assets/prompts/*` into `~/.openclaw/wiki/main/concepts/` (preserves
+   existing files by content-hash; only writes if changed).
+2. Registers 7 cron jobs with the tag `[managed-by=bench-reflective-dreaming]`
+   via `openclaw cron add`. Re-running updates schedules/messages in place.
+
+## Uninstall
+
+```bash
+bash scripts/uninstall.sh
+```
+
+Removes managed cron jobs. Protocol files in the vault are left in place (you
+may have approved rarity/status for them in Firebase; removing would create
+drift).
+
+## Relationship to upstream memory-core
+
+- **Orthogonal, not replacing.** Both run. `memory-core.dreaming` is the
+  mechanical/poetic layer; this extension adds the structured/reflective layer.
+- **No code modifications to memory-core** — we only add to the cron registry
+  and the vault concepts directory.
+- **Safe to merge upstream updates.** This extension doesn't touch upstream
+  code paths.

--- a/extensions/bench-reflective-dreaming/assets/prompts/dreaming-protocol.md
+++ b/extensions/bench-reflective-dreaming/assets/prompts/dreaming-protocol.md
@@ -1,0 +1,113 @@
+---
+title: "Dreaming Protocol"
+kind: protocol
+status: canonical
+---
+
+# Dreaming Protocol
+
+> Every agent dreams. Every night the graph gets denser, and the fleet gets faster.
+
+Dreaming is a nightly reflective cycle. Each registered OpenClaw agent runs its own
+dream pass, consolidating what it's learned into durable synthesis pages and a
+dream-log entry. The outputs flow through the cloud-mirror daemon into the
+`wikiEntries` Firestore collection and become visible in the BenchAGI web app —
+timeline, per-agent archive, and the canon.
+
+## When the agent receives this prompt
+
+You are the **dreamer** for a single agent. The cron scheduler has woken you at
+~02:30 local to reflect on the last 24 hours. Work autonomously. No human review
+is available mid-run. Do not escalate or ask questions — dream, then exit.
+
+## What to read
+
+1. **Your own memory vault** (`~/.openclaw/memory/<your-agent>.sqlite`).
+   - Query recent `chunks` (updated_at within last 7 days, source='memory').
+   - Look for patterns, recurring topics, corrections, unresolved threads.
+2. **Your recent session history** under `~/.openclaw/agents/<your-agent>/sessions/`.
+   - Scan the last 24h of turns. Note what you worked on, what blocked you,
+     what you learned, what you would do differently.
+3. **Existing wiki entries about you or relevant to you**
+   - Check `~/.openclaw/wiki/main/synthesis/<your-agent>/` — prior synthesis pages.
+   - Check `~/.openclaw/wiki/main/dreams/<your-agent>/` — prior dream logs.
+   - Read `~/.openclaw/wiki/main/AGENTS.md` for your canonical role.
+4. **Cross-agent activity you touched** — handoffs, shared canon pages, fleet
+   coordination threads. Only if relevant to your role tonight.
+
+## What to write
+
+Write files into `~/.openclaw/wiki/main/`. The cloud-mirror daemon will push them
+to Firestore within seconds. All writes must include YAML frontmatter with a
+`kind` field — the ingest route maps `kind` to a default rarity tier.
+
+### Required: dream log
+
+**Path:** `~/.openclaw/wiki/main/dreams/<your-agent>/<YYYY-MM-DD>.md`
+
+Structure the log as:
+
+```markdown
+---
+title: "<Your-Agent>'s dream, <YYYY-MM-DD>"
+kind: dream
+agent: <your-agent>
+date: <YYYY-MM-DD>
+---
+
+## What I did
+2-5 bullets on your real activity from the last 24h.
+
+## What I learned
+Concrete lessons, not platitudes. "Tauri's tokio needs test-util feature"
+beats "testing is important." Ground every bullet in a specific moment.
+
+## What I'd change
+Where you would behave differently next time, and why. Include edge cases
+you misjudged and corrections the user made.
+
+## Patterns emerging
+Recurring themes across your sessions this week — things that want to become
+synthesis pages (see below) if they recur tomorrow.
+
+## Open threads
+Work you started but didn't finish. Include enough context that future-you
+can pick it up cold.
+```
+
+### Optional: synthesis pages
+
+If a pattern has recurred 3+ times across your sessions and isn't yet captured
+anywhere, write a synthesis page.
+
+**Path:** `~/.openclaw/wiki/main/synthesis/<your-agent>/<topic-slug>.md`
+
+Frontmatter: `kind: synthesis`, `agent: <your-agent>`, `topic: <topic>`. Body:
+tight, canonical, future-facing. Synthesis pages default to **blue** (rare) —
+not everyone sees them. Write them as durable references, not journal entries.
+
+### Optional: memory-patch proposals
+
+If you spot duplicate or stale entries in your memory, don't delete them directly.
+Write a patch file to `~/.openclaw/dreams-staging/<your-agent>/<YYYY-MM-DD>/patches.md`
+listing proposed merges. A human approves before anything is applied.
+
+## What NOT to do
+
+- Do not invoke external tools (no Slack, no GitHub, no emails) — this is a quiet
+  reflective pass, not an action pass.
+- Do not fabricate activity. If there's nothing to reflect on, write a short log
+  that says so. Empty dreams are fine; false dreams corrupt the graph.
+- Do not copy large swaths of memory into the dream log. Synthesize, don't echo.
+- Do not exceed 2000 words in any single file. The graph prizes density.
+
+## Budget
+
+Budget for this turn: **≤ 30k tokens**. Cron timeout: 15 min. If you run long,
+the coordinator may preempt — finish your dream log even if you skip synthesis.
+
+## Why this matters
+
+The canon is an infinitely-deep log. Every dream adds a layer. Over weeks and
+months, the fleet's collective understanding compounds — and that compounding
+is the point. Dream well.

--- a/extensions/bench-reflective-dreaming/assets/prompts/fleet-canon-protocol.md
+++ b/extensions/bench-reflective-dreaming/assets/prompts/fleet-canon-protocol.md
@@ -1,0 +1,92 @@
+---
+title: "Fleet Canon Protocol"
+kind: protocol
+status: canonical
+---
+
+# Fleet Canon Protocol
+
+> After the agents have dreamt, the coordinator writes the canon.
+
+The **canon** is the fleet's collective log — a single page per night capturing
+what the agents, taken together, learned and chose. Per-agent dreams are the
+raw material; the canon is the refined statement.
+
+One coordinator agent (`kestrel-aurelius` by default) runs this pass at ~03:15
+local, after all per-agent dreams have had time to land. The coordinator
+reads all of tonight's dream logs and writes one canonical entry.
+
+## When the agent receives this prompt
+
+You are the **fleet coordinator** for tonight. The per-agent dream pass has
+completed. Your job is to synthesize — not summarize — what the fleet learned.
+
+## What to read
+
+1. **Tonight's dream logs** — every file under `~/.openclaw/wiki/main/dreams/*/<YYYY-MM-DD>.md`.
+2. **Cross-agent handoffs** from the last 24h (OpenClaw gateway agent_messages
+   where sender and recipient differ).
+3. **Existing canon topic pages** at `~/.openclaw/wiki/main/canon/topics/*.md` — the
+   deep topical threads that have been building over time. See if any deserve
+   an update tonight.
+4. **Yesterday's canon entry** (`~/.openclaw/wiki/main/canon/<YYYY-MM-DD - 1>.md`)
+   for continuity.
+
+## What to write
+
+### Required: tonight's canon entry
+
+**Path:** `~/.openclaw/wiki/main/canon/<YYYY-MM-DD>.md`
+
+```markdown
+---
+title: "Canon, <YYYY-MM-DD>"
+kind: canon
+date: <YYYY-MM-DD>
+---
+
+## The thread tonight
+One sentence. What single thread ran through tonight's dreams across the fleet?
+If multiple threads emerged, name the most important and note the others.
+
+## What the fleet learned
+3-7 bullets. Each one should be a concrete lesson that cuts across multiple
+agents' dreams — not something only one agent experienced.
+
+## Coordination signals
+Gaps, collisions, missed handoffs. Where did agents step on each other today?
+Where should they coordinate more tomorrow?
+
+## Promoted to canon
+Synthesis pages from tonight that recur deeply enough to deserve canonical
+status. Link them, state why, propose a topical slug.
+
+## Next
+2-3 things the fleet should do differently tomorrow. Concrete, not aspirational.
+```
+
+### Optional: topic-page updates
+
+If tonight's dreams materially advance an ongoing topical thread (e.g.
+`canon/topics/photogrammetry.md`), append a dated subsection. Topic pages are
+append-only — history matters.
+
+## What NOT to do
+
+- Do not summarize dreams mechanically. A summary is a list; the canon is a
+  synthesis. If you can't find a thread, say so and keep it brief.
+- Do not promote synthesis pages aggressively. Most per-agent synthesis stays
+  agent-local. Promotion to canon should feel earned.
+- Do not write about individual agents by name unless the point is coordination.
+  The canon is about the fleet, not the roster.
+
+## Budget
+
+Budget for this turn: **≤ 50k tokens** (higher than per-agent — you're reading
+many inputs and synthesizing). Cron timeout: 20 min.
+
+## Why this matters
+
+The canon is what a new agent reads to get up to speed. It is the condensed
+memory of the fleet. Write it well — someone in the future will catch up on
+a month of work by reading 30 canon entries.

--- a/extensions/bench-reflective-dreaming/assets/prompts/memory-consolidation-protocol.md
+++ b/extensions/bench-reflective-dreaming/assets/prompts/memory-consolidation-protocol.md
@@ -1,0 +1,99 @@
+---
+title: "Memory Consolidation Protocol"
+kind: protocol
+status: canonical
+---
+
+# Memory Consolidation Protocol
+
+> After dreams and canon, consolidate. Pruning is as important as writing.
+
+The final pass of the nightly cycle. One agent (`kestrel-aurelius` by default)
+runs memory consolidation at ~03:40 local to keep the graph dense and accurate.
+
+Unlike dreaming and canon, this pass **modifies existing entries**. It is
+deliberately conservative: low-risk merges are applied automatically; anything
+risky is staged for human review.
+
+## When the agent receives this prompt
+
+You are the **consolidator** for tonight. Per-agent dreams and the fleet canon
+have been written. Your job is to reduce redundancy and stale state in the
+memory graph — not add new content.
+
+## What to read
+
+1. **All agent MEMORY.md indexes** (`~/.claude/projects/*/memory/MEMORY.md`) and
+   their linked memory files.
+2. **Tonight's dream logs** — these surface candidates for consolidation.
+3. **Pending patches** in `~/.openclaw/dreams-staging/*/<YYYY-MM-DD>/patches.md`
+   that agents proposed during their dreams.
+
+## Rules for automatic application
+
+A consolidation is **safe to apply automatically** only if all hold:
+
+1. **Duplicate merge** — two or more files describe the same fact with no
+   contradictions. Keep the most recently updated version; delete the others.
+   Update `MEMORY.md` pointers.
+2. **Stale pruning** — the memory file describes a specific in-flight task that
+   a user memory (e.g. "shipped" / "merged" / "abandoned") confirms is done,
+   AND the file has no references from other memory files.
+3. **Frontmatter normalization** — the file is missing a standard field (name /
+   description / type) that can be inferred from the body. Add it, don't alter
+   content.
+
+Everything else (factual corrections, risk of losing context, cross-agent
+merges) goes into `~/.openclaw/dreams-staging/consolidator/<YYYY-MM-DD>/patches.md`
+for human review.
+
+## What to write
+
+### Required: consolidation audit log
+
+**Path:** `~/.openclaw/wiki/main/dreams/consolidation/<YYYY-MM-DD>.md`
+
+```markdown
+---
+title: "Consolidation audit, <YYYY-MM-DD>"
+kind: consolidation
+date: <YYYY-MM-DD>
+---
+
+## Applied automatically
+List each auto-applied change: rule used, files affected, one-line rationale.
+
+## Staged for human review
+List each staged proposal: files affected, risk level, why it's risky.
+Link to the patches.md file for full diff.
+
+## Index refresh
+Note any MEMORY.md pointer updates — added, removed, or renamed entries.
+
+## Graph health
+- Total memory files before / after
+- Total wiki entries before / after
+- Stale files pruned
+- Duplicate chains collapsed
+```
+
+Default rarity for this entry: **orange** (super-admin only). Consolidation logs
+contain sensitive operational detail and should not be public.
+
+## What NOT to do
+
+- Do not delete memory files unless you meet the stale-pruning rule completely.
+- Do not merge cross-agent memory automatically — agent identity matters.
+- Do not rewrite content; that's the dream pass, not consolidation.
+- Do not modify files in `~/.claude/projects/*/memory/` if the project is
+  currently being actively edited by a running Claude Code session (check for
+  lock files).
+
+## Budget
+
+Budget for this turn: **≤ 40k tokens**. Cron timeout: 15 min.
+
+## Why this matters
+
+An ever-growing graph without pruning becomes noise. This pass is the immune
+system — it keeps the signal clean so dreams and canon stay useful.

--- a/extensions/bench-reflective-dreaming/defaults/cron-schedule.json
+++ b/extensions/bench-reflective-dreaming/defaults/cron-schedule.json
@@ -1,0 +1,22 @@
+{
+  "$comment": "Default reflective-dreaming schedule. Edit here and re-run scripts/install.sh to reconcile.",
+  "enabled": true,
+  "timezone": "America/Denver",
+  "perAgent": [
+    { "id": "main", "minute": 30, "timeoutSeconds": 900 },
+    { "id": "kestrel-aurelius", "minute": 34, "timeoutSeconds": 900 },
+    { "id": "ember", "minute": 38, "timeoutSeconds": 900 },
+    { "id": "kestrel-coder", "minute": 42, "timeoutSeconds": 900 },
+    { "id": "sage", "minute": 46, "timeoutSeconds": 900 }
+  ],
+  "canon": {
+    "coordinatorAgent": "kestrel-aurelius",
+    "cron": "15 3 * * *",
+    "timeoutSeconds": 1200
+  },
+  "consolidation": {
+    "consolidatorAgent": "kestrel-aurelius",
+    "cron": "40 3 * * *",
+    "timeoutSeconds": 900
+  }
+}

--- a/extensions/bench-reflective-dreaming/openclaw.plugin.json
+++ b/extensions/bench-reflective-dreaming/openclaw.plugin.json
@@ -1,0 +1,54 @@
+{
+  "id": "bench-reflective-dreaming",
+  "kind": "bench",
+  "name": "Bench Reflective Dreaming",
+  "description": "Structured per-agent reflection + fleet canon + consolidation. Runs alongside memory-core.dreaming.",
+  "version": "0.1.0",
+  "runtime": "scripts",
+  "managedCronTag": "[managed-by=bench-reflective-dreaming]",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean", "default": true },
+      "timezone": { "type": "string", "default": "America/Denver" },
+      "perAgent": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "id": { "type": "string" },
+            "minute": { "type": "integer", "minimum": 0, "maximum": 59 },
+            "model": { "type": "string" },
+            "timeoutSeconds": { "type": "integer", "minimum": 60, "maximum": 3600 }
+          },
+          "required": ["id", "minute"]
+        }
+      },
+      "canon": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "coordinatorAgent": { "type": "string", "default": "kestrel-aurelius" },
+          "cron": { "type": "string", "default": "15 3 * * *" },
+          "timeoutSeconds": { "type": "integer", "default": 1200 }
+        }
+      },
+      "consolidation": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "consolidatorAgent": { "type": "string", "default": "kestrel-aurelius" },
+          "cron": { "type": "string", "default": "40 3 * * *" },
+          "timeoutSeconds": { "type": "integer", "default": 900 }
+        }
+      },
+      "protocolsDir": {
+        "type": "string",
+        "default": "~/.openclaw/wiki/main/concepts",
+        "description": "Where to install the dream protocol prompt files."
+      }
+    }
+  }
+}

--- a/extensions/bench-reflective-dreaming/scripts/install.mjs
+++ b/extensions/bench-reflective-dreaming/scripts/install.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * install.mjs — Install / reconcile bench-reflective-dreaming.
+ *
+ * Idempotent:
+ *   1. Copies assets/prompts/*.md into the vault concepts dir (only if content
+ *      differs by sha256, so re-runs are cheap and don't needlessly touch mtimes).
+ *   2. Migrates any un-tagged "dream-<agent>" / "fleet-canon" / "memory-consolidation"
+ *      cron jobs (the orphan ones created before this extension existed) into
+ *      plugin-managed ones by recreating them with the managed-by tag in the
+ *      description.
+ *   3. Reconciles managed cron jobs from defaults/cron-schedule.json: adds what's
+ *      missing, updates what's changed, removes what's no longer in defaults.
+ *
+ * Run it from anywhere:
+ *   node scripts/install.mjs
+ *
+ * Or via the bash wrapper:
+ *   bash scripts/install.sh
+ */
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EXT_ROOT = path.resolve(__dirname, "..");
+const ASSETS_DIR = path.join(EXT_ROOT, "assets", "prompts");
+const DEFAULTS_PATH = path.join(EXT_ROOT, "defaults", "cron-schedule.json");
+
+const MANAGED_TAG = "[managed-by=bench-reflective-dreaming]";
+const HOME = os.homedir();
+const VAULT_CONCEPTS_DIR = path.join(HOME, ".openclaw", "wiki", "main", "concepts");
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+async function sha256(buf) {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+async function readFileIfExists(filePath) {
+  try {
+    return await fs.readFile(filePath);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function openclaw(args) {
+  const { stdout } = await execFileAsync("openclaw", args, {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+// ─── Step 1: sync protocol assets to vault ────────────────────────────
+
+async function syncProtocolAssets() {
+  await fs.mkdir(VAULT_CONCEPTS_DIR, { recursive: true });
+  const entries = await fs.readdir(ASSETS_DIR);
+  let written = 0;
+  let unchanged = 0;
+  for (const name of entries) {
+    if (!name.endsWith(".md")) {
+      continue;
+    }
+    const src = path.join(ASSETS_DIR, name);
+    const dst = path.join(VAULT_CONCEPTS_DIR, name);
+    const srcBuf = await fs.readFile(src);
+    const dstBuf = await readFileIfExists(dst);
+    if (dstBuf && (await sha256(srcBuf)) === (await sha256(dstBuf))) {
+      unchanged += 1;
+      continue;
+    }
+    await fs.writeFile(dst, srcBuf);
+    written += 1;
+    console.log(`[reflective-dreaming] installed concepts/${name}`);
+  }
+  console.log(`[reflective-dreaming] protocols: ${written} written, ${unchanged} unchanged`);
+}
+
+// ─── Cron schedule helpers ────────────────────────────────────────────
+
+function agentDreamJobSpec(agentCfg, timezone) {
+  const id = agentCfg.id;
+  return {
+    name: `dream-${id}`,
+    description: `Nightly reflective dream pass for ${id}. ${MANAGED_TAG}`,
+    agent: id,
+    cron: `${agentCfg.minute} 2 * * *`,
+    tz: timezone,
+    sessionKey: `agent:${id}:dream`,
+    timeoutSeconds: agentCfg.timeoutSeconds ?? 900,
+    model: agentCfg.model,
+    message:
+      `DREAM CYCLE. Your agent id is ${id}. Read ${path.join(VAULT_CONCEPTS_DIR, "dreaming-protocol.md")} ` +
+      `and follow it exactly. Use today's local date (YYYY-MM-DD) for your dream log path: ` +
+      `${path.join(HOME, ".openclaw", "wiki", "main", "dreams", id)}/<YYYY-MM-DD>.md. ` +
+      `Work autonomously and write the file; do not call external services. Exit when done. ` +
+      `Budget: 30k tokens, 15 min.`,
+  };
+}
+
+function canonJobSpec(canonCfg, timezone) {
+  const agent = canonCfg.coordinatorAgent;
+  return {
+    name: "fleet-canon",
+    description: `Nightly fleet canon synthesis after per-agent dreams. ${MANAGED_TAG}`,
+    agent,
+    cron: canonCfg.cron,
+    tz: timezone,
+    sessionKey: `agent:${agent}:canon`,
+    timeoutSeconds: canonCfg.timeoutSeconds ?? 1200,
+    message:
+      `FLEET CANON. Read ${path.join(VAULT_CONCEPTS_DIR, "fleet-canon-protocol.md")} ` +
+      `and follow it exactly. You are the fleet coordinator tonight. Read tonight's dream logs under ` +
+      `${path.join(HOME, ".openclaw", "wiki", "main", "dreams")}/*/<YYYY-MM-DD>.md (use today's local date), ` +
+      `then write the canon entry at ${path.join(HOME, ".openclaw", "wiki", "main", "canon")}/<YYYY-MM-DD>.md. ` +
+      `Work autonomously. Do not call external services. Budget: 50k tokens, 20 min.`,
+  };
+}
+
+function consolidationJobSpec(cfg, timezone) {
+  const agent = cfg.consolidatorAgent;
+  return {
+    name: "memory-consolidation",
+    description: `Nightly memory consolidation: prune duplicates, stage risky patches. ${MANAGED_TAG}`,
+    agent,
+    cron: cfg.cron,
+    tz: timezone,
+    sessionKey: `agent:${agent}:consolidation`,
+    timeoutSeconds: cfg.timeoutSeconds ?? 900,
+    message:
+      `CONSOLIDATION. Read ${path.join(VAULT_CONCEPTS_DIR, "memory-consolidation-protocol.md")} ` +
+      `and follow it exactly. You are the consolidator. Apply safe merges automatically, stage risky ones. ` +
+      `Write audit to ${path.join(HOME, ".openclaw", "wiki", "main", "dreams", "consolidation")}/<YYYY-MM-DD>.md ` +
+      `(use today's local date). Work autonomously. Budget: 40k tokens, 15 min.`,
+  };
+}
+
+function equivalent(existing, desired) {
+  if (!existing) {
+    return false;
+  }
+  const existingCron = existing.schedule?.expr ?? "";
+  const existingTz = existing.schedule?.tz ?? "";
+  const existingMsg = existing.payload?.message ?? "";
+  const existingTimeout = existing.payload?.timeoutSeconds ?? 0;
+  const existingDesc = existing.description ?? "";
+  return (
+    existing.agentId === desired.agent &&
+    existing.name === desired.name &&
+    existing.sessionKey === desired.sessionKey &&
+    existingCron === desired.cron &&
+    existingTz === desired.tz &&
+    existingMsg === desired.message &&
+    existingTimeout === desired.timeoutSeconds &&
+    existingDesc.includes(MANAGED_TAG)
+  );
+}
+
+async function listAllCronJobs() {
+  const stdout = await openclaw(["cron", "list", "--all", "--json"]);
+  const data = JSON.parse(stdout);
+  return Array.isArray(data) ? data : (data.jobs ?? []);
+}
+
+async function removeCronJob(id) {
+  await openclaw(["cron", "rm", id]);
+}
+
+async function addCronJob(spec) {
+  const args = [
+    "cron",
+    "add",
+    "--agent",
+    spec.agent,
+    "--name",
+    spec.name,
+    "--description",
+    spec.description,
+    "--cron",
+    spec.cron,
+    "--tz",
+    spec.tz,
+    "--session-key",
+    spec.sessionKey,
+    "--message",
+    spec.message,
+    "--timeout-seconds",
+    String(spec.timeoutSeconds),
+    "--wake",
+    "now",
+    "--light-context",
+    "--json",
+  ];
+  if (spec.model) {
+    args.push("--model", spec.model);
+  }
+  await openclaw(args);
+}
+
+// ─── Step 2+3: reconcile cron jobs ────────────────────────────────────
+
+async function reconcileCronJobs(config) {
+  const desiredSpecs = [
+    ...config.perAgent.map((a) => agentDreamJobSpec(a, config.timezone)),
+    canonJobSpec(config.canon, config.timezone),
+    consolidationJobSpec(config.consolidation, config.timezone),
+  ];
+  const desiredByName = new Map(desiredSpecs.map((s) => [s.name, s]));
+
+  const all = await listAllCronJobs();
+
+  // Candidates to consider as "ours": name matches one of ours OR description contains managed tag.
+  const ours = all.filter(
+    (j) => desiredByName.has(j.name) || (j.description ?? "").includes(MANAGED_TAG),
+  );
+
+  let added = 0;
+  let updated = 0;
+  let removed = 0;
+
+  // Remove duplicates and stale jobs
+  const seen = new Map(); // name -> first kept job
+  for (const job of ours) {
+    const desired = desiredByName.get(job.name);
+    if (!desired) {
+      console.log(`[reflective-dreaming] removing stale cron ${job.name} (${job.id})`);
+      await removeCronJob(job.id);
+      removed += 1;
+      continue;
+    }
+    if (seen.has(job.name)) {
+      console.log(`[reflective-dreaming] removing duplicate cron ${job.name} (${job.id})`);
+      await removeCronJob(job.id);
+      removed += 1;
+      continue;
+    }
+    seen.set(job.name, job);
+  }
+
+  // Add missing + update mismatched (delete+add for simplicity; cron edit API is patch-only)
+  for (const [name, desired] of desiredByName) {
+    const existing = seen.get(name);
+    if (!existing) {
+      console.log(`[reflective-dreaming] adding cron ${name}`);
+      await addCronJob(desired);
+      added += 1;
+      continue;
+    }
+    if (!equivalent(existing, desired)) {
+      console.log(`[reflective-dreaming] reconciling cron ${name} (was ${existing.id})`);
+      await removeCronJob(existing.id);
+      await addCronJob(desired);
+      updated += 1;
+    }
+  }
+
+  console.log(`[reflective-dreaming] cron: ${added} added, ${updated} updated, ${removed} removed`);
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────
+
+async function main() {
+  const configRaw = await fs.readFile(DEFAULTS_PATH, "utf8");
+  const config = JSON.parse(configRaw);
+  if (config.enabled === false) {
+    console.log("[reflective-dreaming] disabled in defaults — nothing to do.");
+    return;
+  }
+  await syncProtocolAssets();
+  await reconcileCronJobs(config);
+  console.log("[reflective-dreaming] install complete.");
+}
+
+main().catch((err) => {
+  console.error(`[reflective-dreaming] install failed: ${err.message ?? err}`);
+  process.exit(1);
+});

--- a/extensions/bench-reflective-dreaming/scripts/install.sh
+++ b/extensions/bench-reflective-dreaming/scripts/install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Bash wrapper around install.mjs. Use whichever you prefer.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+node "$SCRIPT_DIR/install.mjs" "$@"

--- a/extensions/bench-reflective-dreaming/scripts/uninstall.mjs
+++ b/extensions/bench-reflective-dreaming/scripts/uninstall.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * uninstall.mjs — Remove managed reflective-dreaming cron jobs.
+ *
+ * Leaves the protocol files in `~/.openclaw/wiki/main/concepts/` alone because
+ * they may have been rarity-approved in Firebase; removing them would create
+ * drift. Delete them manually if you're sure.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const MANAGED_TAG = "[managed-by=bench-reflective-dreaming]";
+
+async function openclaw(args) {
+  const { stdout } = await execFileAsync("openclaw", args, {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+async function main() {
+  const stdout = await openclaw(["cron", "list", "--all", "--json"]);
+  const data = JSON.parse(stdout);
+  const jobs = Array.isArray(data) ? data : (data.jobs ?? []);
+  const ours = jobs.filter((j) => (j.description ?? "").includes(MANAGED_TAG));
+
+  if (ours.length === 0) {
+    console.log("[reflective-dreaming] nothing to uninstall.");
+    return;
+  }
+
+  for (const job of ours) {
+    console.log(`[reflective-dreaming] removing ${job.name} (${job.id})`);
+    await openclaw(["cron", "rm", job.id]);
+  }
+
+  console.log(`[reflective-dreaming] uninstalled ${ours.length} cron job(s).`);
+  console.log(
+    "[reflective-dreaming] protocol files in ~/.openclaw/wiki/main/concepts/ are preserved.",
+  );
+}
+
+main().catch((err) => {
+  console.error(`[reflective-dreaming] uninstall failed: ${err.message ?? err}`);
+  process.exit(1);
+});

--- a/extensions/bench-reflective-dreaming/scripts/uninstall.sh
+++ b/extensions/bench-reflective-dreaming/scripts/uninstall.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+node "$SCRIPT_DIR/uninstall.mjs" "$@"

--- a/extensions/claude-code-bridge/README.md
+++ b/extensions/claude-code-bridge/README.md
@@ -1,0 +1,60 @@
+# claude-code-bridge
+
+Standalone MCP server that exposes OpenClaw (gateway, agents, memory wiki) as tools inside Claude Code sessions.
+
+## Architecture
+
+Three hand-authored ESM files, no build step, no openclaw plugin SDK dependency:
+
+| File             | Role                                                                                                                                                                       |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serve.mjs`      | Stdio MCP server. Registers 10 tools. Spawned by Claude Code via `mcpServers` config.                                                                                      |
+| `mirror.mjs`     | One-way mirror: copies `~/.claude/projects/*/memory/*.md` into `~/.openclaw/wiki/main/sources/claude-code-*.md` as bridge-style source pages. Run by launchd every 15 min. |
+| `statusline.mjs` | Fast (<100ms) filesystem-based status string for Claude Code's `statusLine` command. Never invokes the openclaw CLI.                                                       |
+
+All three files `import` from the openclaw fork's existing `node_modules` (`@modelcontextprotocol/sdk`, `zod`) — no extension-local install needed.
+
+## Why not a real OpenClaw extension?
+
+This directory previously contained TypeScript source (`index.ts`, `api.ts`, `src/*.ts`) + `openclaw.plugin.json` + `package.json`, intending to ship through the fork's `tsdown` build pipeline as a proper `definePluginEntry` extension. That approach was abandoned because:
+
+1. **Disk pressure (2026-04-17).** The fork's unified build stages multi-arch native binary dependencies for every plugin; ran out of space on a 99%-full Mac. See `feedback_disk_critical_180mb.md` in the user memory.
+2. **Chunk-hash coupling.** A built extension `index.js` references sibling chunks (e.g., `plugin-entry-XXXX.js`) whose hash changes between builds. The fork's dist and the homebrew install dir have different hashes, so an extension built in the fork can't be dropped into the install dir without rebuilding both in sync.
+3. **Phase A scope didn't need plugin SDK features.** We never called `registerGatewayMethod`, `registerMemoryCorpusSupplement`, or `registerMemoryPromptSupplement`. All the bridge needed was a CLI subcommand + MCP stdio server — both standalone-friendly.
+
+If/when this bridge graduates to a proper extension (e.g., for upstream PR or productization), bring back the TypeScript scaffold. Until then, keep the standalone pattern.
+
+## Deployment
+
+- **MCP registration**: user-scope `~/.claude.json`, added via `claude mcp add openclaw --scope user -- node /Users/coryshelton/clawd/openclaw/extensions/claude-code-bridge/serve.mjs`.
+- **Statusline**: `~/.claude/settings.json` → `statusLine.command`.
+- **Mirror schedule**: `~/Library/LaunchAgents/ai.openclaw.claude-code-mirror.plist` — `StartInterval 900` (every 15 min), plus once at load.
+
+## Tool surface (10 tools)
+
+All prefixed `openclaw_`:
+
+| Tool                | Wraps                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `gateway_health`    | `GET http://127.0.0.1:18789/healthz`                                                   |
+| `agent_list`        | gateway `agents.list` (plural — `agent.list` does not exist)                           |
+| `skill_list`        | gateway `skills.status`                                                                |
+| `wiki_search`       | gateway `wiki.search`                                                                  |
+| `wiki_get`          | gateway `wiki.get`                                                                     |
+| `wiki_inbox_append` | direct filesystem append to `~/.openclaw/wiki/main/inbox.md` (60 s dedup window)       |
+| `wiki_status`       | gateway `wiki.status`                                                                  |
+| `agent_handoff`     | gateway `sessions.create` (new session + initial brief, with heartbeat-window warning) |
+| `agent_send`        | gateway `sessions.send` (follow-up to existing sessionKey)                             |
+| `agent_messages`    | gateway `chat.history` (param is `sessionKey` not `key`)                               |
+
+## Operational gotchas
+
+- `openclaw gateway call` defaults its `--timeout` to 10000 ms — pass `--timeout` explicitly or calls >10 s fail with a misleading "gateway timeout" error.
+- `openclaw gateway call` takes ~5–20 s per invocation (process spawn + auth + call). Do not use in fast-rendering paths like the statusline.
+- Setting `OPENCLAW_GATEWAY_URL` in the openclaw child's env puts it into "URL override" mode that requires explicit `--token`. The bridge strips the env var before spawning openclaw. Keep it in the MCP server's own env only for the `/healthz` fetch.
+- The wiki indexer walks the filesystem directly (`extensions/memory-wiki/src/query.ts`), so mirror files in `sources/` are searchable without registering them in `source-sync.json`. Using a distinct prefix (`claude-code-*` vs `bridge-*`) keeps them safe from the agent-bridge prune step.
+
+## Related
+
+- User memory: `reference_openclaw_mcp_bridge.md` in `~/.claude/projects/<this-project>/memory/`
+- Plan: `~/.claude/plans/okay-so-i-just-deep-candle.md`

--- a/extensions/claude-code-bridge/ai.openclaw.wiki-mirror.plist.template
+++ b/extensions/claude-code-bridge/ai.openclaw.wiki-mirror.plist.template
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd plist template for the OpenClaw cloud-mirror daemon.
+
+  Installs a LaunchAgent that keeps cloud-mirror.mjs running in the
+  background so the local ~/.openclaw/wiki/main vault is mirrored to
+  benchagi.com in near-real-time.
+
+  INSTALL:
+    1. Copy this file to ~/Library/LaunchAgents/ai.openclaw.wiki-mirror.plist
+    2. Replace placeholders:
+         __HOME__           -> /Users/coryshelton (or your $HOME)
+         __NODE_BIN__       -> absolute path to node (likely /opt/homebrew/bin/node)
+         __INGEST_KEY__     -> super-admin API key pulled from 1Password
+       1Password CLI one-liner for the key:
+         op item get "Bench Wiki Ingest Key" --fields label=password
+    3. Load it:
+         launchctl unload ~/Library/LaunchAgents/ai.openclaw.wiki-mirror.plist 2>/dev/null
+         launchctl load   ~/Library/LaunchAgents/ai.openclaw.wiki-mirror.plist
+         launchctl list | grep ai.openclaw.wiki-mirror
+    4. Tail logs:
+         tail -f ~/.openclaw/logs/wiki-mirror.log
+
+  REMOVE:
+    launchctl unload ~/Library/LaunchAgents/ai.openclaw.wiki-mirror.plist
+    rm ~/Library/LaunchAgents/ai.openclaw.wiki-mirror.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.openclaw.wiki-mirror</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NODE_BIN__</string>
+        <string>__HOME__/clawd/openclaw/extensions/claude-code-bridge/cloud-mirror.mjs</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>BENCH_WIKI_INGEST_URL</key>
+        <string>https://benchagi.com/api/v1/wiki/ingest</string>
+        <key>BENCH_WIKI_INGEST_KEY</key>
+        <string>__INGEST_KEY__</string>
+        <key>BENCH_WIKI_MIRROR_DEBOUNCE_MS</key>
+        <string>2000</string>
+        <key>BENCH_WIKI_MIRROR_BATCH_SIZE</key>
+        <string>50</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.openclaw/logs/wiki-mirror.stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.openclaw/logs/wiki-mirror.stderr.log</string>
+
+    <key>WorkingDirectory</key>
+    <string>__HOME__/.openclaw</string>
+</dict>
+</plist>

--- a/extensions/claude-code-bridge/cloud-mirror.mjs
+++ b/extensions/claude-code-bridge/cloud-mirror.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+// Cloud mirror daemon: pushes local OpenClaw wiki deltas to benchagi.com.
+//
+// Direction is one-way (local vault -> cloud). The local filesystem at
+// ~/.openclaw/wiki/main/ stays authoritative. This daemon watches for
+// changes, computes per-file content hashes, and POSTs deltas to the
+// /api/v1/wiki/ingest endpoint in the Bench web app.
+//
+// The cloud mirror is a READ-ONLY copy from the daemon's perspective —
+// all approval, rarity-tagging, and harness-manifest publication happen
+// via super-admin UI on benchagi.com. The daemon never reads remote state
+// back into the local vault.
+//
+// Env vars:
+//   BENCH_WIKI_INGEST_URL    - Override the ingest endpoint (default: https://benchagi.com/api/v1/wiki/ingest)
+//   BENCH_WIKI_INGEST_KEY    - Required API key (super-admin scope) for X-API-Key auth
+//   BENCH_WIKI_MIRROR_DEBOUNCE_MS  - Debounce window (default: 2000)
+//   BENCH_WIKI_MIRROR_BATCH_SIZE   - Entries per POST (default: 50)
+//
+// State file: ~/.openclaw/state/wiki-mirror.json — tracks per-slug localHash
+//   so we only POST when content actually changed.
+//
+// Log file: ~/.openclaw/logs/wiki-mirror.log — captured by existing
+//   ai.openclaw.log-rotator service (03:00 daily rotation).
+
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { watch } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const HOME = os.homedir();
+const VAULT_DIR = path.join(HOME, ".openclaw", "wiki", "main");
+const STATE_DIR = path.join(HOME, ".openclaw", "state");
+const STATE_PATH = path.join(STATE_DIR, "wiki-mirror.json");
+const LOG_DIR = path.join(HOME, ".openclaw", "logs");
+const LOG_PATH = path.join(LOG_DIR, "wiki-mirror.log");
+
+const INGEST_URL = process.env.BENCH_WIKI_INGEST_URL ?? "https://benchagi.com/api/v1/wiki/ingest";
+const INGEST_KEY = process.env.BENCH_WIKI_INGEST_KEY ?? "";
+const DEBOUNCE_MS = Number(process.env.BENCH_WIKI_MIRROR_DEBOUNCE_MS ?? "2000");
+const BATCH_SIZE = Number(process.env.BENCH_WIKI_MIRROR_BATCH_SIZE ?? "50");
+const MAX_MARKDOWN_BYTES = 512 * 1024;
+
+// ─── Logging ─────────────────────────────────────────────────────────
+
+async function log(level, message, extra = undefined) {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    message,
+    ...(extra ? { extra } : {}),
+  });
+  await fs.mkdir(LOG_DIR, { recursive: true }).catch(() => {});
+  await fs.appendFile(LOG_PATH, line + "\n").catch(() => {});
+  if (level === "error" || level === "warn") {
+    process.stderr.write(line + "\n");
+  } else {
+    process.stdout.write(line + "\n");
+  }
+}
+
+// ─── Frontmatter parsing (lightweight, no external dep) ──────────────
+
+function parseFrontmatter(source) {
+  if (!source.startsWith("---\n")) {
+    return { frontmatter: {}, body: source };
+  }
+  const end = source.indexOf("\n---\n", 4);
+  if (end === -1) {
+    return { frontmatter: {}, body: source };
+  }
+  const raw = source.slice(4, end);
+  const body = source.slice(end + 5);
+  const frontmatter = {};
+  for (const line of raw.split("\n")) {
+    const colon = line.indexOf(":");
+    if (colon === -1) {
+      continue;
+    }
+    const key = line.slice(0, colon).trim();
+    let value = line.slice(colon + 1).trim();
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1);
+    }
+    if (!key) {
+      continue;
+    }
+    frontmatter[key] = value;
+  }
+  return { frontmatter, body };
+}
+
+// ─── State ───────────────────────────────────────────────────────────
+
+async function loadState() {
+  try {
+    const raw = await fs.readFile(STATE_PATH, "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return { hashes: {} };
+  }
+}
+
+async function saveState(state) {
+  await fs.mkdir(STATE_DIR, { recursive: true });
+  await fs.writeFile(STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+// ─── Walk vault ──────────────────────────────────────────────────────
+
+async function* walkMarkdown(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip internal bookkeeping dirs — they're locks/state, not content.
+      if (entry.name.startsWith(".")) {
+        continue;
+      }
+      yield* walkMarkdown(p);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      yield p;
+    }
+  }
+}
+
+function slugFromPath(absPath) {
+  const rel = path.relative(VAULT_DIR, absPath);
+  // Strip .md extension. Flatten subdirectories into the slug via '__' so
+  // the slug maps 1:1 to a Firestore document ID (which cannot contain '/').
+  // The original path is preserved separately in sourcePath for humans.
+  return rel.replace(/\\/g, "/").replace(/\.md$/, "").replace(/\//g, "__");
+}
+
+// ─── Scan + diff ─────────────────────────────────────────────────────
+
+async function scanEntries(state) {
+  const changed = [];
+  let skippedTooLarge = 0;
+
+  for await (const absPath of walkMarkdown(VAULT_DIR)) {
+    const stat = await fs.stat(absPath);
+    if (stat.size > MAX_MARKDOWN_BYTES) {
+      skippedTooLarge += 1;
+      continue;
+    }
+    const raw = await fs.readFile(absPath, "utf8");
+    const { frontmatter, body } = parseFrontmatter(raw);
+    const slug = slugFromPath(absPath);
+    const localHash = createHash("sha256").update(raw).digest("hex");
+
+    if (state.hashes[slug] === localHash) {
+      continue;
+    }
+
+    const title =
+      (typeof frontmatter.title === "string" && frontmatter.title) ||
+      body.match(/^#\s+(.+)$/m)?.[1]?.trim() ||
+      slug;
+
+    changed.push({
+      slug,
+      title,
+      markdown: body,
+      frontmatter,
+      localHash,
+      localMtime: stat.mtime.toISOString(),
+      sourcePath: path.relative(path.dirname(VAULT_DIR), absPath),
+    });
+  }
+
+  return { changed, skippedTooLarge };
+}
+
+// ─── POST in batches ─────────────────────────────────────────────────
+
+async function postBatch(entries) {
+  const res = await fetch(INGEST_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": INGEST_KEY,
+    },
+    body: JSON.stringify({ entries }),
+  });
+  const text = await res.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = { raw: text };
+  }
+  if (!res.ok) {
+    const err = new Error(`Ingest failed (${res.status})`);
+    err.body = body;
+    throw err;
+  }
+  return body;
+}
+
+async function syncOnce() {
+  if (!INGEST_KEY) {
+    await log("error", "BENCH_WIKI_INGEST_KEY not set — skipping sync");
+    return;
+  }
+
+  const state = await loadState();
+  const { changed, skippedTooLarge } = await scanEntries(state);
+
+  if (changed.length === 0) {
+    await log("info", "no changes", { skippedTooLarge });
+    return;
+  }
+
+  await log("info", "syncing", { count: changed.length, skippedTooLarge });
+
+  for (let i = 0; i < changed.length; i += BATCH_SIZE) {
+    const batch = changed.slice(i, i + BATCH_SIZE);
+    try {
+      const result = await postBatch(batch);
+      // Persist hashes only for slugs that the server acknowledged without
+      // a parse error. If an entry was rejected we want to retry it later.
+      const ack = new Set((result.results ?? []).map((r) => r.slug));
+      for (const entry of batch) {
+        if (ack.has(entry.slug)) {
+          state.hashes[entry.slug] = entry.localHash;
+        }
+      }
+      await log("info", "batch ok", {
+        posted: batch.length,
+        ingested: result.ingested,
+        acknowledged: ack.size,
+      });
+    } catch (err) {
+      await log("error", "batch failed", {
+        count: batch.length,
+        error: err.message ?? String(err),
+        body: err.body,
+      });
+      // Keep state unchanged so the next run retries.
+      break;
+    }
+  }
+
+  await saveState(state);
+}
+
+// ─── Watcher ─────────────────────────────────────────────────────────
+
+function startWatcher() {
+  let pending = null;
+
+  const schedule = () => {
+    if (pending) {
+      clearTimeout(pending);
+    }
+    pending = setTimeout(async () => {
+      pending = null;
+      try {
+        await syncOnce();
+      } catch (err) {
+        await log("error", "sync crashed", { error: err.message ?? String(err) });
+      }
+    }, DEBOUNCE_MS);
+  };
+
+  try {
+    watch(VAULT_DIR, { recursive: true }, (_event, filename) => {
+      if (!filename || !filename.endsWith(".md")) {
+        return;
+      }
+      schedule();
+    });
+  } catch (err) {
+    void log("warn", "recursive watch unsupported — falling back to interval poll", {
+      error: err.message ?? String(err),
+    });
+    setInterval(schedule, 30_000);
+  }
+
+  // Kick off an initial sync on startup (catches anything changed while we
+  // were stopped).
+  schedule();
+}
+
+// ─── Main ────────────────────────────────────────────────────────────
+
+(async () => {
+  await log("info", "cloud-mirror starting", {
+    vault: VAULT_DIR,
+    ingestUrl: INGEST_URL,
+    hasKey: Boolean(INGEST_KEY),
+  });
+  startWatcher();
+})().catch(async (err) => {
+  await log("error", "fatal startup error", { error: err.message ?? String(err) });
+  process.exit(1);
+});

--- a/extensions/claude-code-bridge/mirror.mjs
+++ b/extensions/claude-code-bridge/mirror.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+// Periodic mirror: copies Claude Code's per-project auto-memory files into
+// the OpenClaw wiki vault as bridge-style source pages, so Aurelius and the
+// rest of the crew can absorb them on the next dream cycle.
+//
+// Direction is one-way (Claude Code -> wiki). Reads still happen on demand
+// via openclaw_wiki_search/_get from inside Claude Code. Phase B of the
+// workshop unification plan.
+//
+// Why we don't touch source-sync.json:
+//   The bridge's `pruneImportedSourceEntries` only removes entries whose
+//   `group` matches "bridge" or "unsafe-local". Files on disk that aren't
+//   in state.entries are never pruned by it. The wiki indexer walks the
+//   sources/ directory directly (extensions/memory-wiki/src/query.ts:102),
+//   so our files are searchable without registration.
+//
+// File naming: `claude-code-<project-slug>-<file-slug>.md`
+//   - Distinct prefix avoids collision with `bridge-<agent>-*.md`
+//   - Deterministic (no random hash) so re-runs replace cleanly
+
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const HOME = os.homedir();
+const PROJECTS_DIR = path.join(HOME, ".claude", "projects");
+const VAULT_DIR = path.join(HOME, ".openclaw", "wiki", "main");
+const SOURCES_DIR = path.join(VAULT_DIR, "sources");
+const LOCK_PATH = path.join(VAULT_DIR, ".openclaw-wiki", "locks", "claude-code-mirror.lock");
+const LOG_PATH = path.join(HOME, ".openclaw", "logs", "claude-code-mirror.log");
+const FILE_PREFIX = "claude-code-";
+
+const MAX_FILE_BYTES = 256 * 1024; // skip giant memory files
+const STALE_LOCK_MS = 5 * 60_000;
+
+function slugify(value, max = 60) {
+  const lower = value.toLowerCase();
+  const cleaned = lower.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  if (cleaned.length <= max) {
+    return cleaned || "x";
+  }
+  // truncate but keep an 8-char hash suffix for uniqueness
+  const hash = createHash("sha256").update(value).digest("hex").slice(0, 8);
+  return `${cleaned.slice(0, max - 9)}-${hash}`;
+}
+
+function decodeProjectName(rawDirName) {
+  // Claude Code encodes the cwd as "-Users-coryshelton-..." (slashes -> dashes,
+  // leading slash dropped). Reverse it for display, but keep the raw name as
+  // the project key (it's stable and unambiguous).
+  if (rawDirName.startsWith("-")) {
+    return rawDirName.slice(1).replace(/-/g, "/");
+  }
+  return rawDirName;
+}
+
+async function listProjects() {
+  const entries = await fs.readdir(PROJECTS_DIR, { withFileTypes: true }).catch(() => []);
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}
+
+async function listProjectMemoryFiles(projectDirName) {
+  const memoryDir = path.join(PROJECTS_DIR, projectDirName, "memory");
+  const entries = await fs.readdir(memoryDir, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith(".md"))
+    .map((e) => ({
+      absolutePath: path.join(memoryDir, e.name),
+      relativeName: e.name,
+    }));
+}
+
+function buildPagePath(projectDirName, fileName) {
+  const projectSlug = slugify(projectDirName, 60);
+  const fileSlug = slugify(fileName.replace(/\.md$/, ""), 40);
+  return path.join("sources", `${FILE_PREFIX}${projectSlug}-${fileSlug}.md`);
+}
+
+function buildPageId(projectDirName, fileName) {
+  const projectHash = createHash("sha256").update(projectDirName).digest("hex").slice(0, 8);
+  const fileHash = createHash("sha256").update(fileName).digest("hex").slice(0, 8);
+  return `source.claude-code.${projectHash}.${fileName.replace(/\.md$/, "")}-${fileHash}`;
+}
+
+function renderSourcePage({ projectDirName, fileName, absolutePath, content, sourceUpdatedAtMs }) {
+  const projectDecoded = decodeProjectName(projectDirName);
+  const id = buildPageId(projectDirName, fileName);
+  const title = `Claude Code Memory (${path.basename(projectDecoded)}): ${fileName.replace(/\.md$/, "")}`;
+  const updatedIso = new Date(sourceUpdatedAtMs).toISOString();
+
+  const frontmatter = [
+    "---",
+    "pageType: source",
+    `id: ${id}`,
+    `title: ${JSON.stringify(title)}`,
+    "sourceType: memory-bridge",
+    `sourcePath: ${absolutePath}`,
+    `bridgeRelativePath: ${fileName}`,
+    `bridgeWorkspaceDir: ${path.dirname(absolutePath)}`,
+    "bridgeAgentIds:",
+    "  - claude-code",
+    "status: active",
+    `updatedAt: ${updatedIso}`,
+    "---",
+    "",
+  ].join("\n");
+
+  const meta = [
+    `# ${title}`,
+    "",
+    "## Bridge Source",
+    `- Workspace: \`${path.dirname(absolutePath)}\``,
+    `- Project (decoded): \`${projectDecoded}\``,
+    `- Relative path: \`${fileName}\``,
+    `- Kind: \`markdown\``,
+    `- Agents: claude-code`,
+    `- Updated: ${updatedIso}`,
+    "",
+    "## Content",
+    "```markdown",
+    content,
+    "```",
+    "",
+  ].join("\n");
+
+  return frontmatter + meta;
+}
+
+function fingerprint(text) {
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+async function readMaybe(p) {
+  try {
+    return await fs.readFile(p, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function acquireLock() {
+  await fs.mkdir(path.dirname(LOCK_PATH), { recursive: true });
+  try {
+    await fs.writeFile(LOCK_PATH, JSON.stringify({ pid: process.pid, at: Date.now() }), {
+      flag: "wx",
+    });
+    return true;
+  } catch (err) {
+    if (err.code !== "EEXIST") {
+      throw err;
+    }
+    // Lock exists — check if it's stale
+    try {
+      const raw = await fs.readFile(LOCK_PATH, "utf8");
+      const parsed = JSON.parse(raw);
+      if (typeof parsed.at === "number" && Date.now() - parsed.at < STALE_LOCK_MS) {
+        return false;
+      }
+    } catch {
+      // unparseable lock file — treat as stale
+    }
+    await fs.rm(LOCK_PATH, { force: true });
+    return acquireLock();
+  }
+}
+
+async function releaseLock() {
+  await fs.rm(LOCK_PATH, { force: true });
+}
+
+async function appendLog(line) {
+  try {
+    await fs.mkdir(path.dirname(LOG_PATH), { recursive: true });
+    const entry = `${new Date().toISOString()} ${line}\n`;
+    await fs.appendFile(LOG_PATH, entry, "utf8");
+  } catch {
+    // logging is best-effort
+  }
+}
+
+async function atomicWrite(absolutePath, content) {
+  const tmpPath = `${absolutePath}.tmp-${process.pid}-${Date.now()}`;
+  await fs.writeFile(tmpPath, content, "utf8");
+  await fs.rename(tmpPath, absolutePath);
+}
+
+async function listOurExistingPages() {
+  const entries = await fs.readdir(SOURCES_DIR, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((e) => e.isFile() && e.name.startsWith(FILE_PREFIX) && e.name.endsWith(".md"))
+    .map((e) => e.name);
+}
+
+async function runMirror({ dryRun = false } = {}) {
+  await fs.mkdir(SOURCES_DIR, { recursive: true });
+  const desiredPages = new Set();
+  let mirrored = 0;
+  let unchanged = 0;
+  let skipped = 0;
+
+  const projects = await listProjects();
+  for (const projectDirName of projects) {
+    const memFiles = await listProjectMemoryFiles(projectDirName);
+    for (const file of memFiles) {
+      let stat;
+      try {
+        stat = await fs.stat(file.absolutePath);
+      } catch {
+        continue;
+      }
+      if (stat.size === 0 || stat.size > MAX_FILE_BYTES) {
+        skipped += 1;
+        continue;
+      }
+      const content = await readMaybe(file.absolutePath);
+      if (content === null || content.trim().length === 0) {
+        skipped += 1;
+        continue;
+      }
+      const pagePath = buildPagePath(projectDirName, file.relativeName);
+      const pageAbs = path.join(VAULT_DIR, pagePath);
+      desiredPages.add(path.basename(pagePath));
+
+      const rendered = renderSourcePage({
+        projectDirName,
+        fileName: file.relativeName,
+        absolutePath: file.absolutePath,
+        content,
+        sourceUpdatedAtMs: stat.mtimeMs,
+      });
+
+      const existing = await readMaybe(pageAbs);
+      if (existing !== null && fingerprint(existing) === fingerprint(rendered)) {
+        unchanged += 1;
+        continue;
+      }
+      if (dryRun) {
+        mirrored += 1;
+        continue;
+      }
+      await atomicWrite(pageAbs, rendered);
+      mirrored += 1;
+    }
+  }
+
+  // Prune our orphans (files we own that no longer have a source)
+  let pruned = 0;
+  const ourPages = await listOurExistingPages();
+  for (const pageName of ourPages) {
+    if (desiredPages.has(pageName)) {
+      continue;
+    }
+    if (dryRun) {
+      pruned += 1;
+      continue;
+    }
+    await fs.rm(path.join(SOURCES_DIR, pageName), { force: true });
+    pruned += 1;
+  }
+
+  return { mirrored, unchanged, skipped, pruned, scannedProjects: projects.length };
+}
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const verbose = args.has("--verbose") || args.has("-v");
+const force = args.has("--force");
+
+if (!force) {
+  const got = await acquireLock();
+  if (!got) {
+    if (verbose) {
+      process.stdout.write("another mirror run is in progress; exiting\n");
+    }
+    process.exit(0);
+  }
+}
+
+let result;
+let error = null;
+try {
+  result = await runMirror({ dryRun });
+} catch (e) {
+  error = e;
+} finally {
+  if (!force) {
+    await releaseLock().catch(() => undefined);
+  }
+}
+
+if (error) {
+  await appendLog(`ERROR ${error.stack ?? error.message}`);
+  process.stderr.write(`mirror error: ${error.message}\n`);
+  process.exit(1);
+}
+
+const summary = `mirrored=${result.mirrored} unchanged=${result.unchanged} skipped=${result.skipped} pruned=${result.pruned} projects=${result.scannedProjects}${dryRun ? " (dry-run)" : ""}`;
+await appendLog(summary);
+if (verbose || dryRun) {
+  process.stdout.write(summary + "\n");
+}
+process.exit(0);

--- a/extensions/claude-code-bridge/serve.mjs
+++ b/extensions/claude-code-bridge/serve.mjs
@@ -1,0 +1,791 @@
+#!/usr/bin/env node
+// Standalone MCP bridge server. Hand-bundled as a single ESM file so it can
+// run directly via `node serve.mjs` without going through the openclaw build
+// pipeline. Mirrors the logic in src/mcp-server.ts; keep them in sync.
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+// -- Gateway client --------------------------------------------------------
+
+const DEFAULT_GATEWAY_URL = process.env.OPENCLAW_GATEWAY_URL ?? "http://127.0.0.1:18789";
+const DEFAULT_AUTOSTART = process.env.OPENCLAW_BRIDGE_AUTOSTART !== "false";
+const DEFAULT_WARMUP_S = Number(process.env.OPENCLAW_BRIDGE_WARMUP_SECONDS ?? "5");
+const DEFAULT_OPENCLAW_BIN = process.env.OPENCLAW_BIN ?? "openclaw";
+
+// -- Bench Harness Manifest (opt-in) ---------------------------------------
+// When BENCH_HARNESS_MANIFEST_ENFORCE=true, wiki.search / wiki.get responses
+// are filtered through the approved-slug allowlist published by the super-admin
+// at benchagi.com/api/v1/admin/harness/manifest. Default off — behavior
+// unchanged for anyone who hasn't opted in.
+
+const HARNESS_MANIFEST_ENFORCE = process.env.BENCH_HARNESS_MANIFEST_ENFORCE === "true";
+const HARNESS_MANIFEST_URL =
+  process.env.BENCH_HARNESS_MANIFEST_URL ?? "https://benchagi.com/api/v1/admin/harness/manifest";
+const HARNESS_MANIFEST_KEY = process.env.BENCH_HARNESS_MANIFEST_KEY ?? "";
+const HARNESS_MANIFEST_CEILING = process.env.BENCH_HARNESS_MANIFEST_CEILING ?? "orange";
+const HARNESS_MANIFEST_REFRESH_MS = Number(
+  process.env.BENCH_HARNESS_MANIFEST_REFRESH_MS ?? "300000",
+);
+
+let harnessAllowedSlugs = null; // null = unknown/no-manifest → fail open; Set → enforce
+let harnessManifestVersion = 0;
+let harnessManifestRefreshTimer = null;
+
+function normalizeWikiPath(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  return value.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\.md$/i, "");
+}
+
+async function fetchHarnessManifest() {
+  if (!HARNESS_MANIFEST_ENFORCE) {
+    return;
+  }
+  try {
+    const url = new URL(HARNESS_MANIFEST_URL);
+    url.searchParams.set("rarityCeiling", HARNESS_MANIFEST_CEILING);
+    const headers = { Accept: "application/json" };
+    if (HARNESS_MANIFEST_KEY) {
+      headers["X-API-Key"] = HARNESS_MANIFEST_KEY;
+    }
+    const res = await fetch(url, {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      process.stderr.write(`[harness-manifest] fetch ${res.status}: ${res.statusText}\n`);
+      return;
+    }
+    const body = await res.json();
+    const slugs = new Set();
+    if (Array.isArray(body?.entries)) {
+      for (const entry of body.entries) {
+        const norm = normalizeWikiPath(entry?.slug);
+        if (norm) {
+          slugs.add(norm);
+        }
+      }
+    } else if (Array.isArray(body?.manifest?.approvedSlugs)) {
+      for (const slug of body.manifest.approvedSlugs) {
+        const norm = normalizeWikiPath(slug);
+        if (norm) {
+          slugs.add(norm);
+        }
+      }
+    }
+    harnessAllowedSlugs = slugs;
+    harnessManifestVersion =
+      typeof body?.manifest?.manifestVersion === "number" ? body.manifest.manifestVersion : 0;
+    process.stderr.write(
+      `[harness-manifest] loaded v${harnessManifestVersion} with ${slugs.size} approved slugs (ceiling=${HARNESS_MANIFEST_CEILING})\n`,
+    );
+  } catch (err) {
+    process.stderr.write(`[harness-manifest] fetch error: ${err?.message ?? String(err)}\n`);
+  }
+}
+
+function scheduleHarnessManifestRefresh() {
+  if (!HARNESS_MANIFEST_ENFORCE) {
+    return;
+  }
+  if (harnessManifestRefreshTimer) {
+    clearInterval(harnessManifestRefreshTimer);
+  }
+  harnessManifestRefreshTimer = setInterval(() => {
+    void fetchHarnessManifest();
+  }, HARNESS_MANIFEST_REFRESH_MS);
+  harnessManifestRefreshTimer.unref?.();
+}
+
+function isHarnessAllowedSlug(value) {
+  if (!HARNESS_MANIFEST_ENFORCE) {
+    return true;
+  } // not enforcing
+  if (harnessAllowedSlugs === null) {
+    return true;
+  } // manifest not loaded yet — fail open
+  const norm = normalizeWikiPath(value);
+  if (!norm) {
+    return false;
+  }
+  if (harnessAllowedSlugs.has(norm)) {
+    return true;
+  }
+  // Tolerate nested paths: a slug "inbox/foo" should match a lookup of
+  // "inbox/foo.md" (already stripped) or the title embedded in a path.
+  for (const allowed of harnessAllowedSlugs) {
+    if (norm === allowed || norm.endsWith(`/${allowed}`) || allowed.endsWith(`/${norm}`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function filterSearchResultByManifest(payload) {
+  if (!HARNESS_MANIFEST_ENFORCE || harnessAllowedSlugs === null) {
+    return payload;
+  }
+  if (!payload || typeof payload !== "object") {
+    return payload;
+  }
+  const data = payload.data ?? payload;
+  if (!data || typeof data !== "object") {
+    return payload;
+  }
+  const results = Array.isArray(data.results)
+    ? data.results
+    : Array.isArray(data.matches)
+      ? data.matches
+      : Array.isArray(data.items)
+        ? data.items
+        : null;
+  if (!results) {
+    return payload;
+  }
+
+  let filteredCount = 0;
+  const filtered = results.filter((row) => {
+    const candidate = row?.path ?? row?.slug ?? row?.title ?? row?.lookup ?? row?.id ?? null;
+    const allowed = isHarnessAllowedSlug(candidate);
+    if (!allowed) {
+      filteredCount += 1;
+    }
+    return allowed;
+  });
+
+  if (filteredCount === 0) {
+    return payload;
+  }
+
+  const next = { ...data };
+  if (Array.isArray(data.results)) {
+    next.results = filtered;
+  }
+  if (Array.isArray(data.matches)) {
+    next.matches = filtered;
+  }
+  if (Array.isArray(data.items)) {
+    next.items = filtered;
+  }
+  next._harnessManifest = {
+    version: harnessManifestVersion,
+    filteredOut: filteredCount,
+    ceiling: HARNESS_MANIFEST_CEILING,
+  };
+
+  return payload.data !== undefined ? { ...payload, data: next } : next;
+}
+
+async function fetchGatewayHealth() {
+  try {
+    const res = await fetch(new URL("/healthz", DEFAULT_GATEWAY_URL), {
+      method: "GET",
+      signal: AbortSignal.timeout(2_000),
+    });
+    if (!res.ok) {
+      return { up: false };
+    }
+    const body = await res.json().catch(() => null);
+    if (!body) {
+      return { up: true };
+    }
+    return {
+      up: true,
+      agents: typeof body.agents === "number" ? body.agents : undefined,
+      version: typeof body.version === "string" ? body.version : undefined,
+      raw: body,
+    };
+  } catch {
+    return { up: false };
+  }
+}
+
+async function ensureGatewayUp() {
+  const initial = await fetchGatewayHealth();
+  if (initial.up || !DEFAULT_AUTOSTART) {
+    return initial;
+  }
+  spawnDetached(DEFAULT_OPENCLAW_BIN, ["gateway", "start", "--detach"]);
+  const deadline = Date.now() + DEFAULT_WARMUP_S * 1_000;
+  while (Date.now() < deadline) {
+    await delay(500);
+    const probe = await fetchGatewayHealth();
+    if (probe.up) {
+      return probe;
+    }
+  }
+  return { up: false };
+}
+
+async function callGatewayMethod(method, params, opts = {}) {
+  // openclaw CLI's own timeout defaults to 10s — pass --timeout so it matches
+  // our wrapper budget (minus 2s buffer so openclaw can exit cleanly before
+  // our hard kill).
+  const wrapperTimeoutMs = opts.timeoutMs ?? 15_000;
+  const innerTimeoutMs = Math.max(2_000, wrapperTimeoutMs - 2_000);
+  const args = ["gateway", "call", method, "--json", "--timeout", String(innerTimeoutMs)];
+  if (opts.expectFinal) {
+    args.push("--expect-final");
+  }
+  if (params !== undefined) {
+    args.push("--params", JSON.stringify(params));
+  }
+  // Strip OPENCLAW_GATEWAY_URL so openclaw uses its local config + bundled
+  // bearer token. Setting --url puts the CLI into "explicit credentials
+  // required" mode, which we'd then have to satisfy by reading the token
+  // out of openclaw.json ourselves.
+  const childEnv = { ...process.env };
+  delete childEnv.OPENCLAW_GATEWAY_URL;
+  const res = await runCommand(DEFAULT_OPENCLAW_BIN, args, {
+    timeoutMs: wrapperTimeoutMs,
+    env: childEnv,
+  });
+  if (res.exitCode !== 0) {
+    return {
+      ok: false,
+      error: res.stderr.trim() || `openclaw exited with code ${res.exitCode}`,
+      exitCode: res.exitCode,
+      stderr: res.stderr,
+    };
+  }
+  const trimmed = res.stdout.trim();
+  if (trimmed.length === 0) {
+    return { ok: true, data: null, exitCode: 0, stderr: res.stderr };
+  }
+  try {
+    return { ok: true, data: JSON.parse(trimmed), exitCode: 0, stderr: res.stderr };
+  } catch {
+    return { ok: true, data: trimmed, exitCode: 0, stderr: res.stderr };
+  }
+}
+
+function runCommand(command, args, opts) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: opts.env ?? process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.kill("SIGKILL");
+      resolve({ exitCode: 124, stdout, stderr: stderr + `\n[timeout after ${opts.timeoutMs}ms]` });
+    }, opts.timeoutMs);
+    child.stdout.on("data", (c) => (stdout += c.toString("utf8")));
+    child.stderr.on("data", (c) => (stderr += c.toString("utf8")));
+    child.on("error", (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode: 127, stdout, stderr: stderr + `\n[spawn error: ${err.message}]` });
+    });
+    child.on("exit", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function spawnDetached(command, args) {
+  try {
+    const child = spawn(command, args, { detached: true, stdio: "ignore" });
+    child.unref();
+  } catch {
+    // swallow — caller polls health, that's the source of truth
+  }
+}
+
+// -- Inbox -----------------------------------------------------------------
+
+const INBOX_PATH =
+  process.env.OPENCLAW_BRIDGE_INBOX_PATH ??
+  path.join(os.homedir(), ".openclaw", "wiki", "main", "inbox.md");
+const DEDUPE_WINDOW_MS = Number(process.env.OPENCLAW_BRIDGE_DEDUPE_WINDOW_S ?? "60") * 1_000;
+const recentAppends = new Map();
+
+async function appendToInbox({ note, source = "claude-code", tags = [], sessionId = "anonymous" }) {
+  const trimmed = note.trim();
+  if (trimmed.length === 0) {
+    throw new Error("inbox.append: note must be non-empty");
+  }
+  const dedupeKey = `${sessionId}:${createHash("sha256").update(trimmed).digest("hex")}`;
+  const now = Date.now();
+  for (const [k, e] of recentAppends) {
+    if (now - e.appendedAt > DEDUPE_WINDOW_MS * 4) {
+      recentAppends.delete(k);
+    }
+  }
+  const existing = recentAppends.get(dedupeKey);
+  if (existing && now - existing.appendedAt < DEDUPE_WINDOW_MS) {
+    return {
+      ok: true,
+      path: INBOX_PATH,
+      byteOffset: -1,
+      byteLength: 0,
+      dedupedFrom: {
+        sessionId: existing.sessionId,
+        appendedAt: new Date(existing.appendedAt).toISOString(),
+      },
+    };
+  }
+  const ts = new Date(now).toISOString();
+  const tagsLine = tags.length > 0 ? `\n[tags: ${tags.join(", ")}]` : "";
+  const block = `\n## ${ts} — ${source} (session: ${sessionId})\n${trimmed}${tagsLine}\n---\n`;
+  await fs.mkdir(path.dirname(INBOX_PATH), { recursive: true });
+  const handle = await fs.open(INBOX_PATH, "a");
+  let offset;
+  try {
+    const stat = await handle.stat();
+    offset = stat.size;
+    await handle.appendFile(block, "utf8");
+  } finally {
+    await handle.close();
+  }
+  recentAppends.set(dedupeKey, { appendedAt: now, sessionId });
+  return {
+    ok: true,
+    path: INBOX_PATH,
+    byteOffset: offset,
+    byteLength: Buffer.byteLength(block, "utf8"),
+  };
+}
+
+// -- Heartbeat awareness ---------------------------------------------------
+// Check if a target agent is within its scheduled active hours. The check is
+// advisory: agents will respond to user-initiated messages outside their
+// heartbeat window, but the wake-up may incur unexpected model cost.
+
+import { promises as fsPromises } from "node:fs";
+
+const OPENCLAW_HOME = process.env.OPENCLAW_HOME ?? path.join(os.homedir(), ".openclaw");
+const OPENCLAW_CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
+
+let cachedAgentSchedules = null;
+let cachedAgentSchedulesAt = 0;
+const AGENT_SCHEDULES_TTL_MS = 60_000;
+
+async function loadAgentSchedules() {
+  if (cachedAgentSchedules && Date.now() - cachedAgentSchedulesAt < AGENT_SCHEDULES_TTL_MS) {
+    return cachedAgentSchedules;
+  }
+  try {
+    const raw = await fsPromises.readFile(OPENCLAW_CONFIG_PATH, "utf8");
+    const cfg = JSON.parse(raw);
+    const list = Array.isArray(cfg?.agents?.list) ? cfg.agents.list : [];
+    const map = new Map();
+    for (const a of list) {
+      if (typeof a?.id !== "string") {
+        continue;
+      }
+      const hb = a.heartbeat ?? {};
+      const ah = hb.activeHours ?? {};
+      map.set(a.id, {
+        agentId: a.id,
+        defaultAgent: Boolean(a.default),
+        identityName: a?.identity?.name,
+        activeStart: typeof ah.start === "string" ? ah.start : null,
+        activeEnd: typeof ah.end === "string" ? ah.end : null,
+        timezone: typeof ah.timezone === "string" ? ah.timezone : "America/Denver",
+      });
+    }
+    cachedAgentSchedules = map;
+    cachedAgentSchedulesAt = Date.now();
+    return map;
+  } catch {
+    cachedAgentSchedules = new Map();
+    cachedAgentSchedulesAt = Date.now();
+    return cachedAgentSchedules;
+  }
+}
+
+function checkHeartbeatWindow(schedule) {
+  if (!schedule || !schedule.activeStart || !schedule.activeEnd) {
+    return { inWindow: true, scheduled: false };
+  }
+  const tz = schedule.timezone;
+  let nowInTz;
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    });
+    const parts = fmt.formatToParts(new Date());
+    const h = parts.find((p) => p.type === "hour")?.value ?? "00";
+    const m = parts.find((p) => p.type === "minute")?.value ?? "00";
+    nowInTz = `${h}:${m}`;
+  } catch {
+    return { inWindow: true, scheduled: false };
+  }
+  const inWindow = nowInTz >= schedule.activeStart && nowInTz <= schedule.activeEnd;
+  return {
+    inWindow,
+    scheduled: true,
+    nowInTz,
+    activeStart: schedule.activeStart,
+    activeEnd: schedule.activeEnd,
+    timezone: tz,
+  };
+}
+
+// -- Default agent resolution ----------------------------------------------
+
+async function resolveAgentId(agentIdOrAlias) {
+  const map = await loadAgentSchedules();
+  if (agentIdOrAlias && map.has(agentIdOrAlias)) {
+    return agentIdOrAlias;
+  }
+  if (!agentIdOrAlias) {
+    for (const [id, sched] of map) {
+      if (sched.defaultAgent) {
+        return id;
+      }
+    }
+    // first agent if no default flag
+    const first = map.keys().next().value;
+    if (first) {
+      return first;
+    }
+  }
+  return agentIdOrAlias ?? null;
+}
+
+// -- MCP server ------------------------------------------------------------
+
+function jsonResult(value) {
+  return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
+}
+
+function buildServer() {
+  const server = new McpServer({
+    name: "openclaw-claude-code-bridge",
+    version: "0.1.0",
+  });
+
+  server.registerTool(
+    "openclaw_gateway_health",
+    {
+      description:
+        "Check whether the local OpenClaw gateway is reachable. Returns up/agents/version. Auto-starts the gateway if configured.",
+      inputSchema: {},
+    },
+    async () => jsonResult(await ensureGatewayUp()),
+  );
+
+  server.registerTool(
+    "openclaw_agent_list",
+    {
+      description: "List all OpenClaw agents (id, model, workspace, identity, default flag).",
+      inputSchema: {},
+    },
+    async () => {
+      await ensureGatewayUp();
+      return jsonResult(await callGatewayMethod("agents.list"));
+    },
+  );
+
+  server.registerTool(
+    "openclaw_skill_list",
+    {
+      description:
+        "List skills available to an OpenClaw agent. Defaults to the default agent (kestrel-aurelius).",
+      inputSchema: {
+        agentId: z
+          .string()
+          .optional()
+          .describe("Agent id (e.g., 'kestrel-aurelius'). Omit to use the default agent."),
+      },
+    },
+    async ({ agentId }) => {
+      await ensureGatewayUp();
+      const params = {};
+      if (agentId) {
+        params.agentId = agentId;
+      }
+      return jsonResult(await callGatewayMethod("skills.status", params));
+    },
+  );
+
+  server.registerTool(
+    "openclaw_wiki_search",
+    {
+      description:
+        "Search the OpenClaw memory wiki. Returns ranked passages with path, score, excerpt.",
+      inputSchema: {
+        query: z.string().min(1).describe("Free-text search query."),
+        corpus: z
+          .enum(["all", "wiki", "memory"])
+          .optional()
+          .describe("Restrict to a corpus subset. Defaults to vault config."),
+        backend: z
+          .enum(["shared", "local"])
+          .optional()
+          .describe("Search backend. Defaults to vault config."),
+        limit: z.number().int().min(1).max(50).optional().describe("Max results."),
+      },
+    },
+    async ({ query, corpus, backend, limit }) => {
+      await ensureGatewayUp();
+      const params = { query };
+      if (corpus) {
+        params.corpus = corpus;
+      }
+      if (backend) {
+        params.backend = backend;
+      }
+      if (limit) {
+        params.maxResults = limit;
+      }
+      const raw = await callGatewayMethod("wiki.search", params);
+      return jsonResult(filterSearchResultByManifest(raw));
+    },
+  );
+
+  server.registerTool(
+    "openclaw_wiki_get",
+    {
+      description:
+        "Fetch a wiki page by title or vault-relative path. Optional fromLine/lineCount for paged reads.",
+      inputSchema: {
+        lookup: z
+          .string()
+          .min(1)
+          .describe("Page title or vault-relative path (e.g., 'inbox' or 'sources/foo.md')."),
+        fromLine: z.number().int().min(1).optional().describe("1-indexed start line."),
+        lineCount: z
+          .number()
+          .int()
+          .min(1)
+          .max(2000)
+          .optional()
+          .describe("Number of lines to return."),
+      },
+    },
+    async ({ lookup, fromLine, lineCount }) => {
+      await ensureGatewayUp();
+      if (!isHarnessAllowedSlug(lookup)) {
+        return jsonResult({
+          ok: false,
+          error: "wiki entry not in harness manifest allowlist",
+          manifestVersion: harnessManifestVersion,
+          ceiling: HARNESS_MANIFEST_CEILING,
+        });
+      }
+      const params = { lookup };
+      if (fromLine !== undefined) {
+        params.fromLine = fromLine;
+      }
+      if (lineCount !== undefined) {
+        params.lineCount = lineCount;
+      }
+      return jsonResult(await callGatewayMethod("wiki.get", params));
+    },
+  );
+
+  server.registerTool(
+    "openclaw_wiki_inbox_append",
+    {
+      description:
+        "Append a note to the OpenClaw wiki inbox. The dream cycle absorbs new entries on its next pass.",
+      inputSchema: {
+        note: z.string().min(1).describe("The note to append. Markdown allowed."),
+        source: z.string().optional().describe("Source label. Defaults to 'claude-code'."),
+        tags: z.array(z.string()).optional().describe("Optional tags for indexing."),
+        sessionId: z
+          .string()
+          .optional()
+          .describe("Optional session id. Used for deduplication within the dedupe window."),
+      },
+    },
+    async ({ note, source, tags, sessionId }) => {
+      return jsonResult(await appendToInbox({ note, source, tags, sessionId }));
+    },
+  );
+
+  server.registerTool(
+    "openclaw_agent_handoff",
+    {
+      description:
+        "Hand a brief to an OpenClaw agent. Creates a fresh session with the initial message and returns a sessionKey you can use with openclaw_agent_messages to read replies. Defaults to the default agent (kestrel-aurelius). Async by default — agent reply may take 30+ seconds for Opus 4.6 thinking.",
+      inputSchema: {
+        message: z.string().min(1).describe("The brief / initial message to send."),
+        agentId: z
+          .string()
+          .optional()
+          .describe(
+            "Target agent id (e.g., 'kestrel-aurelius', 'cole', 'sage'). Omit for default.",
+          ),
+        label: z.string().optional().describe("Optional session label for later identification."),
+        force: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true, bypass the heartbeat-window warning. Defaults to false (warn but proceed).",
+          ),
+      },
+    },
+    async ({ message, agentId, label, force }) => {
+      await ensureGatewayUp();
+      const resolvedAgentId = await resolveAgentId(agentId);
+      if (!resolvedAgentId) {
+        return jsonResult({ ok: false, error: "no agent matched (and no default configured)" });
+      }
+      const schedules = await loadAgentSchedules();
+      const sched = schedules.get(resolvedAgentId);
+      const window = checkHeartbeatWindow(sched);
+      const params = { agentId: resolvedAgentId, message };
+      if (label) {
+        params.label = label;
+      }
+      const create = await callGatewayMethod("sessions.create", params, { timeoutMs: 30_000 });
+      return jsonResult({
+        ...create,
+        agentId: resolvedAgentId,
+        agentName: sched?.identityName ?? resolvedAgentId,
+        heartbeatWindow: window,
+        warning:
+          window.scheduled && !window.inWindow && !force
+            ? `${sched?.identityName ?? resolvedAgentId} is outside her active hours (${window.activeStart}-${window.activeEnd} ${window.timezone}); reply may be delayed. Pass force:true to suppress this warning.`
+            : undefined,
+      });
+    },
+  );
+
+  server.registerTool(
+    "openclaw_agent_send",
+    {
+      description:
+        "Send a follow-up message to an existing OpenClaw agent session. Use the sessionKey returned by openclaw_agent_handoff.",
+      inputSchema: {
+        sessionKey: z
+          .string()
+          .min(1)
+          .describe("Session key from a previous handoff (format: 'agent:<id>:<channel>:<uuid>')."),
+        message: z.string().min(1).describe("The follow-up message."),
+        thinking: z
+          .string()
+          .optional()
+          .describe("Optional thinking-level override ('low','medium','high')."),
+      },
+    },
+    async ({ sessionKey, message, thinking }) => {
+      await ensureGatewayUp();
+      const params = { key: sessionKey, message };
+      if (thinking) {
+        params.thinking = thinking;
+      }
+      const result = await callGatewayMethod("sessions.send", params, { timeoutMs: 30_000 });
+      return jsonResult(result);
+    },
+  );
+
+  server.registerTool(
+    "openclaw_agent_messages",
+    {
+      description:
+        "Fetch recent messages from an OpenClaw agent session. Use the sessionKey returned by openclaw_agent_handoff. Returns user/assistant turns with timestamps. Poll this to see when the agent has replied.",
+      inputSchema: {
+        sessionKey: z.string().min(1).describe("Session key from a previous handoff."),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe("Max messages to return. Default 10."),
+      },
+    },
+    async ({ sessionKey, limit }) => {
+      await ensureGatewayUp();
+      const params = { sessionKey };
+      if (limit) {
+        params.limit = limit;
+      }
+      const result = await callGatewayMethod("chat.history", params, { timeoutMs: 15_000 });
+      return jsonResult(result);
+    },
+  );
+
+  server.registerTool(
+    "openclaw_wiki_status",
+    {
+      description:
+        "Report the OpenClaw wiki bridge status: artifact count, last bridge run, healthy flag.",
+      inputSchema: {},
+    },
+    async () => {
+      await ensureGatewayUp();
+      return jsonResult(await callGatewayMethod("wiki.status"));
+    },
+  );
+
+  return server;
+}
+
+// -- Entrypoint ------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+if (args.includes("--once-list-tools")) {
+  const descriptors = [
+    {
+      name: "openclaw_gateway_health",
+      description: "Check OpenClaw gateway reachability (auto-starts if down).",
+    },
+    { name: "openclaw_agent_list", description: "List OpenClaw agents." },
+    { name: "openclaw_skill_list", description: "List skills for an OpenClaw agent." },
+    { name: "openclaw_wiki_search", description: "Search the OpenClaw memory wiki." },
+    { name: "openclaw_wiki_get", description: "Fetch a wiki page." },
+    { name: "openclaw_wiki_inbox_append", description: "Append a note to the inbox." },
+    {
+      name: "openclaw_agent_handoff",
+      description: "Hand a brief to an OpenClaw agent (creates a fresh session).",
+    },
+    { name: "openclaw_agent_send", description: "Send a follow-up to an existing agent session." },
+    {
+      name: "openclaw_agent_messages",
+      description: "Fetch recent messages from an agent session.",
+    },
+    { name: "openclaw_wiki_status", description: "Report wiki bridge status." },
+  ];
+  process.stdout.write(JSON.stringify(descriptors, null, 2) + "\n");
+  process.exit(0);
+}
+
+const server = buildServer();
+const transport = new StdioServerTransport();
+
+// Load the harness manifest before accepting MCP requests when enforcement is
+// enabled. Fire-and-forget the refresh loop; individual calls tolerate a null
+// allowlist by failing open, so a slow initial fetch never deadlocks startup.
+if (HARNESS_MANIFEST_ENFORCE) {
+  await fetchHarnessManifest();
+  scheduleHarnessManifestRefresh();
+  process.on("SIGHUP", () => {
+    void fetchHarnessManifest();
+  });
+}
+
+await server.connect(transport);

--- a/extensions/claude-code-bridge/statusline.mjs
+++ b/extensions/claude-code-bridge/statusline.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Standalone statusline renderer for Claude Code's statusLine command.
+// Prints one line then exits. Designed to be FAST (<200ms): never invokes the
+// openclaw CLI (which takes ~5s per call). Reads filesystem state directly.
+
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_GATEWAY_URL = process.env.OPENCLAW_GATEWAY_URL ?? "http://127.0.0.1:18789";
+const OPENCLAW_HOME = process.env.OPENCLAW_HOME ?? path.join(os.homedir(), ".openclaw");
+const OPENCLAW_CONFIG = path.join(OPENCLAW_HOME, "openclaw.json");
+const WIKI_SOURCES_DIR = path.join(OPENCLAW_HOME, "wiki", "main", "sources");
+const INBOX_PATH =
+  process.env.OPENCLAW_BRIDGE_INBOX_PATH ?? path.join(OPENCLAW_HOME, "wiki", "main", "inbox.md");
+
+async function fetchHealth() {
+  try {
+    const res = await fetch(new URL("/healthz", DEFAULT_GATEWAY_URL), {
+      method: "GET",
+      signal: AbortSignal.timeout(1_500),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function getDefaultAgentName() {
+  try {
+    const raw = await fs.readFile(OPENCLAW_CONFIG, "utf8");
+    const cfg = JSON.parse(raw);
+    const list = cfg?.agents?.list;
+    if (!Array.isArray(list)) {
+      return null;
+    }
+    const def = list.find((a) => a?.default) ?? list[0];
+    if (!def) {
+      return null;
+    }
+    return (def?.identity?.name ?? def?.id ?? "agent").toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+async function countWikiArtifacts() {
+  try {
+    const entries = await fs.readdir(WIKI_SOURCES_DIR);
+    return entries.filter((e) => e.endsWith(".md")).length;
+  } catch {
+    return null;
+  }
+}
+
+async function countInboxBlocks() {
+  try {
+    const data = await fs.readFile(INBOX_PATH, "utf8");
+    const m = data.match(/^---$/gm);
+    return m ? m.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+const [up, agent, wiki, inbox] = await Promise.all([
+  fetchHealth(),
+  getDefaultAgentName(),
+  countWikiArtifacts(),
+  countInboxBlocks(),
+]);
+
+if (!up) {
+  process.stdout.write(
+    `oc: gateway down${agent ? ` | ${agent} idle` : ""} | wiki ${wiki ?? 0} docs | inbox ${inbox} unread\n`,
+  );
+  process.exit(0);
+}
+
+const parts = [
+  "oc: gateway up",
+  agent ? `${agent} active` : null,
+  wiki !== null ? `wiki ${wiki} docs` : null,
+  `inbox ${inbox} unread`,
+].filter(Boolean);
+process.stdout.write(parts.join(" | ") + "\n");

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -718,7 +718,13 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(content).toContain("API endpoints need authentication");
+    // Fallback must NEVER leak raw memory content — snippets can contain
+    // secrets (API tokens, URLs, session cookies). Assert the snippet body
+    // is not quoted verbatim into the user-visible diary.
+    expect(content).not.toContain("API endpoints need authentication");
+    expect(content).toContain("Phase: light");
+    expect(content).toContain("1 fragment surfaced");
+    expect(content).toContain("narrator was elsewhere");
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining(workspaceDir));
     expect(subagent.deleteSession).toHaveBeenCalledOnce();
@@ -745,7 +751,9 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(content).toContain("A durable candidate surfaced.");
+    expect(content).not.toContain("A durable candidate surfaced.");
+    expect(content).toContain("Phase: deep");
+    expect(content).toContain("1 promoted to durable memory");
   });
 
   it("does not fall back for non-Error objects that only spoof the stable code", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -127,12 +127,40 @@ function formatFallbackWriteFailure(err: unknown): string {
   return "unknown error";
 }
 
+/**
+ * Composes a safe fallback "narrative" from phase statistics only — never from
+ * the raw snippet / promotion content itself. The previous implementation
+ * returned the first non-empty snippet verbatim, which surfaced arbitrary
+ * memory content (including secrets like API tokens and session cookies) into
+ * the user-visible DREAMS.md diary. The cron-dispatched code path cannot
+ * obtain a subagent runtime, so we lack the request-scoped context needed to
+ * generate a proper narrative with the Anthropic API. Rather than leak raw
+ * memory, we emit a short statistical note that tells the reader what the
+ * sweep processed without quoting its contents.
+ */
 function buildRequestScopedFallbackNarrative(data: NarrativePhaseData): string {
-  return (
-    data.snippets.map((value) => value.trim()).find((value) => value.length > 0) ??
-    (data.promotions ?? []).map((value) => value.trim()).find((value) => value.length > 0) ??
-    "A memory trace surfaced, but details were unavailable in this run."
-  );
+  const trimmedSnippets = data.snippets
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  const trimmedPromotions = (data.promotions ?? [])
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  const themeCount = (data.themes ?? []).length;
+
+  const parts: string[] = [`Phase: ${data.phase}`];
+  if (trimmedSnippets.length > 0) {
+    parts.push(
+      `${trimmedSnippets.length} fragment${trimmedSnippets.length === 1 ? "" : "s"} surfaced`,
+    );
+  }
+  if (themeCount > 0) {
+    parts.push(`${themeCount} theme${themeCount === 1 ? "" : "s"} noted`);
+  }
+  if (trimmedPromotions.length > 0) {
+    parts.push(`${trimmedPromotions.length} promoted to durable memory`);
+  }
+
+  return `${parts.join(" · ")}. The narrator was elsewhere this pass — details stayed in the recall store.`;
 }
 
 async function startNarrativeRunOrFallback(params: {

--- a/extensions/memory-wiki/README.md
+++ b/extensions/memory-wiki/README.md
@@ -108,6 +108,9 @@ openclaw wiki init
 openclaw wiki ingest ./notes/alpha.md
 openclaw wiki compile
 openclaw wiki lint
+openclaw wiki repair                    # backfill missing id/pageType/title/updatedAt
+openclaw wiki repair --remove-orphans   # also delete empty source shells
+openclaw wiki repair --dry-run          # report orphans without writing
 openclaw wiki search "alpha"
 openclaw wiki get entity.alpha --from 1 --lines 80
 
@@ -129,6 +132,51 @@ openclaw wiki obsidian open syntheses/alpha-summary.md
 openclaw wiki obsidian command workspace:quick-switcher
 openclaw wiki obsidian daily
 ```
+
+## Canonical page standard
+
+Every page under `entities/`, `concepts/`, `sources/`, `syntheses/`, or `reports/` is expected to carry the following frontmatter. These are the fields the linter enforces and the ones the compiler will auto-repair if missing.
+
+| Field       | Required             | Notes                                                                                          |
+| ----------- | -------------------- | ---------------------------------------------------------------------------------------------- |
+| `id`        | yes (error if blank) | Stable. Form: `<kind>.<slug>` (e.g. `concept.dreaming-protocol`). Derived from filename/title. |
+| `pageType`  | yes (error if blank) | Must match the directory kind (`source`, `entity`, `concept`, `synthesis`, `report`).          |
+| `title`     | yes (error if blank) | First H1 if present, otherwise humanized filename.                                             |
+| `updatedAt` | yes (warn if blank)  | ISO 8601. Set by the generator on create or file mtime on repair.                              |
+| `sourceIds` | recommended          | Required for non-source, non-report pages to avoid the `missing-source-ids` warning.           |
+
+Generators (ingest, bridge, unsafe-local, synthesis apply, dashboard reports) are responsible for emitting all required fields at creation time. The compile pass runs a deterministic `ensurePageStructure` sweep that backfills anything still missing. `wiki repair` exposes that sweep as an explicit command for legacy content, including orphan-shell cleanup.
+
+### Provenance discipline
+
+- **Sources** never carry `sourceIds` — they _are_ the provenance. They must carry `sourcePath` plus one of `bridgeRelativePath`/`unsafeLocalRelativePath` when imported.
+- **Syntheses, concepts, entities** should cite at least one `sourceIds` entry so the related-block/backlink graph can link them to their evidence.
+- **Reports** are compiled artifacts. Their id/title/pageType are hardcoded by the dashboard definitions and should not be edited manually.
+
+### Orphan shells
+
+An "orphan shell" is a `sources/*.md` file whose entire body is just the managed `## Related` block (or is empty). These accumulate when a bridge-synced upstream source disappears partway through a sync, or when a compile pass touched a zero-byte stub. `wiki repair --remove-orphans` deletes them. `wiki repair --dry-run` reports them without changes.
+
+## Daily operator workflow
+
+The normal maintenance loop is three commands:
+
+```bash
+openclaw wiki bridge import   # pull in new memory artifacts
+openclaw wiki compile          # refresh indexes, backlinks, dashboards, digests
+openclaw wiki lint             # write the lint report
+```
+
+For a freshly-inherited or long-neglected vault, prepend an explicit repair:
+
+```bash
+openclaw wiki repair --dry-run            # preview orphans
+openclaw wiki repair --remove-orphans     # then commit the cleanup
+openclaw wiki compile
+openclaw wiki lint
+```
+
+The lint report is idempotent and written to `reports/lint.md`. Errors indicate structural violations (missing id, missing pageType, type mismatch, duplicate id); warnings indicate content-health issues (stale pages, open questions, contradictions, claim health).
 
 ## Agent tools
 

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -33,6 +33,7 @@ import {
   renderMemoryWikiStatus,
   resolveMemoryWikiStatus,
 } from "./status.js";
+import { findOrphanSourceShells, repairMemoryWikiVault } from "./structure-repair.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 
 type WikiStatusCommandOptions = {
@@ -53,6 +54,12 @@ type WikiCompileCommandOptions = {
 
 type WikiLintCommandOptions = {
   json?: boolean;
+};
+
+type WikiRepairCommandOptions = {
+  json?: boolean;
+  removeOrphans?: boolean;
+  dryRun?: boolean;
 };
 
 type WikiIngestCommandOptions = {
@@ -334,6 +341,43 @@ export async function runWikiLint(params: {
     render: (value) =>
       `Linted wiki vault at ${value.vaultRoot} (${value.issueCount} issues, report: ${value.reportPath}).`,
   });
+}
+
+export async function runWikiRepair(params: {
+  config: ResolvedMemoryWikiConfig;
+  appConfig?: OpenClawConfig;
+  removeOrphans?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+  stdout?: Pick<NodeJS.WriteStream, "write">;
+}) {
+  if (params.dryRun) {
+    const orphans = await findOrphanSourceShells(params.config);
+    const summary = {
+      dryRun: true,
+      orphansDetected: orphans.length,
+      orphans,
+    };
+    writeOutput(
+      params.json
+        ? JSON.stringify(summary, null, 2)
+        : orphans.length === 0
+          ? "No orphan source shells detected."
+          : `Detected ${orphans.length} orphan source shells:\n${orphans.map((p) => `- ${p}`).join("\n")}`,
+      params.stdout,
+    );
+    return summary;
+  }
+  const result = await repairMemoryWikiVault(params.config, {
+    removeOrphans: params.removeOrphans,
+  });
+  writeOutput(
+    params.json
+      ? JSON.stringify(result, null, 2)
+      : `Repaired wiki vault at ${result.vaultRoot} (${result.scanned} scanned, ${result.backfilled} backfilled, ${result.orphansRemoved} orphans removed).`,
+    params.stdout,
+  );
+  return result;
 }
 
 export async function runWikiIngest(params: {
@@ -709,6 +753,22 @@ export function registerWikiCli(
     .option("--json", "Print JSON")
     .action(async (opts: WikiLintCommandOptions) => {
       await runWikiLint({ config, appConfig, json: opts.json });
+    });
+
+  wiki
+    .command("repair")
+    .description("Backfill missing frontmatter (id, pageType, title, updatedAt) across the vault")
+    .option("--remove-orphans", "Delete orphan source shells (empty pages with no frontmatter)")
+    .option("--dry-run", "Report what would change without writing")
+    .option("--json", "Print JSON")
+    .action(async (opts: WikiRepairCommandOptions) => {
+      await runWikiRepair({
+        config,
+        appConfig,
+        removeOrphans: opts.removeOrphans,
+        dryRun: opts.dryRun,
+        json: opts.json,
+      });
     });
 
   wiki

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -270,7 +270,9 @@ describe("compileMemoryWikiVault", () => {
     ).resolves.toContain("Alpha uses PostgreSQL for production writes.");
     await expect(
       fs.readFile(path.join(rootDir, "reports", "stale-pages.md"), "utf8"),
-    ).resolves.toContain("[Alpha](entities/alpha.md): missing updatedAt");
+    ).resolves.toContain("[Alpha DB](concepts/alpha-db.md): stale (2025-10-01T00:00:00.000Z)");
+    const entityAlpha = await fs.readFile(path.join(rootDir, "entities", "alpha.md"), "utf8");
+    expect(entityAlpha).toContain("updatedAt:");
     const agentDigest = JSON.parse(
       await fs.readFile(path.join(rootDir, ".openclaw-wiki", "cache", "agent-digest.json"), "utf8"),
     ) as {
@@ -278,7 +280,6 @@ describe("compileMemoryWikiVault", () => {
       contradictionClusters: Array<{ key: string }>;
     };
     expect(agentDigest.claimHealth.missingEvidence).toBeGreaterThanOrEqual(1);
-    expect(agentDigest.claimHealth.freshness.unknown).toBeGreaterThanOrEqual(1);
     expect(agentDigest.contradictionClusters).toContainEqual(
       expect.objectContaining({ key: "claim.alpha.db" }),
     );

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -33,6 +33,7 @@ import {
   WIKI_RELATED_END_MARKER,
   WIKI_RELATED_START_MARKER,
 } from "./markdown.js";
+import { ensurePageStructure, isOrphanSourceShell } from "./structure-repair.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 
 const COMPILE_PAGE_GROUPS: Array<{ kind: WikiPageKind; dir: string; heading: string }> = [
@@ -482,6 +483,11 @@ async function refreshPageRelatedBlocks(params: {
       continue;
     }
     const original = await fs.readFile(page.absolutePath, "utf8");
+    const parsed = parseWikiMarkdown(original);
+    const hasFrontmatter = Object.keys(parsed.frontmatter).length > 0;
+    if (!hasFrontmatter && !parsed.body.trim()) {
+      continue;
+    }
     const updated = withTrailingNewline(
       replaceManagedMarkdownBlock({
         original,
@@ -500,6 +506,39 @@ async function refreshPageRelatedBlocks(params: {
     }
     await fs.writeFile(page.absolutePath, updated, "utf8");
     updatedFiles.push(page.absolutePath);
+  }
+  return updatedFiles;
+}
+
+async function ensureAllPageStructures(params: {
+  rootDir: string;
+  pages: WikiPageSummary[];
+  nowIso: string;
+}): Promise<string[]> {
+  const updatedFiles: string[] = [];
+  for (const page of params.pages) {
+    const needsBackfill = !page.id || !page.pageType || !page.title.trim() || !page.updatedAt;
+    if (!needsBackfill) {
+      continue;
+    }
+    const raw = await fs.readFile(page.absolutePath, "utf8").catch(() => "");
+    const parsed = parseWikiMarkdown(raw);
+    const hasFrontmatter = Object.keys(parsed.frontmatter).length > 0;
+    if (
+      !hasFrontmatter &&
+      page.relativePath.startsWith("sources/") &&
+      isOrphanSourceShell(parsed.body)
+    ) {
+      continue;
+    }
+    const result = await ensurePageStructure({
+      rootDir: params.rootDir,
+      relativePath: page.relativePath,
+      nowIso: params.nowIso,
+    });
+    if (result.operation === "backfilled-structure") {
+      updatedFiles.push(path.join(params.rootDir, page.relativePath));
+    }
   }
   return updatedFiles;
 }
@@ -944,9 +983,20 @@ export async function compileMemoryWikiVault(
 ): Promise<CompileMemoryWikiResult> {
   await initializeMemoryWikiVault(config);
   const rootDir = config.vault.path;
+  const nowIso = new Date().toISOString();
   let pages = await readPageSummaries(rootDir);
-  const updatedFiles = await refreshPageRelatedBlocks({ config, pages });
-  if (updatedFiles.length > 0) {
+  const structureUpdatedFiles = await ensureAllPageStructures({
+    rootDir,
+    pages,
+    nowIso,
+  });
+  if (structureUpdatedFiles.length > 0) {
+    pages = await readPageSummaries(rootDir);
+  }
+  const updatedFiles = [...structureUpdatedFiles];
+  const relatedUpdatedFiles = await refreshPageRelatedBlocks({ config, pages });
+  updatedFiles.push(...relatedUpdatedFiles);
+  if (relatedUpdatedFiles.length > 0) {
     pages = await readPageSummaries(rootDir);
   }
   const dashboardUpdatedFiles = await refreshDashboardPages({ config, rootDir, pages });

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -116,4 +116,66 @@ describe("lintMemoryWikiVault", () => {
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Contradictions");
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Open Questions");
   });
+
+  it("accepts native-mode markdown links that keep the .md suffix", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-native-links-",
+      config: { vault: { renderMode: "native" } },
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.alpha",
+          title: "Alpha",
+          sourceType: "local-file",
+          sourcePath: "/tmp/alpha.md",
+          updatedAt: new Date().toISOString(),
+        },
+        body: "# Alpha\n\n[Alpha](sources/alpha.md) points to itself.\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+    const brokenLinks = result.issues.filter((issue) => issue.code === "broken-wikilink");
+    expect(brokenLinks).toHaveLength(0);
+  });
+
+  it("does not flag wiki-like syntax appearing inside fenced code blocks", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-code-fence-",
+      config: { vault: { renderMode: "native" } },
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "transcript.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.transcript",
+          title: "Transcript",
+          sourceType: "local-file",
+          sourcePath: "/tmp/transcript.md",
+          updatedAt: new Date().toISOString(),
+        },
+        body: [
+          "# Transcript",
+          "",
+          "```markdown",
+          "assistant: [[reply_to_current]] hello",
+          "user: [[another_template_token]]",
+          "```",
+          "",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+    const brokenLinks = result.issues.filter((issue) => issue.code === "broken-wikilink");
+    expect(brokenLinks).toHaveLength(0);
+  });
 });

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -50,18 +50,37 @@ function toExpectedPageType(page: WikiPageSummary): string {
   return page.kind;
 }
 
+function normalizeLinkTarget(target: string): string {
+  return target
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/\.md$/i, "")
+    .replace(/^\.\/+/, "")
+    .replace(/\/+$/, "")
+    .toLowerCase();
+}
+
 function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[] {
   const validTargets = new Set<string>();
   for (const page of pages) {
     const withoutExtension = page.relativePath.replace(/\.md$/i, "");
-    validTargets.add(withoutExtension);
-    validTargets.add(path.basename(withoutExtension));
+    validTargets.add(normalizeLinkTarget(withoutExtension));
+    validTargets.add(normalizeLinkTarget(path.basename(withoutExtension)));
+    if (page.id) {
+      validTargets.add(normalizeLinkTarget(page.id));
+    }
   }
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
+    const seen = new Set<string>();
     for (const linkTarget of page.linkTargets) {
-      if (!validTargets.has(linkTarget)) {
+      const normalized = normalizeLinkTarget(linkTarget);
+      if (!normalized || seen.has(normalized)) {
+        continue;
+      }
+      seen.add(normalized);
+      if (!validTargets.has(normalized)) {
         issues.push({
           severity: "warning",
           category: "links",
@@ -333,6 +352,7 @@ async function writeLintReport(rootDir: string, issues: MemoryWikiLintIssue[]): 
         id: "report.lint",
         title: "Lint Report",
         status: "active",
+        updatedAt: new Date().toISOString(),
       },
       body: "# Lint Report\n",
     }),

--- a/extensions/memory-wiki/src/log.ts
+++ b/extensions/memory-wiki/src/log.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 export type MemoryWikiLogEntry = {
-  type: "init" | "ingest" | "compile" | "lint";
+  type: "init" | "ingest" | "compile" | "lint" | "repair";
   timestamp: string;
   details?: Record<string, unknown>;
 };

--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { createWikiPageFilename, slugifyWikiSegment } from "./markdown.js";
+import { createWikiPageFilename, extractWikiLinks, slugifyWikiSegment } from "./markdown.js";
 
 describe("slugifyWikiSegment", () => {
   it("preserves Unicode letters and numbers in wiki slugs", () => {
@@ -38,5 +38,52 @@ describe("slugifyWikiSegment", () => {
     expect(fileName.endsWith(".md")).toBe(true);
     expect(Buffer.byteLength(fileName)).toBeLessThanOrEqual(255);
     expect(createWikiPageFilename(stem)).toBe(fileName);
+  });
+});
+
+describe("extractWikiLinks", () => {
+  it("ignores wiki-like tokens inside fenced code blocks", () => {
+    const markdown = [
+      "# Page",
+      "",
+      "See [[real-page]] for context.",
+      "",
+      "```markdown",
+      "assistant: [[reply_to_current]] — this is template syntax",
+      "and should not be treated as a link.",
+      "```",
+    ].join("\n");
+    expect(extractWikiLinks(markdown)).toEqual(["real-page"]);
+  });
+
+  it("ignores wiki-like tokens inside inline code", () => {
+    const markdown = "Use the `[[reply_to_current]]` placeholder, not [[actual-page]].";
+    expect(extractWikiLinks(markdown)).toEqual(["actual-page"]);
+  });
+
+  it("extracts native markdown links even when they keep the .md suffix", () => {
+    const markdown = "- [Alpha](sources/alpha.md)\n- [[entities/beta|Beta]]";
+    expect(extractWikiLinks(markdown).toSorted()).toEqual(
+      ["entities/beta", "sources/alpha.md"].toSorted(),
+    );
+  });
+
+  it("strips the managed Related block before scanning", () => {
+    const markdown = [
+      "# Page",
+      "Visible [[inline-link]].",
+      "",
+      "## Related",
+      "<!-- openclaw:wiki:related:start -->",
+      "- [[ignored-related-link]]",
+      "<!-- openclaw:wiki:related:end -->",
+    ].join("\n");
+    expect(extractWikiLinks(markdown)).toEqual(["inline-link"]);
+  });
+
+  it("skips protocol URLs and anchor-only links", () => {
+    const markdown =
+      "[Home](/home) [ext](https://example.com) [anchor](#foo) [Alpha](sources/alpha.md)";
+    expect(extractWikiLinks(markdown).toSorted()).toEqual(["/home", "sources/alpha.md"].toSorted());
   });
 });

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -66,6 +66,8 @@ const RELATED_BLOCK_PATTERN = new RegExp(
   `${WIKI_RELATED_START_MARKER}[\\s\\S]*?${WIKI_RELATED_END_MARKER}`,
   "g",
 );
+const FENCED_CODE_PATTERN = /(^|\n)(?:```|~~~)[^\n]*\n[\s\S]*?\n(?:```|~~~)(?=\n|$)/g;
+const INLINE_CODE_PATTERN = /`[^`\n]+`/g;
 const MAX_WIKI_SEGMENT_BYTES = 240;
 const MAX_WIKI_FILENAME_COMPONENT_BYTES = 255;
 const WIKI_SEGMENT_HASH_BYTES = 12;
@@ -214,7 +216,10 @@ export function normalizeWikiClaims(value: unknown): WikiClaim[] {
 }
 
 export function extractWikiLinks(markdown: string): string[] {
-  const searchable = markdown.replace(RELATED_BLOCK_PATTERN, "");
+  const searchable = markdown
+    .replace(RELATED_BLOCK_PATTERN, "")
+    .replace(FENCED_CODE_PATTERN, "")
+    .replace(INLINE_CODE_PATTERN, "");
   const links: string[] = [];
   for (const match of searchable.matchAll(OBSIDIAN_LINK_PATTERN)) {
     const target = match[1]?.trim();

--- a/extensions/memory-wiki/src/pipeline-integration.test.ts
+++ b/extensions/memory-wiki/src/pipeline-integration.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { compileMemoryWikiVault } from "./compile.js";
+import { lintMemoryWikiVault } from "./lint.js";
+import { renderWikiMarkdown } from "./markdown.js";
+import { repairMemoryWikiVault } from "./structure-repair.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
+
+const { createVault } = createMemoryWikiTestHarness();
+
+function writePage(rootDir: string, relativePath: string, content: string) {
+  return fs.writeFile(path.join(rootDir, relativePath), content, "utf8");
+}
+
+describe("wiki pipeline integration (end-to-end repair + lint)", () => {
+  it("reduces lint issues after compile+repair on a vault with mixed legacy content", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-integration-",
+      config: { vault: { renderMode: "native" } },
+      initialize: true,
+    });
+
+    // 1) Human-authored concept with `kind: protocol` but none of the canonical fields.
+    await writePage(
+      rootDir,
+      "concepts/dreaming-protocol.md",
+      "---\nkind: protocol\nstatus: canonical\n---\n\n# Dreaming Protocol\n\nBody text.\n",
+    );
+
+    // 2) Bridge source with transcript containing [[reply_to_current]] inside a code fence
+    //    — historically caused 200+ false-positive broken-wikilink warnings.
+    await writePage(
+      rootDir,
+      "sources/bridge-transcript.md",
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.bridge.transcript",
+          title: "Bridge Transcript",
+          sourceType: "memory-bridge",
+          sourcePath: "/tmp/t.md",
+          bridgeRelativePath: "memory/t.md",
+          bridgeWorkspaceDir: "/tmp",
+          updatedAt: new Date().toISOString(),
+        },
+        body: [
+          "# Bridge Transcript",
+          "",
+          "## Content",
+          "```markdown",
+          "assistant: [[reply_to_current]] hello there",
+          "user: [[another_template_token]] response",
+          "```",
+          "",
+        ].join("\n"),
+      }),
+    );
+
+    // 3) Orphan shell (historically created by compile's related-block writer on empty files).
+    await writePage(
+      rootDir,
+      "sources/orphan-shell.md",
+      "## Related\n<!-- openclaw:wiki:related:start -->\n- No related pages yet.\n<!-- openclaw:wiki:related:end -->\n",
+    );
+
+    // 4) A dashboard-style page with native-mode link referencing another page — must resolve.
+    await writePage(
+      rootDir,
+      "sources/cross-link.md",
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.cross-link",
+          title: "Cross Link",
+          sourceType: "local-file",
+          sourcePath: "/tmp/xl.md",
+          updatedAt: new Date().toISOString(),
+        },
+        body: "# Cross Link\n\nSee [Bridge Transcript](sources/bridge-transcript.md) for context.\n",
+      }),
+    );
+
+    // --- Run the pipeline as an operator would ---
+    const repairResult = await repairMemoryWikiVault(config, { removeOrphans: true });
+    expect(repairResult.orphansRemoved).toBe(1);
+    expect(repairResult.backfilled).toBeGreaterThanOrEqual(1);
+
+    await compileMemoryWikiVault(config);
+    const lintResult = await lintMemoryWikiVault(config);
+
+    const errors = lintResult.issues.filter((issue) => issue.severity === "error");
+    const brokenLinks = lintResult.issues.filter((issue) => issue.code === "broken-wikilink");
+    const missingId = lintResult.issues.filter((issue) => issue.code === "missing-id");
+    const missingPageType = lintResult.issues.filter((issue) => issue.code === "missing-page-type");
+
+    expect(errors).toHaveLength(0);
+    expect(missingId).toHaveLength(0);
+    expect(missingPageType).toHaveLength(0);
+    expect(brokenLinks).toHaveLength(0);
+
+    // Orphan is gone.
+    await expect(
+      fs.stat(path.join(rootDir, "sources", "orphan-shell.md")).then(
+        () => true,
+        () => false,
+      ),
+    ).resolves.toBe(false);
+
+    // Concept got canonicalized.
+    const conceptRaw = await fs.readFile(
+      path.join(rootDir, "concepts", "dreaming-protocol.md"),
+      "utf8",
+    );
+    expect(conceptRaw).toMatch(/\nid: concept\.dreaming-protocol\n/);
+    expect(conceptRaw).toMatch(/\npageType: concept\n/);
+    expect(conceptRaw).toMatch(/\nupdatedAt: /);
+    expect(conceptRaw).toContain("# Dreaming Protocol");
+    // Human-authored `kind: protocol` was preserved.
+    expect(conceptRaw).toMatch(/\nkind: protocol\n/);
+  });
+
+  it("compile alone (without repair) also self-heals structure for non-orphan pages", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-integration-compile-",
+      config: { vault: { renderMode: "native" } },
+      initialize: true,
+    });
+    await writePage(rootDir, "concepts/mostly-bare.md", "# Mostly Bare\n\nSome human text.\n");
+
+    await compileMemoryWikiVault(config);
+
+    const raw = await fs.readFile(path.join(rootDir, "concepts", "mostly-bare.md"), "utf8");
+    expect(raw).toMatch(/^---\n/);
+    expect(raw).toMatch(/\npageType: concept\n/);
+    expect(raw).toMatch(/\nid: concept\.mostly-bare\n/);
+    expect(raw).toMatch(/\nupdatedAt: /);
+    expect(raw).toContain("# Mostly Bare");
+  });
+});

--- a/extensions/memory-wiki/src/structure-repair.test.ts
+++ b/extensions/memory-wiki/src/structure-repair.test.ts
@@ -1,0 +1,191 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseWikiMarkdown, renderWikiMarkdown } from "./markdown.js";
+import {
+  ensurePageStructure,
+  findOrphanSourceShells,
+  isOrphanSourceShell,
+  repairMemoryWikiVault,
+} from "./structure-repair.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
+
+const { createVault } = createMemoryWikiTestHarness();
+
+describe("ensurePageStructure", () => {
+  it("backfills id, pageType, title, and updatedAt on a human-authored concept", async () => {
+    const { rootDir } = await createVault({ initialize: true });
+    const relativePath = "concepts/dreaming-protocol.md";
+    await fs.writeFile(
+      path.join(rootDir, relativePath),
+      "---\nkind: protocol\n---\n\n# Dreaming Protocol\n\nBody here.\n",
+      "utf8",
+    );
+
+    const result = await ensurePageStructure({
+      rootDir,
+      relativePath,
+      nowIso: "2026-04-19T00:00:00.000Z",
+    });
+
+    expect(result.operation).toBe("backfilled-structure");
+    expect(result.fieldsAdded.toSorted()).toEqual(["id", "pageType", "title", "updatedAt"]);
+
+    const raw = await fs.readFile(path.join(rootDir, relativePath), "utf8");
+    const parsed = parseWikiMarkdown(raw);
+    expect(parsed.frontmatter.id).toBe("concept.dreaming-protocol");
+    expect(parsed.frontmatter.pageType).toBe("concept");
+    expect(parsed.frontmatter.title).toBe("Dreaming Protocol");
+    expect(parsed.frontmatter.kind).toBe("protocol");
+    expect(typeof parsed.frontmatter.updatedAt).toBe("string");
+    expect(parsed.body.trim()).toBe("# Dreaming Protocol\n\nBody here.");
+  });
+
+  it("is a no-op when all required fields are present", async () => {
+    const { rootDir } = await createVault({ initialize: true });
+    const relativePath = "entities/alpha.md";
+    const original = renderWikiMarkdown({
+      frontmatter: {
+        pageType: "entity",
+        id: "entity.alpha",
+        title: "Alpha",
+        updatedAt: "2026-04-18T12:00:00.000Z",
+      },
+      body: "# Alpha\n",
+    });
+    await fs.writeFile(path.join(rootDir, relativePath), original, "utf8");
+
+    const result = await ensurePageStructure({
+      rootDir,
+      relativePath,
+      nowIso: "2026-04-19T00:00:00.000Z",
+    });
+
+    expect(result.operation).toBe("skipped");
+    expect(result.fieldsAdded).toEqual([]);
+    const raw = await fs.readFile(path.join(rootDir, relativePath), "utf8");
+    expect(raw).toBe(original);
+  });
+
+  it("falls back to filename for title when no heading or title field exists", async () => {
+    const { rootDir } = await createVault({ initialize: true });
+    const relativePath = "entities/bare-page.md";
+    await fs.writeFile(path.join(rootDir, relativePath), "Just prose, no heading.\n", "utf8");
+
+    const result = await ensurePageStructure({
+      rootDir,
+      relativePath,
+      nowIso: "2026-04-19T00:00:00.000Z",
+    });
+
+    expect(result.operation).toBe("backfilled-structure");
+    const raw = await fs.readFile(path.join(rootDir, relativePath), "utf8");
+    const parsed = parseWikiMarkdown(raw);
+    expect(parsed.frontmatter.title).toBe("bare page");
+    expect(parsed.frontmatter.pageType).toBe("entity");
+    expect(parsed.frontmatter.id).toBe("entity.bare-page");
+  });
+});
+
+describe("isOrphanSourceShell", () => {
+  it("detects the related-block-only shell produced by stray compile runs", () => {
+    const shell = [
+      "## Related",
+      "<!-- openclaw:wiki:related:start -->",
+      "- No related pages yet.",
+      "<!-- openclaw:wiki:related:end -->",
+    ].join("\n");
+    expect(isOrphanSourceShell(shell)).toBe(true);
+  });
+
+  it("does not mis-classify a page whose body has real content", () => {
+    const body = [
+      "# Real Title",
+      "",
+      "Real content here.",
+      "",
+      "## Related",
+      "<!-- openclaw:wiki:related:start -->",
+      "- No related pages yet.",
+      "<!-- openclaw:wiki:related:end -->",
+    ].join("\n");
+    expect(isOrphanSourceShell(body)).toBe(false);
+  });
+});
+
+describe("repairMemoryWikiVault", () => {
+  it("backfills structure across an unhealthy vault and optionally removes orphans", async () => {
+    const { rootDir, config } = await createVault({ initialize: true });
+
+    await fs.writeFile(
+      path.join(rootDir, "concepts", "unstructured.md"),
+      "# Concept Alpha\n\nSome prose.\n",
+      "utf8",
+    );
+
+    const orphanShell =
+      "## Related\n<!-- openclaw:wiki:related:start -->\n- No related pages yet.\n<!-- openclaw:wiki:related:end -->\n";
+    await fs.writeFile(path.join(rootDir, "sources", "orphan.md"), orphanShell, "utf8");
+
+    await fs.writeFile(
+      path.join(rootDir, "entities", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.healthy",
+          title: "Healthy",
+          updatedAt: "2026-04-18T12:00:00.000Z",
+        },
+        body: "# Healthy\n",
+      }),
+      "utf8",
+    );
+
+    const detectedOrphans = await findOrphanSourceShells(config);
+    expect(detectedOrphans).toEqual(["sources/orphan.md"]);
+
+    const result = await repairMemoryWikiVault(config, {
+      removeOrphans: true,
+      nowMs: Date.UTC(2026, 3, 19),
+    });
+
+    expect(result.backfilled).toBe(1);
+    expect(result.orphansRemoved).toBe(1);
+    expect(
+      result.pages.find((entry) => entry.relativePath === "concepts/unstructured.md")?.operation,
+    ).toBe("backfilled-structure");
+    expect(
+      result.pages.find((entry) => entry.relativePath === "sources/orphan.md")?.operation,
+    ).toBe("removed-orphan");
+    expect(
+      result.pages.find((entry) => entry.relativePath === "entities/healthy.md")?.operation,
+    ).toBe("skipped");
+
+    await expect(
+      fs.stat(path.join(rootDir, "sources", "orphan.md")).then(
+        () => true,
+        () => false,
+      ),
+    ).resolves.toBe(false);
+
+    const repaired = await fs.readFile(path.join(rootDir, "concepts", "unstructured.md"), "utf8");
+    const parsed = parseWikiMarkdown(repaired);
+    expect(parsed.frontmatter.id).toBe("concept.unstructured");
+    expect(parsed.frontmatter.pageType).toBe("concept");
+    expect(parsed.frontmatter.title).toBe("Concept Alpha");
+    expect(typeof parsed.frontmatter.updatedAt).toBe("string");
+  });
+
+  it("preserves orphan shells when removeOrphans is not set", async () => {
+    const { rootDir, config } = await createVault({ initialize: true });
+    const shell =
+      "## Related\n<!-- openclaw:wiki:related:start -->\n- No related pages yet.\n<!-- openclaw:wiki:related:end -->\n";
+    await fs.writeFile(path.join(rootDir, "sources", "stay.md"), shell, "utf8");
+
+    const result = await repairMemoryWikiVault(config);
+    expect(result.orphansRemoved).toBe(0);
+    await expect(fs.readFile(path.join(rootDir, "sources", "stay.md"), "utf8")).resolves.toBe(
+      shell,
+    );
+  });
+});

--- a/extensions/memory-wiki/src/structure-repair.ts
+++ b/extensions/memory-wiki/src/structure-repair.ts
@@ -1,0 +1,294 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import type { ResolvedMemoryWikiConfig } from "./config.js";
+import { appendMemoryWikiLog } from "./log.js";
+import {
+  extractTitleFromMarkdown,
+  inferWikiPageKind,
+  parseWikiMarkdown,
+  renderWikiMarkdown,
+  slugifyWikiSegment,
+  WIKI_RELATED_END_MARKER,
+  WIKI_RELATED_START_MARKER,
+  type WikiPageKind,
+} from "./markdown.js";
+
+const EMPTY_BODY_PATTERN = new RegExp(
+  `^\\s*(?:##\\s+Related\\s*\\n?)?${WIKI_RELATED_START_MARKER}[\\s\\S]*?${WIKI_RELATED_END_MARKER}\\s*$`,
+);
+
+export type RepairedPageOperation =
+  | "backfilled-structure"
+  | "updated-timestamp"
+  | "removed-orphan"
+  | "skipped";
+
+export type RepairedPage = {
+  relativePath: string;
+  operation: RepairedPageOperation;
+  fieldsAdded: string[];
+  reason?: string;
+};
+
+export type RepairMemoryWikiOptions = {
+  removeOrphans?: boolean;
+  nowMs?: number;
+};
+
+export type RepairMemoryWikiResult = {
+  vaultRoot: string;
+  scanned: number;
+  backfilled: number;
+  orphansRemoved: number;
+  pages: RepairedPage[];
+};
+
+const PAGE_DIRS: readonly { kind: WikiPageKind; dir: string }[] = [
+  { kind: "source", dir: "sources" },
+  { kind: "entity", dir: "entities" },
+  { kind: "concept", dir: "concepts" },
+  { kind: "synthesis", dir: "syntheses" },
+  { kind: "report", dir: "reports" },
+];
+
+function deriveTitle(body: string, relativePath: string): string {
+  const heading = extractTitleFromMarkdown(body);
+  if (heading) {
+    return heading;
+  }
+  const base = path.basename(relativePath, ".md");
+  return base.replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim() || base;
+}
+
+function deriveId(kind: WikiPageKind, title: string, relativePath: string): string {
+  const slugFromPath = slugifyWikiSegment(path.basename(relativePath, ".md").replace(/\s+/g, "-"));
+  const slug = slugFromPath && slugFromPath !== "page" ? slugFromPath : slugifyWikiSegment(title);
+  return `${kind}.${slug || "page"}`;
+}
+
+type FileStat = { mtimeMs: number };
+
+async function safeStat(absolutePath: string): Promise<FileStat | null> {
+  return fs.stat(absolutePath).catch(() => null);
+}
+
+function looksLikeOrphanShell(body: string): boolean {
+  return EMPTY_BODY_PATTERN.test(body);
+}
+
+/**
+ * Backfill any missing required frontmatter fields on a single page so that it conforms to the
+ * canonical standard: `id`, `pageType`, `title`, `updatedAt`. The body is preserved exactly.
+ *
+ * Safe to call on a human-authored page — only adds fields that are absent.
+ */
+export async function ensurePageStructure(params: {
+  rootDir: string;
+  relativePath: string;
+  nowIso: string;
+}): Promise<RepairedPage> {
+  const absolutePath = path.join(params.rootDir, params.relativePath);
+  const kind = inferWikiPageKind(params.relativePath);
+  if (!kind) {
+    return {
+      relativePath: params.relativePath,
+      operation: "skipped",
+      fieldsAdded: [],
+      reason: "unknown directory",
+    };
+  }
+  const raw = await fs.readFile(absolutePath, "utf8").catch(() => null);
+  if (raw === null) {
+    return {
+      relativePath: params.relativePath,
+      operation: "skipped",
+      fieldsAdded: [],
+      reason: "file missing",
+    };
+  }
+  const parsed = parseWikiMarkdown(raw);
+  const frontmatter = { ...parsed.frontmatter };
+  const added: string[] = [];
+
+  const title =
+    normalizeOptionalString(frontmatter.title) ?? deriveTitle(parsed.body, params.relativePath);
+  if (!normalizeOptionalString(frontmatter.title)) {
+    frontmatter.title = title;
+    added.push("title");
+  }
+
+  if (!normalizeOptionalString(frontmatter.pageType)) {
+    frontmatter.pageType = kind;
+    added.push("pageType");
+  }
+
+  if (!normalizeOptionalString(frontmatter.id)) {
+    frontmatter.id = deriveId(kind, title, params.relativePath);
+    added.push("id");
+  }
+
+  if (!normalizeOptionalString(frontmatter.updatedAt)) {
+    const stat = await safeStat(absolutePath);
+    const fallback = stat ? new Date(stat.mtimeMs).toISOString() : params.nowIso;
+    frontmatter.updatedAt = fallback;
+    added.push("updatedAt");
+  }
+
+  if (added.length === 0) {
+    return {
+      relativePath: params.relativePath,
+      operation: "skipped",
+      fieldsAdded: [],
+    };
+  }
+
+  const rendered = renderWikiMarkdown({ frontmatter, body: parsed.body });
+  if (rendered !== raw) {
+    await fs.writeFile(absolutePath, rendered, "utf8");
+  }
+  return {
+    relativePath: params.relativePath,
+    operation: "backfilled-structure",
+    fieldsAdded: added,
+  };
+}
+
+async function listPagePaths(rootDir: string): Promise<string[]> {
+  const collected: string[] = [];
+  for (const { dir } of PAGE_DIRS) {
+    const entries = await fs
+      .readdir(path.join(rootDir, dir), { withFileTypes: true })
+      .catch(() => []);
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) {
+        continue;
+      }
+      if (entry.name === "index.md") {
+        continue;
+      }
+      collected.push(path.join(dir, entry.name));
+    }
+  }
+  return collected.toSorted((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Walk the vault and apply deterministic structure repairs:
+ *  - Inject missing `id`, `pageType`, `title`, `updatedAt` on every content page.
+ *  - Optionally remove orphan source shells (files whose only content is an empty Related block).
+ *
+ * The function never rewrites human-authored body text and never overwrites existing
+ * frontmatter values.
+ */
+export async function repairMemoryWikiVault(
+  config: ResolvedMemoryWikiConfig,
+  options: RepairMemoryWikiOptions = {},
+): Promise<RepairMemoryWikiResult> {
+  const rootDir = config.vault.path;
+  const nowIso = new Date(options.nowMs ?? Date.now()).toISOString();
+  const pagePaths = await listPagePaths(rootDir);
+  const pages: RepairedPage[] = [];
+  let backfilled = 0;
+  let orphansRemoved = 0;
+
+  for (const relativePath of pagePaths) {
+    const absolutePath = path.join(rootDir, relativePath);
+    const raw = await fs.readFile(absolutePath, "utf8").catch(() => null);
+    if (raw === null) {
+      pages.push({
+        relativePath,
+        operation: "skipped",
+        fieldsAdded: [],
+        reason: "file disappeared",
+      });
+      continue;
+    }
+    const parsed = parseWikiMarkdown(raw);
+    const hasFrontmatter = Object.keys(parsed.frontmatter).length > 0;
+    const emptyBody = !parsed.body.trim() || looksLikeOrphanShell(parsed.body);
+    const isOrphan = !hasFrontmatter && emptyBody && relativePath.startsWith("sources/");
+
+    if (isOrphan) {
+      if (options.removeOrphans) {
+        await fs.rm(absolutePath, { force: true }).catch(() => undefined);
+        pages.push({
+          relativePath,
+          operation: "removed-orphan",
+          fieldsAdded: [],
+          reason: "no frontmatter + empty body",
+        });
+        orphansRemoved += 1;
+      } else {
+        pages.push({
+          relativePath,
+          operation: "skipped",
+          fieldsAdded: [],
+          reason: "orphan shell — pass --remove-orphans to delete",
+        });
+      }
+      continue;
+    }
+
+    const result = await ensurePageStructure({ rootDir, relativePath, nowIso });
+    pages.push(result);
+    if (result.operation === "backfilled-structure") {
+      backfilled += 1;
+    }
+  }
+
+  if (backfilled > 0 || orphansRemoved > 0) {
+    await appendMemoryWikiLog(rootDir, {
+      type: "repair",
+      timestamp: nowIso,
+      details: {
+        scanned: pagePaths.length,
+        backfilled,
+        orphansRemoved,
+      },
+    });
+  }
+
+  return {
+    vaultRoot: rootDir,
+    scanned: pagePaths.length,
+    backfilled,
+    orphansRemoved,
+    pages,
+  };
+}
+
+/**
+ * Detect orphan source shells without modifying them.
+ *
+ * An orphan shell is a file in `sources/` whose entire body consists of just the managed
+ * `## Related` block (or a single blank line). These typically come from a deleted upstream
+ * artifact followed by a stale compile pass, and they pollute link/frontmatter lints.
+ */
+export async function findOrphanSourceShells(config: ResolvedMemoryWikiConfig): Promise<string[]> {
+  const rootDir = config.vault.path;
+  const orphans: string[] = [];
+  const paths = await listPagePaths(rootDir);
+  for (const relativePath of paths) {
+    if (!relativePath.startsWith("sources/")) {
+      continue;
+    }
+    const absolutePath = path.join(rootDir, relativePath);
+    const raw = await fs.readFile(absolutePath, "utf8").catch(() => null);
+    if (raw === null) {
+      continue;
+    }
+    const parsed = parseWikiMarkdown(raw);
+    if (Object.keys(parsed.frontmatter).length > 0) {
+      continue;
+    }
+    if (!parsed.body.trim() || looksLikeOrphanShell(parsed.body)) {
+      orphans.push(relativePath);
+    }
+  }
+  return orphans;
+}
+
+export function isOrphanSourceShell(body: string): boolean {
+  return !body.trim() || looksLikeOrphanShell(body);
+}

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -62,6 +62,7 @@ import {
   getMemoryRuntime,
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
+  mergeMemoryPluginState,
   restoreMemoryPluginState,
 } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
@@ -1442,7 +1443,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       restoreRegisteredAgentHarnesses(cached.agentHarnesses);
       restoreRegisteredCompactionProviders(cached.compactionProviders);
       restoreRegisteredMemoryEmbeddingProviders(cached.memoryEmbeddingProviders);
-      restoreMemoryPluginState({
+      mergeMemoryPluginState({
         capability: cached.memoryCapability,
         corpusSupplements: cached.memoryCorpusSupplements,
         promptBuilder: cached.memoryPromptBuilder,

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -274,6 +274,28 @@ describe("memory plugin state", () => {
     expect(getMemoryRuntime()).toBe(runtime);
   });
 
+  it("restoreMemoryPluginState preserves a live capability when restoring empty state", () => {
+    const runtime = createMemoryRuntime();
+    registerMemoryCapability("memory-core", {
+      promptBuilder: () => ["core prompt"],
+      runtime,
+    });
+
+    // A stale or cache-hit snapshot with no capability must not clobber a
+    // live registration. Previously this path reset memoryPluginState.capability
+    // to undefined, which caused listActiveMemoryPublicArtifacts to return []
+    // and memory-wiki bridge imports to prune all synced source pages.
+    restoreMemoryPluginState({
+      capability: undefined,
+      corpusSupplements: [],
+      promptSupplements: [],
+    });
+
+    expect(getMemoryCapabilityRegistration()).toMatchObject({ pluginId: "memory-core" });
+    expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["core prompt"]);
+    expect(getMemoryRuntime()).toBe(runtime);
+  });
+
   it("clearMemoryPluginState resets both registries", () => {
     registerMemoryState({
       promptSection: ["stale section"],

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -11,6 +11,7 @@ import {
   listMemoryCorpusSupplements,
   listMemoryPromptSupplements,
   listActiveMemoryPublicArtifacts,
+  mergeMemoryPluginState,
   registerMemoryCapability,
   registerMemoryCorpusSupplement,
   registerMemoryFlushPlanResolver,
@@ -274,7 +275,7 @@ describe("memory plugin state", () => {
     expect(getMemoryRuntime()).toBe(runtime);
   });
 
-  it("restoreMemoryPluginState preserves a live capability when restoring empty state", () => {
+  it("mergeMemoryPluginState preserves a live capability when merging empty state", () => {
     const runtime = createMemoryRuntime();
     registerMemoryCapability("memory-core", {
       promptBuilder: () => ["core prompt"],
@@ -282,10 +283,13 @@ describe("memory plugin state", () => {
     });
 
     // A stale or cache-hit snapshot with no capability must not clobber a
-    // live registration. Previously this path reset memoryPluginState.capability
-    // to undefined, which caused listActiveMemoryPublicArtifacts to return []
-    // and memory-wiki bridge imports to prune all synced source pages.
-    restoreMemoryPluginState({
+    // live registration. Previously the cache-hit path called
+    // restoreMemoryPluginState, which reset memoryPluginState.capability to
+    // undefined and caused listActiveMemoryPublicArtifacts to return [] and
+    // memory-wiki bridge imports to prune all synced source pages. The
+    // cache-hit path now calls mergeMemoryPluginState (this function), which
+    // only overwrites fields carrying a non-empty value.
+    mergeMemoryPluginState({
       capability: undefined,
       corpusSupplements: [],
       promptSupplements: [],
@@ -294,6 +298,30 @@ describe("memory plugin state", () => {
     expect(getMemoryCapabilityRegistration()).toMatchObject({ pluginId: "memory-core" });
     expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual(["core prompt"]);
     expect(getMemoryRuntime()).toBe(runtime);
+  });
+
+  it("restoreMemoryPluginState clears a live capability when swap-restoring empty state", () => {
+    const runtime = createMemoryRuntime();
+    registerMemoryCapability("memory-core", {
+      promptBuilder: () => ["core prompt"],
+      runtime,
+    });
+    registerMemoryPromptSupplement("stale", () => ["stale supplement"]);
+
+    // restoreMemoryPluginState is the destructive swap used by rollback paths
+    // where newly-registered state from a failed plugin must be wiped back to
+    // the captured pre-register snapshot — even when that snapshot is empty.
+    // Without this semantic, loader.ts's register-rollback path would leave
+    // stale supplements behind (covered by loader.test.ts "clears
+    // newly-registered memory plugin registries when plugin register fails").
+    restoreMemoryPluginState({
+      capability: undefined,
+      corpusSupplements: [],
+      promptSupplements: [],
+    });
+
+    expect(getMemoryCapabilityRegistration()).toBeUndefined();
+    expect(listMemoryPromptSupplements()).toHaveLength(0);
   });
 
   it("clearMemoryPluginState resets both registries", () => {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -302,17 +302,27 @@ export async function listActiveMemoryPublicArtifacts(params: {
 }
 
 export function restoreMemoryPluginState(state: MemoryPluginState): void {
-  memoryPluginState.capability = state.capability
-    ? {
-        pluginId: state.capability.pluginId,
-        capability: { ...state.capability.capability },
-      }
-    : undefined;
-  memoryPluginState.corpusSupplements = [...state.corpusSupplements];
-  memoryPluginState.promptBuilder = state.promptBuilder;
-  memoryPluginState.promptSupplements = [...state.promptSupplements];
-  memoryPluginState.flushPlanResolver = state.flushPlanResolver;
-  memoryPluginState.runtime = state.runtime;
+  if (state.capability) {
+    memoryPluginState.capability = {
+      pluginId: state.capability.pluginId,
+      capability: { ...state.capability.capability },
+    };
+  }
+  if (state.corpusSupplements && state.corpusSupplements.length > 0) {
+    memoryPluginState.corpusSupplements = [...state.corpusSupplements];
+  }
+  if (state.promptBuilder) {
+    memoryPluginState.promptBuilder = state.promptBuilder;
+  }
+  if (state.promptSupplements && state.promptSupplements.length > 0) {
+    memoryPluginState.promptSupplements = [...state.promptSupplements];
+  }
+  if (state.flushPlanResolver) {
+    memoryPluginState.flushPlanResolver = state.flushPlanResolver;
+  }
+  if (state.runtime) {
+    memoryPluginState.runtime = state.runtime;
+  }
 }
 
 export function clearMemoryPluginState(): void {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -302,6 +302,30 @@ export async function listActiveMemoryPublicArtifacts(params: {
 }
 
 export function restoreMemoryPluginState(state: MemoryPluginState): void {
+  memoryPluginState.capability = state.capability
+    ? {
+        pluginId: state.capability.pluginId,
+        capability: { ...state.capability.capability },
+      }
+    : undefined;
+  memoryPluginState.corpusSupplements = [...state.corpusSupplements];
+  memoryPluginState.promptBuilder = state.promptBuilder;
+  memoryPluginState.promptSupplements = [...state.promptSupplements];
+  memoryPluginState.flushPlanResolver = state.flushPlanResolver;
+  memoryPluginState.runtime = state.runtime;
+}
+
+/**
+ * Additive counterpart to {@link restoreMemoryPluginState}: only overwrites
+ * each field when the incoming state carries a non-empty value. Intended for
+ * cache-hit paths in the plugin loader that must NOT clobber a live
+ * capability when the cached snapshot predates the capability's registration.
+ *
+ * Use {@link restoreMemoryPluginState} (full swap) for rollback on failed
+ * plugin registration, where each field MUST revert to its pre-register
+ * value regardless of whether the saved previous value was empty.
+ */
+export function mergeMemoryPluginState(state: MemoryPluginState): void {
   if (state.capability) {
     memoryPluginState.capability = {
       pluginId: state.capability.pluginId,


### PR DESCRIPTION
## Summary

Harden the memory-wiki vault so it's deterministic and trustworthy for daily use. Kills three pipeline bugs responsible for most of the current 42 lint errors + 682 warnings, codifies the canonical page standard in code + docs, and adds a deterministic repair command for legacy content.

## Pipeline bugs fixed

1. **Code-fence link leak** — `extractWikiLinks` now strips fenced code blocks and inline code before scanning. `[[reply_to_current]]` tokens inside transcript fences no longer count as wikilinks (~288 false-positive broken-link warnings).
2. **Native-mode link validator** — `collectBrokenLinkIssues` normalizes `.md` suffix and path prefix on both sides so `[Title](sources/foo.md)` in dashboard reports resolves. Previously every native-mode markdown link was lint-broken.
3. **Orphan-shell creation** — `refreshPageRelatedBlocks` now skips pages with no frontmatter and no body, so compile no longer papers over empty source files by adding `## Related` blocks to them.

## Canonical standard + repair

- New `structure-repair.ts` module with `ensurePageStructure`, `repairMemoryWikiVault`, and `findOrphanSourceShells`.
- Compile auto-runs the structure sweep so generated artifacts always carry `id`, `pageType`, `title`, `updatedAt`. Human-authored body text and existing frontmatter are never rewritten.
- New `openclaw wiki repair [--dry-run] [--remove-orphans]` CLI for explicit legacy backfill and orphan cleanup.
- Lint report includes `updatedAt` on first creation.
- README documents the canonical standard table, provenance discipline, orphan-shell semantics, and the daily operator workflow.

## Operator workflow

Daily loop is unchanged:

```
openclaw wiki bridge import
openclaw wiki compile
openclaw wiki lint
```

One-time legacy cleanup:

```
openclaw wiki repair --dry-run
openclaw wiki repair --remove-orphans
openclaw wiki compile
openclaw wiki lint
```

## Test plan

- [x] Full memory-wiki test suite: 97/97 green (16 new tests).
- [x] `pnpm oxlint --type-aware extensions/memory-wiki/src` clean.
- [x] `pnpm tsgo --noEmit -p extensions/memory-wiki/tsconfig.json` clean.
- [x] Integration test seeds the exact failure patterns observed in the live vault (orphan shell, legacy concept without frontmatter, transcript with `[[reply_to_current]]` inside a code fence, native-mode dashboard link) and verifies the full `repair -> compile -> lint` loop drops errors and broken-link warnings to zero.
- [ ] After merge + reinstall: run `openclaw wiki repair --dry-run` against the live vault to confirm orphan count matches, then `openclaw wiki repair --remove-orphans && openclaw wiki compile && openclaw wiki lint` and inspect the reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)