### PR TITLE
fix(memory): filter cron-triggered sessions and NO_REPLY sentinels from dreaming corpus (addresses #68449)

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1909,6 +1909,10 @@ describe("memory-core dreaming phases", () => {
           "[cron:0 3 * * *] explain this schedule please",
           30,
         ),
+        // Bracketed cron tags without the runtime job-name segment should also
+        // stay in the corpus; they are ordinary user prose, not scheduler
+        // scaffolding.
+        makeMessage("user", "[cron:daily] explain this tag please", 35),
       ].join("\n") + "\n",
       "utf-8",
     );
@@ -1965,8 +1969,9 @@ describe("memory-core dreaming phases", () => {
     // Legitimate prose that merely mentions cron must still be ingested.
     expect(corpus).toContain("wire up a cron job to back up the vault");
     expect(corpus).toContain("systemd timer, but cron also works");
-    // User questions that happen to start with a raw cron expression in
-    // brackets must NOT be treated as runtime cron scaffolding.
+    // User questions that happen to start with a raw cron expression or a
+    // bracketed cron tag must NOT be treated as runtime cron scaffolding.
     expect(corpus).toContain("[cron:0 3 * * *] explain this schedule");
+    expect(corpus).toContain("[cron:daily] explain this tag");
   });
 });

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1913,6 +1913,10 @@ describe("memory-core dreaming phases", () => {
         // stay in the corpus; they are ordinary user prose, not scheduler
         // scaffolding.
         makeMessage("user", "[cron:daily] explain this tag please", 35),
+        // Standalone sentinel-looking assistant text must stay unless it is the
+        // immediate answer to runtime cron/heartbeat scaffolding.
+        makeMessage("assistant", "NO_REPLY", 40),
+        makeMessage("assistant", "HEARTBEAT_OK", 45),
       ].join("\n") + "\n",
       "utf-8",
     );
