### PR TITLE
perf: share JITI instances across plugins with identical alias configs

### DIFF
--- a/src/plugins/jiti-loader-cache.test.ts
+++ b/src/plugins/jiti-loader-cache.test.ts
@@ -146,6 +146,44 @@ describe("getCachedPluginJitiLoader", () => {
     );
   });
 
+  it("shares one JITI instance across callers with different modulePaths but identical configs and no jitiFilename", async () => {
+    const createJiti = vi.fn((filename: string, options: Record<string, unknown>) =>
+      Object.assign(vi.fn(), {
+        filename,
+        options,
+      }),
+    );
+    vi.doMock("jiti", () => ({
+      createJiti,
+    }));
+
+    const { getCachedPluginJitiLoader } = await importFreshModule<
+      typeof import("./jiti-loader-cache.js")
+    >(import.meta.url, "./jiti-loader-cache.js?scope=no-filename-sharing");
+
+    const cache = new Map();
+    const first = getCachedPluginJitiLoader({
+      cache,
+      modulePath: "/repo/dist/extensions/plugin-a/index.js",
+      importerUrl: "file:///repo/src/plugins/setup-registry.ts",
+      argvEntry: "/repo/openclaw.mjs",
+    });
+    const second = getCachedPluginJitiLoader({
+      cache,
+      modulePath: "/repo/dist/extensions/plugin-b/index.js",
+      importerUrl: "file:///repo/src/plugins/setup-registry.ts",
+      argvEntry: "/repo/openclaw.mjs",
+    });
+
+    expect(second).toBe(first);
+    expect(createJiti).toHaveBeenCalledTimes(1);
+    expect(createJiti).toHaveBeenCalledWith(
+      "/repo/dist/extensions/plugin-a/index.js",
+      expect.objectContaining({ interopDefault: true }),
+    );
+    expect(cache.size).toBe(1);
+  });
+
   it("lets callers intentionally share loaders behind a custom cache scope key", async () => {
     const createJiti = vi.fn((filename: string, options: Record<string, unknown>) =>
       Object.assign(vi.fn(), {

--- a/src/plugins/jiti-loader-cache.ts
+++ b/src/plugins/jiti-loader-cache.ts
@@ -46,7 +46,12 @@ export function getCachedPluginJitiLoader(params: {
     tryNative,
     aliasMap,
   });
-  const scopedCacheKey = `${params.jitiFilename ?? params.modulePath}::${params.cacheScopeKey ?? cacheKey}`;
+  // Only scope by filename when the caller explicitly provides jitiFilename (an
+  // intentional override). Without it, scope by config content only so plugins
+  // with identical alias maps share one JITI instance and trigger normalizeAliases once.
+  const scopedCacheKey = params.jitiFilename
+    ? `${params.jitiFilename}::${params.cacheScopeKey ?? cacheKey}`
+    : (params.cacheScopeKey ?? cacheKey);
   const cached = params.cache.get(scopedCacheKey);
   if (cached) {
     return cached;


### PR DESCRIPTION
## Problem

`getCachedPluginJitiLoader` scopes its cache key with `jitiFilename ?? modulePath`, which creates a separate JITI instance for every plugin file — even when all plugins have identical `{tryNative, aliasMap}` configurations. Each JITI instance creation triggers `normalizeAliases` on the full 264-entry plugin SDK alias map.

On a system with 46+ bundled plugins, this means 46 × `normalizeAliases(264 entries)` on every startup. V8 CPU profiling confirmed `normalizeAliases` consumed ~50% of openclaw startup time.

## Fix

Only scope the cache key by `jitiFilename` when the caller **explicitly provides** it (an intentional override for a different resolution context). When no `jitiFilename` override is given, scope by config content only (`cacheScopeKey ?? cacheKey`), so all plugins with identical `{tryNative, aliasMap}` share a single JITI instance.

Callers that explicitly pass `jitiFilename: import.meta.url` retain their per-module isolation. Callers that only pass `modulePath` (e.g. `setup-registry.ts`, `doctor-contract-registry.ts`) now share across plugins with matching configs.

## Before / After

| Command | Before | After | Δ |
|---------|--------|-------|---|
| `openclaw agents list` | 20.5s | 5.4s | **−75%** |
| `openclaw status` (with lmstudio reachable) | ~20–22s | ~5–7s | **−75%** |

> Note: `openclaw status` on this test machine showed 40.9s → 23.5s because lmstudio at `192.168.86.29:1234` was unreachable and the embeddings warmup timed out (~18s). The JITI portion dropped from ~20s to ~5s.

## Safety

- Callers that load plugins by absolute path are unaffected — JITI resolves imports relative to the module being loaded, not the `createJiti` filename.
- Callers that pass an explicit `jitiFilename` override retain full isolation (unchanged behavior).
- `pnpm tsgo:core` passes. `pnpm build` passes.

## Testing

Tested locally on macOS with openclaw 2026.4.19-beta.1 fork. No plugin regressions observed (lmstudio/gemma, memory-core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)