### PR TITLE
Fix security audit startup and configured-channel loading

### DIFF
--- a/src/agents/context.eager-warmup.test.ts
+++ b/src/agents/context.eager-warmup.test.ts
@@ -19,6 +19,7 @@ describe("agents/context eager warmup", () => {
   it.each([
     ["models", ["node", "openclaw", "models", "set", "openai/gpt-5.4"]],
     ["agent", ["node", "openclaw", "agent", "--message", "ok"]],
+    ["security", ["node", "openclaw", "security", "audit"]],
   ])("does not eager-load config for %s commands on import", async (_label, argv) => {
     process.argv = argv;
     await importFreshModule(import.meta.url, `./context.js?scope=${_label}`);

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -140,6 +140,7 @@ const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
   "models",
   "plugins",
   "secrets",
+  "security",
   "status",
   "update",
   "webhooks",

--- a/src/security/audit-configured-channel-setup-fastpath.test.ts
+++ b/src/security/audit-configured-channel-setup-fastpath.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const {
+  hasPotentialConfiguredChannelsMock,
+  resolveConfiguredChannelPluginIdsMock,
+  getBundledChannelSetupPluginMock,
+  loadPluginManifestRegistryMock,
+  ensurePluginRegistryLoadedMock,
+  listChannelPluginsMock,
+  collectChannelSecurityFindingsMock,
+} = vi.hoisted(() => ({
+  hasPotentialConfiguredChannelsMock: vi.fn(() => true),
+  resolveConfiguredChannelPluginIdsMock: vi.fn(),
+  getBundledChannelSetupPluginMock: vi.fn(),
+  loadPluginManifestRegistryMock: vi.fn(),
+  ensurePluginRegistryLoadedMock: vi.fn(),
+  listChannelPluginsMock: vi.fn(),
+  collectChannelSecurityFindingsMock: vi.fn(async () => []),
+}));
+
+vi.mock("../channels/config-presence.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../channels/config-presence.js")>();
+  return {
+    ...actual,
+    hasPotentialConfiguredChannels: hasPotentialConfiguredChannelsMock,
+  };
+});
+
+vi.mock("../plugins/channel-plugin-ids.js", () => ({
+  resolveConfiguredChannelPluginIds: resolveConfiguredChannelPluginIdsMock,
+}));
+
+vi.mock("../channels/plugins/bundled.js", () => ({
+  getBundledChannelSetupPlugin: getBundledChannelSetupPluginMock,
+}));
+
+vi.mock("../plugins/manifest-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/manifest-registry.js")>();
+  return {
+    ...actual,
+    loadPluginManifestRegistry: loadPluginManifestRegistryMock,
+  };
+});
+
+vi.mock("../plugins/runtime/runtime-registry-loader.js", () => ({
+  ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
+}));
+
+vi.mock("../channels/plugins/index.js", () => ({
+  listChannelPlugins: listChannelPluginsMock,
+}));
+
+vi.mock("./audit-channel.collect.runtime.js", () => ({
+  collectChannelSecurityFindings: collectChannelSecurityFindingsMock,
+}));
+
+function makeReadonlyPlugin(id: string) {
+  return {
+    id,
+    security: {},
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ id: "default" }),
+    },
+  };
+}
+
+function makeConfig(): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        workspace: "/workspace/test-agent",
+      },
+    },
+    channels: {
+      telegram: { enabled: true, botToken: "telegram-token" },
+      whatsapp: { enabled: true, selfChatMode: true },
+    },
+  };
+}
+
+describe("security audit configured-channel setup fast path", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    hasPotentialConfiguredChannelsMock.mockReset();
+    hasPotentialConfiguredChannelsMock.mockReturnValue(true);
+    resolveConfiguredChannelPluginIdsMock.mockReset();
+    getBundledChannelSetupPluginMock.mockReset();
+    loadPluginManifestRegistryMock.mockReset();
+    ensurePluginRegistryLoadedMock.mockReset();
+    listChannelPluginsMock.mockReset();
+    collectChannelSecurityFindingsMock.mockReset();
+    collectChannelSecurityFindingsMock.mockImplementation(async () => []);
+  });
+
+  it("uses bundled setup plugins when every configured channel exposes the required audit surface", async () => {
+    const telegramSetup = makeReadonlyPlugin("telegram");
+    const whatsappSetup = makeReadonlyPlugin("whatsapp");
+
+    resolveConfiguredChannelPluginIdsMock.mockReturnValue(["telegram", "whatsapp"]);
+    loadPluginManifestRegistryMock.mockReturnValue({
+      plugins: [
+        { id: "telegram", origin: "bundled" },
+        { id: "whatsapp", origin: "bundled" },
+      ],
+      diagnostics: [],
+    });
+    getBundledChannelSetupPluginMock.mockImplementation((id: string) => {
+      if (id === "telegram") {
+        return telegramSetup;
+      }
+      if (id === "whatsapp") {
+        return whatsappSetup;
+      }
+      return undefined;
+    });
+
+    const { runSecurityAudit } = await import("./audit.js");
+    const cfg = makeConfig();
+
+    await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: true,
+    });
+
+    expect(resolveConfiguredChannelPluginIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: cfg,
+        activationSourceConfig: cfg,
+        workspaceDir: "/workspace/test-agent",
+      }),
+    );
+    expect(loadPluginManifestRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: cfg,
+        workspaceDir: "/workspace/test-agent",
+      }),
+    );
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+    expect(listChannelPluginsMock).not.toHaveBeenCalled();
+    expect(collectChannelSecurityFindingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        sourceConfig: cfg,
+        plugins: [telegramSetup, whatsappSetup],
+      }),
+    );
+  });
+
+  it("falls back to the full configured-channel registry load when a setup plugin is insufficient", async () => {
+    const telegramSetup = makeReadonlyPlugin("telegram");
+    const fallbackPlugins = [makeReadonlyPlugin("telegram"), makeReadonlyPlugin("whatsapp")];
+
+    resolveConfiguredChannelPluginIdsMock.mockReturnValue(["telegram", "whatsapp"]);
+    loadPluginManifestRegistryMock.mockReturnValue({
+      plugins: [
+        { id: "telegram", origin: "bundled" },
+        { id: "whatsapp", origin: "bundled" },
+      ],
+      diagnostics: [],
+    });
+    getBundledChannelSetupPluginMock.mockImplementation((id: string) => {
+      if (id === "telegram") {
+        return telegramSetup;
+      }
+      if (id === "whatsapp") {
+        return {
+          id,
+          security: {},
+          config: {
+            listAccountIds: () => ["default"],
+          },
+        };
+      }
+      return undefined;
+    });
+    listChannelPluginsMock.mockReturnValue(fallbackPlugins);
+
+    const { runSecurityAudit } = await import("./audit.js");
+    const cfg = makeConfig();
+
+    await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: true,
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "configured-channels",
+        config: cfg,
+        activationSourceConfig: cfg,
+      }),
+    );
+    expect(listChannelPluginsMock).toHaveBeenCalled();
+    expect(collectChannelSecurityFindingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: fallbackPlugins,
+      }),
+    );
+  });
+
+  it("falls back when a configured channel is shadowed by a non-bundled plugin winner", async () => {
+    const fallbackPlugins = [makeReadonlyPlugin("telegram"), makeReadonlyPlugin("whatsapp")];
+
+    resolveConfiguredChannelPluginIdsMock.mockReturnValue(["telegram", "whatsapp"]);
+    loadPluginManifestRegistryMock.mockReturnValue({
+      plugins: [
+        { id: "telegram", origin: "bundled" },
+        { id: "whatsapp", origin: "workspace" },
+      ],
+      diagnostics: [],
+    });
+    getBundledChannelSetupPluginMock.mockImplementation((id: string) => makeReadonlyPlugin(id));
+    listChannelPluginsMock.mockReturnValue(fallbackPlugins);
+
+    const { runSecurityAudit } = await import("./audit.js");
+    const cfg = makeConfig();
+
+    await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: true,
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "configured-channels",
+        config: cfg,
+        activationSourceConfig: cfg,
+      }),
+    );
+    expect(listChannelPluginsMock).toHaveBeenCalled();
+    expect(collectChannelSecurityFindingsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: fallbackPlugins,
+      }),
+    );
+  });
+});

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1,5 +1,6 @@
 import { isIP } from "node:net";
 import path from "node:path";