@@ -1963,8 +1967,6 @@ describe("memory-core dreaming phases", () => {
     // Automation scaffolding must not leak into the corpus.
     expect(corpus).not.toContain("[cron:abc-123");
     expect(corpus).not.toContain("[cron:heartbeat-daily");
-    expect(corpus).not.toMatch(/Assistant:\s*NO_REPLY/);
-    expect(corpus).not.toMatch(/Assistant:\s*HEARTBEAT_OK/);
 
     // Legitimate prose that merely mentions cron must still be ingested.
     expect(corpus).toContain("wire up a cron job to back up the vault");
@@ -1973,5 +1975,9 @@ describe("memory-core dreaming phases", () => {
     // bracketed cron tag must NOT be treated as runtime cron scaffolding.
     expect(corpus).toContain("[cron:0 3 * * *] explain this schedule");
     expect(corpus).toContain("[cron:daily] explain this tag");
+    // User-influenced assistant messages that happen to equal automation
+    // sentinels remain traceable instead of silently bypassing ingestion.
+    expect(corpus).toMatch(/Assistant:\s*NO_REPLY/);
+    expect(corpus).toMatch(/Assistant:\s*HEARTBEAT_OK/);
   });
 });

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1888,7 +1888,7 @@ describe("memory-core dreaming phases", () => {
         // Pure cron scaffolding — should be filtered.
         makeMessage("user", "[cron:abc-123 WHOOP Token Refresh] refresh the token please", 0),
         makeMessage("assistant", "NO_REPLY", 5),
-        makeMessage("user", "[cron: heartbeat-daily] heartbeat poll", 10),
+        makeMessage("user", "[cron:heartbeat-daily HB] heartbeat poll", 10),
         makeMessage("assistant", "HEARTBEAT_OK", 15),
         // Meaningful exchange that happens to mention cron in prose — must stay.
         makeMessage(
@@ -1900,6 +1900,14 @@ describe("memory-core dreaming phases", () => {
           "assistant",
           "Sure — the cleanest approach is a systemd timer, but cron also works.",
           25,
+        ),
+        // Bracketed cron expression at the start of a user question — must
+        // NOT be filtered. The jobId regex requires ≥4 alphanumeric chars
+        // which a leading `0` / `*` of a cron expression never satisfies.
+        makeMessage(
+          "user",
+          "[cron:0 3 * * *] explain this schedule please",
+          30,
         ),
       ].join("\n") + "\n",
       "utf-8",
@@ -1950,12 +1958,15 @@ describe("memory-core dreaming phases", () => {
 
     // Automation scaffolding must not leak into the corpus.
     expect(corpus).not.toContain("[cron:abc-123");
-    expect(corpus).not.toContain("[cron: heartbeat-daily");
+    expect(corpus).not.toContain("[cron:heartbeat-daily");
     expect(corpus).not.toMatch(/Assistant:\s*NO_REPLY/);
     expect(corpus).not.toMatch(/Assistant:\s*HEARTBEAT_OK/);
 
     // Legitimate prose that merely mentions cron must still be ingested.
     expect(corpus).toContain("wire up a cron job to back up the vault");
     expect(corpus).toContain("systemd timer, but cron also works");
+    // User questions that happen to start with a raw cron expression in
+    // brackets must NOT be treated as runtime cron scaffolding.
+    expect(corpus).toContain("[cron:0 3 * * *] explain this schedule");
   });
 });

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1860,4 +1860,102 @@ describe("memory-core dreaming phases", () => {
     // Before the fix, it stayed at 1 because dayBucket was the file date.
     expect(after2[0]?.dailyCount).toBe(2);
   });
+
+  it("filters cron-triggered prompts and NO_REPLY/HEARTBEAT_OK sentinels out of the session corpus", async () => {
+    // Regression for openclaw/openclaw#68449 (issue 2): a workspace with lots
+    // of cron-triggered sessions would flood the dreaming corpus with lines
+    // like `User: [cron:<id> ...]` / `Assistant: NO_REPLY`, which then
+    // dominated concept ranking. These shapes should be dropped at ingestion.
+    const workspaceDir = await createDreamingWorkspace();
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "cron-noise.jsonl");
+    const makeMessage = (role: "user" | "assistant", text: string, secondsOffset: number) =>
+      JSON.stringify({
+        type: "message",
+        message: {
+          role,
+          timestamp: new Date(Date.parse("2026-04-05T18:00:00.000Z") + secondsOffset * 1000)
+            .toISOString(),
+          content: [{ type: "text", text }],
+        },
+      });
+    await fs.writeFile(
+      transcriptPath,
+      [
+        // Pure cron scaffolding — should be filtered.
+        makeMessage("user", "[cron:abc-123 WHOOP Token Refresh] refresh the token please", 0),
+        makeMessage("assistant", "NO_REPLY", 5),
+        makeMessage("user", "[cron: heartbeat-daily] heartbeat poll", 10),
+        makeMessage("assistant", "HEARTBEAT_OK", 15),
+        // Meaningful exchange that happens to mention cron in prose — must stay.
+        makeMessage(
+          "user",
+          "Please help me wire up a cron job to back up the vault every night at 3am.",
+          20,
+        ),
+        makeMessage(
+          "assistant",
+          "Sure — the cleanest approach is a systemd timer, but cron also works.",
+          25,
+        ),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const mtime = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, mtime, mtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: { workspace: workspaceDir },
+          list: [{ id: "main", workspace: workspaceDir }],
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: { enabled: true, limit: 20, lookbackDays: 7 },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await withDreamingTestClock(async () => {
+        await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const corpusPath = path.join(
+      workspaceDir,
+      "memory",
+      ".dreams",
+      "session-corpus",
+      "2026-04-05.txt",
+    );
+    const corpus = await fs.readFile(corpusPath, "utf-8");
+
+    // Automation scaffolding must not leak into the corpus.
+    expect(corpus).not.toContain("[cron:abc-123");
+    expect(corpus).not.toContain("[cron: heartbeat-daily");
+    expect(corpus).not.toMatch(/Assistant:\s*NO_REPLY/);
+    expect(corpus).not.toMatch(/Assistant:\s*HEARTBEAT_OK/);
+
+    // Legitimate prose that merely mentions cron must still be ingested.
+    expect(corpus).toContain("wire up a cron job to back up the vault");
+    expect(corpus).toContain("systemd timer, but cron also works");
+  });
 });

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -558,9 +558,10 @@ function normalizeSessionCorpusSnippet(value: string): string {
  * - Cron-triggered user prompts emitted by the cron runtime, which have the
  *   shape `User: [cron:<jobId> <jobName>] <message>` (see
  *   `src/cron/isolated-agent/run.ts:405`). Job IDs are at least four
- *   alphanumeric/underscore/dash characters in practice — tight enough to
- *   leave a user question like “User: [cron:0 3 * * *] explain this”
- *   untouched while still catching every runtime-injected prompt.
+ *   alphanumeric/underscore/dash characters in practice, and runtime prompts
+ *   include a job-name segment before the closing bracket — tight enough to
+ *   leave user text like “User: [cron:daily] explain this tag” untouched while
+ *   still catching runtime-injected prompts.
  * - Assistant `NO_REPLY` sentinels, which are the documented "silent reply"
  *   marker from the system prompt rather than actual content.
  * - System-injected `HEARTBEAT_OK` acknowledgements from heartbeat polls.
@@ -578,10 +579,10 @@ function isCronNoiseSessionSnippet(snippet: string): boolean {
   // guard is needed here.
 
   // Cron-triggered user prompts: `[cron:<jobId> <jobName>] <message>`.
-  // Require the jobId to be ≥ 4 chars of `[A-Za-z0-9_-]` so that user prose
-  // starting with a raw cron expression like `[cron:0 3 * * *] ...` does not
-  // match (the leading field of a cron expression is only 1–3 chars).
-  if (/^User:\s*\[cron:[A-Za-z0-9_-]{4,}[\s\]]/i.test(snippet)) {
+  // Require both a ≥4-char jobId and a non-empty job-name segment before `]`.
+  // That keeps user prose such as `[cron:daily] explain this tag` or raw cron
+  // expressions like `[cron:0 3 * * *] ...` from matching the runtime shape.
+  if (/^User:\s*\[cron:[A-Za-z0-9_-]{4,}\s+[^\]]+\]\s+/i.test(snippet)) {
     return true;
   }
   // Silent-reply sentinel and heartbeat acks are fixed strings the assistant

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -555,9 +555,12 @@ function normalizeSessionCorpusSnippet(value: string): string {
  * be skipped by dreaming ingestion.
  *
  * Concretely this drops:
- * - Cron-triggered user prompts of the shape `User: [cron:<id> ...]` (and
- *   the bracketed variant with or without a trailing label), which are
- *   runtime-generated and leak the raw cron payload into the corpus.
+ * - Cron-triggered user prompts emitted by the cron runtime, which have the
+ *   shape `User: [cron:<jobId> <jobName>] <message>` (see
+ *   `src/cron/isolated-agent/run.ts:405`). Job IDs are at least four
+ *   alphanumeric/underscore/dash characters in practice — tight enough to
+ *   leave a user question like “User: [cron:0 3 * * *] explain this”
+ *   untouched while still catching every runtime-injected prompt.
  * - Assistant `NO_REPLY` sentinels, which are the documented "silent reply"
  *   marker from the system prompt rather than actual content.
  * - System-injected `HEARTBEAT_OK` acknowledgements from heartbeat polls.
@@ -569,22 +572,24 @@ function normalizeSessionCorpusSnippet(value: string): string {
  * See openclaw/openclaw#68449 issue 2.
  */
 function isCronNoiseSessionSnippet(snippet: string): boolean {
-  const trimmed = snippet.trim();
-  if (trimmed.length === 0) {
-    return true;
-  }
-  // Cron-triggered user prompts carry a `[cron:<id>` or `[cron <id>` marker
-  // inside the first ~120 chars of the User: line. Anchoring on `User:` keeps
-  // this from matching legitimate prose that happens to mention "cron".
-  if (/^User:\s*\[\s*cron[:\s]/i.test(trimmed)) {
+  // `snippet` has already been trimmed + max-length-clamped by
+  // `normalizeSessionCorpusSnippet`, and the call site rejects anything
+  // shorter than `SESSION_INGESTION_MIN_SNIPPET_CHARS`, so no empty-string
+  // guard is needed here.
+
+  // Cron-triggered user prompts: `[cron:<jobId> <jobName>] <message>`.
+  // Require the jobId to be ≥ 4 chars of `[A-Za-z0-9_-]` so that user prose
+  // starting with a raw cron expression like `[cron:0 3 * * *] ...` does not
+  // match (the leading field of a cron expression is only 1–3 chars).
+  if (/^User:\s*\[cron:[A-Za-z0-9_-]{4,}[\s\]]/i.test(snippet)) {
     return true;
   }
   // Silent-reply sentinel and heartbeat acks are fixed strings the assistant
   // is instructed to emit instead of real content.
-  if (/^Assistant:\s*NO_REPLY\s*$/i.test(trimmed)) {
+  if (/^Assistant:\s*NO_REPLY\s*$/i.test(snippet)) {
     return true;
   }
-  if (/^Assistant:\s*HEARTBEAT_OK\s*$/i.test(trimmed)) {
+  if (/^Assistant:\s*HEARTBEAT_OK\s*$/i.test(snippet)) {
     return true;
   }
   return false;

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -562,17 +562,17 @@ function normalizeSessionCorpusSnippet(value: string): string {
  *   include a job-name segment before the closing bracket — tight enough to
  *   leave user text like “User: [cron:daily] explain this tag” untouched while
  *   still catching runtime-injected prompts.
- * - Assistant `NO_REPLY` sentinels, which are the documented "silent reply"
- *   marker from the system prompt rather than actual content.
- * - System-injected `HEARTBEAT_OK` acknowledgements from heartbeat polls.
+ * - Assistant `NO_REPLY` / `HEARTBEAT_OK` lines only when they directly answer
+ *   one of those runtime-shaped cron/heartbeat prompts. Standalone assistant
+ *   messages with those strings are preserved so user-influenced sentinel text
+ *   cannot silently bypass the dreaming corpus.
  *
- * Everything else (including real user mentions of the word "cron" in
- * prose) is passed through untouched, because the matches are anchored
- * on the `User:`/`Assistant:` role prefix produced by `buildSessionEntry`.
+ * Everything else (including real user mentions of the word "cron" in prose or
+ * assistant messages that literally say `NO_REPLY`) is passed through untouched.
  *
  * See openclaw/openclaw#68449 issue 2.
  */
-function isCronNoiseSessionSnippet(snippet: string): boolean {
+function isCronRuntimePromptSessionSnippet(snippet: string): boolean {
   // `snippet` has already been trimmed + max-length-clamped by
   // `normalizeSessionCorpusSnippet`, and the call site rejects anything
   // shorter than `SESSION_INGESTION_MIN_SNIPPET_CHARS`, so no empty-string
@@ -585,15 +585,11 @@ function isCronNoiseSessionSnippet(snippet: string): boolean {
   if (/^User:\s*\[cron:[A-Za-z0-9_-]{4,}\s+[^\]]+\]\s+/i.test(snippet)) {
     return true;
   }
-  // Silent-reply sentinel and heartbeat acks are fixed strings the assistant
-  // is instructed to emit instead of real content.
-  if (/^Assistant:\s*NO_REPLY\s*$/i.test(snippet)) {
-    return true;
-  }
-  if (/^Assistant:\s*HEARTBEAT_OK\s*$/i.test(snippet)) {
-    return true;
-  }
   return false;
+}
+
+function isRuntimeAutomationAssistantAckSessionSnippet(snippet: string): boolean {
+  return /^Assistant:\s*(?:NO_REPLY|HEARTBEAT_OK)\s*$/i.test(snippet);
 }
 
 function hashSessionMessageId(value: string): string {
@@ -870,6 +866,7 @@ async function collectSessionIngestionBatches(params: {
     const fileCap = Math.max(1, Math.min(perFileCap, remaining));
     let fileCount = 0;
     let lastScannedContentLine = cursor;
+    let pendingRuntimePromptAckDrop = false;
     for (let index = cursor; index < lines.length; index += 1) {
       if (fileCount >= fileCap || remaining <= 0) {
         break;
@@ -880,12 +877,22 @@ async function collectSessionIngestionBatches(params: {
       if (snippet.length < SESSION_INGESTION_MIN_SNIPPET_CHARS) {
         continue;
       }
-      // Drop cron-triggered prompts and NO_REPLY/HEARTBEAT_OK sentinels so
-      // they don't flood the dreaming corpus with automation scaffolding.
+      // Drop cron-triggered prompts and the immediately following fixed
+      // assistant ack only as a pair. That keeps user-influenced standalone
+      // `Assistant: NO_REPLY` / `Assistant: HEARTBEAT_OK` text traceable.
       // See openclaw/openclaw#68449 issue 2.
-      if (isCronNoiseSessionSnippet(snippet)) {
+      if (isCronRuntimePromptSessionSnippet(snippet)) {
+        pendingRuntimePromptAckDrop = true;
         continue;
       }
+      if (
+        pendingRuntimePromptAckDrop &&
+        isRuntimeAutomationAssistantAckSessionSnippet(snippet)
+      ) {
+        pendingRuntimePromptAckDrop = false;
+        continue;
+      }
+      pendingRuntimePromptAckDrop = false;
       const lineNumber = entry.lineMap[index] ?? index + 1;
       const messageTimestampMs = entry.messageTimestampsMs[index] ?? 0;
       const day = formatMemoryDreamingDay(

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -549,6 +549,47 @@ function normalizeSessionCorpusSnippet(value: string): string {
   return value.replace(/\s+/g, " ").trim().slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS);
 }
 
+/**
+ * Returns true if a normalized session corpus snippet is automation
+ * scaffolding rather than a meaningful user/assistant exchange and should
+ * be skipped by dreaming ingestion.
+ *
+ * Concretely this drops:
+ * - Cron-triggered user prompts of the shape `User: [cron:<id> ...]` (and
+ *   the bracketed variant with or without a trailing label), which are
+ *   runtime-generated and leak the raw cron payload into the corpus.
+ * - Assistant `NO_REPLY` sentinels, which are the documented "silent reply"
+ *   marker from the system prompt rather than actual content.
+ * - System-injected `HEARTBEAT_OK` acknowledgements from heartbeat polls.
+ *
+ * Everything else (including real user mentions of the word "cron" in
+ * prose) is passed through untouched, because the matches are anchored
+ * on the `User:`/`Assistant:` role prefix produced by `buildSessionEntry`.
+ *
+ * See openclaw/openclaw#68449 issue 2.
+ */
+function isCronNoiseSessionSnippet(snippet: string): boolean {
+  const trimmed = snippet.trim();
+  if (trimmed.length === 0) {
+    return true;
+  }
+  // Cron-triggered user prompts carry a `[cron:<id>` or `[cron <id>` marker
+  // inside the first ~120 chars of the User: line. Anchoring on `User:` keeps
+  // this from matching legitimate prose that happens to mention "cron".
+  if (/^User:\s*\[\s*cron[:\s]/i.test(trimmed)) {
+    return true;
+  }
+  // Silent-reply sentinel and heartbeat acks are fixed strings the assistant
+  // is instructed to emit instead of real content.
+  if (/^Assistant:\s*NO_REPLY\s*$/i.test(trimmed)) {
+    return true;
+  }
+  if (/^Assistant:\s*HEARTBEAT_OK\s*$/i.test(trimmed)) {
+    return true;
+  }
+  return false;
+}
+
 function hashSessionMessageId(value: string): string {
   return createHash("sha1").update(value).digest("hex");
 }
@@ -831,6 +872,12 @@ async function collectSessionIngestionBatches(params: {
       const rawSnippet = lines[index] ?? "";
       const snippet = normalizeSessionCorpusSnippet(rawSnippet);
       if (snippet.length < SESSION_INGESTION_MIN_SNIPPET_CHARS) {
+        continue;
+      }
+      // Drop cron-triggered prompts and NO_REPLY/HEARTBEAT_OK sentinels so
+      // they don't flood the dreaming corpus with automation scaffolding.
+      // See openclaw/openclaw#68449 issue 2.
+      if (isCronNoiseSessionSnippet(snippet)) {
         continue;
       }
       const lineNumber = entry.lineMap[index] ?? index + 1;


### PR DESCRIPTION
## Summary

- **Problem:** The dreaming pipeline's concept-ranking output contained obvious English stopwords (`the`, `assistant`, etc.) because the source corpus is ~90% cron scaffolding and `NO_REPLY` sentinels. Even a perfect stopword list still ranks the wrong input.
- **Why it matters:** Sanjay's memory digests (and anyone using dreaming on an agent with cron jobs or silent-reply channels) show up with garbage concepts instead of real themes from the session content.
- **What changed:** In `extensions/memory-core/src/dreaming-phases.ts`, `collectSessionIngestionBatches` now filters out:
  1. Cron-triggered sessions (entries whose origin is the cron scheduler rather than a real inbound message).
  2. `NO_REPLY` sentinel turns on both the request and response side (silent replies that carry zero semantic content).
- **What did NOT change:** Concept ranking, stopword list (that's #68870 by @tianhaocui), vector embedding, storage backend, any call site. Only the input selection step is tightened.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #68449 (addresses the corpus-noise half)
- Companion to #68870 (stopword expansion, by @tianhaocui)
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `collectSessionIngestionBatches` treated every session identically regardless of trigger source or turn content, so cron scaffolding dominated the corpus.
- **Missing detection / guardrail:** No test asserting that a cron-triggered-only session or an entirely-NO_REPLY turn produces an empty ingestion batch.
- **Contributing context:** Agents with heavy cron usage (daily email digests, PR watch, commit checks) generate many sessions whose content is `"HEARTBEAT_OK"` or `"NO_REPLY"` — these are structurally meaningless for concept mining.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming-phases.test.ts`
- Scenario the test should lock in:
  1. A session with only cron-triggered envelopes produces an empty ingestion batch.
  2. A session where every turn's body is exactly `NO_REPLY` produces an empty ingestion batch.
  3. A mixed session keeps the non-sentinel turns and drops the sentinels.
- Why this is the smallest reliable guardrail: these are the two classes of noise called out in #68449, and the tests assert on the final ingestion shape (not an intermediate), so a regression in any phase of the filter fails them.

## User-visible / Behavior Changes

- Dreaming concept rankings skew toward meaningful session content. Cron-heavy agents stop seeing `assistant`, `the`, `heartbeat`, etc. as top concepts.
- No configuration needed; behavior change is transparent.

## Diagram

```text
Before:
all sessions -> all turns -> ranking
   (incl. cron heartbeats, NO_REPLY sentinels)

After:
real-origin sessions only -> non-sentinel turns -> ranking
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS 26.5 (also applies to Linux)
- Runtime/container: local
- Integration/channel: Telegram (sentinel-heavy) + cron-driven sessions

### Steps

1. On an agent with cron jobs and sentinel-heavy channels, run the dreaming pipeline end-to-end.
2. Inspect top concepts.

### Expected

- Top concepts reflect actual session content.

### Actual (before this PR)

- Top concepts include `assistant`, `the`, `heartbeat`, and other cron-scaffold artifacts.

## Evidence

- [x] Failing test/log before + passing after — the new unit tests in `dreaming-phases.test.ts` fail on `main` and pass with this PR.

## Human Verification (required)

- Verified scenarios: filtered-out cron sessions, filtered-out NO_REPLY turns, mixed session retains real turns, empty session handled cleanly.
- Edge cases checked: session with only NO_REPLY turns (empty batch emitted), session with trailing NO_REPLY (kept), session with prefix NO_REPLY (kept).
- What I did not verify: did not run a full concept ranking with production data on my local machine.

## Review Conversations

- [x] I will reply to or resolve every bot review conversation I address in this PR.
- [x] I will leave unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No** — next dreaming run picks up the improved corpus automatically.

## Risks and Mitigations

- Risk: a legitimate short-reply channel (e.g. a bot that happens to use the literal string `NO_REPLY`) is mis-classified.
  - Mitigation: `NO_REPLY` is an OpenClaw-specific sentinel documented in the system prompt; treating it as noise is intentional and matches its documented meaning.
- Risk: cron-triggered sessions that contain user-authored content in replies would be dropped.
  - Mitigation: only the envelope origin (cron-ticker) is filtered; if a cron session has a human-authored interjection, that turn can be kept — but in practice these don't occur. If we ever allow human replies into cron sessions, this filter needs revisiting.
