### PR TITLE
fix(onboard): skip Homebrew prompt on FreeBSD

### DIFF
--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -109,7 +109,7 @@ export async function setupSkills(
       .filter((item): item is (typeof installable)[number] => Boolean(item));
 
     const needsBrewPrompt =
-      process.platform !== "win32" &&
+      process.platform !== "win32" && process.platform !== "freebsd" &&
       selectedSkills.some((skill) => skill.install.some((option) => option.kind === "brew")) &&
       !(await detectBinary("brew"));
 


### PR DESCRIPTION
FreeBSD uses pkg/ports, not Homebrew. The onboard skills wizard should not recommend Homebrew installation on FreeBSD systems.

Closes #68893