+import { resolveDefaultAgentId, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
 import { hasPotentialConfiguredChannels } from "../channels/config-presence.js";
 import type { listChannelPlugins } from "../channels/plugins/index.js";
@@ -17,6 +18,7 @@ import {
 import { listRiskyConfiguredSafeBins } from "../infra/exec-safe-bin-semantics.js";
 import { normalizeTrustedSafeBinDirs } from "../infra/exec-safe-bin-trust.js";
 import { hasNonEmptyString } from "../infra/outbound/channel-target.js";
+import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { asNullableRecord } from "../shared/record-coerce.js";
@@ -98,6 +100,7 @@ type AuditExecutionContext = {
   plugins?: ReturnType<typeof listChannelPlugins>;
   configSnapshot: ConfigFileSnapshot | null;
   codeSafetySummaryCache: Map<string, Promise<unknown>>;
+  workspaceDir?: string;
   deepProbeAuth?: { token?: string; password?: string };
 };
 
@@ -111,6 +114,12 @@ let pluginRegistryLoaderModulePromise:
   | undefined;
 let pluginMetadataRegistryLoaderModulePromise:
   | Promise<typeof import("../plugins/runtime/metadata-registry-loader.js")>
+  | undefined;
+let bundledChannelModulePromise:
+  | Promise<typeof import("../channels/plugins/bundled.js")>
+  | undefined;
+let channelPluginIdsModulePromise:
+  | Promise<typeof import("../plugins/channel-plugin-ids.js")>
   | undefined;
 let gatewayProbeDepsPromise:
   | Promise<{
@@ -145,6 +154,16 @@ async function loadPluginMetadataRegistryLoaderModule() {
   pluginMetadataRegistryLoaderModulePromise ??=
     import("../plugins/runtime/metadata-registry-loader.js");
   return await pluginMetadataRegistryLoaderModulePromise;
+}
+
+async function loadBundledChannelModule() {
+  bundledChannelModulePromise ??= import("../channels/plugins/bundled.js");
+  return await bundledChannelModulePromise;
+}
+
+async function loadChannelPluginIdsModule() {
+  channelPluginIdsModulePromise ??= import("../plugins/channel-plugin-ids.js");
+  return await channelPluginIdsModulePromise;
 }
 
 async function loadGatewayProbeDeps() {
@@ -1266,8 +1285,68 @@ async function createAuditExecutionContext(
     plugins: opts.plugins,
     configSnapshot,
     codeSafetySummaryCache: opts.codeSafetySummaryCache ?? new Map<string, Promise<unknown>>(),
+    workspaceDir: resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)),
     deepProbeAuth: opts.deepProbeAuth,
   };
+}
+
+function isReadonlyChannelSecurityPlugin(
+  plugin: unknown,
+): plugin is NonNullable<ReturnType<typeof listChannelPlugins>[number]> {
+  return Boolean(
+    plugin &&
+    typeof plugin === "object" &&
+    "security" in plugin &&
+    "config" in plugin &&
+    asNullableRecord((plugin as { config?: unknown }).config)?.listAccountIds &&
+    asNullableRecord((plugin as { config?: unknown }).config)?.resolveAccount,
+  );
+}
+
+async function resolveChannelSecurityPlugins(
+  context: AuditExecutionContext,
+): Promise<ReturnType<typeof listChannelPlugins>> {
+  if (context.plugins !== undefined) {
+    return context.plugins;
+  }
+  const channelPluginIdsModule = await loadChannelPluginIdsModule();
+  const configuredPluginIds = channelPluginIdsModule.resolveConfiguredChannelPluginIds({
+    config: context.cfg,
+    activationSourceConfig: context.sourceConfig,
+    workspaceDir: context.workspaceDir,
+    env: context.env,
+  });
+  if (configuredPluginIds.length === 0) {
+    return [];
+  }
+  const bundledChannelModule = await loadBundledChannelModule();
+  const manifestRegistry = loadPluginManifestRegistry({
+    config: context.cfg,
+    workspaceDir: context.workspaceDir,
+    env: context.env,
+  });
+  const manifestById = new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]));
+  const setupPlugins = configuredPluginIds
+    .map((pluginId) => {
+      const manifest = manifestById.get(pluginId);
+      if (!manifest || manifest.origin !== "bundled") {
+        return undefined;
+      }
+      return bundledChannelModule.getBundledChannelSetupPlugin(
+        pluginId as Parameters<typeof bundledChannelModule.getBundledChannelSetupPlugin>[0],
+      );
+    })
+    .filter(isReadonlyChannelSecurityPlugin);
+  if (setupPlugins.length === configuredPluginIds.length) {
+    return setupPlugins;
+  }
+  (await loadPluginRegistryLoaderModule()).ensurePluginRegistryLoaded({
+    scope: "configured-channels",
+    config: context.cfg,
+    activationSourceConfig: context.sourceConfig,
+    env: context.env,
+  });
+  return (await loadChannelPlugins()).listChannelPlugins();
 }
 
 export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<SecurityAuditReport> {
@@ -1348,15 +1427,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
     context.includeChannelSecurity &&
     (context.plugins !== undefined || hasPotentialConfiguredChannels(cfg, env));
   if (shouldAuditChannelSecurity) {
-    if (context.plugins === undefined) {
-      (await loadPluginRegistryLoaderModule()).ensurePluginRegistryLoaded({
-        scope: "configured-channels",
-        config: cfg,
-        activationSourceConfig: context.sourceConfig,
-        env,
-      });
-    }
-    const channelPlugins = context.plugins ?? (await loadChannelPlugins()).listChannelPlugins();
+    const channelPlugins = await resolveChannelSecurityPlugins(context);
     const { collectChannelSecurityFindings } = await loadAuditChannelModule();
     findings.push(
       ...(await collectChannelSecurityFindings({


### PR DESCRIPTION
## Summary
- skip eager context-window warmup for `openclaw security ...` commands
- use bundled channel setup plugins for security-audit channel checks when they expose the required readonly audit surface
- add regression coverage for the `security audit` warmup skip plus fast-path and fallback channel-loading behavior

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/context.eager-warmup.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-security.config.ts src/security/audit-channel-readonly-resolution.test.ts src/security/audit-configured-channel-setup-fastpath.test.ts`

## Notes
- This PR replaces #69087, which was opened from a stale branch base and pulled unrelated breakage into CI.
- Independent review approved the patch as safe to upstream.
