### PR TITLE
fix: ignore stale auto-fallback model overrides on session reload

### DIFF
--- a/src/auto-reply/reply/stored-model-override.ts
+++ b/src/auto-reply/reply/stored-model-override.ts
@@ -31,12 +31,17 @@ export function resolveStoredModelOverride(params: {
   parentSessionKey?: string;
   defaultProvider: string;
 }): StoredModelOverride | null {
+  // Issue #68706: auto-source overrides are transient fallback selections
+  // that should only survive for the duration of the current turn.  If the
+  // process crashed after persisting the override but before the rollback
+  // ran, a stale "auto" override would pin the session to the fallback model
+  // indefinitely.  Ignore it here so the default model is re-resolved.
   const direct = resolvePersistedOverrideModelRef({
     defaultProvider: params.defaultProvider,
     overrideProvider: params.sessionEntry?.providerOverride,
     overrideModel: params.sessionEntry?.modelOverride,
   });
-  if (direct) {
+  if (direct && params.sessionEntry?.modelOverrideSource !== "auto") {
     return { ...direct, source: "session" };
   }
   const parentKey = resolveParentSessionKeyCandidate({


### PR DESCRIPTION
## Problem

Closes #68706

When auto-fallback selects an alternative model (e.g. primary model is rate-limited), it writes `modelOverride`/`providerOverride`/`modelOverrideSource:"auto"` to the persisted session store. A rollback mechanism clears this after the turn completes, but if the process crashes between persist and rollback, the stale `"auto"` override survives and pins the session to the fallback model indefinitely.

Subsequent messages continue using the fallback model even after the primary model becomes available again, because `resolveStoredModelOverride()` does not distinguish between user-initiated and auto-fallback overrides.

## Fix

In `resolveStoredModelOverride()` (`src/auto-reply/reply/stored-model-override.ts`), skip the override when `modelOverrideSource === "auto"`. This causes the session to re-resolve the default model on the next turn.

This is safe because:
- `"auto"` overrides are transient by design (they exist only for the current turn)
- If the primary model is still unavailable, auto-fallback will re-select an alternative on the next turn
- User-sourced overrides (`modelOverrideSource: "user"` or `undefined`) are completely unaffected
- This is the single entry point for reading stored overrides — all channels (Discord, Telegram, etc.) go through it

## Impact

- 1 file changed, 6 insertions(+), 1 deletion(-)
- Only affects sessions with stale `"auto"` source overrides after a crash
- No changes to normal auto-fallback or user override behavior