### PR TITLE
fix(voice-call): skip speakInitialMessage when realtime mode is active

### DIFF
--- a/extensions/voice-call/src/manager.realtime.test.ts
+++ b/extensions/voice-call/src/manager.realtime.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { createManagerHarness, FakeProvider } from "./manager.test-harness.js";
+
+/**
+ * Regression test for issue #68713:
+ * Realtime voice bridge fails on outbound calls — status callback race
+ * overwrites <Connect><Stream> TwiML.
+ *
+ * When realtime.enabled is true, the regular call path's speakInitialMessage
+ * should be skipped because the realtime handler manages its own greeting
+ * via onReady → triggerGreeting. Speaking here would overwrite the
+ * TwiML <Connect><Stream> with a REST API <Say>, breaking the realtime bridge.
+ */
+describe("CallManager realtime mode", () => {
+  it("should skip speakInitialMessage when realtime is enabled", async () => {
+    const provider = new FakeProvider("twilio");
+    const { manager } = await createManagerHarness(
+      {
+        enabled: true,
+        provider: "twilio",
+        fromNumber: "+15555555555",
+        realtime: { enabled: true },
+        streaming: { enabled: false },
+      },
+      provider,
+    );
+
+    const speakInitialMessageSpy = vi.spyOn(manager as any, "speakInitialMessage");
+
+    // Simulate an answered call with initial message
+    const callRecord = {
+      callId: "test-call-id",
+      providerCallId: "twilio-call-id",
+      status: "answered" as const,
+      direction: "outbound" as const,
+      from: "+15555555555",
+      to: "+15555555556",
+      createdAt: Date.now(),
+      metadata: {
+        mode: "conversation",
+        initialMessage: "Hello, this is a test message",
+      },
+    };
+
+    // Access the private method for testing
+    (manager as any).maybeSpeakInitialMessageOnAnswered(callRecord);
+
+    // speakInitialMessage should NOT be called when realtime is enabled
+    expect(speakInitialMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("should call speakInitialMessage when realtime is disabled", async () => {
+    const provider = new FakeProvider("twilio");
+    const { manager } = await createManagerHarness(
+      {
+        enabled: true,
+        provider: "twilio",
+        fromNumber: "+15555555555",
+        realtime: { enabled: false },
+        streaming: { enabled: false },
+      },
+      provider,
+    );
+
+    const speakInitialMessageSpy = vi.spyOn(manager as any, "speakInitialMessage");
+
+    // Simulate an answered call with initial message
+    const callRecord = {
+      callId: "test-call-id",
+      providerCallId: "twilio-call-id",
+      status: "answered" as const,
+      direction: "outbound" as const,
+      from: "+15555555555",
+      to: "+15555555556",
+      createdAt: Date.now(),
+      metadata: {
+        mode: "conversation",
+        initialMessage: "Hello, this is a test message",
+      },
+    };
+
+    // Access the private method for testing
+    (manager as any).maybeSpeakInitialMessageOnAnswered(callRecord);
+
+    // speakInitialMessage should be called when realtime is disabled
+    expect(speakInitialMessageSpy).toHaveBeenCalledWith("twilio-call-id");
+  });
+
+  it("should call speakInitialMessage when realtime config uses default (disabled)", async () => {
+    const provider = new FakeProvider("twilio");
+    const { manager } = await createManagerHarness(
+      {
+        enabled: true,
+        provider: "twilio",
+        fromNumber: "+15555555555",
+        // realtime not specified — defaults to { enabled: false }
+        streaming: { enabled: false },
+      },
+      provider,
+    );
+
+    const speakInitialMessageSpy = vi.spyOn(manager as any, "speakInitialMessage");
+
+    // Simulate an answered call with initial message
+    const callRecord = {
+      callId: "test-call-id",
+      providerCallId: "twilio-call-id",
+      status: "answered" as const,
+      direction: "outbound" as const,
+      from: "+15555555555",
+      to: "+15555555556",
+      createdAt: Date.now(),
+      metadata: {
+        mode: "conversation",
+        initialMessage: "Hello, this is a test message",
+      },
+    };
+
+    // Access the private method for testing
+    (manager as any).maybeSpeakInitialMessageOnAnswered(callRecord);
+
+    // speakInitialMessage should be called when realtime is not enabled
+    expect(speakInitialMessageSpy).toHaveBeenCalledWith("twilio-call-id");
+  });
+});

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -288,6 +288,13 @@ export class CallManager {
   }
 
   private maybeSpeakInitialMessageOnAnswered(call: CallRecord): void {
+    // Skip initial message in realtime mode — the realtime handler manages its own
+    // greeting via onReady → triggerGreeting. Speaking here would overwrite the
+    // TwiML <Connect><Stream> with a REST API <Say>, breaking the realtime bridge.
+    if (this.config.realtime?.enabled) {
+      return;
+    }
+
     const initialMessage = normalizeOptionalString(call.metadata?.initialMessage) ?? "";
 
     if (!initialMessage) {


### PR DESCRIPTION
## Summary

Fixes #68713

When making outbound calls with `realtime.enabled = true`, the OpenAI Realtime voice bridge consistently failed with "WebSocket was closed before the connection was established". This was caused by a race condition where the regular call path's `speakInitialMessage` would overwrite the TwiML `<Connect><Stream>` with a REST API `<Say>` call.

## Root Cause

When Twilio initiates an outbound call, two webhook callbacks arrive nearly simultaneously:

1. **TwiML-fetch** correctly returns `<Connect><Stream url="wss://...">` via the realtime shortcircuit
2. **Status callback** goes through the regular path, triggering `maybeSpeakInitialMessageOnAnswered` → `speakInitialMessage` → `playTts`

The `playTts` call issues a Twilio REST API POST to `/Calls/<sid>.json` with `<Say><Gather>` TwiML, which **overwrites the in-progress `<Connect><Stream>`**. Twilio then tears down the media stream WebSocket.

## Fix

Add an early return in `maybeSpeakInitialMessageOnAnswered` when `this.config.realtime?.enabled` is true. The realtime handler manages its own greeting via `onReady → triggerGreeting → response.create` to the OpenAI Realtime API, so the regular path's `speakInitialMessage` is redundant and destructive in this mode.

## Test Plan

- [x] Added regression tests in `manager.realtime.test.ts`
- [x] Verified `speakInitialMessage` is skipped when realtime is enabled
- [x] Verified `speakInitialMessage` is called when realtime is disabled or unset
- [x] All 3 new tests pass

Closes openclaw#68713