### PR TITLE
fix(gateway): add lazy eviction to costUsageCache

### DIFF
--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -310,6 +310,10 @@ async function loadCostUsageSummaryCached(params: {
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
     return cached.summary;
   }
+  // Lazy eviction: prune stale entries to prevent unbounded growth across days.
+  if (cached && cached.updatedAt && now - cached.updatedAt >= COST_USAGE_CACHE_TTL_MS) {
+    costUsageCache.delete(cacheKey);
+  }
 
   if (cached?.inFlight) {
     if (cached.summary) {


### PR DESCRIPTION
`costUsageCache` uses a TTL to skip stale entries on read, but never deletes them. Since cache keys are derived from `(startMs, endMs)`, each new day produces new keys while old entries accumulate indefinitely. Add lazy eviction on read to prevent unbounded memory growth.

Closes #68841