### PR TITLE
fix: always send stream_options.include_usage when streaming (openai-completions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/openai-completions: always send `stream_options.include_usage` on streaming requests, so local and custom OpenAI-compatible backends report real context usage instead of showing 0%. (#68746) Thanks @kagura-agent.
+
 ## 2026.4.19-beta.1
 
 ### Fixes

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1251,6 +1251,35 @@ describe("openai transport stream", () => {
     expect(params.stream_options).toMatchObject({ include_usage: true });
   });
 
+  it("always includes stream_options.include_usage for non-standard backends like llama-cpp", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "llama-3",
+        name: "Llama 3",
+        api: "openai-completions",
+        provider: "custom-cpa",
+        baseUrl: "http://localhost:8080/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 4096,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    ) as {
+      stream?: boolean;
+      stream_options?: { include_usage?: boolean };
+    };
+
+    expect(params.stream).toBe(true);
+    expect(params.stream_options).toEqual({ include_usage: true });
+  });
+
   it("disables developer-role-only compat defaults for configured custom proxy completions providers", () => {
     const params = buildOpenAICompletionsParams(
       {
@@ -1289,7 +1318,7 @@ describe("openai transport stream", () => {
 
     expect(params.messages?.[0]).toMatchObject({ role: "system" });
     expect(params).not.toHaveProperty("reasoning_effort");
-    expect(params).not.toHaveProperty("stream_options");
+    expect(params.stream_options).toMatchObject({ include_usage: true });
     expect(params).not.toHaveProperty("store");
     expect(params.tools?.[0]?.function).not.toHaveProperty("strict");
   });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1272,11 +1272,9 @@ describe("openai transport stream", () => {
       } as never,
       undefined,
     ) as {
-      stream?: boolean;
       stream_options?: { include_usage?: boolean };
     };
 
-    expect(params.stream).toBe(true);
     expect(params.stream_options).toEqual({ include_usage: true });
   });
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1502,10 +1502,8 @@ export function buildOpenAICompletionsParams(
       ? flattenCompletionMessagesToStringContent(messages)
       : messages,
     stream: true,
+    stream_options: { include_usage: true },
   };
-  if (compat.supportsUsageInStreaming) {
-    params.stream_options = { include_usage: true };
-  }
   if (compat.supportsStore) {
     params.store = false;
   }


### PR DESCRIPTION
Fixes #68707

## Problem
`buildOpenAICompletionsParams()` only included `stream_options: { include_usage: true }` when `compat.supportsUsageInStreaming` was true. For non-standard/custom endpoints (llama-cpp, LM Studio, etc.), this flag resolved to `false`, so the gateway's `resolveIncludeUsageForStreaming()` never saw the field and context token tracking was always 0%.

## Fix
Always include `stream_options: { include_usage: true }` in streaming request payloads, matching the OpenAI SDK's default behavior. Backends that don't support the field simply ignore it.

## Changes
- `src/agents/openai-transport-stream.ts` — unconditionally include `stream_options` instead of gating on `compat.supportsUsageInStreaming`
- `src/agents/openai-transport-stream.test.ts` — added test for non-standard backends, updated existing assertion