### PR TITLE
[AI-assisted] fix(tts): ignore literal directives inside markdown code

### DIFF
--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -144,4 +144,63 @@ describe("parseTtsDirectives provider-aware routing", () => {
     expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.2 });
     expect(result.overrides.providerOverrides?.elevenlabs).toBeUndefined();
   });
+
+  it("ignores directive-like tags inside inline code spans", () => {
+    const input = '`messages.tts.auto = "tagged"` -> need `[[tts:text]]` tag';
+    const result = parseTtsDirectives(input, fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    expect(result.hasDirective).toBe(false);
+    expect(result.cleanedText).toBe(input);
+    expect(result.overrides).toEqual({});
+  });
+
+  it("ignores TTS directive blocks inside fenced code blocks", () => {
+    const input = "Example:\n```md\n[[tts:text]]\nquoted example\n[[/tts:text]]\n```\nDone.";
+    const result = parseTtsDirectives(input, fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    expect(result.hasDirective).toBe(false);
+    expect(result.cleanedText).toBe(input);
+    expect(result.overrides).toEqual({});
+  });
+
+  it("keeps parsing real TTS text blocks when their body contains code", () => {
+    const input = "[[tts:text]]Use `pnpm test` here.\n```sh\necho hello\n```\n[[/tts:text]]";
+    const result = parseTtsDirectives(input, fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    expect(result.hasDirective).toBe(true);
+    expect(result.cleanedText).toBe("");
+    expect(result.ttsText).toBe("Use `pnpm test` here.\n```sh\necho hello\n```");
+  });
+
+  it("still parses real directives outside code regions", () => {
+    const input =
+      "`[[tts:text]]` is literal here, but [[tts:provider=minimax speed=1.2]] should still apply.";
+    const result = parseTtsDirectives(input, fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    expect(result.hasDirective).toBe(true);
+    expect(result.cleanedText).toContain("`[[tts:text]]`");
+    expect(result.cleanedText).not.toContain("[[tts:provider=minimax speed=1.2]]");
+    expect(result.overrides.provider).toBe("minimax");
+    expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.2 });
+  });
+
+  it("still parses real text blocks that contain inline code", () => {
+    const input = "[[tts:text]]Read `[[tts:text]]` literally.[[/tts:text]]";
+    const result = parseTtsDirectives(input, fullPolicy, {
+      providers: [elevenlabs, minimax],
+    });
+
+    expect(result.hasDirective).toBe(true);
+    expect(result.cleanedText).toBe("");
+    expect(result.ttsText).toBe("Read `[[tts:text]]` literally.");
+    expect(result.overrides).toEqual({ ttsText: "Read `[[tts:text]]` literally." });
+  });
 });

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { findCodeRegions, isInsideCode } from "../shared/text/code-regions.js";
 import { listSpeechProviders } from "./provider-registry.js";
 import type {
   SpeechModelOverridePolicy,
@@ -53,6 +54,36 @@ function prioritizeProvider(
   return [preferredProvider, ...providers.filter((provider) => provider.id !== providerId)];
 }
 
+function replaceOutsideCodeRegions(
+  text: string,
+  regex: RegExp,
+  replacer: (match: RegExpMatchArray) => string,
+  shouldPreserveMatch: (
+    match: RegExpMatchArray,
+    start: number,
+    codeRegions: { start: number; end: number }[],
+  ) => boolean = (_match, start, codeRegions) => isInsideCode(start, codeRegions),
+): string {
+  regex.lastIndex = 0;
+  const codeRegions = findCodeRegions(text);
+  let out = "";
+  let cursor = 0;
+
+  for (const match of text.matchAll(regex)) {
+    const start = match.index ?? 0;
+    out += text.slice(cursor, start);
+    if (shouldPreserveMatch(match, start, codeRegions)) {
+      out += match[0];
+    } else {
+      out += replacer(match);
+    }
+    cursor = start + match[0].length;
+  }
+
+  out += text.slice(cursor);
+  return out;
+}
+
 export function parseTtsDirectives(
   text: string,
   policy: SpeechModelOverridePolicy,
@@ -69,16 +100,34 @@ export function parseTtsDirectives(
   let hasDirective = false;
 
   const blockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
-  cleanedText = cleanedText.replace(blockRegex, (_match, inner: string) => {
-    hasDirective = true;
-    if (policy.allowText && overrides.ttsText == null) {
-      overrides.ttsText = inner.trim();
-    }
-    return "";
-  });
+  const ttsTextOpenTagLength = "[[tts:text]]".length;
+  const ttsTextCloseTagLength = "[[/tts:text]]".length;
+  cleanedText = replaceOutsideCodeRegions(
+    cleanedText,
+    blockRegex,
+    (match) => {
+      const inner = match[1] ?? "";
+      hasDirective = true;
+      if (policy.allowText && overrides.ttsText == null) {
+        overrides.ttsText = inner.trim();
+      }
+      return "";
+    },
+    (match, start, codeRegions) => {
+      const end = start + match[0].length;
+      const closingTagStart = end - ttsTextCloseTagLength;
+      return (
+        isInsideCode(start, codeRegions) ||
+        isInsideCode(start + ttsTextOpenTagLength - 1, codeRegions) ||
+        isInsideCode(closingTagStart, codeRegions) ||
+        isInsideCode(closingTagStart + ttsTextCloseTagLength - 1, codeRegions)
+      );
+    },
+  );
 
   const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
-  cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
+  cleanedText = replaceOutsideCodeRegions(cleanedText, directiveRegex, (match) => {
+    const body = match[1] ?? "";
     hasDirective = true;
     const tokens = body.split(/\s+/).filter(Boolean);
 


### PR DESCRIPTION
## Summary

- Problem: `parseTtsDirectives` treated literal `[[tts:...]]` tokens inside inline code spans and fenced code blocks as real directives.
- Why it matters: in `messages.tts.auto="tagged"`, troubleshooting or documentation replies could trigger unintended TTS synthesis and strip visible example text.
- What changed: skip TTS directive parsing when the directive tag itself starts inside a markdown code region, and add regression tests for inline code, fenced code, mixed literal+real directives, and real text blocks that contain inline code.
- What did NOT change (scope boundary): this does not address other TTS parser issues such as orphaned closing-tag leakage in #68553.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68769
- Related #68553
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the TTS directive regexes were markdown-blind and stripped any literal `[[tts:...]]` token even when that token lived inside inline or fenced code.
- Missing detection / guardrail: no code-region check existed before applying the directive regexes.
- Contributing context (if known): `[[tts:text]]...[[/tts:text]]` blocks can legitimately contain inline code, so the guardrail has to ignore directive tags inside code without suppressing real text blocks that merely contain code.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/tts/directives.test.ts`
- Scenario the test should lock in: literal directive examples inside inline/fenced markdown code stay visible text and do not trigger TTS; real directives outside code still parse.
- Why this is the smallest reliable guardrail: the bug lives entirely inside `parseTtsDirectives`, so a focused parser unit test exercises the broken branch directly without needing live provider/channel setup.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Literal TTS directive examples inside inline code or fenced code stay visible text and no longer trigger tagged-mode TTS.
- Real TTS directives outside markdown code still behave as before, including `[[tts:text]]...[[/tts:text]]` blocks that contain inline code.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v24.15.0 / pnpm v10.33.0
- Model/provider: N/A
- Integration/channel (if any): tagged TTS parser (`messages.tts.auto="tagged"`)
- Relevant config (redacted): `messages.tts.auto="tagged"`

### Steps

1. Put a literal TTS token inside markdown code, for example `` `[[tts:text]]` `` or a fenced block containing `[[tts:text]]...[[/tts:text]]`.
2. Run the message through `parseTtsDirectives`.
3. Observe whether the parser marks `hasDirective=true` and strips the literal text.

### Expected

- Literal examples inside markdown code remain untouched and do not trigger TTS.
- Real directives outside code still parse.

### Actual

- Before this patch, literal examples inside inline/fenced code set `hasDirective=true` and were stripped; mixed content also lost the inline-code literal token.
- After this patch, only directives whose tag starts outside code are parsed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - On a detached `origin/main` checkout, the new parser regressions failed for inline code, fenced code, and mixed literal+real directive boundaries.
  - On this branch, `corepack pnpm test src/tts/directives.test.ts` passed.
  - On this branch, `corepack pnpm test src/shared/text/code-regions.test.ts` passed.
  - On this branch, `corepack pnpm build` passed.
- Edge cases checked:
  - real directive adjacent to inline code
  - real `[[tts:text]]...[[/tts:text]]` block containing inline code
- What you did **not** verify:
  - live Telegram or provider delivery end-to-end; this patch stays in the parser unit.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: malformed tags that straddle code-boundary positions could still be preserved as literal text.
  - Mitigation: scope stays intentionally narrow, and the new tests lock the supported inline/fenced boundaries plus real text-block parsing with inline code.
