### PR TITLE
fix: allow systemEvent cron jobs to specify custom timeoutSeconds

### DIFF
--- a/src/cron/service/timeout-policy.test.ts
+++ b/src/cron/service/timeout-policy.test.ts
@@ -46,4 +46,18 @@ describe("timeout-policy", () => {
     );
     expect(timeout).toBe(1_900);
   });
+
+  it("applies explicit timeoutSeconds on systemEvent payloads", () => {
+    const timeout = resolveCronJobTimeoutMs(
+      makeJob({ kind: "systemEvent", text: "dream", timeoutSeconds: 120 }),
+    );
+    expect(timeout).toBe(120_000);
+  });
+
+  it("disables timeout when systemEvent timeoutSeconds <= 0", () => {
+    const timeout = resolveCronJobTimeoutMs(
+      makeJob({ kind: "systemEvent", text: "dream", timeoutSeconds: 0 }),
+    );
+    expect(timeout).toBeUndefined();
+  });
 });

--- a/src/cron/service/timeout-policy.ts
+++ b/src/cron/service/timeout-policy.ts
@@ -15,7 +15,7 @@ export const AGENT_TURN_SAFETY_TIMEOUT_MS = 60 * 60_000; // 60 minutes
 
 export function resolveCronJobTimeoutMs(job: CronJob): number | undefined {
   const configuredTimeoutMs =
-    job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+    typeof job.payload.timeoutSeconds === "number"
       ? Math.floor(job.payload.timeoutSeconds * 1_000)
       : undefined;
   if (configuredTimeoutMs === undefined) {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -81,9 +81,13 @@ export type CronFailureAlert = {
   accountId?: string;
 };
 
-export type CronPayload = { kind: "systemEvent"; text: string } | CronAgentTurnPayload;
+export type CronPayload =
+  | { kind: "systemEvent"; text: string; timeoutSeconds?: number }
+  | CronAgentTurnPayload;
 
-export type CronPayloadPatch = { kind: "systemEvent"; text?: string } | CronAgentTurnPayloadPatch;
+export type CronPayloadPatch =
+  | { kind: "systemEvent"; text?: string; timeoutSeconds?: number }
+  | CronAgentTurnPayloadPatch;
 
 type CronAgentTurnPayloadFields = {
   message: string;


### PR DESCRIPTION
Fixes #68743

## Problem
The Memory Dreaming Promotion cron job uses `payload.kind='systemEvent'`, which gets the default 10-minute timeout (`DEFAULT_JOB_TIMEOUT_MS`). However, dreaming triggers a full agent turn via the main session heartbeat that typically takes 2-4 minutes but can exceed 10 minutes on slower providers or large memory stores. The job times out and is killed every night.

The `timeoutSeconds` field was only available on `agentTurn` payloads, so there was no way for `systemEvent` jobs (like dreaming) to configure a longer timeout.

## Fix
1. Added optional `timeoutSeconds` to the `systemEvent` payload type
2. Updated `resolveCronJobTimeoutMs()` to read `timeoutSeconds` from any payload kind, not just `agentTurn`
3. When `timeoutSeconds` is unset, defaults remain unchanged (10min for systemEvent, 60min for agentTurn)

This enables the dreaming plugin (and any other managed cron job) to set an appropriate timeout via `timeoutSeconds` in the job payload.

## Changes
- `src/cron/types.ts` — added `timeoutSeconds?` to systemEvent payload
- `src/cron/service/timeout-policy.ts` — removed agentTurn-only guard on timeoutSeconds
- `src/cron/service/timeout-policy.test.ts` — added tests for systemEvent timeout configuration