### PR TITLE
build: avoid readlink crashes in Windows runtime deps fingerprinting

### DIFF
--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -431,20 +431,23 @@ function appendDirectoryFingerprint(hash, rootDir, currentDir = rootDir) {
   for (const entry of entries) {
     const fullPath = path.join(currentDir, entry.name);
     const relativePath = path.relative(rootDir, fullPath).replace(/\\/g, "/");
-    if (entry.isSymbolicLink()) {
+    // On Windows, some pnpm-materialized files can look symlink-like at the
+    // Dirent layer even when lstat reports a regular file. Re-check the path
+    // before calling readlink so runtime fingerprinting stays stable.
+    const entryStats = fs.lstatSync(fullPath);
+    if (entryStats.isSymbolicLink()) {
       hash.update(`symlink:${relativePath}->${fs.readlinkSync(fullPath).replace(/\\/g, "/")}\n`);
       continue;
     }
-    if (entry.isDirectory()) {
+    if (entryStats.isDirectory()) {
       hash.update(`dir:${relativePath}\n`);
       appendDirectoryFingerprint(hash, rootDir, fullPath);
       continue;
     }
-    if (!entry.isFile()) {
+    if (!entryStats.isFile()) {
       continue;
     }
-    const stat = fs.statSync(fullPath);
-    hash.update(`file:${relativePath}:${stat.size}\n`);
+    hash.update(`file:${relativePath}:${entryStats.size}\n`);
     hash.update(fs.readFileSync(fullPath));
   }
 }

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   collectRuntimeDependencyInstallManifest,
   collectRuntimeDependencyInstallSpecs,
@@ -9,6 +9,10 @@ import {
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("stageBundledPluginRuntimeDeps", () => {
   function createBundledPluginFixture(params: {
@@ -280,6 +284,70 @@ describe("stageBundledPluginRuntimeDeps", () => {
     expect(
       fs.readFileSync(path.join(pluginDir, "node_modules", "direct", "index.js"), "utf8"),
     ).toBe("module.exports = 'second';\n");
+  });
+
+  it("ignores dirent symlink false positives for runtime fingerprinting", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { direct: "1.0.0" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const directDir = path.join(repoRoot, "node_modules", "direct");
+    const packageJsonPath = path.join(directDir, "package.json");
+    fs.mkdirSync(directDir, { recursive: true });
+    fs.writeFileSync(
+      packageJsonPath,
+      '{ "name": "direct", "version": "1.0.0" }\n',
+      "utf8",
+    );
+    fs.writeFileSync(path.join(directDir, "index.js"), "module.exports = 'runtime';\n", "utf8");
+
+    const originalReaddirSync = fs.readdirSync.bind(fs);
+    const readlinkSpy = vi.spyOn(fs, "readlinkSync");
+
+    vi.spyOn(fs, "readdirSync").mockImplementation(
+      ((targetPath: Parameters<typeof fs.readdirSync>[0], options?: unknown) => {
+        if (
+          String(targetPath) === directDir &&
+          typeof options === "object" &&
+          options !== null &&
+          "withFileTypes" in options &&
+          (options as { withFileTypes?: boolean }).withFileTypes === true
+        ) {
+          const makeDirent = (
+            name: string,
+            kind: "file" | "directory" | "symlink",
+          ): fs.Dirent<string> =>
+            ({
+              name,
+              isBlockDevice: () => false,
+              isCharacterDevice: () => false,
+              isDirectory: () => kind === "directory",
+              isFIFO: () => false,
+              isFile: () => kind === "file",
+              isSocket: () => false,
+              isSymbolicLink: () => kind === "symlink",
+            }) as fs.Dirent<string>;
+          return [
+            makeDirent("index.js", "file"),
+            makeDirent("package.json", "symlink"),
+          ] as ReturnType<typeof fs.readdirSync>;
+        }
+        return originalReaddirSync(
+          targetPath,
+          options as Parameters<typeof fs.readdirSync>[1],
+        ) as ReturnType<typeof fs.readdirSync>;
+      }) as typeof fs.readdirSync,
+    );
+
+    expect(() => stageBundledPluginRuntimeDeps({ cwd: repoRoot })).not.toThrow();
+    expect(readlinkSpy).not.toHaveBeenCalledWith(packageJsonPath);
+    expect(
+      fs.readFileSync(path.join(pluginDir, "node_modules", "direct", "index.js"), "utf8"),
+    ).toBe("module.exports = 'runtime';\n");
   });
 
   it("refuses to replace a symlinked plugin node_modules directory", () => {


### PR DESCRIPTION
## Summary
- re-check runtime-deps fingerprint entries with `lstatSync()` before calling `readlinkSync()`
- add a regression for Windows directory entries that look symlink-like at the `Dirent` layer but are regular files underneath

## Repro
On this Windows OneDrive checkout, the native source path failed before the CLI could print a version:

```bash
corepack pnpm openclaw --version
```

It died in `scripts/stage-bundled-plugin-runtime-deps.mjs` with:

```text
EINVAL: invalid argument, readlink '...node_modules/@isaacs/fs-minipass/dist/commonjs/package.json'
```

The root cause was that the runtime-deps fingerprint walk trusted `Dirent.isSymbolicLink()` directly. In this environment some `pnpm`-materialized entries reported as symlink-like there, while `lstat` said they were regular files, so `readlinkSync()` crashed.

## Testing
- AI-assisted: Codex
- `corepack pnpm test test/scripts/stage-bundled-plugin-runtime-deps.test.ts -t "restages when installed root runtime dependency contents change|ignores dirent symlink false positives for runtime fingerprinting|stages runtime deps from the root node_modules when already installed"`
- `corepack pnpm openclaw --version`
- `corepack pnpm openclaw plugins list --json`

## Notes
- I also ran the full `test/scripts/stage-bundled-plugin-runtime-deps.test.ts` file in this Windows shell. It still has pre-existing `EPERM` symlink-creation failures on tests that require real symlink privileges, so I used the tighter runtime-deps slice above as the honest gate for this change.