### PR TITLE
tasks: extract detached task lifecycle runtime

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -10,7 +10,7 @@ import {
   completeTaskRunByRunId,
   failTaskRunByRunId,
   startTaskRunByRunId,
-} from "../../tasks/task-executor.js";
+} from "../../tasks/detached-task-runtime.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
 import {
   AcpRuntimeError,

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -8,7 +8,7 @@ import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import { normalizeAssistantPhase } from "../shared/chat-message-content.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
-import { recordTaskRunProgressByRunId } from "../tasks/task-executor.js";
+import { recordTaskRunProgressByRunId } from "../tasks/detached-task-runtime.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -122,7 +122,7 @@ vi.mock("../infra/heartbeat-wake.js", () => ({
   areHeartbeatsEnabled: hoisted.areHeartbeatsEnabledMock,
 }));
 
-vi.mock("../tasks/task-executor.js", () => ({
+vi.mock("../tasks/detached-task-runtime.js", () => ({
   createRunningTaskRun: hoisted.createRunningTaskRunMock,
 }));
 

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -59,7 +59,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
-import { createRunningTaskRun } from "../tasks/task-executor.js";
+import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
 import {
   deliveryContextFromSession,
   formatConversationTarget,

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
@@ -307,7 +307,7 @@ vi.mock("../config/sessions.js", () => ({
   },
 }));
 
-vi.mock("../tasks/task-executor.js", () => ({
+vi.mock("../tasks/detached-task-runtime.js", () => ({
   completeTaskRunByRunId: vi.fn(),
   createRunningTaskRun: vi.fn(),
   failTaskRunByRunId: vi.fn(),

--- a/src/agents/pi-embedded-runner/context-engine-maintenance.ts
+++ b/src/agents/pi-embedded-runner/context-engine-maintenance.ts
@@ -15,7 +15,7 @@ import {
   recordTaskRunProgressByRunId,
   setDetachedTaskDeliveryStatusByRunId,
   startTaskRunByRunId,
-} from "../../tasks/task-executor.js";
+} from "../../tasks/detached-task-runtime.js";
 import {
   cancelTaskByIdForOwner,
   findTaskByRunIdForOwner,

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -27,7 +27,7 @@ const browserLifecycleCleanupMocks = vi.hoisted(() => ({
   cleanupBrowserSessionsForLifecycleEnd: vi.fn(async () => {}),
 }));
 
-vi.mock("../tasks/task-executor.js", () => ({
+vi.mock("../tasks/detached-task-runtime.js", () => ({
   completeTaskRunByRunId: taskExecutorMocks.completeTaskRunByRunId,
   failTaskRunByRunId: taskExecutorMocks.failTaskRunByRunId,
   setDetachedTaskDeliveryStatusByRunId: taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId,

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -7,7 +7,7 @@ import {
   completeTaskRunByRunId,
   failTaskRunByRunId,
   setDetachedTaskDeliveryStatusByRunId,
-} from "../tasks/task-executor.js";
+} from "../tasks/detached-task-runtime.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import {
   captureSubagentCompletionReply,

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import { createRunningTaskRun } from "../tasks/task-executor.js";
+import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { waitForAgentRun } from "./run-wait.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -10,7 +10,7 @@ import {
   createRunningTaskRun,
   failTaskRunByRunId,
   recordTaskRunProgressByRunId,
-} from "../../tasks/task-executor.js";
+} from "../../tasks/detached-task-runtime.js";
 import { sendMessage } from "../../tasks/task-registry-delivery-runtime.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";

--- a/src/agents/tools/music-generate-background.test.ts
+++ b/src/agents/tools/music-generate-background.test.ts
@@ -12,7 +12,7 @@ import {
   taskExecutorMocks,
 } from "./media-generate-background.test-support.js";
 
-vi.mock("../../tasks/task-executor.js", () => taskExecutorMocks);
+vi.mock("../../tasks/detached-task-runtime.js", () => taskExecutorMocks);
 vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskDeliveryRuntimeMocks);
 vi.mock("../subagent-announce-delivery.js", () => announceDeliveryMocks);
 

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -98,7 +98,7 @@ vi.mock("../../media/web-media.js", () => ({
 vi.mock("../../music-generation/runtime.js", () => musicGenerationRuntimeMocks);
 vi.mock("./music-generate-background.js", () => musicGenerateBackgroundMocks);
 vi.mock("../../tasks/runtime-internal.js", () => taskRuntimeInternalMocks);
-vi.mock("../../tasks/task-executor.js", () => taskExecutorMocks);
+vi.mock("../../tasks/detached-task-runtime.js", () => taskExecutorMocks);
 
 function asConfig(value: unknown): OpenClawConfig {
   return value as OpenClawConfig;

--- a/src/agents/tools/video-generate-background.test.ts
+++ b/src/agents/tools/video-generate-background.test.ts
@@ -12,7 +12,7 @@ import {
   taskExecutorMocks,
 } from "./media-generate-background.test-support.js";
 
-vi.mock("../../tasks/task-executor.js", () => taskExecutorMocks);
+vi.mock("../../tasks/detached-task-runtime.js", () => taskExecutorMocks);
 vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskDeliveryRuntimeMocks);
 vi.mock("../subagent-announce-delivery.js", () => announceDeliveryMocks);
 

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -17,7 +17,7 @@ const taskExecutorMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../tasks/runtime-internal.js", () => taskRuntimeInternalMocks);
-vi.mock("../../tasks/task-executor.js", () => taskExecutorMocks);
+vi.mock("../../tasks/detached-task-runtime.js", () => taskExecutorMocks);
 
 function asConfig(value: unknown): OpenClawConfig {
   return value as OpenClawConfig;

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import * as taskExecutor from "../../tasks/task-executor.js";
+import * as detachedTaskRuntime from "../../tasks/detached-task-runtime.js";
 import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../service.test-harness.js";
 import type { CronJob } from "../types.js";
@@ -212,7 +212,7 @@ describe("cron service ops seam coverage", () => {
     });
 
     const createTaskRecordSpy = vi
-      .spyOn(taskExecutor, "createRunningTaskRun")
+      .spyOn(detachedTaskRuntime, "createRunningTaskRun")
       .mockImplementation(() => {
         throw new Error("disk full");
       });
@@ -237,7 +237,7 @@ describe("cron service ops seam coverage", () => {
     await writeDueIsolatedJobSnapshot(storePath, now);
 
     const updateTaskRecordSpy = vi
-      .spyOn(taskExecutor, "completeTaskRunByRunId")
+      .spyOn(detachedTaskRuntime, "completeTaskRunByRunId")
       .mockImplementation(() => {
         throw new Error("disk full");
       });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -5,7 +5,7 @@ import {
   completeTaskRunByRunId,
   createRunningTaskRun,
   failTaskRunByRunId,
-} from "../../tasks/task-executor.js";
+} from "../../tasks/detached-task-runtime.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
 import {
   applyJobPatch,

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -4,7 +4,7 @@ import { setupCronServiceSuite, writeCronStoreSnapshot } from "../../cron/servic
 import { createCronServiceState } from "../../cron/service/state.js";
 import { onTimer } from "../../cron/service/timer.js";
 import type { CronJob } from "../../cron/types.js";
-import * as taskExecutor from "../../tasks/task-executor.js";
+import * as detachedTaskRuntime from "../../tasks/detached-task-runtime.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
@@ -96,7 +96,7 @@ describe("cron service timer seam coverage", () => {
     });
 
     const createTaskRecordSpy = vi
-      .spyOn(taskExecutor, "createRunningTaskRun")
+      .spyOn(detachedTaskRuntime, "createRunningTaskRun")
       .mockImplementation(() => {
         throw new Error("disk full");
       });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -7,7 +7,7 @@ import {
   completeTaskRunByRunId,
   createRunningTaskRun,
   failTaskRunByRunId,
-} from "../../tasks/task-executor.js";
+} from "../../tasks/detached-task-runtime.js";
 import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
 import { resolveCronDeliveryPlan } from "../delivery-plan.js";
 import { sweepCronRunSessions } from "../session-reaper.js";

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1027,7 +1027,8 @@ describe("gateway agent handler", () => {
           runtime: "cli",
           runId: "task-registry-agent-seam",
           childSessionKey: "agent:main:main",
-          task: "background cli seam task",
+          sourceId: "task-registry-agent-seam",
+          task: expect.stringContaining("background cli seam task"),
         }),
       );
       expect(findTaskByRunId("task-registry-agent-seam")).toMatchObject({

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
+import {
+  getDetachedTaskLifecycleRuntime,
+  resetDetachedTaskLifecycleRuntimeForTests,
+  setDetachedTaskLifecycleRuntime,
+} from "../../tasks/detached-task-runtime.js";
 import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
 import { agentHandlers } from "./agent.js";
@@ -327,6 +332,7 @@ describe("gateway agent handler", () => {
     } else {
       process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
     }
+    resetDetachedTaskLifecycleRuntimeForTests();
     resetTaskRegistryForTests();
     mocks.resolveBareResetBootstrapFileAccess.mockReset().mockReturnValue(true);
   });
@@ -983,6 +989,48 @@ describe("gateway agent handler", () => {
       );
 
       expect(findTaskByRunId("task-registry-agent-run")).toMatchObject({
+        runtime: "cli",
+        childSessionKey: "agent:main:main",
+        status: "running",
+      });
+    });
+  });
+
+  it("dispatches async gateway agent task creation through the detached task runtime seam", async () => {
+    await withTempDir({ prefix: "openclaw-gateway-agent-seam-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      primeMainAgentRun();
+
+      const defaultRuntime = getDetachedTaskLifecycleRuntime();
+      const createRunningTaskRunSpy = vi.fn(
+        (...args: Parameters<typeof defaultRuntime.createRunningTaskRun>) =>
+          defaultRuntime.createRunningTaskRun(...args),
+      );
+
+      setDetachedTaskLifecycleRuntime({
+        ...defaultRuntime,
+        createRunningTaskRun: createRunningTaskRunSpy,
+      });
+
+      await invokeAgent(
+        {
+          message: "background cli seam task",
+          sessionKey: "agent:main:main",
+          idempotencyKey: "task-registry-agent-seam",
+        },
+        { reqId: "task-registry-agent-seam" },
+      );
+
+      expect(createRunningTaskRunSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runtime: "cli",
+          runId: "task-registry-agent-seam",
+          childSessionKey: "agent:main:main",
+          task: "background cli seam task",
+        }),
+      );
+      expect(findTaskByRunId("task-registry-agent-seam")).toMatchObject({
         runtime: "cli",
         childSessionKey: "agent:main:main",
         status: "running",

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -45,7 +45,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
-import { createRunningTaskRun } from "../../tasks/task-executor.js";
+import { createRunningTaskRun } from "../../tasks/detached-task-runtime.js";
 import {
   mergeDeliveryContext,
   normalizeDeliveryContext,

--- a/src/tasks/detached-task-runtime.test.ts
+++ b/src/tasks/detached-task-runtime.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TaskRecord } from "./task-registry.types.js";
+import {
+  completeTaskRunByRunId,
+  createQueuedTaskRun,
+  createRunningTaskRun,
+  failTaskRunByRunId,
+  getDetachedTaskLifecycleRuntime,
+  recordTaskRunProgressByRunId,
+  resetDetachedTaskLifecycleRuntimeForTests,
+  setDetachedTaskLifecycleRuntime,
+  setDetachedTaskDeliveryStatusByRunId,
+  startTaskRunByRunId,
+} from "./detached-task-runtime.js";
+
+function createFakeTaskRecord(overrides?: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: "task-fake",
+    runtime: "cli",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    runId: "run-fake",
+    task: "Fake task",
+    status: "running",
+    deliveryStatus: "pending",
+    notifyPolicy: "done_only",
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+describe("detached-task-runtime", () => {
+  afterEach(() => {
+    resetDetachedTaskLifecycleRuntimeForTests();
+  });
+
+  it("dispatches lifecycle operations through the installed runtime", () => {
+    const defaultRuntime = getDetachedTaskLifecycleRuntime();
+    const queuedTask = createFakeTaskRecord({
+      taskId: "task-queued",
+      runId: "run-queued",
+      status: "queued",
+    });
+    const runningTask = createFakeTaskRecord({
+      taskId: "task-running",
+      runId: "run-running",
+    });
+
+    const fakeRuntime = {
+      createQueuedTaskRun: vi.fn(() => queuedTask),
+      createRunningTaskRun: vi.fn(() => runningTask),
+      startTaskRunByRunId: vi.fn(() => undefined),
+      recordTaskRunProgressByRunId: vi.fn(() => undefined),
+      completeTaskRunByRunId: vi.fn(() => undefined),
+      failTaskRunByRunId: vi.fn(() => undefined),
+      setDetachedTaskDeliveryStatusByRunId: vi.fn(() => undefined),
+    };
+
+    setDetachedTaskLifecycleRuntime(fakeRuntime);
+
+    expect(
+      createQueuedTaskRun({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterSessionKey: "agent:main:main",
+        runId: "run-queued",
+        task: "Queue task",
+      }),
+    ).toBe(queuedTask);
+    expect(
+      createRunningTaskRun({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterSessionKey: "agent:main:main",
+        runId: "run-running",
+        task: "Run task",
+      }),
+    ).toBe(runningTask);
+
+    startTaskRunByRunId({ runId: "run-running", startedAt: 10 });
+    recordTaskRunProgressByRunId({ runId: "run-running", lastEventAt: 20 });
+    completeTaskRunByRunId({ runId: "run-running", endedAt: 30 });
+    failTaskRunByRunId({ runId: "run-running", endedAt: 40 });
+    setDetachedTaskDeliveryStatusByRunId({
+      runId: "run-running",
+      deliveryStatus: "delivered",
+    });
+
+    expect(fakeRuntime.createQueuedTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-queued", task: "Queue task" }),
+    );
+    expect(fakeRuntime.createRunningTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-running", task: "Run task" }),
+    );
+    expect(fakeRuntime.startTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-running", startedAt: 10 }),
+    );
+    expect(fakeRuntime.recordTaskRunProgressByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-running", lastEventAt: 20 }),
+    );
+    expect(fakeRuntime.completeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-running", endedAt: 30 }),
+    );
+    expect(fakeRuntime.failTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-running", endedAt: 40 }),
+    );
+    expect(fakeRuntime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-running", deliveryStatus: "delivered" }),
+    );
+
+    resetDetachedTaskLifecycleRuntimeForTests();
+    expect(getDetachedTaskLifecycleRuntime()).toBe(defaultRuntime);
+  });
+});

--- a/src/tasks/detached-task-runtime.ts
+++ b/src/tasks/detached-task-runtime.ts
@@ -1,0 +1,85 @@
+import {
+  completeTaskRunByRunId as completeTaskRunByRunIdInCore,
+  createQueuedTaskRun as createQueuedTaskRunInCore,
+  createRunningTaskRun as createRunningTaskRunInCore,
+  failTaskRunByRunId as failTaskRunByRunIdInCore,
+  recordTaskRunProgressByRunId as recordTaskRunProgressByRunIdInCore,
+  setDetachedTaskDeliveryStatusByRunId as setDetachedTaskDeliveryStatusByRunIdInCore,
+  startTaskRunByRunId as startTaskRunByRunIdInCore,
+} from "./task-executor.js";
+
+export type DetachedTaskLifecycleRuntime = {
+  createQueuedTaskRun: typeof createQueuedTaskRunInCore;
+  createRunningTaskRun: typeof createRunningTaskRunInCore;
+  startTaskRunByRunId: typeof startTaskRunByRunIdInCore;
+  recordTaskRunProgressByRunId: typeof recordTaskRunProgressByRunIdInCore;
+  completeTaskRunByRunId: typeof completeTaskRunByRunIdInCore;
+  failTaskRunByRunId: typeof failTaskRunByRunIdInCore;
+  setDetachedTaskDeliveryStatusByRunId: typeof setDetachedTaskDeliveryStatusByRunIdInCore;
+};
+
+const DEFAULT_DETACHED_TASK_LIFECYCLE_RUNTIME: DetachedTaskLifecycleRuntime = {
+  createQueuedTaskRun: createQueuedTaskRunInCore,
+  createRunningTaskRun: createRunningTaskRunInCore,
+  startTaskRunByRunId: startTaskRunByRunIdInCore,
+  recordTaskRunProgressByRunId: recordTaskRunProgressByRunIdInCore,
+  completeTaskRunByRunId: completeTaskRunByRunIdInCore,
+  failTaskRunByRunId: failTaskRunByRunIdInCore,
+  setDetachedTaskDeliveryStatusByRunId: setDetachedTaskDeliveryStatusByRunIdInCore,
+};
+
+let detachedTaskLifecycleRuntime = DEFAULT_DETACHED_TASK_LIFECYCLE_RUNTIME;
+
+export function getDetachedTaskLifecycleRuntime(): DetachedTaskLifecycleRuntime {
+  return detachedTaskLifecycleRuntime;
+}
+
+export function setDetachedTaskLifecycleRuntime(runtime: DetachedTaskLifecycleRuntime): void {
+  detachedTaskLifecycleRuntime = runtime;
+}
+
+export function resetDetachedTaskLifecycleRuntimeForTests(): void {
+  detachedTaskLifecycleRuntime = DEFAULT_DETACHED_TASK_LIFECYCLE_RUNTIME;
+}
+
+export function createQueuedTaskRun(
+  ...args: Parameters<DetachedTaskLifecycleRuntime["createQueuedTaskRun"]>
+): ReturnType<DetachedTaskLifecycleRuntime["createQueuedTaskRun"]> {
+  return detachedTaskLifecycleRuntime.createQueuedTaskRun(...args);
+}
+
+export function createRunningTaskRun(
+  ...args: Parameters<DetachedTaskLifecycleRuntime["createRunningTaskRun"]>
+): ReturnType<DetachedTaskLifecycleRuntime["createRunningTaskRun"]> {
+  return detachedTaskLifecycleRuntime.createRunningTaskRun(...args);
+}
+
+export function startTaskRunByRunId(
+  ...args: Parameters<DetachedTaskLifecycleRuntime["startTaskRunByRunId"]>
+): ReturnType<DetachedTaskLifecycleRuntime["startTaskRunByRunId"]> {
+  return detachedTaskLifecycleRuntime.startTaskRunByRunId(...args);
+}
+
+export function recordTaskRunProgressByRunId(
+  ...args: Parameters<DetachedTaskLifecycleRuntime["recordTaskRunProgressByRunId"]>
+): ReturnType<DetachedTaskLifecycleRuntime["recordTaskRunProgressByRunId"]> {
+  return detachedTaskLifecycleRuntime.recordTaskRunProgressByRunId(...args);
+}
+
+export function completeTaskRunByRunId(
+  ...args: Parameters<DetachedTaskLifecycleRuntime["completeTaskRunByRunId"]>
+): ReturnType<DetachedTaskLifecycleRuntime["completeTaskRunByRunId"]> {
+  return detachedTaskLifecycleRuntime.completeTaskRunByRunId(...args);
+}
+
+export function failTaskRunByRunId(
+  ...args: Parameters<DetachedTaskLifecycleRuntime["failTaskRunByRunId"]>
+): ReturnType<DetachedTaskLifecycleRuntime["failTaskRunByRunId"]> {
+  return detachedTaskLifecycleRuntime.failTaskRunByRunId(...args);
+}
+
+export function setDetachedTaskDeliveryStatusByRunId(
+  ...args: Parameters<DetachedTaskLifecycleRuntime["setDetachedTaskDeliveryStatusByRunId"]>
+): ReturnType<DetachedTaskLifecycleRuntime["setDetachedTaskDeliveryStatusByRunId"]> {
+  return detachedTaskLifecycleRuntime.setDetachedTaskDeliveryStatusByRunId(...args);
+}


### PR DESCRIPTION
## Summary

- Problem: detached task lifecycle calls were imported directly from `src/tasks/task-executor.ts` across ACP, cron, gateway, subagent, and background-task paths, leaving no clean seam for alternate detached-work execution.
- Why it matters: we want to explore plugin-backed or externally managed detached execution without forking Tasks/TaskFlow or duplicating task state logic in core.
- What changed: added `src/tasks/detached-task-runtime.ts` as a behavior-preserving lifecycle seam, rerouted detached-run callers to it, and added seam contract coverage.
- What did NOT change (scope boundary): no task schema changes, no TaskFlow changes, no executor semantics changes, no retry/crash-recovery/stall-detection implementation, and no plugin registration yet.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #68718
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: detached-work lifecycle was coupled directly to core `task-executor` imports in each caller, so there was no narrow override point for alternate executor/runtime ownership.
- Missing detection / guardrail: no seam-contract test existed to prove callers routed through an overridable lifecycle runtime.
- Contributing context (if known): PR #68718 explored a second detached execution substrate; this PR is the first extraction step so that future work can extend Tasks rather than bypass them.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/tasks/detached-task-runtime.test.ts`
  - `src/gateway/server-methods/agent.test.ts`
  - Existing touched-surface tests in ACP, cron, agents, and gateway
- Scenario the test should lock in: detached-run callers use the seam, and existing task-registry behavior is preserved after rerouting imports.
- Why this is the smallest reliable guardrail: it proves both the seam dispatch itself and one representative caller path, while existing behavior tests cover the rest of the touched surfaces.
- Existing test that already covers this (if any): ACP manager, gateway async agent runs, cron manual/timer runs, ACP spawn, subagent lifecycle, media background flows, and context-engine maintenance already covered preserved behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[detached caller] -> task-executor lifecycle functions

After:
[detached caller] -> detached-task-runtime seam -> default task-executor lifecycle functions
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS on `mb-server`
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): gateway, ACP, cron, subagent runtime paths
- Relevant config (redacted): default test harness config

### Steps

1. Add `src/tasks/detached-task-runtime.ts` as a delegating lifecycle seam.
2. Reroute detached lifecycle call sites to import the seam instead of `task-executor` directly.
3. Add a seam-contract unit test and a gateway caller-level seam dispatch test.
4. Rebase onto latest `origin/main` and run the targeted touched-surface tests.

### Expected

- Existing detached task behavior remains unchanged.
- Callers can be intercepted through the seam.

### Actual

- Targeted tests passed.
- `pnpm build` on `mb-server` hit an existing `runtime-postbuild` bundled-plugin dependency staging issue in the installed workspace graph, not an error in the seam diff itself.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - targeted tests for tasks seam, gateway agent, ACP manager, cron ops/timer, ACP spawn, subagent lifecycle, sessions-spawn lifecycle, media background flows, and context-engine maintenance
  - rebase onto latest `origin/main`
  - branch push to origin
- Edge cases checked:
  - seam dispatch can be overridden in tests
  - gateway async run still creates task records through the seam
  - cron still tolerates ledger create/update failures through the seam
- What you did **not** verify:
  - full repo-wide build on `mb-server` due unrelated `runtime-postbuild` dependency staging issue in the installed workspace graph
  - any alternate executor/plugin implementation beyond the seam extraction

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: future callers might bypass the seam and import `task-executor` directly again.
  - Mitigation: added direct seam dispatch coverage plus a representative caller-level seam test.
- Risk: this seam alone does not solve executor ownership, crash recovery, retry, or stall detection.
  - Mitigation: kept scope explicit; those belong in follow-up work, not hidden inside this PR.
