### PR TITLE
fix(memory): expose vectorScore and textScore in hybrid search results

### DIFF
--- a/extensions/memory-core/src/memory/hybrid.ts
+++ b/extensions/memory-core/src/memory/hybrid.ts
@@ -74,6 +74,8 @@ export async function mergeHybridResults(params: {
     score: number;
     snippet: string;
     source: HybridSource;
+    vectorScore: number;
+    textScore: number;
   }>
 > {
   const byId = new Map<
@@ -133,6 +135,8 @@ export async function mergeHybridResults(params: {
       score,
       snippet: entry.snippet,
       source: entry.source,
+      vectorScore: entry.vectorScore,
+      textScore: entry.textScore,
     };
   });
 

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -8,6 +8,8 @@ export type MemorySearchResult = {
   snippet: string;
   source: MemorySource;
   citation?: string;
+  vectorScore?: number;
+  textScore?: number;
 };
 
 export type MemoryEmbeddingProbeResult = {

--- a/src/memory-host-sdk/host/types.ts
+++ b/src/memory-host-sdk/host/types.ts
@@ -8,6 +8,8 @@ export type MemorySearchResult = {
   snippet: string;
   source: MemorySource;
   citation?: string;
+  vectorScore?: number;
+  textScore?: number;
 };
 
 export type MemoryEmbeddingProbeResult = {


### PR DESCRIPTION
Fixes #68166

## Summary

`mergeHybridResults()` computes per-result `vectorScore` (cosine similarity) and `textScore` (BM25) internally but drops them when building the final output array. This prevents consumers from inspecting individual signal contributions for debugging search quality or building relevance UIs.

## Changes

1. **`extensions/memory-core/src/memory/hybrid.ts`** — Added `vectorScore` and `textScore` to the return type and the output `.map()` call
2. **`src/memory-host-sdk/host/types.ts`** — Added optional `vectorScore` and `textScore` fields to `MemorySearchResult`
3. **`packages/memory-host-sdk/src/host/types.ts`** — Same type update (mirrored package)

Net: 8 lines added across 3 files. Fields are optional so existing consumers are unaffected.

## Test Plan

- Run existing hybrid search tests: `pnpm test extensions/memory-core/src/memory/hybrid.test.ts`
- Verify results now include `vectorScore` and `textScore` fields
- Verify existing consumers compile without changes (fields are optional)