### PR TITLE
fix: enforce chmod 0o600 after atomic rename of config file

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1699,6 +1699,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         });
         throw err;
       }
+      await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
+        // best-effort; rename may not preserve source file mode
+      });
       logConfigOverwrite();
       logConfigWriteAnomalies();
       await appendWriteAudit(


### PR DESCRIPTION
## Problem

Closes #68709

On Linux, the atomic config write creates a temp file with `mode: 0o600`, then calls `rename()` to replace the target. However, `rename(2)` preserves the existing inode permissions, so the resulting file ends up with the old mode (typically `0664` under systemd default `UMask=0002`).

This leaves `openclaw.json` group-readable, exposing API keys, exec security policies, and other secrets to any user in the same group.

## Fix

Add `chmod(configPath, 0o600)` after the successful `rename()` on the Linux/POSIX path, matching the Windows fallback that already calls `chmod(configPath, 0o600)` at line 1682.

The chmod is best-effort (wrapped in `.catch()`) to avoid breaking on read-only filesystems or permission-constrained environments.

## Testing

- Verified the change is on the same pattern as the existing Windows fallback at line 1682
- `rename()` path now has parity with `copyFile()` fallback for permission enforcement