### PR TITLE
fix(mattermost): anchor slash command state to globalThis to fix dual-instance 503s

### DIFF
--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -32,8 +32,21 @@ export type SlashCommandAccountState = {
   triggerMap: Map<string, string>;
 };
 
-/** Map from accountId → per-account slash command state. */
-const accountStates = new Map<string, SlashCommandAccountState>();
+/**
+ * Map from accountId → per-account slash command state.
+ *
+ * Anchored to globalThis so that jiti-loaded (route registration) and
+ * native-ESM-loaded (monitor/activation) module instances share the
+ * same Map.  Without this, each module loader creates its own copy of
+ * the module-level variable and the HTTP handler never sees the tokens
+ * populated by the monitor.
+ */
+const ACCOUNT_STATES_KEY = Symbol.for("openclaw.mattermost.slash-account-states");
+const _global = globalThis as typeof globalThis & {
+  [ACCOUNT_STATES_KEY]?: Map<string, SlashCommandAccountState>;
+};
+const accountStates: Map<string, SlashCommandAccountState> = (_global[ACCOUNT_STATES_KEY] ??=
+  new Map<string, SlashCommandAccountState>());
 
 export function resolveSlashHandlerForToken(token: string): {
   kind: "none" | "single" | "ambiguous";


### PR DESCRIPTION
## Summary

Fixes #68113

- Mattermost slash command callbacks always returned 503 ("not yet initialized") even after successful registration, because `accountStates` in `slash-state.ts` was a plain module-level `Map` that got instantiated twice — once by jiti (route registration path via `loadBundledEntryExportSync`) and once by native ESM (monitor/activation path via dynamic `import()`).
- Fix: anchor `accountStates` to `globalThis` via `Symbol.for()` so both module loader instances share the same Map.

## Test plan

- [x] `pnpm test:extension mattermost` — all 319 tests pass
- [x] `pnpm check` — all type, lint, import-cycle checks pass
- [x] `pnpm build` — clean build, no warnings
- [x] Manually verified on a live Mattermost instance: slash commands now respond correctly after gateway startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)