### PR TITLE
fix(cron): split --tools on whitespace in addition to commas (Windows/PowerShell)

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -153,7 +153,7 @@ export function registerCronAddCommand(cron: Command) {
               toolsAllow:
                 typeof opts.tools === "string" && opts.tools.trim()
                   ? opts.tools
-                      .split(",")
+                      .split(/[,\s]+/)
                       .map((t: string) => normalizeOptionalString(t))
                       .filter((t): t is string => Boolean(t))
                   : undefined,

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -219,7 +219,7 @@ export function registerCronEditCommand(cron: Command) {
               payload.toolsAllow = null;
             } else if (typeof opts.tools === "string" && opts.tools.trim()) {
               payload.toolsAllow = opts.tools
-                .split(",")
+                .split(/[,\s]+/)
                 .map((t: string) => t.trim())
                 .filter(Boolean);
             }


### PR DESCRIPTION
## Summary

On Windows PowerShell, an unquoted `--tools exec,read,write` is parsed by the shell as three separate arguments and reaches Node/Commander as a single space-joined string `"exec read write"`. Splitting only on commas produces one element `["exec read write"]` instead of the intended `["exec", "read", "write"]`.

## Changes

- **`register.cron-add.ts`**: Change `.split(",")` → `.split(/[,\s]+/)`
- **`register.cron-edit.ts`**: Same change

The regex `/[,\s]+/` splits on one or more commas or whitespace characters, so both:
- Comma-separated (Unix/quoted): `"exec,read,write"` → `["exec", "read", "write"]` ✅
- Space-separated (PowerShell/unquoted): `"exec read write"` → `["exec", "read", "write"]` ✅
- Mixed: `"exec, read, write"` → `["exec", "read", "write"]` ✅

The existing `.filter(Boolean)` / `.filter((t): t is string => Boolean(t))` already handles any empty strings from consecutive delimiters.

## Impact

Minimal — only affects the CLI `--tools` option parsing in `cron add` and `cron edit`. No behavioral change for callers that already quoted the value correctly.

Fixes #68826