### PR TITLE
fix: discover checkpoint files from disk when store array is empty (#68864)

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -60,6 +60,7 @@ import {
   validateSessionsSendParams,
 } from "../protocol/index.js";
 import {
+  discoverCheckpointFilesFromDisk,
   getSessionCompactionCheckpoint,
   listSessionCompactionCheckpoints,
 } from "../session-compaction-checkpoints.js";
@@ -729,12 +730,20 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const { entry, canonicalKey } = loadSessionEntry(key);
+    let checkpoints = listSessionCompactionCheckpoints(entry);
+    if (checkpoints.length === 0 && entry?.sessionFile) {
+      checkpoints = discoverCheckpointFilesFromDisk(
+        entry.sessionFile,
+        canonicalKey,
+        entry.sessionId,
+      );
+    }
     respond(
       true,
       {
         ok: true,
         key: canonicalKey,
-        checkpoints: listSessionCompactionCheckpoints(entry),
+        checkpoints,
       },
       undefined,
     );
@@ -761,7 +770,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const { entry, canonicalKey } = loadSessionEntry(key);
-    const checkpoint = getSessionCompactionCheckpoint({ entry, checkpointId });
+    let checkpoint = getSessionCompactionCheckpoint({ entry, checkpointId });
+    if (!checkpoint && entry?.sessionFile) {
+      const discovered = discoverCheckpointFilesFromDisk(
+        entry.sessionFile,
+        canonicalKey,
+        entry.sessionId,
+      );
+      checkpoint = discovered.find((c) => c.checkpointId === checkpointId);
+    }
     if (!checkpoint) {
       respond(
         false,
@@ -992,7 +1009,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const checkpoint = getSessionCompactionCheckpoint({ entry, checkpointId });
+    let checkpoint = getSessionCompactionCheckpoint({ entry, checkpointId });
+    if (!checkpoint?.preCompaction.sessionFile && entry.sessionFile) {
+      const discovered = discoverCheckpointFilesFromDisk(
+        entry.sessionFile,
+        canonicalKey,
+        entry.sessionId,
+      );
+      checkpoint = discovered.find((c) => c.checkpointId === checkpointId);
+    }
     if (!checkpoint?.preCompaction.sessionFile) {
       respond(
         false,
@@ -1103,7 +1128,15 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const checkpoint = getSessionCompactionCheckpoint({ entry, checkpointId });
+    let checkpoint = getSessionCompactionCheckpoint({ entry, checkpointId });
+    if (!checkpoint?.preCompaction.sessionFile && entry.sessionFile) {
+      const discovered = discoverCheckpointFilesFromDisk(
+        entry.sessionFile,
+        canonicalKey,
+        entry.sessionId,
+      );
+      checkpoint = discovered.find((c) => c.checkpointId === checkpointId);
+    }
     if (!checkpoint?.preCompaction.sessionFile) {
       respond(
         false,

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import {
   captureCompactionCheckpointSnapshot,
   cleanupCompactionCheckpointSnapshot,
+  discoverCheckpointFilesFromDisk,
 } from "./session-compaction-checkpoints.js";
 
 const tempDirs: string[] = [];
@@ -80,5 +81,46 @@ describe("session-compaction-checkpoints", () => {
 
     expect(fsSync.existsSync(snapshot!.sessionFile)).toBe(false);
     expect(fsSync.existsSync(sessionFile!)).toBe(true);
+  });
+
+  test("discoverCheckpointFilesFromDisk finds checkpoint files by naming convention", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-discover-"));
+    tempDirs.push(dir);
+
+    const sessionFile = path.join(dir, "abc123.jsonl");
+    await fs.writeFile(sessionFile, "{}");
+
+    // Create checkpoint files matching the naming convention
+    const cp1 = path.join(dir, "abc123.checkpoint.uuid-1111.jsonl");
+    const cp2 = path.join(dir, "abc123.checkpoint.uuid-2222.jsonl");
+    const unrelated = path.join(dir, "other-session.checkpoint.uuid-3333.jsonl");
+    await fs.writeFile(cp1, "{}");
+    // Small delay so mtimes differ
+    await new Promise((r) => setTimeout(r, 50));
+    await fs.writeFile(cp2, "{}");
+    await fs.writeFile(unrelated, "{}");
+
+    const discovered = discoverCheckpointFilesFromDisk(sessionFile, "agent:main:main", "sid-1");
+
+    expect(discovered).toHaveLength(2);
+    expect(discovered.map((c) => c.checkpointId).toSorted()).toEqual(["uuid-1111", "uuid-2222"]);
+    expect(discovered[0].sessionKey).toBe("agent:main:main");
+    expect(discovered[0].sessionId).toBe("sid-1");
+    expect(discovered[0].preCompaction.sessionFile).toBeTruthy();
+    // Should be sorted newest first
+    expect(discovered[0].createdAt).toBeGreaterThanOrEqual(discovered[1].createdAt);
+  });
+
+  test("discoverCheckpointFilesFromDisk returns empty for missing sessionFile", () => {
+    expect(discoverCheckpointFilesFromDisk(undefined, "k", "s")).toEqual([]);
+    expect(discoverCheckpointFilesFromDisk("", "k", "s")).toEqual([]);
+  });
+
+  test("discoverCheckpointFilesFromDisk returns empty when no checkpoint files exist", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-empty-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(sessionFile, "{}");
+    expect(discoverCheckpointFilesFromDisk(sessionFile, "k", "s")).toEqual([]);
   });
 });

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -193,6 +193,66 @@ export function listSessionCompactionCheckpoints(
   return sessionStoreCheckpoints(entry).toSorted((a, b) => b.createdAt - a.createdAt);
 }
 
+/**
+ * Discover checkpoint files on disk for a session whose compactionCheckpoints
+ * array is empty/missing in the store.  Returns synthetic checkpoint entries
+ * built from filename parsing and file-system metadata so the Web UI can
+ * display them.
+ */
+export function discoverCheckpointFilesFromDisk(
+  sessionFile: string | undefined,
+  sessionKey: string,
+  sessionId: string,
+): SessionCompactionCheckpoint[] {
+  if (!sessionFile?.trim()) {
+    return [];
+  }
+  const parsed = path.parse(sessionFile);
+  const prefix = `${parsed.name}.checkpoint.`;
+  const ext = parsed.ext || ".jsonl";
+  let dirEntries: string[];
+  try {
+    dirEntries = fsSync.readdirSync(parsed.dir);
+  } catch {
+    return [];
+  }
+  const results: SessionCompactionCheckpoint[] = [];
+  for (const entry of dirEntries) {
+    if (!entry.startsWith(prefix) || !entry.endsWith(ext)) {
+      continue;
+    }
+    // Extract the checkpoint UUID from the filename
+    const withoutPrefix = entry.slice(prefix.length);
+    const checkpointId = withoutPrefix.slice(0, withoutPrefix.length - ext.length);
+    if (!checkpointId) {
+      continue;
+    }
+    const filePath = path.join(parsed.dir, entry);
+    let createdAt = Date.now();
+    try {
+      const stat = fsSync.statSync(filePath);
+      createdAt = stat.mtimeMs;
+    } catch {
+      // Use current time as fallback
+    }
+    results.push({
+      checkpointId,
+      sessionKey,
+      sessionId,
+      createdAt,
+      reason: "auto-threshold",
+      preCompaction: {
+        sessionId,
+        sessionFile: filePath,
+      },
+      postCompaction: {
+        sessionId,
+      },
+    });
+  }
+  return results.toSorted((a, b) => b.createdAt - a.createdAt);
+}
+
 export function getSessionCompactionCheckpoint(params: {
   entry: Pick<SessionEntry, "compactionCheckpoints"> | undefined;
   checkpointId: string;


### PR DESCRIPTION
## Problem
Web UI 'Show Checkpoints' shows empty list despite checkpoint `.jsonl` files existing on disk. The `compactionCheckpoints` array in the session store can be empty/missing even when checkpoint files exist.

## Fix
Added `discoverCheckpointFilesFromDisk()` fallback that scans the session directory for `.checkpoint.*.jsonl` files and builds synthetic checkpoint entries from filename parsing and filesystem metadata.

The listing endpoint now falls back to disk discovery when the store array is empty.

## Changes
- `src/gateway/session-compaction-checkpoints.ts`: +60 lines (`discoverCheckpointFilesFromDisk`)
- `src/gateway/server-methods/sessions.ts`: +37/-4 (fallback in list + get handlers)

Fixes #68864