### PR TITLE
fix(gateway): SIGUSR1 restart fast path that doesn't break Windows schtasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/restart: keep top-level restart requests on the SIGUSR1 fast path while Windows schtasks-supervised process exits relaunch through the scheduled-task helper directly, so Windows supervised restarts do not skip the task handoff. Carries forward #68853 after #68507. Thanks @grimmjoww.
 - Control UI/Agents: redact tool-call args, partial/final results, derived exec output, and configured custom secret patterns before streaming tool events to the Control UI, so tool output cannot expose provider or channel credentials. Fixes #72283. (#72319) Thanks @volcano303 and @BunsDev.
 - Models/fallbacks: treat user-selected session models as exact choices, so `/model ollama/...` and model-picker switches fail visibly when the selected provider is unreachable instead of answering from an unrelated configured fallback. Fixes #73023. Thanks @pavelyortho-cyber.
 - CLI/model probes: fail local `infer model run` probes when the provider returns no text output, so unreachable local providers and empty completions no longer look like successful smoke tests. Refs #73023. Thanks @pavelyortho-cyber.

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -3,7 +3,7 @@ import { captureFullEnv } from "../test-utils/env.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "./supervisor-markers.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
-const triggerOpenClawRestartMock = vi.hoisted(() => vi.fn());
+const relaunchGatewayScheduledTaskMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
@@ -14,8 +14,8 @@ vi.mock("node:child_process", async () => {
     },
   );
 });
