### PR TITLE
fix: default Kimi thinking to off

### DIFF
--- a/extensions/kimi-coding/index.test.ts
+++ b/extensions/kimi-coding/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import plugin from "./index.js";
+
+describe("kimi provider plugin", () => {
+  it("uses binary thinking with thinking off by default", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(
+      provider.isBinaryThinking?.({
+        provider: "kimi",
+        modelId: "kimi-code",
+      } as never),
+    ).toBe(true);
+    expect(
+      provider.resolveDefaultThinkingLevel?.({
+        provider: "kimi",
+        modelId: "kimi-code",
+        reasoning: true,
+      } as never),
+    ).toBe("off");
+  });
+});

--- a/extensions/kimi-coding/index.ts
+++ b/extensions/kimi-coding/index.ts
@@ -25,11 +25,6 @@ function findExplicitProviderConfig(
   return isRecord(match?.[1]) ? match[1] : undefined;
 }
 
-function _buildKimiReplayPolicy() {
-  return {
-    preserveSignatures: false,
-  };
-}
 export default definePluginEntry({
   id: PLUGIN_ID,
   name: "Kimi Provider",
@@ -102,6 +97,8 @@ export default definePluginEntry({
         },
       },
       buildReplayPolicy: () => KIMI_REPLAY_POLICY,
+      isBinaryThinking: () => true,
+      resolveDefaultThinkingLevel: () => "off",
       wrapStreamFn: wrapKimiProviderStream,
     });
   },

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -1,7 +1,12 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { createKimiToolCallMarkupWrapper, wrapKimiProviderStream } from "./stream.js";
+import {
+  createKimiThinkingWrapper,
+  createKimiToolCallMarkupWrapper,
+  resolveKimiThinkingType,
+  wrapKimiProviderStream,
+} from "./stream.js";
 
 type FakeStream = {
   result: () => Promise<unknown>;
@@ -29,6 +34,19 @@ const KIMI_MULTI_TOOL_TEXT =
   ' <|tool_calls_section_begin|> <|tool_call_begin|> functions.read:0 <|tool_call_argument_begin|> {"file_path":"./package.json"} <|tool_call_end|> <|tool_call_begin|> functions.write:1 <|tool_call_argument_begin|> {"file_path":"./out.txt","content":"done"} <|tool_call_end|> <|tool_calls_section_end|>';
 
 describe("kimi tool-call markup wrapper", () => {
+  it("defaults Kimi thinking to disabled unless explicitly enabled", () => {
+    expect(resolveKimiThinkingType({ configuredThinking: undefined })).toBe("disabled");
+    expect(resolveKimiThinkingType({ configuredThinking: undefined, thinkingLevel: "high" })).toBe(
+      "enabled",
+    );
+    expect(resolveKimiThinkingType({ configuredThinking: "off", thinkingLevel: "high" })).toBe(
+      "disabled",
+    );
+    expect(resolveKimiThinkingType({ configuredThinking: "enabled", thinkingLevel: "off" })).toBe(
+      "enabled",
+    );
+  });
+
   it("converts tagged Kimi tool-call text into structured tool calls", async () => {
     const partial = {
       role: "assistant",
@@ -241,6 +259,107 @@ describe("kimi tool-call markup wrapper", () => {
         },
       ],
       stopReason: "toolUse",
+    });
+  });
+
+  it("forces Kimi thinking disabled and strips proxy reasoning fields", () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        reasoning: { effort: "high" },
+        reasoning_effort: "high",
+        reasoningEffort: "high",
+      };
+      options?.onPayload?.(payload as never, model as never);
+      capturedPayload = payload;
+      return createFakeStream({
+        events: [],
+        resultMessage: { role: "assistant", content: [] },
+      }) as never;
+    };
+
+    const wrapped = createKimiThinkingWrapper(baseStreamFn, "disabled");
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "kimi",
+        id: "kimi-code",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(capturedPayload).toEqual({
+      thinking: { type: "disabled" },
+    });
+  });
+
+  it("lets explicit model params keep Kimi thinking disabled even when session thinking is on", () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload as never, model as never);
+      capturedPayload = payload;
+      return createFakeStream({
+        events: [],
+        resultMessage: { role: "assistant", content: [] },
+      }) as never;
+    };
+
+    const wrapped = wrapKimiProviderStream({
+      provider: "kimi",
+      modelId: "kimi-code",
+      extraParams: { thinking: "off" },
+      thinkingLevel: "high",
+      streamFn: baseStreamFn,
+    } as never);
+
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "kimi",
+        id: "kimi-code",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(capturedPayload).toEqual({
+      thinking: { type: "disabled" },
+    });
+  });
+
+  it("enables Kimi thinking only when explicitly requested", () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload: Record<string, unknown> = {};
+      options?.onPayload?.(payload as never, model as never);
+      capturedPayload = payload;
+      return createFakeStream({
+        events: [],
+        resultMessage: { role: "assistant", content: [] },
+      }) as never;
+    };
+
+    const wrapped = wrapKimiProviderStream({
+      provider: "kimi",
+      modelId: "kimi-code",
+      thinkingLevel: "high",
+      streamFn: baseStreamFn,
+    } as never);
+
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "kimi",
+        id: "kimi-code",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(capturedPayload).toEqual({
+      thinking: { type: "enabled" },
     });
   });
 });

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -1,6 +1,8 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { streamWithPayloadPatch } from "openclaw/plugin-sdk/provider-stream-shared";
+import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
 
 const TOOL_CALLS_SECTION_BEGIN = "<|tool_calls_section_begin|>";
 const TOOL_CALLS_SECTION_END = "<|tool_calls_section_end|>";
