### PR TITLE
fix(auto-reply): don't persist automatic fallback runtime as next-turn selected model

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -317,4 +317,85 @@ describe("updateSessionStoreAfterAgentRun", () => {
       expect(persisted[sessionKey]?.totalTokensFresh).toBe(false);
     });
   });
+
+  it("persists the originally selected model when a transient fallback ran this turn", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      // Minimal cfg with both selected and fallback models registered so
+      // resolveContextTokensForModel can find their context windows.
+      const cfg = {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                {
+                  id: "claude-opus-4-7",
+                  name: "Claude Opus 4.7",
+                  input: ["text"] as Array<"text" | "image">,
+                  reasoning: false,
+                  cost: { input: 0, output: 0 },
+                  contextWindow: 200_000,
+                  maxTokens: 8_192,
+                },
+                {
+                  id: "claude-3-5-sonnet-20240620",
+                  name: "Claude 3.5 Sonnet",
+                  input: ["text"] as Array<"text" | "image">,
+                  reasoning: false,
+                  cost: { input: 0, output: 0 },
+                  contextWindow: 200_000,
+                  maxTokens: 8_192,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-sticky-fallback";
+      const sessionId = "test-openclaw-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          modelProvider: "anthropic",
+          model: "claude-opus-4-7",
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      // Turn actually ran on the fallback (sonnet) — e.g. opus timed out once
+      // and the runtime fell back. The selected model is still opus.
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            sessionId,
+            provider: "anthropic",
+            model: "claude-3-5-sonnet-20240620",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-7",
+        fallbackProvider: "anthropic",
+        fallbackModel: "claude-3-5-sonnet-20240620",
+        result,
+      });
+
+      // Next-turn selection must still be the originally selected model.
+      expect(sessionStore[sessionKey]?.model).toBe("claude-opus-4-7");
+      expect(sessionStore[sessionKey]?.modelProvider).toBe("anthropic");
+
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.model).toBe("claude-opus-4-7");
+      expect(persisted[sessionKey]?.modelProvider).toBe("anthropic");
+    });
+  });
 });

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -60,16 +60,30 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const compactionsThisRun = Math.max(0, result.meta.agentMeta?.compactionCount ?? 0);
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
+  const { resolveContextTokensForModel } = await getContextModule();
+  // `contextTokens` drives cost/context accounting for this turn and must
+  // match the runtime that actually executed (may be the fallback model).
   const contextTokens =
