### PR TITLE
fix(slack): share HTTP route registry via globalThis across module instances

### DIFF
--- a/extensions/slack/src/http/registry.ts
+++ b/extensions/slack/src/http/registry.ts
@@ -15,7 +15,20 @@ type RegisterSlackHttpHandlerArgs = {
   accountId?: string;
 };
 
-const slackHttpRoutes = new Map<string, SlackHttpRequestHandler>();
+// Back the route registry with a globalThis-keyed singleton. Without this,
+// the provider side (loaded through the jiti plugin loader) and the dispatcher
+// side (loaded lazily via native dynamic import()) end up with two separate
+// module instances of this file, each with its own Map. Routes registered on
+// one map are invisible to the other, so every inbound Slack webhook 404s.
+const SLACK_HTTP_ROUTES_GLOBAL_KEY = Symbol.for("openclaw.slack.httpRoutes.v1");
+const slackHttpRoutesGlobal = globalThis as unknown as Record<
+  symbol,
+  Map<string, SlackHttpRequestHandler> | undefined
+>;
+if (!slackHttpRoutesGlobal[SLACK_HTTP_ROUTES_GLOBAL_KEY]) {
+  slackHttpRoutesGlobal[SLACK_HTTP_ROUTES_GLOBAL_KEY] = new Map<string, SlackHttpRequestHandler>();
+}
+const slackHttpRoutes = slackHttpRoutesGlobal[SLACK_HTTP_ROUTES_GLOBAL_KEY];
 
 export function registerSlackHttpHandler(params: RegisterSlackHttpHandlerArgs): () => void {
   const normalizedPath = normalizeSlackWebhookPath(params.path);


### PR DESCRIPTION
## Summary

When the Slack extension's `registry.ts` module is loaded twice — once through jiti (plugin registration) and once through native `import()` (runtime dispatch) — each load creates its own `Map` instance. Routes registered on the jiti-loaded Map are invisible to the native-import-loaded dispatcher, so every inbound Slack webhook silently 404s even though the logs show "http mode listening."

This PR replaces the module-scoped `new Map()` with a `globalThis`-backed singleton keyed by `Symbol.for(...)`, ensuring both module instances share a single route registry.

## Root cause

The gateway uses **jiti** to evaluate plugin configs at registration time and **native dynamic `import()`** for runtime dispatch. When a module uses `new Map()` at module scope, each loader creates a separate instance. The registration side writes to Map A; the dispatch side reads from Map B — always empty.

## Fix

- Use `Symbol.for("openclaw.slack.httpRoutes.v1")` on `globalThis` to store the shared Map
- Both module instances now resolve to the same Map regardless of which loader imported them
- Versioned key (`v1`) allows future schema migrations without collisions

## Test plan

- [ ] POST to `/slack/events/<account>` returns 401 (signature check), not 404
- [ ] Send a real Slack DM and verify it reaches the gateway
- [ ] Restart gateway and confirm route survives reload
- [ ] Grep other extensions for `new Map()` / `new Set()` at module scope to check for similar patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)