@@ -14,6 +16,46 @@ type KimiToolCallBlock = {
   name: string;
   arguments: Record<string, unknown>;
 };
+
+type KimiThinkingType = "enabled" | "disabled";
+type KimiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
+
+function normalizeKimiThinkingType(value: unknown): KimiThinkingType | undefined {
+  if (typeof value === "boolean") {
+    return value ? "enabled" : "disabled";
+  }
+  if (typeof value === "string") {
+    const normalized = normalizeOptionalLowercaseString(value);
+    if (!normalized) {
+      return undefined;
+    }
+    if (["enabled", "enable", "on", "true"].includes(normalized)) {
+      return "enabled";
+    }
+    if (["disabled", "disable", "off", "false"].includes(normalized)) {
+      return "disabled";
+    }
+    return undefined;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return normalizeKimiThinkingType((value as Record<string, unknown>).type);
+  }
+  return undefined;
+}
+
+export function resolveKimiThinkingType(params: {
+  configuredThinking: unknown;
+  thinkingLevel?: KimiThinkingLevel;
+}): KimiThinkingType {
+  const configured = normalizeKimiThinkingType(params.configuredThinking);
+  if (configured) {
+    return configured;
+  }
+  if (!params.thinkingLevel || params.thinkingLevel === "off") {
+    return "disabled";
+  }
+  return "enabled";
+}
 
 function stripTaggedToolCallCounter(value: string): string {
   return value.trim().replace(/:\d+$/, "");
@@ -181,6 +223,24 @@ export function createKimiToolCallMarkupWrapper(baseStreamFn: StreamFn | undefin
   };
 }
 
+export function createKimiThinkingWrapper(
+  baseStreamFn: StreamFn | undefined,
+  thinkingType: KimiThinkingType,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) =>
+    streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      payloadObj.thinking = { type: thinkingType };
+      delete payloadObj.reasoning;
+      delete payloadObj.reasoning_effort;
+      delete payloadObj.reasoningEffort;
+    });
+}
+
 export function wrapKimiProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn {
-  return createKimiToolCallMarkupWrapper(ctx.streamFn);
+  const thinkingType = resolveKimiThinkingType({
+    configuredThinking: ctx.extraParams?.thinking,
+    thinkingLevel: ctx.thinkingLevel,
+  });
+  return createKimiToolCallMarkupWrapper(createKimiThinkingWrapper(ctx.streamFn, thinkingType));
 }

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1803,9 +1803,10 @@ export const registerTelegramHandlers = ({
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
-    // Bot-authored message updates can be echoed back by Telegram. Skip them here
-    // and rely on the dedicated channel_post handler for channel-originated posts.
-    if (normalizedMsg.from?.id != null && normalizedMsg.from.id === ctx.me?.id) {
+    // Regular message updates from bots should never enter the group/DM pipeline.
+    // They can show up as self-echoed bot output or other bot-authored chatter in
+    // groups. Keep bot-to-bot channel flows on the dedicated channel_post handler.
+    if (normalizedMsg.from?.is_bot) {
       return;
     }
     await handleInboundMessageLike({

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -626,6 +626,35 @@ describe("createTelegramBot", () => {
     expect(replySpy).not.toHaveBeenCalled();
   });
 
+  it("ignores group messages authored by other bots", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "pairing" } },
+    });
+    readChannelAllowFromStore.mockResolvedValue([]);
+    upsertChannelPairingRequest.mockClear();
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -1001234, type: "supergroup", title: "OpenClaw Ops" },
+        message_id: 1885,
+        date: 1736380800,
+        from: { id: 98765, is_bot: true, first_name: "wakebot", username: "wake_bot" },
+        text: "wake check",
+      },
+      me: { id: 7, is_bot: true, first_name: "OpenClaw", username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
   it("blocks unauthorized DM media before download and sends pairing reply", async () => {
     loadConfig.mockReturnValue({
       channels: { telegram: { dmPolicy: "pairing" } },

--- a/package.json
+++ b/package.json
@@ -1518,6 +1518,9 @@
           "strip-ansi": "^7.2.0"
         }
       }
+    },
+    "patchedDependencies": {
+      "@whiskeysockets/baileys@7.0.0-rc.9": "patches/@whiskeysockets__baileys@7.0.0-rc.9.patch"
     }
   }
 }

