### PR TITLE
fix: guard against non-string content delta and thinking blocks

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1182,7 +1182,7 @@ async function processOpenAICompletionsStream(
     if (!choice.delta) {
       continue;
     }
-    if (choice.delta.content) {
+    if (typeof choice.delta.content === "string" && choice.delta.content) {
       if (currentBlock?.type === "toolCall") {
         queuePostToolCallDelta({ kind: "text", text: choice.delta.content });
       } else {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -48,10 +48,20 @@ export function extractThinking(message: unknown): string | null {
   if (Array.isArray(content)) {
     for (const p of content) {
       const item = p as Record<string, unknown>;
-      if (item.type === "thinking" && typeof item.thinking === "string") {
-        const cleaned = item.thinking.trim();
-        if (cleaned) {
-          parts.push(cleaned);
+      if (item.type === "thinking") {
+        const thinkingValue =
+          typeof item.thinking === "string"
+            ? item.thinking
+            : typeof item.thinking === "object" &&
+                item.thinking !== null &&
+                typeof (item.thinking as Record<string, unknown>).text === "string"
+              ? ((item.thinking as Record<string, unknown>).text as string)
+              : null;
+        if (thinkingValue) {
+          const cleaned = thinkingValue.trim();
+          if (cleaned) {
+            parts.push(cleaned);
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #68309

## Summary

Mistral (and potentially other providers) may send thinking content as an object in `choice.delta.content` rather than a string. Without a type guard, the object is coerced to `"[object Object]"` when appended to the text buffer via `appendTextDelta`.

## Changes

1. **`src/agents/openai-transport-stream.ts:1185`** — Added `typeof === "string"` check on `choice.delta.content` before appending to the text buffer. Non-string content (objects) is now skipped instead of being coerced.

2. **`ui/src/ui/chat/message-extract.ts:51`** — Extended `extractThinking` to handle object-form thinking blocks where the text lives in a `.text` property (e.g. `{ type: "thinking", thinking: { text: "..." } }`) in addition to plain string form.

## Test Plan

- With Mistral Small thinking enabled, verify thinking content renders as readable text, not `[object Object]`
- With Anthropic/OpenAI models, verify no regression in normal text streaming or thinking display