### PR TITLE
docs(providers): fix contextTokens placement for openai-codex

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -304,7 +304,7 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
   `chatgpt.com/backend-api`, not generic OpenAI-compatible proxies
 - Shares the same `/fast` toggle and `params.fastMode` config as direct `openai/*`; OpenClaw maps that to `service_tier=priority`
 - `openai-codex/gpt-5.3-codex-spark` remains available when the Codex OAuth catalog exposes it; entitlement-dependent
-- `openai-codex/gpt-5.4` keeps native `contextWindow = 1050000` and a default runtime `contextTokens = 272000`; override the runtime cap with `models.providers.openai-codex.models[].contextTokens`
+- `openai-codex/gpt-5.4` keeps native `contextWindow = 1050000` and a default runtime `contextTokens = 272000`; override the runtime cap globally with `agents.defaults.contextTokens` or per-model with `models.providers.openai-codex.models[].contextTokens` (requires a complete provider entry with `baseUrl` and model `name`)
 - Policy note: OpenAI Codex OAuth is explicitly supported for external tools/workflows like OpenClaw.
 
 ```json5

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1243,6 +1243,7 @@ Time format in system prompt. Default: `auto` (OS preference).
 - `embeddedHarness`: default low-level embedded agent runtime policy. Use `runtime: "auto"` to let registered plugin harnesses claim supported models, `runtime: "pi"` to force the built-in PI harness, or a registered harness id such as `runtime: "codex"`. Set `fallback: "none"` to disable automatic PI fallback.
 - Config writers that mutate these fields (for example `/models set`, `/models set-image`, and fallback add/remove commands) save canonical object form and preserve existing fallback lists when possible.
 - `maxConcurrent`: max parallel agent runs across sessions (each session still serialized). Default: 4.
+- `contextTokens`: runtime context budget cap applied to the default model. Overrides the provider's built-in default without changing native model metadata. For example, `openai-codex/gpt-5.4` defaults to a `272000` runtime cap against its native `1050000` window; set `contextTokens: 1050000` to use the full window.
 
 ### `agents.defaults.embeddedHarness`
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -131,19 +131,19 @@ Choose your preferred auth method and follow the setup steps.
     - Native `contextWindow`: `1050000`
     - Default runtime `contextTokens` cap: `272000`
 
-    The smaller default cap has better latency and quality characteristics in practice. Override it with `contextTokens`:
+    The smaller default cap has better latency and quality characteristics in practice. Override it globally with `agents.defaults.contextTokens`:
 
     ```json5
     {
-      models: {
-        providers: {
-          "openai-codex": {
-            models: [{ id: "gpt-5.4", contextTokens: 160000 }],
-          },
+      agents: {
+        defaults: {
+          contextTokens: 1050000,
         },
       },
     }
     ```
+
+    For a per-model override on a custom (non-OAuth) provider, use `models.providers.*.models[].contextTokens` instead. OAuth-backed providers like `openai-codex` are auto-configured and do not accept partial entries in `models.providers`.
 
     <Note>
     Use `contextWindow` to declare native model metadata. Use `contextTokens` to limit the runtime context budget.


### PR DESCRIPTION
## Summary

- Problem: Docs show `contextTokens` override at `models.providers.openai-codex.models[]`, but for OAuth-configured providers the gateway validator requires `baseUrl` and model `name` — fields that don't apply to auto-configured providers. Users following the docs hit a startup failure.
- Why it matters: Anyone raising GPT-5.4 from the 272K default to its native 1.05M context window can't follow the documented path.
- What changed: Added `agents.defaults.contextTokens` as the primary override path in openai.md, model-providers.md, and configuration-reference.md. Added missing bullet point for `contextTokens` in the config reference.
- What did NOT change (scope boundary): No code changes. Per-model `contextTokens` in `models.providers` is still documented for custom (non-OAuth) providers.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Docs only showed the `models.providers` path for overriding `contextTokens`. That path requires a complete provider entry (`baseUrl`, model `name`), which doesn't apply to OAuth-backed auto-configured providers like `openai-codex`.
- Missing detection / guardrail: N/A (docs-only)
- Contributing context: The working path (`agents.defaults.contextTokens`) was present in the config reference example but had no descriptive bullet point.

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None — docs only.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: OpenClaw 2026.4.15 (041266a)
- Model/provider: openai-codex/gpt-5.4

### Steps

1. Follow current docs: add `models.providers.openai-codex.models: [{ id: "gpt-5.4", contextTokens: 1050000 }]`
2. Restart gateway
3. Gateway refuses to start: `models.providers.openai-codex.baseUrl: Invalid input: expected string, received undefined`

### Expected

- Docs should point to a path that works for OAuth providers

### Actual

- Docs-only path requires fields that OAuth providers don't use

## Evidence

- [x] Trace/log snippets: direct config validation error reproduced locally against the documented partial provider shape

## Human Verification (required)

- Verified scenarios: Confirmed `agents.defaults.contextTokens: 1050000` starts cleanly on 2026.4.15. Confirmed `models.providers.openai-codex` path fails without `baseUrl`/`name`.
- Edge cases checked: Verified the per-provider path still works when a complete provider entry is supplied (custom non-OAuth providers).
- What you did **not** verify: Whether the gateway team intends to relax validation for partial provider entries under `models.mode: "merge"`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None

## AI Disclosure

- [x] Mark as AI-assisted in the PR title or description
- [x] Fully tested — confirmed both the failing and working config paths on OpenClaw 2026.4.15
- [x] I understand what the changes do
- [ ] Codex review: N/A
- [x] Resolve or reply to bot review conversations after addressing them

Claude Code hit this wall face-first, tried three wrong config paths, and eventually found the one that works. This PR is the scar tissue.
