### PR TITLE
fix: strip reasoning_content from conversation history for Gemma 4 models

### DIFF
--- a/src/agents/pi-embedded-helpers/google.ts
+++ b/src/agents/pi-embedded-helpers/google.ts
@@ -1,7 +1,21 @@
 import { sanitizeGoogleTurnOrdering } from "./bootstrap.js";
+import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 
 export function isGoogleModelApi(api?: string | null): boolean {
   return api === "google-gemini-cli" || api === "google-generative-ai";
+}
+
+/**
+ * Returns true for Gemma model IDs that produce reasoning_content which must
+ * NOT be replayed in conversation history. Per Google's Gemma 4 specification,
+ * thinking/reasoning content from prior turns must be stripped before sending
+ * history to the model.
+ */
+export function isGemmaModelRequiringReasoningStrip(modelId?: string | null): boolean {
+  const id = normalizeLowercaseStringOrEmpty(modelId);
+  // Match gemma-4 (e.g. gemma-4-27b-it, google/gemma-4-E2B-it) and future
+  // Gemma generations that may also produce reasoning_content.
+  return /gemma-[4-9]/.test(id) || /gemma-\d{2,}/.test(id);
 }
 
 export { sanitizeGoogleTurnOrdering };

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -40,7 +40,7 @@ import {
   type AssistantUsageSnapshot,
   type UsageLike,
 } from "../usage.js";
-import { dropThinkingBlocks } from "./thinking.js";
+import { dropThinkingBlocks, stripAllThinkingBlocks } from "./thinking.js";
 
 const INTER_SESSION_PREFIX_BASE = "[Inter-session message]";
 const MODEL_SNAPSHOT_CUSTOM_TYPE = "model-snapshot";
@@ -426,9 +426,11 @@ export async function sanitizeSessionHistory(params: {
       ...resolveImageSanitizationLimits(params.config),
     },
   );
-  const droppedThinking = policy.dropThinkingBlocks
-    ? dropThinkingBlocks(sanitizedImages)
-    : sanitizedImages;
+  const droppedThinking = policy.dropReasoningFromHistory
+    ? stripAllThinkingBlocks(sanitizedImages)
+    : policy.dropThinkingBlocks
+      ? dropThinkingBlocks(sanitizedImages)
+      : sanitizedImages;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,
     allowProviderOwnedThinkingReplay,

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -112,7 +112,7 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
   return touched ? out : messages;
 }
 
