### PR TITLE
fix(slack): ensure message ordering by setting maxRequestConcurrency to 1

### DIFF
--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -69,6 +69,18 @@ describe("slack web client config", () => {
     expect(options.retryConfig).toEqual(SLACK_WRITE_RETRY_OPTIONS);
   });
 
+  it("sets maxRequestConcurrency to 1 by default for write client", () => {
+    const options = resolveSlackWriteClientOptions();
+
+    expect(options.maxRequestConcurrency).toBe(1);
+  });
+
+  it("allows overriding maxRequestConcurrency in write client options", () => {
+    const options = resolveSlackWriteClientOptions({ maxRequestConcurrency: 5 });
+
+    expect(options.maxRequestConcurrency).toBe(5);
+  });
+
   it("passes no-retry config into the write client by default", () => {
     createSlackWriteClient("xoxb-test", { timeout: 4321 });
 

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -91,6 +91,7 @@ export function resolveSlackWriteClientOptions(options: WebClientOptions = {}): 
     ...options,
     agent: options.agent ?? resolveSlackProxyAgent(),
     retryConfig: options.retryConfig ?? SLACK_WRITE_RETRY_OPTIONS,
+    maxRequestConcurrency: options.maxRequestConcurrency ?? 1,
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes openclaw#69101

When OpenClaw sends multiple Slack messages in rapid succession, messages frequently arrive on the Slack client in an order different from the order they were sent.

## Root Cause
The underlying @slack/web-api WebClient instantiates a p-queue request queue with a default maxRequestConcurrency: 100. p-queue with concurrency > 1 starts requests in order but does not guarantee they complete in order.

## Fix
Set maxRequestConcurrency: 1 on write-client options in resolveSlackWriteClientOptions(). This serializes all write-side API calls for a given WebClient instance.

The performance impact is negligible because:
1. chat.postMessage is subject to Slack's own ~1 msg/sec per channel rate limit anyway
2. In-order delivery is a correctness property, not a performance one
3. Reads (createSlackWebClient) can keep their existing concurrency — this only affects writes

## Test Plan
- [x] Relevant unit tests pass (extensions/slack/src/client.test.ts)
- [x] Added regression tests for maxRequestConcurrency behavior

Closes openclaw#69101