### PR TITLE
agents: classify undici stream-terminated errors as timeout

### DIFF
--- a/src/agents/pi-embedded-helpers/failover-matches.test.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.test.ts
@@ -3,6 +3,7 @@ import {
   isAuthErrorMessage,
   isBillingErrorMessage,
   isRateLimitErrorMessage,
+  isTimeoutErrorMessage,
 } from "./failover-matches.js";
 
 describe("Z.ai vendor error codes (#48988)", () => {
@@ -75,5 +76,37 @@ describe("Z.ai vendor error codes (#48988)", () => {
     it("auth still classified correctly", () => {
       expect(isAuthErrorMessage("invalid api key provided")).toBe(true);
     });
+  });
+});
+
+describe("undici stream-terminated errors (reason=null regression)", () => {
+  // When an upstream provider (observed with Grok-Vertex streamGenerateContent)
+  // closes the fetch body stream mid-read, Node/undici throws a bare
+  // `TypeError: terminated`. Without a classifier match the failover reason
+  // stays `null`, shouldRotateAssistant stays false, and openclaw retries the
+  // same provider until MAX_RUN_LOOP_ITERATIONS, then silently returns an
+  // error payload — configured fallback models never get a turn.
+  it("classifies bare 'terminated' as timeout", () => {
+    expect(isTimeoutErrorMessage("terminated")).toBe(true);
+  });
+
+  it("classifies 'Error: terminated' as timeout", () => {
+    expect(isTimeoutErrorMessage("Error: terminated")).toBe(true);
+  });
+
+  it("classifies 'TypeError: terminated' as timeout", () => {
+    expect(isTimeoutErrorMessage("TypeError: terminated")).toBe(true);
+  });
+
+  it("does not match 'subscription terminated' (billing-adjacent prose)", () => {
+    expect(isTimeoutErrorMessage("subscription terminated due to nonpayment")).toBe(false);
+  });
+
+  it("does not match 'account terminated by policy' (auth-adjacent prose)", () => {
+    expect(isTimeoutErrorMessage("account terminated by policy")).toBe(false);
+  });
+
+  it("does not shadow billing classification on 'subscription terminated'", () => {
+    expect(isBillingErrorMessage("subscription terminated — payment required")).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -126,6 +126,11 @@ const ERROR_PATTERNS = {
     // falls through to reason=unknown (#58315).
     /\boperation was aborted\b/i,
     /\bstream (?:was )?(?:closed|aborted)\b/i,
+    // Undici throws `TypeError: terminated` when an upstream closes the fetch
+    // body stream mid-read (e.g. Grok-Vertex streamGenerateContent dropping
+    // connection after first tokens). Without this the bare message falls
+    // through to reason=null, which disables fallback-model rotation.
+    /(?:^|[\s:])terminated\s*$/i,
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,


### PR DESCRIPTION
## Summary

- **Problem:** when an upstream streaming endpoint (observed: Grok-Vertex `streamGenerateContent`) drops the fetch body mid-response, Node/undici throws `TypeError: terminated`. The bare word `"terminated"` isn't in any classifier pattern, so `isTimeoutErrorMessage()` returns false → `classifyFailoverReason()` returns `null` → `shouldRotateAssistant()` returns false (it requires `failoverReason !== null`).
- **Consequence:** openclaw retries the *same provider* up to `MAX_RUN_LOOP_ITERATIONS` times, produces malformed half-turns in session history (e.g. `content: \"**G\", stopReason: \"error\", usage: 0`), then silently returns an error payload. Configured fallback models (`gemini-3-flash-preview`, `groq/llama-4-scout`) never get a turn. Worse, those broken half-turns then get replayed to subsequent providers on the next user turn, and stricter providers (Gemini) reject the whole history with \"Invalid arguments passed to the model\" — the session becomes unusable until reset.
- **Fix:** add a narrowly-scoped regex `/(?:^|[\s:])terminated\s*$/i` to `ERROR_PATTERNS.timeout`. Terminated classified as `timeout` → `failoverReason = \"timeout\"` → `shouldRotateAssistant` returns true → `resolveRunFailoverDecision({ stage: \"assistant\" })` returns `{ action: \"fallback_model\", reason: \"timeout\" }` on the **first** stream abort. No more same-provider retry loop, no more poison half-turns in history.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra
- [x] Agent runtime / failover classification

## Linked Issue/PR

- Closes #
- Related: #58315 (prior AbortError classification bug with similar shape)
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `ERROR_PATTERNS.timeout` in \`src/agents/pi-embedded-helpers/failover-matches.ts\` enumerates ~20 transient-transport signatures (\`socket hang up\`, \`fetch failed\`, \`econnreset\`, \`operation was aborted\`, \`stream (?:was )?(?:closed|aborted)\`, etc.) but has no case for undici's one-word \`terminated\` message thrown when an upstream body closes mid-read.
- Missing detection / guardrail: no regression test exercised \`isTimeoutErrorMessage(\"terminated\")\` or the downstream \`shouldRotateAssistant\` path for this input.
- Contributing context: observed with Grok-Vertex \`streamGenerateContent\` on a prompt that included competitor-model references + self-identity question. Deterministic content-triggered stream reset, 4 same-provider retries, dead session.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: \`src/agents/pi-embedded-helpers/failover-matches.test.ts\`
- Scenarios the test locks in:
  1. bare \`\"terminated\"\` → \`timeout\`
  2. \`\"Error: terminated\"\` → \`timeout\`
  3. \`\"TypeError: terminated\"\` → \`timeout\`
  4. \`\"subscription terminated due to nonpayment\"\` → **not** timeout (prose protection)
  5. \`\"account terminated by policy\"\` → **not** timeout (prose protection)
  6. \`\"subscription terminated — payment required\"\` → billing (not shadowed by new pattern)
- Why this is the smallest reliable guardrail: the bug is entirely inside the regex-list → classifier mapping. A handful of pattern tests is enough without replaying the whole runner.

## User-visible / Behavior Changes

Before: Grok-Vertex stream-abort → 4 silent retries → dead session → downstream providers also fail because history contains malformed half-turns.

After: Grok-Vertex stream-abort → immediate rotation to next configured fallback model (if any) → user gets a response from \`gemini-3-flash-preview\`/etc. History remains clean.

## Diagram

\`\`\`text
Before:
undici \"terminated\" → classifier(pattern list) → no match
                    → isTimeoutErrorMessage = false
                    → classifyFailoverClassificationFromMessage = null
                    → failoverReason = null
                    → shouldRotateAssistant = false
                    → retry same provider ×4 → return_error_payload (silent)
                    → malformed half-turns persist in history → next turn broken on ALL providers

After:
undici \"terminated\" → classifier matches /(?:^|[\s:])terminated\s*$/i
                    → isTimeoutErrorMessage = true
                    → classifyFailoverClassificationFromMessage = { reason: \"timeout\" }
                    → failoverReason = \"timeout\"
                    → shouldRotateAssistant = true
                    → resolveRunFailoverDecision → fallback_model (if configured)
                    → next turn assembled from fallback model; history clean
\`\`\`

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? No.

## Repro + Verification

### Environment

- OS: macOS 15.x (Darwin 25.3.0)
- Runtime: Node 22 / pnpm 10.33.0
- Model/provider: grok-vertex/xai/grok-4.20-reasoning with fallbacks google-vertex/gemini-3-flash-preview, groq/llama-4-scout

### Steps

1. Check out this branch.
2. \`pnpm test src/agents/pi-embedded-helpers/failover-matches.test.ts\`.
3. Manual: replay a session where Grok-Vertex dropped stream → observe failover to Gemini on first failure instead of 4 retries.

### Expected

- 18/18 tests pass (6 new, 12 existing).
- Scoped test runs in <200ms.
- No import cycles introduced (pre-commit \`pnpm check\` confirms).

### Actual

- \`pnpm test src/agents/pi-embedded-helpers/failover-matches.test.ts\` → 18/18 passing in 88ms.
- Pre-commit \`pnpm check\` → green, 0 runtime value cycles, 0 madge cycles.

## Evidence

- [x] Passing tests locally
- [x] Pre-commit \`pnpm check\` green

## Human Verification

- Verified: bare \"terminated\", \"Error: terminated\", \"TypeError: terminated\" all classify as timeout.
- Verified negative: \"subscription terminated due to nonpayment\" does **not** classify as timeout; \"subscription terminated — payment required\" still routes to billing via the earlier billing matcher.
- Not verified end-to-end: live Grok-Vertex failover in a real session with the patched gateway (the originally-poisoned session was reset by auto-recovery before the patch landed).

## Compatibility / Migration

- Backward compatible? Yes — strictly additive classification; no existing pattern changed.
- Config/env changes? No.
- Migration needed? No.

## Risks and Mitigations

- Risk: future error messages contain the word \"terminated\" in a non-transient context (e.g. \"account terminated by TOS\").
  - Mitigation: regex anchors \`terminated\` to end-of-string with optional trailing whitespace, so prose like \"subscription terminated due to X\" does not match. Negative tests lock this in.
- Risk: CLI-timeout error messages (\`\"CLI exceeded timeout (60s) and was terminated.\"\`) would suddenly classify as timeout.
  - Mitigation: trailing period after \"terminated.\" does not match the regex anchor. Verified by inspection; not an observed regression.