-function stripAllThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
+export function stripAllThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
   let touched = false;
   const out: AgentMessage[] = [];
   for (const message of messages) {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -3,6 +3,7 @@ import { resolveProviderRuntimePlugin } from "../plugins/provider-hook-runtime.j
 import { shouldPreserveThinkingBlocks } from "../plugins/provider-replay-helpers.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import type { ProviderReplayPolicy } from "../plugins/types.js";
+import { isGemmaModelRequiringReasoningStrip } from "./pi-embedded-helpers/google.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { normalizeProviderId } from "./model-selection.js";
 import { isGoogleModelApi } from "./pi-embedded-helpers/google.js";
@@ -23,6 +24,7 @@ export type TranscriptPolicy = {
   };
   sanitizeThinkingSignatures: boolean;
   dropThinkingBlocks: boolean;
+  dropReasoningFromHistory: boolean;
   applyGoogleTurnOrdering: boolean;
   validateGeminiTurns: boolean;
   validateAnthropicTurns: boolean;
@@ -54,6 +56,7 @@ const DEFAULT_TRANSCRIPT_POLICY: TranscriptPolicy = {
   sanitizeThoughtSignatures: undefined,
   sanitizeThinkingSignatures: false,
   dropThinkingBlocks: false,
+  dropReasoningFromHistory: false,
   applyGoogleTurnOrdering: false,
   validateGeminiTurns: false,
   validateAnthropicTurns: false,
@@ -114,6 +117,9 @@ function buildUnownedProviderTransportReplayFallback(params: {
     ...(isAnthropic && modelId.includes("claude")
       ? { dropThinkingBlocks: !shouldPreserveThinkingBlocks(modelId) }
       : {}),
+    ...(isGemmaModelRequiringReasoningStrip(params.modelId)
+      ? { dropReasoningFromHistory: true }
+      : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { applyAssistantFirstOrderingFix: true } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { validateGeminiTurns: true } : {}),
     ...(isAnthropic || isStrictOpenAiCompatible ? { validateAnthropicTurns: true } : {}),
@@ -150,6 +156,9 @@ function mergeTranscriptPolicy(
       : {}),
     ...(typeof policy.dropThinkingBlocks === "boolean"
       ? { dropThinkingBlocks: policy.dropThinkingBlocks }
+      : {}),
+    ...(typeof policy.dropReasoningFromHistory === "boolean"
+      ? { dropReasoningFromHistory: policy.dropReasoningFromHistory }
       : {}),
     ...(typeof policy.applyAssistantFirstOrderingFix === "boolean"
       ? { applyGoogleTurnOrdering: policy.applyAssistantFirstOrderingFix }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -621,6 +621,7 @@ export type ProviderReplayPolicy = {
     includeCamelCase?: boolean;
   };
   dropThinkingBlocks?: boolean;
+  dropReasoningFromHistory?: boolean;
   repairToolUseResultPairing?: boolean;
   applyAssistantFirstOrderingFix?: boolean;
   validateGeminiTurns?: boolean;


### PR DESCRIPTION
## Problem

Closes #68704

When using Gemma 4 models via LM Studio, Ollama, or vLLM (OpenAI-compatible endpoints), `reasoning_content` from prior turns is re-sent in the conversation history. Google Gemma 4 documentation explicitly states that thinking/reasoning content must NOT be included in history.

This degrades response quality because the model receives internal reasoning from previous turns as visible context, confusing the conversation flow.

## Root Cause

The transport layer captures `reasoning_content` as `thinking` blocks and persists them in the transcript. The existing `dropThinkingBlocks` mechanism:

1. Only applies to **Anthropic Claude** models (via `modelId.includes("claude")`)
2. Preserves thinking in the **latest** turn for signed-thinking replay cache matching

Neither of these is correct for Gemma 4, which needs **all** reasoning stripped from **all** turns.

## Fix

Add a new `dropReasoningFromHistory` policy flag that strips ALL thinking blocks from ALL assistant messages (unlike `dropThinkingBlocks` which preserves the latest):

1. **`src/agents/pi-embedded-helpers/google.ts`** — New `isGemmaModelRequiringReasoningStrip()` helper detecting `gemma-4+` model IDs
2. **`src/agents/transcript-policy.ts`** — Add `dropReasoningFromHistory` to `TranscriptPolicy` type, default, and merge logic; auto-enable for Gemma 4+ in `buildUnownedProviderTransportReplayFallback`
3. **`src/plugins/types.ts`** — Add `dropReasoningFromHistory` to `ProviderReplayPolicy` type
4. **`src/agents/pi-embedded-runner/thinking.ts`** — Export `stripAllThinkingBlocks()` (was module-private)
5. **`src/agents/pi-embedded-runner/replay-history.ts`** — Apply `stripAllThinkingBlocks` when `dropReasoningFromHistory` is true

## Testing

Models that trigger the new policy:
- `gemma-4-27b-it`, `gemma-4-12b-it` (Ollama)
- `google/gemma-4-E2B-it` (HuggingFace)
- Future `gemma-5+` models via the `gemma-[4-9]|gemma-\d{2,}` pattern

Models that do NOT trigger it:
- `gemma-2b`, `gemma-3-4b` (not reasoning models)
- Claude, GPT, other models (unchanged behavior)

## Impact

- 5 files changed, 31 insertions(+), 5 deletions(-)
- Only affects transcript replay policy for Gemma 4+ models
- No changes to non-Gemma model behavior