### PR TITLE
feat(moonshot): default to Kimi K2.6 with K2.6-only thinking.keep support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Cron: split runtime execution state into `jobs-state.json` so `jobs.json` stays stable for git-tracked job definitions. (#63105) Thanks @Feelw00.
 - Agents/compaction: send opt-in start and completion notices during context compaction. (#67830) Thanks @feniix.
 - Moonshot/Kimi: default bundled Moonshot setup, web search, and media-understanding surfaces to `kimi-k2.6` while keeping `kimi-k2.5` available for compatibility. (#69477) Thanks @scoootscooob.
+- Moonshot/Kimi: allow `thinking.keep = "all"` on `moonshot/kimi-k2.6`, and strip it for other Moonshot models or requests where pinned `tool_choice` disables thinking. (#68816) Thanks @aniaan.
 
 ### Fixes
 

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -431,7 +431,7 @@ See [/providers/kilocode](/providers/kilocode) for setup details.
   `input: ["text", "image"]`; the bundled provider catalog keeps the chat refs
   text-only until that provider config is materialized
 - Moonshot: `moonshot` (`MOONSHOT_API_KEY`)
-- Example model: `moonshot/kimi-k2.5`
+- Example model: `moonshot/kimi-k2.6`
 - Kimi Coding: `kimi` (`KIMI_API_KEY` or `KIMICODE_API_KEY`)
 - Example model: `kimi/kimi-code`
 - Qianfan: `qianfan` (`QIANFAN_API_KEY`)
@@ -488,13 +488,14 @@ need to override the base URL or model metadata:
 
 - Provider: `moonshot`
 - Auth: `MOONSHOT_API_KEY`
-- Example model: `moonshot/kimi-k2.5`
+- Example model: `moonshot/kimi-k2.6`
 - CLI: `openclaw onboard --auth-choice moonshot-api-key` or `openclaw onboard --auth-choice moonshot-api-key-cn`
 
 Kimi K2 model IDs:
 
 [//]: # "moonshot-kimi-k2-model-refs:start"
 
+- `moonshot/kimi-k2.6`
 - `moonshot/kimi-k2.5`
 - `moonshot/kimi-k2-thinking`
 - `moonshot/kimi-k2-thinking-turbo`
@@ -505,7 +506,7 @@ Kimi K2 model IDs:
 ```json5
 {
   agents: {
-    defaults: { model: { primary: "moonshot/kimi-k2.5" } },
+    defaults: { model: { primary: "moonshot/kimi-k2.6" } },
   },
   models: {
     mode: "merge",
@@ -514,7 +515,7 @@ Kimi K2 model IDs:
         baseUrl: "https://api.moonshot.ai/v1",
         apiKey: "${MOONSHOT_API_KEY}",
         api: "openai-completions",
-        models: [{ id: "kimi-k2.5", name: "Kimi K2.5" }],
+        models: [{ id: "kimi-k2.6", name: "Kimi K2.6" }],
       },
     },
   },

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2673,8 +2673,8 @@ Set `ZAI_API_KEY`. `z.ai/*` and `z-ai/*` are accepted aliases. Shortcut: `opencl
   env: { MOONSHOT_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "moonshot/kimi-k2.5" },
-      models: { "moonshot/kimi-k2.5": { alias: "Kimi K2.5" } },
+      model: { primary: "moonshot/kimi-k2.6" },
+      models: { "moonshot/kimi-k2.6": { alias: "Kimi K2.6" } },
     },
   },
   models: {
@@ -2686,8 +2686,8 @@ Set `ZAI_API_KEY`. `z.ai/*` and `z-ai/*` are accepted aliases. Shortcut: `opencl
         api: "openai-completions",
         models: [
           {
-            id: "kimi-k2.5",
-            name: "Kimi K2.5",
+            id: "kimi-k2.6",
+            name: "Kimi K2.6",
             reasoning: false,
             input: ["text", "image"],
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -10,7 +10,7 @@ title: "Moonshot AI"
 # Moonshot AI (Kimi)
 
 Moonshot provides the Kimi API with OpenAI-compatible endpoints. Configure the
-provider and set the default model to `moonshot/kimi-k2.5`, or use
+provider and set the default model to `moonshot/kimi-k2.6`, or use
 Kimi Coding with `kimi/kimi-code`.
 
 <Warning>
@@ -23,6 +23,7 @@ Moonshot and Kimi Coding are **separate providers**. Keys are not interchangeabl
 
 | Model ref                         | Name                   | Reasoning | Input       | Context | Max output |
 | --------------------------------- | ---------------------- | --------- | ----------- | ------- | ---------- |
+| `moonshot/kimi-k2.6`              | Kimi K2.6              | No        | text, image | 262,144 | 262,144    |
 | `moonshot/kimi-k2.5`              | Kimi K2.5              | No        | text, image | 262,144 | 262,144    |
 | `moonshot/kimi-k2-thinking`       | Kimi K2 Thinking       | Yes       | text        | 262,144 | 262,144    |
 | `moonshot/kimi-k2-thinking-turbo` | Kimi K2 Thinking Turbo | Yes       | text        | 262,144 | 262,144    |
@@ -61,7 +62,7 @@ Choose your provider and follow the setup steps.
         {
           agents: {
             defaults: {
-              model: { primary: "moonshot/kimi-k2.5" },
+              model: { primary: "moonshot/kimi-k2.6" },
             },
           },
         }
@@ -81,9 +82,10 @@ Choose your provider and follow the setup steps.
       env: { MOONSHOT_API_KEY: "sk-..." },
       agents: {
         defaults: {
-          model: { primary: "moonshot/kimi-k2.5" },
+          model: { primary: "moonshot/kimi-k2.6" },
           models: {
             // moonshot-kimi-k2-aliases:start
+            "moonshot/kimi-k2.6": { alias: "Kimi K2.6" },
             "moonshot/kimi-k2.5": { alias: "Kimi K2.5" },
             "moonshot/kimi-k2-thinking": { alias: "Kimi K2 Thinking" },
             "moonshot/kimi-k2-thinking-turbo": { alias: "Kimi K2 Thinking Turbo" },
@@ -101,6 +103,15 @@ Choose your provider and follow the setup steps.
             api: "openai-completions",
             models: [
               // moonshot-kimi-k2-models:start
+              {
+                id: "kimi-k2.6",
+                name: "Kimi K2.6",
+                reasoning: false,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 262144,
+                maxTokens: 262144,
+              },
               {
                 id: "kimi-k2.5",
                 name: "Kimi K2.5",
@@ -218,7 +229,7 @@ search.
     | Setting             | Options                                                              |
     | ------------------- | -------------------------------------------------------------------- |
     | API region          | `https://api.moonshot.ai/v1` (international) or `https://api.moonshot.cn/v1` (China) |
-    | Web search model    | Defaults to `kimi-k2.5`                                             |
+    | Web search model    | Defaults to `kimi-k2.6`                                             |
 
   </Step>
 </Steps>
@@ -234,7 +245,7 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
           webSearch: {
             apiKey: "sk-...", // or use KIMI_API_KEY / MOONSHOT_API_KEY
             baseUrl: "https://api.moonshot.ai/v1",
-            model: "kimi-k2.5",
+            model: "kimi-k2.6",
           },
         },
       },
@@ -266,7 +277,7 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
       agents: {
         defaults: {
           models: {
-            "moonshot/kimi-k2.5": {
+            "moonshot/kimi-k2.6": {
               params: {
                 thinking: { type: "disabled" },
               },
@@ -288,6 +299,28 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
     When Moonshot thinking is enabled, `tool_choice` must be `auto` or `none`. OpenClaw normalizes incompatible `tool_choice` values to `auto` for compatibility.
     </Warning>
 
+    Kimi K2.6 also accepts an optional `thinking.keep` field that controls
+    multi-turn retention of `reasoning_content`. Set it to `"all"` to keep full
+    reasoning across turns; omit it (or leave it `null`) to use the server
+    default strategy. OpenClaw only forwards `thinking.keep` for
+    `moonshot/kimi-k2.6` and strips it from other models.
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          models: {
+            "moonshot/kimi-k2.6": {
+              params: {
+                thinking: { type: "enabled", keep: "all" },
+              },
+            },
+          },
+        },
+      },
+    }
+    ```
+
   </Accordion>
 
   <Accordion title="Streaming usage compatibility">
@@ -306,7 +339,7 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
     | Kimi Coding| `kimi/`          | Kimi Coding endpoint          | `KIMI_API_KEY`      |
     | Web search | N/A              | Same as Moonshot API region   | `KIMI_API_KEY` or `MOONSHOT_API_KEY` |
 
-    - Kimi web search uses `KIMI_API_KEY` or `MOONSHOT_API_KEY`, and defaults to `https://api.moonshot.ai/v1` with model `kimi-k2.5`.
+    - Kimi web search uses `KIMI_API_KEY` or `MOONSHOT_API_KEY`, and defaults to `https://api.moonshot.ai/v1` with model `kimi-k2.6`.
     - Override pricing and context metadata in `models.providers` if needed.
     - If Moonshot publishes different context limits for a model, adjust `contextWindow` accordingly.
 

--- a/docs/tools/kimi-search.md
+++ b/docs/tools/kimi-search.md
@@ -34,7 +34,7 @@ When you choose **Kimi** during `openclaw onboard` or
 - the Moonshot API region:
   - `https://api.moonshot.ai/v1`
   - `https://api.moonshot.cn/v1`
-- the default Kimi web-search model (defaults to `kimi-k2.5`)
+- the default Kimi web-search model (defaults to `kimi-k2.6`)
 
 ## Config
 
@@ -47,7 +47,7 @@ When you choose **Kimi** during `openclaw onboard` or
           webSearch: {
             apiKey: "sk-...", // optional if KIMI_API_KEY or MOONSHOT_API_KEY is set
             baseUrl: "https://api.moonshot.ai/v1",
-            model: "kimi-k2.5",
+            model: "kimi-k2.6",
           },
         },
       },
@@ -74,7 +74,7 @@ with `tools.web.search.kimi.baseUrl` when you need a different search base URL.
 Gateway environment. For a gateway install, put it in `~/.openclaw/.env`.
 
 If you omit `baseUrl`, OpenClaw defaults to `https://api.moonshot.ai/v1`.
-If you omit `model`, OpenClaw defaults to `kimi-k2.5`.
+If you omit `model`, OpenClaw defaults to `kimi-k2.6`.
 
 ## How it works
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -220,7 +220,7 @@ When you choose **Kimi** during `openclaw onboard` or
 `openclaw configure --section web`, OpenClaw can also ask for:
 
 - the Moonshot API region (`https://api.moonshot.ai/v1` or `https://api.moonshot.cn/v1`)
-- the default Kimi web-search model (defaults to `kimi-k2.5`)
+- the default Kimi web-search model (defaults to `kimi-k2.6`)
 
 For `x_search`, configure `plugins.entries.xai.config.xSearch.*`. It uses the
 same `XAI_API_KEY` fallback as Grok web search.

--- a/src/agents/pi-embedded-runner-extraparams-moonshot.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams-moonshot.test.ts
@@ -3,6 +3,7 @@ import { runExtraParamsPayloadCase } from "./pi-embedded-runner-extraparams.test
 import { __testing as extraParamsTesting } from "./pi-embedded-runner/extra-params.js";
 import {
   createMoonshotThinkingWrapper,
+  resolveMoonshotThinkingKeep,
   resolveMoonshotThinkingType,
 } from "./pi-embedded-runner/moonshot-stream-wrappers.js";
 
@@ -15,7 +16,10 @@ beforeEach(() => {
           configuredThinking: params.context.extraParams?.thinking,
           thinkingLevel: params.context.thinkingLevel,
         });
-        return createMoonshotThinkingWrapper(params.context.streamFn, thinkingType);
+        const thinkingKeep = resolveMoonshotThinkingKeep({
+          configuredThinking: params.context.extraParams?.thinking,
+        });
+        return createMoonshotThinkingWrapper(params.context.streamFn, thinkingType, thinkingKeep);
       }
       return params.context.streamFn;
     },
@@ -73,6 +77,89 @@ describe("applyExtraParamsToAgent Moonshot", () => {
               "moonshot/kimi-k2.5": {
                 params: {
                   thinking: { type: "disabled" },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("forwards thinking.keep=all to kimi-k2.6 requests", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.6",
+      thinkingLevel: "low",
+      payload: { model: "kimi-k2.6" },
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "moonshot/kimi-k2.6": {
+                params: {
+                  thinking: { type: "enabled", keep: "all" },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.thinking).toEqual({ type: "enabled", keep: "all" });
+  });
+
+  it("omits thinking.keep on kimi-k2.6 when not configured", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.6",
+      thinkingLevel: "low",
+      payload: { model: "kimi-k2.6" },
+    });
+
+    expect(payload.thinking).toEqual({ type: "enabled" });
+  });
+
+  it("strips thinking.keep for non-k2.6 models even when configured", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.5",
+      thinkingLevel: "low",
+      payload: { model: "kimi-k2.5" },
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "moonshot/kimi-k2.5": {
+                params: {
+                  thinking: { type: "enabled", keep: "all" },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.thinking).toEqual({ type: "enabled" });
+  });
+
+  it("drops thinking.keep on kimi-k2.6 when thinking is forced off by pinned tool_choice", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.6",
+      thinkingLevel: "low",
+      payload: { model: "kimi-k2.6", tool_choice: { type: "tool", name: "read" } },
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "moonshot/kimi-k2.6": {
+                params: {
+                  thinking: { type: "enabled", keep: "all" },
                 },
               },
             },

--- a/src/agents/pi-embedded-runner/moonshot-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/moonshot-stream-wrappers.ts
@@ -5,6 +5,7 @@ import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
 export {
   createMoonshotThinkingWrapper,
+  resolveMoonshotThinkingKeep,
   resolveMoonshotThinkingType,
 } from "./moonshot-thinking-stream-wrappers.js";
 

--- a/src/agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.ts
@@ -4,6 +4,8 @@ import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js"
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
 type MoonshotThinkingType = "enabled" | "disabled";
+type MoonshotThinkingKeep = "all";
+const MOONSHOT_THINKING_KEEP_MODEL_ID = "kimi-k2.6";
 let piAiRuntimePromise: Promise<typeof import("@mariozechner/pi-ai")> | undefined;
 
 async function loadDefaultStreamFn(): Promise<StreamFn> {
@@ -33,6 +35,17 @@ function normalizeMoonshotThinkingType(value: unknown): MoonshotThinkingType | u
     return normalizeMoonshotThinkingType((value as Record<string, unknown>).type);
   }
   return undefined;
+}
+
+function normalizeMoonshotThinkingKeep(value: unknown): MoonshotThinkingKeep | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const keepValue = (value as Record<string, unknown>).keep;
+  if (typeof keepValue !== "string") {
+    return undefined;
+  }
+  return normalizeOptionalLowercaseString(keepValue) === "all" ? "all" : undefined;
 }
 
 function isMoonshotToolChoiceCompatible(toolChoice: unknown): boolean {
@@ -68,9 +81,16 @@ export function resolveMoonshotThinkingType(params: {
   return params.thinkingLevel === "off" ? "disabled" : "enabled";
 }
 
+export function resolveMoonshotThinkingKeep(params: {
+  configuredThinking: unknown;
+}): MoonshotThinkingKeep | undefined {
+  return normalizeMoonshotThinkingKeep(params.configuredThinking);
+}
+
 export function createMoonshotThinkingWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingType?: MoonshotThinkingType,
+  thinkingKeep?: MoonshotThinkingKeep,
 ): StreamFn {
   return async (model, context, options) => {
     const underlying = baseStreamFn ?? (await loadDefaultStreamFn());
@@ -90,6 +110,19 @@ export function createMoonshotThinkingWrapper(
           payloadObj.tool_choice = "auto";
         } else if (isPinnedToolChoice(payloadObj.tool_choice)) {
           payloadObj.thinking = { type: "disabled" };
+          effectiveThinkingType = "disabled";
+        }
+      }
+
+      // thinking.keep is only valid on kimi-k2.6 when thinking is enabled. Gate
+      // by the final payload.model and final type so stray config never leaks.
+      const isKeepCapableModel = payloadObj.model === MOONSHOT_THINKING_KEEP_MODEL_ID;
+      if (payloadObj.thinking && typeof payloadObj.thinking === "object") {
+        const thinkingObj = payloadObj.thinking as Record<string, unknown>;
+        if (isKeepCapableModel && effectiveThinkingType === "enabled" && thinkingKeep === "all") {
+          thinkingObj.keep = "all";
+        } else if ("keep" in thinkingObj) {
+          delete thinkingObj.keep;
         }
       }
     });

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -83,13 +83,16 @@ describe("buildProviderStreamFamilyHooks", () => {
     let capturedPayload: Record<string, unknown> | undefined;
     let capturedModelId: string | undefined;
     let capturedHeaders: Record<string, string> | undefined;
+    let payloadSeed: Record<string, unknown> | undefined;
 
     const baseStreamFn: StreamFn = (model, _context, options) => {
       capturedModelId = model.id;
-      const payload = { config: { thinkingConfig: { thinkingBudget: -1 } } } as Record<
-        string,
-        unknown
-      >;
+      const payload = {
+        model: model.id,
+        config: { thinkingConfig: { thinkingBudget: -1 } },
+        ...payloadSeed,
+      } as Record<string, unknown>;
+      payloadSeed = undefined;
       options?.onPayload?.(payload as never, model as never);
       capturedPayload = payload;
       capturedHeaders = options?.headers;
@@ -171,6 +174,47 @@ describe("buildProviderStreamFamilyHooks", () => {
       config: { thinkingConfig: { thinkingBudget: -1 } },
       thinking: { type: "disabled" },
     });
+
+    const moonshotKeepStream = requireStreamFn(
+      requireWrapStreamFn(moonshotHooks.wrapStreamFn)({
+        streamFn: baseStreamFn,
+        thinkingLevel: "low",
+        extraParams: { thinking: { type: "enabled", keep: "all" } },
+      } as never),
+    );
+    await moonshotKeepStream(
+      { api: "openai-completions", id: "kimi-k2.6" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({
+      config: { thinkingConfig: { thinkingBudget: -1 } },
+      thinking: { type: "enabled", keep: "all" },
+    });
+
+    await moonshotKeepStream(
+      { api: "openai-completions", id: "kimi-k2.5" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({
+      config: { thinkingConfig: { thinkingBudget: -1 } },
+      thinking: { type: "enabled" },
+    });
+    expect((capturedPayload?.thinking as Record<string, unknown>) ?? {}).not.toHaveProperty("keep");
+
+    payloadSeed = { tool_choice: { type: "tool", name: "read" } };
+    await moonshotKeepStream(
+      { api: "openai-completions", id: "kimi-k2.6" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({
+      config: { thinkingConfig: { thinkingBudget: -1 } },
+      tool_choice: { type: "tool", name: "read" },
+      thinking: { type: "disabled" },
+    });
+    expect((capturedPayload?.thinking as Record<string, unknown>) ?? {}).not.toHaveProperty("keep");
 
     const openAiHooks = OPENAI_RESPONSES_STREAM_HOOKS;
     void requireStreamFn(

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -3,6 +3,7 @@ import {
   sanitizeGoogleThinkingPayload,
 } from "../agents/pi-embedded-runner/google-stream-wrappers.js";
 import { createMinimaxFastModeWrapper } from "../agents/pi-embedded-runner/minimax-stream-wrappers.js";
+import { resolveMoonshotThinkingKeep } from "../agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.js";
 import {
   createCodexNativeWebSearchWrapper,
   createOpenAIAttributionHeadersWrapper,
@@ -73,7 +74,10 @@ export function buildProviderStreamFamilyHooks(
             configuredThinking: ctx.extraParams?.thinking,
             thinkingLevel: ctx.thinkingLevel,
           });
-          return createMoonshotThinkingWrapper(ctx.streamFn, thinkingType);
+          const thinkingKeep = resolveMoonshotThinkingKeep({
+            configuredThinking: ctx.extraParams?.thinking,
+          });
+          return createMoonshotThinkingWrapper(ctx.streamFn, thinkingType, thinkingKeep);
         },
       };
     case "kilocode-thinking":


### PR DESCRIPTION
## Summary

- **Problem:** Moonshot just released Kimi K2.6 and the K2.6-only `thinking.keep` parameter for full multi-turn `reasoning_content` retention; the bundled plugin still defaulted to K2.5 and had no way to opt into keep.
- **Why it matters:** New onboards should land on the latest Kimi model, and K2.6 users need a supported path to enable `thinking.keep = "all"` without sending the field to models that reject it.
- **What changed:** Bumped the Moonshot default to `kimi-k2.6` across provider catalog, onboarding, Kimi web search, media understanding (image/video), and core bundled media fallback; added a `thinking.keep` pass-through that is strictly gated on `model === "kimi-k2.6"` (stripped elsewhere, cleared when pinned `tool_choice` forces thinking off); catalog still ships K2.5 as an explicit option; docs + CHANGELOG synced.
- **What did NOT change:** K2.5 remains registered in the catalog and fully functional; existing configs with an explicit `moonshot/kimi-k2.5` primary keep running on K2.5; `thinking.type` semantics for all other models are untouched.

## Change Type (select all)

- [x] Feature
- [x] Docs

## Scope (select all touched areas)

- [x] Integrations
- [x] API / contracts

## Linked Issue/PR

- Related #7180 (previous K2.5 default bump)
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — this is a forward-looking feature/default update, not a bug fix.

## Regression Test Plan (if applicable)

N/A — new `extraparams-moonshot` cases lock in the keep gate (passthrough, default omit, non-K2.6 strip, pinned-tool_choice downgrade clears keep); existing moonshot/media-understanding tests cover the default bump.

## User-visible / Behavior Changes

- Fresh onboards and re-onboards now write `moonshot/kimi-k2.6` as the agent primary and alias.
- Moonshot media understanding (image/video) and Kimi web search now default to `kimi-k2.6` when no explicit `model` is configured — existing configs with explicit values are unchanged.
- Users can opt into multi-turn reasoning retention by setting `agents.defaults.models."moonshot/kimi-k2.6".params.thinking.keep = "all"`; the flag is silently ignored for non-K2.6 models.

## Diagram (if applicable)

```text
Before:
onboard moonshot -> primary = moonshot/kimi-k2.5
user config thinking.keep="all" -> forwarded to every moonshot model (unsupported on K2.5)

After:
onboard moonshot -> primary = moonshot/kimi-k2.6
user config thinking.keep="all" on K2.6 -> forwarded verbatim
user config thinking.keep="all" on non-K2.6 -> stripped before send
pinned tool_choice on K2.6 -> thinking.type=disabled, keep cleared
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same `https://api.moonshot.ai/v1` host, new request field only for K2.6)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 25.4.0 (Darwin)
- Runtime/container: Node 22+ / pnpm local dev
- Model/provider: `moonshot/kimi-k2.6`, `moonshot/kimi-k2.5`
- Integration/channel: chat, Kimi web search, media understanding (image/video)
- Relevant config: `MOONSHOT_API_KEY` env + `thinking.keep` extraParams

### Steps

1. Fresh `openclaw onboard --auth-choice moonshot-api-key`, verify primary is `moonshot/kimi-k2.6`.
2. Send image → verify media understanding resolves to `kimi-k2.6`.
3. Set `agents.defaults.models."moonshot/kimi-k2.6".params.thinking.keep = "all"`, capture request, confirm `thinking.keep=all` in payload.
4. Repeat with non-K2.6 model, confirm `keep` is stripped.
5. Pin `tool_choice` on K2.6, confirm `thinking.type` downgrades to `disabled` and `keep` is cleared.

### Expected

- Per-scenario assertions above all hold; see `src/agents/pi-embedded-runner-extraparams-moonshot.test.ts` for the automated equivalents.

### Actual

- `pnpm check`, `pnpm build`, and scoped tests (`src/media-understanding`, `src/agents/pi-embedded-runner-extraparams-moonshot.test.ts`, `extensions/moonshot`) all pass locally.

## Evidence

- [x] Failing test/log before + passing after — new extraparams cases fail against prior wrapper logic; pass after patch.

## Human Verification (required)

- Verified scenarios: default bump across chat/web-search/media; `thinking.keep=all` forwarded only on K2.6; keep stripped for non-K2.6; keep cleared when pinned `tool_choice` downgrades thinking.
- Edge cases checked: user-configured `thinking.type=disabled` on K2.6 still suppresses keep; catalog still lists K2.5; `resolveDefaultMediaModel` returns K2.6 via both provider registry and bundled-defaults fallback (no split-brain).
- What I did **not** verify: live API round-trip against `api.moonshot.cn/v1`; only `api.moonshot.ai/v1` was exercised.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — existing explicit `moonshot/kimi-k2.5` configs continue working; `thinking.keep` is opt-in.
- Config/env changes? No required changes; optional `thinking.keep` field accepted for K2.6.
- Migration needed? No.
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: Users who relied on the implicit default (no explicit `moonshot/kimi-*` primary) for media/web-search paths get auto-bumped to K2.6 on upgrade.
  - Mitigation: Merge timing is gated on Moonshot's public K2.6 launch so the new default is a valid model when shipped; K2.5 remains registered for anyone who wants to pin it.