### PR TITLE
fix(telegram): wire humanDelay config into block streaming dispatcher

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1,4 +1,5 @@
 import type { Bot } from "grammy";
+import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
   logAckFailure,
   logTypingFailure,
@@ -687,6 +688,7 @@ export const dispatchTelegramMessage = async ({
         cfg,
         dispatcherOptions: {
           ...replyPipeline,
+          humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
           deliver: async (payload, info) => {
             if (isDispatchSuperseded()) {
               return;


### PR DESCRIPTION
## Summary

Fixes #68945

The Telegram channel was not applying `agents.defaults.humanDelay` (or per-agent overrides) to block streaming replies. Messages were sent back-to-back without human-like pacing.

## Root Cause

`dispatchReplyWithBufferedBlockDispatcher` was not receiving the `humanDelay` configuration. All other channels (Slack, Discord, Signal, iMessage, Matrix, MS Teams, Feishu, Tlon, Mattermost) wire `resolveHumanDelayConfig(cfg, agentId)` into their dispatchers, but Telegram did not.

## Fix

- Import `resolveHumanDelayConfig` from `openclaw/plugin-sdk/agent-runtime`
- Pass `humanDelay: resolveHumanDelayConfig(cfg, route.agentId)` to `dispatcherOptions`

This mirrors the pattern used by all other messaging channels.

## Test Plan
- [x] `pnpm test -- extensions/telegram/src/bot-message-dispatch.test.ts` - 90 tests pass
- [x] `pnpm lint` - no errors

Closes openclaw#68945