### PR TITLE
feat(tts): add xAI OpenAI-compatible bridge

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1377,6 +1377,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Removes the acknowledgment reaction after final reply delivery when enabled. Keep enabled for cleaner UX in channels where persistent ack reactions create clutter.",
   "messages.tts":
     "Text-to-speech policy for reading agent replies aloud on supported voice or audio surfaces. Keep disabled unless voice playback is part of your operator/user workflow.",
+  "messages.tts.xai":
+    "xAI TTS configuration for the OpenAI-compatible xAI bridge. Uses the xAI OpenAI-style TTS endpoint and an xAI API key.",
   channels:
     "Channel provider configurations plus shared defaults that control access policies, heartbeat visibility, and per-surface behavior. Keep defaults centralized and override per provider only where required.",
   "channels.telegram":

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -66,6 +66,18 @@ export type TtsConfig = {
     /** System-level instructions for the TTS model (gpt-4o-mini-tts only). */
     instructions?: string;
   };
+  /** xAI configuration. */
+  xai?: {
+    apiKey?: SecretInput;
+    baseUrl?: string;
+    model?: string;
+    voiceId?: string;
+    voice?: string;
+    language?: string;
+    sampleRate?: number;
+    bitRate?: number;
+    outputFormat?: "mp3" | "wav" | "pcm" | "mulaw" | "ulaw" | "alaw";
+  };
   /** Legacy alias for Microsoft speech configuration. */
   edge?: {
     /** Explicitly allow Microsoft speech usage (no API key required). */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -445,6 +445,20 @@ export const TtsConfigSchema = z
       })
       .strict()
       .optional(),
+    xai: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        model: z.string().optional(),
+        voiceId: z.string().optional(),
+        voice: z.string().optional(),
+        language: z.string().optional(),
+        sampleRate: z.number().int().positive().optional(),
+        bitRate: z.number().int().positive().optional(),
+        outputFormat: z.enum(["mp3", "wav", "pcm", "mulaw", "ulaw", "alaw"]).optional(),
+      })
+      .strict()
+      .optional(),
     edge: TtsMicrosoftConfigSchema,
     microsoft: TtsMicrosoftConfigSchema,
     prefsPath: z.string().optional(),

--- a/src/config/zod-schema.tts.test.ts
+++ b/src/config/zod-schema.tts.test.ts
@@ -33,4 +33,16 @@ describe("TtsConfigSchema openai speed and instructions", () => {
       }),
     ).toThrow();
   });
+
+  it("accepts xAI bridge config", () => {
+    const parsed = TtsConfigSchema.parse({
+      xai: {
+        apiKey: "key",
+        baseUrl: "https://api.x.ai/v1",
+        model: "gpt-4o-mini-tts",
+        voiceId: "alloy",
+      },
+    });
+    expect(parsed.xai?.voiceId).toBe("alloy");
+  });
 });

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -39,6 +39,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         prefsPath,
         hasOpenAIKey: Boolean(resolveTtsApiKey(config, "openai")),
         hasElevenLabsKey: Boolean(resolveTtsApiKey(config, "elevenlabs")),
+        hasXaiKey: Boolean(resolveTtsApiKey(config, "xai")),
         microsoftEnabled: isTtsProviderConfigured(config, "microsoft", cfg),
       });
     } catch (err) {
@@ -111,7 +112,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         undefined,
         errorShape(
           ErrorCodes.INVALID_REQUEST,
-          "Invalid provider. Use a registered TTS provider id such as openai, elevenlabs, or microsoft.",
+          "Invalid provider. Use a registered TTS provider id such as openai, elevenlabs, xai, or microsoft.",
         ),
       );
       return;

--- a/src/secrets/runtime-config-collectors-tts.ts
+++ b/src/secrets/runtime-config-collectors-tts.ts
@@ -43,4 +43,19 @@ export function collectTtsApiKeyAssignments(params: {
       },
     });
   }
