### PR TITLE
fix(telegram): require explicit exec approvers

### DIFF
--- a/extensions/telegram/src/approval-native.ts
+++ b/extensions/telegram/src/approval-native.ts
@@ -9,7 +9,6 @@ import {
   createChannelNativeOriginTargetResolver,
 } from "openclaw/plugin-sdk/approval-native-runtime";
 import type { ChannelApprovalCapability } from "openclaw/plugin-sdk/channel-contract";
-import type { ExecApprovalRequest, PluginApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -18,16 +17,14 @@ import { listTelegramAccountIds } from "./accounts.js";
 import {
   getTelegramExecApprovalApprovers,
   isTelegramExecApprovalApprover,
-  isTelegramExecApprovalAuthorizedSender,
   isTelegramExecApprovalClientEnabled,
-  isTelegramExecApprovalTargetRecipient,
   resolveTelegramExecApprovalTarget,
   shouldHandleTelegramExecApprovalRequest,
 } from "./exec-approvals.js";
 import { parseTelegramThreadId } from "./outbound-params.js";
 import { normalizeTelegramChatId, parseTelegramTarget } from "./targets.js";
 
-type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalRequest = Parameters<typeof shouldHandleTelegramExecApprovalRequest>[0]["request"];
 type TelegramOriginTarget = { to: string; threadId?: number };
 
 function resolveTurnSourceTelegramOriginTarget(
@@ -102,7 +99,7 @@ const telegramNativeApprovalCapability = createApproverRestrictedNativeApprovalC
   hasApprovers: ({ cfg, accountId }) =>
     getTelegramExecApprovalApprovers({ cfg, accountId }).length > 0,
   isExecAuthorizedSender: ({ cfg, accountId, senderId }) =>
-    isTelegramExecApprovalAuthorizedSender({ cfg, accountId, senderId }),
+    isTelegramExecApprovalApprover({ cfg, accountId, senderId }),
   isPluginAuthorizedSender: ({ cfg, accountId, senderId }) =>
     isTelegramExecApprovalApprover({ cfg, accountId, senderId }),
   isNativeDeliveryEnabled: ({ cfg, accountId }) =>
@@ -140,20 +137,11 @@ const resolveTelegramApproveCommandBehavior: NonNullable<
 > = (
   params: Parameters<NonNullable<ChannelApprovalCapability["resolveApproveCommandBehavior"]>>[0],
 ) => {
-  const { cfg, accountId, senderId, approvalKind } = params;
+  const { cfg, accountId, approvalKind } = params;
   if (approvalKind !== "exec") {
     return undefined;
   }
   if (isTelegramExecApprovalClientEnabled({ cfg, accountId })) {
-    return undefined;
-  }
-  if (isTelegramExecApprovalTargetRecipient({ cfg, accountId, senderId })) {
-    return undefined;
-  }
-  if (
-    isTelegramExecApprovalAuthorizedSender({ cfg, accountId, senderId }) &&
-    !isTelegramExecApprovalApprover({ cfg, accountId, senderId })
-  ) {
     return undefined;
   }
   return {

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -548,7 +548,7 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-error");
   });
 
-  it("allows exec approval callbacks from target-only Telegram recipients", async () => {
+  it("blocks exec approval callbacks from target-only Telegram recipients", async () => {
     onSpy.mockClear();
     editMessageReplyMarkupSpy.mockClear();
     editMessageTextSpy.mockClear();
@@ -591,32 +591,18 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
-    expect(resolveExecApprovalSpy).toHaveBeenCalledWith({
-      cfg: expect.objectContaining({
-        approvals: expect.objectContaining({
-          exec: expect.objectContaining({
-            enabled: true,
-            mode: "targets",
-          }),
-        }),
-      }),
-      approvalId: "138e9b8c",
-      decision: "allow-once",
-      allowPluginFallback: false,
-      senderId: "9",
-    });
-    expect(editMessageReplyMarkupSpy).toHaveBeenCalledTimes(1);
+    expect(resolveExecApprovalSpy).not.toHaveBeenCalled();
+    expect(editMessageReplyMarkupSpy).not.toHaveBeenCalled();
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-approve-target");
   });
 
-  it("keeps legacy plugin fallback approval failures retryable for target-only recipients", async () => {
+  it("blocks legacy plugin fallback approval attempts from target-only recipients", async () => {
     onSpy.mockClear();
     editMessageReplyMarkupSpy.mockClear();
     editMessageTextSpy.mockClear();
     resolveExecApprovalSpy.mockClear();
     replySpy.mockClear();
     sendMessageSpy.mockClear();
-    resolveExecApprovalSpy.mockRejectedValueOnce(new Error("unknown or expired approval id"));
 
     loadConfig.mockReturnValue({
       approvals: {
@@ -639,38 +625,23 @@ describe("createTelegramBot", () => {
     ) => Promise<void>;
     expect(callbackHandler).toBeDefined();
 
-    await expect(
-      callbackHandler({
-        callbackQuery: {
-          id: "cbq-legacy-plugin-fallback-blocked",
-          data: "/approve 138e9b8c allow-once",
-          from: { id: 9, first_name: "Ada", username: "ada_bot" },
-          message: {
-            chat: { id: 1234, type: "private" },
-            date: 1736380800,
-            message_id: 25,
-            text: "Legacy plugin approval required.",
-          },
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-legacy-plugin-fallback-blocked",
+        data: "/approve 138e9b8c allow-once",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 25,
+          text: "Legacy plugin approval required.",
         },
-        me: { username: "openclaw_bot" },
-        getFile: async () => ({ download: async () => new Uint8Array() }),
-      }),
-    ).rejects.toThrow("unknown or expired approval id");
-
-    expect(resolveExecApprovalSpy).toHaveBeenCalledWith({
-      cfg: expect.objectContaining({
-        approvals: expect.objectContaining({
-          exec: expect.objectContaining({
-            enabled: true,
-            mode: "targets",
-          }),
-        }),
-      }),
-      approvalId: "138e9b8c",
-      decision: "allow-once",
-      allowPluginFallback: false,
-      senderId: "9",
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
     });
+
+    expect(resolveExecApprovalSpy).not.toHaveBeenCalled();
     expect(editMessageReplyMarkupSpy).not.toHaveBeenCalled();
     expect(replySpy).not.toHaveBeenCalled();
     expect(sendMessageSpy).not.toHaveBeenCalled();

--- a/extensions/telegram/src/exec-approvals.test.ts
+++ b/extensions/telegram/src/exec-approvals.test.ts
@@ -472,7 +472,7 @@ describe("telegram exec approvals", () => {
       expect(isTelegramExecApprovalAuthorizedSender({ cfg, senderId: "123" })).toBe(true);
     });
 
-    it("accepts active forwarded DM targets", () => {
+    it("rejects active forwarded DM targets that are not explicit approvers", () => {
       const cfg = {
         channels: { telegram: { botToken: "tok" } },
         approvals: {
@@ -483,7 +483,7 @@ describe("telegram exec approvals", () => {
           },
         },
       } as OpenClawConfig;
-      expect(isTelegramExecApprovalAuthorizedSender({ cfg, senderId: "12345" })).toBe(true);
+      expect(isTelegramExecApprovalAuthorizedSender({ cfg, senderId: "12345" })).toBe(false);
     });
   });
 });

--- a/extensions/telegram/src/exec-approvals.ts
+++ b/extensions/telegram/src/exec-approvals.ts
@@ -7,8 +7,6 @@ import {
 } from "openclaw/plugin-sdk/approval-client-runtime";
 import { resolveApprovalRequestChannelAccountId } from "openclaw/plugin-sdk/approval-native-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import type { TelegramExecApprovalConfig } from "openclaw/plugin-sdk/config-runtime";
-import type { ExecApprovalRequest, PluginApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import {
@@ -18,6 +16,12 @@ import {
 import { listTelegramAccountIds, resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramInlineButtonsConfigScope } from "./inline-buttons.js";
 import { normalizeTelegramChatId, resolveTelegramTargetChatType } from "./targets.js";
+
+// Local generic wrapper to defer union resolution. Works around a single-file-mode limitation
+// in the type-aware lint where imported plugin-sdk barrel types are treated as `error` and trip
+// `no-redundant-type-constituents` on otherwise-valid unions.
+type Maybe<T> = T | undefined;
+type ApprovalRequest = Parameters<typeof resolveApprovalRequestChannelAccountId>[0]["request"];
 
 function normalizeApproverId(value: string | number): string {
   return normalizeOptionalString(String(value)) ?? "";
@@ -35,7 +39,7 @@ function normalizeTelegramDirectApproverId(value: string | number): string | und
 export function resolveTelegramExecApprovalConfig(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
-}): TelegramExecApprovalConfig | undefined {
+}): Maybe<ReturnType<typeof resolveTelegramAccount>["config"]["execApprovals"]> {
   const account = resolveTelegramAccount(params);
   const config = account.config.execApprovals;
   if (!config) {
@@ -80,7 +84,7 @@ export function isTelegramExecApprovalTargetRecipient(params: {
 
 function countTelegramExecApprovalEligibleAccounts(params: {
   cfg: OpenClawConfig;
-  request: ExecApprovalRequest | PluginApprovalRequest;
+  request: ApprovalRequest;
 }): number {
   return listTelegramAccountIds(params.cfg).filter((accountId) => {
     const account = resolveTelegramAccount({ cfg: params.cfg, accountId });
@@ -109,7 +113,7 @@ function countTelegramExecApprovalEligibleAccounts(params: {
 function matchesTelegramRequestAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
-  request: ExecApprovalRequest | PluginApprovalRequest;
+  request: ApprovalRequest;
 }): boolean {
   const turnSourceChannel = normalizeLowercaseStringOrEmpty(
     params.request.request.turnSourceChannel,
@@ -146,8 +150,9 @@ const telegramExecApprovalProfile = createChannelExecApprovalProfile({
 
 export const isTelegramExecApprovalClientEnabled = telegramExecApprovalProfile.isClientEnabled;
 export const isTelegramExecApprovalApprover = telegramExecApprovalProfile.isApprover;
-export const isTelegramExecApprovalAuthorizedSender =
-  telegramExecApprovalProfile.isAuthorizedSender;
+// Exec forwarding targets control delivery only; resolving approvals still requires an
+// explicit Telegram approver so notification recipients do not gain approval authority.
+export const isTelegramExecApprovalAuthorizedSender = telegramExecApprovalProfile.isApprover;
 export const resolveTelegramExecApprovalTarget = telegramExecApprovalProfile.resolveTarget;
 export const shouldHandleTelegramExecApprovalRequest =
   telegramExecApprovalProfile.shouldHandleRequest;

--- a/src/auto-reply/reply/commands-approve.test.ts
+++ b/src/auto-reply/reply/commands-approve.test.ts
@@ -215,33 +215,6 @@ function getTelegramExecApprovalApprovers(params: {
   });
 }
 
-function isTelegramExecApprovalTargetRecipient(params: {
-  cfg: OpenClawConfig;
-  senderId?: string | null;
-  accountId?: string | null;
-}): boolean {
-  const senderId = params.senderId?.trim();
-  const execApprovals = params.cfg.approvals?.exec;
-  if (
-    !senderId ||
-    execApprovals?.enabled !== true ||
-    (execApprovals.mode !== "targets" && execApprovals.mode !== "both")
-  ) {
-    return false;
-  }
-  const accountId = params.accountId ? normalizeAccountId(params.accountId) : undefined;
-  return (execApprovals.targets ?? []).some((target) => {
-    if (target.channel?.trim().toLowerCase() !== "telegram") {
-      return false;
-    }
-    if (accountId && target.accountId && normalizeAccountId(target.accountId) !== accountId) {
-      return false;
-    }
-    const to = target.to ? normalizeTelegramDirectApproverId(target.to) : undefined;
-    return Boolean(to && to === senderId);
-  });
-}
-
 function isTelegramExecApprovalAuthorizedSender(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
@@ -251,10 +224,7 @@ function isTelegramExecApprovalAuthorizedSender(params: {
   if (!senderId) {
     return false;
   }
-  return (
-    getTelegramExecApprovalApprovers(params).includes(senderId) ||
-    isTelegramExecApprovalTargetRecipient(params)
-  );
+  return getTelegramExecApprovalApprovers(params).includes(senderId);
 }
 
 function isTelegramExecApprovalClientEnabled(params: {
@@ -317,20 +287,11 @@ const telegramApproveTestPlugin: ChannelPlugin = {
   approvalCapability: {
     authorizeActorAction: telegramNativeApprovalAdapter.auth.authorizeActorAction,
     getActionAvailabilityState: telegramNativeApprovalAdapter.auth.getActionAvailabilityState,
-    resolveApproveCommandBehavior: ({ cfg, accountId, senderId, approvalKind }) => {
+    resolveApproveCommandBehavior: ({ cfg, accountId, approvalKind }) => {
       if (approvalKind !== "exec") {
         return undefined;
       }
       if (isTelegramExecApprovalClientEnabled({ cfg, accountId })) {
-        return undefined;
-      }
-      if (isTelegramExecApprovalTargetRecipient({ cfg, accountId, senderId })) {
-        return undefined;
-      }
-      if (
-        isTelegramExecApprovalAuthorizedSender({ cfg, accountId, senderId }) &&
-        !getTelegramExecApprovalApprovers({ cfg, accountId }).includes(senderId?.trim() ?? "")
-      ) {
         return undefined;
       }
       return {
@@ -700,7 +661,7 @@ describe("handleApproveCommand", () => {
     );
   });
 
-  it("accepts Telegram /approve from exec target recipients when native approvals are disabled", async () => {
+  it("rejects Telegram /approve from exec target recipients when native approvals are disabled", async () => {
     const params = buildApproveParams(
       "/approve abc12345 allow-once",
       {
@@ -729,13 +690,8 @@ describe("handleApproveCommand", () => {
 
     const result = await handleApproveCommand(params, true);
     expect(result?.shouldContinue).toBe(false);
-    expect(result?.reply?.text).toContain("Approval allow-once submitted");
-    expect(callGatewayMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        method: "exec.approval.resolve",
-        params: { id: "abc12345", decision: "allow-once" },
-      }),
-    );
+    expect(result?.reply?.text).toContain("Telegram exec approvals are not enabled");
+    expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
   it("requires configured Discord approvers for exec approvals", async () => {


### PR DESCRIPTION
## Summary

- Problem: Telegram exec approval forwarding targets were treated as authorized approval senders for inline callbacks and `/approve` resolution.
- Why it matters: a target recipient in `approvals.exec.targets` could approve exec requests even when it was not listed in `channels.telegram.*.execApprovals.approvers`.
- What changed: exec approvals now require explicit Telegram approver membership again, while `approvals.exec.targets` remains delivery-only; regression tests now block target-only recipients for callbacks and `/approve`.
- What did NOT change (scope boundary): approval forwarding still delivers to configured Telegram targets, and non-Telegram approval flows were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Telegram exec approval authorization reused the broader "authorized sender" concept, which included recipients from `approvals.exec.targets`, instead of requiring explicit approver membership.
- Missing detection / guardrail: tests had encoded the permissive target-recipient behavior instead of asserting that only explicit approvers may resolve exec approvals.
- Contributing context (if known): forwarding targets and approvers were conflated so delivery configuration also granted approval authority.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/exec-approvals.test.ts`, `extensions/telegram/src/bot.test.ts`, `src/auto-reply/reply/commands-approve.test.ts`
- Scenario the test should lock in: a Telegram target-only recipient must not be able to approve via inline callback or `/approve` unless it is also configured as an explicit exec approver.
- Why this is the smallest reliable guardrail: the bug spans the Telegram approval helper, the native callback path, and the `/approve` command flow.
- Existing test that already covers this (if any): none after the regression, because the affected tests were asserting the wrong behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Telegram exec approval forwarding targets still receive approval deliveries, but they no longer gain approval authority unless they are explicitly listed as approvers.

## Diagram (if applicable)

```text
Before:
[exec approval forwarded to Telegram target] -> [target clicks callback or runs /approve] -> [approval accepted]

After:
[exec approval forwarded to Telegram target] -> [explicit approver check] -> [only approver may resolve]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this narrows exec approval authority back to the explicit Telegram approver list instead of implicitly granting it to notification targets.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Telegram exec approvals and `/approve`
- Relevant config (redacted): `approvals.exec.targets` set to a Telegram DM recipient that is not present in `channels.telegram.*.execApprovals.approvers`

### Steps

1. Configure a Telegram forwarding target for exec approvals that is not an explicit Telegram approver.
2. Deliver an exec approval to that target.
3. Attempt to approve via the inline callback or `/approve` from that target account.

### Expected

- The target-only recipient is rejected because it is not an explicit Telegram approver.

### Actual

- Before this fix, the target-only recipient could resolve the exec approval.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Telegram approval tests for callback auth, `/approve` auth, and helper-level authorization; full `pnpm check` also passed via the commit hook.
- Edge cases checked: explicit approvers still authorize correctly, and forwarding-only targets still receive notifications.
- What you did **not** verify: live Telegram bot interaction against a real chat/account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: add any Telegram target that should also approve to the explicit `execApprovals.approvers` list.

## Risks and Mitigations

- Risk: installs that relied on target-only recipients approving requests will now see those approvals rejected.
  - Mitigation: delivery behavior is unchanged, and the config can explicitly add those accounts as approvers if that authority is intended.

## AI Assistance

- AI-assisted: Codex
- Testing degree: fully tested
- I understand what the code does: Yes
