### PR TITLE
fix(gateway): preserve cron delivery validation semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles: consolidate outbound HTTP through a typed `BlueBubblesClient` that resolves the SSRF policy once at construction so image attachments stop getting blocked on localhost and reactions stop getting blocked on private-IP BB deployments. Fixes #34749 and #59722. (#68234) Thanks @omarshahine.
 - Cron/gateway: reject ambiguous announce delivery config at add/update time so invalid multi-channel or target-id provider settings fail early instead of persisting broken cron jobs. (#69015) Thanks @obviyus.
 - Cron/main-session delivery: preserve `heartbeat.target="last"` through deferred wake queuing, gateway wake forwarding, and same-target wake coalescing so queued cron replies still return to the last active chat. (#69021) Thanks @obviyus.
+- Cron/gateway: ignore disabled channels when announce delivery ambiguity is checked, and validate main-session delivery patches against the live cron service default agent so hot-reloaded agent config does not falsely reject valid updates. (#69040) Thanks @obviyus.
 
 ## 2026.4.19-beta.2
 

--- a/src/cron/service-contract.ts
+++ b/src/cron/service-contract.ts
@@ -51,5 +51,6 @@ export interface CronServiceContract {
   run(id: string, mode?: CronRunMode): Promise<CronServiceRunResult>;
   enqueueRun(id: string, mode?: CronRunMode): Promise<CronServiceRunResult>;
   getJob(id: string): CronJob | undefined;
+  getDefaultAgentId(): string | undefined;
   wake(opts: { mode: CronWakeMode; text: string }): CronWakeResult;
 }

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -70,6 +70,10 @@ export class CronService implements CronServiceContract {
     return this.state.store?.jobs.find((job) => job.id === id);
   }
 
+  getDefaultAgentId(): string | undefined {
+    return this.state.deps.defaultAgentId;
+  }
+
   wake(opts: { mode: "now" | "next-heartbeat"; text: string }) {
     return ops.wakeNow(this.state, opts);
   }

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1,4 +1,3 @@
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { listPotentialConfiguredChannelIds } from "../../channels/config-presence.js";
 import { loadConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -29,6 +28,12 @@ import {
 } from "../protocol/index.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+function listConfiguredAnnounceChannelIds(cfg: OpenClawConfig): string[] {
+  return listPotentialConfiguredChannelIds(cfg, process.env, {
+    includePersistedAuthState: false,
+  }).filter((channelId) => cfg.channels?.[channelId]?.enabled !== false);
+}
+
 function assertConfiguredAnnounceChannel(params: {
   cfg: OpenClawConfig;
   channel?: string;
@@ -38,9 +43,7 @@ function assertConfiguredAnnounceChannel(params: {
     return;
   }
 
-  const configuredChannels = listPotentialConfiguredChannelIds(params.cfg, process.env, {
-    includePersistedAuthState: false,
-  }).toSorted();
+  const configuredChannels = listConfiguredAnnounceChannelIds(params.cfg).toSorted();
   const normalizedChannel = normalizeMessageChannel(params.channel);
   if (!normalizedChannel) {
     if (configuredChannels.length <= 1) {
@@ -90,6 +93,7 @@ function assertValidCronCreateDelivery(cfg: OpenClawConfig, jobCreate: CronJobCr
 
 function assertValidCronUpdateDelivery(params: {
   cfg: OpenClawConfig;
+  defaultAgentId?: string;
   currentJob: CronJob | undefined;
   patch: CronJobPatch;
 }) {
@@ -99,7 +103,7 @@ function assertValidCronUpdateDelivery(params: {
 
   const nextJob = structuredClone(params.currentJob);
   applyJobPatch(nextJob, params.patch, {
-    defaultAgentId: resolveDefaultAgentId(params.cfg),
+    defaultAgentId: params.defaultAgentId,
   });
   assertValidCronAnnounceDelivery({
     cfg: params.cfg,
@@ -295,6 +299,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     try {
       assertValidCronUpdateDelivery({
         cfg,
+        defaultAgentId: context.cron.getDefaultAgentId(),
         currentJob: context.cron.getJob(jobId),
         patch,
       });

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -581,6 +581,135 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("accepts implicit announce delivery when extra configured channels are disabled", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-disabled-channel-ambiguity-",
+      cronEnabled: false,
+    });
+
+    await writeCronConfig({
+      session: {
+        mainKey: "main",
+      },
+      channels: {
+        telegram: {
+          botToken: "telegram-token",
+        },
+        slack: {
+          enabled: false,
+          botToken: "xoxb-slack-token",
+          appToken: "xapp-slack-token",
+        },
+      },
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      const addRes = await rpcReq(ws, "cron.add", {
+        name: "disabled extra channel",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: { mode: "announce" },
+      });
+
+      if (!addRes.ok) {
+        throw new Error(addRes.error?.message ?? "cron.add failed");
+      }
+      expect(addRes.ok).toBe(true);
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  });
+
+  test("keeps delivery updates valid after gateway config changes the default agent", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-main-default-agent-drift-",
+      cronEnabled: false,
+    });
+
+    await writeCronConfig({
+      session: {
+        mainKey: "main",
+      },
+      agents: {
+        list: [{ id: "ops", default: true }],
+      },
+      channels: {
+        telegram: {
+          botToken: "telegram-token",
+        },
+      },
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      const addRes = await rpcReq(ws, "cron.add", {
+        name: "main default agent drift",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "main",
+        agentId: "ops",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "hello" },
+      });
+      expect(addRes.ok).toBe(true);
+      const jobIdValue = (addRes.payload as { id?: unknown } | null)?.id;
+      const jobId = typeof jobIdValue === "string" ? jobIdValue : "";
+      expect(jobId.length > 0).toBe(true);
+
+      const { writeConfigFile } = await import("../config/config.js");
+      await writeConfigFile({
+        session: {
+          mainKey: "main",
+        },
+        agents: {
+          list: [{ id: "main", default: true }, { id: "ops" }],
+        },
+        channels: {
+          telegram: {
+            botToken: "telegram-token",
+          },
+        },
+      });
+
+      let agentIds: string[] = [];
+      for (let i = 0; i < 20; i += 1) {
+        const agentsRes = await rpcReq<{ agents?: Array<{ id?: string }> }>(ws, "agents.list", {});
+        expect(agentsRes.ok).toBe(true);
+        agentIds = (agentsRes.payload?.agents ?? [])
+          .map((agent) => agent.id)
+          .filter((id): id is string => typeof id === "string");
+        if (agentIds.includes("main") && agentIds.includes("ops")) {
+          break;
+        }
+        await yieldToEventLoop();
+      }
+      expect(agentIds).toContain("main");
+      expect(agentIds).toContain("ops");
+
+      const updateRes = await rpcReq(ws, "cron.update", {
+        id: jobId,
+        patch: {
+          delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+        },
+      });
+
+      if (!updateRes.ok) {
+        throw new Error(updateRes.error?.message ?? "cron.update failed");
+      }
+      expect(updateRes.ok).toBe(true);
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  });
+
   test("rejects ambiguous announce delivery on add when multiple channels are configured", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-ambiguous-delivery-add-",


### PR DESCRIPTION
Keeps cron delivery validation aligned with actual runtime behavior.

Fixes the two follow-ups from #69015: disabled channels no longer create false ambiguity, and delivery patch validation now uses the live cron service default agent.