### PR TITLE
fix: prevent auto-fallback model from persisting into session state

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1727,9 +1727,10 @@ describe("runAgentTurnWithFallback", () => {
       authProfileId: undefined,
       authProfileIdSource: undefined,
     });
-    expect(sessionEntry.providerOverride).toBe("openai-codex");
-    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
-    expect(sessionEntry.modelOverrideSource).toBe("auto");
+    // After #68706 fix: auto-fallback override is rolled back after successful run
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
     expect(sessionEntry.authProfileOverride).toBeUndefined();
     expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
     expect(sessionStore.main.authProfileOverride).toBeUndefined();
@@ -1901,5 +1902,136 @@ describe("runAgentTurnWithFallback", () => {
       authProfileOverride: "anthropic:openclaw",
       authProfileOverrideSource: "user",
     });
+  });
+});
+
+describe("auto-fallback model override rollback after successful run (#68706)", () => {
+  beforeEach(() => {
+    state.runEmbeddedPiAgentMock.mockReset();
+    state.runWithModelFallbackMock.mockReset();
+    state.isInternalMessageChannelMock.mockReset();
+    state.isInternalMessageChannelMock.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rolls back auto-fallback model override after successful run", async () => {
+    // Simulate fallback: primary is anthropic/claude but run uses openai/gpt-4
+    state.runWithModelFallbackMock.mockImplementation(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await params.run("openai", "gpt-4"),
+        provider: "openai",
+        model: "gpt-4",
+        attempts: [
+          { provider: "anthropic", model: "claude", error: "rate_limit", reason: "rate_limit" },
+        ],
+      }),
+    );
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+    } as SessionEntry;
+    const sessionStore: Record<string, SessionEntry> = {
+      main: sessionEntry,
+    };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => sessionEntry,
+      activeSessionStore: sessionStore,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    // Auto-fallback override should be rolled back after successful run
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
+    expect(sessionEntry.providerOverride).toBeUndefined();
+  });
+
+  it("preserves user-initiated model override after fallback run", async () => {
+    state.runWithModelFallbackMock.mockImplementation(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await params.run("openai", "gpt-4"),
+        provider: "openai",
+        model: "gpt-4",
+        attempts: [
+          { provider: "anthropic", model: "claude", error: "rate_limit", reason: "rate_limit" },
+        ],
+      }),
+    );
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: "openai",
+      modelOverride: "gpt-4",
+      modelOverrideSource: "user" as const,
+    } as SessionEntry;
+    const sessionStore: Record<string, SessionEntry> = {
+      main: sessionEntry,
+    };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => sessionEntry,
+      activeSessionStore: sessionStore,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    // User-initiated override should be preserved
+    expect(sessionEntry.modelOverride).toBe("gpt-4");
+    expect(sessionEntry.modelOverrideSource).toBe("user");
+    expect(sessionEntry.providerOverride).toBe("openai");
   });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1507,6 +1507,47 @@ export async function runAgentTurnWithFallback(params: {
     }
   }
 
+  // Roll back auto-fallback model override after a successful run so the next
+  // turn starts from the configured primary model instead of the transient
+  // fallback.  User-initiated model changes (modelOverrideSource === "user")
+  // are preserved.  See: https://github.com/openclaw/openclaw/issues/68706
+  if (
+    params.sessionKey &&
+    params.activeSessionStore &&
+    (fallbackProvider !== params.followupRun.run.provider ||
+      fallbackModel !== params.followupRun.run.model)
+  ) {
+    const activeSessionEntry =
+      params.getActiveSessionEntry() ?? params.activeSessionStore?.[params.sessionKey];
+    if (activeSessionEntry && activeSessionEntry.modelOverrideSource === "auto") {
+      delete activeSessionEntry.providerOverride;
+      delete activeSessionEntry.modelOverride;
+      delete activeSessionEntry.modelOverrideSource;
+      activeSessionEntry.updatedAt = Date.now();
+      if (params.sessionKey && params.activeSessionStore) {
+        params.activeSessionStore[params.sessionKey] = activeSessionEntry;
+      }
+      if (params.storePath && params.sessionKey) {
+        try {
+          await updateSessionStore(params.storePath, (store) => {
+            const persistedEntry = store[params.sessionKey!];
+            if (persistedEntry && persistedEntry.modelOverrideSource === "auto") {
+              delete persistedEntry.providerOverride;
+              delete persistedEntry.modelOverride;
+              delete persistedEntry.modelOverrideSource;
+              persistedEntry.updatedAt = Date.now();
+              store[params.sessionKey!] = persistedEntry;
+            }
+          });
+        } catch (error) {
+          logVerbose(
+            `failed to roll back auto-fallback model override after run (non-fatal): ${String(error)}`,
+          );
+        }
+      }
+    }
+  }
+
   // If the run completed but with an embedded context overflow error that
   // wasn't recovered from (e.g. compaction reset already attempted), surface
   // the error to the user instead of silently returning an empty response.

