### PR TITLE
fix: add "claude" to Windows cmdCommands shim allowlist

### DIFF
--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -11,7 +11,7 @@ const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["npm", "pnpm", "yarn", "npx"],
+    cmdCommands: ["npm", "pnpm", "yarn", "npx", "claude"],
   });
 }
 


### PR DESCRIPTION
Fixes #68788

## Summary

`resolveWindowsCommandShim` resolves `.cmd` shims for Node `spawn()` on Windows. The allowlist includes `npm`, `pnpm`, `yarn`, `npx` but is missing `claude`, causing `spawn claude ENOENT` when routing to the `claude-cli` provider.

## Changes

Added `"claude"` to the `cmdCommands` array in `src/process/supervisor/adapters/child.ts`.

## Test Plan

- On Windows with `claude.cmd` on PATH, verify `provider=claude-cli` model calls succeed
- On non-Windows, no behavior change (`resolveWindowsCommandShim` is a no-op)