### PR TITLE
fix(feishu): add application-level WebSocket reconnection with backoff

### DIFF
--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -116,10 +116,12 @@ export async function monitorWebSocket({
     }
 
     wsClients.set(accountId, wsClient);
+    let closedByAbort = false;
 
     try {
       await new Promise<void>((resolve, reject) => {
         function handleAbort() {
+          closedByAbort = true;
           try {
             wsClient.close();
           } catch {}
@@ -150,12 +152,14 @@ export async function monitorWebSocket({
     } catch (err) {
       error(`feishu[${accountId}]: WebSocket error: ${String(err)}`);
     } finally {
-      try {
-        wsClient.close();
-      } catch {}
-      wsClients.delete(accountId);
-      botOpenIds.delete(accountId);
-      botNames.delete(accountId);
+      if (!closedByAbort) {
+        try {
+          wsClient.close();
+        } catch {}
+        wsClients.delete(accountId);
+        botOpenIds.delete(accountId);
+        botNames.delete(accountId);
+      }
     }
 
     if (isAborted()) {

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -91,53 +91,81 @@ export async function monitorWebSocket({
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
-  log(`feishu[${accountId}]: starting WebSocket connection...`);
 
-  const wsClient = await createFeishuWSClient(account);
-  wsClients.set(accountId, wsClient);
+  const initialDelayMs = 2_000;
+  const maxDelayMs = 60_000;
+  let retryDelay = initialDelayMs;
 
-  return new Promise((resolve, reject) => {
-    let cleanedUp = false;
+  const isAborted = () => abortSignal?.aborted === true;
 
-    const cleanup = () => {
-      if (cleanedUp) {
+  while (!isAborted()) {
+    log(`feishu[${accountId}]: starting WebSocket connection...`);
+
+    let wsClient: Lark.WSClient;
+    try {
+      wsClient = await createFeishuWSClient(account);
+    } catch (err) {
+      error(`feishu[${accountId}]: failed to create WebSocket client: ${String(err)}`);
+      if (isAborted()) {
         return;
       }
-      cleanedUp = true;
-      abortSignal?.removeEventListener("abort", handleAbort);
-      try {
-        wsClient.close();
-      } catch (err) {
-        error(`feishu[${accountId}]: error closing WebSocket client: ${String(err)}`);
-      } finally {
-        wsClients.delete(accountId);
-        botOpenIds.delete(accountId);
-        botNames.delete(accountId);
-      }
-    };
-
-    function handleAbort() {
-      log(`feishu[${accountId}]: abort signal received, stopping`);
-      cleanup();
-      resolve();
+      log(`feishu[${accountId}]: retrying in ${retryDelay}ms...`);
+      await sleepAbortable(retryDelay, abortSignal);
+      retryDelay = Math.min(retryDelay * 2, maxDelayMs);
+      continue;
     }
 
-    if (abortSignal?.aborted) {
-      cleanup();
-      resolve();
+    wsClients.set(accountId, wsClient);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        function handleAbort() {
+          try {
+            wsClient.close();
+          } catch {}
+          wsClients.delete(accountId);
+          botOpenIds.delete(accountId);
+          botNames.delete(accountId);
+          resolve();
+        }
+
+        if (isAborted()) {
+          handleAbort();
+          return;
+        }
+
+        abortSignal?.addEventListener("abort", handleAbort, { once: true });
+
+        try {
+          void wsClient.start({ eventDispatcher });
+          log(`feishu[${accountId}]: WebSocket client started`);
+        } catch (err) {
+          abortSignal?.removeEventListener("abort", handleAbort);
+          reject(err);
+        }
+      });
+
+      // Normal close — reset backoff
+      retryDelay = initialDelayMs;
+    } catch (err) {
+      error(`feishu[${accountId}]: WebSocket error: ${String(err)}`);
+    } finally {
+      try {
+        wsClient.close();
+      } catch {}
+      wsClients.delete(accountId);
+      botOpenIds.delete(accountId);
+      botNames.delete(accountId);
+    }
+
+    if (isAborted()) {
       return;
     }
 
-    abortSignal?.addEventListener("abort", handleAbort, { once: true });
-
-    try {
-      void wsClient.start({ eventDispatcher });
-      log(`feishu[${accountId}]: WebSocket client started`);
-    } catch (err) {
-      cleanup();
-      reject(err);
-    }
-  });
+    log(`feishu[${accountId}]: reconnecting in ${retryDelay}ms...`);
+    await sleepAbortable(retryDelay, abortSignal);
+    retryDelay = Math.min(retryDelay * 2, maxDelayMs);
+  }
 }
 
 export async function monitorWebhook({
@@ -287,5 +315,23 @@ export async function monitorWebhook({
       abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
     });
+  });
+}
+
+function sleepAbortable(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }


### PR DESCRIPTION
Fixes #68766

## Summary

The Feishu WebSocket transport relied solely on the Lark SDK's built-in `autoReconnect`, which silently gives up after exhausting its internal retry budget. When this happens the bot goes permanently offline with no recovery path.

## Root Cause

- The Lark SDK's internal reconnection has a limited retry budget
- `cleanup()` calls `wsClient.close()` which permanently kills the SDK's reconnection loop
- No application-level recovery exists — once the SDK gives up, the bot stays offline

## Fix

Wrap the WebSocket lifecycle in an application-level reconnection loop with exponential backoff (2s initial, 60s max), following the same pattern used by the Mattermost channel (`runWithReconnect`).

The loop:
- Retries on both client creation failures (e.g. token refresh timeout) and runtime disconnects
- Resets backoff on successful connections (normal close)
- Respects the abort signal for clean shutdown
- Cleans up `wsClient`/`botOpenIds`/`botNames` state on each cycle

## Test Plan

- Start Feishu WebSocket transport
- Simulate token refresh failure (e.g. network interruption during refresh)
- Verify bot reconnects with exponential backoff instead of going permanently offline
- Verify abort signal still cleanly stops the transport