### PR TITLE
feat(exec): inject OPENCLAW_SESSION_KEY env var for child processes

### DIFF
--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -66,6 +66,8 @@ OpenClaw also injects context markers into spawned child processes:
 - `OPENCLAW_SHELL=acp`: set for ACP runtime backend process spawns (for example `acpx`).
 - `OPENCLAW_SHELL=acp-client`: set for `openclaw acp client` when it spawns the ACP bridge process.
 - `OPENCLAW_SHELL=tui-local`: set for local TUI `!` shell commands.
+- `OPENCLAW_SESSION_KEY`: set for commands run through the `exec` tool when a session key is available (e.g., `agent:it:main`). This allows scripts to reliably identify their session context without relying on model parameter passing.
+- `OPENCLAW_AGENT_ID`: set for commands run through the `exec` tool when an agent ID is available (e.g., `it`). This allows scripts to identify the running agent.
 
 These are runtime markers (not required user config). They can be used in shell/profile logic
 to apply context-specific rules.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -44,6 +44,7 @@ Notes:
 - Host execution (`gateway`/`node`) rejects `env.PATH` and loader overrides (`LD_*`/`DYLD_*`) to
   prevent binary hijacking or injected code.
 - OpenClaw sets `OPENCLAW_SHELL=exec` in the spawned command environment (including PTY and sandbox execution) so shell/profile rules can detect exec-tool context.
+- When available, OpenClaw also sets `OPENCLAW_SESSION_KEY` (e.g., `agent:it:main`) and `OPENCLAW_AGENT_ID` (e.g., `it`) so scripts can identify the calling session and agent without relying on model parameter passing.
 - Important: sandboxing is **off by default**. If sandboxing is off, implicit `host=auto`
   resolves to `gateway`. Explicit `host=sandbox` still fails closed instead of silently
   running on the gateway host. Enable sandboxing or use `host=gateway` with approvals.

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -511,6 +511,7 @@ export async function runExecProcess(opts: {
   pendingMaxOutput: number;
   notifyOnExit: boolean;
   notifyOnExitEmptySuccess?: boolean;
+  agentId?: string;
   scopeKey?: string;
   sessionKey?: string;
   notifyDeliveryContext?: DeliveryContext;
@@ -523,6 +524,8 @@ export async function runExecProcess(opts: {
   const supervisor = getProcessSupervisor();
   const shellRuntimeEnv: Record<string, string> = {
     ...opts.env,
+    ...(opts.sessionKey ? { OPENCLAW_SESSION_KEY: opts.sessionKey } : {}),
+    ...(opts.agentId ? { OPENCLAW_AGENT_ID: opts.agentId } : {}),
     OPENCLAW_SHELL: "exec",
   };
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1673,6 +1673,7 @@ export function createExecTool(
         pendingMaxOutput,
         notifyOnExit,
         notifyOnExitEmptySuccess,
+        agentId,
         scopeKey: defaults?.scopeKey,
         sessionKey: notifySessionKey,
         notifyDeliveryContext,


### PR DESCRIPTION
## Summary
Inject OPENCLAW_SESSION_KEY environment variable into child processes spawned by the exec tool, allowing scripts and skills to reliably identify the current session without relying on model parameter passing.

## Problem
Currently, skills and scripts executed via exec have no reliable way to determine which session they belong to. While the model can pass session keys as parameters, this approach is prone to hallucination errors where the model may provide incorrect session identifiers.

## Solution
Automatically inject OPENCLAW_SESSION_KEY into the environment of child processes spawned by exec.

### Changes
- Modified src/agents/bash-tools.exec-runtime.ts
- Added conditional injection of OPENCLAW_SESSION_KEY in runExecProcess
- Only injected when sessionKey is available (maintains backward compatibility)

## Testing
- [x] Local gateway execution (host=gateway)
- [x] Sandbox execution (host=sandbox)
- [x] PTY mode (pty=true)

## Usage Example
```python
import os
session_key = os.environ.get("OPENCLAW_SESSION_KEY")
```

## Backward Compatibility
Fully backward compatible - variable only injected when session key is available.