--- a/src/auto-reply/reply/stored-model-override.test.ts
+++ b/src/auto-reply/reply/stored-model-override.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { resolveStoredModelOverride } from "./stored-model-override.js";
+
+function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  } as SessionEntry;
+}
+
+describe("resolveStoredModelOverride", () => {
+  it("returns user-initiated model override", () => {
+    const entry = makeEntry({
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus",
+      modelOverrideSource: "user",
+    });
+    const result = resolveStoredModelOverride({
+      sessionEntry: entry,
+      defaultProvider: "anthropic",
+    });
+    expect(result).toEqual({
+      provider: "anthropic",
+      model: "claude-opus",
+      source: "session",
+    });
+  });
+
+  it("skips auto-fallback model override so it does not persist across turns", () => {
+    const entry = makeEntry({
+      providerOverride: "anthropic",
+      modelOverride: "claude-haiku",
+      modelOverrideSource: "auto",
+    });
+    const result = resolveStoredModelOverride({
+      sessionEntry: entry,
+      defaultProvider: "anthropic",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("skips auto-fallback from parent session", () => {
+    const parentEntry = makeEntry({
+      providerOverride: "anthropic",
+      modelOverride: "claude-haiku",
+      modelOverrideSource: "auto",
+    });
+    const result = resolveStoredModelOverride({
+      sessionEntry: makeEntry(),
+      sessionStore: { parent: parentEntry },
+      sessionKey: "child",
+      parentSessionKey: "parent",
+      defaultProvider: "anthropic",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns parent session user override", () => {
+    const parentEntry = makeEntry({
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus",
+      modelOverrideSource: "user",
+    });
+    const result = resolveStoredModelOverride({
+      sessionEntry: makeEntry(),
+      sessionStore: { parent: parentEntry },
+      sessionKey: "child",
+      parentSessionKey: "parent",
+      defaultProvider: "anthropic",
+    });
+    expect(result).toEqual({
+      provider: "anthropic",
+      model: "claude-opus",
+      source: "parent",
+    });
+  });
+
+  it("returns override when modelOverrideSource is undefined (legacy)", () => {
+    const entry = makeEntry({
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus",
+    });
+    const result = resolveStoredModelOverride({
+      sessionEntry: entry,
+      defaultProvider: "anthropic",
+    });
+    expect(result).toEqual({
+      provider: "anthropic",
+      model: "claude-opus",
+      source: "session",
+    });
+  });
+
+  it("returns null when no override is set", () => {
+    const result = resolveStoredModelOverride({
+      sessionEntry: makeEntry(),
+      defaultProvider: "anthropic",
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/src/auto-reply/reply/stored-model-override.ts
+++ b/src/auto-reply/reply/stored-model-override.ts
@@ -31,11 +31,16 @@ export function resolveStoredModelOverride(params: {
   parentSessionKey?: string;
   defaultProvider: string;
 }): StoredModelOverride | null {
-  const direct = resolvePersistedOverrideModelRef({
-    defaultProvider: params.defaultProvider,
-    overrideProvider: params.sessionEntry?.providerOverride,
-    overrideModel: params.sessionEntry?.modelOverride,
-  });
+  // Skip auto-fallback overrides so they don't leak into the next turn.
+  // Only user-initiated model changes (/model) should persist across turns.
+  const isAutoFallback = params.sessionEntry?.modelOverrideSource === "auto";
+  const direct = isAutoFallback
+    ? null
+    : resolvePersistedOverrideModelRef({
+        defaultProvider: params.defaultProvider,
+        overrideProvider: params.sessionEntry?.providerOverride,
+        overrideModel: params.sessionEntry?.modelOverride,
+      });
   if (direct) {
     return { ...direct, source: "session" };
   }
@@ -47,6 +52,10 @@ export function resolveStoredModelOverride(params: {
     return null;
   }
   const parentEntry = params.sessionStore[parentKey];
+  const isParentAutoFallback = parentEntry?.modelOverrideSource === "auto";
+  if (isParentAutoFallback) {
+    return null;
+  }
   const parentOverride = resolvePersistedOverrideModelRef({
     defaultProvider: params.defaultProvider,
     overrideProvider: parentEntry?.providerOverride,


### PR DESCRIPTION
## Problem

When the primary model is unavailable (rate limit, overloaded, etc.) and a fallback model is selected automatically, the fallback model override (`modelOverrideSource: 'auto'`) is persisted to session state via `persistFallbackCandidateSelection()` but never rolled back after a successful run. This causes subsequent turns to start from the fallback model instead of the configured primary model.

## Root Cause

In `agent-runner-execution.ts`, `persistFallbackCandidateSelection()` writes `modelOverride`, `providerOverride`, and `modelOverrideSource: 'auto'` to both in-memory and on-disk session state. The returned rollback function is only called on error paths. On success, the auto-fallback override persists indefinitely.

## Fix

1. **Post-run rollback** (`agent-runner-execution.ts`): After a successful run where fallback was used, clear the auto-fallback model override (`providerOverride`, `modelOverride`, `modelOverrideSource`) from both in-memory and persisted session state. User-initiated model changes (`modelOverrideSource: 'user'`, set via `/model` command) are preserved.

2. **Defense-in-depth** (`stored-model-override.ts`): `resolveStoredModelOverride()` now skips overrides with `modelOverrideSource: 'auto'` when resolving the stored model for the next turn. This prevents stale auto-fallback state from affecting model selection even if the post-run rollback fails.

## Tests

- ✅ Auto-fallback model override is rolled back after a successful run
- ✅ User-initiated model override (`/model`) is preserved after a fallback run
- ✅ `resolveStoredModelOverride()` skips auto-fallback overrides (direct and parent session)
- ✅ All 33 existing tests in `agent-runner-execution.test.ts` pass (1 updated to match new behavior)

Closes #68706