### PR TITLE
fix(process): shim claude on Windows child spawns

### DIFF
--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -202,6 +202,20 @@ describe("createChildAdapter", () => {
     expect(settled).toHaveBeenCalledWith({ code: 0, signal: null });
   });
 
+  it("appends .cmd for claude on Windows child spawns", async () => {
+    setPlatform("win32");
+
+    await createAdapterHarness({
+      pid: 7777,
+      argv: ["claude", "--version"],
+    });
+
+    const spawnArgs = spawnWithFallbackMock.mock.calls[0]?.[0] as {
+      argv?: string[];
+    };
+    expect(spawnArgs.argv?.[0]).toBe("claude.cmd");
+  });
+
   it("disables detached mode in service-managed runtime", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
 

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -11,7 +11,7 @@ const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["npm", "pnpm", "yarn", "npx"],
+    cmdCommands: ["claude", "npm", "pnpm", "yarn", "npx"],
   });
 }
 


### PR DESCRIPTION
## Summary
- add `claude` to the Windows `.cmd` shim allowlist used by the child supervisor adapter
- cover the regression with a focused Windows child-spawn test

## Why
Windows installs the Claude CLI as `claude.cmd`. The child adapter already rewrites other known shimmed commands like `npm`, `pnpm`, `yarn`, and `npx`, but it leaves `claude` unchanged. That makes `provider=claude-cli` fail immediately with `spawn claude ENOENT` before any reply can be produced.

## Testing
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec vitest run src/process/supervisor/adapters/child.test.ts src/process/windows-command.test.ts`
