### PR TITLE
fix(whatsapp): respect audioAsVoice flag in outbound delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ Docs: https://docs.openclaw.ai
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
 - Plugins/Comfy: read workflow and cloud auth configuration from `plugins.entries.comfy.config` while preserving legacy Comfy config fallback, so image, video, and music workflows pass config validation. Fixes #61915. (#63058) Thanks @547895019.
 - Gateway/secrets: restart secret-backed channels such as Slack and Zalo during `secrets.reload` so rotated webhook secrets take effect immediately, with the reload serialized and per-channel restart errors isolated. (#70720) Thanks @drobison00.
+- WhatsApp: respect the `[[audio_as_voice]]` directive in outbound delivery. Replies carrying `audioAsVoice` with a verified audio source now reach WhatsApp as PTT voice notes instead of document attachments. Adds channel-agnostic MIME/filename sanitization helpers to `openclaw/plugin-sdk/media-runtime`. Fixes #66053. Thanks @masatohoshino.
 
 ## 2026.4.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,7 +224,7 @@ Docs: https://docs.openclaw.ai
 - Agents/CLI: keep `--agent` plus `--session-id` lookup scoped to the requested agent store, so explicit agent resumes cannot select another agent's session. (#70985) Thanks @frankekn.
 - Plugins/Comfy: read workflow and cloud auth configuration from `plugins.entries.comfy.config` while preserving legacy Comfy config fallback, so image, video, and music workflows pass config validation. Fixes #61915. (#63058) Thanks @547895019.
 - Gateway/secrets: restart secret-backed channels such as Slack and Zalo during `secrets.reload` so rotated webhook secrets take effect immediately, with the reload serialized and per-channel restart errors isolated. (#70720) Thanks @drobison00.
-- WhatsApp: respect the `[[audio_as_voice]]` directive in outbound delivery. Replies carrying `audioAsVoice` with a verified audio source now reach WhatsApp as PTT voice notes instead of document attachments. Adds channel-agnostic MIME/filename sanitization helpers to `openclaw/plugin-sdk/media-runtime`. Fixes #66053. Thanks @masatohoshino.
+- WhatsApp: respect the `[[audio_as_voice]]` directive in outbound delivery. Replies carrying `audioAsVoice` with a verified audio source now reach WhatsApp as PTT voice notes instead of document attachments, with `isVerifiedAudioSource` tightened to require a caller-classified audio `kind` rather than trusting `Content-Type` headers (CWE-345). Adds channel-agnostic MIME/filename sanitization helpers to `openclaw/plugin-sdk/media-runtime`. Fixes #66053. Thanks @masatohoshino.
 
 ## 2026.4.22
 

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -546,6 +546,252 @@ describe("deliverWebReply", () => {
     );
   });
 
+  it("rejects voice-note coercion when audioAsVoice is true but media is not verified audio", async () => {
+    const msg = makeMsg();
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
+      buffer: Buffer.from("aud"),
+      contentType: "application/octet-stream",
+      kind: "document",
+      fileName: "voice.ogg",
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "cap", mediaUrl: "http://example.com/voice.ogg", audioAsVoice: true },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.any(Buffer),
+        fileName: "voice.ogg",
+        mimetype: "application/octet-stream",
+        caption: "cap",
+      }),
+      undefined,
+    );
+  });
+
+  it("falls back to opus mimetype when contentType contains control characters", async () => {
+    const msg = makeMsg();
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
+      buffer: Buffer.from("aud"),
+      contentType: "audio/ogg\r\nX-Inj: bad",
+      kind: "audio",
+      fileName: "voice.ogg",
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "cap", mediaUrl: "http://example.com/voice.ogg", audioAsVoice: true },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audio: expect.any(Buffer),
+        ptt: true,
+        mimetype: "audio/ogg; codecs=opus",
+        caption: "cap",
+      }),
+      undefined,
+    );
+  });
+
+  it("uses image/jpeg fallback when image contentType contains control characters", async () => {
+    const msg = makeMsg();
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
+      buffer: Buffer.from("img"),
+      contentType: "image/png\r\nX-Inj: bad",
+      kind: "image",
+      fileName: "photo.png",
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "img cap", mediaUrl: "http://example.com/photo.png" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image: expect.any(Buffer),
+        mimetype: "image/jpeg",
+        caption: "img cap",
+      }),
+      undefined,
+    );
+  });
+
+  it("uses video/mp4 fallback when video contentType contains control characters", async () => {
+    const msg = makeMsg();
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
+      buffer: Buffer.from("vid"),
+      contentType: "video/quicktime\r\nX-Inj: bad",
+      kind: "video",
+      fileName: "movie.mov",
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "vid cap", mediaUrl: "http://example.com/movie.mov" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        video: expect.any(Buffer),
+        mimetype: "video/mp4",
+        caption: "vid cap",
+      }),
+      undefined,
+    );
+  });
+
+  it("uses octet-stream fallback when document contentType contains control characters", async () => {
+    const msg = makeMsg();
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
+      buffer: Buffer.from("doc"),
+      contentType: "application/pdf\r\nX-Inj: bad",
+      kind: "document",
+      fileName: "report.pdf",
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "doc cap", mediaUrl: "http://example.com/report.pdf" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.any(Buffer),
+        fileName: "report.pdf",
+        mimetype: "application/octet-stream",
+        caption: "doc cap",
+      }),
+      undefined,
+    );
+  });
+
+  it("sanitizes document fileName when it contains control characters", async () => {
+    const msg = makeMsg();
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
+      buffer: Buffer.from("doc"),
+      contentType: "application/pdf",
+      kind: "document",
+      fileName: "evil.pdf\r\nX-Inj: bad",
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "doc cap", mediaUrl: "http://example.com/report.pdf" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.any(Buffer),
+        fileName: "evil.pdfX-Inj: bad",
+        mimetype: "application/pdf",
+        caption: "doc cap",
+      }),
+      undefined,
+    );
+  });
+
+  it("keeps non-audio documents as documents even when audioAsVoice is true", async () => {
+    const msg = makeMsg();
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
+      buffer: Buffer.from("pdf"),
+      contentType: "application/pdf",
+      kind: "document",
+      fileName: "file.pdf",
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "cap", mediaUrl: "http://example.com/file.pdf", audioAsVoice: true },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.any(Buffer),
+        fileName: "file.pdf",
+        mimetype: "application/pdf",
+        caption: "cap",
+      }),
+      undefined,
+    );
+  });
+
+  it("keeps document path for audio-like file when audioAsVoice is unset", async () => {
+    const msg = makeMsg();
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
+      buffer: Buffer.from("aud"),
+      contentType: "application/octet-stream",
+      kind: "document",
+      fileName: "voice.ogg",
+    });
+
+    await deliverWebReply({
+      replyResult: { text: "cap", mediaUrl: "http://example.com/voice.ogg" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(msg.sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.any(Buffer),
+        fileName: "voice.ogg",
+        mimetype: "application/octet-stream",
+        caption: "cap",
+      }),
+      undefined,
+    );
+  });
+
   it("sends video media", async () => {
     const msg = makeMsg();
     (

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -1,4 +1,9 @@
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
+import {
+  isVerifiedAudioSource,
+  sanitizeFileName,
+  sanitizeMediaMime,
+} from "openclaw/plugin-sdk/media-runtime";
 import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-chunking";
 import {
@@ -135,27 +140,39 @@ export async function deliverWebReply(params: {
       }
       if (media.kind === "image") {
         const quote = getQuote();
+        const safeMime = sanitizeMediaMime(media.mimetype);
         await sendWithRetry(
           () =>
             msg.sendMedia(
               {
                 image: media.buffer,
                 caption,
-                mimetype: media.mimetype,
+                mimetype: safeMime?.startsWith("image/") ? safeMime : "image/jpeg",
               },
               quote,
             ),
           "media:image",
         );
-      } else if (media.kind === "audio") {
+      } else if (
+        media.kind === "audio" ||
+        (replyResult.audioAsVoice === true &&
+          isVerifiedAudioSource({ kind: media.kind, contentType: media.mimetype }))
+      ) {
         const quote = getQuote();
+        const sanitized = sanitizeMediaMime(media.mimetype, { preserveCodecsParam: true });
+        const voiceMimetype =
+          sanitized === "audio/ogg"
+            ? "audio/ogg; codecs=opus"
+            : sanitized?.startsWith("audio/")
+              ? sanitized
+              : "audio/ogg; codecs=opus";
         await sendWithRetry(
           () =>
             msg.sendMedia(
               {
                 audio: media.buffer,
                 ptt: true,
-                mimetype: media.mimetype,
+                mimetype: voiceMimetype,
                 caption,
               },
               quote,
@@ -164,28 +181,31 @@ export async function deliverWebReply(params: {
         );
       } else if (media.kind === "video") {
         const quote = getQuote();
+        const safeMime = sanitizeMediaMime(media.mimetype);
         await sendWithRetry(
           () =>
             msg.sendMedia(
               {
                 video: media.buffer,
                 caption,
-                mimetype: media.mimetype,
+                mimetype: safeMime?.startsWith("video/") ? safeMime : "video/mp4",
               },
               quote,
             ),
           "media:video",
         );
       } else {
+        const fileName = sanitizeFileName(media.fileName);
+        const mimetype = sanitizeMediaMime(media.mimetype) ?? "application/octet-stream";
         const quote = getQuote();
         await sendWithRetry(
           () =>
             msg.sendMedia(
               {
                 document: media.buffer,
-                fileName: media.fileName,
+                fileName,
                 caption,
-                mimetype: media.mimetype,
+                mimetype,
               },
               quote,
             ),

--- a/extensions/whatsapp/src/outbound-adapter.sendpayload.test.ts
+++ b/extensions/whatsapp/src/outbound-adapter.sendpayload.test.ts
@@ -41,6 +41,29 @@ describe("whatsappOutbound sendPayload", () => {
     });
   });
 
+  it("forwards audioAsVoice when delegating media sends", async () => {
+    const sendWhatsApp = vi.fn(async () => ({ messageId: "wa-1", toJid: "jid" }));
+
+    await whatsappOutbound.sendMedia!({
+      cfg: {},
+      to: "5511999999999@c.us",
+      text: "voice",
+      mediaUrl: "/tmp/test.ogg",
+      audioAsVoice: true,
+      deps: { sendWhatsApp },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledWith("5511999999999@c.us", "voice", {
+      verbose: false,
+      cfg: {},
+      mediaUrl: "/tmp/test.ogg",
+      audioAsVoice: true,
+      mediaLocalRoots: undefined,
+      accountId: undefined,
+      gifPlayback: undefined,
+    });
+  });
+
   it("trims leading whitespace for sendPayload text and caption delivery", async () => {
     const sendWhatsApp = vi.fn(async () => ({ messageId: "wa-1", toJid: "jid" }));
 

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -55,6 +55,41 @@ describe("createWhatsAppOutboundBase", () => {
     expect(result).toMatchObject({ channel: "whatsapp", messageId: "msg-1" });
   });
 
+  it("forwards audioAsVoice to sendMessageWhatsApp", async () => {
+    const sendMessageWhatsApp = vi.fn(async () => ({
+      messageId: "msg-voice",
+      toJid: "15551234567@s.whatsapp.net",
+    }));
+    const outbound = createWhatsAppOutboundBase({
+      chunker: (text) => [text],
+      sendMessageWhatsApp,
+      sendPollWhatsApp: vi.fn(),
+      shouldLogVerbose: () => false,
+      resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+    });
+
+    await outbound.sendMedia!({
+      cfg: {} as never,
+      to: "whatsapp:+15551234567",
+      text: "voice",
+      mediaUrl: "/tmp/workspace/voice.ogg",
+      audioAsVoice: true,
+      accountId: "default",
+      deps: { sendWhatsApp: sendMessageWhatsApp },
+      gifPlayback: false,
+    });
+
+    expect(sendMessageWhatsApp).toHaveBeenCalledWith(
+      "whatsapp:+15551234567",
+      "voice",
+      expect.objectContaining({
+        mediaUrl: "/tmp/workspace/voice.ogg",
+        audioAsVoice: true,
+        accountId: "default",
+      }),
+    );
+  });
+
   it("uses the configured default account for quote metadata lookup when accountId is omitted", async () => {
     cacheInboundMessageMeta("work", "15551234567@s.whatsapp.net", "reply-1", {
       participant: "111@s.whatsapp.net",

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -32,6 +32,7 @@ type WhatsAppSendTextOptions = {
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
   gifPlayback?: boolean;
   accountId?: string;
+  audioAsVoice?: boolean;
   quotedMessageKey?: {
     id: string;
     remoteJid: string;
@@ -175,6 +176,7 @@ export function createWhatsAppOutboundBase({
         to,
         text,
         mediaUrl,
+        audioAsVoice,
         mediaAccess,
         mediaLocalRoots,
         mediaReadFile,
@@ -197,6 +199,7 @@ export function createWhatsAppOutboundBase({
           verbose: false,
           cfg,
           mediaUrl,
+          audioAsVoice: audioAsVoice === true ? true : undefined,
           mediaAccess,
           mediaLocalRoots,
           mediaReadFile,

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -238,6 +238,164 @@ describe("web outbound", () => {
     );
   });
 
+  it("rejects voice-note coercion when audioAsVoice is true but media is not verified audio", async () => {
+    const buf = Buffer.from("voice-bytes");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "application/octet-stream",
+      kind: "document",
+      fileName: "voice.ogg",
+    });
+
+    await sendMessageWhatsApp("+1555", "voice override", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/voice.ogg",
+      audioAsVoice: true,
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith(
+      "+1555",
+      "voice override",
+      buf,
+      "application/octet-stream",
+      { fileName: "voice.ogg" },
+    );
+  });
+
+  it("forces voice-note when audioAsVoice is true and contentType is null", async () => {
+    const buf = Buffer.from("aud");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: null,
+      kind: "audio",
+      fileName: "voice.ogg",
+    });
+
+    await sendMessageWhatsApp("+1555", "voice null content type", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/voice.ogg",
+      audioAsVoice: true,
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith(
+      "+1555",
+      "voice null content type",
+      buf,
+      "audio/ogg; codecs=opus",
+    );
+  });
+
+  it("falls back to opus mimetype when contentType contains control characters", async () => {
+    const buf = Buffer.from("voice");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "audio/ogg\r\nX-Inj: bad",
+      kind: "audio",
+      fileName: "voice.ogg",
+    });
+
+    await sendMessageWhatsApp("+1555", "voice crlf", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/voice.ogg",
+      audioAsVoice: true,
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith(
+      "+1555",
+      "voice crlf",
+      buf,
+      "audio/ogg; codecs=opus",
+    );
+  });
+
+  it("uses image/jpeg fallback when image contentType contains control characters", async () => {
+    const buf = Buffer.from("img");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "image/png\r\nX-Inj: bad",
+      kind: "image",
+      fileName: "photo.png",
+    });
+
+    await sendMessageWhatsApp("+1555", "img cap", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/photo.png",
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "img cap", buf, "image/jpeg");
+  });
+
+  it("sanitizes documentFileName when it contains control characters", async () => {
+    const buf = Buffer.from("doc");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "application/pdf",
+      kind: "document",
+      fileName: "evil.pdf\r\nX-Inj: bad",
+    });
+
+    await sendMessageWhatsApp("+1555", "doc cap", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/report.pdf",
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc cap", buf, "application/pdf", {
+      fileName: "evil.pdfX-Inj: bad",
+    });
+  });
+
+  it("does not force voice-note for non-audio files when audioAsVoice is true", async () => {
+    const buf = Buffer.from("pdf");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "application/pdf",
+      kind: "document",
+      fileName: "file.pdf",
+    });
+
+    await sendMessageWhatsApp("+1555", "doc", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/file.pdf",
+      audioAsVoice: true,
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
+      fileName: "file.pdf",
+    });
+  });
+
+  it("keeps document path for audio-like file when audioAsVoice is unset", async () => {
+    const buf = Buffer.from("voice-doc");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "application/octet-stream",
+      kind: "document",
+      fileName: "voice.ogg",
+    });
+
+    await sendMessageWhatsApp("+1555", "doc voice", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "/tmp/voice.ogg",
+    });
+
+    expect(sendMessage).toHaveBeenLastCalledWith(
+      "+1555",
+      "doc voice",
+      buf,
+      "application/octet-stream",
+      {
+        fileName: "voice.ogg",
+      },
+    );
+  });
+
   it("maps video with caption", async () => {
     const buf = Buffer.from("video");
     loadWebMediaMock.mockResolvedValueOnce({

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -6,6 +6,11 @@ import {
   convertMarkdownTables,
   resolveMarkdownTableMode,
 } from "openclaw/plugin-sdk/markdown-table-runtime";
+import {
+  isVerifiedAudioSource,
+  sanitizeFileName,
+  sanitizeMediaMime,
+} from "openclaw/plugin-sdk/media-runtime";
 import { normalizePollInput, type PollInput } from "openclaw/plugin-sdk/poll-runtime";
 import { createSubsystemLogger, getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -67,6 +72,7 @@ export async function sendMessageWhatsApp(
     mediaLocalRoots?: readonly string[];
     mediaReadFile?: (filePath: string) => Promise<Buffer>;
     gifPlayback?: boolean;
+    audioAsVoice?: boolean;
     accountId?: string;
     quotedMessageKey?: {
       id: string;
@@ -126,12 +132,42 @@ export async function sendMessageWhatsApp(
       );
       const caption = text || undefined;
       mediaBuffer = media.buffer;
-      mediaType = media.mimetype;
-      if (media.kind === "document") {
+      const sanitizedMediaType = sanitizeMediaMime(media.mimetype);
+      mediaType = sanitizedMediaType ?? "application/octet-stream";
+      const forceVoiceDelivery =
+        options.audioAsVoice === true &&
+        isVerifiedAudioSource({ kind: media.kind, contentType: media.mimetype });
+      if (forceVoiceDelivery) {
+        // WhatsApp PTT requires opus codec. Preserve a sanitized codecs param and fall back
+        // to canonical opus when the input is unsafe or lacks an audio base type.
+        const sanitized = sanitizeMediaMime(media.mimetype, { preserveCodecsParam: true });
+        mediaType =
+          sanitized === "audio/ogg"
+            ? "audio/ogg; codecs=opus"
+            : sanitized?.startsWith("audio/")
+              ? sanitized
+              : "audio/ogg; codecs=opus";
         text = caption ?? "";
-        documentFileName = media.fileName;
+      } else if (media.kind === "audio") {
+        // Non-PTT audio. normalizeWhatsAppLoadedMedia already rewrites "audio/ogg" to
+        // "audio/ogg; codecs=opus"; sanitize with preserveCodecsParam to guard header
+        // injection while keeping the opus codec intact.
+        const sanitized = sanitizeMediaMime(media.mimetype, { preserveCodecsParam: true });
+        mediaType =
+          sanitized === "audio/ogg"
+            ? "audio/ogg; codecs=opus"
+            : (sanitized ?? "application/octet-stream");
+        text = caption ?? "";
+      } else if (media.kind === "video") {
+        mediaType = sanitizedMediaType?.startsWith("video/") ? sanitizedMediaType : "video/mp4";
+        text = caption ?? "";
+      } else if (media.kind === "image") {
+        mediaType = sanitizedMediaType?.startsWith("image/") ? sanitizedMediaType : "image/jpeg";
+        text = caption ?? "";
       } else {
+        mediaType = sanitizedMediaType ?? "application/octet-stream";
         text = caption ?? "";
+        documentFileName = sanitizeFileName(media.fileName);
       }
     }
     outboundLog.info(`Sending message -> ${redactedJid}${primaryMediaUrl ? " (media)" : ""}`);

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -171,9 +171,9 @@ describe("isAudioFileName", () => {
 describe("isVerifiedAudioSource", () => {
   it.each([
     { media: { kind: "audio", contentType: null }, expected: true },
-    { media: { kind: "document", contentType: "audio/ogg" }, expected: true },
-    { media: { kind: "document", contentType: "audio/mpeg" }, expected: true },
-    { media: { kind: "document", contentType: "AUDIO/OGG" }, expected: true },
+    { media: { kind: "document", contentType: "audio/ogg" }, expected: false },
+    { media: { kind: "document", contentType: "audio/mpeg" }, expected: false },
+    { media: { kind: "document", contentType: "AUDIO/OGG" }, expected: false },
     { media: { kind: "document", contentType: "audio/ogg\r\nX-Inj: bad" }, expected: false },
     { media: { kind: "document", contentType: "audio/" }, expected: false },
     { media: { kind: "document", contentType: null }, expected: false },
@@ -181,6 +181,14 @@ describe("isVerifiedAudioSource", () => {
     { media: { kind: undefined, contentType: undefined }, expected: false },
   ] as const)("classifies $media as $expected", ({ media, expected }) => {
     expect(isVerifiedAudioSource(media)).toBe(expected);
+  });
+
+  it("rejects spoofed audio Content-Type when kind is not audio (CWE-345)", () => {
+    // An attacker-controlled mediaUrl response could set Content-Type:
+    // audio/ogg while serving non-audio bytes. Only a caller-classified
+    // kind === "audio" is trusted for PTT coercion.
+    expect(isVerifiedAudioSource({ kind: "document", contentType: "audio/ogg" })).toBe(false);
+    expect(isVerifiedAudioSource({ kind: undefined, contentType: "audio/opus" })).toBe(false);
   });
 });
 

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -6,8 +6,11 @@ import {
   extensionForMime,
   imageMimeFromFormat,
   isAudioFileName,
+  isVerifiedAudioSource,
   kindFromMime,
   normalizeMimeType,
+  sanitizeFileName,
+  sanitizeMediaMime,
 } from "./mime.js";
 
 async function makeOoxmlZip(opts: { mainMime: string; partPath: string }): Promise<Buffer> {
@@ -162,6 +165,90 @@ describe("isAudioFileName", () => {
     { fileName: "voice.bin", expected: false },
   ] as const)("matches audio extension for $fileName", ({ fileName, expected }) => {
     expectAudioFileNameCase(fileName, expected);
+  });
+});
+
+describe("isVerifiedAudioSource", () => {
+  it.each([
+    { media: { kind: "audio", contentType: null }, expected: true },
+    { media: { kind: "document", contentType: "audio/ogg" }, expected: true },
+    { media: { kind: "document", contentType: "audio/mpeg" }, expected: true },
+    { media: { kind: "document", contentType: "AUDIO/OGG" }, expected: true },
+    { media: { kind: "document", contentType: "audio/ogg\r\nX-Inj: bad" }, expected: false },
+    { media: { kind: "document", contentType: "audio/" }, expected: false },
+    { media: { kind: "document", contentType: null }, expected: false },
+    { media: { kind: "document", contentType: "application/pdf" }, expected: false },
+    { media: { kind: undefined, contentType: undefined }, expected: false },
+  ] as const)("classifies $media as $expected", ({ media, expected }) => {
+    expect(isVerifiedAudioSource(media)).toBe(expected);
+  });
+});
+
+describe("sanitizeMediaMime", () => {
+  it.each([
+    { input: "audio/ogg", expected: "audio/ogg" },
+    { input: "AUDIO/OGG", expected: "audio/ogg" },
+    { input: "audio/ogg; codecs=opus", expected: "audio/ogg" },
+    { input: "audio/ogg\r\nX-Inj: bad", expected: null },
+    { input: "audio/ogg\nfoo", expected: null },
+    { input: "audio/ogg\0nul", expected: null },
+    { input: "", expected: null },
+    { input: "  ", expected: null },
+    { input: undefined, expected: null },
+    { input: null, expected: null },
+    { input: "invalid mime", expected: null },
+    { input: "audio/", expected: null },
+    { input: "/ogg", expected: null },
+  ] as const)("sanitizes $input to $expected", ({ input, expected }) => {
+    expect(sanitizeMediaMime(input)).toBe(expected);
+  });
+
+  it("preserves codecs parameter when requested", () => {
+    expect(sanitizeMediaMime("audio/ogg; codecs=opus", { preserveCodecsParam: true })).toBe(
+      "audio/ogg; codecs=opus",
+    );
+  });
+});
+
+describe("sanitizeFileName", () => {
+  it.each([
+    { input: "report.pdf", expected: "report.pdf" },
+    { input: "voice.ogg", expected: "voice.ogg" },
+    { input: "  trimmed.txt  ", expected: "trimmed.txt" },
+    { input: "evil.pdf\r\nX-Inj: bad", expected: "evil.pdfX-Inj: bad" },
+    { input: "name\nwith\nnewlines.txt", expected: "namewithnewlines.txt" },
+    { input: "name\twith\ttab.txt", expected: "namewithtab.txt" },
+    { input: "null\0byte.txt", expected: "nullbyte.txt" },
+    { input: "del\x7fchar.txt", expected: "delchar.txt" },
+    { input: "../../../etc/passwd", expected: ".._.._.._etc_passwd" },
+    { input: "C:\\Windows\\System32", expected: "C:_Windows_System32" },
+    { input: 'name"with"quotes.txt', expected: "name_with_quotes.txt" },
+    { input: "invoice\u202Egnp.exe", expected: "invoicegnp.exe" },
+    { input: "name\u200Ewith\u200Fmarks.txt", expected: "namewithmarks.txt" },
+    { input: "iso\u2066late\u2069d.txt", expected: "isolated.txt" },
+    { input: "arabic\u061Cmark.txt", expected: "arabicmark.txt" },
+    { input: "", expected: "file" },
+    { input: "   ", expected: "file" },
+    { input: null, expected: "file" },
+    { input: undefined, expected: "file" },
+    { input: "\r\n\t\0", expected: "file" },
+    { input: "a".repeat(200), expected: "a".repeat(128) },
+    { input: "a".repeat(127) + ".txt", expected: "a".repeat(127) + "." },
+    {
+      input:
+        "extremely-long-filename-that-exceeds-the-cap-limit-of-128-characters-for-testing-purposes-and-should-be-truncated-properly-here.pdf",
+      expected:
+        "extremely-long-filename-that-exceeds-the-cap-limit-of-128-characters-for-testing-purposes-and-should-be-truncated-properly-here.",
+    },
+  ] as const)("sanitizes $input correctly", ({ input, expected }) => {
+    expect(sanitizeFileName(input)).toBe(expected);
+  });
+
+  it("caps very long inputs at 128 characters without quadratic-time blowup", () => {
+    const longInput = "a".repeat(100000);
+    const result = sanitizeFileName(longInput);
+    expect(result).toBe("a".repeat(128));
+    expect(result.length).toBe(128);
   });
 });
 

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -250,6 +250,22 @@ describe("sanitizeFileName", () => {
     expect(result).toBe("a".repeat(128));
     expect(result.length).toBe(128);
   });
+
+  it("strips zero-width space (U+200B) from filename", () => {
+    expect(sanitizeFileName("invoice\u200B.pdf.exe")).toBe("invoice.pdf.exe");
+  });
+
+  it("strips zero-width joiner (U+200D) from filename", () => {
+    expect(sanitizeFileName("a\u200Db\u200Dc.txt")).toBe("abc.txt");
+  });
+
+  it("strips byte order mark (U+FEFF) from filename", () => {
+    expect(sanitizeFileName("\uFEFFreport.pdf")).toBe("report.pdf");
+  });
+
+  it("strips soft hyphen (U+00AD) from filename", () => {
+    expect(sanitizeFileName("doc\u00AD.pdf")).toBe("doc.pdf");
+  });
 });
 
 describe("normalizeMimeType", () => {

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -118,17 +118,20 @@ export function isAudioFileName(fileName?: string | null): boolean {
 /**
  * Determines whether a media payload qualifies as a verified audio source
  * for voice-note delivery.
+ *
+ * Only a caller-classified `kind === "audio"` is accepted. A raw
+ * `contentType` starting with `audio/` is NOT trusted because it can be
+ * derived from an attacker-controlled HTTP `Content-Type` header
+ * (CWE-345: insufficient verification of data authenticity). The
+ * `contentType` field is retained on the parameter shape as a seam for
+ * a future `sniffedMime`-based extension once magic-byte sniffing is
+ * plumbed through `loadWebMedia` / `detectMime` cross-channel.
  */
 export function isVerifiedAudioSource(media: {
   kind?: string | null;
   contentType?: string | null;
 }): boolean {
-  if (media.kind === "audio") {
-    return true;
-  }
-  // Normalize through sanitizeMediaMime before classifying audio content.
-  const sanitized = sanitizeMediaMime(media.contentType);
-  return sanitized?.startsWith("audio/") === true;
+  return media.kind === "audio";
 }
 
 /**

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -184,23 +184,25 @@ export function sanitizeMediaMime(
   return base;
 }
 
-// Unicode bidirectional and invisible format characters that can be used for
-// filename UI spoofing (RTLO trick and similar).
-const BIDI_AND_INVISIBLE_CHARS = /[\u202A-\u202E\u2066-\u2069\u200E\u200F\u061C]/g;
+// Unicode format/invisible characters that can be used for filename UI spoofing.
+// Covers General Category Cf: bidi marks (RTLO/LRM/etc.), zero-width
+// joiners/spaces, BOM, and Soft Hyphen (U+00AD is itself Cf).
+const INVISIBLE_FORMAT_CHARS = /\p{Cf}/gu;
 
 /**
  * Sanitizes an outbound document filename for safe use in downstream payloads.
- * Strips ASCII control characters and Unicode bidirectional/invisible format
- * characters, replaces path separators and quotes, caps length at 128 chars,
- * and falls back to "file" when empty.
+ * Strips ASCII control characters and Unicode format characters (General
+ * Category Cf: bidi marks, zero-width joiners/spaces, BOM, Soft Hyphen);
+ * replaces path separators and quotes; caps length at 128 chars; falls back
+ * to "file" when empty.
  *
- * The bidi-stripping prevents UI spoofing via right-to-left override (RTLO,
- * U+202E) and related directional formatting characters.
+ * Mitigates filename UI spoofing (CWE-451) via RTLO, ZWSP, BOM, and related
+ * invisible-character injection.
  * Linear time complexity: the loop bounds itself by min(input length, 128)
  * to avoid O(n^2) build cost on attacker-controlled large filenames.
  */
 export function sanitizeFileName(input: string | null | undefined): string {
-  const trimmed = (input ?? "").trim().replace(BIDI_AND_INVISIBLE_CHARS, "");
+  const trimmed = (input ?? "").trim().replace(INVISIBLE_FORMAT_CHARS, "");
   if (!trimmed) {
     return "file";
   }

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -115,6 +115,112 @@ export function isAudioFileName(fileName?: string | null): boolean {
   return AUDIO_FILE_EXTENSIONS.has(ext);
 }
 
+/**
+ * Determines whether a media payload qualifies as a verified audio source
+ * for voice-note delivery.
+ */
+export function isVerifiedAudioSource(media: {
+  kind?: string | null;
+  contentType?: string | null;
+}): boolean {
+  if (media.kind === "audio") {
+    return true;
+  }
+  // Normalize through sanitizeMediaMime before classifying audio content.
+  const sanitized = sanitizeMediaMime(media.contentType);
+  return sanitized?.startsWith("audio/") === true;
+}
+
+/**
+ * Validates and normalizes a MIME type for outbound media headers.
+ * Returns null when the input is unsafe or malformed.
+ */
+// Reject ASCII control characters (U+0000-U+001F) and DEL (U+007F) to avoid
+// downstream header injection (CWE-93). Implemented via charCodeAt instead of
+// a control-character regex to keep the intent explicit and to avoid the
+// no-control-regex lint rule.
+function hasAsciiControlChar(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function sanitizeMediaMime(
+  input: string | null | undefined,
+  options?: { preserveCodecsParam?: boolean },
+): string | null {
+  if (input == null) {
+    return null;
+  }
+  const value = input.trim();
+  if (!value) {
+    return null;
+  }
+
+  if (hasAsciiControlChar(value)) {
+    return null;
+  }
+
+  const parts = value.split(";");
+  const base = parts[0]?.trim().toLowerCase() ?? "";
+  if (!/^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/.test(base)) {
+    return null;
+  }
+
+  if (options?.preserveCodecsParam && parts.length > 1) {
+    const codecsParam = parts
+      .slice(1)
+      .map((part) => part.trim().toLowerCase())
+      .find((part) => /^codecs=[a-z0-9._-]+$/.test(part));
+    if (codecsParam) {
+      return `${base}; ${codecsParam}`;
+    }
+  }
+
+  return base;
+}
+
+// Unicode bidirectional and invisible format characters that can be used for
+// filename UI spoofing (RTLO trick and similar).
+const BIDI_AND_INVISIBLE_CHARS = /[\u202A-\u202E\u2066-\u2069\u200E\u200F\u061C]/g;
+
+/**
+ * Sanitizes an outbound document filename for safe use in downstream payloads.
+ * Strips ASCII control characters and Unicode bidirectional/invisible format
+ * characters, replaces path separators and quotes, caps length at 128 chars,
+ * and falls back to "file" when empty.
+ *
+ * The bidi-stripping prevents UI spoofing via right-to-left override (RTLO,
+ * U+202E) and related directional formatting characters.
+ * Linear time complexity: the loop bounds itself by min(input length, 128)
+ * to avoid O(n^2) build cost on attacker-controlled large filenames.
+ */
+export function sanitizeFileName(input: string | null | undefined): string {
+  const trimmed = (input ?? "").trim().replace(BIDI_AND_INVISIBLE_CHARS, "");
+  if (!trimmed) {
+    return "file";
+  }
+
+  const out: string[] = [];
+  for (let i = 0; i < trimmed.length && out.length < 128; i += 1) {
+    const ch = trimmed[i];
+    if (!ch) {
+      continue;
+    }
+    const code = ch.charCodeAt(0);
+    if (code <= 0x1f || code === 0x7f) {
+      continue;
+    }
+    out.push(ch === "/" || ch === "\\" || ch === '"' ? "_" : ch);
+  }
+  const safe = out.join("");
+  return safe || "file";
+}
+
 export function detectMime(opts: {
   buffer?: Buffer;
   headerMime?: string | null;


### PR DESCRIPTION
## Summary

Fixes #66053. The WhatsApp adapter dropped the `audioAsVoice` flag from
`ChannelOutboundContext`, so replies with `[[audio_as_voice]]` were
delivered as document attachments instead of PTT voice notes. This PR
wires the flag through `createWhatsAppOutboundBase` →
`sendMessageWhatsApp` / `deliverWebReply`, and adds channel-agnostic
MIME/filename hardening.

## Changes

**Commit 1 — `feat(media)`:** adds to `src/media/mime.ts` (exported via
`openclaw/plugin-sdk/media-runtime`):
- `isVerifiedAudioSource({ kind, contentType })` — predicate gating
  voice-note routing.
- `sanitizeMediaMime(input, { preserveCodecsParam? })` — rejects control
  characters (CWE-93), preserves `codecs=` param only for audio.
- `sanitizeFileName(input)` — strips ASCII control + Unicode General
  Category Cf characters (`\p{Cf}`, CWE-451), caps length at 128.

Signatures are channel-agnostic so Telegram, Discord, and Matrix can
adopt the same helpers in a follow-up.

**Commit 2 — `fix(whatsapp)`:** consumes the new helpers.
- `sendMessageWhatsApp`: `forceVoiceDelivery` gated on
  `isVerifiedAudioSource`; PTT mimetype rebuilt with opus codec
  preservation/fallback.
- `createWhatsAppOutboundBase`: forwards `audioAsVoice` through
  `sendMedia`.
- `deliverWebReply`: audio / audio-as-voice paths route to PTT with
  sanitized opus mime; image/video/document branches use sanitized
  allowlisted mime; document `fileName` sanitized.

**Commit 3 — `fix(media)`:** widens `sanitizeFileName` invisible-character
coverage to all Unicode Category Cf (addresses Aisle Finding 1).

Rebased onto `main` after #69813 landed; the audio mimetype
canonicalization that previously lived inline is now delegated to
`normalizeWhatsAppLoadedMedia`, and this PR layers PTT routing +
security hardening on top.

## Verification

- `pnpm test extensions/whatsapp` → 567 passed / 0 failed
- `pnpm test src/media/mime.test.ts` → 106 passed / 0 failed (after Aisle #1 fix)
- `pnpm tsgo:prod` → exit 0
- `codex review --base upstream/main` → no P1 findings

## Security notes

- Finding 1 (Aisle, CWE-451, filename UI spoofing): fixed in commit 3.
- Finding 2 (Aisle, CWE-20, magic-byte verification): deferred to a
  cross-channel follow-up. The upstream auto-reply path already lands
  `ptt: true` based on `media.kind === "audio"` (derived from
  `detectMime` extension/header fallback), so the correct fix plumbs a
  sniffed content-type through `loadWebMedia` and has Telegram,
  Discord, Matrix, and WhatsApp all adopt the verified source together.

## Follow-ups

- Magic-byte audio verification in `loadWebMedia` / `detectMime` (see
  security notes).
- Telegram / Discord / Matrix adoption of the channel-agnostic helpers
  in `src/media/mime.ts`.