-    typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0
-      ? params.contextTokensOverride
-      : ((await getContextModule()).resolveContextTokensForModel({
-          cfg,
-          provider: providerUsed,
-          model: modelUsed,
-          fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
-          allowAsyncLoad: false,
-        }) ?? DEFAULT_CONTEXT_TOKENS);
+    resolveContextTokensForModel({
+      cfg,
+      provider: providerUsed,
+      model: modelUsed,
+      contextTokensOverride: params.contextTokensOverride,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      allowAsyncLoad: false,
+    }) ?? DEFAULT_CONTEXT_TOKENS;
+  // `persistedContextTokens` is what the session remembers for the NEXT turn,
+  // so it must reflect the originally selected model (defaultProvider/Model),
+  // not a transient automatic fallback runtime.
+  const persistedContextTokens =
+    resolveContextTokensForModel({
+      cfg,
+      provider: defaultProvider,
+      model: defaultModel,
+      contextTokensOverride: params.contextTokensOverride,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      allowAsyncLoad: false,
+    }) ?? DEFAULT_CONTEXT_TOKENS;
 
   const entry = sessionStore[sessionKey] ?? {
     sessionId,
@@ -79,11 +93,15 @@ export async function updateSessionStoreAfterAgentRun(params: {
     ...entry,
     sessionId,
     updatedAt: Date.now(),
-    contextTokens,
+    // Persist the SELECTED context window for the next turn; the runtime
+    // `contextTokens` computed above is only used for this turn's accounting.
+    contextTokens: persistedContextTokens,
   };
+  // Persist the originally selected provider/model so a transient automatic
+  // fallback (e.g. provider timeout) does not stick as the next-turn runtime.
   setSessionRuntimeModel(next, {
-    provider: providerUsed,
-    model: modelUsed,
+    provider: defaultProvider,
+    model: defaultModel,
   });
   if (isCliProvider(providerUsed, cfg)) {
     const cliSessionBinding = result.meta.agentMeta?.cliSessionBinding;

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1885,6 +1885,8 @@ describe("runReplyAgent fallback reasoning tags", () => {
     sessionEntry?: SessionEntry;
     sessionKey?: string;
     agentCfgContextTokens?: number;
+    sessionStore?: Record<string, SessionEntry>;
+    storePath?: string;
   }) {
     const typing = createMockTypingController();
     const sessionCtx = {
@@ -1936,6 +1938,8 @@ describe("runReplyAgent fallback reasoning tags", () => {
       typing,
       sessionCtx,
       sessionEntry: params?.sessionEntry,
+      sessionStore: params?.sessionStore,
+      storePath: params?.storePath,
       sessionKey,
       defaultModel: "anthropic/claude-opus-4-6",
       agentCfgContextTokens: params?.agentCfgContextTokens,
@@ -1965,6 +1969,54 @@ describe("runReplyAgent fallback reasoning tags", () => {
 
     const call = runEmbeddedPiAgentMock.mock.calls[0]?.[0] as EmbeddedPiAgentParams | undefined;
     expect(call?.enforceFinalTag).toBe(true);
+  });
+
+  it("does not persist automatic fallback as the next-turn selected model", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sticky-fallback-"));
+    try {
+      const storePath = path.join(tmpDir, "sessions.json");
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { main: sessionEntry };
+      await saveSessionStore(storePath, sessionStore);
+
+      runEmbeddedPiAgentMock.mockResolvedValueOnce({
+        payloads: [{ text: "final" }],
+        meta: {},
+      });
+      runWithModelFallbackMock.mockImplementationOnce(
+        async ({ run }: RunWithModelFallbackParams) => ({
+          result: await run("openai", "gpt-4o-mini"),
+          provider: "openai",
+          model: "gpt-4o-mini",
+          attempts: [
+            {
+              provider: "anthropic",
+              model: "claude",
+              error: "Provider anthropic timed out",
+              reason: "timeout",
+            },
+          ],
+        }),
+      );
+
+      await createRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+
+      const stored = loadSessionStore(storePath);
+      expect(stored.main?.modelProvider).toBe("anthropic");
+      expect(stored.main?.model).toBe("claude");
+      expect(stored.main?.fallbackNoticeReason).toBe("timeout");
+      expect(stored.main?.fallbackNoticeActiveModel).toBe("openai/gpt-4o-mini");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("enforces <final> during memory flush on fallback providers", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1320,6 +1320,20 @@ export async function runReplyAgent(params: {
         fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
         allowAsyncLoad: false,
       }) ?? DEFAULT_CONTEXT_TOKENS;
+    // When the turn ran on an automatic fallback runtime (e.g. provider
+    // timeout), persist the originally selected model/provider so the next
+    // turn resumes with the user's selection rather than stickily staying on
+    // the fallback. Runtime values (providerUsed/modelUsed/contextTokensUsed)
+    // continue to drive this turn's cost/context accounting and usage logs.
+    const persistedContextTokens =
+      resolveContextTokensForModel({
+        cfg,
+        provider: selectedProvider,
+        model: selectedModel,
+        contextTokensOverride: agentCfgContextTokens,
+        fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+        allowAsyncLoad: false,
+      }) ?? DEFAULT_CONTEXT_TOKENS;
 
     await persistRunSessionUsage({
       storePath,
@@ -1331,6 +1345,9 @@ export async function runReplyAgent(params: {
       modelUsed,
       providerUsed,
       contextTokensUsed,
+      persistedModel: selectedModel,
+      persistedProvider: selectedProvider,
+      persistedContextTokens,
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,
       cliSessionBinding,

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -214,9 +214,9 @@ async function persistRunSessionUsageForFollowupTest(
   const nextEntry: SessionEntry = {
     ...entry,
     updatedAt: Date.now(),
-    modelProvider: params.providerUsed ?? entry.modelProvider,
-    model: params.modelUsed ?? entry.model,
-    contextTokens: params.contextTokensUsed ?? entry.contextTokens,
+    modelProvider: params.persistedProvider ?? params.providerUsed ?? entry.modelProvider,
+    model: params.persistedModel ?? params.modelUsed ?? entry.model,
+    contextTokens: params.persistedContextTokens ?? params.contextTokensUsed ?? entry.contextTokens,
     systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
   };
   if (params.usage) {
@@ -1240,6 +1240,57 @@ describe("createFollowupRunner messaging tool dedupe", () => {
       expect.objectContaining({
         providerUsed: "anthropic",
         usageIsContextSnapshot: true,
+      }),
+    );
+    persistSpy.mockRestore();
+  });
+
+  it("persists the queued selection separately from a transient fallback runtime", async () => {
+    const storePath = "/tmp/openclaw-followup-sticky-fallback.json";
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = { sessionId: "session", updatedAt: Date.now() };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    const persistSpy = vi.spyOn(sessionRunAccounting, "persistRunSessionUsage");
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      meta: {
+        agentMeta: {
+          usage: { input: 10, output: 5 },
+          lastCallUsage: { input: 6, output: 3 },
+          model: "gpt-4o-mini",
+          provider: "openai",
+        },
+      },
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply: createAsyncReplySpy() },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+    });
+
+    await expect(
+      runner(
+        createQueuedRun({
+          run: {
+            provider: "anthropic",
+            model: "claude-opus-4-6",
+          },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(persistSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerUsed: "openai",
+        modelUsed: "gpt-4o-mini",
+        persistedProvider: "anthropic",
+        persistedModel: "claude-opus-4-6",
       }),
     );
     persistSpy.mockRestore();

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -309,6 +309,18 @@ export function createFollowupRunner(params: {
           fallbackContextTokens: sessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
           allowAsyncLoad: false,
         }) ?? DEFAULT_CONTEXT_TOKENS;
+      // Persist the originally selected provider/model for the next turn so a
+      // transient fallback (e.g. provider timeout) does not stick. Runtime
+      // values above still drive this turn's cost/context accounting.
+      const persistedContextTokens =
+        resolveContextTokensForModel({
+          cfg: queued.run.config,
+          provider: queued.run.provider,
+          model: queued.run.model,
+          contextTokensOverride: agentCfgContextTokens,
+          fallbackContextTokens: sessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+          allowAsyncLoad: false,
+        }) ?? DEFAULT_CONTEXT_TOKENS;
 
       if (storePath && sessionKey) {
         await persistRunSessionUsage({
@@ -321,6 +333,9 @@ export function createFollowupRunner(params: {
           modelUsed,
           providerUsed,
           contextTokensUsed,
+          persistedModel: queued.run.model,
+          persistedProvider: queued.run.provider,
+          persistedContextTokens,
           systemPromptReport: runResult.meta?.systemPromptReport,
           cliSessionBinding: runResult.meta?.agentMeta?.cliSessionBinding,
           usageIsContextSnapshot: isCliProvider(providerUsed, runtimeConfig),

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -178,7 +178,13 @@ export async function persistSessionUsageUpdate(params: {
     return;
   }
 
-  if (params.modelUsed || params.contextTokensUsed) {
+  if (
+    params.modelUsed ||
+    params.contextTokensUsed !== undefined ||
+    params.persistedModel ||
+    params.persistedProvider ||
+    params.persistedContextTokens !== undefined
+  ) {
     try {
       await updateSessionStoreEntry({
         storePath,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -83,6 +83,17 @@ export async function persistSessionUsageUpdate(params: {
   modelUsed?: string;
   providerUsed?: string;
   contextTokensUsed?: number;
+  /**
+   * Next-turn persistence override. When the current turn ran on a transient
+   * automatic fallback (e.g. provider timed out), callers pass the originally
+   * selected model/provider here so the session store keeps the user's
+   * selection for the next turn instead of sticking on the fallback runtime.
+   * `modelUsed`/`providerUsed`/`contextTokensUsed` remain the runtime values
+   * used for this turn's cost and context accounting.
+   */
+  persistedModel?: string;
+  persistedProvider?: string;
+  persistedContextTokens?: number;
   promptTokens?: number;
   usageIsContextSnapshot?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
@@ -134,9 +145,9 @@ export async function persistSessionUsageUpdate(params: {
           });
           const existingEstimatedCostUsd = resolveNonNegativeNumber(entry.estimatedCostUsd) ?? 0;
           const patch: Partial<SessionEntry> = {
-            modelProvider: params.providerUsed ?? entry.modelProvider,
-            model: params.modelUsed ?? entry.model,
-            contextTokens: resolvedContextTokens,
+            modelProvider: params.persistedProvider ?? params.providerUsed ?? entry.modelProvider,
+            model: params.persistedModel ?? params.modelUsed ?? entry.model,
+            contextTokens: params.persistedContextTokens ?? resolvedContextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
           };
@@ -174,9 +185,10 @@ export async function persistSessionUsageUpdate(params: {
         sessionKey,
         update: async (entry) => {
           const patch: Partial<SessionEntry> = {
-            modelProvider: params.providerUsed ?? entry.modelProvider,
-            model: params.modelUsed ?? entry.model,
-            contextTokens: params.contextTokensUsed ?? entry.contextTokens,
+            modelProvider: params.persistedProvider ?? params.providerUsed ?? entry.modelProvider,
+            model: params.persistedModel ?? params.modelUsed ?? entry.model,
+            contextTokens:
+              params.persistedContextTokens ?? params.contextTokensUsed ?? entry.contextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
           };

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2407,6 +2407,74 @@ describe("persistSessionUsageUpdate", () => {
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
     expect(stored[sessionKey].estimatedCostUsd).toBe(0);
   });
+
+  it("persists the selected model separately from the active fallback runtime (usage branch)", async () => {
+    const storePath = await createStorePath("openclaw-sticky-fallback-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        modelProvider: "anthropic",
+        model: "claude-opus-4-7",
+        contextTokens: 200_000,
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      usage: { input: 1_000, output: 500, total: 1_500 },
+      lastCallUsage: { input: 1_000, output: 500, total: 1_500 },
+      // Active fallback runtime (this turn) — a transient substitute.
+      modelUsed: "claude-3-5-sonnet-20240620",
+      providerUsed: "anthropic",
+      contextTokensUsed: 180_000,
+      // Originally selected model — must be what survives to the next turn.
+      persistedModel: "claude-opus-4-7",
+      persistedProvider: "anthropic",
+      persistedContextTokens: 200_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].model).toBe("claude-opus-4-7");
+    expect(stored[sessionKey].modelProvider).toBe("anthropic");
+    expect(stored[sessionKey].contextTokens).toBe(200_000);
+  });
+
+  it("persists the selected model separately from the active fallback runtime (model/context-only branch)", async () => {
+    const storePath = await createStorePath("openclaw-sticky-fallback-nousage-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        modelProvider: "anthropic",
+        model: "claude-opus-4-7",
+        contextTokens: 200_000,
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      modelUsed: "claude-3-5-sonnet-20240620",
+      providerUsed: "anthropic",
+      contextTokensUsed: 180_000,
+      persistedModel: "claude-opus-4-7",
+      persistedProvider: "anthropic",
+      persistedContextTokens: 200_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].model).toBe("claude-opus-4-7");
+    expect(stored[sessionKey].modelProvider).toBe("anthropic");
+    expect(stored[sessionKey].contextTokens).toBe(200_000);
+  });
 });
 
 describe("initSessionState stale threadId fallback", () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2475,6 +2475,43 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored[sessionKey].modelProvider).toBe("anthropic");
     expect(stored[sessionKey].contextTokens).toBe(200_000);
   });
+
+  it(
+    "persists the selected model when only persisted* params are provided " +
+      "(no modelUsed/contextTokensUsed/usage)",
+    async () => {
+      // Guards against a future caller that wants to push a persisted-only
+      // selection update through persistSessionUsageUpdate without reporting
+      // any runtime usage for the turn. The no-usage branch must still
+      // update the session entry rather than silently drop the update.
+      const storePath = await createStorePath("openclaw-sticky-fallback-persist-only-");
+      const sessionKey = "main";
+      await seedSessionStore({
+        storePath,
+        sessionKey,
+        entry: {
+          sessionId: "s1",
+          updatedAt: Date.now(),
+          modelProvider: "anthropic",
+          model: "claude-3-5-sonnet-20240620",
+          contextTokens: 180_000,
+        },
+      });
+
+      await persistSessionUsageUpdate({
+        storePath,
+        sessionKey,
+        persistedModel: "claude-opus-4-7",
+        persistedProvider: "anthropic",
+        persistedContextTokens: 200_000,
+      });
+
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].model).toBe("claude-opus-4-7");
+      expect(stored[sessionKey].modelProvider).toBe("anthropic");
+      expect(stored[sessionKey].contextTokens).toBe(200_000);
+    },
+  );
 });
 
 describe("initSessionState stale threadId fallback", () => {

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -234,6 +234,42 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     );
   });
 
+  it("does not persist an automatic fallback runtime as the next-turn cron selection", async () => {
+    runWithModelFallbackMock.mockResolvedValueOnce({
+      result: {
+        payloads: [{ text: "task complete" }],
+        meta: {
+          agentMeta: {
+            model: "gpt-4o-mini",
+            provider: "openai",
+            usage: { input: 100, output: 50 },
+          },
+        },
+      },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      attempts: [
+        {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          error: "Provider anthropic timed out",
+          reason: "timeout",
+        },
+      ],
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeParams());
+
+    expect(result.status).toBe("ok");
+    // Persisted next-turn selection must remain the requested cron model,
+    // not the transient fallback runtime that executed this turn.
+    expect(cronSession.sessionEntry.model).toBe("claude-sonnet-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+    // Fallback runtime still executed for this turn.
+    expect(result.model).toBe("gpt-4o-mini");
+    expect(result.provider).toBe("openai");
+  });
+
   it("persists default model pre-run when no payload override is present", async () => {
     // No cron payload model override
     const jobWithoutModel = makeJob({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -540,6 +540,7 @@ async function finalizeCronRun(params: {
     finalRunResult.meta?.agentMeta?.provider ??
     execution.fallbackProvider ??
     execution.liveSelection.provider;
+  // Runtime context window for this turn's accounting (may be the fallback).
   const contextTokens =
     resolvePositiveContextTokens(prepared.agentCfg?.contextTokens) ??
     (await loadCronContextRuntime()).lookupContextTokens(modelUsed, {
@@ -547,12 +548,23 @@ async function finalizeCronRun(params: {
     }) ??
     resolvePositiveContextTokens(prepared.cronSession.sessionEntry.contextTokens) ??
     DEFAULT_CONTEXT_TOKENS;
+  // Context window persisted for the NEXT turn — must follow the originally
+  // selected model (liveSelection), not a transient automatic fallback.
+  const persistedContextTokens =
+    resolvePositiveContextTokens(prepared.agentCfg?.contextTokens) ??
+    (await loadCronContextRuntime()).lookupContextTokens(execution.liveSelection.model, {
+      allowAsyncLoad: false,
+    }) ??
+    resolvePositiveContextTokens(prepared.cronSession.sessionEntry.contextTokens) ??
+    DEFAULT_CONTEXT_TOKENS;
 
+  // Persist the originally selected provider/model so a transient automatic
+  // fallback (e.g. provider timeout) does not stick as the next-turn runtime.
   setSessionRuntimeModel(prepared.cronSession.sessionEntry, {
-    provider: providerUsed,
-    model: modelUsed,
+    provider: execution.liveSelection.provider,
+    model: execution.liveSelection.model,
   });
-  prepared.cronSession.sessionEntry.contextTokens = contextTokens;
+  prepared.cronSession.sessionEntry.contextTokens = persistedContextTokens;
   if (isCliProvider(providerUsed, prepared.cfgWithAgentDefaults)) {
     const cliSessionId = finalRunResult.meta?.agentMeta?.sessionId?.trim();
     if (cliSessionId) {


### PR DESCRIPTION
## Summary

- **Problem:** When a reply agent turn fell back to a secondary provider/model (e.g. the Anthropic provider timed out and fallback promoted the next candidate), the post-run session persistence path wrote the *runtime* provider/model into `sessionEntry.modelProvider` / `sessionEntry.model`. The next turn resolved the session's model from those fields and kept running on the fallback runtime, so a transient timeout silently became a permanent provider switch.
- **Why it matters:** User-selected models are a per-session concern, automatic fallback is a per-request concern. Conflating the two makes a single transient error permanently "promote" the fallback model, drifts live sessions off the default/intended model, and mis-attributes future cost/behavior to a model the user never selected.
- **What changed:** `persistSessionUsageUpdate` now accepts optional `persistedModel` / `persistedProvider` / `persistedContextTokens` alongside the existing `modelUsed` / `providerUsed` / `contextTokensUsed`. Runtime values continue to drive this turn's accounting; `persisted*` drives what the next turn resumes on. All four reply-agent / followup-runner / command session-store / cron isolated-agent callsites pass the originally selected model as `persisted*`.
- **What did NOT change (scope boundary):** Explicit user model overrides (`/model`, per-session config, cron `model:` field) still persist. ACP and MCP paths are untouched. Session store schema is unchanged (uses existing fields, no migration). Usage/cost accounting for the turn that actually ran on fallback is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `persistSessionUsageUpdate` in `src/auto-reply/reply/session-usage.ts` used a single pair of fields (`providerUsed` / `modelUsed`) to represent two distinct concerns: (a) which runtime actually served this turn (for cost/context accounting), and (b) which model/provider the next turn should resume with (persisted selection). On an automatic fallback turn, those two values differ, but the existing code wrote the runtime into the persisted selection fields, clobbering the user's choice.
- **Missing detection / guardrail:** No regression test asserted that a fallback turn leaves the persisted `sessionEntry.model` / `sessionEntry.modelProvider` equal to the *originally selected* model rather than the runtime used for the turn. The existing tests only covered explicit model overrides, which matched behavior on that path.
- **Contributing context (if known):** The fallback pathway and the session persistence pathway evolved independently. Fallback was built as a per-request runtime concept; persistence treated whichever provider/model the turn reported back as authoritative. The mismatch only surfaces when a provider actually times out in production, which is rare per-session but high-impact when it happens (sticks until someone notices or re-selects manually).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/session.test.ts`, `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`, `src/auto-reply/reply/followup-runner.test.ts`, `src/agents/command/session-store.test.ts`, `src/cron/isolated-agent/run.cron-model-override.test.ts`
- Scenario the test should lock in: "A turn that actually ran on an automatic fallback runtime must not overwrite the persisted next-turn selected model / provider / context-token value." Authored as RED against `2026.4.15` (reproduced the bug) and GREEN after the fix.
- Why this is the smallest reliable guardrail: These five tests cover every callsite of `persistSessionUsageUpdate` that participates in the fallback code path (reply agent, followup, command session store, cron isolated agent) plus the persistence helper itself (existing-session + new-session branches). Anything that reintroduces the sticky behavior at any layer fails at least one of these.
- Existing test that already covers this (if any): None — all coverage of this behavior is added in this PR.
- If no new test is added, why not: N/A (tests are added).

## User-visible / Behavior Changes

- An automatic fallback event no longer persists the fallback provider/model into the session. The next turn resumes on the originally selected model.
- No change to explicit user model overrides, no change to usage/cost accounting for the turn that actually ran on fallback, no config defaults changed.

## Diagram (if applicable)

```text
Before (bug):
  Turn N selected=opus, fallback=sonnet, runtime=sonnet (opus timed out)
    └─ persistSessionUsageUpdate({ modelUsed: sonnet, providerUsed: anthropic })
         └─ sessionEntry.model := sonnet   ← sticky
  Turn N+1 resumes on sonnet (user never asked)

After (fix):
  Turn N selected=opus, fallback=sonnet, runtime=sonnet (opus timed out)
    └─ persistSessionUsageUpdate({
         modelUsed: sonnet, providerUsed: anthropic,              // runtime accounting
         persistedModel: opus, persistedProvider: anthropic,      // next-turn selection
         persistedContextTokens: <opus window>,
       })
         └─ sessionEntry.model := opus     ← user's selection preserved
  Turn N+1 resumes on opus
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Linux 6.8.0 x64)
- Runtime/container: Node 22.22.0, pnpm 9, vitest 4.1.4
- Model/provider: Anthropic (primary) with fallback candidate configured
- Integration/channel (if any): Telegram group (also reproduced in isolated cron and command session store)
- Relevant config (redacted): default config with two Anthropic models registered and provider-level timeout fallback enabled

### Steps

1. Check out `2026.4.15` and configure a session to run a reply turn with an Anthropic-backed model that will trigger an automatic fallback (e.g. forced timeout on the selected model).
2. Run the turn, let fallback complete successfully.
3. Inspect `sessions.json` for that session entry.
4. Trigger the next turn on the same session without any explicit `/model` override.

### Expected

- After step 3, `sessionEntry.model` / `sessionEntry.modelProvider` equal the *originally selected* model/provider (the turn ran on fallback, but selection did not change).
- Step 4 runs on the originally selected model.

### Actual (before this PR)

- After step 3, `sessionEntry.model` / `sessionEntry.modelProvider` equal the *fallback* runtime's model/provider.
- Step 4 runs on the fallback — sticky.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

### Reproduction commands

```
pnpm vitest run src/auto-reply/reply/session.test.ts \
  -t "persists the selected model separately from the active fallback runtime"
pnpm vitest run src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts \
  -t "does not persist automatic fallback as the next-turn selected model"
pnpm vitest run \
  src/auto-reply/reply/session.test.ts \
  src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts \
  src/auto-reply/reply/followup-runner.test.ts \
  src/agents/command/session-store.test.ts \
  src/cron/isolated-agent/run.cron-model-override.test.ts \
  src/auto-reply/reply/model-selection.test.ts \
  src/gateway/session-utils.test.ts
pnpm build
```

Result on this branch: **203 tests passed across 7 test files**; full `pnpm build` green (tsdown + runtime-postbuild + tsgo typecheck + plugin-sdk dts + import-cycle checks).

## Human Verification (required)

- **Verified scenarios:**
  - RED-first authoring on `2026.4.15` for each new test (each new test failed against the unchanged code with the exact assertion the fix defends).
  - GREEN after applying the fix: full listed test suite and full `pnpm build`.
  - Live deploy from this branch onto a running OpenClaw gateway (`npm pack` + global install + `openclaw doctor` + systemd restart). Confirmed the new `persistedModel` / `persistedProvider` / `persistedContextTokens` markers are present in the installed `dist/agent-runner.runtime-*.js`.
  - On the live gateway, a session that had previously drifted off its default model onto the fallback was cleared, and a subsequent reply turn resumed on the intended selected model instead of the fallback.
- **Edge cases checked:** existing-session update path, new-session bootstrap path, followup-runner path, command session-store path, cron isolated-agent path, explicit-override path (unchanged behavior), `contextTokens` resolution for the persisted model (separate lookup from runtime context tokens so the persisted entry's window reflects the selected model, not the fallback).
- **What you did not verify:** Provider-specific retry semantics for non-Anthropic providers under automatic fallback were not exercised beyond the unit/seam tests. ACP and MCP session persistence paths were not touched and not exercised live.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- **Risk:** A caller forgets to pass `persisted*` and the intent was to persist the runtime (rare: only on an explicit user-intent switch).
  - **Mitigation:** When `persisted*` is omitted the behavior is identical to today (runtime values are persisted), preserving backward compatibility for every call path that isn't a fallback. All four in-tree callsites that sit on the fallback path are updated and tested.
- **Risk:** `persistedContextTokens` uses the *selected* model's context window, which for a session mid-turn on a fallback could briefly diverge from the runtime window until the next turn actually runs on the selected model.
  - **Mitigation:** This is the intended invariant — persisted entry reflects the selected-model session state, while runtime accounting for the fallback turn is reported separately via `contextTokensUsed`. Verified by `session.test.ts` assertions on both fields.
