### PR TITLE
fix(discord): honor native command allowlists

### DIFF
--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -165,6 +165,37 @@ describe("Discord native slash commands with commands.allowFrom", () => {
     expectNotUnauthorizedReply(interaction);
   });
 
+  it("rejects guild slash commands from allowlisted channels when user restrictions deny the sender", async () => {
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      userId: "999999999999999999",
+      mutateConfig: (cfg) => {
+        cfg.commands = {
+          ...cfg.commands,
+          allowFrom: undefined,
+        };
+        cfg.channels = {
+          ...cfg.channels,
+          discord: {
+            ...cfg.channels?.discord,
+            guilds: {
+              "345678901234567890": {
+                users: ["user:111111111111111111"],
+                channels: {
+                  "234567890123456789": {
+                    enabled: true,
+                    requireMention: false,
+                  },
+                },
+              },
+            },
+          },
+        };
+      },
+    });
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expectUnauthorizedReply(interaction);
+  });
+
   it("rejects guild slash commands outside the Discord allowlist when commands.useAccessGroups is false and commands.allowFrom is not configured", async () => {
     const { dispatchSpy, interaction } = await runGuildSlashCommand({
       mutateConfig: (cfg) => {

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -242,7 +242,15 @@ function resolveDiscordGuildNativeCommandAuthorized(params: {
     configured: hasAccessRestrictions,
     allowed: memberAllowed,
   };
-  const fallbackAuthorizers = [policyAuthorizer, ownerAuthorizer, memberAuthorizer];
+  const fallbackAuthorizers = [ownerAuthorizer, memberAuthorizer];
+  if (
+    params.useAccessGroups &&
+    !params.commandsAllowFromAccess.configured &&
+    !ownerAuthorizer.configured &&
+    !memberAuthorizer.configured
+  ) {
+    return true;
+  }
   return resolveCommandAuthorizedFromAuthorizers({
     useAccessGroups: params.useAccessGroups,
     authorizers: params.useAccessGroups


### PR DESCRIPTION
## Summary

- Problem: when `commands.allowFrom` was unset, Discord native slash commands treated the guild/channel policy authorizer as an alternative to sender-specific allowlists.
- Why it matters: any member in an allowlisted guild/channel could run native commands even when `users` or `roles` restrictions should deny them.
- What changed: kept the guild/channel allowlist as a prerequisite, but stopped it from acting as a fallback authorizer over user/role checks; added a regression test for an allowlisted channel with a denied sender.
- What did NOT change (scope boundary): explicit `commands.allowFrom` handling, DM/group DM authorization, and guild/channel allowlist policy semantics outside this native-command path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveDiscordGuildNativeCommandAuthorized(...)` first required `policyAuthorizer.allowed`, then still included `policyAuthorizer` in the OR-based authorizer list, so an allowlisted guild/channel could short-circuit sender-specific restrictions.
- Missing detection / guardrail: there was no regression test for the case where a guild/channel is allowlisted but the sender is denied by `users` or `roles` restrictions.
- Contributing context (if known): the policy authorizer was trying to preserve access-group behavior when `commands.allowFrom` is not configured, but it widened authorization instead of remaining a gate.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts`
- Scenario the test should lock in: a Discord slash command from an allowlisted guild/channel must still be rejected when sender-specific restrictions deny that member.
- Why this is the smallest reliable guardrail: the bug lives in the native-command authorization seam where guild policy, sender restrictions, and dispatch all meet.
- Existing test that already covers this (if any): existing tests covered allowlisted channels and explicit `commands.allowFrom`, but not the denied-sender combination.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Unauthorized Discord members no longer gain native slash-command access solely by being in an allowlisted guild/channel when sender restrictions are configured.

## Diagram (if applicable)

```text
Before:
[allowlisted guild/channel] -> [policy authorizer allows] -> [slash command dispatches]
                              [sender restrictions ignored]

After:
[allowlisted guild/channel] -> [policy gate passes] -> [sender restrictions checked] -> [only authorized sender dispatches]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this narrows Discord native command execution back to the intended sender allowlists when they are configured.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Discord native slash commands
- Relevant config (redacted): allowlisted Discord guild/channel with sender-specific restrictions under `channels.discord.guilds`

### Steps

1. Configure a Discord guild or channel as allowlisted.
2. Add `users` or `roles` restrictions that do not include the invoking member.
3. Leave `commands.allowFrom` unset and invoke a native slash command from that member.

### Expected

- The command is rejected as unauthorized and does not dispatch.

### Actual

- Before this fix, the allowlisted guild/channel policy authorizer could still authorize the command.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Discord native-command regression test for an allowlisted channel with a denied sender, plus full `pnpm check`.
- Edge cases checked: allowlisted channels still work when no sender-specific restrictions are configured.
- What you did **not** verify: live Discord end-to-end behavior against a real bot/server.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: installs that unintentionally relied on the broader fallback may now block unauthorized members once sender restrictions are present.
  - Mitigation: the guild/channel allowlist still works when there are no sender-specific restrictions, and the new regression test locks in both allowed and denied behavior.

## AI Assistance

- AI-assisted: Codex
- Testing degree: fully tested
- I understand what the code does: Yes
