### PR TITLE
fix(cron): stop persisting "last" as literal delivery channel value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/cron: keep the runtime-only `last` delivery sentinel from being materialized into persisted cron delivery and failure-alert channel configs when jobs are created or edited. (#68829) Thanks @tianhaocui.
+
 ## 2026.4.19-beta.2
 
 ### Fixes

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -575,6 +575,49 @@ describe("cron controller", () => {
     ).toBeUndefined();
   });
 
+  it('sends delivery.channel="last" when editing clears an explicit channel back to implicit-last', async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-clear-delivery-channel" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-clear-delivery-channel" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const job = {
+      id: "job-clear-delivery-channel",
+      name: "Clear delivery channel",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "cron" as const, expr: "0 * * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "run" },
+      delivery: { mode: "announce" as const, channel: "telegram", to: "123" },
+      state: {},
+    };
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronJobs: [job],
+    });
+
+    startCronEdit(state, job);
+    state.cronForm.deliveryChannel = "last";
+    await addCronJob(state);
+
+    const updateCall = request.mock.calls.find(([method]) => method === "cron.update");
+    expect(updateCall).toBeDefined();
+    expect(
+      (updateCall?.[1] as { patch?: { delivery?: { channel?: string } } } | undefined)?.patch
+        ?.delivery?.channel,
+    ).toBe("last");
+  });
+
   it("includes model/thinking/stagger/bestEffort in cron.update patch", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.update") {
@@ -825,6 +868,50 @@ describe("cron controller", () => {
       (updateCall?.[1] as { patch?: { failureAlert?: { channel?: string } } } | undefined)?.patch
         ?.failureAlert?.channel,
     ).toBeUndefined();
+  });
+
+  it('sends failureAlert.channel="last" when editing clears an explicit failure channel back to implicit-last', async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-clear-failure-channel" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-clear-failure-channel" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const job = {
+      id: "job-clear-failure-channel",
+      name: "Clear failure channel",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "cron" as const, expr: "0 * * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "run" },
+      delivery: { mode: "announce" as const, channel: "telegram", to: "123" },
+      failureAlert: { after: 2, channel: "telegram", to: "123" },
+      state: {},
+    };
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronJobs: [job],
+    });
+
+    startCronEdit(state, job);
+    state.cronForm.failureAlertChannel = "last";
+    await addCronJob(state);
+
+    const updateCall = request.mock.calls.find(([method]) => method === "cron.update");
+    expect(updateCall).toBeDefined();
+    expect(
+      (updateCall?.[1] as { patch?: { failureAlert?: { channel?: string } } } | undefined)?.patch
+        ?.failureAlert?.channel,
+    ).toBe("last");
   });
 
   it("omits failureAlert.cooldownMs when custom cooldown is left blank", async () => {

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -163,6 +163,48 @@ describe("cron controller", () => {
     });
   });
 
+  it('omits delivery.channel when the form still uses the "last" sentinel', async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.add") {
+        return { id: "job-last-add" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 0, nextWakeAtMs: null };
+      }
+      return {};
+    });
+
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "implicit channel",
+        scheduleKind: "cron",
+        cronExpr: "0 * * * *",
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payloadKind: "agentTurn",
+        payloadText: "run this",
+        deliveryMode: "announce",
+        deliveryChannel: "last",
+      },
+    });
+
+    await addCronJob(state);
+
+    const addCall = request.mock.calls.find(([method]) => method === "cron.add");
+    expect(addCall).toBeDefined();
+    expect(addCall?.[1]).toMatchObject({
+      delivery: { mode: "announce" },
+    });
+    expect(
+      (addCall?.[1] as { delivery?: { channel?: string } } | undefined)?.delivery?.channel,
+    ).toBeUndefined();
+  });
+
   it("forwards lightContext in cron payload", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.add") {
@@ -485,6 +527,54 @@ describe("cron controller", () => {
     expect(state.cronForm.deliveryAccountId).toBe("bot-2");
   });
 
+  it('keeps implicit announce delivery implicit when editing a job that shows "last" in the form', async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-implicit-delivery" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-implicit-delivery" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const job = {
+      id: "job-implicit-delivery",
+      name: "Implicit delivery",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "cron" as const, expr: "0 * * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "run" },
+      delivery: { mode: "announce" as const, to: "123" },
+      state: {},
+    };
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronJobs: [job],
+    });
+
+    startCronEdit(state, job);
+    await addCronJob(state);
+
+    const updateCall = request.mock.calls.find(([method]) => method === "cron.update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1]).toMatchObject({
+      id: "job-implicit-delivery",
+      patch: {
+        delivery: { mode: "announce", to: "123" },
+      },
+    });
+    expect(
+      (updateCall?.[1] as { patch?: { delivery?: { channel?: string } } } | undefined)?.patch
+        ?.delivery?.channel,
+    ).toBeUndefined();
+  });
+
   it("includes model/thinking/stagger/bestEffort in cron.update patch", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.update") {
@@ -682,6 +772,59 @@ describe("cron controller", () => {
         },
       },
     });
