### PR TITLE
fix: handle partial DmChannel in slash command dispatch

### DIFF
--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -412,7 +412,7 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
     channelType === ChannelType.PublicThread ||
     channelType === ChannelType.PrivateThread ||
     channelType === ChannelType.AnnouncementThread;
-  const channelName = channel && "name" in channel ? (channel.name as string) : undefined;
+  const channelName = (() => { try { return channel && "name" in channel ? (channel.name as string) : undefined; } catch { return undefined; } })();
   const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
   const rawChannelId = channel?.id ?? "";
   const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)
@@ -801,7 +801,7 @@ async function dispatchDiscordCommandInteraction(params: {
     channelType === ChannelType.PublicThread ||
     channelType === ChannelType.PrivateThread ||
     channelType === ChannelType.AnnouncementThread;
-  const channelName = channel && "name" in channel ? (channel.name as string) : undefined;
+  const channelName = (() => { try { return channel && "name" in channel ? (channel.name as string) : undefined; } catch { return undefined; } })();
   const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
   const rawChannelId = channel?.id ?? "";
   const memberRoleIds = Array.isArray(interaction.rawData.member?.roles)


### PR DESCRIPTION
## Problem

All Discord slash commands (`/new`, `/compact`, `/status`, etc.) crash when used in DM channels:

```
Error: Cannot access rawData on partial Channel. Use fetch() to populate data.
    at DmChannel.get rawData [as rawData] (@buape/carbon/src/abstracts/BaseChannel.ts:65:10)
    at DmChannel.get name [as name] (@buape/carbon/src/structures/DmChannel.ts:18:13)
    at dispatchDiscordCommandInteraction (native-command.ts:804)
```

## Root Cause

In `native-command.ts` (lines 415 and 804):

```ts
const channelName = channel && "name" in channel ? (channel.name as string) : undefined;
```

Discord sends **partial** channel objects for DM slash command interactions. The `"name" in channel` check returns `true` because `DmChannel` has a `name` getter, but that getter internally accesses `rawData` which throws on partial channels.

## Fix

Wrap `channel.name` access in try-catch at both call sites to gracefully fall back to `undefined` when the channel is partial. This is the minimal safe fix — a more thorough solution could call `channel.fetch()` first, but that would add async complexity and an API call for information that is not critical to command dispatch.

## Testing

- Verified slash commands work in DM after applying the equivalent patch to the dist bundle
- Guild channel slash commands continue to work (unaffected by this change)

Fixes #68990