### PR TITLE
docs: clarify source Control UI dev/build flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,21 +212,34 @@ Runbook: [iOS connect](https://docs.openclaw.ai/platforms/ios).
 
 Prefer `pnpm` for builds from source. Bun is optional for running TypeScript directly.
 
+For the dev loop:
+
 ```bash
 git clone https://github.com/openclaw/openclaw.git
 cd openclaw
 
 pnpm install
-pnpm ui:build # auto-installs UI deps on first run
-pnpm build
 
-pnpm openclaw onboard --install-daemon
+# First run only (or after resetting local OpenClaw config/workspace)
+pnpm openclaw setup
+
+# Optional: prebuild Control UI before first startup
+pnpm ui:build
 
 # Dev loop (auto-reload on source/config changes)
 pnpm gateway:watch
 ```
 
-Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` produces `dist/` for running via Node / the packaged `openclaw` binary.
+If you need a built `dist/` from the checkout (for Node, packaging, or release validation), run:
+
+```bash
+pnpm build
+pnpm ui:build
+```
+
+`pnpm openclaw setup` writes the local config/workspace needed for `pnpm gateway:watch`. It is safe to re-run, but you normally only need it on first setup or after resetting local state. `pnpm gateway:watch` does not rebuild `dist/control-ui`, so rerun `pnpm ui:build` after `ui/` changes or use `pnpm ui:dev` when iterating on the Control UI. If you want this checkout to run onboarding directly, use `pnpm openclaw onboard --install-daemon`.
+
+Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` produces `dist/` for running via Node / the packaged `openclaw` binary, while `pnpm gateway:watch` rebuilds the runtime on demand during the dev loop.
 
 ## Development channels
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -160,7 +160,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
     cd openclaw
     pnpm install
     pnpm build
-    pnpm ui:build # auto-installs UI deps on first run
+    pnpm ui:build
     openclaw onboard
     ```
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -115,7 +115,7 @@ For contributors or anyone who wants to run from a local checkout:
 ```bash
 git clone https://github.com/openclaw/openclaw.git
 cd openclaw
-pnpm install && pnpm ui:build && pnpm build
+pnpm install && pnpm build && pnpm ui:build
 pnpm link --global
 openclaw onboard --install-daemon
 ```

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -222,15 +222,25 @@ systemctl --user status
 
 ### 3) Install OpenClaw (inside WSL)
 
-Follow the Linux Getting Started flow inside WSL:
+For a normal first-time setup inside WSL, follow the Linux Getting Started flow:
 
 ```bash
 git clone https://github.com/openclaw/openclaw.git
 cd openclaw
 pnpm install
-pnpm ui:build # auto-installs UI deps on first run
 pnpm build
-openclaw onboard
+pnpm ui:build
+pnpm openclaw onboard --install-daemon
+```
+
+If you are developing from source instead of doing first-time onboarding, use the
+source dev loop from [Setup](/start/setup):
+
+```bash
+pnpm install
+# First run only (or after resetting local OpenClaw config/workspace)
+pnpm openclaw setup
+pnpm gateway:watch
 ```
 
 Full guide: [Getting Started](/start/getting-started)

--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -91,16 +91,22 @@ If you also want the macOS app on the bleeding edge:
 
 ```bash
 pnpm install
+# First run only (or after resetting local OpenClaw config/workspace)
+pnpm openclaw setup
 pnpm gateway:watch
 ```
 
 `gateway:watch` runs the gateway in watch mode and reloads on relevant source,
 config, and bundled-plugin metadata changes.
+`pnpm openclaw setup` is the one-time local config/workspace initialization step for a fresh checkout.
+`pnpm gateway:watch` does not rebuild `dist/control-ui`, so rerun `pnpm ui:build` after `ui/` changes or use `pnpm ui:dev` while developing the Control UI.
 
 If you are intentionally using the Bun workflow, the equivalent commands are:
 
 ```bash
 bun install
+# First run only (or after resetting local OpenClaw config/workspace)
+bun run openclaw setup
 bun run gateway:watch
 ```
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -278,7 +278,7 @@ See [Tailscale](/gateway/tailscale) for HTTPS setup guidance.
 The Gateway serves static files from `dist/control-ui`. Build them with:
 
 ```bash
-pnpm ui:build # auto-installs UI deps on first run
+pnpm ui:build
 ```
 
 Optional absolute base (when you want fixed asset URLs):
@@ -290,7 +290,7 @@ OPENCLAW_CONTROL_UI_BASE_PATH=/openclaw/ pnpm ui:build
 For local development (separate dev server):
 
 ```bash
-pnpm ui:dev # auto-installs UI deps on first run
+pnpm ui:dev
 ```
 
 Then point the UI at your Gateway WS URL (e.g. `ws://127.0.0.1:18789`).

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -122,5 +122,5 @@ Open:
 The Gateway serves static files from `dist/control-ui`. Build them with:
 
 ```bash
-pnpm ui:build # auto-installs UI deps on first run
+pnpm ui:build
 ```

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -226,7 +226,7 @@ describe("gateway run option collisions", () => {
     await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
 
     expect(gatewayLogMessages).toContain(
-      "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. Prebuild with `pnpm ui:build` for a faster first boot.",
+      "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. `pnpm gateway:watch` does not rebuild Control UI assets, so rerun `pnpm ui:build` after UI changes or use `pnpm ui:dev` while developing the Control UI. For a full local dist, run `pnpm build && pnpm ui:build`.",
     );
   });
 

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -176,7 +176,7 @@ function maybeLogPendingControlUiBuild(cfg: OpenClawConfig): void {
     return;
   }
   gatewayLog.info(
-    "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. Prebuild with `pnpm ui:build` for a faster first boot.",
+    "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. `pnpm gateway:watch` does not rebuild Control UI assets, so rerun `pnpm ui:build` after UI changes or use `pnpm ui:dev` while developing the Control UI. For a full local dist, run `pnpm build && pnpm ui:build`.",
   );
 }
 


