### PR TITLE
fix: allow browser tool via HTTP API /tools/invoke

### DIFF
--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -34,6 +34,7 @@ type CoreToolDefinition = {
   sectionId: string;
   profiles: ToolProfileId[];
   includeInOpenClawGroup?: boolean;
+  pluginImplemented?: boolean;
 };
 
 const CORE_TOOL_SECTION_ORDER: Array<{ id: string; label: string }> = [
@@ -391,4 +392,9 @@ export function resolveCoreToolProfiles(toolId: string): ToolProfileId[] {
 
 export function isKnownCoreToolId(toolId: string): boolean {
   return CORE_TOOL_BY_ID.has(toolId);
+}
+
+export function isCoreToolPluginImplemented(toolName: string): boolean {
+  const tool = CORE_TOOL_DEFINITIONS.find(t => t.id === toolName);
+  return tool?.pluginImplemented === true;
 }

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -201,6 +201,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   {
     id: "browser",
     label: "browser",
+    pluginImplemented: true,
     description: "Control web browser",
     sectionId: "ui",
     profiles: [],

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -128,6 +128,11 @@ vi.mock("../agents/openclaw-tools.js", () => {
       execute: async () => ({ ok: true, result: "nodes" }),
     },
     {
+      name: "browser",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ ok: true, enabled: true }),
+    },
+    {
       name: "owner_only_test",
       ownerOnly: true,
       parameters: { type: "object", properties: {} },
@@ -878,4 +883,16 @@ describe("POST /tools/invoke", () => {
     expect(nodesRes.status).toBe(404);
     expect(nodesAdminRes.status).toBe(404);
   });
-});
+
+  it("keeps plugin tools enabled for browser tool invoke despite being in CORE_TOOL_DEFINITIONS", async () => {
+    setMainAllowedTools({ allow: ["browser"] });
+
+    const res = await invokeToolAuthed({
+      tool: "browser",
+      args: {},
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(200);
+    expect(lastCreateOpenClawToolsContext?.disablePluginTools).toBe(false);
+  });});

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { runBeforeToolCallHook } from "../agents/pi-tools.before-tool-call.js";
 import { resolveToolLoopDetectionConfig } from "../agents/pi-tools.js";
-import { isKnownCoreToolId } from "../agents/tool-catalog.js";
+import { isKnownCoreToolId, isCoreToolPluginImplemented } from "../agents/tool-catalog.js";
 import { applyOwnerOnlyToolPolicy } from "../agents/tool-policy.js";
 import { ToolInputError, type AnyAgentTool } from "../agents/tools/common.js";
 import { loadConfig } from "../config/config.js";
@@ -248,7 +248,7 @@ export async function handleToolsInvokeHttpRequest(
     allowGatewaySubagentBinding: true,
     allowMediaInvokeCommands: true,
     surface: "http",
-    disablePluginTools: isKnownCoreToolId(toolName),
+    disablePluginTools: isKnownCoreToolId(toolName) && !isCoreToolPluginImplemented(toolName),
     senderIsOwner,
   });
   const gatewayFiltered = applyOwnerOnlyToolPolicy(tools, senderIsOwner);


### PR DESCRIPTION
The rowser tool returns "Tool not available" when called via HTTP API /tools/invoke.

## Root Cause
rowser is defined in CORE_TOOL_DEFINITIONS but its implementation comes only from the plugin.

## Fix
Add pluginImplemented flag and use isCoreToolPluginImplemented function.

**Files:**
- src/agents/tool-catalog.ts: Add pluginImplemented?: boolean and export function
- src/gateway/tools-invoke-http.ts: Use !isCoreToolPluginImplemented(toolName) 
- src/gateway/tools-invoke-http.test.ts: Add browser tool test
- src/tasks/detached-task-runtime.test.ts: Fix mock return type