+  const xai = params.tts.xai;
+  if (isRecord(xai)) {
+    collectSecretInputAssignment({
+      value: xai.apiKey,
+      path: `${params.pathPrefix}.xai.apiKey`,
+      expected: "string",
+      defaults: params.defaults,
+      context: params.context,
+      active: params.active,
+      inactiveReason: params.inactiveReason,
+      apply: (value) => {
+        xai.apiKey = value;
+      },
+    });
+  }
 }

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -651,6 +651,17 @@ const SECRET_TARGET_REGISTRY: SecretTargetRegistryEntry[] = [
     includeInAudit: true,
   },
   {
+    id: "messages.tts.xai.apiKey",
+    targetType: "messages.tts.xai.apiKey",
+    configFile: "openclaw.json",
+    pathPattern: "messages.tts.xai.apiKey",
+    secretShape: SECRET_INPUT_SHAPE,
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
     id: "models.providers.*.apiKey",
     targetType: "models.providers.apiKey",
     targetTypeAliases: ["models.providers.*.apiKey"],

--- a/src/tts/provider-registry.ts
+++ b/src/tts/provider-registry.ts
@@ -6,10 +6,12 @@ import type { SpeechProviderId } from "./provider-types.js";
 import { buildElevenLabsSpeechProvider } from "./providers/elevenlabs.js";
 import { buildMicrosoftSpeechProvider } from "./providers/microsoft.js";
 import { buildOpenAISpeechProvider } from "./providers/openai.js";
+import { buildXaiSpeechProvider } from "./providers/xai.js";
 
 const BUILTIN_SPEECH_PROVIDER_BUILDERS = [
   buildOpenAISpeechProvider,
   buildElevenLabsSpeechProvider,
+  buildXaiSpeechProvider,
   buildMicrosoftSpeechProvider,
 ] as const satisfies readonly (() => SpeechProviderPlugin)[];
 

--- a/src/tts/providers/xai.test.ts
+++ b/src/tts/providers/xai.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SpeechSynthesisRequest } from "../provider-types.js";
+
+vi.mock("../tts-core.js", () => ({
+  openaiTTS: vi.fn().mockResolvedValue(Buffer.from("xai-audio")),
+}));
+
+import { openaiTTS } from "../tts-core.js";
+import { buildXaiSpeechProvider } from "./xai.js";
+
+describe("xAI speech provider bridge", () => {
+  it("uses the OpenAI-compatible xAI endpoint", async () => {
+    const provider = buildXaiSpeechProvider();
+    const request = {
+      text: "hello",
+      cfg: {
+        tts: {
+          xai: {
+            apiKey: "xai-key",
+            baseUrl: "https://api.x.ai/v1/",
+            model: "gpt-4o-mini-tts",
+            voiceId: "alloy",
+          },
+        },
+      },
+      config: {
+        xai: {
+          apiKey: "xai-key",
+          baseUrl: "https://api.x.ai/v1/",
+          model: "gpt-4o-mini-tts",
+          voiceId: "alloy",
+          outputFormat: "mp3",
+        },
+        openai: {
+          apiKey: undefined,
+          baseUrl: "https://api.openai.com/v1",
+          model: "gpt-4o-mini-tts",
+          voice: "alloy",
+        },
+        elevenlabs: {
+          apiKey: undefined,
+          baseUrl: "https://api.elevenlabs.io",
+          voiceId: "v",
+          modelId: "m",
+          voiceSettings: {
+            stability: 0.5,
+            similarityBoost: 0.75,
+            style: 0,
+            useSpeakerBoost: true,
+            speed: 1,
+          },
+        },
+        edge: {
+          enabled: true,
+          voice: "en-US-MichelleNeural",
+          lang: "en-US",
+          outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+          saveSubtitles: false,
+        },
+        microsoft: {
+          enabled: true,
+          voice: "en-US-MichelleNeural",
+          lang: "en-US",
+          outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+          saveSubtitles: false,
+        },
+        auto: "off",
+        enabled: false,
+        mode: "final",
+        provider: "xai",
+        modelOverrides: {},
+        summaryModel: undefined,
+        prefsPath: undefined,
+        maxTextLength: 4096,
+        timeoutMs: 30_000,
+      },
+      target: "audio-file",
+    } as unknown as SpeechSynthesisRequest;
+    const result = await provider.synthesize(request);
+    expect(result.outputFormat).toBe("mp3");
+    expect(openaiTTS).toHaveBeenCalled();
+  });
+});

