### PR TITLE
fix(gateway): clean up nodeWakeById entry on no-registration early return

### DIFF
--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -332,6 +332,7 @@ export async function maybeWakeNodeWithApns(
     try {
       const registration = await loadApnsRegistration(nodeId);
       if (!registration) {
+        nodeWakeById.delete(nodeId);
         return withDuration({ available: false, throttled: false, path: "no-registration" });
       }
 


### PR DESCRIPTION
`maybeWakeNodeWithApns` sets `nodeWakeById.set(nodeId, state)` on entry, but the `no-registration` early return path does not clean up the entry, causing stale entries to accumulate for unregistered nodeIds. Add `nodeWakeById.delete(nodeId)` before the early return.

Closes #68847