### PR TITLE
fix(active-memory): skip non-string entries in pluginConfig.agents du…

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -134,6 +134,27 @@ describe("active-memory plugin", () => {
     expect(api.on).toHaveBeenCalledWith("before_prompt_build", expect.any(Function));
   });
 
+  it("tolerates non-string entries in pluginConfig.agents without crashing register", async () => {
+    api.pluginConfig = {
+      agents: ["main", null, 42, "", "  support  "] as unknown as string[],
+      logging: false,
+    };
+
+    expect(() => plugin.register(api as unknown as OpenClawPluginApi)).not.toThrow();
+
+    // "support" (trimmed) must have survived normalization so the hook actually runs for it.
+    await hooks.before_prompt_build(
+      { prompt: "defensive agents config", messages: [] },
+      {
+        agentId: "support",
+        trigger: "user",
+        sessionKey: "agent:support:defensive-agents",
+        messageProvider: "webchat",
+      },
+    );
+    expect(runEmbeddedPiAgent).toHaveBeenCalled();
+  });
+
   it("registers a session-scoped active-memory toggle command", async () => {
     const command = registeredCommands["active-memory"];
     const sessionKey = "agent:main:active-memory-toggle";

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -615,7 +615,10 @@ function normalizePluginConfig(pluginConfig: unknown): ResolvedActiveRecallPlugi
   return {
     enabled: raw.enabled !== false,
     agents: Array.isArray(raw.agents)
-      ? raw.agents.map((agentId) => agentId.trim()).filter(Boolean)
+      ? raw.agents
+          .filter((agentId): agentId is string => typeof agentId === "string")
+          .map((agentId) => agentId.trim())
+          .filter(Boolean)
       : [],
     model: typeof raw.model === "string" && raw.model.trim() ? raw.model.trim() : undefined,
     modelFallback:


### PR DESCRIPTION
# fix(active-memory): skip non-string entries in pluginConfig.agents during normalization

## Summary

- **Problem:** The `normalizePluginConfig` function previously called `.map((agentId) => agentId.trim())` directly on `raw.agents` without first filtering out non-string values. When `pluginConfig.agents` contained non-string entries (e.g., `null`, `42`, or other invalid types), the `.trim()` method would throw a runtime error (`agentId.trim is not a function`), causing the plugin registration to crash.
- **Why it matters:** Users or external integrations could inadvertently provide malformed configuration (e.g., mixed-type arrays, legacy config structures, or JSON parsing artifacts) that would break the entire active-memory plugin registration, making memory features unavailable without clear error messaging.
- **What changed:** Added a type guard filter `filter((agentId): agentId is string => typeof agentId === "string")` before the `.map()` and `.filter(Boolean)` chain. Non-string entries are now silently skipped during normalization, and only valid string agent IDs proceed through trimming and empty-string filtering.
- **What did NOT change:** Behavior for valid `agents` arrays (all string entries) remains identical. The plugin's runtime functionality, hooks, and memory search logic are completely unaffected. No changes to public API or configuration schema.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** The normalization logic assumed `raw.agents` would always be an array of strings. When non-string values appeared, calling `.trim()` on them caused a runtime `TypeError` because non-string primitives (and `null`/`undefined`) lack a `.trim()` method.
- **Missing detection / guardrail:** No unit test covered a scenario where `pluginConfig.agents` contained non-string entries. Existing tests only validated the happy path with clean string arrays.
- **Contributing context (if known):** The original implementation likely prioritized simplicity over defensive programming, trusting that configuration inputs would always be well-formed. The fix adds a defensive type guard without changing the intended behavior.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/active-memory/index.test.ts` (new test case: `"tolerates non-string entries in pluginConfig.agents without crashing register"`)
- **Scenario the test should lock in:** `pluginConfig.agents` set to `["main", null, 42, "", " support "]` (mixed valid strings, null, number, and empty string). Registration should not throw, and valid agent IDs (including `"support"` after trimming) should still trigger the expected hooks.
- **Why this is the smallest reliable guardrail:** A focused unit test that directly invokes `plugin.register()` with malformed configuration isolates the regression without requiring full integration or E2E setup.
- **Existing test that already covers this (if any):** None.
- **If no new test is added, why not:** N/A – a regression test has been added as part of this PR.

## User‑visible / Behavior Changes

None. This fix prevents a crash that would otherwise occur with malformed configuration. Users with correctly configured `agents` arrays will see no difference. Users with malformed config will now see the plugin register successfully (with non-string entries ignored) instead of crashing.

## Diagram (if applicable)

```text
Before:
[pluginConfig.agents = ["main", null, 42]] → .map(agentId => agentId.trim())
→ TypeError: agentId.trim is not a function → plugin registration crashes

After:
[pluginConfig.agents = ["main", null, 42]]
→ .filter(agentId => typeof agentId === "string") → ["main"]
→ .map(agentId => agentId.trim()) → ["main"]
→ .filter(Boolean) → ["main"]
→ plugin registers successfully for agent "main"