### PR TITLE
fix: add claude, codex, hermes to Windows .cmd shim allowlist

### DIFF
--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -11,7 +11,7 @@ const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["npm", "pnpm", "yarn", "npx"],
+    cmdCommands: ["npm", "pnpm", "yarn", "npx", "claude", "codex", "hermes"],
   });
 }
 

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -32,6 +32,18 @@ describe("resolveWindowsCommandShim", () => {
     ).toBe("corepack.cmd");
   });
 
+  it("appends .cmd for CLI tools with .cmd shims on Windows", () => {
+    for (const cmd of ["claude", "codex", "hermes"]) {
+      expect(
+        resolveWindowsCommandShim({
+          command: cmd,
+          cmdCommands: ["npm", "pnpm", "yarn", "npx", "claude", "codex", "hermes"],
+          platform: "win32",
+        }),
+      ).toBe(`${cmd}.cmd`);
+    }
+  });
+
   it("keeps explicit extensions on Windows", () => {
     expect(
       resolveWindowsCommandShim({


### PR DESCRIPTION
Fixes #68788

On Windows, spawning `claude` (and similar CLI tools installed via npm) fails with `ENOENT` because `resolveWindowsCommandShim` only appends `.cmd` for a hardcoded allowlist of commands (`npm`, `pnpm`, `yarn`, `npx`).

This PR adds `claude`, `codex`, and `hermes` to the `cmdCommands` array so their `.cmd` shims are found on Windows.

Also adds a test covering the new entries.