### PR TITLE
fix: exclude implicit providers when models.mode=replace

### DIFF
--- a/src/agents/models-config.plan.test.ts
+++ b/src/agents/models-config.plan.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveProvidersForModelsJsonWithDeps } from "./models-config.plan.js";
+import type { ProviderConfig } from "./models-config.providers.secrets.js";
+
+describe("models-config.plan", () => {
+  describe("resolveProvidersForModelsJsonWithDeps", () => {
+    it("skips implicit provider discovery when models.mode is replace", async () => {
+      const resolveImplicitProviders = vi.fn<
+        typeof import("./models-config.providers.js").resolveImplicitProviders
+      >(async () => ({
+        openai: {
+          apiKey: "implicit-key-from-plugin",
+          models: [{ id: "gpt-4", name: "GPT-4" }],
+        } satisfies ProviderConfig,
+      }));
+
+      const cfg: OpenClawConfig = {
+        models: {
+          mode: "replace",
+          providers: {
+            openai: {
+              apiKey: "explicit-key",
+            },
+          },
+        },
+      };
+
+      const result = await resolveProvidersForModelsJsonWithDeps(
+        {
+          cfg,
+          agentDir: "/tmp/agent",
+          env: process.env,
+        },
+        { resolveImplicitProviders },
+      );
+
+      // Should NOT call resolveImplicitProviders when mode is replace
+      expect(resolveImplicitProviders).not.toHaveBeenCalled();
+
+      // Should return only explicit providers
+      expect(result).toEqual({
+        openai: {
+          apiKey: "explicit-key",
+        },
+      });
+    });
+
+    it("loads implicit providers when models.mode is merge", async () => {
+      const resolveImplicitProviders = vi.fn<
+        typeof import("./models-config.providers.js").resolveImplicitProviders
+      >(async () => ({
+        anthropic: {
+          apiKey: "implicit-key",
+          models: [{ id: "claude-3", name: "Claude 3" }],
+        } satisfies ProviderConfig,
+      }));
+
+      const cfg: OpenClawConfig = {
+        models: {
+          mode: "merge",
+          providers: {
+            openai: {
+              apiKey: "explicit-key",
+            },
+          },
+        },
+      };
+
+      const result = await resolveProvidersForModelsJsonWithDeps(
+        {
+          cfg,
+          agentDir: "/tmp/agent",
+          env: process.env,
+        },
+        { resolveImplicitProviders },
+      );
+
+      // Should call resolveImplicitProviders when mode is merge
+      expect(resolveImplicitProviders).toHaveBeenCalled();
+
+      // Should merge explicit and implicit providers
+      expect(result.openai).toEqual({ apiKey: "explicit-key" });
+      expect(result.anthropic).toEqual({
+        apiKey: "implicit-key",
+        models: [{ id: "claude-3", name: "Claude 3" }],
+      });
+    });
+
+    it("loads implicit providers when models.mode is undefined (defaults to merge)", async () => {
+      const resolveImplicitProviders = vi.fn<
+        typeof import("./models-config.providers.js").resolveImplicitProviders
+      >(async () => ({
+        anthropic: {
+          apiKey: "implicit-key",
+        } satisfies ProviderConfig,
+      }));
+
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            openai: {
+              apiKey: "explicit-key",
+            },
+          },
+        },
+      };
+
+      const result = await resolveProvidersForModelsJsonWithDeps(
+        {
+          cfg,
+          agentDir: "/tmp/agent",
+          env: process.env,
+        },
+        { resolveImplicitProviders },
+      );
+
+      // Should call resolveImplicitProviders when mode is undefined (defaults to merge behavior)
+      expect(resolveImplicitProviders).toHaveBeenCalled();
+      expect(result.anthropic).toEqual({ apiKey: "implicit-key" });
+    });
+  });
+});

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -45,6 +45,13 @@ export async function resolveProvidersForModelsJsonWithDeps(
 ): Promise<Record<string, ProviderConfig>> {
   const { cfg, agentDir, env } = params;
   const explicitProviders = cfg.models?.providers ?? {};
+
+  // When models.mode is "replace", skip loading implicit providers from bundled plugins
+  // and use only explicitly configured providers
+  if (cfg.models?.mode === "replace") {
+    return explicitProviders;
+  }
+
   const resolveImplicitProvidersImpl = deps?.resolveImplicitProviders ?? resolveImplicitProviders;
   const implicitProviders = await resolveImplicitProvidersImpl({
     agentDir,


### PR DESCRIPTION
## 问题
当  时，bundled plugins 仍然加载其 implicit providers，但应该被排除。

## 修复
修改  中的 ，在解析 implicit providers 之前检查 。当 replace 模式设置时，只返回显式配置的 providers。

## 测试覆盖
- 验证 mode="replace" 时跳过 implicit providers
- 验证 mode="merge" 时加载 implicit providers
- 验证 mode=undefined 时默认加载 implicit providers (向后兼容)