### PR TITLE
fix(telegram): wire humanDelay config into block streaming dispatcher

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -486,6 +486,34 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("passes humanDelay config to the block dispatcher", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Hello" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext(),
+      cfg: {
+        agents: {
+          defaults: {
+            humanDelay: { mode: "custom", minMs: 800, maxMs: 2500 },
+          },
+        },
+      },
+      telegramCfg: { streaming: { block: { enabled: true } } },
+    });
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatcherOptions: expect.objectContaining({
+          humanDelay: { mode: "custom", minMs: 800, maxMs: 2500 },
+        }),
+      }),
+    );
+  });
+
   it("sends error replies silently when silentErrorReplies is enabled", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver({ text: "oops", isError: true }, { kind: "final" });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1,4 +1,5 @@
 import type { Bot } from "grammy";
+import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
   logAckFailure,
   logTypingFailure,
@@ -687,6 +688,7 @@ export const dispatchTelegramMessage = async ({
         cfg,
         dispatcherOptions: {
           ...replyPipeline,
+          humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
           deliver: async (payload, info) => {
             if (isDispatchSuperseded()) {
               return;


### PR DESCRIPTION
## Summary
Fixes #68945 - Telegram block streaming was not respecting the humanDelay configuration, causing replies to be sent back-to-back without pacing.

## Root Cause
The Telegram extension was missing the humanDelay wiring that other channels (Slack, Discord, Signal, Matrix, etc.) already had. The block streaming dispatcher options did not include the humanDelay field.

## Fix
- Added import for resolveHumanDelayConfig from openclaw/plugin-sdk/agent-runtime
- Passed humanDelay: resolveHumanDelayConfig(cfg, route.agentId) to dispatchReplyWithBufferedBlockDispatcher

This matches the pattern used by all other messaging channels.

## Test Plan
- [x] Added regression test: "passes humanDelay config to the block dispatcher"
- [x] All 91 existing Telegram dispatch tests pass
- [x] Formatting verified with oxfmt

## Changes
- extensions/telegram/src/bot-message-dispatch.ts: +2 lines (import + humanDelay option)
- extensions/telegram/src/bot-message-dispatch.test.ts: +28 lines (regression test)

Closes #68945