### PR TITLE
fix: remove unnecessary explicit undefined on optional parameter

### DIFF
--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -611,7 +611,7 @@ function normalizePersistedDeliveryChannel(
   return channel;
 }
 
-function buildFailureAlert(form: CronFormState, existingChannel?: string | undefined) {
+function buildFailureAlert(form: CronFormState, existingChannel?: string) {
   if (form.failureAlertMode === "disabled") {
     return false as const;
   }


### PR DESCRIPTION
## Summary

The `existingChannel` parameter in `buildFailureAlert` (`ui/src/ui/controllers/cron.ts:614`) was typed as `string | undefined` while already being optional (`?`). The explicit `| undefined` is redundant and triggers the oxlint `no-unnecessary-optional-parameter` rule.

This is currently breaking the `check` CI lane on `main` and all open PRs.

## Changes

- Remove redundant `| undefined` from the optional parameter type

## Test plan

- [x] `pnpm lint` passes locally (0 errors)
- CI `check` lane should go green after this lands