--- a/src/tts/providers/xai.ts
+++ b/src/tts/providers/xai.ts
@@ -1,0 +1,62 @@
+import type { SpeechProviderPlugin } from "../../plugins/types.js";
+import { openaiTTS } from "../tts-core.js";
+
+const DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1";
+const DEFAULT_XAI_VOICE = "alloy";
+const DEFAULT_XAI_MODEL = "gpt-4o-mini-tts";
+
+function normalizeBaseUrl(baseUrl: string | undefined): string {
+  const trimmed = baseUrl?.trim();
+  return (trimmed || DEFAULT_XAI_BASE_URL).replace(/\/+$/, "");
+}
+
+export function buildXaiSpeechProvider(): SpeechProviderPlugin {
+  return {
+    id: "xai",
+    label: "xAI",
+    isConfigured: ({ config }) => Boolean(config.xai.apiKey || process.env.XAI_API_KEY),
+    synthesize: async (req) => {
+      const apiKey = req.config.xai.apiKey || process.env.XAI_API_KEY;
+      if (!apiKey) {
+        throw new Error("xAI API key missing");
+      }
+      const outputFormat = req.target === "voice-note" ? "opus" : "mp3";
+      const audioBuffer = await openaiTTS({
+        text: req.text,
+        apiKey,
+        baseUrl: normalizeBaseUrl(req.config.xai.baseUrl),
+        model: req.overrides?.xai?.model ?? req.config.xai.model ?? DEFAULT_XAI_MODEL,
+        voice:
+          req.overrides?.xai?.voiceId ??
+          req.overrides?.xai?.voice ??
+          req.config.xai.voiceId ??
+          req.config.xai.voice ??
+          DEFAULT_XAI_VOICE,
+        responseFormat: outputFormat,
+        timeoutMs: req.config.timeoutMs,
+      });
+      return {
+        audioBuffer,
+        outputFormat,
+        fileExtension: outputFormat === "opus" ? ".opus" : ".mp3",
+        voiceCompatible: req.target === "voice-note",
+      };
+    },
+    synthesizeTelephony: async (req) => {
+      const apiKey = req.config.xai.apiKey || process.env.XAI_API_KEY;
+      if (!apiKey) {
+        throw new Error("xAI API key missing");
+      }
+      const audioBuffer = await openaiTTS({
+        text: req.text,
+        apiKey,
+        baseUrl: normalizeBaseUrl(req.config.xai.baseUrl),
+        model: req.config.xai.model ?? DEFAULT_XAI_MODEL,
+        voice: req.config.xai.voiceId ?? req.config.xai.voice ?? DEFAULT_XAI_VOICE,
+        responseFormat: "pcm",
+        timeoutMs: req.config.timeoutMs,
+      });
+      return { audioBuffer, outputFormat: "pcm", sampleRate: 24_000 };
+    },
+  };
+}

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -116,6 +116,17 @@ export type ResolvedTtsConfig = {
     speed?: number;
     instructions?: string;
   };
+  xai: {
+    apiKey?: string;
+    baseUrl: string;
+    model: string;
+    voiceId: string;
+    voice?: string;
+    language?: string;
+    sampleRate?: number;
+    bitRate?: number;
+    outputFormat: "mp3" | "wav" | "pcm" | "mulaw" | "ulaw" | "alaw";
+  };
   edge: {
     enabled: boolean;
     voice: string;
@@ -161,6 +172,15 @@ export type TtsDirectiveOverrides = {
   openai?: {
     voice?: string;
     model?: string;
+  };
+  xai?: {
+    model?: string;
+    voiceId?: string;
+    voice?: string;
+    language?: string;
+    sampleRate?: number;
+    bitRate?: number;
+    outputFormat?: "mp3" | "wav" | "pcm" | "mulaw" | "ulaw" | "alaw";
   };
   elevenlabs?: {
     voiceId?: string;
@@ -305,6 +325,24 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
       speed: raw.openai?.speed,
       instructions: raw.openai?.instructions?.trim() || undefined,
+    },
+    xai: {
+      apiKey: normalizeResolvedSecretInputString({
+        value: raw.xai?.apiKey,
+        path: "messages.tts.xai.apiKey",
+      }),
+      baseUrl: (
+        raw.xai?.baseUrl?.trim() ||
+        process.env.XAI_TTS_BASE_URL?.trim() ||
+        "https://api.x.ai/v1"
+      ).replace(/\/+$/, ""),
+      model: raw.xai?.model?.trim() || "grok-3-mini-tts",
+      voiceId: raw.xai?.voiceId?.trim() || raw.xai?.voice?.trim() || "Asteria",
+      voice: raw.xai?.voice?.trim() || undefined,
+      language: raw.xai?.language?.trim() || undefined,
+      sampleRate: raw.xai?.sampleRate,
+      bitRate: raw.xai?.bitRate,
+      outputFormat: raw.xai?.outputFormat ?? "mp3",
     },
     edge: {
       enabled: rawMicrosoft.enabled ?? true,
@@ -458,6 +496,9 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   if (resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
+  if (resolveTtsApiKey(config, "xai")) {
+    return "xai";
+  }
   return "microsoft";
 }
 
@@ -526,10 +567,13 @@ export function resolveTtsApiKey(
   if (normalizedProvider === "openai") {
     return config.openai.apiKey || process.env.OPENAI_API_KEY;
   }
+  if (normalizedProvider === "xai") {
+    return config.xai.apiKey || process.env.XAI_API_KEY;
+  }
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "microsoft"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "xai", "microsoft"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider, cfg?: OpenClawConfig): TtsProvider[] {
   const normalizedPrimary = normalizeSpeechProviderId(primary) ?? primary;


### PR DESCRIPTION
Implements xAI TTS via the OpenAI-compatible bridge at /v1, points local TTS config at that endpoint, and adds tests for the bridge path.