### PR TITLE
fix(slack): dedupe delivery in streaming fallback catch path

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -560,10 +560,20 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         danger(`slack-stream: streaming API call failed: ${formatErrorMessage(err)}, falling back`),
       );
       streamFailed = true;
+      const fallbackThreadTs = streamSession?.threadTs ?? plannedThreadTs;
+      if (
+        deliveryTracker.hasDelivered({
+          kind: params.kind,
+          payload: params.payload,
+          threadTs: fallbackThreadTs,
+        })
+      ) {
+        return;
+      }
       await deliverNormally({
         payload: params.payload,
         kind: params.kind,
-        forcedThreadTs: streamSession?.threadTs ?? plannedThreadTs,
+        forcedThreadTs: fallbackThreadTs,
       });
     }
   };


### PR DESCRIPTION
## What
When `appendSlackStream` throws (e.g. `missing_recipient_user_id`), the `catch` block calls `deliverNormally` without checking `deliveryTracker.hasDelivered()`. This causes the same payload to be sent twice: once via the streaming error path and once via the fallback normal path.

## Why
The `catch` block at `extensions/slack/src/monitor/message-handler/dispatch.ts` directly invokes `deliverNormally` after setting `streamFailed = true`, bypassing the deduplication check that exists in all other delivery paths.

## How
- Added `hasDelivered()` check before calling `deliverNormally` in the `catch` block
- Extracted `fallbackThreadTs` to a consistent variable (instead of recomputing `streamSession?.threadTs ?? plannedThreadTs` inline)
- If already delivered, return early without calling `deliverNormally`

## Test
Mock `appendSlackStream` to throw `missing_recipient_user_id`, then verify:
1. Only one Slack message is delivered per reply turn (not two)
2. The `deliveryTracker` correctly suppresses the duplicate fallback delivery
3. Normal (non-streaming) delivery is unaffected