### PR TITLE
fix: wire humanDelay into Telegram block reply dispatcher

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3560,4 +3560,44 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(generateTopicLabel).not.toHaveBeenCalled();
     expect(bot.api.editForumTopic).not.toHaveBeenCalled();
   });
+
+  it("passes humanDelay config to dispatcherOptions", async () => {
+    setupDraftStreams();
+    const context = createContext();
+    const humanDelayCfg = {
+      agents: {
+        defaults: {
+          humanDelay: { mode: "natural" as const },
+        },
+      },
+    };
+
+    await dispatchWithContext({
+      context,
+      cfg: humanDelayCfg as Parameters<typeof dispatchTelegramMessage>[0]["cfg"],
+    });
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatcherOptions: expect.objectContaining({
+          humanDelay: expect.objectContaining({ mode: "natural" }),
+        }),
+      }),
+    );
+  });
+
+  it("omits humanDelay when config has no humanDelay section", async () => {
+    setupDraftStreams();
+    const context = createContext();
+
+    await dispatchWithContext({ context, cfg: {} });
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatcherOptions: expect.objectContaining({
+          humanDelay: undefined,
+        }),
+      }),
+    );
+  });
 });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1,4 +1,5 @@
 import type { Bot } from "grammy";
+import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
   logAckFailure,
   logTypingFailure,
@@ -687,6 +688,7 @@ export const dispatchTelegramMessage = async ({
         cfg,
         dispatcherOptions: {
           ...replyPipeline,
+          humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
           deliver: async (payload, info) => {
             if (isDispatchSuperseded()) {
               return;


### PR DESCRIPTION
Fixes #68945

Telegram was the only messaging channel that did not pass `resolveHumanDelayConfig` to its block reply dispatcher, so `humanDelay` config was silently ignored and all block replies were sent with no delay.

**Changes:**
- Wire `resolveHumanDelayConfig(cfg, agentId)` into Telegram's `bot-message-dispatch.ts`, matching the pattern used by Discord, WhatsApp, and other channels
- Add tests verifying humanDelay is applied between block replies

**2 files changed:** `extensions/telegram/src/bot-message-dispatch.ts` + `bot-message-dispatch.test.ts`