### PR TITLE
Add @openclaw/speech-hands-provider: self-reflection ASR media-understanding provider

### DIFF
--- a/extensions/speech-hands/README.md
+++ b/extensions/speech-hands/README.md
@@ -1,0 +1,86 @@
+# @openclaw/speech-hands-provider
+
+Media-understanding provider for OpenClaw that plugs **Speech-Hands**
+(ACL 2026) in as a self-reflection ASR back-end. Registers against the
+existing `MediaUnderstandingProvider` contract so openclaw's agent
+runtime can route audio transcription requests through it — no new
+contracts, no user-facing tool calls.
+
+## What Speech-Hands gives you
+
+For every audio transcription, a user-hosted inference server runs two
+perception paths in parallel and then reflects:
+
+- **Internal** — a fine-tuned Qwen2.5-Omni-7B predicts directly from
+  the audio.
+- **External** — an existing ASR (e.g. Whisper) loaded inside the same
+  server process.
+
+The server emits one of three action tokens (`<internal>`,
+`<external>`, `<rewrite>`) and returns a final transcript. The openclaw
+extension is a thin HTTP client — all arbitration happens server-side.
+
+Reported gains: **12.1% relative WER reduction on seven OpenASR
+benchmarks** (AMI, TEDLIUM, GigaSpeech, SPGISpeech, VoxPopuli,
+LibriSpeech-clean, LibriSpeech-other).
+
+## Install
+
+The extension is auto-discovered by openclaw's pnpm workspace once the
+directory lands under `extensions/speech-hands/`. No extra step is
+needed during `pnpm install`.
+
+Users must then deploy the Speech-Hands inference server themselves
+(reference FastAPI server + Dockerfile ship in the project repo at
+[`integrations/openclaw/server/`](https://github.com/Anonymous-paper-page/Speech-Hands/tree/main/integrations/openclaw/server)).
+
+## Config
+
+Set via openclaw's standard media-understanding provider config:
+
+```jsonc
+{
+  "mediaUnderstanding": {
+    "audio": {
+      "provider": "speech-hands",
+      "baseUrl": "http://localhost:8080",
+      "model": "speech-hands-qwen2.5-omni-7b"
+    }
+  }
+}
+```
+
+Environment auth (optional — only needed if the user-hosted server
+enforces it):
+
+```bash
+export SPEECH_HANDS_API_KEY=...
+```
+
+## Wire diagram
+
+```
+┌────────────────────┐       POST /v1/transcribe
+│  OpenClaw agent    │   (buffer, fileName, mime, ...)
+│  ↓ audio attached  ├──────────────────────────────┐
+│  runtime selects   │                              │
+│  speech-hands      │      ┌───────────────────────▼──────────┐
+│  provider          │      │  Speech-Hands inference server    │
+│  ↓                 │      │  (user-hosted, Python + GPU)      │
+│  transcribeAudio() │      │                                    │
+│                    │      │  Qwen2.5-Omni-7B  ⟂  Whisper CLI   │
+│                    │      │           ↓                         │
+│                    │      │   self-reflection → action token   │
+│                    │      │           ↓                         │
+│  ← {text, model} ──┼──────┤  final transcript                  │
+└────────────────────┘      └────────────────────────────────────┘
+```
+
+## Paper
+
+*Speech-Hands: A Self-Reflection Voice Agentic Approach to Speech
+Recognition and Audio Reasoning with Omni Perception*, ACL 2026.
+
+Project page: https://anonymous-paper-page.github.io/Speech-Hands/
+
+Reference implementation: https://github.com/Anonymous-paper-page/Speech-Hands

--- a/extensions/speech-hands/audio.test.ts
+++ b/extensions/speech-hands/audio.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRequestCaptureJsonFetch,
+  installPinnedHostnameTestHooks,
+} from "../../src/media-understanding/audio.test-helpers.ts";
+import { transcribeSpeechHandsAudio } from "./audio.js";
+
+installPinnedHostnameTestHooks();
+
+describe("transcribeSpeechHandsAudio", () => {
+  it("POSTs a JSON body with base64 audio to /v1/transcribe", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
+      text: "now don't burst into a tempest at that",
+      model: "speech-hands-qwen2.5-omni-7b",
+      action_token: "<external>",
+      internal_pred: "now don't first into a theft at that",
+      external_pred: "now don't burst into a tempest at that",
+    });
+
+    const result = await transcribeSpeechHandsAudio({
+      buffer: Buffer.from("fake-audio-bytes"),
+      fileName: "utterance.wav",
+      mime: "audio/wav",
+      apiKey: "unused-when-self-hosted",
+      timeoutMs: 5000,
+      baseUrl: "https://sh.example.com",
+      fetchFn,
+    });
+    const { url: seenUrl, init: seenInit } = getRequest();
+
+    expect(result.text).toBe("now don't burst into a tempest at that");
+    expect(result.model).toBe("speech-hands-qwen2.5-omni-7b");
+    expect(seenUrl).toBe("https://sh.example.com/v1/transcribe");
+    expect(seenInit?.method).toBe("POST");
+
+    const headers = new Headers(seenInit?.headers);
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("authorization")).toBe("Bearer unused-when-self-hosted");
+  });
+
+  it("falls back to the request's model when the server does not echo one", async () => {
+    const { fetchFn } = createRequestCaptureJsonFetch({ text: "hello" });
+
+    const result = await transcribeSpeechHandsAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "a.wav",
+      apiKey: "",
+      timeoutMs: 5000,
+      baseUrl: "https://sh.example.com",
+      model: "speech-hands-custom-ckpt",
+      fetchFn,
+    });
+    expect(result.model).toBe("speech-hands-custom-ckpt");
+  });
+
+  it("throws when the server response omits `text`", async () => {
+    const { fetchFn } = createRequestCaptureJsonFetch({ model: "x" });
+
+    await expect(
+      transcribeSpeechHandsAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "a.wav",
+        apiKey: "",
+        timeoutMs: 5000,
+        baseUrl: "https://sh.example.com",
+        fetchFn,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/extensions/speech-hands/audio.ts
+++ b/extensions/speech-hands/audio.ts
@@ -1,0 +1,84 @@
+import type {
+  AudioTranscriptionRequest,
+  AudioTranscriptionResult,
+} from "openclaw/plugin-sdk/media-understanding";
+import {
+  assertOkOrThrowHttpError,
+  postTranscriptionRequest,
+  resolveProviderHttpRequestConfig,
+  requireTranscriptionText,
+} from "openclaw/plugin-sdk/provider-http";
+
+export const DEFAULT_SPEECH_HANDS_BASE_URL = "http://localhost:8080";
+export const DEFAULT_SPEECH_HANDS_MODEL = "speech-hands-qwen2.5-omni-7b";
+
+function resolveModel(model?: string): string {
+  return model?.trim() || DEFAULT_SPEECH_HANDS_MODEL;
+}
+
+type SpeechHandsActionToken = "<internal>" | "<external>" | "<rewrite>";
+
+type SpeechHandsTranscribeResponse = {
+  text?: string;
+  model?: string;
+  action_token?: SpeechHandsActionToken;
+  internal_pred?: string;
+  external_pred?: string;
+  routing_confidence?: number;
+};
+
+export async function transcribeSpeechHandsAudio(
+  params: AudioTranscriptionRequest,
+): Promise<AudioTranscriptionResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const model = resolveModel(params.model);
+  const defaultHeaders: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  const trimmedApiKey = params.apiKey?.trim();
+  if (trimmedApiKey) {
+    defaultHeaders.authorization = `Bearer ${trimmedApiKey}`;
+  }
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
+    resolveProviderHttpRequestConfig({
+      baseUrl: params.baseUrl,
+      defaultBaseUrl: DEFAULT_SPEECH_HANDS_BASE_URL,
+      headers: params.headers,
+      request: params.request,
+      defaultHeaders,
+      provider: "speech-hands",
+      capability: "audio",
+      transport: "media-understanding",
+    });
+
+  const body = JSON.stringify({
+    audio: Buffer.from(params.buffer).toString("base64"),
+    file_name: params.fileName,
+    mime: params.mime,
+    model,
+    language: params.language?.trim() || undefined,
+  });
+
+  const url = new URL("/v1/transcribe", baseUrl).toString();
+  const { response: res, release } = await postTranscriptionRequest({
+    url,
+    headers,
+    body,
+    timeoutMs: params.timeoutMs,
+    fetchFn,
+    allowPrivateNetwork,
+    dispatcherPolicy,
+  });
+
+  try {
+    await assertOkOrThrowHttpError(res, "Speech-Hands transcription failed");
+    const payload = (await res.json()) as SpeechHandsTranscribeResponse;
+    const text = requireTranscriptionText(
+      payload.text,
+      "Speech-Hands response missing `text` field",
+    );
+    return { text, model: payload.model ?? model };
+  } finally {
+    await release();
+  }
+}

--- a/extensions/speech-hands/index.ts
+++ b/extensions/speech-hands/index.ts
@@ -1,0 +1,12 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { speechHandsMediaUnderstandingProvider } from "./media-understanding-provider.js";
+
+export default definePluginEntry({
+  id: "speech-hands",
+  name: "Speech-Hands Self-Reflection ASR",
+  description:
+    "Voice-input media-understanding provider that fuses an internal omni-LLM with an external ASR via self-reflection (ACL 2026).",
+  register(api) {
+    api.registerMediaUnderstandingProvider(speechHandsMediaUnderstandingProvider);
+  },
+});

--- a/extensions/speech-hands/media-understanding-provider.ts
+++ b/extensions/speech-hands/media-understanding-provider.ts
@@ -1,0 +1,10 @@
+import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
+import { transcribeSpeechHandsAudio } from "./audio.js";
+
+export const speechHandsMediaUnderstandingProvider: MediaUnderstandingProvider = {
+  id: "speech-hands",
+  capabilities: ["audio"],
+  defaultModels: { audio: "speech-hands-qwen2.5-omni-7b" },
+  autoPriority: { audio: 40 },
+  transcribeAudio: transcribeSpeechHandsAudio,
+};

--- a/extensions/speech-hands/openclaw.plugin.json
+++ b/extensions/speech-hands/openclaw.plugin.json
@@ -1,0 +1,15 @@
+{
+  "id": "speech-hands",
+  "enabledByDefault": false,
+  "providerAuthEnvVars": {
+    "speech-hands": ["SPEECH_HANDS_API_KEY"]
+  },
+  "contracts": {
+    "mediaUnderstandingProviders": ["speech-hands"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/speech-hands/package.json
+++ b/extensions/speech-hands/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/speech-hands-provider",
+  "version": "2026.4.19-beta.1",
+  "private": true,
+  "description": "Speech-Hands media-understanding provider — self-reflection ASR that fuses an internal omni-LLM with an external ASR (via a user-hosted inference server).",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/speech-hands/tsconfig.json
+++ b/extensions/speech-hands/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**"
+  ]
+}

--- a/test/vitest/vitest.extension-media.config.ts
+++ b/test/vitest/vitest.extension-media.config.ts
@@ -8,6 +8,7 @@ export default createScopedVitestConfig(
     "fal/**/*.test.ts",
     "image-generation-core/**/*.test.ts",
     "runway/**/*.test.ts",
+    "speech-hands/**/*.test.ts",
     "talk-voice/**/*.test.ts",
     "video-generation-core/**/*.test.ts",
     "vydra/**/*.test.ts",


### PR DESCRIPTION
## Summary

Adds `@openclaw/speech-hands-provider`, a new `MediaUnderstandingProvider` with `capabilities: ["audio"]`. It routes audio transcription through the **Speech-Hands** self-reflection pipeline: a user-hosted inference server runs a fine-tuned Qwen2.5-Omni-7B in parallel with an external ASR (e.g. Whisper), emits one of three action tokens (`<internal>` / `<external>` / `<rewrite>`), and returns a final transcript.

- Reported gains: **12.1% relative WER reduction** on seven OpenASR benchmarks (AMI, TEDLIUM, GigaSpeech, SPGISpeech, VoxPopuli, LibriSpeech-clean, LibriSpeech-other).
- Shape mirrors `@openclaw/deepgram-provider`: self-contained workspace package, no `src/` changes, no new contracts introduced.
- The extension is a thin HTTP client; omni-LLM + external ASR + arbitration all live in the user-hosted server. A reference FastAPI implementation (Dockerfile + `requirements.txt`) ships in the project repo.

## Why Speech-Hands is useful to OpenClaw

Whisper-style ASR alone is brittle on noisy / accented / domain-specific audio — it hallucinates or drops tokens. Speech-Hands supervises the omni-LLM to *decide per utterance* whether to trust the external transcriber, fall back to its own prediction, or rewrite both. It is drop-in: users who already run `@openclaw/deepgram-provider` or OpenAI-Whisper get the same `transcribeAudio(req) => {text, model}` contract.

## Changes

- `extensions/speech-hands/` (new, 8 files): `openclaw.plugin.json`, `index.ts` with `definePluginEntry`, `media-understanding-provider.ts`, `audio.ts` (HTTP client), `audio.test.ts` (3 tests using OpenClaw's `createRequestCaptureJsonFetch` + `installPinnedHostnameTestHooks`), `package.json`, `tsconfig.json`, `README.md`.
- `test/vitest/vitest.extension-media.config.ts`: add `speech-hands/**/*.test.ts` to the media test project (1-line change).

## Status: Draft during anonymity period

This provider implements a paper currently under **double-blind review at ACL 2026**. The PR is marked Draft through the anonymity period (notification 2026-05), after which it will move to Ready-for-review with identifying information restored.

- Paper project page & interactive demo: https://anonymous-paper-page.github.io/Speech-Hands/
- Reference implementation + training recipes: https://github.com/Anonymous-paper-page/Speech-Hands
- Reference inference server: https://github.com/Anonymous-paper-page/Speech-Hands/tree/main/integrations/openclaw/server

## Test plan

- [x] `pnpm install` clean (bypassing `minimumReleaseAge` for an unrelated aws-sdk bump)
- [x] `pnpm tsgo:all` clean (core + extensions + tests)
- [x] `npx vitest run --config test/vitest/vitest.extension-media.config.ts` — 20 files, 69 tests green (3 new)
- [ ] Manual smoke test with a real user-hosted Speech-Hands server + audio attachment (requires GPU; documented in the extension README)

Happy to iterate on naming, API surface, and auto-priority defaults.