-vi.mock("./restart.js", () => ({
-  triggerOpenClawRestart: (...args: unknown[]) => triggerOpenClawRestartMock(...args),
+vi.mock("./windows-task-restart.js", () => ({
+  relaunchGatewayScheduledTask: (...args: unknown[]) => relaunchGatewayScheduledTaskMock(...args),
 }));
 
 import {
@@ -43,7 +43,7 @@ afterEach(() => {
   process.argv = [...originalArgv];
   process.execArgv = [...originalExecArgv];
   spawnMock.mockClear();
-  triggerOpenClawRestartMock.mockClear();
+  relaunchGatewayScheduledTaskMock.mockClear();
   if (originalPlatformDescriptor) {
     Object.defineProperty(process, "platform", originalPlatformDescriptor);
   }
@@ -63,7 +63,7 @@ function expectLaunchdSupervisedWithoutKickstart(params?: { launchJobLabel?: str
   process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
   const result = restartGatewayProcessWithFreshPid();
   expect(result).toEqual({ mode: "supervised" });
-  expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+  expect(relaunchGatewayScheduledTaskMock).not.toHaveBeenCalled();
   expect(spawnMock).not.toHaveBeenCalled();
 }
 
@@ -84,7 +84,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     const result = restartGatewayProcessWithFreshPid();
 
     expect(result).toEqual({ mode: "disabled" });
-    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+    expect(relaunchGatewayScheduledTaskMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -97,20 +97,20 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expectLaunchdSupervisedWithoutKickstart({ launchJobLabel: "ai.openclaw.gateway" });
   });
 
-  it("launchd supervisor never returns failed regardless of triggerOpenClawRestart outcome", () => {
+  it("launchd supervisor never calls the Windows scheduled-task relaunch", () => {
     clearSupervisorHints();
     setPlatform("darwin");
     process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    // Even if triggerOpenClawRestart *would* fail, launchd path must not call it.
-    triggerOpenClawRestartMock.mockReturnValue({
+    // Even if the scheduled-task relaunch *would* fail, launchd path must not call it.
+    relaunchGatewayScheduledTaskMock.mockReturnValue({
       ok: false,
-      method: "launchctl",
-      detail: "Bootstrap failed: 5: Input/output error",
+      method: "schtasks",
+      detail: "mocked failure",
     });
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
     expect(result.mode).not.toBe("failed");
-    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+    expect(relaunchGatewayScheduledTaskMock).not.toHaveBeenCalled();
   });
 
   it("does not schedule kickstart on non-darwin platforms", () => {
@@ -121,7 +121,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     const result = restartGatewayProcessWithFreshPid();
 
     expect(result.mode).toBe("supervised");
-    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+    expect(relaunchGatewayScheduledTaskMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -131,7 +131,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     process.env.XPC_SERVICE_NAME = "ai.openclaw.gateway";
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
-    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+    expect(relaunchGatewayScheduledTaskMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -175,10 +175,26 @@ describe("restartGatewayProcessWithFreshPid", () => {
     setPlatform("win32");
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     process.env.OPENCLAW_SERVICE_KIND = "gateway";
-    triggerOpenClawRestartMock.mockReturnValue({ ok: true, method: "schtasks" });
+    relaunchGatewayScheduledTaskMock.mockReturnValue({ ok: true, method: "schtasks" });
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
-    expect(triggerOpenClawRestartMock).toHaveBeenCalledOnce();
+    expect(relaunchGatewayScheduledTaskMock).toHaveBeenCalledOnce();
+    expect(relaunchGatewayScheduledTaskMock).toHaveBeenCalledWith(process.env);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates schtasks failure as mode=failed on Windows", () => {
+    clearSupervisorHints();
+    setPlatform("win32");
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    process.env.OPENCLAW_SERVICE_KIND = "gateway";
+    relaunchGatewayScheduledTaskMock.mockReturnValue({
+      ok: false,
+      method: "schtasks",
+      detail: "scheduled task not registered",
+    });
+    const result = restartGatewayProcessWithFreshPid();
+    expect(result).toEqual({ mode: "failed", detail: "scheduled task not registered" });
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -192,7 +208,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     const result = restartGatewayProcessWithFreshPid();
 
     expect(result).toEqual({ mode: "spawned", pid: 4242 });
-    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+    expect(relaunchGatewayScheduledTaskMock).not.toHaveBeenCalled();
   });
 
   it("returns disabled on Windows without Scheduled Task markers", () => {
@@ -217,7 +233,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     const result = restartGatewayProcessWithFreshPid();
 
     expect(result.mode).toBe("disabled");
-    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+    expect(relaunchGatewayScheduledTaskMock).not.toHaveBeenCalled();
     expect(spawnMock).not.toHaveBeenCalled();
   });
 

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -101,12 +101,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     clearSupervisorHints();
     setPlatform("darwin");
     process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    // Even if the scheduled-task relaunch *would* fail, launchd path must not call it.
-    relaunchGatewayScheduledTaskMock.mockReturnValue({
-      ok: false,
-      method: "schtasks",
-      detail: "mocked failure",
-    });
+    // On darwin under launchd, the scheduled-task relaunch path must not be reached.
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
     expect(result.mode).not.toBe("failed");

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -257,6 +257,38 @@ describe("respawnGatewayProcessForUpdate", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  it("relaunches the Windows scheduled task directly when update restart is supervised", () => {
+    clearSupervisorHints();
+    setPlatform("win32");
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    process.env.OPENCLAW_SERVICE_KIND = "gateway";
+    relaunchGatewayScheduledTaskMock.mockReturnValue({ ok: true, method: "schtasks" });
+
+    const result = respawnGatewayProcessForUpdate();
+
+    expect(result).toEqual({ mode: "supervised" });
+    expect(relaunchGatewayScheduledTaskMock).toHaveBeenCalledOnce();
+    expect(relaunchGatewayScheduledTaskMock).toHaveBeenCalledWith(process.env);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates supervised Windows update schtasks failure", () => {
+    clearSupervisorHints();
+    setPlatform("win32");
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    process.env.OPENCLAW_SERVICE_KIND = "gateway";
+    relaunchGatewayScheduledTaskMock.mockReturnValue({
+      ok: false,
+      method: "schtasks",
+      detail: "scheduled task not registered",
+    });
+
+    const result = respawnGatewayProcessForUpdate();
+
+    expect(result).toEqual({ mode: "failed", detail: "scheduled task not registered" });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it("allows detached respawn on unmanaged Windows during updates", () => {
     clearSupervisorHints();
     setPlatform("win32");

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -1,8 +1,8 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { formatErrorMessage } from "./errors.js";
-import { triggerOpenClawRestart } from "./restart.js";
 import { detectRespawnSupervisor } from "./supervisor-markers.js";
+import { relaunchGatewayScheduledTask } from "./windows-task-restart.js";
 
 type RespawnMode = "spawned" | "supervised" | "disabled" | "failed";
 
@@ -48,7 +48,13 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     // Avoid detached kickstart/start handoffs here so restart timing stays tied
     // to launchd's native supervision rather than a second helper process.
     if (supervisor === "schtasks") {
-      const restart = triggerOpenClawRestart();
+      // Call the scheduled-task relaunch directly rather than routing through
+      // triggerOpenClawRestart. This codepath is already the Windows-specific
+      // handoff, and triggerOpenClawRestart carries cross-cutting logic
+      // (stale-pid cleanup, platform dispatch, SIGUSR1 fast-path for top-level
+      // callers) that is either redundant here or can skip the scheduled-task
+      // spawn entirely, leaving the gateway dead on exit (see closed #68507).
+      const restart = relaunchGatewayScheduledTask(process.env);
       if (!restart.ok) {
         return {
           mode: "failed",

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -32,6 +32,17 @@ function spawnDetachedGatewayProcess(): { child: ChildProcess; pid?: number } {
   return { child, pid: child.pid ?? undefined };
 }
 
+function relaunchWindowsScheduledTask(): GatewayRespawnResult | null {
+  const restart = relaunchGatewayScheduledTask(process.env);
+  if (!restart.ok) {
+    return {
+      mode: "failed",
+      detail: restart.detail ?? `${restart.method} restart failed`,
+    };
+  }
+  return null;
+}
+
 /**
  * Attempt to restart this process with a fresh PID.
  * - supervised environments (launchd/systemd/schtasks): caller should exit and let supervisor restart
@@ -48,18 +59,9 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     // Avoid detached kickstart/start handoffs here so restart timing stays tied
     // to launchd's native supervision rather than a second helper process.
     if (supervisor === "schtasks") {
-      // Call the scheduled-task relaunch directly rather than routing through
-      // triggerOpenClawRestart. This codepath is already the Windows-specific
-      // handoff, and triggerOpenClawRestart carries cross-cutting logic
-      // (stale-pid cleanup, platform dispatch, SIGUSR1 fast-path for top-level
-      // callers) that is either redundant here or can skip the scheduled-task
-      // spawn entirely, leaving the gateway dead on exit (see closed #68507).
-      const restart = relaunchGatewayScheduledTask(process.env);
-      if (!restart.ok) {
-        return {
-          mode: "failed",
-          detail: restart.detail ?? `${restart.method} restart failed`,
-        };
+      const failed = relaunchWindowsScheduledTask();
+      if (failed) {
+        return failed;
       }
     }
     return { mode: "supervised" };
@@ -97,12 +99,9 @@ export function respawnGatewayProcessForUpdate(): GatewayUpdateRespawnResult {
   const supervisor = detectRespawnSupervisor(process.env);
   if (supervisor) {
     if (supervisor === "schtasks") {
-      const restart = triggerOpenClawRestart();
-      if (!restart.ok) {
-        return {
-          mode: "failed",
-          detail: restart.detail ?? `${restart.method} restart failed`,
-        };
+      const failed = relaunchWindowsScheduledTask();
+      if (failed) {
+        return failed;
       }
     }
     return { mode: "supervised" };

--- a/src/infra/restart-trigger.test.ts
+++ b/src/infra/restart-trigger.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureFullEnv } from "../test-utils/env.js";
+
+const cleanStaleGatewayProcessesSyncMock = vi.hoisted(() => vi.fn());
+const relaunchGatewayScheduledTaskMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./restart-stale-pids.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./restart-stale-pids.js")>("./restart-stale-pids.js");
+  return {
+    ...actual,
+    cleanStaleGatewayProcessesSync: (...args: unknown[]) =>
+      cleanStaleGatewayProcessesSyncMock(...args),
+  };
+});
+
+vi.mock("./windows-task-restart.js", () => ({
+  relaunchGatewayScheduledTask: (...args: unknown[]) => relaunchGatewayScheduledTaskMock(...args),
+}));
+
+import { __testing, triggerOpenClawRestart } from "./restart.js";
+
+const envSnapshot = captureFullEnv();
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: string) {
+  if (!originalPlatformDescriptor) {
+    return;
+  }
+  Object.defineProperty(process, "platform", {
+    ...originalPlatformDescriptor,
+    value: platform,
+  });
+}
+
+beforeEach(() => {
+  cleanStaleGatewayProcessesSyncMock.mockReset();
+  relaunchGatewayScheduledTaskMock.mockReset();
+  // The SIGUSR1 fast path is gated by test-mode early-return; opt out here so
+  // the real platform branch is exercised.
+  delete process.env.VITEST;
+  delete process.env.NODE_ENV;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  __testing.resetSigusr1State();
+  envSnapshot.restore();
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  }
+  while (process.listenerCount("SIGUSR1") > 0) {
+    const [first] = process.listeners("SIGUSR1");
+    if (first) {
+      process.removeListener("SIGUSR1", first);
+    }
+  }
+});
+
+describe("triggerOpenClawRestart SIGUSR1 fast path", () => {
+  it("returns method=sigusr1 when a SIGUSR1 listener is registered", () => {
+    const listener = vi.fn();
+    process.on("SIGUSR1", listener);
+    setPlatform("linux");
+
+    const result = triggerOpenClawRestart();
+
+    expect(result.ok).toBe(true);
+    expect(result.method).toBe("sigusr1");
+    // Fast path must skip platform-specific spawns.
+    expect(cleanStaleGatewayProcessesSyncMock).not.toHaveBeenCalled();
+    expect(relaunchGatewayScheduledTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("takes the fast path on Windows as well — the scheduled-task relaunch is handled by process-respawn.ts during the subsequent SIGUSR1 drain/exit cycle, not here", () => {
+    const listener = vi.fn();
+    process.on("SIGUSR1", listener);
+    setPlatform("win32");
+
+    const result = triggerOpenClawRestart();
+
+    expect(result.method).toBe("sigusr1");
+    expect(relaunchGatewayScheduledTaskMock).not.toHaveBeenCalled();
+  });
+
+  it("falls through to platform dispatch when no SIGUSR1 listener is registered", () => {
+    setPlatform("win32");
+    relaunchGatewayScheduledTaskMock.mockReturnValue({ ok: true, method: "schtasks" });
+
+    const result = triggerOpenClawRestart();
+
+    expect(relaunchGatewayScheduledTaskMock).toHaveBeenCalledOnce();
+    expect(result.method).toBe("schtasks");
+  });
+});

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -509,6 +509,20 @@ export function triggerOpenClawRestart(): RestartAttempt {
     return { ok: true, method: "supervisor", detail: "test mode" };
   }
 
+  // Prefer the in-process SIGUSR1 handoff when the gateway run-loop is up.
+  // Spawning systemctl/launchctl/schtasks from inside the gateway is prone
+  // to child-dies-with-parent races (see #40932): the caller often exits
+  // shortly after triggerOpenClawRestart returns, and a synchronous child
+  // that has already signalled the supervisor can still race the exit.
+  // SIGUSR1 feeds the run-loop's graceful drain/restart cycle instead —
+  // and because process-respawn.ts calls relaunchGatewayScheduledTask
+  // directly for the Windows schtasks handoff, taking this fast path here
+  // no longer bypasses the scheduled-task spawn on exit.
+  if (process.listenerCount("SIGUSR1") > 0) {
+    scheduleGatewaySigusr1Restart({ reason: "cli" });
+    return { ok: true, method: "sigusr1", tried: [] };
+  }
+
   cleanStaleGatewayProcessesSync();
 
   const tried: string[] = [];

--- a/src/infra/restart.types.ts
+++ b/src/infra/restart.types.ts
@@ -1,6 +1,6 @@
 export type RestartAttempt = {
   ok: boolean;
-  method: "launchctl" | "systemd" | "schtasks" | "supervisor";
+  method: "launchctl" | "systemd" | "schtasks" | "supervisor" | "sigusr1";
   detail?: string;
   tried?: string[];
 };


### PR DESCRIPTION
## Summary

Addresses #40932 (gateway restart fails from exec tool) without reintroducing the Windows regression that caused closed PR #68507 to be reverted.

## Background

PR #68507 tried to fix #40932 by adding a SIGUSR1 fast path to `triggerOpenClawRestart()`. Codex correctly flagged that as a P1 on Windows: the gateway run-loop always registers a SIGUSR1 listener, so the fast path fired when `triggerOpenClawRestart` was re-entered from `restartGatewayProcessWithFreshPid`'s schtasks branch — bypassing `relaunchGatewayScheduledTask`, which is the only thing that tells the Windows Scheduled Task to start a new instance after exit. Gateway stopped instead of restarting.

The structural issue: `triggerOpenClawRestart` had two caller classes with contradictory needs.

- **Top-level callers** (CLI, exec tool, any direct caller) want "restart however possible" — SIGUSR1 fast path is correct here.
- **Supervisor-handoff caller** (`restartGatewayProcessWithFreshPid` schtasks branch) is already inside the SIGUSR1 drain/exit sequence and needs `relaunchGatewayScheduledTask` to fire before the process exits. Taking the SIGUSR1 fast path there coalesces with the in-flight restart and skips the Scheduled Task spawn.

## Fix

Two changes that, together, restore the #40932 fix without the Windows regression:

1. **SIGUSR1 fast path in `triggerOpenClawRestart`** — when a SIGUSR1 listener is registered (i.e. the gateway run-loop is up), route through `scheduleGatewaySigusr1Restart` instead of spawning `systemctl` / `launchctl` / `schtasks`. This is the original #68507 change, now safe because of (2).
2. **Direct `relaunchGatewayScheduledTask` call** in the schtasks branch of `restartGatewayProcessWithFreshPid`. Mirrors the existing launchd handling (which also bypasses `triggerOpenClawRestart` and relies on its supervisor-specific helper). Prevents the re-entry into the SIGUSR1 fast path that broke #68507.

## Tests

- **`process-respawn.test.ts` (updated)** — mock renamed from `triggerOpenClawRestartMock` to `relaunchGatewayScheduledTaskMock`. Existing Windows-supervised test now asserts `relaunchGatewayScheduledTask` is called with `process.env` directly. New test covers schtasks failure propagation as `mode: "failed"`.
- **`restart-trigger.test.ts` (new)** — addresses Greptile's P2 from #68507:
  - SIGUSR1 fast path returns `method: "sigusr1"` when a listener is registered (Linux)
  - SIGUSR1 fast path takes precedence on Windows too — the scheduled-task relaunch is handled by `process-respawn.ts` later in the drain/exit cycle, not here
  - Falls through to platform dispatch when no listener is registered

## Verification

- `oxlint` — clean (0 warnings, 0 errors on the 5 changed files)
- `oxfmt --check` — clean
- `tsgo:core` — clean
- 19/19 tests pass in the two affected test files

No live Windows schtasks end-to-end repro was available on my machine; the fix is validated structurally — the schtasks branch of `process-respawn.ts` no longer routes through `triggerOpenClawRestart`, so the re-entry loop Codex flagged cannot happen.

## AI-assisted

Drafted and implemented with Claude Code. Testing level: **lightly tested** (targeted unit tests pass; no live Windows schtasks end-to-end repro available). I reviewed the full call graph and understand the structural change before authoring this.

Refs: #40932, closed PR #68507