### PR TITLE
fix: skip Homebrew prompt on FreeBSD

### DIFF
--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -186,4 +186,26 @@ describe("setupSkills", () => {
     const brewNote = notes.find((n) => n.title === "Homebrew recommended");
     expect(brewNote).toBeDefined();
   });
+
+  it("does not recommend Homebrew on FreeBSD even when brew-backed installs are selected", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("freebsd");
+    try {
+      mockMissingBrewStatus([
+        createBundledSkill({
+          name: "video-frames",
+          description: "ffmpeg",
+          bins: ["ffmpeg"],
+          installLabel: "Install ffmpeg (brew)",
+        }),
+      ]);
+
+      const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
+      await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+      const brewNote = notes.find((n) => n.title === "Homebrew recommended");
+      expect(brewNote).toBeUndefined();
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
 });

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -108,8 +108,9 @@ export async function setupSkills(
       .map((name) => installable.find((s) => s.name === name))
       .filter((item): item is (typeof installable)[number] => Boolean(item));
 
+    const supportsBrewInstallPrompt = process.platform === "darwin" || process.platform === "linux";
     const needsBrewPrompt =
-      process.platform !== "win32" &&
+      supportsBrewInstallPrompt &&
       selectedSkills.some((skill) => skill.install.some((option) => option.kind === "brew")) &&
       !(await detectBinary("brew"));
 


### PR DESCRIPTION
## Summary

Avoid showing the Homebrew install prompt during `openclaw onboard` on FreeBSD. The onboarding flow was treating every non-Windows platform as Homebrew-capable, which led to a misleading brew recommendation on FreeBSD.

## Changes

- restrict the Homebrew recommendation prompt to macOS and Linux
- keep the existing behavior unchanged on macOS and Linux
- add a regression test that mocks `process.platform = "freebsd"`

## Testing

- `pnpm exec vitest run src/commands/onboard-skills.test.ts`
- repo commit hook checks during `git commit` (tsgo, lint, import-cycle checks)

Fixes openclaw/openclaw#68893