### PR TITLE
fix(onboard): don't suggest Homebrew on non-macOS/Linux platforms (closes #68893)

### DIFF
--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -186,4 +186,34 @@ describe("setupSkills", () => {
     const brewNote = notes.find((n) => n.title === "Homebrew recommended");
     expect(brewNote).toBeDefined();
   });
+
+  it("does not recommend Homebrew on non-macOS/Linux platforms (e.g. FreeBSD)", async () => {
+    mockMissingBrewStatus([
+      createBundledSkill({
+        name: "video-frames",
+        description: "ffmpeg",
+        bins: ["ffmpeg"],
+        installLabel: "Install ffmpeg (brew)",
+      }),
+    ]);
+
+    const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
+
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "freebsd",
+    });
+    try {
+      await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        configurable: true,
+        value: originalPlatform,
+      });
+    }
+
+    const brewNote = notes.find((n) => n.title === "Homebrew recommended");
+    expect(brewNote).toBeUndefined();
+  });
 });

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -109,7 +109,7 @@ export async function setupSkills(
       .filter((item): item is (typeof installable)[number] => Boolean(item));
 
     const needsBrewPrompt =
-      process.platform !== "win32" &&
+      (process.platform === "darwin" || process.platform === "linux") &&
       selectedSkills.some((skill) => skill.install.some((option) => option.kind === "brew")) &&
       !(await detectBinary("brew"));
 


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw onboard` was suggesting **Homebrew** installation on FreeBSD (and any non-Windows/non-macOS/non-Linux platform), because the gate in `setupSkills` only excluded `win32`.
- **Why it matters:** Homebrew is [officially supported on macOS and Linux only](https://docs.brew.sh/Homebrew-on-Linux). Suggesting it elsewhere leads users into dead ends on FreeBSD, OpenBSD, SunOS, AIX, and any future unsupported platform.
- **What changed:** Changed the platform check in `src/commands/onboard-skills.ts` from a blocklist (`!== "win32"`) to an allowlist (`=== "darwin" || === "linux"`), plus a regression test asserting the Homebrew skill is not recommended on FreeBSD.

---

**Closing:** Extremely niche edge case (FreeBSD users running openclaw) with no reviewer engagement. Happy to reopen if there's interest.