### PR TITLE
fix(gateway): bound costUsageCache with MAX + FIFO eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Webchat/images: treat inline image attachments as media for empty-turn gating while still ignoring metadata-only blank turns. (#69474) Thanks @Jaswir.
 - Discord/think: only show `adaptive` in `/think` autocomplete for provider/model pairs that actually support provider-managed adaptive thinking, so GPT/OpenAI models no longer advertise an Anthropic-only option.
 - Thinking: only expose `max` for models that explicitly support provider max reasoning, and remap stored `max` settings to the largest supported thinking mode when users switch to another model.
+- Gateway/usage: bound the cost usage cache with FIFO eviction so date/range lookups cannot grow unbounded. (#68842) Thanks @Feelw00.
 - OpenAI/Responses: resolve `/think` levels against each GPT model's supported reasoning efforts so `/think off` no longer becomes high reasoning or sends unsupported `reasoning.effort: "none"` payloads.
 - Lobster/TaskFlow: allow managed approval resumes to use `approvalId` without a resume token, and persist that id in approval wait state. (#69559) Thanks @kirkluokun.
 - Plugins/startup: install bundled runtime dependencies into each plugin's own runtime directory, reuse source-checkout repair caches after rebuilds, and log only packages that were actually installed so repeated Gateway starts stay quiet once deps are present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI/Responses: resolve `/think` levels against each GPT model's supported reasoning efforts so `/think off` no longer becomes high reasoning or sends unsupported `reasoning.effort: "none"` payloads.
 - Lobster/TaskFlow: allow managed approval resumes to use `approvalId` without a resume token, and persist that id in approval wait state. (#69559) Thanks @kirkluokun.
 - Plugins/startup: install bundled runtime dependencies into each plugin's own runtime directory, reuse source-checkout repair caches after rebuilds, and log only packages that were actually installed so repeated Gateway starts stay quiet once deps are present.
-- Plugins/startup: ignore pnpm's `npm_execpath` when repairing bundled plugin runtime dependencies so npm-only install flags are not passed to pnpm-launched gateways.
+- Plugins/startup: ignore pnpm's `npm_execpath` when repairing bundled plugin runtime dependencies and skip workspace-only package specs so npm-only install flags or local workspace links do not break packaged plugin startup.
 - Setup/TUI: relaunch the setup hatch TUI in a fresh process while preserving the configured gateway target and auth source, so onboarding recovers terminal state cleanly without exposing gateway secrets on command-line args. (#69524) Thanks @shakkernerd.
 - Codex: avoid re-exposing the image-generation tool on native vision turns with inbound images, and keep bare image-model overrides on the configured image provider. (#65061) Thanks @zhulijin1991.
 - Sessions/reset: clear auto-sourced model, provider, and auth-profile overrides on `/new` and `/reset` while preserving explicit user selections, so channel sessions stop staying pinned to runtime fallback choices. (#69419) Thanks @sk7n4k3d.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - OpenAI/Responses: resolve `/think` levels against each GPT model's supported reasoning efforts so `/think off` no longer becomes high reasoning or sends unsupported `reasoning.effort: "none"` payloads.
 - Lobster/TaskFlow: allow managed approval resumes to use `approvalId` without a resume token, and persist that id in approval wait state. (#69559) Thanks @kirkluokun.
 - Plugins/startup: install bundled runtime dependencies into each plugin's own runtime directory, reuse source-checkout repair caches after rebuilds, and log only packages that were actually installed so repeated Gateway starts stay quiet once deps are present.
+- Plugins/startup: ignore pnpm's `npm_execpath` when repairing bundled plugin runtime dependencies so npm-only install flags are not passed to pnpm-launched gateways.
 - Setup/TUI: relaunch the setup hatch TUI in a fresh process while preserving the configured gateway target and auth source, so onboarding recovers terminal state cleanly without exposing gateway secrets on command-line args. (#69524) Thanks @shakkernerd.
 - Codex: avoid re-exposing the image-generation tool on native vision turns with inbound images, and keep bare image-model overrides on the configured image provider. (#65061) Thanks @zhulijin1991.
 - Sessions/reset: clear auto-sourced model, provider, and auth-profile overrides on `/new` and `/reset` while preserving explicit user selections, so channel sessions stop staying pinned to runtime fallback choices. (#69419) Thanks @sk7n4k3d.

--- a/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
+++ b/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
@@ -43,8 +43,10 @@ describe("doctor bundled plugin runtime deps", () => {
 
     writeJson(path.join(root, "dist", "extensions", "alpha", "package.json"), {
       dependencies: {
+        "@openclaw/plugin-sdk": "workspace:*",
         "dep-one": "1.0.0",
         "@scope/dep-two": "2.0.0",
+        openclaw: "workspace:*",
       },
       optionalDependencies: {
         "dep-opt": "3.0.0",

--- a/src/gateway/server-methods/usage.cost-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.cost-usage-cache.test.ts
@@ -1,0 +1,90 @@
+// Regression: costUsageCache (usage.ts:65) has no production delete/prune/evict
+// path. The TTL at L310 is read-only — on a miss after expiry, set() overwrites
+// the same key but never removes stale keys. parseDateRange derives cacheKey
+// from getTodayStartMs so cacheKey rolls at every UTC 00:00, and additional
+// axes (days, startDate, endDate, utcOffset) multiply cardinality.
+//
+// The same file has three sibling caches that implement MAX + FIFO eviction
+// (resolvedSessionKeyByRunId, TRANSCRIPT_SESSION_KEY_CACHE,
+// sessionTitleFieldsCache); costUsageCache alone lacked the pattern.
+//
+// Production trigger: MenuSessionsInjector polls usage.cost every ~45s with
+// no params, exercising parseDateRange's default branch on every UTC day
+// rollover. The Control UI adds more key variance via explicit startDate /
+// endDate / utcTimeZone combinations.
+//
+// CAL-003 compliance: no mock of internal branches. Growth is driven through
+// the __test.loadCostUsageSummaryCached seam (same entry point usage.test.ts
+// already exercises) with distinct (startMs, endMs) pairs. Only the external
+// loadCostUsageSummary dependency is stubbed.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+vi.mock("../../infra/session-cost-usage.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/session-cost-usage.js")>(
+    "../../infra/session-cost-usage.js",
+  );
+  return {
+    ...actual,
+    loadCostUsageSummary: vi.fn(async () => ({
+      updatedAt: Date.now(),
+      startDate: "2026-02-01",
+      endDate: "2026-02-02",
+      daily: [],
+      totals: {
+        totalTokens: 1,
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalCost: 0,
+      },
+    })),
+  };
+});
+
+import { __test } from "./usage.js";
+
+describe("costUsageCache bounded growth", () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  beforeEach(() => {
+    __test.costUsageCache.clear();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("does not grow without bound when (startMs, endMs) varies across day rollover and range switches", async () => {
+    const config = {} as OpenClawConfig;
+
+    // 600 distinct (startMs, endMs) pairs — larger than the 256 caps used by
+    // the smallest sibling caches (RUN_LOOKUP_CACHE_LIMIT,
+    // TRANSCRIPT_SESSION_KEY_CACHE_MAX) and small enough that the test runs
+    // quickly.
+    const ITERATIONS = 600;
+
+    for (let i = 0; i < ITERATIONS; i++) {
+      const startMs = Date.UTC(2026, 0, 1) + i * DAY_MS;
+      const endMs = startMs + (i % 3 === 0 ? DAY_MS : 7 * DAY_MS) - 1;
+      await __test.loadCostUsageSummaryCached({ startMs, endMs, config });
+    }
+
+    // Primary: map must be bounded. Pre-fix this equals ITERATIONS (600).
+    expect(__test.costUsageCache.size).toBeLessThan(ITERATIONS);
+
+    // Secondary: the most recent entry must still be present. FIFO evicts
+    // oldest-first, never the newest.
+    const lastStartMs = Date.UTC(2026, 0, 1) + (ITERATIONS - 1) * DAY_MS;
+    const lastEndMs = lastStartMs + ((ITERATIONS - 1) % 3 === 0 ? DAY_MS : 7 * DAY_MS) - 1;
+    const lastCacheKey = `${lastStartMs}-${lastEndMs}`;
+    expect(__test.costUsageCache.has(lastCacheKey)).toBe(true);
+
+    // Tertiary: the oldest entry must have been evicted once the cap was
+    // exceeded. Pre-fix all 600 entries remain and this fails too.
+    const firstStartMs = Date.UTC(2026, 0, 1);
+    const firstEndMs = firstStartMs + DAY_MS - 1;
+    const firstCacheKey = `${firstStartMs}-${firstEndMs}`;
+    expect(__test.costUsageCache.has(firstCacheKey)).toBe(false);
+  });
+});

--- a/src/gateway/server-methods/usage.cost-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.cost-usage-cache.test.ts
@@ -21,26 +21,34 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 
+const mocks = vi.hoisted(() => ({
+  loadCostUsageSummary: vi.fn(),
+}));
+
+function createSummary() {
+  return {
+    updatedAt: Date.now(),
+    startDate: "2026-02-01",
+    endDate: "2026-02-02",
+    daily: [],
+    totals: {
+      totalTokens: 1,
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalCost: 0,
+    },
+  };
+}
+
 vi.mock("../../infra/session-cost-usage.js", async () => {
   const actual = await vi.importActual<typeof import("../../infra/session-cost-usage.js")>(
     "../../infra/session-cost-usage.js",
   );
   return {
     ...actual,
-    loadCostUsageSummary: vi.fn(async () => ({
-      updatedAt: Date.now(),
-      startDate: "2026-02-01",
-      endDate: "2026-02-02",
-      daily: [],
-      totals: {
-        totalTokens: 1,
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalCost: 0,
-      },
-    })),
+    loadCostUsageSummary: mocks.loadCostUsageSummary,
   };
 });
 
@@ -53,6 +61,7 @@ describe("costUsageCache bounded growth", () => {
     __test.costUsageCache.clear();
     vi.useRealTimers();
     vi.clearAllMocks();
+    mocks.loadCostUsageSummary.mockResolvedValue(createSummary());
   });
 
   it("does not grow without bound when (startMs, endMs) varies across day rollover and range switches", async () => {
@@ -86,5 +95,39 @@ describe("costUsageCache bounded growth", () => {
     const firstEndMs = firstStartMs + DAY_MS - 1;
     const firstCacheKey = `${firstStartMs}-${firstEndMs}`;
     expect(__test.costUsageCache.has(firstCacheKey)).toBe(false);
+  });
+
+  it("evicts settled entries before in-flight entries when possible", async () => {
+    const config = {} as OpenClawConfig;
+    const pending = new Promise<ReturnType<typeof createSummary>>(() => {});
+    mocks.loadCostUsageSummary.mockReturnValueOnce(pending);
+
+    const inFlight = __test.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+    });
+    await Promise.resolve();
+
+    for (let i = 0; i < 256; i++) {
+      const startMs = Date.UTC(2026, 0, 1) + i * DAY_MS;
+      await __test.loadCostUsageSummaryCached({
+        startMs,
+        endMs: startMs + DAY_MS - 1,
+        config,
+      });
+    }
+
+    const repeated = __test.loadCostUsageSummaryCached({
+      startMs: 1,
+      endMs: 2,
+      config,
+    });
+    await Promise.resolve();
+
+    expect(__test.costUsageCache.has("1-2")).toBe(true);
+    expect(mocks.loadCostUsageSummary).toHaveBeenCalledTimes(257);
+    void inFlight.catch(() => {});
+    void repeated.catch(() => {});
   });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -65,15 +65,22 @@ type CostUsageCacheEntry = {
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
 
-// Store an entry with FIFO eviction when adding a new key would exceed the
-// cap. Mirrors the pattern in session-transcript-key.ts and server-session-key.ts
-// so the cache stays bounded under sliding-window usage queries (each
-// day/range combination produces a distinct key).
+function findCostUsageCacheEvictionKey(): string | undefined {
+  for (const [key, entry] of costUsageCache) {
+    if (!entry.inFlight) {
+      return key;
+    }
+  }
+  return costUsageCache.keys().next().value;
+}
+
+// Keep the cache bounded while preserving in-flight request coalescing when a
+// settled entry is available to evict.
 function setCostUsageCache(cacheKey: string, entry: CostUsageCacheEntry): void {
   if (!costUsageCache.has(cacheKey) && costUsageCache.size >= COST_USAGE_CACHE_MAX) {
-    const oldest = costUsageCache.keys().next().value;
-    if (oldest !== undefined) {
-      costUsageCache.delete(oldest);
+    const evictKey = findCostUsageCacheEvictionKey();
+    if (evictKey !== undefined) {
+      costUsageCache.delete(evictKey);
     }
   }
   costUsageCache.set(cacheKey, entry);

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -49,6 +49,7 @@ import {
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
+const COST_USAGE_CACHE_MAX = 256;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 type DateRange = { startMs: number; endMs: number };
@@ -63,6 +64,20 @@ type CostUsageCacheEntry = {
 };
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
+
+// Store an entry with FIFO eviction when adding a new key would exceed the
+// cap. Mirrors the pattern in session-transcript-key.ts and server-session-key.ts
+// so the cache stays bounded under sliding-window usage queries (each
+// day/range combination produces a distinct key).
+function setCostUsageCache(cacheKey: string, entry: CostUsageCacheEntry): void {
+  if (!costUsageCache.has(cacheKey) && costUsageCache.size >= COST_USAGE_CACHE_MAX) {
+    const oldest = costUsageCache.keys().next().value;
+    if (oldest !== undefined) {
+      costUsageCache.delete(oldest);
+    }
+  }
+  costUsageCache.set(cacheKey, entry);
+}
 
 function resolveSessionUsageFileOrRespond(
   key: string,
@@ -325,7 +340,7 @@ async function loadCostUsageSummaryCached(params: {
     config: params.config,
   })
     .then((summary) => {
-      costUsageCache.set(cacheKey, { summary, updatedAt: Date.now() });
+      setCostUsageCache(cacheKey, { summary, updatedAt: Date.now() });
       return summary;
     })
     .catch((err) => {
@@ -338,12 +353,12 @@ async function loadCostUsageSummaryCached(params: {
       const current = costUsageCache.get(cacheKey);
       if (current?.inFlight === inFlight) {
         current.inFlight = undefined;
-        costUsageCache.set(cacheKey, current);
+        setCostUsageCache(cacheKey, current);
       }
     });
 
   entry.inFlight = inFlight;
-  costUsageCache.set(cacheKey, entry);
+  setCostUsageCache(cacheKey, entry);
 
   if (entry.summary) {
     return entry.summary;

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -68,6 +68,25 @@ describe("resolveBundledRuntimeDepsNpmRunner", () => {
     });
   });
 
+  it("ignores pnpm npm_execpath and falls back to npm", () => {
+    const execPath = "/opt/node/bin/node";
+    const npmCliPath = "/opt/node/lib/node_modules/npm/bin/npm-cli.js";
+    const runner = resolveBundledRuntimeDepsNpmRunner({
+      env: {
+        npm_execpath: "/home/runner/setup-pnpm/node_modules/.bin/pnpm.cjs",
+      },
+      execPath,
+      existsSync: (candidate) => candidate === npmCliPath,
+      npmArgs: ["install", "acpx@0.5.3"],
+      platform: "linux",
+    });
+
+    expect(runner).toEqual({
+      command: execPath,
+      args: [npmCliPath, "install", "acpx@0.5.3"],
+    });
+  });
+
   it("falls back to npm.cmd through shell on Windows", () => {
     const runner = resolveBundledRuntimeDepsNpmRunner({
       env: {},

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -239,6 +239,72 @@ describe("ensureBundledPluginRuntimeDeps", () => {
     ]);
   });
 
+  it("skips workspace-only runtime deps before npm install", () => {
+    const packageRoot = makeTempDir();
+    const extensionsRoot = path.join(packageRoot, "dist", "extensions");
+    const pluginRoot = path.join(extensionsRoot, "qa-channel");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          "@openclaw/plugin-sdk": "workspace:*",
+          "external-runtime": "^1.2.3",
+          openclaw: "workspace:*",
+        },
+      }),
+    );
+
+    const calls: BundledRuntimeDepsInstallParams[] = [];
+    const result = ensureBundledPluginRuntimeDeps({
+      env: {},
+      installDeps: (params) => {
+        calls.push(params);
+      },
+      pluginId: "qa-channel",
+      pluginRoot,
+    });
+
+    expect(result).toEqual({
+      installedSpecs: ["external-runtime@^1.2.3"],
+      retainSpecs: ["external-runtime@^1.2.3"],
+    });
+    expect(calls).toEqual([
+      {
+        installRoot: pluginRoot,
+        missingSpecs: ["external-runtime@^1.2.3"],
+        installSpecs: ["external-runtime@^1.2.3"],
+      },
+    ]);
+  });
+
+  it("does not install when runtime deps are only workspace links", () => {
+    const packageRoot = makeTempDir();
+    const extensionsRoot = path.join(packageRoot, "dist", "extensions");
+    const pluginRoot = path.join(extensionsRoot, "qa-channel");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          "@openclaw/plugin-sdk": "workspace:*",
+          openclaw: "workspace:*",
+        },
+      }),
+    );
+
+    const result = ensureBundledPluginRuntimeDeps({
+      env: {},
+      installDeps: () => {
+        throw new Error("workspace-only runtime deps should not install");
+      },
+      pluginId: "qa-channel",
+      pluginRoot,
+    });
+
+    expect(result).toEqual({ installedSpecs: [], retainSpecs: [] });
+  });
+
   it("skips install when staged plugin-local runtime deps are present", () => {
     const packageRoot = makeTempDir();
     const extensionsRoot = path.join(packageRoot, "dist", "extensions");

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -194,6 +194,11 @@ function resolvePathEnvKey(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): s
   return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "Path";
 }
 
+function isNpmCliPath(candidate: string): boolean {
+  const normalized = candidate.replaceAll("\\", "/").toLowerCase();
+  return normalized.endsWith("/npm-cli.js") || normalized.endsWith("/npm/bin/npm-cli.js");
+}
+
 export function resolveBundledRuntimeDepsNpmRunner(params: {
   npmArgs: string[];
   env?: NodeJS.ProcessEnv;
@@ -207,9 +212,10 @@ export function resolveBundledRuntimeDepsNpmRunner(params: {
   const platform = params.platform ?? process.platform;
   const pathImpl = platform === "win32" ? path.win32 : path.posix;
   const nodeDir = pathImpl.dirname(execPath);
-  const npmExecPath = normalizeOptionalLowercaseString(env.npm_execpath)
+  const rawNpmExecPath = normalizeOptionalLowercaseString(env.npm_execpath)
     ? env.npm_execpath
     : undefined;
+  const npmExecPath = rawNpmExecPath && isNpmCliPath(rawNpmExecPath) ? rawNpmExecPath : undefined;
 
   const npmCliCandidates = [
     npmExecPath,

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -62,6 +62,17 @@ function collectRuntimeDeps(packageJson: JsonObject): Record<string, unknown> {
   };
 }
 
+function normalizeInstallableRuntimeDepVersion(rawVersion: unknown): string | null {
+  if (typeof rawVersion !== "string") {
+    return null;
+  }
+  const version = rawVersion.trim();
+  if (version === "" || version.toLowerCase().startsWith("workspace:")) {
+    return null;
+  }
+  return version;
+}
+
 function isSourceCheckoutRoot(packageRoot: string): boolean {
   return (
     fs.existsSync(path.join(packageRoot, ".git")) &&
@@ -363,10 +374,10 @@ function collectBundledPluginRuntimeDeps(params: {
       continue;
     }
     for (const [name, rawVersion] of Object.entries(collectRuntimeDeps(packageJson))) {
-      if (typeof rawVersion !== "string" || rawVersion.trim() === "") {
+      const version = normalizeInstallableRuntimeDepVersion(rawVersion);
+      if (!version) {
         continue;
       }
-      const version = rawVersion.trim();
       const byVersion = versionMap.get(name) ?? new Map<string, Set<string>>();
       const pluginIds = byVersion.get(version) ?? new Set<string>();
       pluginIds.add(pluginId);
@@ -519,11 +530,10 @@ export function ensureBundledPluginRuntimeDeps(params: {
     return { installedSpecs: [], retainSpecs: [] };
   }
   const deps = Object.entries(collectRuntimeDeps(packageJson))
-    .map(([name, rawVersion]) =>
-      typeof rawVersion === "string" && rawVersion.trim() !== ""
-        ? { name, version: rawVersion.trim() }
-        : null,
-    )
+    .map(([name, rawVersion]) => {
+      const version = normalizeInstallableRuntimeDepVersion(rawVersion);
+      return version ? { name, version } : null;
+    })
     .filter((entry): entry is { name: string; version: string } => Boolean(entry));
   if (deps.length === 0) {
     return { installedSpecs: [], retainSpecs: [] };


### PR DESCRIPTION
## Summary

- **Problem**: `costUsageCache` in `src/gateway/server-methods/usage.ts:65` has no delete/prune/evict path. The 30s TTL only gates stale reads; on a miss after expiry, `set()` overwrites the same key but never removes stale keys. `parseDateRange` derives cacheKey from `getTodayStartMs`, so cacheKey rolls at every UTC 00:00, and additional axes (days / startDate / endDate / utcOffset) multiply cardinality.
- **Why it matters**: the macOS menu polls `usage.cost` every ~45s with no params (\`MenuSessionsInjector.swift\`), exercising \`parseDateRange\`'s default branch on every UTC day rollover. Over gateway uptime the Map grows monotonically.
- **What changed**: adds \`COST_USAGE_CACHE_MAX = 256\` + a \`setCostUsageCache\` helper that evicts the oldest key when a new key would exceed the cap. Mirrors the pattern already used by \`resolvedSessionKeyByRunId\`, \`TRANSCRIPT_SESSION_KEY_CACHE\`, and \`sessionTitleFieldsCache\` in the same subsystem.
- **What did NOT change**: TTL-on-read, in-flight dedup, and overwrite-on-same-key semantics are all preserved. No public API or config surface touched.

## Change Type

- [x] Bug fix

## Scope

- [x] gateway

## Linked Issue

Closes #68841

## Root Cause

The write path never considered cache size. Missing guardrail: a bound matching the sibling caches in the same file tree. Three other gateway caches (\`resolvedSessionKeyByRunId\`, \`TRANSCRIPT_SESSION_KEY_CACHE\`, \`sessionTitleFieldsCache\`) already implement MAX + FIFO eviction; \`costUsageCache\` alone was an outlier.

## Regression Test Plan

Added \`src/gateway/server-methods/usage.cost-usage-cache.test.ts\`:

- Drives growth through \`__test.loadCostUsageSummaryCached\` (same seam \`usage.test.ts\` already uses).
- Only the external \`loadCostUsageSummary\` dependency is mocked (same pattern as the existing \`usage.test.ts\` top-level \`vi.mock\`).
- 600 distinct (startMs, endMs) pairs that mirror day rollover + range switches.

**Pre-fix**: Map grows to 600. Post-fix: Map plateaus at the cap, the last-inserted key is retained, and the first-inserted key is evicted (FIFO).

## Security Impact

None. No new permissions, secrets, network calls, or data scope change.

## Repro + Verification

**Environment**: Node 22, macOS, \`pnpm 10.33.0\`.

**Steps**:
1. \`pnpm test src/gateway/server-methods/usage.cost-usage-cache.test.ts\`

**Expected** (post-fix): 1 passed.
**Actual** (pre-fix): the primary assertion \`size < 600\` failed (all 600 entries retained).

## Evidence

- Pre-fix (stashed): 1 failed.
- Post-fix: 1 passed.
- Full \`src/gateway/server-methods/\` suite: 36 files / 432 tests passed.
- \`pnpm check\` + \`pnpm build\` clean.

## Human Verification

- Confirmed sibling pattern in \`src/gateway/server-session-key.ts:22-34\`, \`src/gateway/session-transcript-key.ts:141-150\`, and \`src/gateway/session-utils.fs.ts:57-69\`.
- Verified the three \`costUsageCache.set(...)\` call sites (line 329 on-success, 342 in-flight clear, 347 initial insert) all route through the new helper.
- \`MAX = 256\` matches the smaller sibling caps (RUN_LOOKUP_CACHE_LIMIT = 256, TRANSCRIPT_SESSION_KEY_CACHE_MAX = 256) rather than the largest (sessionTitleFieldsCache = 5000); 256 is sufficient headroom for the day × range × utcOffset axes the cache is actually indexed by.

## Review Conversations

Greptile + Codex reviews will run on the PR; will respond to any flagged items.

### Prior Art

- PR #36682 (CLOSED, author self-closed): attempted a related LRU + MAX=64 eviction with broader scope. This PR differs: FIFO (not LRU) matches the three siblings in this file tree; MAX=256 matches those siblings; scope is strictly this one cache so the change stays XS.
- PR #56318 (OPEN, bundled change covering multiple gateway areas): does not touch \`costUsageCache\`. This PR is intentionally scoped to the single outlier.

## Compatibility / Migration

None. Internal behavioral fix; no public API or config surface touched.

## Risks and Mitigations

- **Risk**: cap of 256 is too aggressive and forces frequent re-fetches of cold entries. Mitigation: 256 matches two sibling caps in the same subsystem; usage queries are operator-facing and tolerate a cold re-fetch (each call is ~30s TTL anyway).
- **Risk**: FIFO evicts a key that is still hot (e.g. a pinned date range operator keeps switching back to). Mitigation: the three sibling caches use the same FIFO semantics; LRU would diverge from the established pattern and requires extra bookkeeping. If hotness becomes a concern a follow-up PR can promote all four caches to LRU together.
- **Risk**: eviction during an in-flight request. Mitigation: \`setCostUsageCache\` preserves the existing 3-step write flow (initial insert with inFlight, on-success set, in-flight clear); eviction only happens when adding a new key. An in-flight entry for the same key is overwritten, not evicted.

---

**AI-assisted** (fully tested). Generated via openclaw-audit pipeline (gatekeeper approve + post-harness cross-review 5/5 real-problem-real-fix + pre-pr cross-review 3/3 real-problem-real-fix).