### PR TITLE
fix(auto-reply): add identity guard in drain finally to prevent queue orphaning

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -263,8 +263,10 @@ export function scheduleFollowupDrain(
     } finally {
       queue.draining = false;
       if (queue.items.length === 0 && queue.droppedCount === 0) {
-        FOLLOWUP_QUEUES.delete(key);
-        clearFollowupDrainCallback(key);
+        if (FOLLOWUP_QUEUES.get(key) === queue) {
+          FOLLOWUP_QUEUES.delete(key);
+          clearFollowupDrainCallback(key);
+        }
       } else {
         scheduleFollowupDrain(key, effectiveRunFollowup);
       }


### PR DESCRIPTION
The drain finally block deletes `FOLLOWUP_QUEUES` entries by key only, without verifying the current map entry is the same queue reference. If `/stop` or session reset clears the original queue and a new one is registered under the same key, the original drain finally will delete the new queue. Add identity check: `if (FOLLOWUP_QUEUES.get(key) === queue)`.

Closes #68838