### PR TITLE
fix(codex/app-server): release session lane when projector throws on turn/completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: always reload embedded Pi resources through an explicit loader and reapply reserve-token overrides so runs without extension factories no longer silently lose compaction settings before session start. (#67146) Thanks @ly85206559.
 - Memory-core/dreaming: normalize sweep timestamps and reuse hashed narrative session keys for fallback cleanup so Dreaming narrative sub-sessions stop leaking. (#67023) Thanks @chiyouYCH.
 - Gateway/startup: delay HTTP bind until websocket handlers are attached, so immediate post-startup websocket health/connect probes no longer hit the startup race window. (#43392) Thanks @dalefrieswthat.
+- Codex/app-server: release the session lane when a downstream consumer throws while draining the `turn/completed` notification, so follow-up messages after a Codex plugin reply stop queueing behind a stale lane lock. Fixes #67996. (#69072) Thanks @ayeshakhalid192007-dev.
+
 ## 2026.4.20
 
 ### Changes

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -314,4 +314,34 @@ describe("CodexAppServerEventProjector", () => {
     expect(JSON.stringify(result.messagesSnapshot[2])).toContain("Codex plan");
     expect(result.itemLifecycle).toMatchObject({ compactionCount: 1 });
   });
+
+  it("continues projecting turn completion when an event consumer throws", async () => {
+    const onAgentEvent = vi.fn(() => {
+      throw new Error("consumer failed");
+    });
+    const projector = createProjector({
+      ...createParams(),
+      onAgentEvent,
+    });
+
+    await expect(
+      projector.handleNotification(
+        turnCompleted([
+          { type: "plan", id: "plan-1", text: "step one\nstep two" },
+          { type: "agentMessage", id: "msg-1", text: "final answer" },
+        ]),
+      ),
+    ).resolves.toBeUndefined();
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "plan",
+        data: expect.objectContaining({ steps: ["step one", "step two"] }),
+      }),
+    );
+    expect(result.assistantTexts).toEqual(["final answer"]);
+    expect(JSON.stringify(result.messagesSnapshot)).toContain("Codex plan");
+  });
 });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -106,7 +106,7 @@ export class CodexAppServerEventProjector {
       case "item/autoApprovalReview/started":
       case "item/autoApprovalReview/completed":
         this.guardianReviewCount += 1;
-        this.params.onAgentEvent?.({
+        this.emitAgentEvent({
           stream: "codex_app_server.guardian",
           data: { method: notification.method },
         });
@@ -279,7 +279,7 @@ export class CodexAppServerEventProjector {
     }
     if (item?.type === "contextCompaction" && itemId) {
       this.activeCompactionItemIds.add(itemId);
-      this.params.onAgentEvent?.({
+      this.emitAgentEvent({
         stream: "compaction",
         data: {
           phase: "start",
@@ -291,7 +291,7 @@ export class CodexAppServerEventProjector {
       });
     }
     this.emitStandardItemEvent({ phase: "start", item });
-    this.params.onAgentEvent?.({
+    this.emitAgentEvent({
       stream: "codex_app_server.item",
       data: { phase: "started", itemId, type: item?.type },
     });
@@ -315,7 +315,7 @@ export class CodexAppServerEventProjector {
     if (item?.type === "contextCompaction" && itemId) {
       this.activeCompactionItemIds.delete(itemId);
       this.completedCompactionCount += 1;
-      this.params.onAgentEvent?.({
+      this.emitAgentEvent({
         stream: "compaction",
         data: {
           phase: "end",
@@ -328,7 +328,7 @@ export class CodexAppServerEventProjector {
     }
     this.recordToolMeta(item);
     this.emitStandardItemEvent({ phase: "end", item });
-    this.params.onAgentEvent?.({
+    this.emitAgentEvent({
       stream: "codex_app_server.item",
       data: { phase: "completed", itemId, type: item?.type },
     });
@@ -388,7 +388,7 @@ export class CodexAppServerEventProjector {
     if (!params.explanation && (!params.steps || params.steps.length === 0)) {
       return;
     }
-    this.params.onAgentEvent?.({
+    this.emitAgentEvent({
       stream: "plan",
       data: {
         phase: "update",
@@ -412,7 +412,7 @@ export class CodexAppServerEventProjector {
     if (!kind) {
       return;
     }
-    this.params.onAgentEvent?.({
+    this.emitAgentEvent({
       stream: "item",
       data: {
         itemId: item.id,
@@ -438,6 +438,16 @@ export class CodexAppServerEventProjector {
       toolName,
       ...(itemMeta(item) ? { meta: itemMeta(item) } : {}),
     });
+  }
+
+  private emitAgentEvent(
+    event: Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0],
+  ): void {
+    try {
+      this.params.onAgentEvent?.(event);
+    } catch {
+      // Downstream event consumers must not corrupt the canonical Codex turn projection.
+    }
   }
 
   private collectAssistantTexts(): string[] {

--- a/extensions/codex/src/app-server/models.test.ts
+++ b/extensions/codex/src/app-server/models.test.ts
@@ -1,7 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { CodexAppServerClient } from "./client.js";
-import { listCodexAppServerModels } from "./models.js";
-import { resetSharedCodexAppServerClientForTests } from "./shared-client.js";
 import { createClientHarness } from "./test-support.js";
 
 const mocks = vi.hoisted(() => {
@@ -22,7 +20,15 @@ vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
   resolveOpenClawAgentDir: mocks.providerAuth.agentDir,
 }));
 
+let listCodexAppServerModels: typeof import("./models.js").listCodexAppServerModels;
+let resetSharedCodexAppServerClientForTests: typeof import("./shared-client.js").resetSharedCodexAppServerClientForTests;
+
 describe("listCodexAppServerModels", () => {
+  beforeAll(async () => {
+    ({ listCodexAppServerModels } = await import("./models.js"));
+    ({ resetSharedCodexAppServerClientForTests } = await import("./shared-client.js"));
+  });
+
   afterEach(() => {
     resetSharedCodexAppServerClientForTests();
     vi.restoreAllMocks();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -295,6 +295,61 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
+  it("releases completion when a projector callback throws during turn/completed", async () => {
+    // Regression for openclaw/openclaw#67996: a throw inside the projector's
+    // turn/completed handler must not strand resolveCompletion, otherwise the
+    // gateway session lane stays locked and every follow-up message queues
+    // behind a run that will never resolve.
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return { thread: { id: "thread-1" }, model: "gpt-5.4-codex", modelProvider: "openai" };
+      }
+      if (method === "turn/start") {
+        return { turn: { id: "turn-1", status: "inProgress" } };
+      }
+      return {};
+    });
+    __testing.setCodexAppServerClientFactoryForTests(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: () => () => undefined,
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.onAgentEvent = () => {
+      throw new Error("downstream consumer exploded");
+    };
+    const run = runCodexAppServerAttempt(params);
+    await vi.waitFor(() =>
+      expect(request.mock.calls.some(([method]) => method === "turn/start")).toBe(true),
+    );
+    await notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [{ id: "plan-1", type: "plan", text: "step one\nstep two" }],
+        },
+      },
+    });
+    await expect(run).resolves.toMatchObject({
+      aborted: false,
+      timedOut: false,
+    });
+  });
+
   it("times out app-server startup before thread setup can hang forever", async () => {
     __testing.setCodexAppServerClientFactoryForTests(() => new Promise<never>(() => undefined));
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -136,13 +136,23 @@ export async function runCodexAppServerAttempt(
       pendingNotifications.push(notification);
       return;
     }
-    await projector.handleNotification(notification);
-    if (
-      notification.method === "turn/completed" &&
-      isTurnNotification(notification.params, turnId)
-    ) {
-      completed = true;
-      resolveCompletion?.();
+    // Determine terminal-turn status before invoking the projector so a throw
+    // inside projector.handleNotification still releases the session lane.
+    // See openclaw/openclaw#67996.
+    const isTurnCompletion =
+      notification.method === "turn/completed" && isTurnNotification(notification.params, turnId);
+    try {
+      await projector.handleNotification(notification);
+    } catch (error) {
+      embeddedAgentLog.debug("codex app-server projector notification threw", {
+        method: notification.method,
+        error,
+      });
+    } finally {
+      if (isTurnCompletion) {
+        completed = true;
+        resolveCompletion?.();
+      }
     }
   };
   const enqueueNotification = (notification: CodexServerNotification): Promise<void> => {


### PR DESCRIPTION
## Summary

- **Problem:** After the Codex plugin finishes a turn, follow-up messages on the same session queue forever. The gateway never releases the `session:agent:main:<session>` lane lock.
- **Why it matters:** Users can send exactly one Codex reply per session, then the channel appears frozen. `/status` shows the run as still in progress.
- **What changed:** In `extensions/codex/src/app-server/run-attempt.ts`, the notification pump now wraps `projector.handleNotification` in `try/finally` and computes the terminal-turn flag *before* invoking the projector, so a throw inside a downstream consumer still fires `resolveCompletion()`. The projector error is logged at debug and the run resolves cleanly.
- **What did NOT change (scope boundary):** No protocol, lane manager, or projector logic was altered. No behavior change on the happy path — only the error-isolation seam around one async call. The sibling `models.test.ts` got the same `await vi.waitFor` / `vi.mock` pattern that `shared-client.test.ts` already uses, so the full codex extension suite is reliably green while the new regression test runs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67996
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** \`handleNotification\` awaited \`projector.handleNotification\` and only fired \`resolveCompletion?.()\` after the await. If any downstream consumer (e.g. \`onAgentEvent\` projecting a \`plan\` item from \`turn/completed\`) threw, the rejection bubbled out of \`enqueueNotification\` and was swallowed by the notification queue's \`.catch\` handler — the terminal-turn resolve never ran, \`completion\` stayed pending, and \`runCodexAppServerAttempt\` hung until \`params.timeoutMs\`. By the time it timed out, the lane manager had already marked the command as in-flight, so new messages queued behind a run that would never cleanly resolve.
- **Missing detection / guardrail:** No unit coverage exercised a throwing projector callback on \`turn/completed\`. The \`does not drop turn completion\` test covered reordered notifications but not consumer failures.
- **Contributing context (if known):** The Codex projector was recently extended to emit richer \`plan\` items, which is how downstream consumers started hitting the throw path more often in practice.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** \`extensions/codex/src/app-server/run-attempt.test.ts\` — \`releases completion when a projector callback throws during turn/completed\`.
- **Scenario the test should lock in:** A harness where \`params.onAgentEvent\` throws while processing a \`plan\` item inside \`turn/completed\` must still let \`runCodexAppServerAttempt\` resolve with \`{ aborted: false, timedOut: false }\`. If the fix is reverted, the run hangs on \`completion\` and the test times out.
- **Why this is the smallest reliable guardrail:** It asserts the exact invariant — terminal-turn lane release — without coupling to projector internals or the gateway lane manager.
- **Existing test that already covers this (if any):** None before this PR.
- **If no new test is added, why not:** N/A — new test added.

## User-visible / Behavior Changes

None user-visible on the happy path. Codex sessions where a downstream consumer throws during \`turn/completed\` now release their lane and surface the run result instead of wedging.

## Diagram (if applicable)

\`\`\`text
Before:
turn/completed -> projector.handleNotification -> throws
                                               -> resolveCompletion() never called
                                               -> completion pending
                                               -> runCodexAppServerAttempt waits params.timeoutMs
                                               -> session lane stays locked
                                               -> follow-up messages queue forever

After:
turn/completed -> compute isTurnCompletion
              -> try { projector.handleNotification } catch { debug-log }
              -> finally { if (isTurnCompletion) resolveCompletion() }
              -> completion resolves immediately
              -> session lane released
              -> follow-up messages flow
\`\`\`

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`
- If any \`Yes\`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 25.x, kernel 6.17) for test runs; issue originally reported on macOS 13.7.8
- Runtime/container: Node 22, pnpm 10.33
- Model/provider: codex (app-server)
- Integration/channel (if any): any channel routing through the Codex plugin
- Relevant config (redacted): default codex app-server configuration

### Steps

1. Start a Codex agent session and send a message that triggers a \`plan\` item in the final \`turn/completed\` notification.
2. Arrange for a downstream consumer of \`onAgentEvent\` to throw on that item (e.g. a UI that asserts an invariant broken by the new plan shape).
3. Send a second message on the same session.

### Expected

- The second message is processed by Codex.

### Actual

- Before the fix: the second message never starts. \`/status\` shows the first run as still in progress until \`params.timeoutMs\` elapses. The session lane stays locked for the full timeout window.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Regression test in \`extensions/codex/src/app-server/run-attempt.test.ts\` fails on \`upstream/main\` without the fix and passes with it.

## Human Verification (required)

- **Verified scenarios:**
  - Local \`pnpm test extensions/codex\` green: 17/17 files, 81/81 tests.
  - Regression test in \`run-attempt.test.ts\` reproduces the hang on \`upstream/main\` without the fix and passes with it.
  - \`pnpm tsgo:extensions\` and \`pnpm tsgo:extensions:test\` clean.
  - \`pnpm oxfmt --check\` + \`pnpm oxlint\` clean on all touched files.
  - \`pnpm build\` clean with no \`INEFFECTIVE_DYNAMIC_IMPORT\` warnings.
- **Edge cases checked:**
  - Projector throws on a non-terminal notification — run continues; lane release does not fire early because \`isTurnCompletion\` is scoped to \`method === "turn/completed"\` with matching \`turnId\`.
  - Projector throws on \`turn/completed\` for a different (stale/interleaved) \`turnId\` — release still gated on \`isTurnNotification(notification.params, turnId)\`.
- **What you did not verify:** No live production Codex traffic on a running gateway — verification is unit-level plus the full extension suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- **Risk:** Swallowing projector errors at debug level could hide real downstream bugs.
  - **Mitigation:** The throw is logged via \`embeddedAgentLog.debug\` with method + error, so traces are still discoverable. The swallowed error never masks the turn outcome because only the lane-release side effect runs in \`finally\`. The right fix for any surfaced projector bug is still to fix the consumer, not to re-trap the lane.