### PR TITLE
fix: skip brew prompt on Linux when native package manager is available

### DIFF
--- a/src/agents/skills-install-fallback.test.ts
+++ b/src/agents/skills-install-fallback.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import { hasBinaryMock, runCommandWithTimeoutMock } from "./skills-install.test-mocks.js";
 import type { SkillEntry, SkillInstallSpec } from "./skills.js";
@@ -79,6 +79,10 @@ describe("skills-install fallback edge cases", () => {
       makeSkillEntry(workspaceDir, "py-tool", {
         kind: "uv",
         package: "example-package",
+      }),
+      makeSkillEntry(workspaceDir, "brew-tool", {
+        kind: "brew",
+        formula: "jq",
       }),
     ]);
     await loadSkillsInstallModulesForTest();
@@ -163,6 +167,164 @@ describe("skills-install fallback edge cases", () => {
 
     // Verify NO curl command was attempted (no auto-install)
     expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  describe("brew fallback to native package managers on Linux", () => {
+    let platformSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    });
+
+    afterEach(() => {
+      platformSpy.mockRestore();
+    });
+
+    it("falls back to apt-get when brew is missing and apt-get is available (root)", async () => {
+      vi.spyOn(process, "getuid").mockReturnValue(0);
+      mockAvailableBinaries(["apt-get"]);
+      // apt-get update (best effort)
+      runCommandWithTimeoutMock.mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+      // apt-get install -y jq
+      runCommandWithTimeoutMock.mockResolvedValueOnce({ code: 0, stdout: "installed", stderr: "" });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toContain("apt-get");
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+        ["apt-get", "install", "-y", "jq"],
+        expect.objectContaining({ timeoutMs: expect.any(Number) }),
+      );
+    });
+
+    it("falls back to apk when brew is missing and apk is available (root)", async () => {
+      vi.spyOn(process, "getuid").mockReturnValue(0);
+      mockAvailableBinaries(["apk"]);
+      // apk add --no-cache jq
+      runCommandWithTimeoutMock.mockResolvedValueOnce({ code: 0, stdout: "installed", stderr: "" });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toContain("apk");
+    });
+
+    it("falls back to dnf when brew is missing and dnf is available (root)", async () => {
+      vi.spyOn(process, "getuid").mockReturnValue(0);
+      mockAvailableBinaries(["dnf"]);
+      runCommandWithTimeoutMock.mockResolvedValueOnce({ code: 0, stdout: "installed", stderr: "" });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.message).toContain("dnf");
+    });
+
+    it("uses sudo for apt-get when not root", async () => {
+      vi.spyOn(process, "getuid").mockReturnValue(1000);
+      mockAvailableBinaries(["apt-get", "sudo"]);
+      // sudo -n true
+      runCommandWithTimeoutMock.mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+      // sudo apt-get update
+      runCommandWithTimeoutMock.mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+      // sudo apt-get install -y jq
+      runCommandWithTimeoutMock.mockResolvedValueOnce({ code: 0, stdout: "installed", stderr: "" });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+        ["sudo", "apt-get", "install", "-y", "jq"],
+        expect.objectContaining({ timeoutMs: expect.any(Number) }),
+      );
+    });
+
+    it("returns failure when native package manager install fails", async () => {
+      vi.spyOn(process, "getuid").mockReturnValue(0);
+      mockAvailableBinaries(["apt-get"]);
+      // apt-get update
+      runCommandWithTimeoutMock.mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+      // apt-get install fails
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 1,
+        stdout: "",
+        stderr: "E: Unable to locate package jq",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("Failed to install");
+      expect(result.message).toContain("apt-get");
+    });
+
+    it("falls through to brew-missing error when no native package manager is available", async () => {
+      mockAvailableBinaries([]);
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("brew not installed");
+    });
+
+    it("returns failure when sudo is unavailable for non-root", async () => {
+      vi.spyOn(process, "getuid").mockReturnValue(1000);
+      mockAvailableBinaries(["apt-get"]);
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("sudo is not installed");
+    });
+
+    it("returns failure when sudo requires a password for non-root", async () => {
+      vi.spyOn(process, "getuid").mockReturnValue(1000);
+      mockAvailableBinaries(["apt-get", "sudo"]);
+      // sudo -n true fails
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 1,
+        stdout: "",
+        stderr: "sudo: a password is required",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("sudo requires a password");
+    });
   });
 
   it("preserves system uv/python env vars when running uv installs", async () => {

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -284,6 +284,104 @@ function resolveBrewMissingFailure(spec: SkillInstallSpec): SkillInstallResult {
   return createInstallFailure({ message: `brew not installed — ${hint}` });
 }
 
+type NativePackageManager = {
+  name: string;
+  bin: string;
+  installArgv: (pkg: string) => string[];
+  updateArgv?: () => string[];
+};
+
+const NATIVE_PACKAGE_MANAGERS: NativePackageManager[] = [
+  {
+    name: "apt-get",
+    bin: "apt-get",
+    installArgv: (pkg) => ["apt-get", "install", "-y", pkg],
+    updateArgv: () => ["apt-get", "update", "-qq"],
+  },
+  {
+    name: "apk",
+    bin: "apk",
+    installArgv: (pkg) => ["apk", "add", "--no-cache", pkg],
+  },
+  {
+    name: "dnf",
+    bin: "dnf",
+    installArgv: (pkg) => ["dnf", "install", "-y", pkg],
+  },
+  {
+    name: "yum",
+    bin: "yum",
+    installArgv: (pkg) => ["yum", "install", "-y", pkg],
+  },
+];
+
+async function installBrewFormulaViaNativePackageManager(
+  formula: string,
+  timeoutMs: number,
+): Promise<SkillInstallResult | undefined> {
+  const deps = getSkillsInstallDeps();
+
+  const pm = NATIVE_PACKAGE_MANAGERS.find((m) => deps.hasBinary(m.bin));
+  if (!pm) {
+    return undefined;
+  }
+
+  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+  if (isRoot) {
+    if (pm.updateArgv) {
+      await runBestEffortCommand(pm.updateArgv(), { timeoutMs });
+    }
+    const result = await runCommandSafely(pm.installArgv(formula), { timeoutMs });
+    if (result.code === 0) {
+      return {
+        ok: true,
+        message: `Installed "${formula}" via ${pm.name}`,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        code: result.code,
+      };
+    }
+    return createInstallFailure({
+      message: `Failed to install "${formula}" via ${pm.name}. Install manually using your system package manager.`,
+      ...result,
+    });
+  }
+
+  if (!deps.hasBinary("sudo")) {
+    return createInstallFailure({
+      message: `${pm.name} is available but sudo is not installed. Install "${formula}" manually.`,
+    });
+  }
+
+  const sudoCheck = await runCommandSafely(["sudo", "-n", "true"], { timeoutMs: 5_000 });
+  if (sudoCheck.code !== 0) {
+    return createInstallFailure({
+      message: `${pm.name} is available but sudo requires a password. Install "${formula}" manually.`,
+      ...sudoCheck,
+    });
+  }
+
+  if (pm.updateArgv) {
+    await runBestEffortCommand(["sudo", ...pm.updateArgv()], { timeoutMs });
+  }
+  const result = await runCommandSafely(["sudo", ...pm.installArgv(formula)], { timeoutMs });
+  if (result.code === 0) {
+    return {
+      ok: true,
+      message: `Installed "${formula}" via sudo ${pm.name}`,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      code: result.code,
+    };
+  }
+
+  return createInstallFailure({
+    message: `Failed to install "${formula}" via ${pm.name}. Install manually using your system package manager.`,
+    ...result,
+  });
+}
+
 async function ensureUvInstalled(params: {
   spec: SkillInstallSpec;
   brewExe?: string;
@@ -505,6 +603,12 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
 
   const brewExe = deps.hasBinary("brew") ? "brew" : deps.resolveBrewExecutable();
   if (spec.kind === "brew" && !brewExe) {
+    if (process.platform === "linux" && spec.formula) {
+      const nativeResult = await installBrewFormulaViaNativePackageManager(spec.formula, timeoutMs);
+      if (nativeResult) {
+        return withWarnings(nativeResult, warnings);
+      }
+    }
     return withWarnings(resolveBrewMissingFailure(spec), warnings);
   }
 

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -186,4 +186,39 @@ describe("setupSkills", () => {
     const brewNote = notes.find((n) => n.title === "Homebrew recommended");
     expect(brewNote).toBeDefined();
   });
+
+  it("shows native package manager fallback note on Linux when apt-get is available", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+
+    try {
+      mockMissingBrewStatus([
+        createBundledSkill({
+          name: "video-frames",
+          description: "ffmpeg",
+          bins: ["ffmpeg"],
+          installLabel: "Install ffmpeg (brew)",
+        }),
+      ]);
+
+      // apt-get is available, brew is not
+      mocks.detectBinary.mockImplementation(async (bin: string) => bin === "apt-get");
+
+      const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
+      await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+      const fallbackNote = notes.find((n) => n.title === "Native package manager fallback");
+      expect(fallbackNote).toBeDefined();
+      expect(fallbackNote!.message).toContain("native package manager was detected");
+
+      const brewNote = notes.find((n) => n.title === "Homebrew recommended");
+      expect(brewNote).toBeUndefined();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    }
+  });
 });

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -108,12 +108,28 @@ export async function setupSkills(
       .map((name) => installable.find((s) => s.name === name))
       .filter((item): item is (typeof installable)[number] => Boolean(item));
 
-    const needsBrewPrompt =
-      process.platform !== "win32" &&
-      selectedSkills.some((skill) => skill.install.some((option) => option.kind === "brew")) &&
-      !(await detectBinary("brew"));
+    const hasBrewSkills = selectedSkills.some((skill) =>
+      skill.install.some((option) => option.kind === "brew"),
+    );
+    const brewMissing = hasBrewSkills && !(await detectBinary("brew"));
+    const hasNativePackageManager =
+      process.platform === "linux" &&
+      ((await detectBinary("apt-get")) ||
+        (await detectBinary("apk")) ||
+        (await detectBinary("dnf")) ||
+        (await detectBinary("yum")));
 
-    if (needsBrewPrompt) {
+    const needsBrewPrompt = process.platform !== "win32" && brewMissing && !hasNativePackageManager;
+
+    if (brewMissing && hasNativePackageManager) {
+      await prompter.note(
+        [
+          "Homebrew is not installed, but a native package manager was detected.",
+          "Brew-based skill dependencies will be installed via your system package manager.",
+        ].join("\n"),
+        "Native package manager fallback",
+      );
+    } else if (needsBrewPrompt) {
       await prompter.note(
         [
           "Many skill dependencies are shipped via Homebrew.",


### PR DESCRIPTION
Fixes #14593

## Problem

When running `openclaw onboard` in a Docker container and selecting a brew-based skill, the wizard shows a confusing "Homebrew recommended" prompt even though:

1. The existing fallback in `skills-install.ts` already handles installing brew formulas via native package managers (apt-get, apk, dnf, yum)
2. Docker containers typically have apt-get/apk available but not Homebrew

## Fix

In `onboard-skills.ts`, before showing the Homebrew prompt, check if a native package manager is available on Linux. If so, show a simpler informational note instead of the scary "you'll need to build from source" warning.

The actual installation fallback logic in `skills-install.ts` was already correct — this PR fixes only the onboarding UX to match the actual behavior.

## Changes

- `src/commands/onboard-skills.ts`: Detect native package managers on Linux and show appropriate messaging
- `src/commands/onboard-skills.test.ts`: Add test for the native PM fallback note path

## Testing

All 14 existing + new tests pass:
```
✓ agents skills-install-fallback.test.ts (11 tests)
✓ commands onboard-skills.test.ts (3 tests)
```