### PR TITLE
[codex] Optimize gateway session listing before full row construction

### DIFF
--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
@@ -185,6 +185,27 @@ describe("listSessionsFromStore search", () => {
       expect(result.sessions).toHaveLength(1);
       expect(result.sessions[0].key).toBe(testCase.expectedKey);
     }
+  });
+
+  test("matches search against derived group display names", () => {
+    const result = listSessionsFromStore({
+      cfg: baseCfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:slack:group:eng": {
+          sessionId: "sess-slack-1",
+          updatedAt: Date.now(),
+          channel: "slack",
+          groupChannel: "eng",
+          space: "acme",
+        } as SessionEntry,
+      },
+      opts: { search: "acme#eng" },
+    });
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]?.displayName).toBe("slack:acme#eng");
+    expect(result.sessions[0]?.key).toBe("agent:main:slack:group:eng");
   });
 
   test("hides cron run alias session keys from sessions list", () => {
@@ -469,6 +490,83 @@ describe("listSessionsFromStore search", () => {
         expect(result.sessions[0]?.estimatedCostUsd).toBeCloseTo(0.007725, 8);
       },
     });
+  });
+
+  test("applies limit before transcript fallback row construction", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-utils-limit-"));
+    const storePath = path.join(tmpDir, "sessions.json");
+    const now = Date.now();
+    const sessions = [
+      { sessionId: "sess-newer", updatedAt: now, totalTokens: 321 },
+      { sessionId: "sess-older", updatedAt: now - 1_000, totalTokens: 654 },
+    ] as const;
+
+    for (const session of sessions) {
+      fs.writeFileSync(
+        path.join(tmpDir, `${session.sessionId}.jsonl`),
+        [
+          JSON.stringify({ type: "session", version: 1, id: session.sessionId }),
+          JSON.stringify({
+            message: {
+              role: "assistant",
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+              usage: {
+                input: session.totalTokens,
+              },
+            },
+          }),
+        ].join("\n"),
+        "utf-8",
+      );
+    }
+
+    const readFileSyncSpy = vi.spyOn(fs, "readFileSync");
+    try {
+      const result = listSessionsFromStore({
+        cfg: baseCfg,
+        storePath,
+        store: {
+          "agent:main:newer": {
+            sessionId: "sess-newer",
+            updatedAt: now,
+            modelProvider: "anthropic",
+            model: "claude-sonnet-4-6",
+            totalTokens: 0,
+            totalTokensFresh: false,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          } as SessionEntry,
+          "agent:main:older": {
+            sessionId: "sess-older",
+            updatedAt: now - 1_000,
+            modelProvider: "anthropic",
+            model: "claude-sonnet-4-6",
+            totalTokens: 0,
+            totalTokensFresh: false,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          } as SessionEntry,
+        },
+        opts: { limit: 1 },
+      });
+
+      const transcriptReads = readFileSyncSpy.mock.calls.filter(
+        ([target, encoding]) => typeof target === "number" && encoding === "utf-8",
+      );
+
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0]?.key).toBe("agent:main:newer");
+      expect(result.sessions[0]?.totalTokens).toBe(321);
+      expect(transcriptReads).toHaveLength(1);
+    } finally {
+      readFileSyncSpy.mockRestore();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   test("uses subagent run model immediately for child sessions while transcript usage fills live totals", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -24,6 +24,9 @@ import {
   listSubagentRunsForController,
   resolveSubagentSessionStatus,
 } from "../agents/subagent-registry-read.js";
+import { subagentRuns } from "../agents/subagent-registry-memory.js";
+import { getSubagentRunsSnapshotForRead } from "../agents/subagent-registry-state.js";
+import type { SubagentRunRecord } from "../agents/subagent-registry.types.js";
 import { loadConfig } from "../config/config.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -326,6 +329,156 @@ function resolveChildSessionKeys(
   }
   const childSessions = Array.from(childSessionKeys);
   return childSessions.length > 0 ? childSessions : undefined;
+}
+
+function resolveSubagentControllerSessionKey(
+  run: Pick<SubagentRunRecord, "controllerSessionKey" | "requesterSessionKey"> | null | undefined,
+): string | undefined {
+  return (
+    normalizeOptionalString(run?.controllerSessionKey) ||
+    normalizeOptionalString(run?.requesterSessionKey) ||
+    undefined
+  );
+}
+
+function buildDisplaySubagentRunIndex(): ReadonlyMap<string, SubagentRunRecord> {
+  const inMemoryActive = new Map<string, SubagentRunRecord>();
+  const inMemoryEnded = new Map<string, SubagentRunRecord>();
+  for (const entry of subagentRuns.values()) {
+    const childSessionKey = normalizeOptionalString(entry.childSessionKey);
+    if (!childSessionKey) {
+      continue;
+    }
+    if (typeof entry.endedAt === "number") {
+      const previous = inMemoryEnded.get(childSessionKey);
+      if (!previous || entry.createdAt > previous.createdAt) {
+        inMemoryEnded.set(childSessionKey, entry);
+      }
+      continue;
+    }
+    const previous = inMemoryActive.get(childSessionKey);
+    if (!previous || entry.createdAt > previous.createdAt) {
+      inMemoryActive.set(childSessionKey, entry);
+    }
+  }
+
+  const fallbackActive = new Map<string, SubagentRunRecord>();
+  const fallbackEnded = new Map<string, SubagentRunRecord>();
+  for (const entry of getSubagentRunsSnapshotForRead(subagentRuns).values()) {
+    const childSessionKey = normalizeOptionalString(entry.childSessionKey);
+    if (!childSessionKey || inMemoryActive.has(childSessionKey) || inMemoryEnded.has(childSessionKey)) {
+      continue;
+    }
+    if (typeof entry.endedAt === "number") {
+      const previous = fallbackEnded.get(childSessionKey);
+      if (!previous || entry.createdAt > previous.createdAt) {
+        fallbackEnded.set(childSessionKey, entry);
+      }
+      continue;
+    }
+    const previous = fallbackActive.get(childSessionKey);
+    if (!previous || entry.createdAt > previous.createdAt) {
+      fallbackActive.set(childSessionKey, entry);
+    }
+  }
+
+  const latestDisplayRuns = new Map<string, SubagentRunRecord>();
+  for (const childSessionKey of new Set([...inMemoryActive.keys(), ...inMemoryEnded.keys()])) {
+    const active = inMemoryActive.get(childSessionKey);
+    const ended = inMemoryEnded.get(childSessionKey);
+    if (ended && (!active || ended.createdAt > active.createdAt)) {
+      latestDisplayRuns.set(childSessionKey, ended);
+      continue;
+    }
+    if (active) {
+      latestDisplayRuns.set(childSessionKey, active);
+    }
+  }
+
+  for (const childSessionKey of new Set([...fallbackActive.keys(), ...fallbackEnded.keys()])) {
+    const active = fallbackActive.get(childSessionKey);
+    const ended = fallbackEnded.get(childSessionKey);
+    if (active) {
+      latestDisplayRuns.set(childSessionKey, active);
+      continue;
+    }
+    if (ended) {
+      latestDisplayRuns.set(childSessionKey, ended);
+    }
+  }
+  return latestDisplayRuns;
+}
+
+function appendChildSessionKey(
+  index: Map<string, Set<string>>,
+  controllerSessionKey: string | undefined,
+  childSessionKey: string,
+): void {
+  const controllerKey = normalizeOptionalString(controllerSessionKey);
+  if (!controllerKey) {
+    return;
+  }
+  const childSet = index.get(controllerKey);
+  if (childSet) {
+    childSet.add(childSessionKey);
+    return;
+  }
+  index.set(controllerKey, new Set([childSessionKey]));
+}
+
+function buildChildSessionIndex(params: {
+  store: Record<string, SessionEntry>;
+  displaySubagentRunsByChildSessionKey: ReadonlyMap<string, SubagentRunRecord>;
+}): ReadonlyMap<string, string[]> {
+  const index = new Map<string, Set<string>>();
+
+  for (const [childSessionKey, run] of params.displaySubagentRunsByChildSessionKey.entries()) {
+    appendChildSessionKey(index, resolveSubagentControllerSessionKey(run), childSessionKey);
+  }
+
+  for (const [key, entry] of Object.entries(params.store)) {
+    if (!entry) {
+      continue;
+    }
+    if (params.displaySubagentRunsByChildSessionKey.has(key)) {
+      continue;
+    }
+    appendChildSessionKey(index, normalizeOptionalString(entry.spawnedBy), key);
+    appendChildSessionKey(index, normalizeOptionalString(entry.parentSessionKey), key);
+  }
+
+  const finalized = new Map<string, string[]>();
+  for (const [controllerSessionKey, childSessionKeys] of index.entries()) {
+    if (childSessionKeys.size > 0) {
+      finalized.set(controllerSessionKey, Array.from(childSessionKeys));
+    }
+  }
+  return finalized;
+}
+
+function resolveGatewaySessionDisplayName(key: string, entry?: SessionEntry): string | undefined {
+  const parsed = parseGroupKey(key);
+  const channel = entry?.channel ?? parsed?.channel;
+  const subject = entry?.subject;
+  const groupChannel = entry?.groupChannel;
+  const space = entry?.space;
+  const id = parsed?.id;
+  const originLabel = entry?.origin?.label;
+  return (
+    entry?.displayName ??
+    (channel
+      ? buildGroupDisplayName({
+          provider: channel,
+          subject,
+          groupChannel,
+          space,
+          id,
+          key,
+        })
+      : undefined) ??
+    entry?.label ??
+    originLabel
+  );
 }
 
 function resolveTranscriptUsageFallback(params: {
@@ -1118,6 +1271,8 @@ export function buildGatewaySessionRow(params: {
   now?: number;
   includeDerivedTitles?: boolean;
   includeLastMessage?: boolean;
+  childSessionKeysByController?: ReadonlyMap<string, string[]>;
+  displaySubagentRunsByChildSessionKey?: ReadonlyMap<string, SubagentRunRecord>;
 }): GatewaySessionRow {
   const { cfg, storePath, store, key, entry } = params;
   const now = params.now ?? Date.now();
@@ -1127,30 +1282,16 @@ export function buildGatewaySessionRow(params: {
   const subject = entry?.subject;
   const groupChannel = entry?.groupChannel;
   const space = entry?.space;
-  const id = parsed?.id;
   const origin = entry?.origin;
-  const originLabel = origin?.label;
-  const displayName =
-    entry?.displayName ??
-    (channel
-      ? buildGroupDisplayName({
-          provider: channel,
-          subject,
-          groupChannel,
-          space,
-          id,
-          key,
-        })
-      : undefined) ??
-    entry?.label ??
-    originLabel;
+  const displayName = resolveGatewaySessionDisplayName(key, entry);
   const deliveryFields = normalizeSessionDeliveryFields(entry);
   const parsedAgent = parseAgentSessionKey(key);
   const sessionAgentId = normalizeAgentId(parsedAgent?.agentId ?? resolveDefaultAgentId(cfg));
-  const subagentRun = getSessionDisplaySubagentRunByChildSessionKey(key);
+  const subagentRun =
+    params.displaySubagentRunsByChildSessionKey?.get(key) ??
+    getSessionDisplaySubagentRunByChildSessionKey(key);
   const subagentOwner =
-    normalizeOptionalString(subagentRun?.controllerSessionKey) ||
-    normalizeOptionalString(subagentRun?.requesterSessionKey);
+    resolveSubagentControllerSessionKey(subagentRun);
   const subagentStatus = subagentRun ? resolveSubagentSessionStatus(subagentRun) : undefined;
   const subagentStartedAt = subagentRun ? getSubagentSessionStartedAt(subagentRun) : undefined;
   const subagentEndedAt = subagentRun ? subagentRun.endedAt : undefined;
@@ -1211,7 +1352,8 @@ export function buildGatewaySessionRow(params: {
     typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0
       ? true
       : transcriptUsage?.totalTokensFresh === true;
-  const childSessions = resolveChildSessionKeys(key, store);
+  const childSessions =
+    params.childSessionKeysByController?.get(key) ?? resolveChildSessionKeys(key, store);
   const latestCompactionCheckpoint = resolveLatestCompactionCheckpoint(entry);
   const estimatedCostUsd =
     resolveEstimatedSessionCostUsd({
@@ -1346,8 +1488,36 @@ export function listSessionsFromStore(params: {
     typeof opts.activeMinutes === "number" && Number.isFinite(opts.activeMinutes)
       ? Math.max(1, Math.floor(opts.activeMinutes))
       : undefined;
+  const displaySubagentRunsByChildSessionKey = buildDisplaySubagentRunIndex();
+  const childSessionKeysByController = buildChildSessionIndex({
+    store,
+    displaySubagentRunsByChildSessionKey,
+  });
+  const matchesSearch = (key: string, entry?: SessionEntry): boolean => {
+    if (!search) {
+      return true;
+    }
+    const fields = [
+      resolveGatewaySessionDisplayName(key, entry),
+      entry?.label,
+      entry?.subject,
+      entry?.sessionId,
+      key,
+    ];
+    return fields.some(
+      (field) =>
+        typeof field === "string" && normalizeLowercaseStringOrEmpty(field).includes(search),
+    );
+  };
+  const isWithinActiveWindow = (entry?: SessionEntry): boolean => {
+    if (activeMinutes === undefined) {
+      return true;
+    }
+    const cutoff = now - activeMinutes * 60_000;
+    return (entry?.updatedAt ?? 0) >= cutoff;
+  };
 
-  let sessions = Object.entries(store)
+  let sessionEntries = Object.entries(store)
     .filter(([key]) => {
       if (isCronRunSessionKey(key)) {
         return false;
@@ -1377,11 +1547,9 @@ export function listSessionsFromStore(params: {
       if (key === "unknown" || key === "global") {
         return false;
       }
-      const latest = getSessionDisplaySubagentRunByChildSessionKey(key);
+      const latest = displaySubagentRunsByChildSessionKey.get(key);
       if (latest) {
-        const latestControllerSessionKey =
-          normalizeOptionalString(latest.controllerSessionKey) ||
-          normalizeOptionalString(latest.requesterSessionKey);
+        const latestControllerSessionKey = resolveSubagentControllerSessionKey(latest);
         return latestControllerSessionKey === spawnedBy;
       }
       return entry?.spawnedBy === spawnedBy || entry?.parentSessionKey === spawnedBy;
@@ -1392,7 +1560,16 @@ export function listSessionsFromStore(params: {
       }
       return entry?.label === label;
     })
-    .map(([key, entry]) =>
+    .filter(([key, entry]) => matchesSearch(key, entry))
+    .filter(([, entry]) => isWithinActiveWindow(entry))
+    .toSorted(([, a], [, b]) => (b?.updatedAt ?? 0) - (a?.updatedAt ?? 0));
+
+  if (typeof opts.limit === "number" && Number.isFinite(opts.limit)) {
+    const limit = Math.max(1, Math.floor(opts.limit));
+    sessionEntries = sessionEntries.slice(0, limit);
+  }
+
+  const sessions = sessionEntries.map(([key, entry]) =>
       buildGatewaySessionRow({
         cfg,
         storePath,
@@ -1402,28 +1579,10 @@ export function listSessionsFromStore(params: {
         now,
         includeDerivedTitles,
         includeLastMessage,
+        childSessionKeysByController,
+        displaySubagentRunsByChildSessionKey,
       }),
-    )
-    .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
-
-  if (search) {
-    sessions = sessions.filter((s) => {
-      const fields = [s.displayName, s.label, s.subject, s.sessionId, s.key];
-      return fields.some(
-        (f) => typeof f === "string" && normalizeLowercaseStringOrEmpty(f).includes(search),
-      );
-    });
-  }
-
-  if (activeMinutes !== undefined) {
-    const cutoff = now - activeMinutes * 60_000;
-    sessions = sessions.filter((s) => (s.updatedAt ?? 0) >= cutoff);
-  }
-
-  if (typeof opts.limit === "number" && Number.isFinite(opts.limit)) {
-    const limit = Math.max(1, Math.floor(opts.limit));
-    sessions = sessions.slice(0, limit);
-  }
+    );
 
   return {
     ts: now,


### PR DESCRIPTION
## Summary

This PR tightens the `sessions.list` hot path in `src/gateway/session-utils.ts`.

It moves cheap filter / sort / limit work ahead of full row construction and replaces per-row child-session scans with a per-request child index.

## Why

`#57715` points out three main problems in the current path:

- full row build happens before `limit`
- transcript fallback work can still happen for rows that will never be returned
- child session resolution repeatedly scans the full store

This change focuses on the first two lower-risk structural wins:

- pre-filter / pre-sort / pre-limit before full row build
- pre-index child session relationships once per request

I intentionally did not include a TTL cache in this PR so the first patch stays easier to review.

## What Changed

1. `listSessionsFromStore()` now performs cheap eligibility filtering, search matching, active-window filtering, sorting, and limit slicing before building `GatewaySessionRow` objects.
2. display subagent runs are indexed once per request and reused.
3. child sessions are indexed once per request and reused during row construction.
4. search behavior remains compatible with derived group display names.
5. regression coverage was added for:
   - searching by a derived group display name
   - applying `limit` before transcript fallback row construction

## Validation

- passed:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/session-utils.search.test.ts src/gateway/session-utils.subagent.test.ts`
- local Windows benchmark on my current store (`81` total sessions, `78` on main, `agents/main/sessions` ~`186.8 MB`):
  - `sessions --json`: `35106.2 ms` -> `34581.4 ms` (`-1.5%`)
  - `status --json`: `10577.0 ms` -> `10268.2 ms` (`-2.9%`)

## Notes

- The local end-to-end gain is modest on this dataset, so I do not want to oversell it.
- The stronger part of this PR is that it removes obviously unnecessary work by construction, and the absolute benefit should grow with larger stores.
- If this direction looks good, a follow-up PR could explore a short TTL cache on top of the same path.
