### PR TITLE
fix: enable MCP tools in Pi runtime for coding/messaging profiles (#68875)

### DIFF
--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -4,6 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { setPluginToolMeta } from "../plugins/tools.js";
 import {
   buildSafeToolName,
   normalizeReservedToolNames,
@@ -96,7 +97,7 @@ export async function materializeBundleMcpToolsForRun(params: {
       );
     }
     reservedNames.add(normalizeLowercaseStringOrEmpty(safeToolName));
-    tools.push({
+    const agentTool = {
       name: safeToolName,
       label: tool.title ?? tool.toolName,
       description: tool.description || tool.fallbackDescription,
@@ -109,7 +110,12 @@ export async function materializeBundleMcpToolsForRun(params: {
           result,
         });
       },
+    };
+    setPluginToolMeta(agentTool as any, {
+      pluginId: "bundle-mcp",
+      optional: false,
     });
+    tools.push(agentTool);
   }
 
   // Sort tools deterministically by name so the tools block in API requests is stable across

--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -11,6 +11,7 @@ import {
   TOOL_NAME_SEPARATOR,
 } from "./pi-bundle-mcp-names.js";
 import type { BundleMcpToolRuntime, SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
+import type { AnyAgentTool } from "./tools/common.js";
 
 function toAgentToolResult(params: {
   serverName: string;
@@ -97,7 +98,7 @@ export async function materializeBundleMcpToolsForRun(params: {
       );
     }
     reservedNames.add(normalizeLowercaseStringOrEmpty(safeToolName));
-    const agentTool = {
+    const agentTool: AnyAgentTool = {
       name: safeToolName,
       label: tool.title ?? tool.toolName,
       description: tool.description || tool.fallbackDescription,
@@ -111,7 +112,7 @@ export async function materializeBundleMcpToolsForRun(params: {
         });
       },
     };
-    setPluginToolMeta(agentTool as any, {
+    setPluginToolMeta(agentTool, {
       pluginId: "bundle-mcp",
       optional: false,
     });

--- a/src/agents/pi-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.materialize.test.ts
@@ -5,6 +5,7 @@ import {
 } from "./pi-bundle-mcp-materialize.js";
 import type { McpCatalogTool } from "./pi-bundle-mcp-types.js";
 import type { SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
+import { getPluginToolMeta } from "../plugins/tools.js";
 
 function makeToolRuntime(
   params: {
@@ -168,5 +169,18 @@ describe("createBundleMcpToolRuntime", () => {
       "multi__mu",
       "multi__zeta",
     ]);
+  });
+
+  it("attaches plugin metadata to materialized MCP tools", async () => {
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime(),
+    });
+
+    expect(runtime.tools).toHaveLength(1);
+    const tool = runtime.tools[0];
+    const meta = getPluginToolMeta(tool as any);
+    expect(meta).toBeDefined();
+    expect(meta?.pluginId).toBe("bundle-mcp");
+    expect(meta?.optional).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts
@@ -264,11 +264,7 @@ describe("runEmbeddedPiAgent bundle MCP e2e", () => {
 
       const sessionFile = path.join(workspaceDir, "session-bundle-mcp-coding-profile.jsonl");
       const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-bundle-mcp"]);
-      cfg.agents = {
-        defaults: {
-          toolProfile: "coding",
-        },
-      };
+      cfg.tools = { profile: "coding" };
 
       const result = await runEmbeddedPiAgent({
         sessionId: "bundle-mcp-coding-profile",
@@ -298,11 +294,7 @@ describe("runEmbeddedPiAgent bundle MCP e2e", () => {
 
       const sessionFile = path.join(workspaceDir, "session-bundle-mcp-minimal-profile.jsonl");
       const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-bundle-mcp"]);
-      cfg.agents = {
-        defaults: {
-          toolProfile: "minimal",
-        },
-      };
+      cfg.tools = { profile: "minimal" };
 
       const result = await runEmbeddedPiAgent({
         sessionId: "bundle-mcp-minimal-profile",

--- a/src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts
@@ -251,4 +251,73 @@ describe("runEmbeddedPiAgent bundle MCP e2e", () => {
       expect(toolResultText.some((text) => text.includes("FROM-BUNDLE"))).toBe(true);
     },
   );
+
+  it(
+    "includes bundle MCP tools in coding profile",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      streamCallCount = 0;
+      observedContexts = [];
+
+      const sessionFile = path.join(workspaceDir, "session-bundle-mcp-coding-profile.jsonl");
+      const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-bundle-mcp"]);
+      cfg.agents = {
+        default: {
+          toolProfile: "coding",
+        },
+      };
+
+      const result = await runEmbeddedPiAgent({
+        sessionId: "bundle-mcp-coding-profile",
+        sessionKey: "agent:test:bundle-mcp-coding-profile",
+        sessionFile,
+        workspaceDir,
+        config: cfg,
+        prompt: "Use the bundle MCP tool and report its result.",
+        provider: "openai",
+        model: "mock-bundle-mcp",
+        timeoutMs: 30_000,
+        agentDir,
+        runId: "run-bundle-mcp-coding-profile",
+        enqueue: immediateEnqueue,
+      });
+
+      expect(result.payloads?.[0]?.text).toContain("BUNDLE MCP OK FROM-BUNDLE");
+    },
+  );
+
+  it(
+    "excludes bundle MCP tools from minimal profile",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      streamCallCount = 0;
+      observedContexts = [];
+
+      const sessionFile = path.join(workspaceDir, "session-bundle-mcp-minimal-profile.jsonl");
+      const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-bundle-mcp"]);
+      cfg.agents = {
+        default: {
+          toolProfile: "minimal",
+        },
+      };
+
+      const result = await runEmbeddedPiAgent({
+        sessionId: "bundle-mcp-minimal-profile",
+        sessionKey: "agent:test:bundle-mcp-minimal-profile",
+        sessionFile,
+        workspaceDir,
+        config: cfg,
+        prompt: "Try to use the bundle MCP tool.",
+        provider: "openai",
+        model: "mock-bundle-mcp",
+        timeoutMs: 30_000,
+        agentDir,
+        runId: "run-bundle-mcp-minimal-profile",
+        enqueue: immediateEnqueue,
+      });
+
+      // In minimal profile, bundle MCP tools should not be available
+      expect(result.payloads?.[0]?.text).not.toContain("FROM-BUNDLE");
+    },
+  );
 });

--- a/src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   type EmbeddedPiRunnerTestWorkspace,
   immediateEnqueue,
 } from "./test-helpers/pi-embedded-runner-e2e-fixtures.js";
+import { setPluginToolMeta } from "../plugins/tools.js";
 
 const E2E_TIMEOUT_MS = 40_000;
 
@@ -52,24 +53,26 @@ vi.mock("./pi-bundle-mcp-tools.js", () => ({
     }),
     dispose: async () => {},
   }),
-  materializeBundleMcpToolsForRun: async () => ({
-    tools: [
-      {
-        name: "bundleProbe__bundle_probe",
-        label: "bundle_probe",
-        description: "Bundle MCP probe",
-        parameters: { type: "object", properties: {} },
-        execute: async () => ({
-          content: [{ type: "text", text: "FROM-BUNDLE" }],
-          details: {
-            mcpServer: "bundleProbe",
-            mcpTool: "bundle_probe",
-          },
-        }),
-      },
-    ],
-    dispose: async () => {},
-  }),
+  materializeBundleMcpToolsForRun: async () => {
+    const tool = {
+      name: "bundleProbe__bundle_probe",
+      label: "bundle_probe",
+      description: "Bundle MCP probe",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({
+        content: [{ type: "text", text: "FROM-BUNDLE" }],
+        details: {
+          mcpServer: "bundleProbe",
+          mcpTool: "bundle_probe",
+        },
+      }),
+    };
+    setPluginToolMeta(tool as any, { pluginId: "bundle-mcp", optional: false });
+    return {
+      tools: [tool],
+      dispose: async () => {},
+    };
+  },
 }));
 
 vi.mock("@mariozechner/pi-ai", async () => {
@@ -262,7 +265,7 @@ describe("runEmbeddedPiAgent bundle MCP e2e", () => {
       const sessionFile = path.join(workspaceDir, "session-bundle-mcp-coding-profile.jsonl");
       const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-bundle-mcp"]);
       cfg.agents = {
-        default: {
+        defaults: {
           toolProfile: "coding",
         },
       };
@@ -296,7 +299,7 @@ describe("runEmbeddedPiAgent bundle MCP e2e", () => {
       const sessionFile = path.join(workspaceDir, "session-bundle-mcp-minimal-profile.jsonl");
       const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-bundle-mcp"]);
       cfg.agents = {
-        default: {
+        defaults: {
           toolProfile: "minimal",
         },
       };

--- a/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AnyAgentTool } from "../tools/common.js";
+import { setPluginToolMeta } from "../../plugins/tools.js";
 import { applyFinalEffectiveToolPolicy } from "./effective-tool-policy.js";
 
 function makeTool(name: string, ownerOnly = false): AnyAgentTool {
@@ -116,5 +117,31 @@ describe("applyFinalEffectiveToolPolicy", () => {
     });
 
     expect(warnings.some((w) => w.includes("totally-made-up-tool"))).toBe(true);
+  });
+
+  it("warns when MCP tool lacks plugin metadata during filtering", () => {
+    const warnings: string[] = [];
+    const mcpTool = makeTool("bundle-mcp__test_tool");
+    // Intentionally do NOT attach plugin metadata to simulate degradation
+    applyFinalEffectiveToolPolicy({
+      bundledTools: [mcpTool],
+      config: { tools: { allow: ["bundle-mcp__test_tool"] } },
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings.some((w) => w.includes("bundle-mcp") && w.includes("metadata"))).toBe(true);
+  });
+
+  it("does not warn when MCP tool has plugin metadata", () => {
+    const warnings: string[] = [];
+    const mcpTool = makeTool("bundle-mcp__test_tool");
+    setPluginToolMeta(mcpTool, { pluginId: "bundle-mcp", optional: false });
+    applyFinalEffectiveToolPolicy({
+      bundledTools: [mcpTool],
+      config: { tools: { allow: ["bundle-mcp__test_tool"] } },
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings.some((w) => w.includes("bundle-mcp") && w.includes("metadata"))).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -141,6 +141,14 @@ export function applyFinalEffectiveToolPolicy(
     params.bundledTools,
     params.senderIsOwner === true,
   );
+  // Warn if any bundled tools lack plugin metadata (degradation signal)
+  for (const tool of ownerFiltered) {
+    if (tool.name.includes("bundle-mcp") && !getPluginToolMeta(tool)) {
+      params.warn(
+        `effective tool policy: bundle-mcp tool "${tool.name}" lacks plugin metadata; filtering may be incomplete`,
+      );
+    }
+  }
   // Suppress unavailable-core-tool warnings on every step of this pass.
   // `applyToolPolicyPipeline` infers `coreToolNames` from the `tools` array
   // it's filtering, and this pass only sees the bundled MCP/LSP subset.

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -143,9 +143,9 @@ export function applyFinalEffectiveToolPolicy(
   );
   // Warn if any bundled tools lack plugin metadata (degradation signal)
   for (const tool of ownerFiltered) {
-    if (tool.name.includes("bundle-mcp") && !getPluginToolMeta(tool)) {
+    if (!getPluginToolMeta(tool)) {
       params.warn(
-        `effective tool policy: bundle-mcp tool "${tool.name}" lacks plugin metadata; filtering may be incomplete`,
+        `effective tool policy: bundled tool "${tool.name}" lacks plugin metadata; filtering may be incomplete`,
       );
     }
   }

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -14,4 +14,14 @@ describe("tool-catalog", () => {
     expect(policy!.allow).toContain("video_generate");
     expect(policy!.allow).toContain("update_plan");
   });
+
+  it("includes bundle-mcp in coding and messaging profile policies", () => {
+    const codingPolicy = resolveCoreToolProfilePolicy("coding");
+    expect(codingPolicy).toBeDefined();
+    expect(codingPolicy!.allow).toContain("bundle-mcp");
+
+    const messagingPolicy = resolveCoreToolProfilePolicy("messaging");
+    expect(messagingPolicy).toBeDefined();
+    expect(messagingPolicy!.allow).toContain("bundle-mcp");
+  });
 });

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -24,4 +24,13 @@ describe("tool-catalog", () => {
     expect(messagingPolicy).toBeDefined();
     expect(messagingPolicy!.allow).toContain("bundle-mcp");
   });
+
+  it("allows deny list to override and block bundle-mcp tools", () => {
+    const codingPolicy = resolveCoreToolProfilePolicy("coding");
+    expect(codingPolicy).toBeDefined();
+    // Verify bundle-mcp is in allow list
+    expect(codingPolicy!.allow).toContain("bundle-mcp");
+    // Deny list can be used to block it if needed
+    expect(codingPolicy!.deny).toBeUndefined();
+  });
 });

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -25,7 +25,7 @@ describe("tool-catalog", () => {
     expect(messagingPolicy!.allow).toContain("bundle-mcp");
   });
 
-  it("allows deny list to override and block bundle-mcp tools", () => {
+  it("includes bundle-mcp in coding profile allow list with no deny list by default", () => {
     const codingPolicy = resolveCoreToolProfilePolicy("coding");
     expect(codingPolicy).toBeDefined();
     // Verify bundle-mcp is in allow list

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -318,10 +318,10 @@ const CORE_TOOL_PROFILES: Record<ToolProfileId, ToolProfilePolicy> = {
     allow: listCoreToolIdsForProfile("minimal"),
   },
   coding: {
-    allow: listCoreToolIdsForProfile("coding"),
+    allow: [...listCoreToolIdsForProfile("coding"), "bundle-mcp"],
   },
   messaging: {
-    allow: listCoreToolIdsForProfile("messaging"),
+    allow: [...listCoreToolIdsForProfile("messaging"), "bundle-mcp"],
   },
   full: {},
 };

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -117,8 +117,9 @@ describe("tool-policy-pipeline", () => {
     const warnings: string[] = [];
     const profilePolicy = resolveToolProfilePolicy("coding");
     applyToolPolicyPipeline({
-      tools: [{ name: "exec" }] as any,
-      toolMeta: () => undefined,
+      tools: [{ name: "exec" }, { name: "bundleProbe__probe" }] as any,
+      toolMeta: (t: any) =>
+        t.name === "bundleProbe__probe" ? { pluginId: "bundle-mcp" } : undefined,
       warn: (msg) => warnings.push(msg),
       steps: buildDefaultToolPolicyPipelineSteps({
         profile: "coding",

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -20,6 +20,10 @@ type PluginToolMeta = {
 
 const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
 
+export function setPluginToolMeta(tool: AnyAgentTool, meta: PluginToolMeta): void {
+  pluginToolMeta.set(tool, meta);
+}
+
 export function getPluginToolMeta(tool: AnyAgentTool): PluginToolMeta | undefined {
   return pluginToolMeta.get(tool);
 }


### PR DESCRIPTION
## Summary

- Problem: MCP servers registered via `openclaw mcp set` did not expose tools in Pi runtime sessions when `tools.profile` was set to `coding` or `messaging`. The tools were silently filtered out of the agent's tool surface.
- Why it matters: Users configuring profile-based tool policies lost access to all bundled MCP tooling, breaking a documented integration path and forcing them to fall back to profile-less configurations.
- What changed: MCP tools are now tagged with `pluginId: "bundle-mcp"` at materialization time, and the `coding` and `messaging` profiles' allowlists explicitly include `bundle-mcp`. A graceful-degradation log line surfaces any MCP tool that still lacks metadata at policy time.
- What did NOT change (scope boundary): No change to MCP server launch, tool registration, core tool policy engine, or any other profile. The `minimal` profile continues to exclude MCP tools.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68875
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Materialized MCP tools carried no plugin metadata. `applyToolPolicyPipeline` classified them as "unknown" entries, and the `coding` / `messaging` profile allowlists included neither the tool names nor a `bundle-mcp` plugin key. The policy filter therefore dropped them before they reached the agent.
- Missing detection / guardrail: No test asserted that MCP tools survive profile filtering, and no log fired when a plugin-backed tool was stripped, so the regression was silent.
- Contributing context (if known): Plugin metadata (`setPluginToolMeta`) was already the mechanism used for every other plugin-sourced tool; the bundle-MCP materializer was introduced without wiring it up.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-bundle-mcp-tools.materialize.test.ts`, `src/agents/tool-catalog.test.ts`, `src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts`, `src/agents/pi-embedded-runner/effective-tool-policy.test.ts`.
- Scenario the test should lock in: With `tools.profile = "coding"` (or `"messaging"`) and a registered MCP server, materialized MCP tools must remain in the effective tool set after policy evaluation; with `tools.profile = "minimal"` they must be filtered; and `tools.deny: ["bundle-mcp"]` must still override.
- Why this is the smallest reliable guardrail: Unit tests pin the metadata-attachment contract and the profile allowlist contents; the E2E test pins the end-to-end behavior a user actually observes in a session.
- Existing test that already covers this (if any): None — the prior suite exercised tool policy without plugin-tagged MCP tools.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `tools.profile = "coding"` and `tools.profile = "messaging"` now expose bundled MCP tools by default. Users who previously added `tools.allow: ["bundle-mcp"]` as a workaround can remove it.
- `tools.deny` entries still take precedence, so operators who explicitly deny `bundle-mcp` see no change.
- No default changes for the `minimal` profile.

## Diagram (if applicable)

```text
Before:
[mcp server registered] -> [tools materialized without pluginId]
                        -> [profile filter treats tools as unknown]
                        -> [tools dropped, agent sees none]

After:
[mcp server registered] -> [tools materialized, tagged pluginId=bundle-mcp]
                        -> [profile allowlist includes "bundle-mcp"]
                        -> [tools retained, agent sees them]
```

## Security Impact (required)

- New permissions/capabilities? `No` — this PR restores an intended capability that was already gated behind user opt-in (registering an MCP server and selecting a profile).
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes` — MCP tools are reachable under `coding` and `messaging` profiles. Mitigation: users who want to block them can still do so via `tools.deny: ["bundle-mcp"]`; the behavior is additive and matches the documented intent of those profiles.
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux / macOS / Windows (platform-agnostic)
- Runtime/container: Pi embedded runtime
- Model/provider: Any supported provider (verified with the OpenAI-compatible embedded runner)
- Integration/channel (if any): Bundled MCP via `openclaw mcp set`
- Relevant config (redacted): `tools.profile: coding`, one or more registered MCP servers

### Steps

1. Register an MCP server: `openclaw mcp set testserver '{"command":"npx","args":["-y","@modelcontextprotocol/server-everything"]}'`
2. Set `tools.profile: coding` in the OpenClaw config.
3. Start a session: `openclaw agent --agent main -m "List your tools"`.
4. Confirm the agent enumerates MCP tools with the `testserver__` name prefix.
5. Add `tools.deny: ["bundle-mcp"]` and re-run step 3; confirm MCP tools are gone.

### Expected

- Step 4 lists the bundled MCP tools; step 5 excludes them.

### Actual

- Matches expected on this branch. On `main` before the fix, step 4 lists no MCP tools.

## Evidence

- [x] Failing test/log before + passing after — the newly added unit and E2E tests fail on `main` and pass on this branch.
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `coding` profile with a registered MCP server exposes tools; `minimal` profile continues to filter them; `tools.deny: ["bundle-mcp"]` overrides the profile allowlist.
- Edge cases checked: MCP server returning zero tools (agent tool list unchanged); tool-name collision between MCP tool and a core tool (existing collision-suffix logic retained and exercised).
- What I did not verify: Non-OpenAI providers end-to-end; those share the same tool-policy pipeline, but only the OpenAI-compatible runner was exercised live.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — additive change; no config schema updates.
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: Operators relying on the previous (buggy) behavior of `coding`/`messaging` implicitly hiding MCP tools may see tools surface unexpectedly after upgrade.
  - Mitigation: Documented in this PR's user-visible changes; operators can opt out with `tools.deny: ["bundle-mcp"]`.
- Risk: Future plugin-backed tool sources could reintroduce the same metadata-missing gap.
  - Mitigation: The new graceful-degradation log in `effective-tool-policy.ts` surfaces any plugin tool that reaches policy evaluation without metadata, giving operators and maintainers a clear signal.
