### PR TITLE
scripts: include ui:build in build-all pipeline

### DIFF
--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -47,6 +47,7 @@ export const BUILD_ALL_STEPS = [
     kind: "node",
     args: ["--import", "tsx", "scripts/copy-export-html-templates.ts"],
   },
+  { label: "ui:build", kind: "pnpm", pnpmArgs: ["ui:build"] },
   {
     label: "write-build-info",
     kind: "node",
@@ -75,6 +76,7 @@ export const BUILD_ALL_PROFILES = {
     "canvas-a2ui-copy",
     "copy-hook-metadata",
     "copy-export-html-templates",
+    "ui:build",
     "write-build-info",
     "write-cli-startup-metadata",
     "write-cli-compat",


### PR DESCRIPTION
## Summary

- Add `ui:build` step to `BUILD_ALL_STEPS` in `scripts/build-all.mjs`
- Add `ui:build` to the `ciArtifacts` profile

Without this step, `pnpm build` rebuilds `dist/` but never produces `dist/control-ui/`, so the gateway serves a 503 "Control UI assets not found" error after any build or restart that cleans the dist directory.

## Test plan

- [ ] Run `pnpm build` and verify `dist/control-ui/` exists afterward
- [ ] Restart gateway and confirm Control UI loads at `/`