+  });
+
+  it('keeps implicit failure alert delivery implicit when editing a job that shows "last" in the form', async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-alert-implicit-channel" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-alert-implicit-channel" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const job = {
+      id: "job-alert-implicit-channel",
+      name: "Implicit failure alert",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "cron" as const, expr: "0 * * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "run" },
+      delivery: { mode: "announce" as const, channel: "telegram", to: "123" },
+      failureAlert: { after: 2, to: "123" },
+      state: {},
+    };
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronJobs: [job],
+    });
+
+    startCronEdit(state, job);
+    await addCronJob(state);
+
+    const updateCall = request.mock.calls.find(([method]) => method === "cron.update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1]).toMatchObject({
+      id: "job-alert-implicit-channel",
+      patch: {
+        failureAlert: {
+          after: 2,
+          to: "123",
+          mode: "announce",
+        },
+      },
+    });
+    expect(
+      (updateCall?.[1] as { patch?: { failureAlert?: { channel?: string } } } | undefined)?.patch
+        ?.failureAlert?.channel,
+    ).toBeUndefined();
   });
 
   it("omits failureAlert.cooldownMs when custom cooldown is left blank", async () => {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -597,12 +597,21 @@ export function buildCronPayload(form: CronFormState) {
   return payload;
 }
 
-function normalizePersistedDeliveryChannel(value: string) {
+function normalizePersistedDeliveryChannel(
+  value: string,
+  options: { preserveLastOnUpdate?: boolean } = {},
+) {
   const channel = value.trim();
-  return channel && channel !== CRON_CHANNEL_LAST ? channel : undefined;
+  if (!channel) {
+    return undefined;
+  }
+  if (channel === CRON_CHANNEL_LAST) {
+    return options.preserveLastOnUpdate ? CRON_CHANNEL_LAST : undefined;
+  }
+  return channel;
 }
 
-function buildFailureAlert(form: CronFormState) {
+function buildFailureAlert(form: CronFormState, existingChannel?: string | undefined) {
   if (form.failureAlertMode === "disabled") {
     return false as const;
   }
@@ -620,7 +629,9 @@ function buildFailureAlert(form: CronFormState) {
   const accountId = form.failureAlertAccountId.trim();
   const patch: Record<string, unknown> = {
     after: after > 0 ? Math.floor(after) : undefined,
-    channel: normalizePersistedDeliveryChannel(form.failureAlertChannel),
+    channel: normalizePersistedDeliveryChannel(form.failureAlertChannel, {
+      preserveLastOnUpdate: Boolean(existingChannel),
+    }),
     to: form.failureAlertTo.trim() || undefined,
     ...(cooldownMs !== undefined ? { cooldownMs } : {}),
   };
@@ -666,7 +677,9 @@ export async function addCronJob(state: CronState) {
             mode: selectedDeliveryMode,
             channel:
               selectedDeliveryMode === "announce"
-                ? normalizePersistedDeliveryChannel(form.deliveryChannel)
+                ? normalizePersistedDeliveryChannel(form.deliveryChannel, {
+                    preserveLastOnUpdate: Boolean(editingJob?.delivery?.channel),
+                  })
                 : undefined,
             to: form.deliveryTo.trim() || undefined,
             accountId:
@@ -676,7 +689,12 @@ export async function addCronJob(state: CronState) {
         : selectedDeliveryMode === "none"
           ? ({ mode: "none" } as const)
           : undefined;
-    const failureAlert = buildFailureAlert(form);
+    const failureAlert = buildFailureAlert(
+      form,
+      editingJob?.failureAlert && typeof editingJob.failureAlert === "object"
+        ? editingJob.failureAlert.channel
+        : undefined,
+    );
     const agentId = form.clearAgent ? null : form.agentId.trim();
     const sessionKeyRaw = form.sessionKey.trim();
     const sessionKey = sessionKeyRaw || (editingJob?.sessionKey ? null : undefined);

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -615,7 +615,7 @@ function buildFailureAlert(form: CronFormState) {
   const accountId = form.failureAlertAccountId.trim();
   const patch: Record<string, unknown> = {
     after: after > 0 ? Math.floor(after) : undefined,
-    channel: form.failureAlertChannel.trim() || CRON_CHANNEL_LAST,
+    channel: form.failureAlertChannel.trim() || undefined,
     to: form.failureAlertTo.trim() || undefined,
     ...(cooldownMs !== undefined ? { cooldownMs } : {}),
   };
@@ -663,7 +663,7 @@ export async function addCronJob(state: CronState) {
             mode: selectedDeliveryMode,
             channel:
               selectedDeliveryMode === "announce"
-                ? form.deliveryChannel.trim() || "last"
+                ? form.deliveryChannel.trim() || undefined
                 : undefined,
             to: form.deliveryTo.trim() || undefined,
             accountId:

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -597,6 +597,11 @@ export function buildCronPayload(form: CronFormState) {
   return payload;
 }
 
+function normalizePersistedDeliveryChannel(value: string) {
+  const channel = value.trim();
+  return channel && channel !== CRON_CHANNEL_LAST ? channel : undefined;
+}
+
 function buildFailureAlert(form: CronFormState) {
   if (form.failureAlertMode === "disabled") {
     return false as const;
@@ -615,15 +620,13 @@ function buildFailureAlert(form: CronFormState) {
   const accountId = form.failureAlertAccountId.trim();
   const patch: Record<string, unknown> = {
     after: after > 0 ? Math.floor(after) : undefined,
-    channel: form.failureAlertChannel.trim() || undefined,
+    channel: normalizePersistedDeliveryChannel(form.failureAlertChannel),
     to: form.failureAlertTo.trim() || undefined,
     ...(cooldownMs !== undefined ? { cooldownMs } : {}),
   };
-  // Always include mode and accountId so users can switch/clear them
   if (deliveryMode) {
     patch.mode = deliveryMode;
   }
-  // Include accountId if explicitly set, or send undefined to allow clearing
   patch.accountId = accountId || undefined;
   return patch;
 }
@@ -663,7 +666,7 @@ export async function addCronJob(state: CronState) {
             mode: selectedDeliveryMode,
             channel:
               selectedDeliveryMode === "announce"
-                ? form.deliveryChannel.trim() || undefined
+                ? normalizePersistedDeliveryChannel(form.deliveryChannel)
                 : undefined,
             to: form.deliveryTo.trim() || undefined,
             accountId:


### PR DESCRIPTION
Fixes #68760

## Summary

The Control UI writes the runtime sentinel `"last"` as a literal value into `jobs.json` when saving a cron job with an empty delivery channel field. This causes user-configured channels (e.g. `"telegram"`) to be overwritten.

## Root Cause

In `ui/src/ui/controllers/cron.ts`, the save path uses:

```typescript
channel: form.deliveryChannel.trim() || "last"
```

When the form's delivery channel is empty (which happens when the job was created without an explicit channel), this writes `"last"` as a literal string to the job's `delivery.channel` field in `jobs.json`.

`"last"` is a runtime-only sentinel meaning "use whatever channel was last used in the session." It should never be persisted — the runtime delivery plan resolver (`delivery-plan.ts:53`) already applies this fallback at execution time when `channel` is `undefined`.

The same issue exists in the failure alert channel save path.

## Changes

- `ui/src/ui/controllers/cron.ts:666`: Changed `form.deliveryChannel.trim() || "last"` to `form.deliveryChannel.trim() || undefined`
- `ui/src/ui/controllers/cron.ts:618`: Changed `form.failureAlertChannel.trim() || CRON_CHANNEL_LAST` to `form.failureAlertChannel.trim() || undefined`

## Test Plan

1. Create a cron job via dashboard with `delivery.channel = "telegram"`
2. Save the job — verify `jobs.json` shows `"channel": "telegram"`
3. Edit the job without changing the channel — save again
4. Verify `jobs.json` still shows `"channel": "telegram"`, not `"channel": "last"`
5. Create a job with no explicit channel — verify `jobs.json` has no `channel` field (not `"last"`)
6. Verify the job still delivers via the "last used" channel at runtime (runtime fallback in `delivery-plan.ts`)