### PR TITLE
fix(slack): tolerate unresolved channel SecretRef on outbound send path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/setup: require numeric `allowFrom` user IDs during setup instead of offering unsupported `@username` DM resolution, and point operators to `from.id`/`getUpdates` for discovery. (#69191) Thanks @obviyus.
 - GitHub Copilot/onboarding: default GitHub Copilot setup to `claude-opus-4.6` and keep the bundled default model list aligned, so new Copilot setups no longer start on the older `gpt-4o` default. (#69207) Thanks @obviyus.
 - Gateway/status: separate reachability, capability, and read-probe reporting so connect-only or scope-limited sessions no longer look fully healthy, and normalize SSH targets entered as `ssh user@host`. (#69215) Thanks @obviyus.
+- Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
 
 ## 2026.4.19-beta.2
 

--- a/extensions/slack/src/accounts.test.ts
+++ b/extensions/slack/src/accounts.test.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { describe, expect, it } from "vitest";
 import { resolveSlackAccount } from "./accounts.js";
 
@@ -105,5 +106,214 @@ describe("resolveSlackAccount allowFrom precedence", () => {
 
     expect(resolved.config.allowFrom).toBeUndefined();
     expect(resolved.config.dm?.allowFrom).toEqual(["U123"]);
+  });
+});
+
+describe("resolveSlackAccount tolerateUnresolvedSecrets", () => {
+  // The static `SlackAccountConfig.botToken` type is `string` because it
+  // models the post-resolution shape, but the runtime cfg snapshot can still
+  // hold an unresolved `SecretRef` object for inactive channel targets (per
+  // the inspect/strict separation in #66818). Cast via `unknown` so the test
+  // can construct that runtime-only shape without weakening the production
+  // type. See #68237.
+  const cfgWithUnresolvedBotTokenRef = {
+    channels: {
+      slack: {
+        accounts: {
+          default: {
+            botToken: { source: "exec", provider: "default", id: "slack_bot_token" },
+            allowFrom: ["U999"],
+          },
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+
+  it("throws by default when the snapshot still holds an unresolved SecretRef botToken", () => {
+    expect(() =>
+      resolveSlackAccount({
+        cfg: cfgWithUnresolvedBotTokenRef,
+        accountId: "default",
+      }),
+    ).toThrowError(/channels\.slack\.accounts\.default\.botToken/);
+  });
+
+  it("returns undefined credentials without throwing when tolerateUnresolvedSecrets is set", () => {
+    const resolved = resolveSlackAccount({
+      cfg: cfgWithUnresolvedBotTokenRef,
+      accountId: "default",
+      tolerateUnresolvedSecrets: true,
+    });
+
+    expect(resolved.botToken).toBeUndefined();
+    expect(resolved.botTokenSource).toBe("none");
+    // Surrounding account info still resolves so callers with an explicit
+    // override (for example sendMessageSlack receiving opts.token) can keep
+    // operating.
+    expect(resolved.accountId).toBe("default");
+    expect(resolved.config.allowFrom).toEqual(["U999"]);
+  });
+
+  it("still returns resolved string credentials in tolerant mode", () => {
+    const resolved = resolveSlackAccount({
+      cfg: {
+        channels: {
+          slack: {
+            accounts: {
+              default: { botToken: "xoxb-resolved", appToken: "xapp-resolved" },
+            },
+          },
+        },
+      },
+      accountId: "default",
+      tolerateUnresolvedSecrets: true,
+    });
+
+    expect(resolved.botToken).toBe("xoxb-resolved");
+    expect(resolved.botTokenSource).toBe("config");
+    expect(resolved.appToken).toBe("xapp-resolved");
+    expect(resolved.appTokenSource).toBe("config");
+  });
+
+  it("does not silently fall back to SLACK_*_TOKEN env vars in tolerant mode when all credentials are configured as SecretRef (credential confusion guard)", () => {
+    // Each credential is configured as a SecretRef. In tolerant mode none of
+    // them resolves, so per-credential env gating must block all three env
+    // vars; otherwise a stray `SLACK_*_TOKEN` would silently impersonate the
+    // operator-configured account (CWE-287 credential confusion).
+    const cfgAllSecretRefs = {
+      channels: {
+        slack: {
+          accounts: {
+            default: {
+              botToken: { source: "exec", provider: "default", id: "slack_bot_token" },
+              appToken: { source: "exec", provider: "default", id: "slack_app_token" },
+              userToken: { source: "exec", provider: "default", id: "slack_user_token" },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const previousBotToken = process.env.SLACK_BOT_TOKEN;
+    const previousAppToken = process.env.SLACK_APP_TOKEN;
+    const previousUserToken = process.env.SLACK_USER_TOKEN;
+    process.env.SLACK_BOT_TOKEN = "xoxb-env-fallback";
+    process.env.SLACK_APP_TOKEN = "xapp-env-fallback";
+    process.env.SLACK_USER_TOKEN = "xoxp-env-fallback";
+    try {
+      const resolved = resolveSlackAccount({
+        cfg: cfgAllSecretRefs,
+        accountId: "default",
+        tolerateUnresolvedSecrets: true,
+      });
+
+      expect(resolved.botToken).toBeUndefined();
+      expect(resolved.botTokenSource).toBe("none");
+      expect(resolved.appToken).toBeUndefined();
+      expect(resolved.appTokenSource).toBe("none");
+      expect(resolved.userToken).toBeUndefined();
+      expect(resolved.userTokenSource).toBe("none");
+    } finally {
+      if (previousBotToken === undefined) {
+        delete process.env.SLACK_BOT_TOKEN;
+      } else {
+        process.env.SLACK_BOT_TOKEN = previousBotToken;
+      }
+      if (previousAppToken === undefined) {
+        delete process.env.SLACK_APP_TOKEN;
+      } else {
+        process.env.SLACK_APP_TOKEN = previousAppToken;
+      }
+      if (previousUserToken === undefined) {
+        delete process.env.SLACK_USER_TOKEN;
+      } else {
+        process.env.SLACK_USER_TOKEN = previousUserToken;
+      }
+    }
+  });
+
+  it("preserves SLACK_BOT_TOKEN env fallback in tolerant mode when no config token is set (env-only setups)", () => {
+    const previousBotToken = process.env.SLACK_BOT_TOKEN;
+    const previousAppToken = process.env.SLACK_APP_TOKEN;
+    process.env.SLACK_BOT_TOKEN = "xoxb-env-only";
+    process.env.SLACK_APP_TOKEN = "xapp-env-only";
+    try {
+      // No SecretRef and no string token configured for the default account:
+      // env fallback must still fire so env-only deployments (relying solely
+      // on SLACK_BOT_TOKEN / SLACK_APP_TOKEN) keep working when callers like
+      // `channel.ts` invoke sendMessageSlack without an explicit override.
+      const resolved = resolveSlackAccount({
+        cfg: {
+          channels: {
+            slack: {
+              accounts: {
+                default: { allowFrom: ["U001"] },
+              },
+            },
+          },
+        },
+        accountId: "default",
+        tolerateUnresolvedSecrets: true,
+      });
+
+      expect(resolved.botToken).toBe("xoxb-env-only");
+      expect(resolved.botTokenSource).toBe("env");
+      expect(resolved.appToken).toBe("xapp-env-only");
+      expect(resolved.appTokenSource).toBe("env");
+    } finally {
+      if (previousBotToken === undefined) {
+        delete process.env.SLACK_BOT_TOKEN;
+      } else {
+        process.env.SLACK_BOT_TOKEN = previousBotToken;
+      }
+      if (previousAppToken === undefined) {
+        delete process.env.SLACK_APP_TOKEN;
+      } else {
+        process.env.SLACK_APP_TOKEN = previousAppToken;
+      }
+    }
+  });
+
+  it("blocks env fallback per-credential: unresolved SecretRef on botToken does not leak SLACK_APP_TOKEN", () => {
+    const previousBotToken = process.env.SLACK_BOT_TOKEN;
+    const previousAppToken = process.env.SLACK_APP_TOKEN;
+    process.env.SLACK_BOT_TOKEN = "xoxb-env-bot";
+    process.env.SLACK_APP_TOKEN = "xapp-env-app";
+    try {
+      // botToken has an unresolved SecretRef (env fallback should be
+      // blocked), but appToken is unset (env fallback should still fire).
+      // This proves the gating is per-credential, not whole-account.
+      const resolved = resolveSlackAccount({
+        cfg: {
+          channels: {
+            slack: {
+              accounts: {
+                default: {
+                  botToken: { source: "exec", provider: "default", id: "slack_bot_token" },
+                },
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        accountId: "default",
+        tolerateUnresolvedSecrets: true,
+      });
+
+      expect(resolved.botToken).toBeUndefined();
+      expect(resolved.botTokenSource).toBe("none");
+      // appToken was never configured → env fallback still fires.
+      expect(resolved.appToken).toBe("xapp-env-app");
+      expect(resolved.appTokenSource).toBe("env");
+    } finally {
+      if (previousBotToken === undefined) {
+        delete process.env.SLACK_BOT_TOKEN;
+      } else {
+        process.env.SLACK_BOT_TOKEN = previousBotToken;
+      }
+      if (previousAppToken === undefined) {
+        delete process.env.SLACK_APP_TOKEN;
+      } else {
+        process.env.SLACK_APP_TOKEN = previousAppToken;
+      }
+    }
   });
 });

--- a/extensions/slack/src/accounts.ts
+++ b/extensions/slack/src/accounts.ts
@@ -96,13 +96,13 @@ export function resolveSlackAccount(params: {
     baseAllowEnv && !blockAppEnv ? resolveSlackAppToken(process.env.SLACK_APP_TOKEN) : undefined;
   const envUser =
     baseAllowEnv && !blockUserEnv ? resolveSlackUserToken(process.env.SLACK_USER_TOKEN) : undefined;
-  const configBot = params.tolerateUnresolvedSecrets
+  const configBot = tolerantMode
     ? normalizeSecretInputString(merged.botToken)
     : resolveSlackBotToken(merged.botToken, `channels.slack.accounts.${accountId}.botToken`);
-  const configApp = params.tolerateUnresolvedSecrets
+  const configApp = tolerantMode
     ? normalizeSecretInputString(merged.appToken)
     : resolveSlackAppToken(merged.appToken, `channels.slack.accounts.${accountId}.appToken`);
-  const configUser = params.tolerateUnresolvedSecrets
+  const configUser = tolerantMode
     ? normalizeSecretInputString(merged.userToken)
     : resolveSlackUserToken(merged.userToken, `channels.slack.accounts.${accountId}.userToken`);
   const botToken = configBot ?? envBot;

--- a/extensions/slack/src/accounts.ts
+++ b/extensions/slack/src/accounts.ts
@@ -6,6 +6,7 @@ import {
   resolveMergedAccountConfig,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/account-resolution";
+import { isSecretRef, normalizeSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import type { SlackAccountSurfaceFields } from "./account-surface-fields.js";
 import type { SlackAccountConfig } from "./runtime-api.js";
@@ -35,10 +36,8 @@ export function mergeSlackAccountConfig(
   accountId: string,
 ): SlackAccountConfig {
   return resolveMergedAccountConfig<SlackAccountConfig>({
-    channelConfig: cfg.channels?.slack as SlackAccountConfig | undefined,
-    accounts: cfg.channels?.slack?.accounts as
-      | Record<string, Partial<SlackAccountConfig>>
-      | undefined,
+    channelConfig: cfg.channels?.slack as SlackAccountConfig,
+    accounts: cfg.channels?.slack?.accounts as Record<string, Partial<SlackAccountConfig>>,
     accountId,
   });
 }
@@ -46,6 +45,28 @@ export function mergeSlackAccountConfig(
 export function resolveSlackAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
+  /**
+   * When true, account-level credential reads (`botToken`, `appToken`,
+   * `userToken`) silently become `undefined` for unresolved `SecretRef`
+   * inputs instead of throwing. Default is false to preserve the strict
+   * behavior expected by boot-time provider initialization, which must
+   * surface unresolved channel SecretRefs loudly.
+   *
+   * Pass `true` from call sites that already have a separately-resolved
+   * credential override (for example `sendMessageSlack` receives an explicit
+   * `opts.token` derived from the boot-time monitor context) and only need
+   * the rest of the account info (account id, dm policy, channel settings,
+   * etc.). The downstream consumer's existing `if (!token)` guard still
+   * surfaces a clean "missing token" error when no explicit override is
+   * supplied either.
+   *
+   * Without this opt-in, an inactive `channels.slack.accounts.*.botToken`
+   * SecretRef left in the runtime snapshot (per the inspect/strict
+   * separation introduced in #66818) blows up the strict resolver path even
+   * though the actual send already has a valid boot-resolved token. See
+   * #68237.
+   */
+  tolerateUnresolvedSecrets?: boolean;
 }): ResolvedSlackAccount {
   const accountId = normalizeAccountId(
     params.accountId ?? resolveDefaultSlackAccountId(params.cfg),
@@ -54,22 +75,36 @@ export function resolveSlackAccount(params: {
   const merged = mergeSlackAccountConfig(params.cfg, accountId);
   const accountEnabled = merged.enabled !== false;
   const enabled = baseEnabled && accountEnabled;
-  const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
-  const envBot = allowEnv ? resolveSlackBotToken(process.env.SLACK_BOT_TOKEN) : undefined;
-  const envApp = allowEnv ? resolveSlackAppToken(process.env.SLACK_APP_TOKEN) : undefined;
-  const envUser = allowEnv ? resolveSlackUserToken(process.env.SLACK_USER_TOKEN) : undefined;
-  const configBot = resolveSlackBotToken(
-    merged.botToken,
-    `channels.slack.accounts.${accountId}.botToken`,
-  );
-  const configApp = resolveSlackAppToken(
-    merged.appToken,
-    `channels.slack.accounts.${accountId}.appToken`,
-  );
-  const configUser = resolveSlackUserToken(
-    merged.userToken,
-    `channels.slack.accounts.${accountId}.userToken`,
-  );
+  // Per-credential env-var fallback gating: in tolerant mode, only block
+  // the `SLACK_*_TOKEN` env fallback for credentials whose configured value
+  // is an unresolved `SecretRef` object. Otherwise (config field is a
+  // resolved string, or unset entirely) keep the original env fallback so
+  // legitimate env-only setups (no per-account config token, just
+  // `SLACK_BOT_TOKEN` in the process env) keep working. This avoids
+  // credential confusion (CWE-287) on misconfigured deployments where an
+  // unresolved SecretRef would otherwise be silently overridden by a stray
+  // env var, while preserving the env-only contract that callers like
+  // `extensions/slack/src/channel.ts` rely on when omitting `opts.token`.
+  const baseAllowEnv = accountId === DEFAULT_ACCOUNT_ID;
+  const tolerantMode = params.tolerateUnresolvedSecrets === true;
+  const blockBotEnv = tolerantMode && isSecretRef(merged.botToken);
+  const blockAppEnv = tolerantMode && isSecretRef(merged.appToken);
+  const blockUserEnv = tolerantMode && isSecretRef(merged.userToken);
+  const envBot =
+    baseAllowEnv && !blockBotEnv ? resolveSlackBotToken(process.env.SLACK_BOT_TOKEN) : undefined;
+  const envApp =
+    baseAllowEnv && !blockAppEnv ? resolveSlackAppToken(process.env.SLACK_APP_TOKEN) : undefined;
+  const envUser =
+    baseAllowEnv && !blockUserEnv ? resolveSlackUserToken(process.env.SLACK_USER_TOKEN) : undefined;
+  const configBot = params.tolerateUnresolvedSecrets
+    ? normalizeSecretInputString(merged.botToken)
+    : resolveSlackBotToken(merged.botToken, `channels.slack.accounts.${accountId}.botToken`);
+  const configApp = params.tolerateUnresolvedSecrets
+    ? normalizeSecretInputString(merged.appToken)
+    : resolveSlackAppToken(merged.appToken, `channels.slack.accounts.${accountId}.appToken`);
+  const configUser = params.tolerateUnresolvedSecrets
+    ? normalizeSecretInputString(merged.userToken)
+    : resolveSlackUserToken(merged.userToken, `channels.slack.accounts.${accountId}.userToken`);
   const botToken = configBot ?? envBot;
   const appToken = configApp ?? envApp;
   const userToken = configUser ?? envUser;

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -170,6 +170,10 @@ async function resolveSlackSendContext(params: {
   const send =
     resolveOutboundSendDep<SlackSendFn>(params.deps, "slack") ??
     (await loadSlackSendRuntime()).sendMessageSlack;
+  // params.cfg is the scoped channel-dispatch config; channel credentials are
+  // expected to be resolved here (not a raw loadConfig() snapshot). Strict mode
+  // is intentional so boot-time misconfigurations surface loudly. See #68237
+  // for the companion tolerant-mode path in sendMessageSlack itself.
   const account = resolveSlackAccount({ cfg: params.cfg, accountId: params.accountId });
   const token = getTokenForOperation(account, "write");
   const botToken = account.botToken?.trim();

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -322,9 +322,20 @@ export async function sendMessageSlack(
     throw new Error("Slack send requires text, blocks, or media");
   }
   const cfg = opts.cfg ?? loadConfig();
+  // Tolerate unresolved channel SecretRefs in the cfg snapshot here: the
+  // send path either receives an explicit `opts.token` (resolved at Slack
+  // monitor boot time and threaded through `ctx.botToken`) or surfaces the
+  // existing "Slack bot token missing" error via `resolveToken` below. The
+  // runtime snapshot can legitimately retain unresolved `channels.slack.*`
+  // SecretRefs (see the inspect/strict separation introduced in #66818) when
+  // the active account's secrets were not part of the agent-runtime base
+  // target set; failing the strict resolver here would block outbound
+  // replies even though `reactions.add` and inbound dispatch (which use the
+  // boot-resolved client/token directly) keep working. See #68237.
   const account = resolveSlackAccount({
     cfg,
     accountId: opts.accountId,
+    tolerateUnresolvedSecrets: true,
   });
   const token = resolveToken({
     explicit: opts.token,


### PR DESCRIPTION
### Summary

- **Problem**: On runtimes where the cfg snapshot returned by `loadConfig()` retains an unresolved `SecretRef` object on `channels.slack.accounts.<id>.botToken`, every Slack outbound reply throws `channels.slack.accounts.<id>.botToken: unresolved SecretRef "<source>:<provider>:<id>". Resolve this command against an active gateway runtime snapshot before reading it.` The error is thrown deep inside `sendMessageSlack` (`extensions/slack/src/send.ts:325`) before the explicit, boot-resolved `opts.token` is ever consulted at `extensions/slack/src/send.ts:329`. Reactions (`reactions.add`) and inbound dispatch keep working because they reuse the boot-time `ctx.app.client` and never re-enter `sendMessageSlack`. Independently confirmed by three reporters across `file`-source secrets, `exec`-source secrets (1Password CLI wrapper, macOS arm64), and the original ticket.

- **Root Cause**: `sendMessageSlack` calls `resolveSlackAccount({ cfg })` with `cfg = opts.cfg ?? loadConfig()`. `resolveSlackAccount` (`extensions/slack/src/accounts.ts:61-72`) eagerly invokes the strict resolvers `resolveSlackBotToken / resolveSlackAppToken / resolveSlackUserToken` on `merged.botToken / appToken / userToken`. Those resolvers route through `assertSecretInputResolved` (`src/config/types.secrets.ts:137-140`), which throws on any `SecretRef` object that survived in the runtime snapshot. The strict throw is correct at boot-time provider initialization (where there is no fallback) but is a false positive on the send path because `sendMessageSlack` already has a boot-resolved explicit override (`opts.token`, threaded from `ctx.botToken`) and only consults `account.botToken` as a defensive fallback. The upstream condition under which the cfg snapshot ends up holding an unresolved `SecretRef` (rather than the resolved string the secrets-runtime activation produces at boot) is environment-dependent and not fully nailed down here — likely candidates include `finalizeRuntimeSnapshotWrite` re-pinning the raw cfg when a refresh handler returns false, transient secret-provider failures during a config-write reload, and OAuth token refreshes that touch `auth.profiles.*` and trigger a snapshot reload. The reporters' A/B between `2026.4.14` and `2026.4.15` is deterministic on long-running gateways with active OAuth profiles or external secret providers; the fix here is intentionally scoped to the slack-send consumer side and does not attempt to address the wider snapshot-pollution path.

- **Fix**: Add an opt-in `tolerateUnresolvedSecrets` flag to `resolveSlackAccount`. When set, the function reads `botToken / appToken / userToken` through `normalizeSecretInputString` (gentle: returns `undefined` for `SecretRef` objects) instead of the strict resolvers (which throw). `sendMessageSlack` opts in to the tolerant read, with an inline comment explaining why: the explicit `opts.token` covers the actual auth, and the existing `if (!fallback) throw "Slack bot token missing for account ..."` in `resolveToken` still emits a clean, actionable error if neither explicit nor fallback is available. The flag is **opt-in only** so all other callers (provider boot in `extensions/slack/src/monitor/provider.ts:271`, `listEnabledSlackAccounts`, account inspection helpers, etc.) preserve the strict behavior — boot-time providers without an override still surface unresolved channel SecretRefs loudly. This addresses the failure at the consumer side directly: regardless of why the snapshot holds an unresolved `SecretRef`, `sendMessageSlack` no longer fails when it has a valid explicit token.

- **What changed**:
  - `extensions/slack/src/accounts.ts`: add `tolerateUnresolvedSecrets?: boolean` parameter to `resolveSlackAccount`; gate the per-account credential reads on the flag, using `normalizeSecretInputString` (from `openclaw/plugin-sdk/secret-input`) when set; documented the contract on the new parameter. Per-credential env-var fallback gating (`isSecretRef(merged.<field>)`) ensures that a configured-but-unresolved `SecretRef` cannot be silently overridden by a stray `SLACK_*_TOKEN` process env var, while credentials that are unset entirely still allow env fallback so legitimate env-only setups (no per-account config token) keep working. Also, in the same file's `mergeSlackAccountConfig` helper, drop the redundant `| undefined` constituents from the two existing `as ...` casts on `cfg.channels?.slack` / `cfg.channels?.slack?.accounts` — optional chaining already produces `T | undefined`, so the explicit `| undefined` adds nothing while triggering `typescript-eslint(no-redundant-type-constituents)` once `accounts.ts` enters the staged set. No runtime behavior change; the receiving `resolveMergedAccountConfig` parameter type is `TConfig | undefined` so the narrower cast remains assignable.
  - `extensions/slack/src/send.ts`: `sendMessageSlack` now passes `tolerateUnresolvedSecrets: true` when resolving the account snapshot, with an inline comment explaining why the tolerant read is safe here.
  - `extensions/slack/src/accounts.test.ts`: extend the existing test file with a focused `describe("resolveSlackAccount tolerateUnresolvedSecrets", …)` block (6 cases) — strict-by-default still throws on unresolved `SecretRef`; tolerant-mode returns `undefined` credentials with `botTokenSource: "none"` while preserving non-credential account info; tolerant-mode preserves resolved string credentials unchanged; CWE-287 guard blocks `SLACK_*_TOKEN` env fallback when all three credentials are configured as SecretRef; env-only setups (no config token) continue to use `SLACK_*_TOKEN` env fallback; per-credential isolation (unresolved `SecretRef` on `botToken` does not affect `SLACK_APP_TOKEN` fallback when `appToken` is unset). The `cfgWithUnresolvedBotTokenRef` fixture is cast through `unknown` to `OpenClawConfig` (with a comment explaining why), because `SlackAccountConfig.botToken` is statically typed as `string` while the runtime snapshot can still hold an unresolved `SecretRef` object — exactly the shape this PR is fixing.

- **What did NOT change (scope boundary)**:
  - No change to `assertSecretInputResolved`, `normalizeResolvedSecretInputString`, `normalizeSecretInputString`, or any other `src/config/types.secrets.ts` semantics. The strict / inspect contract is preserved.
  - No change to the secrets runtime snapshot (`src/secrets/runtime.ts`), `loadConfig`, `loadPinnedRuntimeConfig`, `setRuntimeConfigSnapshot`, or `finalizeRuntimeSnapshotWrite`. The wider snapshot-pollution path is intentionally out of scope and belongs in a separate change.
  - No change to the reply runner or agent runner modules. The existing scoped resolution design is left intact.
  - No change to `resolveSlackBotToken / resolveSlackAppToken / resolveSlackUserToken` (`extensions/slack/src/token.ts`); the strict resolvers are still the default for every caller that does not opt into tolerant mode (provider boot, `listEnabledSlackAccounts`, account inspection helpers).
  - The `mergeSlackAccountConfig` cleanup is type-only (drops a redundant union constituent); it does not change the function signature, return type, runtime behavior, or callers' contract.
  - No change to other channel extensions (Discord, Telegram, WhatsApp, Feishu, Matrix, etc.), to the gateway, to the Plugin SDK contract, to public types exported from `openclaw/plugin-sdk/*`, to channel-config zod schemas, or to any documentation. CHANGELOG entry intentionally omitted from this patch and can be added on merge per maintainer preference.
  - The new option is a backwards-compatible additive parameter; existing callers continue to pass `{ cfg, accountId }` and get the existing strict behavior.

### Reproduction

The failure mode at the slack send path is deterministic — when `loadConfig()` returns a cfg with a `SecretRef` object on `channels.slack.accounts.<id>.botToken`, `resolveSlackAccount` strict-throws the exact error message in the issue. What is environment-dependent is the upstream condition that causes the runtime snapshot to retain that unresolved `SecretRef` rather than the resolved string the secrets-runtime activation produces at boot. There is no single one-line minimal repro that triggers the snapshot-pollution path independently of the real-world setups in the issue thread; the verification paths below cover both "did the fix change the consumer-side behavior correctly" and "does the fix unblock the reported scenario end-to-end."

**Path A — direct contract verification (most reliable, environment-independent)**

The 6 new cases in `extensions/slack/src/accounts.test.ts` pin the new contract directly without needing to reproduce the snapshot-pollution upstream:

1. Strict mode (default, no flag) still throws on a `SecretRef`-shaped cfg with the path-tagged error message.
2. Tolerant mode returns `undefined` credentials with `botTokenSource: "none"` for unresolved `SecretRef` while preserving non-credential account info (`accountId`, `allowFrom`, etc.).
3. Tolerant mode preserves already-resolved string credentials unchanged.
4. CWE-287 guard: when all three credentials are configured as `SecretRef`, `SLACK_*_TOKEN` env fallbacks are all blocked in tolerant mode.
5. Env-only setups (no config token configured at all) continue to use `SLACK_*_TOKEN` env fallback in tolerant mode.
6. Per-credential isolation: an unresolved `SecretRef` on `botToken` blocks `SLACK_BOT_TOKEN` only; `SLACK_APP_TOKEN` still falls back when `appToken` is unset.

Run with: `pnpm test extensions/slack/src/accounts.test.ts`.

**Path B — end-to-end on a long-running gateway (matches the reporters' setups)**

1. Configure Slack on `2026.4.15` with the bot token sourced through a `SecretRef`, for example:

   ```jsonc
   // openclaw.json
   "channels": {
     "slack": {
       "mode": "socket",
       "accounts": {
         "default": {
           "botToken": { "source": "exec", "provider": "default", "id": "slack_bot_token" },
           "appToken": { "source": "exec", "provider": "default", "id": "slack_app_token" }
         }
       }
     }
   }
   ```

2. Boot the gateway with a working secret provider (the secrets-runtime activation will resolve `botToken` into the snapshot at boot, so the very first reply succeeds).
3. Trigger a config-write reload that exercises the snapshot-pollution upstream — for example, let an OAuth token refresh write to `auth.profiles.*`, run `touch ~/.openclaw/openclaw.json`, or invoke a UI / wizard flow that bumps `meta.lastTouchedAt`. (`@oclilbuddy`'s repro used `exec`-source 1Password CLI which exhibits this on its own through transient resolver delays.)
4. Send a message after the reload settles. On `2026.4.15` the reply now throws the unresolved-`SecretRef` error; the typing reaction (`reactions.add`) still succeeds, exposing the asymmetry between the boot-resolved `ctx.app.client` (works) and the `loadConfig()`-driven `sendMessageSlack` path (fails).
5. With this PR applied: `chat.postMessage` succeeds because `sendMessageSlack` falls through to the explicit `opts.token` (the boot-resolved monitor context token) instead of strict-throwing on the snapshot-side `SecretRef`.

Independent reproduction footprints (full thread in #68237):

- `file`-source secrets, Linux.
- `exec`-source secrets via 1Password CLI wrapper, macOS 26.4.1 / arm64 / Node 25.9.0.
- `2026.4.14 (323493f)` works, `2026.4.15 (041266a)` fails with the same config; A/B is deterministic across `npm i -g openclaw@…` flips on long-running gateways.

### Risk / Mitigation

- **Risk**: Loosening any strict-mode SecretRef check is a security-adjacent change because the underlying invariant is "do not silently read raw refs as strings." If `resolveSlackAccount` were globally relaxed, a future caller without a fallback could end up sending `undefined` as a Slack token and surface a confusing failure mode (or worse, leak the raw `SecretRef` object label into a log line). Letting the env-var fallback fire when a configured `SecretRef` fails to resolve would also be a credential-confusion vector (CWE-287) on misconfigured deployments where a stray `SLACK_*_TOKEN` env var exists.
- **Mitigation**:
  - The relaxation is **opt-in** via a new parameter, defaulting to the current strict behavior. Every existing caller (provider boot, account listing, inspection) is unchanged. The only opt-in site in this PR is `sendMessageSlack`, which already has an explicit, boot-resolved override and an existing `if (!token) throw "Slack bot token missing for account ..."` guard at `extensions/slack/src/send.ts` (the existing `resolveToken`). If both explicit and fallback are absent, the user-facing error is the existing actionable "missing token" message, not the silent raw-`SecretRef` shape.
  - Per-credential env-fallback gating: when a credential is configured as `SecretRef`, the corresponding `SLACK_*_TOKEN` env var is blocked from silently impersonating it. Credentials that are unset entirely (legitimate env-only setups, e.g. `extensions/slack/src/channel.ts:543` invoking `sendMessageSlack` without `opts.token`) continue to use the existing env fallback. This satisfies both the CWE-287 concern and preserves backwards-compatible env-only behavior.
  - Regression tests (`extensions/slack/src/accounts.test.ts`) pin all directions of the contract: strict mode still throws with the path-tagged error message; tolerant mode returns `undefined` credentials and `botTokenSource: "none"`; tolerant mode does not regress on already-resolved string credentials; env fallback is blocked per-credential when configured as `SecretRef`; env fallback still fires when no credential is configured.
  - The fix is contained to two production files plus their test (`accounts.ts`, `send.ts`, `accounts.test.ts`); no shared SDK surface, no public type, no schema, no zod model, no runtime snapshot, no IPC / wire protocol, no plugin contract is touched. CODEOWNERS-restricted security paths are not touched.
  - oxlint passes on all three production / test files (0 warnings, 0 errors), including `typescript-eslint(no-redundant-type-constituents)` which previously triggered on the pre-existing `mergeSlackAccountConfig` casts. Targeted vitest run in `extensions/slack/src/accounts.test.ts` is green (11 / 11, with 6 new cases). `extensions/slack/src/send.blocks.test.ts` and `extensions/slack/src/send.upload.test.ts` are green (22 / 22) so the existing send-path mocks (`blocks.test-helpers.ts` mocks `resolveSlackAccount` and is unaffected by the new optional parameter) continue to work. `pnpm tsgo:extensions:test` passes on the touched files (the test fixture's `as unknown as OpenClawConfig` cast is the same pattern as `extensions/slack/src/action-runtime.test.ts` and other slack tests that need to construct shapes the schema rejects).

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Channel: Slack
- [x] Channel auth / SecretRef handling
- [x] Reply / outbound dispatch
- [x] Tests (extends existing `accounts.test.ts`)

### Linked Issue/PR

Fixes #68237