### PR TITLE
fix(pi-embedded): classify provider chat-template render failures separately from context overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Cron/CLI: parse PowerShell-style `--tools` allow-lists the same way as comma-separated input, so `cron add` and `cron edit` no longer persist `exec read write` as one combined tool entry on Windows. (#68858) Thanks @chen-zhang-cs-code.
 - Browser/user-profile: let existing-session `profile="user"` tool calls auto-route to a connected browser node or use explicit `target="node"`, while still honoring explicit `target="host"` pinning. (#48677)
 - Discord/slash commands: tolerate partial Discord channel metadata in slash-command and model-picker flows so partial channel objects no longer crash when channel names, topics, or thread parent metadata are unavailable. (#68953) Thanks @dutifulbob.
+- Agents/pi-embedded: classify provider chat-template render failures (e.g. HuggingFace/TGI "error rendering prompt with jinja template") as template errors instead of context overflow, so users are no longer told to `/reset` or upgrade to a larger-context model when the model's chat template is broken. (#68868)
 
 ## 2026.4.19-beta.2
 

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -43,6 +43,16 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toContain("Context overflow");
   });
+  it("classifies jinja template render errors as template issues, not context overflow (#68868)", () => {
+    const msg = makeAssistantError(
+      "Failed to deserialize the JSON body into the target type: messages[0]: " +
+        "Template error: error rendering prompt with jinja template: " +
+        "Failed rendering Jinja template: No user query found in input",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("chat template");
+    expect(result).not.toContain("Context overflow");
+  });
   it("returns a reasoning-required message for mandatory reasoning endpoint errors", () => {
     const msg = makeAssistantError(
       "400 Reasoning is mandatory for this endpoint and cannot be disabled.",

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -31,6 +31,7 @@ export {
   isCompactionFailureError,
   isContextOverflowError,
   isLikelyContextOverflowError,
+  isPromptTemplateRenderError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
   isImageDimensionErrorMessage,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -88,6 +88,16 @@ function hasRateLimitTpmHint(raw: string): boolean {
   return /\btpm\b/i.test(lower) || lower.includes("tokens per minute");
 }
 
+// Provider template-render failures (e.g. HuggingFace/TGI jinja "No user query found")
+// are emitted as chat-template errors, not context-overflow errors. They must classify
+// separately so users are not nudged to /reset or to a larger-context model (#68868).
+export function isPromptTemplateRenderError(errorMessage?: string): boolean {
+  if (!errorMessage) {
+    return false;
+  }
+  return /error rendering prompt with (?:jinja|chat) template/i.test(errorMessage);
+}
+
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
@@ -100,6 +110,12 @@ export function isContextOverflowError(errorMessage?: string): boolean {
   }
 
   if (isReasoningConstraintErrorMessage(errorMessage)) {
+    return false;
+  }
+
+  // Provider template-render errors are a distinct failure class. Don't misclassify
+  // them as context overflow even if their text mentions "prompt" (#68868).
+  if (isPromptTemplateRenderError(errorMessage)) {
     return false;
   }
 
@@ -157,6 +173,11 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   }
 
   if (isReasoningConstraintErrorMessage(errorMessage)) {
+    return false;
+  }
+
+  // Provider template-render errors are a distinct failure class (#68868).
+  if (isPromptTemplateRenderError(errorMessage)) {
     return false;
   }
 
@@ -1016,6 +1037,14 @@ export function formatAssistantErrorText(
 
   if (providerRuntimeFailureKind === "proxy") {
     return "LLM request failed: proxy or tunnel configuration blocked the provider request.";
+  }
+
+  if (isPromptTemplateRenderError(raw)) {
+    return (
+      "The provider failed to render the model's chat template. " +
+      "This is a model/provider template issue, not a context-overflow problem. " +
+      "Try a different model or switch providers."
+    );
   }
 
   if (isContextOverflowError(raw)) {

--- a/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
+++ b/src/agents/pi-embedded-helpers/provider-error-patterns.test.ts
@@ -20,6 +20,8 @@ import {
   classifyFailoverReason,
   classifyProviderRuntimeFailureKind,
   isContextOverflowError,
+  isLikelyContextOverflowError,
+  isPromptTemplateRenderError,
 } from "./errors.js";
 import {
   classifyProviderSpecificError,
@@ -134,6 +136,31 @@ describe("isContextOverflowError with provider patterns", () => {
   it("still detects standard context overflow patterns", () => {
     expect(isContextOverflowError("context length exceeded")).toBe(true);
     expect(isContextOverflowError("prompt is too long: 150000 tokens > 128000 maximum")).toBe(true);
+  });
+});
+
+describe("prompt template render errors (#68868)", () => {
+  const jinjaNoUserQuery =
+    "Failed to deserialize the JSON body into the target type: messages[0]: " +
+    "Template error: error rendering prompt with jinja template: " +
+    "Failed rendering Jinja template: No user query found in input";
+  const chatTemplateVariant =
+    "400 Bad Request: error rendering prompt with chat template: missing required variable";
+
+  it("detects jinja template render errors", () => {
+    expect(isPromptTemplateRenderError(jinjaNoUserQuery)).toBe(true);
+    expect(isPromptTemplateRenderError(chatTemplateVariant)).toBe(true);
+  });
+
+  it("does not treat template render errors as context overflow", () => {
+    expect(isContextOverflowError(jinjaNoUserQuery)).toBe(false);
+    expect(isLikelyContextOverflowError(jinjaNoUserQuery)).toBe(false);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(isPromptTemplateRenderError("rate limit exceeded")).toBe(false);
+    expect(isPromptTemplateRenderError("context length exceeded")).toBe(false);
+    expect(isPromptTemplateRenderError(undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add a dedicated classifier for provider chat-template render errors (e.g. HuggingFace/TGI "error rendering prompt with jinja template: No user query found"), so they surface their own template-problem message instead of being misclassified as context overflow.
- Keep both `isContextOverflowError` and `isLikelyContextOverflowError` from matching template render errors, so context-overflow auto-compaction / `/reset` nudges don't fire for them.

Closes #68868.

## Why

When a HuggingFace-compatible backend returns a jinja template render error, the raw text contains "prompt" plus wording that is close enough to existing context-overflow heuristics to be wrongly classified. Users then see "Context overflow: prompt too large for the model. Try /reset…" even though the message is only 6 tokens and the model's chat template is the real problem.

This change adds a narrow, dedicated classifier and surfaces a specific message:

> The provider failed to render the model's chat template. This is a model/provider template issue, not a context-overflow problem. Try a different model or switch providers.

It is additive: existing context-overflow and failover paths are unchanged when the new classifier doesn't match.

## Test plan

- [x] `pnpm test src/agents/pi-embedded-helpers/provider-error-patterns.test.ts` (new unit coverage for `isPromptTemplateRenderError`, and confirms `isContextOverflowError` / `isLikelyContextOverflowError` return `false` for the jinja variant)
- [x] `pnpm test src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts` (confirms `formatAssistantErrorText` returns the template-issue message and no longer contains "Context overflow" for the jinja error)
- [x] `pnpm check`