### PR TITLE
fix: enable stream_options.include_usage for local openai-completions endpoints

### DIFF
--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -77,7 +77,7 @@ export function resolveOpenAICompletionsCompatDefaults(
       endpointClass !== "xai-native" &&
       !usesExplicitProxyLikeEndpoint,
     supportsUsageInStreaming:
-      !isNonStandard && (!usesConfiguredNonOpenAIEndpoint || supportsNativeStreamingUsageCompat),
+      !isNonStandard && (!usesConfiguredNonOpenAIEndpoint || supportsNativeStreamingUsageCompat || endpointClass === "local"),
     maxTokensField: usesMaxTokens ? "max_tokens" : "max_completion_tokens",
     thinkingFormat: isZai ? "zai" : isOpenRouterLike ? "openrouter" : "openai",
     visibleReasoningDetailTypes: isOpenRouterLike ? ["response.output_text", "response.text"] : [],


### PR DESCRIPTION
## Problem

Closes #68707

When using local OpenAI-compatible backends (llama.cpp, LM Studio, Ollama), `stream_options: { include_usage: true }` is never sent in streaming requests. This causes context token usage to always show 0% in `/status` and the web UI.

## Root Cause

In `detectOpenAICompletionsCompat()`, `supportsUsageInStreaming` evaluates to `false` for local endpoints because:
- `usesConfiguredNonOpenAIEndpoint = true` (endpointClass `"local"` ≠ `"default"`)
- `supportsNativeStreamingUsageCompat = false` (only moonshot/modelstudio qualify)
- Result: `true && (!true || false) = false`

However, llama.cpp and LM Studio both implement the OpenAI-compatible streaming API and support `stream_options.include_usage`.

## Fix

Add `endpointClass === "local"` to the `supportsUsageInStreaming` condition. This allows local OpenAI-compatible endpoints to receive usage data in streaming responses.

Note: LM Studio extension already works around this in `extensions/lmstudio/src/stream.ts:259-264` by overriding `supportsUsageInStreaming`. This core fix covers llama.cpp, Ollama, and other local backends that do not have their own workaround.