### PR TITLE
fix(agents): restore streaming usage tracking for non-native openai-completions providers

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -232,11 +232,15 @@ describe("normalizeModelCompat", () => {
     });
   });
 
-  it("forces supportsUsageInStreaming off for generic custom openai-completions provider", () => {
-    expectSupportsUsageInStreamingForcedOff({
+  it("defaults supportsUsageInStreaming on for generic custom openai-completions provider", () => {
+    const model = {
+      ...baseModel(),
       provider: "custom-cpa",
       baseUrl: "https://cpa.example.com/v1",
-    });
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model as Model<Api>);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
   });
 
   it("forces supportsStrictMode off for z.ai models", () => {

--- a/src/agents/openai-completions-compat.test.ts
+++ b/src/agents/openai-completions-compat.test.ts
@@ -22,13 +22,13 @@ describe("resolveOpenAICompletionsCompatDefaults", () => {
     ).toBe(true);
   });
 
-  it("does not broaden streaming usage for generic custom providers", () => {
+  it("defaults streaming usage on for generic custom providers (most OpenAI-compat APIs support it)", () => {
     expect(
       resolveOpenAICompletionsCompatDefaults({
         provider: "custom-cpa",
         endpointClass: "custom",
         knownProviderFamily: "custom-cpa",
       }).supportsUsageInStreaming,
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -79,7 +79,7 @@ export function resolveOpenAICompletionsCompatDefaults(
       !usesExplicitProxyLikeEndpoint,
     supportsUsageInStreaming:
       isOllamaCompatProvider ||
-      (!isNonStandard && (!usesConfiguredNonOpenAIEndpoint || supportsNativeStreamingUsageCompat)),
+      (!isNonStandard && (supportsNativeStreamingUsageCompat ?? true)),
     maxTokensField: usesMaxTokens ? "max_tokens" : "max_completion_tokens",
     thinkingFormat: isZai ? "zai" : isOpenRouterLike ? "openrouter" : "openai",
     supportsStrictMode: !isZai && !usesConfiguredNonOpenAIEndpoint,

--- a/src/plugins/provider-model-compat.ts
+++ b/src/plugins/provider-model-compat.ts
@@ -124,13 +124,13 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
           ...(hasStreamingUsageOverride
             ? {}
             : {
-                supportsUsageInStreaming: detectedCompatDefaults?.supportsUsageInStreaming ?? false,
+                supportsUsageInStreaming: detectedCompatDefaults?.supportsUsageInStreaming ?? true,
               }),
           supportsStrictMode: targetStrictMode,
         }
       : {
           supportsDeveloperRole: false,
-          supportsUsageInStreaming: detectedCompatDefaults?.supportsUsageInStreaming ?? false,
+          supportsUsageInStreaming: detectedCompatDefaults?.supportsUsageInStreaming ?? true,
           supportsStrictMode: detectedCompatDefaults?.supportsStrictMode ?? false,
         },
   } as typeof model;


### PR DESCRIPTION
## Summary

Fixes #68707

When using custom openai-completions endpoints (llama-cpp, LM Studio, DashScope, etc.), stream_options.include_usage: true was never injected into the request payload, causing /status to always show 0% context usage.

## Root Cause

In resolveOpenAICompletionsCompatDefaults(), supportsUsageInStreaming was set to false when usesConfiguredNonOpenAIEndpoint was true (i.e. the user pointed to a custom endpoint) and supportsNativeStreamingUsageCompat was not explicitly set. This caused the transport layer to skip injecting stream_options: { include_usage: true }.

## Fix

- openai-completions-compat.ts: Changed the default from opt-in to opt-out. supportsNativeStreamingUsageCompat now defaults to true via ?? true, since most OpenAI-compatible APIs handle stream_options.include_usage correctly (as established by #46142).

- provider-model-compat.ts: Updated the fallback in the compat override layer from ?? false to ?? true to match the new default.

## Impact

- Restores context token tracking for llama-cpp, LM Studio, and other custom openai-completions providers
- No behavioral change for native OpenAI endpoints (already had true)
- No behavioral change for known non-standard providers (already forced false)
- Aligns with prior fix (#46142) which established that most compat APIs support streaming usage

## Testing

- Updated unit tests to reflect the new default
- Existing ollama tests remain passing (explicit isOllamaCompatProvider branch unchanged)