### PR TITLE
fix: skip Homebrew prompt on FreeBSD and other non-Linux/macOS platforms

### DIFF
--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -109,7 +109,7 @@ export async function setupSkills(
       .filter((item): item is (typeof installable)[number] => Boolean(item));
 
     const needsBrewPrompt =
-      process.platform !== "win32" &&
+      (process.platform === "darwin" || process.platform === "linux") &&
       selectedSkills.some((skill) => skill.install.some((option) => option.kind === "brew")) &&
       !(await detectBinary("brew"));
 


### PR DESCRIPTION
## Summary

Fixes #68893.

The `needsBrewPrompt` guard in `src/commands/onboard-skills.ts` used:

```ts
process.platform !== "win32"
```

This incorrectly shows the Homebrew install suggestion on FreeBSD (and any other non-Windows unix that isn't macOS or Linux), where Homebrew is **not supported**.

## Change

Tighten the check to an explicit allowlist of the two platforms Homebrew officially supports:

```ts
// Before
process.platform !== "win32"

// After
(process.platform === "darwin" || process.platform === "linux")
```

## Test plan

- [ ] On macOS/Linux with no `brew` binary: wizard still shows Homebrew prompt
- [ ] On FreeBSD with no `brew` binary: wizard no longer shows Homebrew prompt
- [ ] On Windows: unchanged (prompt was already skipped)
