### PR TITLE
pr-flow: clarify missing wrapper stages

### DIFF
--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -84,11 +84,40 @@ mainline_drift_requires_sync() {
   return 1
 }
 
+print_merge_prereq_guidance() {
+  local pr="$1"
+  local missing=()
+  local required
+  for required in .local/review.md .local/review.json .local/prep.md .local/prep.env; do
+    [ -s "$required" ] || missing+=("$required")
+  done
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  echo "merge prerequisites are missing in the PR wrapper worktree:"
+  printf '  - %s\n' "${missing[@]}"
+  cat <<EOF_GUIDE
+Expected maintainer flow:
+  scripts/pr review-init $pr
+  scripts/pr review-artifacts-init $pr
+  scripts/pr-prepare init $pr
+  scripts/pr-prepare gates $pr
+  scripts/pr-prepare push $pr
+
+If review/prep happened manually in another worktree, the wrapper artifacts were never generated here.
+EOF_GUIDE
+  exit 1
+}
+
 merge_verify() {
   local pr="$1"
   enter_worktree "$pr" false
 
-  require_artifact .local/prep.env
+  if [ ! -s .local/prep.env ]; then
+    print_merge_prereq_guidance "$pr"
+  fi
   # shellcheck disable=SC1091
   source .local/prep.env
   verify_prep_branch_matches_prepared_head "$pr" "$PREP_HEAD_SHA"
@@ -168,10 +197,7 @@ merge_run() {
   local pr="$1"
   enter_worktree "$pr" false
 
-  local required
-  for required in .local/review.md .local/review.json .local/prep.md .local/prep.env; do
-    require_artifact "$required"
-  done
+  print_merge_prereq_guidance "$pr"
 
   merge_verify "$pr"
   # shellcheck disable=SC1091

--- a/scripts/pr-lib/prepare-core.sh
+++ b/scripts/pr-lib/prepare-core.sh
@@ -24,6 +24,29 @@ resolve_prep_branch_name() {
   printf '%s\n' "$prep_branch"
 }
 
+print_prepare_init_prereq_guidance() {
+  local pr="$1"
+  local missing=()
+  [ -s .local/pr-meta.env ] || missing+=(".local/pr-meta.env")
+  [ -s .local/review.md ] || missing+=(".local/review.md")
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  echo "prepare-init prerequisites are missing in the PR wrapper worktree:"
+  printf '  - %s\n' "${missing[@]}"
+  cat <<EOF_GUIDE
+prepare-init is not the first maintainer stage. Run the review bootstrap in this same wrapper worktree first:
+  scripts/pr review-init $pr
+  scripts/pr review-artifacts-init $pr
+
+Then complete or import the review artifacts, and rerun:
+  scripts/pr-prepare init $pr
+EOF_GUIDE
+  exit 1
+}
+
 verify_prep_branch_matches_prepared_head() {
   local pr="$1"
   local prepared_head_sha="$2"
@@ -51,8 +74,7 @@ prepare_init() {
   local pr="$1"
   enter_worktree "$pr" true
 
-  require_artifact .local/pr-meta.env
-  require_artifact .local/review.md
+  print_prepare_init_prereq_guidance "$pr"
 
   if [ ! -s .local/review.json ]; then
     echo "WARNING: .local/review.json is missing; structured findings are expected."

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -57,6 +57,7 @@ enter_worktree() {
   fi
 
   mkdir -p .local
+  echo "PR wrapper worktree: $PWD"
 }
 
 pr_meta_json() {


### PR DESCRIPTION
## Summary

- Problem: the maintainer wrappers fail with opaque missing-artifact errors when `prepare` or `merge` is run before the earlier wrapper stages created the expected `.local/*` files.
- Why it matters: the current output makes it look like the wrapper is broken, when the actual issue is usually that review/prep happened manually or in another worktree outside the wrapper artifact chain.
- What changed: `prepare-init` and `merge-verify`/`merge-run` now print plain-English prerequisite guidance, and the wrapper logs the actual PR wrapper worktree path it switched into.
- What did NOT change (scope boundary): this does not auto-create fake review state, does not change gate behavior, and does not change the canonical wrapper worktree model.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #68891

## Root Cause (if applicable)

- Root cause: the wrapper flow depends on staged `.local/*` artifacts, but the failure path only reported the missing file names, not the missing stage or the actual wrapper worktree being used.
- Missing detection / guardrail: there was no stage-aware guidance when `prepare-init` was invoked without review artifacts or `merge-verify` was invoked without prep artifacts.

## User-visible / Behavior Changes

- Running `scripts/pr-prepare init <PR>` without review bootstrap now tells the operator to run `scripts/pr review-init` and `scripts/pr review-artifacts-init` first.
- Running `scripts/pr-merge verify <PR>` or `scripts/pr-merge run <PR>` without wrapper prep artifacts now explains the expected wrapper flow instead of failing on a raw artifact filename.
- Wrapper entry now prints the PR wrapper worktree path it switched into.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS local maintainer machine
- Runtime/container: bash wrapper scripts in repo worktrees
- Model/provider: N/A
- Integration/channel (if any): maintainer PR wrapper flow

### Steps

1. Run `scripts/pr-prepare init <PR>` in a wrapper worktree that does not yet have `.local/pr-meta.env` / `.local/review.md`.
2. Verify the wrapper prints stage guidance instead of only `Missing required artifact`.
3. Run `scripts/pr-merge verify <PR>` in a wrapper worktree that does not yet have prep artifacts.
4. Verify the wrapper prints the expected review/prepare flow and the actual PR wrapper worktree path.

### Expected

- Errors are explicit about the missing stage and the worktree being used.

### Actual

- Matches expected with the new guidance output.

## Evidence

- [x] Failing behavior reproduced before + clearer guidance after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `prepare-init` now reports missing review bootstrap with exact commands; `merge-verify` now reports missing review/prep chain with exact commands; both print the PR wrapper worktree path.
- Edge cases checked: shell syntax passes for touched wrapper files.
- What you did **not** verify: full wrapper happy-path through review/prepare/merge on a fresh PR after this patch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: none material; this is error-path guidance only.
- Mitigation: kept behavior scoped to missing-artifact branches and did not change any success-path flow.