### PR TITLE
fix: remove blanket heredoc approval gate in allowlist mode

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -158,11 +158,6 @@ export async function processGatewayAllowlist(
       command: params.command,
       resolvedPath,
     });
-  const hasHeredocSegment = allowlistEval.segments.some((segment) =>
-    segment.argv.some((token) => token.startsWith("<<")),
-  );
-  const requiresHeredocApproval =
-    hostSecurity === "allowlist" && analysisOk && allowlistSatisfied && hasHeredocSegment;
   const requiresInlineEvalApproval = inlineEvalHit !== null;
   const requiresAllowlistPlanApproval =
     hostSecurity === "allowlist" &&
@@ -179,13 +174,7 @@ export async function processGatewayAllowlist(
       durableApprovalSatisfied,
     }) ||
     requiresAllowlistPlanApproval ||
-    requiresHeredocApproval ||
     requiresInlineEvalApproval;
-  if (requiresHeredocApproval) {
-    params.warnings.push(
-      "Warning: heredoc execution requires explicit approval in allowlist mode.",
-    );
-  }
   if (requiresAllowlistPlanApproval) {
     params.warnings.push(
       `Warning: allowlist auto-execution is unavailable on ${process.platform}; explicit approval is required.`,


### PR DESCRIPTION
Fixes #68661

## Summary

Removes the overly broad `requiresHeredocApproval` gate in `bash-tools.exec-host-gateway.ts` that forces an approval prompt for **all** heredoc commands in allowlist mode, even when the target binary is already in the allowlist.

## Root Cause

A security hardening added after PR #13811 introduced a blanket `requiresHeredocApproval` check that fires whenever any segment contains a `<<` token — regardless of whether the heredoc is safe (quoted delimiter, no expansion tokens). This regressed the original fix.

## Why This Is Safe

The analysis layer (`splitShellPipeline` in `exec-approvals-analysis.ts`) already handles security:
- Unquoted heredocs containing `$(...)`, backticks, or `${...}` return `ok: false` with reason `"command substitution in unquoted heredoc"`
- This causes `analysisOk` to be `false`, which makes `requiresExecApproval` return `true` and force approval

Safe heredocs (quoted delimiters like `<<'EOF'`) parse as `ok: true` and should pass through the allowlist without an extra approval prompt.

## Changes

- Removed `hasHeredocSegment` and `requiresHeredocApproval` variables
- Removed `requiresHeredocApproval` from the `requiresAsk` OR chain
- Removed the heredoc warning push

Net: 11 lines deleted, 0 lines added.

## Test Plan

- Configure an agent with `security: "allowlist"` and `ask: "off"`
- Add `/usr/bin/cat` to the allowlist
- Run `cat <<'EOF'\nhello world\nEOF`
- Verify: command runs without approval prompt
- Run `cat <<EOF\n$(whoami)\nEOF` (unquoted with expansion)
- Verify: approval is still required (handled by `splitShellPipeline`)