### PR DESCRIPTION
## Summary
- split the source docs into an explicit `pnpm gateway:watch` dev loop and a separate built-dist / onboarding flow
- restore `pnpm openclaw setup` as the first-run/reset step for source dev, instead of implying it belongs in every loop
- clarify that `pnpm gateway:watch` does not rebuild `dist/control-ui` and point Control UI contributors to `pnpm ui:build` or `pnpm ui:dev`
- align the Windows WSL source instructions with the same onboarding-vs-dev distinction
- trim noisy inline comments in the command examples now that the surrounding prose explains the workflow

## Why
The current source instructions mixed three different workflows:
- source dev loop (`pnpm gateway:watch`)
- built-dist flow (`pnpm build` + `pnpm ui:build`)
- first-time onboarding (`openclaw onboard`)

That made it easy to follow a sequence like `pnpm ui:build`, then `pnpm build`, then `pnpm gateway:watch`, which removes `dist/control-ui` and triggers the "assets missing" warning even though the earlier UI build succeeded. Fresh source checkouts and WSL users also needed clearer guidance on when `pnpm openclaw setup` is the right step versus when the broader onboarding flow is the right step.

## Impact
Contributors now get:
- a cleaner source-dev loop
- the correct build order for a full local `dist/`
- explicit first-run/reset wording for `pnpm openclaw setup`
- accurate guidance for iterating on the Control UI without serving stale assets

## Validation
- `pnpm test src/cli/gateway-cli/run.option-collisions.test.ts`
- `codex review --base origin/main`
- Manual validation of the documented source-dev and Control UI flows:
  - fresh isolated source-dev flow with `pnpm openclaw setup` then `pnpm gateway:watch`
  - optional `pnpm ui:build` prebuild path before `pnpm gateway:watch`
  - built-dist flow using `pnpm build && pnpm ui:build`
  - `pnpm ui:dev` against a local gateway using dashboard token bootstrap
  - confirmation that `pnpm gateway:watch` does not refresh `dist/control-ui` after UI changes