### PR TITLE
fix: prevent prompt token double-counting in tool-use loops

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -819,9 +819,10 @@ export async function runEmbeddedPiAgent(
           // reflects current context usage, not accumulated tool-loop usage.
           // Prefer per-message usage from the final assistant; fall back to the
           // accumulator's last-call snapshot which tracks the single most recent
-          // API call.  Do not fall back to attemptUsage — it is the accumulated
-          // total across all API calls in the tool-use loop.
-          lastRunPromptUsage = lastAssistantUsage ?? toLastCallUsage(usageAccumulator);
+          // API call.  Guard on attemptUsage so we don't reuse a stale snapshot
+          // from a previous attempt when this one reported no usage at all.
+          lastRunPromptUsage =
+            lastAssistantUsage ?? (attemptUsage ? toLastCallUsage(usageAccumulator) : undefined);
           lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
           const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
           autoCompactionCount += attemptCompactionCount;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -131,7 +131,11 @@ import type {
   ToolSummaryTrace,
   EmbeddedRunLivenessState,
 } from "./types.js";
-import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
+import {
+  createUsageAccumulator,
+  mergeUsageIntoAccumulator,
+  toLastCallUsage,
+} from "./usage-accumulator.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
 
@@ -813,10 +817,11 @@ export async function runEmbeddedPiAgent(
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
           // Keep prompt size from the latest model call so session totalTokens
           // reflects current context usage, not accumulated tool-loop usage.
-          // Do not fall back to attemptUsage here — it is the accumulated total
-          // across all API calls in the tool-use loop, which double-counts
-          // prompt tokens for providers that report full prompt size per call.
-          lastRunPromptUsage = lastAssistantUsage;
+          // Prefer per-message usage from the final assistant; fall back to the
+          // accumulator's last-call snapshot which tracks the single most recent
+          // API call.  Do not fall back to attemptUsage — it is the accumulated
+          // total across all API calls in the tool-use loop.
+          lastRunPromptUsage = lastAssistantUsage ?? toLastCallUsage(usageAccumulator);
           lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
           const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
           autoCompactionCount += attemptCompactionCount;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -813,7 +813,10 @@ export async function runEmbeddedPiAgent(
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
           // Keep prompt size from the latest model call so session totalTokens
           // reflects current context usage, not accumulated tool-loop usage.
-          lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
+          // Do not fall back to attemptUsage here — it is the accumulated total
+          // across all API calls in the tool-use loop, which double-counts
+          // prompt tokens for providers that report full prompt size per call.
+          lastRunPromptUsage = lastAssistantUsage;
           lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
           const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
           autoCompactionCount += attemptCompactionCount;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -131,11 +131,7 @@ import type {
   ToolSummaryTrace,
   EmbeddedRunLivenessState,
 } from "./types.js";
-import {
-  createUsageAccumulator,
-  mergeUsageIntoAccumulator,
-  toLastCallUsage,
-} from "./usage-accumulator.js";
+import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
 
@@ -817,12 +813,12 @@ export async function runEmbeddedPiAgent(
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
           // Keep prompt size from the latest model call so session totalTokens
           // reflects current context usage, not accumulated tool-loop usage.
-          // Prefer per-message usage from the final assistant; fall back to the
-          // accumulator's last-call snapshot which tracks the single most recent
-          // API call.  Guard on attemptUsage so we don't reuse a stale snapshot
-          // from a previous attempt when this one reported no usage at all.
-          lastRunPromptUsage =
-            lastAssistantUsage ?? (attemptUsage ? toLastCallUsage(usageAccumulator) : undefined);
+          // Only use per-message usage from the final assistant message — it is
+          // the only non-accumulated source.  attemptUsage and the accumulator's
+          // last-call fields both carry accumulated totals after merge, so they
+          // would inflate promptTokens for providers that report full prompt
+          // size per call.
+          lastRunPromptUsage = lastAssistantUsage;
           lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
           const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
           autoCompactionCount += attemptCompactionCount;

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -215,4 +215,26 @@ describe("runEmbeddedPiAgent usage reporting", () => {
     // (input + cacheRead = 5000 + 120000 = 125000), not the accumulated total.
     expect(result.meta.agentMeta?.promptTokens).toBe(125000);
   });
+
+  it("does not reuse stale prompt snapshot when attempt reports no usage", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Response"],
+        lastAssistant: undefined,
+        attemptUsage: undefined,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace",
+      prompt: "hello",
+      timeoutMs: 30000,
+      runId: "run-no-usage-at-all",
+    });
+
+    expect(result.meta.agentMeta?.promptTokens).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -191,4 +191,26 @@ describe("runEmbeddedPiAgent usage reporting", () => {
     // If the bug exists, it will likely be 350
     expect(usage?.total).toBe(200);
   });
+
+  it("does not leak attemptUsage into promptTokens when lastAssistant is undefined", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["Response"],
+        lastAssistant: undefined,
+        attemptUsage: { input: 5000, output: 200, cacheRead: 120000, total: 125200 },
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: "test-session",
+      sessionKey: "test-key",
+      sessionFile: "/tmp/session.json",
+      workspaceDir: "/tmp/workspace",
+      prompt: "hello",
+      timeoutMs: 30000,
+      runId: "run-no-assistant-usage",
+    });
+
+    expect(result.meta.agentMeta?.promptTokens).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -192,7 +192,7 @@ describe("runEmbeddedPiAgent usage reporting", () => {
     expect(usage?.total).toBe(200);
   });
 
-  it("does not leak attemptUsage into promptTokens when lastAssistant is undefined", async () => {
+  it("falls back to last-call usage for promptTokens when lastAssistant is undefined", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Response"],
@@ -211,6 +211,8 @@ describe("runEmbeddedPiAgent usage reporting", () => {
       runId: "run-no-assistant-usage",
     });
 
-    expect(result.meta.agentMeta?.promptTokens).toBeUndefined();
+    // promptTokens should derive from the accumulator's last-call snapshot
+    // (input + cacheRead = 5000 + 120000 = 125000), not the accumulated total.
+    expect(result.meta.agentMeta?.promptTokens).toBe(125000);
   });
 });

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -192,7 +192,7 @@ describe("runEmbeddedPiAgent usage reporting", () => {
     expect(usage?.total).toBe(200);
   });
 
-  it("falls back to last-call usage for promptTokens when lastAssistant is undefined", async () => {
+  it("does not leak attemptUsage into promptTokens when lastAssistant is undefined", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["Response"],
@@ -211,30 +211,8 @@ describe("runEmbeddedPiAgent usage reporting", () => {
       runId: "run-no-assistant-usage",
     });
 
-    // promptTokens should derive from the accumulator's last-call snapshot
-    // (input + cacheRead = 5000 + 120000 = 125000), not the accumulated total.
-    expect(result.meta.agentMeta?.promptTokens).toBe(125000);
-  });
-
-  it("does not reuse stale prompt snapshot when attempt reports no usage", async () => {
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      makeAttemptResult({
-        assistantTexts: ["Response"],
-        lastAssistant: undefined,
-        attemptUsage: undefined,
-      }),
-    );
-
-    const result = await runEmbeddedPiAgent({
-      sessionId: "test-session",
-      sessionKey: "test-key",
-      sessionFile: "/tmp/session.json",
-      workspaceDir: "/tmp/workspace",
-      prompt: "hello",
-      timeoutMs: 30000,
-      runId: "run-no-usage-at-all",
-    });
-
+    // Without per-message usage from the assistant, promptTokens must stay
+    // undefined rather than leaking the accumulated attemptUsage total.
     expect(result.meta.agentMeta?.promptTokens).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes #68470

## Summary

`lastRunPromptUsage` fell back to `attemptUsage` (the accumulated total across all API calls in the tool-use loop) when `lastAssistantUsage` was undefined. For providers like MiniMax that report full prompt size per call rather than incremental deltas, this caused prompt tokens to be summed across loop iterations, inflating the count and triggering premature compaction.

## Root Cause

In `src/agents/pi-embedded-runner/run.ts:803`:

```typescript
lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
```

The comment above this line says "keep prompt size from the latest model call, not accumulated tool-loop usage" — but the `attemptUsage` fallback contradicts this intent because `attemptUsage` IS the accumulated total from `getUsageTotals()`.

## Fix

Remove the `attemptUsage` fallback so `lastRunPromptUsage` only reflects the latest single model call's usage. When no per-message usage is available, `derivePromptTokens` returns `undefined` and compaction decisions are deferred rather than based on inflated numbers.

## Test Plan

- With MiniMax provider, run a multi-turn tool-use conversation
- Verify prompt token count reflects the latest call's context size, not the accumulated total
- Verify compaction does not trigger prematurely
- With Anthropic/OpenAI providers (which report per-message usage), verify no regression