### PR TITLE
fix(gateway): cap and prune costUsageCache to prevent unbounded growth

### DIFF
--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -49,6 +49,7 @@ import {
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
+const MAX_COST_USAGE_CACHE_ENTRIES = 100;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 type DateRange = { startMs: number; endMs: number };
@@ -63,6 +64,28 @@ type CostUsageCacheEntry = {
 };
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
+
+/** Evict stale (TTL-expired, non-in-flight) entries, then FIFO-evict oldest if over cap. */
+function pruneCostUsageCache(now: number): void {
+  // 1. Prune TTL-expired entries that have no in-flight promise.
+  for (const [key, entry] of costUsageCache) {
+    if (
+      !entry.inFlight &&
+      entry.updatedAt !== undefined &&
+      now - entry.updatedAt >= COST_USAGE_CACHE_TTL_MS
+    ) {
+      costUsageCache.delete(key);
+    }
+  }
+  // 2. FIFO evict oldest if still over cap.
+  while (costUsageCache.size > MAX_COST_USAGE_CACHE_ENTRIES) {
+    const oldestKey = costUsageCache.keys().next().value;
+    if (typeof oldestKey !== "string" || !oldestKey) {
+      break;
+    }
+    costUsageCache.delete(oldestKey);
+  }
+}
 
 function resolveSessionUsageFileOrRespond(
   key: string,
@@ -326,6 +349,7 @@ async function loadCostUsageSummaryCached(params: {
   })
     .then((summary) => {
       costUsageCache.set(cacheKey, { summary, updatedAt: Date.now() });
+      pruneCostUsageCache(Date.now());
       return summary;
     })
     .catch((err) => {
@@ -363,6 +387,7 @@ export const __test = {
   discoverAllSessionsForUsage,
   loadCostUsageSummaryCached,
   costUsageCache,
+  pruneCostUsageCache,
 };
 
 export type { SessionUsageEntry, SessionsUsageAggregates, SessionsUsageResult };


### PR DESCRIPTION
## Summary

`costUsageCache` in `usage.ts` stores `CostUsageSummary` results keyed by `(startMs, endMs)`. The 30s TTL only causes stale reads to be ignored on the read path — it never deletes entries from the Map. Each day a new `todayStartMs` produces a new cache key, so entries accumulate indefinitely on long-running gateway processes.

Unlike the other module-level caches in the same codebase (`sessionTitleFieldsCache` with FIFO evict, `resolvedSessionKeyByRunId` with oldest-first evict), `costUsageCache` has no cap or prune mechanism.

## Changes

- Add `MAX_COST_USAGE_CACHE_ENTRIES = 100` constant
- Add `pruneCostUsageCache(now)` helper with two phases:
  1. **TTL prune**: Remove entries where `updatedAt` is past TTL and no `inFlight` promise is active
  2. **FIFO evict**: Delete oldest entries (Map insertion order) when size exceeds cap
- Call `pruneCostUsageCache` after each successful summary load (the `.then()` callback)
- Expose `pruneCostUsageCache` via `__test` for unit testing

## Impact

- Bounds the cache to at most 100 entries (generous headroom for any realistic usage pattern)
- Follows the same eviction pattern as `sessionTitleFieldsCache` and `resolvedSessionKeyByRunId` in the same codebase
- No behavioral change for the read path — TTL semantics are preserved
- Single file change, zero risk to existing functionality

Fixes #68841