### PR TITLE
fix(cron): support space-separated tools list for PowerShell compatibility

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -60,6 +60,18 @@ function registerMalformedBootstrapFileHook() {
   });
 }
 
+async function createHeartbeatAgentsWorkspace() {
+  const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+  await fs.writeFile(path.join(workspaceDir, "HEARTBEAT.md"), "check inbox", "utf8");
+  await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "repo rules", "utf8");
+  return workspaceDir;
+}
+
+function expectHeartbeatExcludedAndAgentsKept(files: WorkspaceBootstrapFile[]) {
+  expect(files.some((file) => file.name === "HEARTBEAT.md")).toBe(false);
+  expect(files.some((file) => file.name === "AGENTS.md")).toBe(true);
+}
+
 describe("resolveBootstrapFilesForRun", () => {
   beforeEach(() => clearInternalHooks());
   afterEach(() => clearInternalHooks());
@@ -148,9 +160,7 @@ describe("resolveBootstrapContextForRun", () => {
   });
 
   it("drops HEARTBEAT.md for non-heartbeat runs when the heartbeat prompt section is disabled", async () => {
-    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
-    await fs.writeFile(path.join(workspaceDir, "HEARTBEAT.md"), "check inbox", "utf8");
-    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "repo rules", "utf8");
+    const workspaceDir = await createHeartbeatAgentsWorkspace();
 
     const files = await resolveBootstrapFilesForRun({
       workspaceDir,
@@ -166,14 +176,11 @@ describe("resolveBootstrapContextForRun", () => {
       },
     });
 
-    expect(files.some((file) => file.name === "HEARTBEAT.md")).toBe(false);
-    expect(files.some((file) => file.name === "AGENTS.md")).toBe(true);
+    expectHeartbeatExcludedAndAgentsKept(files);
   });
 
   it("drops HEARTBEAT.md for non-heartbeat runs when the heartbeat cadence is disabled", async () => {
-    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
-    await fs.writeFile(path.join(workspaceDir, "HEARTBEAT.md"), "check inbox", "utf8");
-    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "repo rules", "utf8");
+    const workspaceDir = await createHeartbeatAgentsWorkspace();
 
     const files = await resolveBootstrapFilesForRun({
       workspaceDir,
@@ -189,8 +196,7 @@ describe("resolveBootstrapContextForRun", () => {
       },
     });
 
-    expect(files.some((file) => file.name === "HEARTBEAT.md")).toBe(false);
-    expect(files.some((file) => file.name === "AGENTS.md")).toBe(true);
+    expectHeartbeatExcludedAndAgentsKept(files);
   });
 
   it("keeps HEARTBEAT.md for actual heartbeat runs even when the prompt section is disabled", async () => {

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -60,6 +60,7 @@ type CronUpdatePatch = {
       model?: string;
       thinking?: string;
       lightContext?: boolean;
+      toolsAllow?: string[] | null;
     };
     delivery?: {
       mode?: string;
@@ -73,7 +74,7 @@ type CronUpdatePatch = {
 
 type CronAddParams = {
   schedule?: { kind?: string; staggerMs?: number };
-  payload?: { model?: string; thinking?: string; lightContext?: boolean };
+  payload?: { model?: string; thinking?: string; lightContext?: boolean; toolsAllow?: string[] };
   delivery?: { mode?: string; accountId?: string };
   deleteAfterRun?: boolean;
   agentId?: string;
@@ -827,6 +828,57 @@ describe("cron cli", () => {
     const updateCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.update");
     const patch = updateCall?.[2] as { patch?: { failureAlert?: boolean } };
     expect(patch?.patch?.failureAlert).toBe(false);
+  });
+
+  it.each([
+    { toolsInput: "exec,read,write", expected: ["exec", "read", "write"], desc: "comma-separated" },
+    {
+      toolsInput: "exec read write",
+      expected: ["exec", "read", "write"],
+      desc: "space-separated (PowerShell)",
+    },
+    {
+      toolsInput: "exec, read, write",
+      expected: ["exec", "read", "write"],
+      desc: "comma-space-separated",
+    },
+    {
+      toolsInput: "  exec  ,  read  ,  write  ",
+      expected: ["exec", "read", "write"],
+      desc: "with extra whitespace",
+    },
+    { toolsInput: "exec", expected: ["exec"], desc: "single tool" },
+  ])("parses --tools $desc on cron add", async ({ toolsInput, expected }) => {
+    const params = await runCronAddAndGetParams([
+      "--name",
+      "Tools test",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+      "--tools",
+      toolsInput,
+    ]);
+    expect(params?.payload?.toolsAllow).toEqual(expected);
+  });
+
+  it.each([
+    { toolsInput: "exec,read,write", expected: ["exec", "read", "write"], desc: "comma-separated" },
+    {
+      toolsInput: "exec read write",
+      expected: ["exec", "read", "write"],
+      desc: "space-separated (PowerShell)",
+    },
+  ])("parses --tools $desc on cron edit", async ({ toolsInput, expected }) => {
+    const patch = await runCronEditAndGetPatch(["--tools", toolsInput, "--message", "hello"]);
+    expect(patch?.patch?.payload?.toolsAllow).toEqual(expected);
+  });
+
+  it("clears tools on cron edit with --clear-tools", async () => {
+    const patch = await runCronEditAndGetPatch(["--clear-tools"]);
+    expect(patch?.patch?.payload?.toolsAllow).toBeNull();
   });
 
   it("patches failure alert mode/accountId on cron edit", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -153,7 +153,7 @@ export function registerCronAddCommand(cron: Command) {
               toolsAllow:
                 typeof opts.tools === "string" && opts.tools.trim()
                   ? opts.tools
-                      .split(",")
+                      .split(/[,\s]+/)
                       .map((t: string) => normalizeOptionalString(t))
                       .filter((t): t is string => Boolean(t))
                   : undefined,

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -219,7 +219,7 @@ export function registerCronEditCommand(cron: Command) {
               payload.toolsAllow = null;
             } else if (typeof opts.tools === "string" && opts.tools.trim()) {
               payload.toolsAllow = opts.tools
-                .split(",")
+                .split(/[,\s]+/)
                 .map((t: string) => t.trim())
                 .filter(Boolean);
             }


### PR DESCRIPTION
## Summary
Fixes issue where --tools CSV argument stores space-separated string instead of array on Windows PowerShell.

## Root Cause
On Windows PowerShell, commas in --tools argument are parsed as PowerShell array separators and re-joined with spaces before reaching Node.js. This causes "exec read write".split(",") to return ["exec read write"] instead of ["exec", "read", "write"].

## Fix
Changed split separator from comma-only to regex /[,\s]+/ to handle both comma and space-separated tool lists, plus any combination thereof.

## Changes
- src/cli/cron-cli/register.cron-add.ts: Changed .split(",") to .split(/[,\s]+/)
- src/cli/cron-cli/register.cron-edit.ts: Changed .split(",") to .split(/[,\s]+/)
- src/cli/cron-cli.test.ts: Added regression tests for various tool list formats

## Test Plan
- [x] All 50 cron-cli tests pass
- [x] New regression tests cover: comma-separated, space-separated, comma-space-separated, extra whitespace, single tool
- [x] Lint check passes (0 warnings, 0 errors)

Closes openclaw#68826