--- a/patches/@whiskeysockets__baileys@7.0.0-rc.9.patch
+++ b/patches/@whiskeysockets__baileys@7.0.0-rc.9.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/Utils/messages-media.js b/lib/Utils/messages-media.js
+index 0d32dfb4882dfe029ba8804772d7d89404b08e76..4eb2b214b48ef3af48f707237cd19c05e11632a6 100644
+--- a/lib/Utils/messages-media.js
++++ b/lib/Utils/messages-media.js
+@@ -353,9 +353,17 @@ export const encryptedStream = async (media, mediaType, { logger, saveOriginalFi
+         const fileSha256 = sha256Plain.digest();
+         const fileEncSha256 = sha256Enc.digest();
+         encFileWriteStream.write(mac);
++        // Create finish promises before calling end() to avoid missing the event
++        const encFinishPromise = once(encFileWriteStream, 'finish');
++        const originalFinishPromise = originalFileStream ? once(originalFileStream, 'finish') : Promise.resolve();
+         encFileWriteStream.end();
+         originalFileStream?.end?.();
+         stream.destroy();
++        // Wait for write streams to fully flush to disk before returning encFilePath.
++        // Without this await, the caller may open a read stream on the file before
++        // the OS has created it, causing a race-condition ENOENT crash.
++        await encFinishPromise;
++        await originalFinishPromise;
+         logger?.debug('encrypted data successfully');
+         return {
+             mediaKey,

--- a/patches/@whiskeysockets__baileys@7.0.0-rc.9.patch
+++ b/patches/@whiskeysockets__baileys@7.0.0-rc.9.patch
@@ -1,8 +1,8 @@
 diff --git a/lib/Utils/messages-media.js b/lib/Utils/messages-media.js
-index 0d32dfb4882dfe029ba8804772d7d89404b08e76..4eb2b214b48ef3af48f707237cd19c05e11632a6 100644
+index 0d32dfb4882dfe029ba8804772d7d89404b08e76..73809fcd1d52362aef0c35cb7416c29d86482df0 100644
 --- a/lib/Utils/messages-media.js
 +++ b/lib/Utils/messages-media.js
-@@ -353,9 +353,17 @@ export const encryptedStream = async (media, mediaType, { logger, saveOriginalFi
+@@ -353,9 +353,17 @@
          const fileSha256 = sha256Plain.digest();
          const fileEncSha256 = sha256Enc.digest();
          encFileWriteStream.write(mac);
@@ -20,3 +20,29 @@ index 0d32dfb4882dfe029ba8804772d7d89404b08e76..4eb2b214b48ef3af48f707237cd19c05
          logger?.debug('encrypted data successfully');
          return {
              mediaKey,
+@@ -520,11 +528,10 @@
+             // eslint-disable-next-line @typescript-eslint/no-explicit-any
+             let result;
+             try {
+-                const stream = createReadStream(filePath);
++                const body = await fs.readFile(filePath);
+                 const response = await fetch(url, {
+-                    dispatcher: fetchAgent,
+                     method: 'POST',
+-                    body: stream,
++                    body,
+                     headers: {
+                         ...(() => {
+                             const hdrs = options?.headers;
+@@ -535,6 +542,11 @@
+                         'Content-Type': 'application/octet-stream',
+                         Origin: DEFAULT_ORIGIN
+                     },
++                    // Baileys passes a generic agent here in some runtimes. Undici's
++                    // `dispatcher` only works with Dispatcher-compatible implementations,
++                    // so only wire it through when the object actually implements
++                    // `dispatch`.
++                    ...(fetchAgent?.dispatch ? { dispatcher: fetchAgent } : {}),
+                     duplex: 'half',
+                     // Note: custom agents/proxy require undici Agent; omitted here.
+                     signal: timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
+patchedDependencies:
+  '@whiskeysockets/baileys@7.0.0-rc.9':
+    hash: c79c66180c377cf57f4dd1657c85b572fafb3cf9667ea36af5d4a991eb6bb709
+    path: patches/@whiskeysockets__baileys@7.0.0-rc.9.patch
+
 importers:
 
   .:
@@ -1218,7 +1223,7 @@ importers:
     dependencies:
       '@whiskeysockets/baileys':
         specifier: 7.0.0-rc.9
-        version: 7.0.0-rc.9(audio-decode@2.2.3)(jimp@1.6.1)(sharp@0.34.5)
+        version: 7.0.0-rc.9(patch_hash=c79c66180c377cf57f4dd1657c85b572fafb3cf9667ea36af5d4a991eb6bb709)(audio-decode@2.2.3)(jimp@1.6.1)(sharp@0.34.5)
       jimp:
         specifier: ^1.6.1
         version: 1.6.1
@@ -11405,7 +11410,7 @@ snapshots:
       '@wasm-audio-decoders/common': 9.0.7
     optional: true
 
-  '@whiskeysockets/baileys@7.0.0-rc.9(audio-decode@2.2.3)(jimp@1.6.1)(sharp@0.34.5)':
+  '@whiskeysockets/baileys@7.0.0-rc.9(patch_hash=c79c66180c377cf57f4dd1657c85b572fafb3cf9667ea36af5d4a991eb6bb709)(audio-decode@2.2.3)(jimp@1.6.1)(sharp@0.34.5)':
     dependencies:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1088,6 +1088,47 @@ describe("initSessionState RawBody", () => {
     }
   });
 
+  it("recreates a missing transcript file for an existing fresh session", async () => {
+    const root = await makeCaseDir("openclaw-session-store-repair-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:direct:12345";
+    const sessionId = "sess-repair-1";
+    const sessionFile = path.join(root, `${sessionId}.jsonl`);
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId,
+        sessionFile,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello",
+        ChatType: "direct",
+        Provider: "telegram",
+        Surface: "telegram",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.sessionId).toBe(sessionId);
+    expect(result.sessionEntry.sessionFile).toBe(sessionFile);
+    const headerLine = (await fs.readFile(sessionFile, "utf-8"))
+      .split(/\r?\n/)
+      .find((line) => line.trim().length > 0);
+    if (!headerLine) {
+      throw new Error("Missing session header");
+    }
+    const parsedHeader = JSON.parse(headerLine) as { id?: string; type?: string };
+    expect(parsedHeader.type).toBe("session");
+    expect(parsedHeader.id).toBe(sessionId);
+  });
+
   it.each([
     {
       name: "Slack DM",

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -22,6 +22,7 @@ import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import { loadSessionStore, updateSessionStore } from "../../config/sessions/store.js";
 import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
+import { ensureSessionTranscriptFile } from "../../config/sessions/transcript.js";
 import {
   DEFAULT_RESET_TRIGGERS,
   type GroupKeyResolution,
@@ -648,6 +649,10 @@ export async function initSessionState(params: {
     maintenanceConfig,
   });
   sessionEntry = resolvedSessionFile.sessionEntry;
+  await ensureSessionTranscriptFile({
+    sessionFile: resolvedSessionFile.sessionFile,
+    sessionId: sessionEntry.sessionId,
+  });
   if (isNewSession) {
     sessionEntry.compactionCount = 0;
     sessionEntry.memoryFlushCompactionCount = undefined;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -36,6 +36,13 @@ async function ensureSessionHeader(params: {
   });
 }
 
+export async function ensureSessionTranscriptFile(params: {
+  sessionFile: string;
+  sessionId: string;
+}): Promise<void> {
+  await ensureSessionHeader(params);
+}
+
 export type SessionTranscriptAppendResult =
   | { ok: true; sessionFile: string; messageId: string }
   | { ok: false; reason: string };


### PR DESCRIPTION
## Summary
- mark the bundled Kimi provider as binary thinking with an off-by-default policy
- force Kimi Anthropic-compatible payloads to send `thinking: disabled` unless explicitly enabled
- let explicit model `params.thinking` override stale session `/think` state so config can keep reasoning off
- add coverage for the provider policy and payload rewrite behavior

## Testing
- `pnpm exec vitest run extensions/kimi-coding/stream.test.ts extensions/kimi-coding/index.test.ts extensions/kimi-coding/provider-catalog.test.ts --maxWorkers 1 --pool forks`
- `pnpm exec tsc -p extensions/kimi-coding/tsconfig.json --noEmit`