### PR TITLE
git-hooks: fall back to corepack pnpm in pre-commit

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -16,6 +16,10 @@ if [[ ! -f "$FILTER_FILES" ]]; then
   exit 1
 fi
 
+has_pnpm_runner() {
+  command -v pnpm >/dev/null 2>&1 || command -v corepack >/dev/null 2>&1
+}
+
 run_pnpm() {
   if command -v pnpm >/dev/null 2>&1; then
     pnpm "$@"
@@ -85,10 +89,11 @@ if [[ -f "$ROOT_DIR/package.json" ]] && [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; the
       if [[ "$docs_only" == true ]]; then
         echo "Docs-only staged changes detected: skipping pnpm check in pre-commit hook."
       else
-        if ! run_pnpm check:changed --staged; then
+        if ! has_pnpm_runner; then
           echo "Missing pnpm and corepack, cannot run repo check in pre-commit hook." >&2
           exit 1
         fi
+        run_pnpm check:changed --staged
       fi
       ;;
   esac

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -16,6 +16,18 @@ if [[ ! -f "$FILTER_FILES" ]]; then
   exit 1
 fi
 
+run_pnpm() {
+  if command -v pnpm >/dev/null 2>&1; then
+    pnpm "$@"
+    return
+  fi
+  if command -v corepack >/dev/null 2>&1; then
+    corepack pnpm "$@"
+    return
+  fi
+  return 1
+}
+
 # Security: avoid option-injection from malicious file names (e.g. "--all", "--force").
 # Robustness: NUL-delimited file list handles spaces/newlines safely.
 # Compatibility: use read loops instead of `mapfile` so this runs on macOS Bash 3.x.
@@ -73,7 +85,10 @@ if [[ -f "$ROOT_DIR/package.json" ]] && [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; the
       if [[ "$docs_only" == true ]]; then
         echo "Docs-only staged changes detected: skipping pnpm check in pre-commit hook."
       else
-        pnpm check:changed --staged
+        if ! run_pnpm check:changed --staged; then
+          echo "Missing pnpm and corepack, cannot run repo check in pre-commit hook." >&2
+          exit 1
+        fi
       fi
       ;;
   esac

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -8,7 +8,18 @@ const baseGitEnv = {
   GIT_CONFIG_NOSYSTEM: "1",
   GIT_TERMINAL_PROMPT: "0",
 };
-const baseRunEnv: NodeJS.ProcessEnv = { ...process.env, ...baseGitEnv };
+const scrubbedGitEnv = { ...process.env };
+delete scrubbedGitEnv.GIT_DIR;
+delete scrubbedGitEnv.GIT_WORK_TREE;
+delete scrubbedGitEnv.GIT_INDEX_FILE;
+delete scrubbedGitEnv.GIT_PREFIX;
+delete scrubbedGitEnv.GIT_AUTHOR_NAME;
+delete scrubbedGitEnv.GIT_AUTHOR_EMAIL;
+delete scrubbedGitEnv.GIT_AUTHOR_DATE;
+delete scrubbedGitEnv.GIT_COMMITTER_NAME;
+delete scrubbedGitEnv.GIT_COMMITTER_EMAIL;
+delete scrubbedGitEnv.GIT_COMMITTER_DATE;
+const baseRunEnv: NodeJS.ProcessEnv = { ...scrubbedGitEnv, ...baseGitEnv };
 const tempDirs: string[] = [];
 
 const run = (cwd: string, cmd: string, args: string[] = [], env?: NodeJS.ProcessEnv) => {
@@ -106,6 +117,60 @@ describe("git-hooks/pre-commit (integration)", () => {
     });
 
     expect(run(dir, "cat", ["pnpm-args.txt"])).toBe("check:changed --staged");
+  });
+
+  it("fails with a missing-tool message when neither pnpm nor corepack exists", () => {
+    const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-no-pnpm-");
+    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
+
+    const fakeBinDir = installPreCommitFixture(dir);
+    writeFileSync(path.join(dir, "package.json"), '{"name":"tmp"}\n', "utf8");
+    writeFileSync(path.join(dir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf8");
+    writeExecutable(fakeBinDir, "git", '#!/bin/sh\n/usr/bin/git "$@"\n');
+    writeExecutable(fakeBinDir, "node", "#!/bin/sh\nexit 0\n");
+
+    writeFileSync(path.join(dir, "tracked.txt"), "hello\n", "utf8");
+    run(dir, "git", ["add", "--", "tracked.txt"]);
+
+    const result = spawnSync("/bin/bash", ["git-hooks/pre-commit"], {
+      cwd: dir,
+      encoding: "utf8",
+      env: { ...baseRunEnv, PATH: fakeBinDir },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Missing pnpm and corepack, cannot run repo check in pre-commit hook.",
+    );
+  });
+
+  it("preserves failing check output instead of replacing it with a missing-tool message", () => {
+    const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-check-fails-");
+    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
+
+    const fakeBinDir = installPreCommitFixture(dir);
+    writeFileSync(path.join(dir, "package.json"), '{"name":"tmp"}\n', "utf8");
+    writeFileSync(path.join(dir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf8");
+    writeExecutable(
+      fakeBinDir,
+      "pnpm",
+      "#!/usr/bin/env bash\necho 'real check failure' >&2\nexit 23\n",
+    );
+
+    writeFileSync(path.join(dir, "tracked.txt"), "hello\n", "utf8");
+    run(dir, "git", ["add", "--", "tracked.txt"]);
+
+    const result = spawnSync("bash", ["git-hooks/pre-commit"], {
+      cwd: dir,
+      encoding: "utf8",
+      env: { ...baseRunEnv, PATH: `${fakeBinDir}:${process.env.PATH ?? ""}` },
+    });
+
+    expect(result.status).toBe(23);
+    expect(result.stderr).toContain("real check failure");
+    expect(result.stderr).not.toContain(
+      "Missing pnpm and corepack, cannot run repo check in pre-commit hook.",
+    );
   });
 
   it("skips changed-scope check when FAST_COMMIT is enabled", () => {


### PR DESCRIPTION
## Summary
- fall back to `corepack pnpm` when plain `pnpm` is not on PATH in the pre-commit hook
- keep the existing repo-wide `check` gate behavior unchanged when `pnpm` is available

## Why
This makes local commits more resilient on hosts where pnpm is installed via Corepack instead of a standalone PATH entry.

## Validation
- `bash -n git-hooks/pre-commit`
- exercised the hook path indirectly during local commits on a Corepack-only host