### PR TITLE
fix(slack): suppress already_reacted error in reactSlackMessage

### DIFF
--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -87,11 +87,19 @@ export async function reactSlackMessage(
   opts: SlackActionClientOpts = {},
 ) {
   const client = await getClient(opts, "write");
-  await client.reactions.add({
-    channel: channelId,
-    timestamp: messageId,
-    name: normalizeEmoji(emoji),
-  });
+  try {
+    await client.reactions.add({
+      channel: channelId,
+      timestamp: messageId,
+      name: normalizeEmoji(emoji),
+    });
+  } catch (err) {
+    // If the reaction already exists, treat it as a no-op — the desired
+    // state (reaction present) is already achieved.
+    if (!(err instanceof Error) || !String(err).includes("already_reacted")) {
+      throw err;
+    }
+  }
 }
 
 export async function removeSlackReaction(


### PR DESCRIPTION
## Problem

**#69005** — When the bot tries to add a reaction that already exists on a message, the Slack API returns `already_reacted`. This is treated as a failure and surfaced as a warning:

```
Error: An API error occurred: already_reacted
  at reactSlackMessage (actions.js:327:2)
  [tools] message failed: An API error occurred: already_reacted
```

## Fix

Wrap `client.reactions.add()` in try-catch. If the error contains `already_reacted`, silently swallow it — the desired state (reaction present) is already achieved.

Note: one call site (`dispatch.ts:276`) already had this check, but `reactSlackMessage()` is also called from `prepare.ts:593` which did not. Handling it at the function level covers all callers.

## Changed
- `extensions/slack/src/actions.ts` — `reactSlackMessage()`