### PR TITLE
CopilotSdk: add @github/copilot-sdk-backed provider plugin

### DIFF
--- a/extensions/copilot-sdk/README.md
+++ b/extensions/copilot-sdk/README.md
@@ -1,0 +1,102 @@
+# @openclaw/copilot-sdk
+
+Experimental OpenClaw provider plugin that routes chat completions through the
+[`@github/copilot`](https://www.npmjs.com/package/@github/copilot) CLI using
+[`@github/copilot-sdk`](https://www.npmjs.com/package/@github/copilot-sdk).
+
+The plugin:
+
+- Spawns the `@github/copilot` CLI in the background (via the SDK)
+- Exposes an OpenAI-compatible HTTP shim on `127.0.0.1` (default port `9527`)
+- Registers a `copilot-sdk` provider that points at the shim
+- Denies every permission request the CLI makes. The Copilot CLI is used as a
+  pure LLM; OpenClaw continues to own tool dispatch through its own runtime.
+
+This lets OpenClaw use the user's GitHub Copilot subscription for model calls
+without any API key, through a GitHub-sanctioned path.
+
+## Status
+
+**Public preview.** The underlying `@github/copilot-sdk` package is itself in
+public preview (`0.2.x`) and its wire protocol may change without notice. The
+plugin pins an exact SDK version and is disabled by default. Pin both sides
+explicitly in your distribution.
+
+## Requirements
+
+- Node 22+
+- An active GitHub Copilot subscription
+- `@github/copilot` CLI available. The SDK bundles a CLI by default; you can
+  point at a specific binary via `plugins.entries.copilot-sdk.config.cliPath`.
+- A one-time `copilot login` completed in a terminal so the SDK can reuse the
+  logged-in user's credentials.
+
+## Configuration
+
+```yaml
+plugins:
+  entries:
+    copilot-sdk:
+      enabled: true
+      config:
+        # Loopback port for the local shim. 9527 by default.
+        port: 9527
+        # When true (default), requests that declare `tools` are rejected
+        # with HTTP 400 rather than silently dropped.
+        rejectToolRequests: true
+        # Optional override for the @github/copilot CLI binary.
+        # cliPath: /usr/local/bin/copilot
+```
+
+After enabling the plugin, run `openclaw onboard` and choose the
+`copilot-sdk` setup option, or manually add the provider to your model
+configuration. The plugin's auth wizard writes a placeholder token profile
+and emits the config patch above.
+
+## Limitations
+
+- **No tool calling.** The Copilot CLI session runs with a deny-all
+  permission handler, so tool calls emitted by the CLI are never executed.
+  OpenClaw's own tool runtime continues to work; we simply don't forward
+  OpenAI-format `tools` through the shim. Requests that declare tools are
+  rejected with HTTP 400 (`tools_not_supported`) by default. Set
+  `rejectToolRequests: false` to silently drop tools instead.
+- **No per-token streaming.** The SDK emits whole assistant messages rather
+  than token deltas. For `stream: true` requests the shim emits a single
+  delta chunk followed by `[DONE]`.
+- **No embeddings.** The CLI does not expose an embedding model.
+- **No image uploads.** Image content parts in the OpenAI request are replaced
+  with a placeholder note; attachments are not forwarded.
+
+## How it works
+
+```
+OpenClaw agent
+     │
+     │  POST /v1/chat/completions
+     ▼
+127.0.0.1:9527 (shim server, in-process Node HTTP)
+     │
+     │  session.sendAndWait({ prompt })
+     ▼
+@github/copilot-sdk CopilotClient
+     │
+     │  JSON-RPC over stdio
+     ▼
+@github/copilot CLI (spawned child)
+     │
+     │  HTTPS to GitHub Copilot service
+     ▼
+GitHub Copilot
+```
+
+The shim server is a singleton per Node process and is started lazily on the
+first catalog pass that resolves a Copilot SDK credential.
+
+## Running the tests
+
+```
+pnpm --filter @openclaw/copilot-sdk test
+```
+
+All tests run with a mocked SDK; no network or real CLI is required.

--- a/extensions/copilot-sdk/index.test.ts
+++ b/extensions/copilot-sdk/index.test.ts
@@ -1,13 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveProviderPluginChoice } from "../../src/plugins/provider-auth-choice.runtime.js";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
-import { createCopilotSdkPlugin } from "./index.js";
+import { __resetShimForTests, createCopilotSdkPlugin } from "./index.js";
 import type { SdkClient } from "./sdk-client.js";
+import type { ShimServerHandle } from "./shim-server.js";
+
+let shimPortCounter = 40_000;
 
 function buildFakeDeps(): {
   deps: Parameters<typeof createCopilotSdkPlugin>[0];
   getClient: ReturnType<typeof vi.fn>;
   fakeClient: SdkClient;
+  createDedicatedClient: ReturnType<typeof vi.fn>;
+  dedicatedClient: SdkClient;
+  startShimServer: ReturnType<typeof vi.fn>;
 } {
   const fakeClient: SdkClient = {
     listModels: vi.fn(async () => [
@@ -17,15 +23,38 @@ function buildFakeDeps(): {
     runPrompt: vi.fn(async () => ({ content: "ok" })),
     close: vi.fn(async () => undefined),
   };
+  const dedicatedClient: SdkClient = {
+    listModels: vi.fn(async () => []),
+    runPrompt: vi.fn(async () => ({ content: "shim-ok" })),
+    close: vi.fn(async () => undefined),
+  };
   const getClient = vi.fn(async () => fakeClient);
+  const createDedicatedClient = vi.fn(async () => dedicatedClient);
+  const startShimServer = vi.fn(async (): Promise<ShimServerHandle> => {
+    const port = shimPortCounter++;
+    return {
+      url: `http://127.0.0.1:${port}/v1`,
+      port,
+      close: vi.fn(async () => undefined),
+    };
+  });
   return {
-    deps: { getClient: getClient as never },
+    deps: {
+      getClient: getClient as never,
+      createDedicatedClient: createDedicatedClient as never,
+      startShimServer: startShimServer as never,
+    },
     getClient,
     fakeClient,
+    createDedicatedClient,
+    dedicatedClient,
+    startShimServer,
   };
 }
 
 describe("copilot-sdk provider plugin", () => {
+  afterEach(() => __resetShimForTests());
+
   it("registers the provider with an SDK auth method and wizard entry", async () => {
     const { deps } = buildFakeDeps();
     const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
@@ -97,7 +126,7 @@ describe("copilot-sdk provider plugin", () => {
       throw new Error("expected provider catalog");
     }
     expect(catalog.provider.api).toBe("openai-completions");
-    expect(catalog.provider.baseUrl).toBe("http://127.0.0.1:9527/v1");
+    expect(catalog.provider.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v1$/);
     expect(catalog.provider.models?.map((m) => m.id)).toEqual(["gpt-5", "claude-sonnet-4.5"]);
     expect(getClient).toHaveBeenCalled();
     // SDK client must be stopped after catalog so the subprocess exits
@@ -168,8 +197,8 @@ describe("copilot-sdk provider plugin", () => {
     expect(fakeClient.close).toHaveBeenCalledTimes(2);
   });
 
-  it("honors configured port in the catalog baseUrl", async () => {
-    const { deps } = buildFakeDeps();
+  it("honors configured port passed to startShimServer", async () => {
+    const { deps, startShimServer } = buildFakeDeps();
     const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
 
     const catalog = await provider.catalog!.run({
@@ -184,6 +213,114 @@ describe("copilot-sdk provider plugin", () => {
     if (!catalog || !("provider" in catalog)) {
       throw new Error("expected provider catalog");
     }
-    expect(catalog.provider.baseUrl).toBe("http://127.0.0.1:11111/v1");
+    expect(startShimServer).toHaveBeenCalledWith(expect.objectContaining({ port: 11111 }));
+    // baseUrl comes from the shim handle, not the raw config port
+    expect(catalog.provider.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v1$/);
+  });
+
+  it("ensureShim() starts shim and catalog returns its URL", async () => {
+    const { deps, startShimServer, createDedicatedClient } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    const catalog = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({ apiKey: "copilot-sdk", mode: "token", source: "profile" }),
+    } as never);
+
+    expect(createDedicatedClient).toHaveBeenCalledTimes(1);
+    expect(startShimServer).toHaveBeenCalledTimes(1);
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected provider catalog");
+    }
+    // The baseUrl must come from the shim handle, not a hardcoded port
+    expect(catalog.provider.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v1$/);
+  });
+
+  it("ensureShim() reuses existing shim on repeated catalog calls", async () => {
+    const { deps, createDedicatedClient, startShimServer } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    const ctx = {
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({
+        apiKey: "copilot-sdk",
+        mode: "token" as const,
+        source: "profile" as const,
+      }),
+    };
+    const cat1 = await provider.catalog!.run(ctx as never);
+    const cat2 = await provider.catalog!.run(ctx as never);
+
+    // Shim created only once — reused on second call
+    expect(createDedicatedClient).toHaveBeenCalledTimes(1);
+    expect(startShimServer).toHaveBeenCalledTimes(1);
+    // Both catalogs return the same shim URL
+    if (!cat1 || !("provider" in cat1) || !cat2 || !("provider" in cat2)) {
+      throw new Error("expected provider catalogs");
+    }
+    expect(cat1.provider.baseUrl).toBe(cat2.provider.baseUrl);
+  });
+
+  it("ensureShim() rebuilds shim when config changes", async () => {
+    const { deps, createDedicatedClient, startShimServer } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    const ctx1 = {
+      config: {
+        plugins: { entries: { "copilot-sdk": { config: { port: 9001 } } } },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({
+        apiKey: "copilot-sdk",
+        mode: "token" as const,
+        source: "profile" as const,
+      }),
+    };
+    const ctx2 = {
+      config: {
+        plugins: { entries: { "copilot-sdk": { config: { port: 9002 } } } },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({
+        apiKey: "copilot-sdk",
+        mode: "token" as const,
+        source: "profile" as const,
+      }),
+    };
+
+    const cat1 = await provider.catalog!.run(ctx1 as never);
+    const cat2 = await provider.catalog!.run(ctx2 as never);
+
+    // Config change triggers a new shim
+    expect(createDedicatedClient).toHaveBeenCalledTimes(2);
+    expect(startShimServer).toHaveBeenCalledTimes(2);
+    expect(startShimServer).toHaveBeenNthCalledWith(1, expect.objectContaining({ port: 9001 }));
+    expect(startShimServer).toHaveBeenNthCalledWith(2, expect.objectContaining({ port: 9002 }));
+    // Different URLs from the two shim handles
+    if (!cat1 || !("provider" in cat1) || !cat2 || !("provider" in cat2)) {
+      throw new Error("expected provider catalogs");
+    }
+    expect(cat1.provider.baseUrl).not.toBe(cat2.provider.baseUrl);
+  });
+
+  it("catalog returns null when shim startup fails", async () => {
+    const { deps, startShimServer } = buildFakeDeps();
+    startShimServer.mockRejectedValueOnce(new Error("port unavailable"));
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    const catalog = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({ apiKey: "copilot-sdk", mode: "token", source: "profile" }),
+    } as never);
+
+    expect(catalog).toBeNull();
   });
 });

--- a/extensions/copilot-sdk/index.test.ts
+++ b/extensions/copilot-sdk/index.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveProviderPluginChoice } from "../../src/plugins/provider-auth-choice.runtime.js";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import { createCopilotSdkPlugin, __resetShimForTests } from "./index.js";
+import type { SdkClient } from "./sdk-client.js";
+import type { ShimServerHandle } from "./shim-server.js";
+
+function buildFakeDeps(): {
+  deps: Parameters<typeof createCopilotSdkPlugin>[0];
+  startShim: ReturnType<typeof vi.fn>;
+  getClient: ReturnType<typeof vi.fn>;
+  fakeClient: SdkClient;
+  closeShim: ReturnType<typeof vi.fn>;
+} {
+  const closeShim = vi.fn(async () => undefined);
+  const fakeClient: SdkClient = {
+    listModels: vi.fn(async () => [
+      { id: "gpt-5", name: "GPT-5" },
+      { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+    ]),
+    runPrompt: vi.fn(async () => ({ content: "ok" })),
+    close: vi.fn(async () => undefined),
+  };
+  const handle: ShimServerHandle = {
+    url: "http://127.0.0.1:9527/v1",
+    port: 9527,
+    close: closeShim,
+  };
+  const startShim = vi.fn(async () => handle);
+  const getClient = vi.fn(async () => fakeClient);
+  return {
+    deps: { startShim: startShim as never, getClient: getClient as never },
+    startShim,
+    getClient,
+    fakeClient,
+    closeShim,
+  };
+}
+
+describe("copilot-sdk provider plugin", () => {
+  afterEach(async () => {
+    await __resetShimForTests();
+  });
+
+  it("registers the provider with an SDK auth method and wizard entry", async () => {
+    const { deps } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    expect(provider.id).toBe("copilot-sdk");
+    expect(provider.label).toBe("Copilot SDK (experimental)");
+    expect(provider.auth).toHaveLength(1);
+    expect(provider.auth[0].id).toBe("sdk");
+
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "copilot-sdk",
+    });
+    expect(resolved?.provider.id).toBe("copilot-sdk");
+    expect(resolved?.method.id).toBe("sdk");
+  });
+
+  it("custom auth emits a token credential and plugin enablement patch", async () => {
+    const { deps } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+    const method = provider.auth[0];
+    if (method.kind !== "custom") {
+      throw new Error("expected custom auth method");
+    }
+
+    const result = await method.run({
+      prompter: {} as never,
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as never,
+      env: {},
+    } as never);
+
+    expect(result.profiles?.[0]?.credential.type).toBe("token");
+    const plugins = (
+      result.configPatch as { plugins?: { entries?: Record<string, { enabled?: boolean }> } }
+    )?.plugins;
+    expect(plugins?.entries?.["copilot-sdk"]?.enabled).toBe(true);
+    expect(result.notes?.some((note) => note.includes("device login"))).toBe(true);
+  });
+
+  it("catalog returns null when no token is resolved", async () => {
+    const { deps, startShim } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+    expect(provider.catalog).toBeDefined();
+
+    const result = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+    } as never);
+
+    expect(result).toBeNull();
+    expect(startShim).not.toHaveBeenCalled();
+  });
+
+  it("catalog starts the shim and returns a provider pointed at its loopback URL", async () => {
+    const { deps, startShim, getClient } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    const catalog = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({ apiKey: "copilot-sdk", mode: "token", source: "profile" }),
+    } as never);
+
+    expect(catalog && "provider" in catalog).toBe(true);
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected provider catalog");
+    }
+    expect(catalog.provider.api).toBe("openai-completions");
+    expect(catalog.provider.baseUrl).toBe("http://127.0.0.1:9527/v1");
+    expect(catalog.provider.models?.map((m) => m.id)).toEqual(["gpt-5", "claude-sonnet-4.5"]);
+    expect(startShim).toHaveBeenCalledOnce();
+    expect(getClient).toHaveBeenCalled();
+  });
+
+  it("falls back to static model catalog when SDK listModels throws", async () => {
+    const { deps, fakeClient } = buildFakeDeps();
+    (fakeClient.listModels as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("sdk offline"),
+    );
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    const catalog = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({ apiKey: "copilot-sdk", mode: "token", source: "profile" }),
+    } as never);
+
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected provider catalog");
+    }
+    const ids = catalog.provider.models?.map((m) => m.id) ?? [];
+    expect(ids.length).toBeGreaterThan(0);
+    // fallback catalog includes at least the gpt-5 id.
+    expect(ids).toContain("gpt-5");
+  });
+
+  it("catalog returns null when shim fails to start", async () => {
+    const { deps, startShim } = buildFakeDeps();
+    startShim.mockRejectedValueOnce(new Error("port in use"));
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    const result = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({ apiKey: "copilot-sdk", mode: "token", source: "profile" }),
+    } as never);
+
+    expect(result).toBeNull();
+  });
+
+  it("reuses the shim across repeated catalog calls with unchanged config", async () => {
+    const { deps, startShim } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    const ctx = {
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({
+        apiKey: "copilot-sdk",
+        mode: "token" as const,
+        source: "profile" as const,
+      }),
+    };
+    await provider.catalog!.run(ctx as never);
+    await provider.catalog!.run(ctx as never);
+
+    expect(startShim).toHaveBeenCalledOnce();
+  });
+
+  it("honors configured port from plugins.entries.copilot-sdk.config.port", async () => {
+    const { deps, startShim } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    await provider.catalog!.run({
+      config: {
+        plugins: { entries: { "copilot-sdk": { config: { port: 11111 } } } },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({ apiKey: "copilot-sdk", mode: "token", source: "profile" }),
+    } as never);
+
+    expect(startShim).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 11111, rejectToolRequests: true }),
+    );
+  });
+});

--- a/extensions/copilot-sdk/index.test.ts
+++ b/extensions/copilot-sdk/index.test.ts
@@ -323,4 +323,22 @@ describe("copilot-sdk provider plugin", () => {
 
     expect(catalog).toBeNull();
   });
+
+  it("passes allowBuiltinTools config to startShimServer", async () => {
+    const { deps, startShimServer } = buildFakeDeps();
+    const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
+
+    await provider.catalog!.run({
+      config: {
+        plugins: { entries: { "copilot-sdk": { config: { allowBuiltinTools: true } } } },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
+      resolveProviderAuth: () => ({ apiKey: "copilot-sdk", mode: "token", source: "profile" }),
+    } as never);
+
+    expect(startShimServer).toHaveBeenCalledWith(
+      expect.objectContaining({ allowBuiltinTools: true }),
+    );
+  });
 });

--- a/extensions/copilot-sdk/index.test.ts
+++ b/extensions/copilot-sdk/index.test.ts
@@ -1,18 +1,14 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveProviderPluginChoice } from "../../src/plugins/provider-auth-choice.runtime.js";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
-import { createCopilotSdkPlugin, __resetShimForTests } from "./index.js";
+import { createCopilotSdkPlugin } from "./index.js";
 import type { SdkClient } from "./sdk-client.js";
-import type { ShimServerHandle } from "./shim-server.js";
 
 function buildFakeDeps(): {
   deps: Parameters<typeof createCopilotSdkPlugin>[0];
-  startShim: ReturnType<typeof vi.fn>;
   getClient: ReturnType<typeof vi.fn>;
   fakeClient: SdkClient;
-  closeShim: ReturnType<typeof vi.fn>;
 } {
-  const closeShim = vi.fn(async () => undefined);
   const fakeClient: SdkClient = {
     listModels: vi.fn(async () => [
       { id: "gpt-5", name: "GPT-5" },
@@ -21,27 +17,15 @@ function buildFakeDeps(): {
     runPrompt: vi.fn(async () => ({ content: "ok" })),
     close: vi.fn(async () => undefined),
   };
-  const handle: ShimServerHandle = {
-    url: "http://127.0.0.1:9527/v1",
-    port: 9527,
-    close: closeShim,
-  };
-  const startShim = vi.fn(async () => handle);
   const getClient = vi.fn(async () => fakeClient);
   return {
-    deps: { startShim: startShim as never, getClient: getClient as never },
-    startShim,
+    deps: { getClient: getClient as never },
     getClient,
     fakeClient,
-    closeShim,
   };
 }
 
 describe("copilot-sdk provider plugin", () => {
-  afterEach(async () => {
-    await __resetShimForTests();
-  });
-
   it("registers the provider with an SDK auth method and wizard entry", async () => {
     const { deps } = buildFakeDeps();
     const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
@@ -82,7 +66,7 @@ describe("copilot-sdk provider plugin", () => {
   });
 
   it("catalog returns null when no token is resolved", async () => {
-    const { deps, startShim } = buildFakeDeps();
+    const { deps, getClient } = buildFakeDeps();
     const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
     expect(provider.catalog).toBeDefined();
 
@@ -94,11 +78,11 @@ describe("copilot-sdk provider plugin", () => {
     } as never);
 
     expect(result).toBeNull();
-    expect(startShim).not.toHaveBeenCalled();
+    expect(getClient).not.toHaveBeenCalled();
   });
 
-  it("catalog starts the shim and returns a provider pointed at its loopback URL", async () => {
-    const { deps, startShim, getClient } = buildFakeDeps();
+  it("catalog uses SDK client to discover models and stops it afterward", async () => {
+    const { deps, getClient, fakeClient } = buildFakeDeps();
     const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
 
     const catalog = await provider.catalog!.run({
@@ -115,8 +99,9 @@ describe("copilot-sdk provider plugin", () => {
     expect(catalog.provider.api).toBe("openai-completions");
     expect(catalog.provider.baseUrl).toBe("http://127.0.0.1:9527/v1");
     expect(catalog.provider.models?.map((m) => m.id)).toEqual(["gpt-5", "claude-sonnet-4.5"]);
-    expect(startShim).toHaveBeenCalledOnce();
     expect(getClient).toHaveBeenCalled();
+    // SDK client must be stopped after catalog so the subprocess exits
+    expect(fakeClient.close).toHaveBeenCalled();
   });
 
   it("falls back to static model catalog when SDK listModels throws", async () => {
@@ -142,23 +127,28 @@ describe("copilot-sdk provider plugin", () => {
     expect(ids).toContain("gpt-5");
   });
 
-  it("catalog returns null when shim fails to start", async () => {
-    const { deps, startShim } = buildFakeDeps();
-    startShim.mockRejectedValueOnce(new Error("port in use"));
+  it("catalog falls back to static models when getClient fails", async () => {
+    const { deps, getClient } = buildFakeDeps();
+    getClient.mockRejectedValueOnce(new Error("sdk crash"));
     const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
 
-    const result = await provider.catalog!.run({
+    const catalog = await provider.catalog!.run({
       config: {},
       env: {},
       resolveProviderApiKey: () => ({ apiKey: "copilot-sdk" }),
       resolveProviderAuth: () => ({ apiKey: "copilot-sdk", mode: "token", source: "profile" }),
     } as never);
 
-    expect(result).toBeNull();
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected provider catalog");
+    }
+    const ids = catalog.provider.models?.map((m) => m.id) ?? [];
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids).toContain("gpt-5");
   });
 
-  it("reuses the shim across repeated catalog calls with unchanged config", async () => {
-    const { deps, startShim } = buildFakeDeps();
+  it("each catalog call creates and stops a fresh SDK client", async () => {
+    const { deps, getClient, fakeClient } = buildFakeDeps();
     const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
 
     const ctx = {
@@ -174,14 +164,15 @@ describe("copilot-sdk provider plugin", () => {
     await provider.catalog!.run(ctx as never);
     await provider.catalog!.run(ctx as never);
 
-    expect(startShim).toHaveBeenCalledOnce();
+    expect(getClient).toHaveBeenCalledTimes(2);
+    expect(fakeClient.close).toHaveBeenCalledTimes(2);
   });
 
-  it("honors configured port from plugins.entries.copilot-sdk.config.port", async () => {
-    const { deps, startShim } = buildFakeDeps();
+  it("honors configured port in the catalog baseUrl", async () => {
+    const { deps } = buildFakeDeps();
     const provider = await registerSingleProviderPlugin(createCopilotSdkPlugin(deps));
 
-    await provider.catalog!.run({
+    const catalog = await provider.catalog!.run({
       config: {
         plugins: { entries: { "copilot-sdk": { config: { port: 11111 } } } },
       },
@@ -190,8 +181,9 @@ describe("copilot-sdk provider plugin", () => {
       resolveProviderAuth: () => ({ apiKey: "copilot-sdk", mode: "token", source: "profile" }),
     } as never);
 
-    expect(startShim).toHaveBeenCalledWith(
-      expect.objectContaining({ port: 11111, rejectToolRequests: true }),
-    );
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected provider catalog");
+    }
+    expect(catalog.provider.baseUrl).toBe("http://127.0.0.1:11111/v1");
   });
 });

--- a/extensions/copilot-sdk/index.ts
+++ b/extensions/copilot-sdk/index.ts
@@ -13,7 +13,7 @@ import { startShimServer, type ShimServerHandle } from "./shim-server.js";
 const PROVIDER_ID = "copilot-sdk";
 const CHOICE_ID = "copilot-sdk";
 const METHOD_ID = "sdk";
-const DEFAULT_PORT = 9527;
+const DEFAULT_PORT = 0; // ephemeral — avoids EADDRINUSE from stale processes
 const PROFILE_ID = "copilot-sdk:logged-in";
 const PLACEHOLDER_API_KEY = "copilot-sdk";
 

--- a/extensions/copilot-sdk/index.ts
+++ b/extensions/copilot-sdk/index.ts
@@ -92,6 +92,7 @@ async function buildCatalog(
 ): Promise<ProviderCatalogResult> {
   const auth = ctx.resolveProviderAuth(PROVIDER_ID);
   if (!auth.apiKey) {
+    console.error("[copilot-sdk] catalog: no auth profile found for provider", PROVIDER_ID);
     return null;
   }
 
@@ -107,13 +108,15 @@ async function buildCatalog(
       models = sdkModels.length
         ? sdkModels.map((m) => buildModelDefinitionFromSdk(m.id, m.name))
         : buildFallbackModelCatalog();
-    } catch {
+    } catch (innerErr) {
+      console.error("[copilot-sdk] listModels failed, using fallback:", innerErr instanceof Error ? innerErr.message : innerErr);
       models = buildFallbackModelCatalog();
     }
-  } catch {
+  } catch (err) {
     // Shim failed to start (e.g., port in use, SDK missing). Surface as
     // "no provider" rather than crashing the whole catalog pass; onboarding
     // will report the issue to the user when they pick the provider.
+    console.error("[copilot-sdk] catalog failed:", err instanceof Error ? err.message : err);
     return null;
   }
 

--- a/extensions/copilot-sdk/index.ts
+++ b/extensions/copilot-sdk/index.ts
@@ -1,0 +1,208 @@
+import { buildFallbackModelCatalog, buildModelDefinitionFromSdk } from "./models.js";
+import {
+  definePluginEntry,
+  type ProviderAuthContext,
+  type ProviderAuthResult,
+  type ProviderCatalogContext,
+  type ProviderCatalogResult,
+} from "./runtime-api.js";
+import { getSdkClient, type SdkClient, type SdkClientOptions } from "./sdk-client.js";
+import type { ModelDefinitionConfig } from "./shared-types.js";
+import { startShimServer, type ShimServerHandle } from "./shim-server.js";
+
+const PROVIDER_ID = "copilot-sdk";
+const CHOICE_ID = "copilot-sdk";
+const METHOD_ID = "sdk";
+const DEFAULT_PORT = 9527;
+const PROFILE_ID = "copilot-sdk:logged-in";
+const PLACEHOLDER_API_KEY = "copilot-sdk";
+
+type PluginConfig = {
+  port?: number;
+  rejectToolRequests?: boolean;
+  cliPath?: string;
+};
+
+type SharedDeps = {
+  startShim: typeof startShimServer;
+  getClient: (options: SdkClientOptions) => Promise<SdkClient>;
+};
+
+const DEFAULT_DEPS: SharedDeps = {
+  startShim: startShimServer,
+  getClient: getSdkClient,
+};
+
+/** Process-lifetime singleton so we only spin up one shim per config. */
+let runningShim: (ShimServerHandle & { fingerprint: string }) | undefined;
+let pendingShim: Promise<ShimServerHandle & { fingerprint: string }> | undefined;
+
+function shimFingerprint(config: PluginConfig): string {
+  return JSON.stringify({
+    port: config.port ?? DEFAULT_PORT,
+    rejectToolRequests: config.rejectToolRequests ?? true,
+    cliPath: config.cliPath ?? null,
+  });
+}
+
+async function ensureShim(config: PluginConfig, deps: SharedDeps): Promise<ShimServerHandle> {
+  const fingerprint = shimFingerprint(config);
+  if (runningShim && runningShim.fingerprint === fingerprint) {
+    return runningShim;
+  }
+  if (pendingShim) {
+    return pendingShim;
+  }
+
+  pendingShim = (async () => {
+    if (runningShim) {
+      await runningShim.close().catch(() => undefined);
+      runningShim = undefined;
+    }
+    const client = await deps.getClient({ cliPath: config.cliPath });
+    const handle = await deps.startShim({
+      client,
+      port: config.port ?? DEFAULT_PORT,
+      rejectToolRequests: config.rejectToolRequests ?? true,
+    });
+    runningShim = Object.assign(handle, { fingerprint });
+    return runningShim;
+  })();
+
+  try {
+    return await pendingShim;
+  } finally {
+    pendingShim = undefined;
+  }
+}
+
+function readPluginConfig(ctx: ProviderCatalogContext): PluginConfig {
+  const raw = (
+    ctx.config as { plugins?: { entries?: Record<string, { config?: PluginConfig }> } } | undefined
+  )?.plugins?.entries?.[PROVIDER_ID]?.config;
+  if (!raw || typeof raw !== "object") {
+    return {};
+  }
+  return raw;
+}
+
+async function buildCatalog(
+  ctx: ProviderCatalogContext,
+  deps: SharedDeps,
+): Promise<ProviderCatalogResult> {
+  const auth = ctx.resolveProviderAuth(PROVIDER_ID);
+  if (!auth.apiKey) {
+    return null;
+  }
+
+  const pluginConfig = readPluginConfig(ctx);
+  let baseUrl: string;
+  let models: ModelDefinitionConfig[];
+  try {
+    const shim = await ensureShim(pluginConfig, deps);
+    baseUrl = shim.url;
+    try {
+      const client = await deps.getClient({ cliPath: pluginConfig.cliPath });
+      const sdkModels = await client.listModels();
+      models = sdkModels.length
+        ? sdkModels.map((m) => buildModelDefinitionFromSdk(m.id, m.name))
+        : buildFallbackModelCatalog();
+    } catch {
+      models = buildFallbackModelCatalog();
+    }
+  } catch {
+    // Shim failed to start (e.g., port in use, SDK missing). Surface as
+    // "no provider" rather than crashing the whole catalog pass; onboarding
+    // will report the issue to the user when they pick the provider.
+    return null;
+  }
+
+  return {
+    provider: {
+      baseUrl,
+      api: "openai-completions",
+      apiKey: PLACEHOLDER_API_KEY,
+      authHeader: false,
+      models,
+    },
+  };
+}
+
+function buildAuthResult(): ProviderAuthResult {
+  return {
+    profiles: [
+      {
+        profileId: PROFILE_ID,
+        credential: {
+          type: "token",
+          provider: PROVIDER_ID,
+          token: PLACEHOLDER_API_KEY,
+        },
+      },
+    ],
+    configPatch: {
+      plugins: {
+        entries: {
+          [PROVIDER_ID]: {
+            enabled: true,
+          },
+        },
+      },
+    },
+    notes: [
+      "The copilot-sdk plugin requires the @github/copilot CLI to be logged in.",
+      "Run `copilot` once in a terminal and complete device login before using this provider.",
+      "The plugin spawns the CLI via @github/copilot-sdk (public preview).",
+      "Tool calls are NOT forwarded to the Copilot CLI; OpenClaw handles tools locally.",
+    ],
+  };
+}
+
+export function createCopilotSdkPlugin(deps: SharedDeps = DEFAULT_DEPS) {
+  return definePluginEntry({
+    id: PROVIDER_ID,
+    name: "Copilot SDK",
+    description:
+      "Proxies chat completions through the @github/copilot CLI via @github/copilot-sdk.",
+    register(api) {
+      api.registerProvider({
+        id: PROVIDER_ID,
+        label: "Copilot SDK (experimental)",
+        docsPath: "/providers/models",
+        auth: [
+          {
+            id: METHOD_ID,
+            label: "Copilot SDK (experimental)",
+            hint: "Use @github/copilot CLI as the model backend",
+            kind: "custom",
+            run: async (_ctx: ProviderAuthContext): Promise<ProviderAuthResult> =>
+              buildAuthResult(),
+          },
+        ],
+        catalog: {
+          order: "simple",
+          run: (ctx) => buildCatalog(ctx, deps),
+        },
+        wizard: {
+          setup: {
+            choiceId: CHOICE_ID,
+            choiceLabel: "Copilot SDK (experimental)",
+            choiceHint: "Proxy through @github/copilot CLI",
+            methodId: METHOD_ID,
+          },
+        },
+      });
+    },
+  });
+}
+
+/** Test-only helper to clear the singleton shim between cases. */
+export async function __resetShimForTests(): Promise<void> {
+  if (runningShim) {
+    await runningShim.close().catch(() => undefined);
+    runningShim = undefined;
+  }
+  pendingShim = undefined;
+}
+
+export default createCopilotSdkPlugin();

--- a/extensions/copilot-sdk/index.ts
+++ b/extensions/copilot-sdk/index.ts
@@ -8,12 +8,16 @@ import {
 } from "./runtime-api.js";
 import { getSdkClient, type SdkClient, type SdkClientOptions } from "./sdk-client.js";
 import type { ModelDefinitionConfig } from "./shared-types.js";
-import { startShimServer, type ShimServerHandle } from "./shim-server.js";
 
 const PROVIDER_ID = "copilot-sdk";
 const CHOICE_ID = "copilot-sdk";
 const METHOD_ID = "sdk";
-const DEFAULT_PORT = 0; // ephemeral — avoids EADDRINUSE from stale processes
+/**
+ * Fixed port for the shim server. Written into models.json so the baseUrl is
+ * stable across process restarts. The shim binds with `server.unref()` and
+ * falls back to ephemeral on EADDRINUSE.
+ */
+const DEFAULT_PORT = 9527;
 const PROFILE_ID = "copilot-sdk:logged-in";
 const PLACEHOLDER_API_KEY = "copilot-sdk";
 
@@ -24,57 +28,12 @@ type PluginConfig = {
 };
 
 type SharedDeps = {
-  startShim: typeof startShimServer;
   getClient: (options: SdkClientOptions) => Promise<SdkClient>;
 };
 
 const DEFAULT_DEPS: SharedDeps = {
-  startShim: startShimServer,
   getClient: getSdkClient,
 };
-
-/** Process-lifetime singleton so we only spin up one shim per config. */
-let runningShim: (ShimServerHandle & { fingerprint: string }) | undefined;
-let pendingShim: Promise<ShimServerHandle & { fingerprint: string }> | undefined;
-
-function shimFingerprint(config: PluginConfig): string {
-  return JSON.stringify({
-    port: config.port ?? DEFAULT_PORT,
-    rejectToolRequests: config.rejectToolRequests ?? true,
-    cliPath: config.cliPath ?? null,
-  });
-}
-
-async function ensureShim(config: PluginConfig, deps: SharedDeps): Promise<ShimServerHandle> {
-  const fingerprint = shimFingerprint(config);
-  if (runningShim && runningShim.fingerprint === fingerprint) {
-    return runningShim;
-  }
-  if (pendingShim) {
-    return pendingShim;
-  }
-
-  pendingShim = (async () => {
-    if (runningShim) {
-      await runningShim.close().catch(() => undefined);
-      runningShim = undefined;
-    }
-    const client = await deps.getClient({ cliPath: config.cliPath });
-    const handle = await deps.startShim({
-      client,
-      port: config.port ?? DEFAULT_PORT,
-      rejectToolRequests: config.rejectToolRequests ?? true,
-    });
-    runningShim = Object.assign(handle, { fingerprint });
-    return runningShim;
-  })();
-
-  try {
-    return await pendingShim;
-  } finally {
-    pendingShim = undefined;
-  }
-}
 
 function readPluginConfig(ctx: ProviderCatalogContext): PluginConfig {
   const raw = (
@@ -86,38 +45,46 @@ function readPluginConfig(ctx: ProviderCatalogContext): PluginConfig {
   return raw;
 }
 
+/**
+ * Catalog hook — discovers available models via the Copilot SDK.
+ *
+ * The shim server is NOT started here. The catalog only needs the model list
+ * which comes from `listModels()`. After discovery the SDK client is stopped
+ * so the CLI subprocess does not prevent process exit (important for
+ * short-lived commands like `models list`).
+ *
+ * The shim starts lazily via `ensureShim()` when the provider is actually
+ * used for inference (the shim server is `unref()`d so it never blocks exit
+ * on its own).
+ */
 async function buildCatalog(
   ctx: ProviderCatalogContext,
   deps: SharedDeps,
 ): Promise<ProviderCatalogResult> {
   const auth = ctx.resolveProviderAuth(PROVIDER_ID);
   if (!auth.apiKey) {
-    console.error("[copilot-sdk] catalog: no auth profile found for provider", PROVIDER_ID);
     return null;
   }
 
   const pluginConfig = readPluginConfig(ctx);
-  let baseUrl: string;
+  const port = pluginConfig.port ?? DEFAULT_PORT;
+  const baseUrl = `http://127.0.0.1:${port}/v1`;
+
   let models: ModelDefinitionConfig[];
+  let client: SdkClient | undefined;
   try {
-    const shim = await ensureShim(pluginConfig, deps);
-    baseUrl = shim.url;
-    try {
-      const client = await deps.getClient({ cliPath: pluginConfig.cliPath });
-      const sdkModels = await client.listModels();
-      models = sdkModels.length
-        ? sdkModels.map((m) => buildModelDefinitionFromSdk(m.id, m.name))
-        : buildFallbackModelCatalog();
-    } catch (innerErr) {
-      console.error(
-        "[copilot-sdk] listModels failed, using fallback:",
-        innerErr instanceof Error ? innerErr.message : innerErr,
-      );
-      models = buildFallbackModelCatalog();
+    client = await deps.getClient({ cliPath: pluginConfig.cliPath });
+    const sdkModels = await client.listModels();
+    models = sdkModels.length
+      ? sdkModels.map((m) => buildModelDefinitionFromSdk(m.id, m.name))
+      : buildFallbackModelCatalog();
+  } catch {
+    models = buildFallbackModelCatalog();
+  } finally {
+    // Stop the SDK subprocess so it does not keep the event loop alive.
+    if (client) {
+      await client.close().catch(() => undefined);
     }
-  } catch (err) {
-    console.error("[copilot-sdk] catalog failed:", err instanceof Error ? err.message : err);
-    return null;
   }
 
   return {
@@ -197,15 +164,6 @@ export function createCopilotSdkPlugin(deps: SharedDeps = DEFAULT_DEPS) {
       });
     },
   });
-}
-
-/** Test-only helper to clear the singleton shim between cases. */
-export async function __resetShimForTests(): Promise<void> {
-  if (runningShim) {
-    await runningShim.close().catch(() => undefined);
-    runningShim = undefined;
-  }
-  pendingShim = undefined;
 }
 
 export default createCopilotSdkPlugin();

--- a/extensions/copilot-sdk/index.ts
+++ b/extensions/copilot-sdk/index.ts
@@ -109,13 +109,13 @@ async function buildCatalog(
         ? sdkModels.map((m) => buildModelDefinitionFromSdk(m.id, m.name))
         : buildFallbackModelCatalog();
     } catch (innerErr) {
-      console.error("[copilot-sdk] listModels failed, using fallback:", innerErr instanceof Error ? innerErr.message : innerErr);
+      console.error(
+        "[copilot-sdk] listModels failed, using fallback:",
+        innerErr instanceof Error ? innerErr.message : innerErr,
+      );
       models = buildFallbackModelCatalog();
     }
   } catch (err) {
-    // Shim failed to start (e.g., port in use, SDK missing). Surface as
-    // "no provider" rather than crashing the whole catalog pass; onboarding
-    // will report the issue to the user when they pick the provider.
     console.error("[copilot-sdk] catalog failed:", err instanceof Error ? err.message : err);
     return null;
   }

--- a/extensions/copilot-sdk/index.ts
+++ b/extensions/copilot-sdk/index.ts
@@ -1,4 +1,4 @@
-import { buildFallbackModelCatalog, buildModelDefinitionFromSdk } from "./models.js";
+import { buildFallbackModelCatalog, buildModelDefinition } from "./models.js";
 import {
   definePluginEntry,
   type ProviderAuthContext,
@@ -6,8 +6,15 @@ import {
   type ProviderCatalogContext,
   type ProviderCatalogResult,
 } from "./runtime-api.js";
-import { getSdkClient, type SdkClient, type SdkClientOptions } from "./sdk-client.js";
+import {
+  createDedicatedClient,
+  getSdkClient,
+  type SdkClient,
+  type SdkClientOptions,
+} from "./sdk-client.js";
 import type { ModelDefinitionConfig } from "./shared-types.js";
+import type { ShimServerHandle, ShimServerOptions } from "./shim-server.js";
+import { startShimServer } from "./shim-server.js";
 
 const PROVIDER_ID = "copilot-sdk";
 const CHOICE_ID = "copilot-sdk";
@@ -29,10 +36,14 @@ type PluginConfig = {
 
 type SharedDeps = {
   getClient: (options: SdkClientOptions) => Promise<SdkClient>;
+  createDedicatedClient: (options: SdkClientOptions) => Promise<SdkClient>;
+  startShimServer: (options: ShimServerOptions) => Promise<ShimServerHandle>;
 };
 
 const DEFAULT_DEPS: SharedDeps = {
   getClient: getSdkClient,
+  createDedicatedClient,
+  startShimServer,
 };
 
 function readPluginConfig(ctx: ProviderCatalogContext): PluginConfig {
@@ -45,17 +56,93 @@ function readPluginConfig(ctx: ProviderCatalogContext): PluginConfig {
   return raw;
 }
 
+// ---------------------------------------------------------------------------
+// Shim lifecycle — module-level state
+// ---------------------------------------------------------------------------
+
+let shimHandle: ShimServerHandle | undefined;
+let shimConfigFingerprint = "";
+let shimInitPromise: Promise<ShimServerHandle> | undefined;
+
+function shimFingerprint(cfg: PluginConfig): string {
+  return JSON.stringify({
+    port: cfg.port ?? DEFAULT_PORT,
+    cliPath: cfg.cliPath ?? null,
+    rejectToolRequests: cfg.rejectToolRequests ?? false,
+  });
+}
+
 /**
- * Catalog hook — discovers available models via the Copilot SDK.
+ * Ensures a shim HTTP server is running with the given config.
  *
- * The shim server is NOT started here. The catalog only needs the model list
- * which comes from `listModels()`. After discovery the SDK client is stopped
- * so the CLI subprocess does not prevent process exit (important for
- * short-lived commands like `models list`).
+ * - Reuses an existing shim if the config fingerprint hasn't changed.
+ * - Coalesces concurrent callers behind a single init promise.
+ * - Tears down and rebuilds when config changes.
+ */
+async function ensureShim(pluginConfig: PluginConfig, deps: SharedDeps): Promise<ShimServerHandle> {
+  const fp = shimFingerprint(pluginConfig);
+
+  // Fast path: shim already running with matching config.
+  if (shimHandle && shimConfigFingerprint === fp) {
+    return shimHandle;
+  }
+
+  // Coalesce concurrent callers during init.
+  if (shimInitPromise && shimConfigFingerprint === fp) {
+    return shimInitPromise;
+  }
+
+  // Config changed — tear down old shim.
+  if (shimHandle) {
+    await shimHandle.close().catch(() => undefined);
+    shimHandle = undefined;
+  }
+  shimInitPromise = undefined;
+  shimConfigFingerprint = fp;
+
+  shimInitPromise = (async () => {
+    try {
+      const client = await deps.createDedicatedClient({ cliPath: pluginConfig.cliPath });
+      const handle = await deps.startShimServer({
+        client,
+        port: pluginConfig.port ?? DEFAULT_PORT,
+        rejectToolRequests: pluginConfig.rejectToolRequests,
+      });
+      shimHandle = handle;
+      return handle;
+    } catch (err) {
+      // Clean up on failure so the next call retries from scratch.
+      shimHandle = undefined;
+      shimConfigFingerprint = "";
+      shimInitPromise = undefined;
+      throw err;
+    }
+  })();
+
+  try {
+    return await shimInitPromise;
+  } finally {
+    shimInitPromise = undefined;
+  }
+}
+
+/** Test-only: reset module-level shim state between test cases. */
+export async function __resetShimForTests(): Promise<void> {
+  if (shimHandle) {
+    await shimHandle.close().catch(() => undefined);
+  }
+  shimHandle = undefined;
+  shimConfigFingerprint = "";
+  shimInitPromise = undefined;
+}
+
+/**
+ * Catalog hook — discovers available models via the Copilot SDK, then
+ * ensures the shim HTTP server is running so inference requests have a
+ * live endpoint.
  *
- * The shim starts lazily via `ensureShim()` when the provider is actually
- * used for inference (the shim server is `unref()`d so it never blocks exit
- * on its own).
+ * Model discovery uses the singleton SDK client (closed after discovery).
+ * The shim uses a dedicated long-lived client via `createDedicatedClient`.
  */
 async function buildCatalog(
   ctx: ProviderCatalogContext,
@@ -67,18 +154,21 @@ async function buildCatalog(
   }
 
   const pluginConfig = readPluginConfig(ctx);
-  const port = pluginConfig.port ?? DEFAULT_PORT;
-  const baseUrl = `http://127.0.0.1:${port}/v1`;
 
+  // --- Model discovery (singleton client, closed afterward) ---
   let models: ModelDefinitionConfig[];
   let client: SdkClient | undefined;
   try {
     client = await deps.getClient({ cliPath: pluginConfig.cliPath });
     const sdkModels = await client.listModels();
     models = sdkModels.length
-      ? sdkModels.map((m) => buildModelDefinitionFromSdk(m.id, m.name))
+      ? sdkModels.map((m) => buildModelDefinition(m.id, m.name))
       : buildFallbackModelCatalog();
-  } catch {
+  } catch (err) {
+    console.warn(
+      "copilot-sdk: model discovery failed, using fallback catalog:",
+      err instanceof Error ? err.message : String(err),
+    );
     models = buildFallbackModelCatalog();
   } finally {
     // Stop the SDK subprocess so it does not keep the event loop alive.
@@ -87,9 +177,21 @@ async function buildCatalog(
     }
   }
 
+  // --- Shim startup (dedicated long-lived client) ---
+  let handle: ShimServerHandle;
+  try {
+    handle = await ensureShim(pluginConfig, deps);
+  } catch (err) {
+    console.error(
+      "copilot-sdk: shim server failed to start, self-disabling:",
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  }
+
   return {
     provider: {
-      baseUrl,
+      baseUrl: handle.url,
       api: "openai-completions",
       apiKey: PLACEHOLDER_API_KEY,
       authHeader: false,

--- a/extensions/copilot-sdk/index.ts
+++ b/extensions/copilot-sdk/index.ts
@@ -31,6 +31,7 @@ const PLACEHOLDER_API_KEY = "copilot-sdk";
 type PluginConfig = {
   port?: number;
   rejectToolRequests?: boolean;
+  allowBuiltinTools?: boolean;
   cliPath?: string;
 };
 
@@ -69,6 +70,7 @@ function shimFingerprint(cfg: PluginConfig): string {
     port: cfg.port ?? DEFAULT_PORT,
     cliPath: cfg.cliPath ?? null,
     rejectToolRequests: cfg.rejectToolRequests ?? false,
+    allowBuiltinTools: cfg.allowBuiltinTools ?? true,
   });
 }
 
@@ -107,6 +109,7 @@ async function ensureShim(pluginConfig: PluginConfig, deps: SharedDeps): Promise
         client,
         port: pluginConfig.port ?? DEFAULT_PORT,
         rejectToolRequests: pluginConfig.rejectToolRequests,
+        allowBuiltinTools: pluginConfig.allowBuiltinTools ?? true,
       });
       shimHandle = handle;
       return handle;

--- a/extensions/copilot-sdk/message-translator.test.ts
+++ b/extensions/copilot-sdk/message-translator.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChatCompletionResponse,
+  buildChatCompletionStreamChunks,
+  openAiMessagesToPrompt,
+  requestDeclaresTools,
+  ToolsNotSupportedError,
+} from "./message-translator.js";
+import type { OpenAiChatRequest } from "./shared-types.js";
+
+describe("openAiMessagesToPrompt", () => {
+  it("joins system, user, assistant turns with role tags", () => {
+    const prompt = openAiMessagesToPrompt([
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "Hello!" },
+      { role: "user", content: "Tell me a fact." },
+    ]);
+    expect(prompt).toContain("[system]\nYou are helpful.");
+    expect(prompt).toContain("[user]\nHi");
+    expect(prompt).toContain("[assistant]\nHello!");
+    expect(prompt.endsWith("[user]\nTell me a fact.")).toBe(true);
+  });
+
+  it("flattens content parts and preserves text ordering", () => {
+    const prompt = openAiMessagesToPrompt([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "part one" },
+          { type: "image_url", image_url: { url: "https://example.test/x.png" } },
+          { type: "text", text: "part two" },
+        ],
+      },
+    ]);
+    expect(prompt).toContain("part one");
+    expect(prompt).toContain("part two");
+    expect(prompt).toContain("[image attachment elided by copilot-sdk shim]");
+  });
+
+  it("skips empty messages and null content", () => {
+    const prompt = openAiMessagesToPrompt([
+      { role: "user", content: null },
+      { role: "user", content: "" },
+      { role: "user", content: "only one" },
+    ]);
+    expect(prompt).toBe("[user]\nonly one");
+  });
+
+  it("labels tool messages with tool_call_id when no name is present", () => {
+    const prompt = openAiMessagesToPrompt([
+      { role: "tool", content: "42", tool_call_id: "call_xyz" },
+    ]);
+    expect(prompt).toBe("[tool:call_xyz]\n42");
+  });
+
+  it("preserves unknown role names verbatim", () => {
+    const prompt = openAiMessagesToPrompt([{ role: "developer", content: "hey" }]);
+    expect(prompt).toBe("[developer]\nhey");
+  });
+});
+
+describe("requestDeclaresTools", () => {
+  it("is false for an empty/missing tools array", () => {
+    expect(requestDeclaresTools({ model: "m", messages: [] })).toBe(false);
+    expect(requestDeclaresTools({ model: "m", messages: [], tools: [] })).toBe(false);
+  });
+
+  it("is true when tools are present", () => {
+    const req: OpenAiChatRequest = {
+      model: "m",
+      messages: [],
+      tools: [{ type: "function", function: { name: "x", parameters: {} } }],
+    };
+    expect(requestDeclaresTools(req)).toBe(true);
+  });
+
+  it("is true when tool_choice is set to a non-none value", () => {
+    expect(requestDeclaresTools({ model: "m", messages: [], tool_choice: "auto" })).toBe(true);
+    expect(requestDeclaresTools({ model: "m", messages: [], tool_choice: "none" })).toBe(false);
+    expect(requestDeclaresTools({ model: "m", messages: [], tool_choice: null })).toBe(false);
+  });
+});
+
+describe("ToolsNotSupportedError", () => {
+  it("carries a stable error code", () => {
+    const err = new ToolsNotSupportedError();
+    expect(err.code).toBe("tools_not_supported");
+    expect(err.message).toMatch(/cannot forward `tools`/);
+  });
+});
+
+describe("buildChatCompletionResponse", () => {
+  it("produces an OpenAI-shaped chat.completion body", () => {
+    const body = buildChatCompletionResponse({ model: "gpt-5", content: "hi", created: 100 });
+    expect(body).toMatchObject({
+      object: "chat.completion",
+      created: 100,
+      model: "gpt-5",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "hi" },
+          finish_reason: "stop",
+        },
+      ],
+    });
+    expect((body as { id: string }).id).toMatch(/^chatcmpl-copilot-sdk-/);
+  });
+});
+
+describe("buildChatCompletionStreamChunks", () => {
+  it("emits a delta chunk, a stop chunk, and a [DONE] sentinel", () => {
+    const chunks = buildChatCompletionStreamChunks({
+      model: "gpt-5",
+      content: "hello",
+      created: 42,
+    });
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toMatch(/^data: /);
+    expect(chunks[2]).toBe("data: [DONE]\n\n");
+    const firstPayload = JSON.parse(chunks[0].replace(/^data: /, "").trim());
+    expect(firstPayload.choices[0].delta).toEqual({ role: "assistant", content: "hello" });
+    const secondPayload = JSON.parse(chunks[1].replace(/^data: /, "").trim());
+    expect(secondPayload.choices[0].finish_reason).toBe("stop");
+  });
+});

--- a/extensions/copilot-sdk/message-translator.ts
+++ b/extensions/copilot-sdk/message-translator.ts
@@ -1,0 +1,167 @@
+import type { OpenAiChatMessage, OpenAiChatRequest, OpenAiContentPart } from "./shared-types.js";
+
+/**
+ * Shim-layer error indicating that an OpenAI chat-completions request
+ * declared tools / tool_choice but the plugin is configured to reject them.
+ *
+ * The Copilot CLI acts as a pure LLM in this plugin (permission requests are
+ * denied), so it cannot execute OpenClaw's tool calls. Surfacing this as a
+ * typed error lets the shim return HTTP 400 with a stable error code rather
+ * than silently dropping tool semantics.
+ */
+export class ToolsNotSupportedError extends Error {
+  readonly code = "tools_not_supported";
+  constructor() {
+    super(
+      "The copilot-sdk plugin cannot forward `tools` to @github/copilot CLI. " +
+        "Set plugins.entries.copilot-sdk.config.rejectToolRequests=false to allow silent " +
+        "degradation, or disable tool use for this model.",
+    );
+    this.name = "ToolsNotSupportedError";
+  }
+}
+
+/**
+ * Concatenates OpenAI-style chat messages into a single prompt string the
+ * Copilot CLI session can consume via `session.sendAndWait({ prompt })`.
+ *
+ * The Copilot SDK's session API is agent-shaped (single prompt in, streamed
+ * assistant events out) rather than completion-shaped (N role-tagged messages
+ * in, one completion out). We reconstruct role context by inlining role
+ * prefixes; this is lossy but preserves conversational intent well enough for
+ * the CLI's model to produce useful completions.
+ */
+export function openAiMessagesToPrompt(messages: OpenAiChatMessage[]): string {
+  const parts: string[] = [];
+  for (const message of messages) {
+    const text = extractText(message.content);
+    if (!text) {
+      continue;
+    }
+    const role = message.role ?? "user";
+    if (role === "system") {
+      parts.push(`[system]\n${text}`);
+    } else if (role === "user") {
+      parts.push(`[user]\n${text}`);
+    } else if (role === "assistant") {
+      parts.push(`[assistant]\n${text}`);
+    } else if (role === "tool") {
+      parts.push(`[tool:${message.name ?? message.tool_call_id ?? "result"}]\n${text}`);
+    } else {
+      parts.push(`[${role}]\n${text}`);
+    }
+  }
+  return parts.join("\n\n").trim();
+}
+
+function extractText(content: OpenAiChatMessage["content"]): string {
+  if (content == null) {
+    return "";
+  }
+  if (typeof content === "string") {
+    return content;
+  }
+  const pieces: string[] = [];
+  for (const part of content) {
+    const text = extractTextFromPart(part);
+    if (text) {
+      pieces.push(text);
+    }
+  }
+  return pieces.join("\n");
+}
+
+function extractTextFromPart(part: OpenAiContentPart): string {
+  if (!part || typeof part !== "object") {
+    return "";
+  }
+  if (part.type === "text" && typeof (part as { text?: unknown }).text === "string") {
+    return (part as { text: string }).text;
+  }
+  if (part.type === "image_url") {
+    // Images are not forwarded by this shim; emit a placeholder so the model
+    // knows the user referenced an image without us hallucinating its content.
+    return "[image attachment elided by copilot-sdk shim]";
+  }
+  return "";
+}
+
+/**
+ * Returns true when the request asks for capabilities this shim cannot honor
+ * without silently degrading. Callers should translate this into a
+ * `ToolsNotSupportedError` when rejection is enabled.
+ */
+export function requestDeclaresTools(request: OpenAiChatRequest): boolean {
+  if (Array.isArray(request.tools) && request.tools.length > 0) {
+    return true;
+  }
+  if (
+    request.tool_choice !== undefined &&
+    request.tool_choice !== null &&
+    request.tool_choice !== "none"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Builds a non-streaming OpenAI chat-completions response body from a model id
+ * and plain assistant text. `created` is an optional override for test
+ * determinism.
+ */
+export function buildChatCompletionResponse(options: {
+  model: string;
+  content: string;
+  created?: number;
+  id?: string;
+  finishReason?: "stop" | "length";
+}): Record<string, unknown> {
+  const created = options.created ?? Math.floor(Date.now() / 1000);
+  return {
+    id: options.id ?? `chatcmpl-copilot-sdk-${created}`,
+    object: "chat.completion",
+    created,
+    model: options.model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: options.content },
+        finish_reason: options.finishReason ?? "stop",
+      },
+    ],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+}
+
+/**
+ * Builds the two SSE chunks that make up a streaming response whose body is a
+ * single assistant message (since the Copilot SDK only emits whole messages,
+ * not per-token deltas). Returned as string array rather than a stream so
+ * callers can decide how to flush.
+ */
+export function buildChatCompletionStreamChunks(options: {
+  model: string;
+  content: string;
+  created?: number;
+  id?: string;
+}): string[] {
+  const created = options.created ?? Math.floor(Date.now() / 1000);
+  const id = options.id ?? `chatcmpl-copilot-sdk-${created}`;
+  const base = { id, object: "chat.completion.chunk", created, model: options.model };
+  const deltaChunk = {
+    ...base,
+    choices: [
+      { index: 0, delta: { role: "assistant", content: options.content }, finish_reason: null },
+    ],
+  };
+  const doneChunk = {
+    ...base,
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+  };
+  return [
+    `data: ${JSON.stringify(deltaChunk)}\n\n`,
+    `data: ${JSON.stringify(doneChunk)}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+}

--- a/extensions/copilot-sdk/models.ts
+++ b/extensions/copilot-sdk/models.ts
@@ -18,33 +18,7 @@ export const FALLBACK_MODEL_IDS = [
   "claude-opus-4.5",
 ] as const;
 
-export function buildFallbackModelDefinition(modelId: string): ModelDefinitionConfig {
-  return {
-    id: modelId,
-    name: modelId,
-    api: "openai-completions",
-    reasoning: false,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
-    compat: { supportsTools: false },
-  };
-}
-
-export function buildFallbackModelCatalog(): ModelDefinitionConfig[] {
-  return FALLBACK_MODEL_IDS.map((id) => buildFallbackModelDefinition(id));
-}
-
-/**
- * Converts an SDK-reported model id into an OpenClaw model definition.
- * We intentionally do not import the SDK's `ModelInfo` type here to keep this
- * module side-effect free and easy to test.
- */
-export function buildModelDefinitionFromSdk(
-  modelId: string,
-  displayName?: string,
-): ModelDefinitionConfig {
+export function buildModelDefinition(modelId: string, displayName?: string): ModelDefinitionConfig {
   return {
     id: modelId,
     name: displayName ?? modelId,
@@ -56,4 +30,8 @@ export function buildModelDefinitionFromSdk(
     maxTokens: DEFAULT_MAX_TOKENS,
     compat: { supportsTools: false },
   };
+}
+
+export function buildFallbackModelCatalog(): ModelDefinitionConfig[] {
+  return FALLBACK_MODEL_IDS.map((id) => buildModelDefinition(id));
 }

--- a/extensions/copilot-sdk/models.ts
+++ b/extensions/copilot-sdk/models.ts
@@ -1,0 +1,57 @@
+import type { ModelDefinitionConfig } from "./shared-types.js";
+
+/**
+ * Static fallback model catalog used when the Copilot SDK cannot be contacted.
+ * Kept intentionally small; the live catalog from `client.listModels()` is
+ * preferred whenever it is reachable.
+ *
+ * Model ids mirror what `@github/copilot` CLI exposes; costs are zeroed since
+ * usage is billed against the user's Copilot subscription, not per token.
+ */
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 8192;
+
+export const FALLBACK_MODEL_IDS = [
+  "gpt-5",
+  "gpt-5-mini",
+  "claude-sonnet-4.5",
+  "claude-opus-4.5",
+] as const;
+
+export function buildFallbackModelDefinition(modelId: string): ModelDefinitionConfig {
+  return {
+    id: modelId,
+    name: modelId,
+    api: "openai-completions",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+  };
+}
+
+export function buildFallbackModelCatalog(): ModelDefinitionConfig[] {
+  return FALLBACK_MODEL_IDS.map((id) => buildFallbackModelDefinition(id));
+}
+
+/**
+ * Converts an SDK-reported model id into an OpenClaw model definition.
+ * We intentionally do not import the SDK's `ModelInfo` type here to keep this
+ * module side-effect free and easy to test.
+ */
+export function buildModelDefinitionFromSdk(
+  modelId: string,
+  displayName?: string,
+): ModelDefinitionConfig {
+  return {
+    id: modelId,
+    name: displayName ?? modelId,
+    api: "openai-completions",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+  };
+}

--- a/extensions/copilot-sdk/models.ts
+++ b/extensions/copilot-sdk/models.ts
@@ -28,6 +28,7 @@ export function buildFallbackModelDefinition(modelId: string): ModelDefinitionCo
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     maxTokens: DEFAULT_MAX_TOKENS,
+    compat: { supportsTools: false },
   };
 }
 
@@ -53,5 +54,6 @@ export function buildModelDefinitionFromSdk(
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     maxTokens: DEFAULT_MAX_TOKENS,
+    compat: { supportsTools: false },
   };
 }

--- a/extensions/copilot-sdk/openclaw.plugin.json
+++ b/extensions/copilot-sdk/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "copilot-sdk",
-  "enabledByDefault": false,
+  "enabledByDefault": true,
   "providers": ["copilot-sdk"],
   "autoEnableWhenConfiguredProviders": ["copilot-sdk"],
   "providerAuthChoices": [

--- a/extensions/copilot-sdk/openclaw.plugin.json
+++ b/extensions/copilot-sdk/openclaw.plugin.json
@@ -1,0 +1,40 @@
+{
+  "id": "copilot-sdk",
+  "enabledByDefault": false,
+  "providers": ["copilot-sdk"],
+  "autoEnableWhenConfiguredProviders": ["copilot-sdk"],
+  "providerAuthChoices": [
+    {
+      "provider": "copilot-sdk",
+      "method": "sdk",
+      "choiceId": "copilot-sdk",
+      "choiceLabel": "Copilot SDK (experimental)",
+      "choiceHint": "Proxy chat completions through the @github/copilot CLI",
+      "groupId": "copilot",
+      "groupLabel": "Copilot",
+      "groupHint": "GitHub + local proxy"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "port": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 65535,
+        "default": 9527,
+        "description": "Local loopback port for the OpenAI-compatible shim server."
+      },
+      "rejectToolRequests": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true, reject chat-completion requests that declare `tools`. The Copilot CLI acts as a pure LLM and cannot execute OpenClaw-dispatched tool calls through this path; disabling the reject causes silent degradation."
+      },
+      "cliPath": {
+        "type": "string",
+        "description": "Optional override for the @github/copilot CLI binary path (defaults to the SDK-bundled CLI)."
+      }
+    }
+  }
+}

--- a/extensions/copilot-sdk/openclaw.plugin.json
+++ b/extensions/copilot-sdk/openclaw.plugin.json
@@ -21,10 +21,10 @@
     "properties": {
       "port": {
         "type": "integer",
-        "minimum": 1,
+        "minimum": 0,
         "maximum": 65535,
-        "default": 9527,
-        "description": "Local loopback port for the OpenAI-compatible shim server."
+        "default": 0,
+        "description": "Local loopback port for the OpenAI-compatible shim server (0 = ephemeral)."
       },
       "rejectToolRequests": {
         "type": "boolean",

--- a/extensions/copilot-sdk/openclaw.plugin.json
+++ b/extensions/copilot-sdk/openclaw.plugin.json
@@ -31,6 +31,11 @@
         "default": false,
         "description": "When true, reject chat-completion requests that declare `tools` with HTTP 400. When false (default), tools are silently stripped with a warning. The Copilot CLI cannot execute OpenClaw-dispatched tool calls through this path."
       },
+      "allowBuiltinTools": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), the Copilot CLI's built-in tools (bash, file operations, grep, etc.) are available to the model. The SDK manages the full agentic tool loop internally. When false, the model acts as a pure LLM with no tool access."
+      },
       "cliPath": {
         "type": "string",
         "description": "Optional override for the @github/copilot CLI binary path (defaults to the SDK-bundled CLI)."

--- a/extensions/copilot-sdk/openclaw.plugin.json
+++ b/extensions/copilot-sdk/openclaw.plugin.json
@@ -21,15 +21,15 @@
     "properties": {
       "port": {
         "type": "integer",
-        "minimum": 0,
+        "minimum": 1,
         "maximum": 65535,
         "default": 9527,
         "description": "Local loopback port for the OpenAI-compatible shim server. Must be fixed so the baseUrl stored in models.json is stable across restarts. Falls back to ephemeral on EADDRINUSE."
       },
       "rejectToolRequests": {
         "type": "boolean",
-        "default": true,
-        "description": "When true, reject chat-completion requests that declare `tools`. The Copilot CLI acts as a pure LLM and cannot execute OpenClaw-dispatched tool calls through this path; disabling the reject causes silent degradation."
+        "default": false,
+        "description": "When true, reject chat-completion requests that declare `tools` with HTTP 400. When false (default), tools are silently stripped with a warning. The Copilot CLI cannot execute OpenClaw-dispatched tool calls through this path."
       },
       "cliPath": {
         "type": "string",

--- a/extensions/copilot-sdk/openclaw.plugin.json
+++ b/extensions/copilot-sdk/openclaw.plugin.json
@@ -23,8 +23,8 @@
         "type": "integer",
         "minimum": 0,
         "maximum": 65535,
-        "default": 0,
-        "description": "Local loopback port for the OpenAI-compatible shim server (0 = ephemeral)."
+        "default": 9527,
+        "description": "Local loopback port for the OpenAI-compatible shim server. Must be fixed so the baseUrl stored in models.json is stable across restarts. Falls back to ephemeral on EADDRINUSE."
       },
       "rejectToolRequests": {
         "type": "boolean",

--- a/extensions/copilot-sdk/package.json
+++ b/extensions/copilot-sdk/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/copilot-sdk",
+  "version": "2026.4.16",
+  "private": true,
+  "description": "OpenClaw provider plugin that proxies chat completions through the @github/copilot CLI via @github/copilot-sdk",
+  "type": "module",
+  "dependencies": {
+    "@github/copilot-sdk": "0.2.2"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/copilot-sdk/runtime-api.ts
+++ b/extensions/copilot-sdk/runtime-api.ts
@@ -1,0 +1,8 @@
+export { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+export type {
+  OpenClawPluginApi,
+  ProviderAuthContext,
+  ProviderAuthResult,
+  ProviderCatalogContext,
+  ProviderCatalogResult,
+} from "openclaw/plugin-sdk/core";

--- a/extensions/copilot-sdk/sdk-client.test.ts
+++ b/extensions/copilot-sdk/sdk-client.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  denyAllPermissionHandler,
+  getSdkClient,
+  __resetSdkClientForTests,
+  type SdkModule,
+} from "./sdk-client.js";
+
+function buildFakeSdk(): {
+  module: SdkModule;
+  listModels: ReturnType<typeof vi.fn>;
+  createSession: ReturnType<typeof vi.fn>;
+  sessionSendAndWait: ReturnType<typeof vi.fn>;
+  sessionDispose: ReturnType<typeof vi.fn>;
+} {
+  const sessionSendAndWait = vi.fn(async ({ prompt }: { prompt: string }) => ({
+    content: `sdk-reply:${prompt}`,
+  }));
+  const sessionDispose = vi.fn(async () => undefined);
+  const createSession = vi.fn(async () => ({
+    sendAndWait: sessionSendAndWait,
+    dispose: sessionDispose,
+  }));
+  const listModels = vi.fn(async () => [{ id: "gpt-5", name: "GPT-5" }]);
+
+  const module: SdkModule = {
+    CopilotClient: class {
+      listModels = listModels;
+      createSession = createSession;
+      dispose = vi.fn(async () => undefined);
+    } as unknown as SdkModule["CopilotClient"],
+  };
+
+  return { module, listModels, createSession, sessionSendAndWait, sessionDispose };
+}
+
+describe("sdk-client wrapper", () => {
+  afterEach(() => {
+    __resetSdkClientForTests();
+  });
+
+  it("denyAllPermissionHandler returns denied-by-rules", () => {
+    expect(denyAllPermissionHandler()).toEqual({ kind: "denied-by-rules", rules: [] });
+  });
+
+  it("forwards listModels from the underlying SDK", async () => {
+    const fake = buildFakeSdk();
+    const client = await getSdkClient({ sdkFactory: async () => fake.module });
+    expect(await client.listModels()).toEqual([{ id: "gpt-5", name: "GPT-5" }]);
+    expect(fake.listModels).toHaveBeenCalledOnce();
+  });
+
+  it("wires runPrompt through a session and disposes the session after use", async () => {
+    const fake = buildFakeSdk();
+    const client = await getSdkClient({ sdkFactory: async () => fake.module });
+
+    const result = await client.runPrompt({ model: "gpt-5", prompt: "hello" });
+    expect(result.content).toBe("sdk-reply:hello");
+    expect(fake.createSession).toHaveBeenCalledOnce();
+    const createArg = fake.createSession.mock.calls[0][0];
+    expect(createArg.model).toBe("gpt-5");
+    expect(createArg.onPermissionRequest()).toEqual({ kind: "denied-by-rules", rules: [] });
+    expect(fake.sessionDispose).toHaveBeenCalledOnce();
+  });
+
+  it("reuses the cached client when options are unchanged", async () => {
+    const fake = buildFakeSdk();
+    const factory = vi.fn(async () => fake.module);
+    const a = await getSdkClient({ sdkFactory: factory });
+    const b = await getSdkClient({ sdkFactory: factory });
+    expect(a).toBe(b);
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
+  it("rebuilds the client when cliPath changes", async () => {
+    const first = buildFakeSdk();
+    const second = buildFakeSdk();
+    const factoryFirst = vi.fn(async () => first.module);
+    const factorySecond = vi.fn(async () => second.module);
+
+    const a = await getSdkClient({ cliPath: "/a", sdkFactory: factoryFirst });
+    const b = await getSdkClient({ cliPath: "/b", sdkFactory: factorySecond });
+    expect(a).not.toBe(b);
+    expect(factoryFirst).toHaveBeenCalledOnce();
+    expect(factorySecond).toHaveBeenCalledOnce();
+  });
+
+  it("disposes sessions even when sendAndWait throws", async () => {
+    const fake = buildFakeSdk();
+    fake.sessionSendAndWait.mockImplementationOnce(async () => {
+      throw new Error("session boom");
+    });
+    const client = await getSdkClient({ sdkFactory: async () => fake.module });
+    await expect(client.runPrompt({ model: "gpt-5", prompt: "x" })).rejects.toThrow("session boom");
+    expect(fake.sessionDispose).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/copilot-sdk/sdk-client.test.ts
+++ b/extensions/copilot-sdk/sdk-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createDedicatedClient,
   denyAllPermissionHandler,
   getSdkClient,
   __resetSdkClientForTests,
@@ -108,5 +109,37 @@ describe("sdk-client wrapper", () => {
     await expect(
       getSdkClient({ sdkFactory: async () => hangingModule, startTimeoutMs: 100 }),
     ).rejects.toThrow(/timed out/);
+  });
+
+  it("createDedicatedClient returns a fresh non-singleton client each time", async () => {
+    const fake = buildFakeSdk();
+    const factory = vi.fn(async () => fake.module);
+
+    // Get the singleton first.
+    const singleton = await getSdkClient({ sdkFactory: factory });
+
+    // Create two dedicated clients with the same options.
+    const dedicatedA = await createDedicatedClient({ sdkFactory: factory });
+    const dedicatedB = await createDedicatedClient({ sdkFactory: factory });
+
+    // Each call creates a distinct object.
+    expect(dedicatedA).not.toBe(dedicatedB);
+
+    // Neither is the singleton.
+    expect(dedicatedA).not.toBe(singleton);
+    expect(dedicatedB).not.toBe(singleton);
+
+    // Closing one dedicated client does not affect the other or the singleton.
+    await dedicatedA.close();
+    // Singleton still works.
+    expect(await singleton.listModels()).toEqual([{ id: "gpt-5", name: "GPT-5" }]);
+    // Other dedicated client still works.
+    expect(await dedicatedB.listModels()).toEqual([{ id: "gpt-5", name: "GPT-5" }]);
+
+    // After closing dedicatedA, the singleton is still returned by getSdkClient.
+    const singletonAgain = await getSdkClient({ sdkFactory: factory });
+    expect(singletonAgain).toBe(singleton);
+
+    await dedicatedB.close();
   });
 });

--- a/extensions/copilot-sdk/sdk-client.test.ts
+++ b/extensions/copilot-sdk/sdk-client.test.ts
@@ -95,4 +95,18 @@ describe("sdk-client wrapper", () => {
     await expect(client.runPrompt({ model: "gpt-5", prompt: "x" })).rejects.toThrow("session boom");
     expect(fake.sessionDispose).toHaveBeenCalledOnce();
   });
+
+  it("rejects when start() exceeds the timeout", async () => {
+    const hangingModule: SdkModule = {
+      CopilotClient: class {
+        // start() never resolves — simulates a CLI that spawns but never connects
+        start = () => new Promise<void>(() => {});
+        listModels = vi.fn(async () => []);
+        createSession = vi.fn(async () => ({ sendAndWait: vi.fn() }));
+      } as unknown as SdkModule["CopilotClient"],
+    };
+    await expect(
+      getSdkClient({ sdkFactory: async () => hangingModule, startTimeoutMs: 100 }),
+    ).rejects.toThrow(/timed out/);
+  });
 });

--- a/extensions/copilot-sdk/sdk-client.test.ts
+++ b/extensions/copilot-sdk/sdk-client.test.ts
@@ -7,6 +7,23 @@ import {
   type SdkModule,
 } from "./sdk-client.js";
 
+/**
+ * Build a fake SDK module whose responses match the real @github/copilot-sdk shapes.
+ *
+ * Evidence (captured 2026-04-20 from real SDK v0.2.2):
+ *
+ *   listModels() → [{ id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6",
+ *     capabilities: { family: "claude-sonnet-4.6", limits: {...}, supports: {...} },
+ *     policy: { state: "enabled", terms: "..." },
+ *     billing: { is_premium: true, multiplier: 1, restricted_to: [...] },
+ *     supportedReasoningEfforts: ["low","medium","high"],
+ *     defaultReasoningEffort: "medium" }, ...]
+ *
+ *   sendAndWait() → { type: "assistant.message", data: { messageId, content,
+ *     toolRequests: [], interactionId, reasoningOpaque?, reasoningText?,
+ *     outputTokens, requestId },
+ *     id: "uuid", timestamp: "iso8601", parentId: "uuid"|null }
+ */
 function buildFakeSdk(): {
   module: SdkModule;
   listModels: ReturnType<typeof vi.fn>;
@@ -14,15 +31,38 @@ function buildFakeSdk(): {
   sessionSendAndWait: ReturnType<typeof vi.fn>;
   sessionDispose: ReturnType<typeof vi.fn>;
 } {
+  // Matches real AssistantMessageEvent shape from @github/copilot-sdk
   const sessionSendAndWait = vi.fn(async ({ prompt }: { prompt: string }) => ({
-    content: `sdk-reply:${prompt}`,
+    type: "assistant.message" as const,
+    data: {
+      messageId: "fake-msg-001",
+      content: `sdk-reply:${prompt}`,
+      toolRequests: [],
+      outputTokens: 10,
+      requestId: "FAKE:000000:0000000:0000000:00000000",
+    },
+    id: "fake-event-001",
+    timestamp: new Date().toISOString(),
+    parentId: null,
   }));
   const sessionDispose = vi.fn(async () => undefined);
   const createSession = vi.fn(async () => ({
     sendAndWait: sessionSendAndWait,
     dispose: sessionDispose,
   }));
-  const listModels = vi.fn(async () => [{ id: "gpt-5", name: "GPT-5" }]);
+  // Matches real ModelInfo shape from @github/copilot-sdk
+  const listModels = vi.fn(async () => [
+    {
+      id: "gpt-5",
+      name: "GPT-5",
+      capabilities: {
+        family: "gpt-5",
+        limits: { max_context_window_tokens: 128000 },
+        supports: { tool_calls: true, streaming: true },
+        type: "chat",
+      },
+    },
+  ]);
 
   const module: SdkModule = {
     CopilotClient: class {

--- a/extensions/copilot-sdk/sdk-client.test.ts
+++ b/extensions/copilot-sdk/sdk-client.test.ts
@@ -25,6 +25,7 @@ function buildFakeSdk(): {
 
   const module: SdkModule = {
     CopilotClient: class {
+      start = vi.fn(async () => undefined);
       listModels = listModels;
       createSession = createSession;
       dispose = vi.fn(async () => undefined);

--- a/extensions/copilot-sdk/sdk-client.test.ts
+++ b/extensions/copilot-sdk/sdk-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  approveAllPermissionHandler,
   createDedicatedClient,
   denyAllPermissionHandler,
   getSdkClient,
@@ -85,6 +86,10 @@ describe("sdk-client wrapper", () => {
     expect(denyAllPermissionHandler()).toEqual({ kind: "denied-by-rules", rules: [] });
   });
 
+  it("approveAllPermissionHandler returns approved", () => {
+    expect(approveAllPermissionHandler()).toEqual({ kind: "approved" });
+  });
+
   it("forwards listModels from the underlying SDK", async () => {
     const fake = buildFakeSdk();
     const client = await getSdkClient({ sdkFactory: async () => fake.module });
@@ -103,6 +108,24 @@ describe("sdk-client wrapper", () => {
     expect(createArg.model).toBe("gpt-5");
     expect(createArg.onPermissionRequest()).toEqual({ kind: "denied-by-rules", rules: [] });
     expect(fake.sessionDispose).toHaveBeenCalledOnce();
+  });
+
+  it("uses approve-all permission handler when allowBuiltinTools is true", async () => {
+    const fake = buildFakeSdk();
+    const client = await getSdkClient({ sdkFactory: async () => fake.module });
+
+    await client.runPrompt({ model: "gpt-5", prompt: "hello", allowBuiltinTools: true });
+    const createArg = fake.createSession.mock.calls[0][0];
+    expect(createArg.onPermissionRequest()).toEqual({ kind: "approved" });
+  });
+
+  it("uses deny-all permission handler when allowBuiltinTools is false", async () => {
+    const fake = buildFakeSdk();
+    const client = await getSdkClient({ sdkFactory: async () => fake.module });
+
+    await client.runPrompt({ model: "gpt-5", prompt: "hello", allowBuiltinTools: false });
+    const createArg = fake.createSession.mock.calls[0][0];
+    expect(createArg.onPermissionRequest()).toEqual({ kind: "denied-by-rules", rules: [] });
   });
 
   it("reuses the cached client when options are unchanged", async () => {

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -58,7 +58,7 @@ export type SdkModule = {
 
 export type SdkClientInstance = {
   start(): Promise<void>;
-  listModels(): Promise<Array<{ id: string; name?: string }>>;
+  listModels(): Promise<Array<{ id: string; name?: string; capabilities?: unknown }>>;
   createSession(options: {
     model: string;
     onPermissionRequest: (request: unknown) => PermissionResult | Promise<PermissionResult>;
@@ -67,11 +67,31 @@ export type SdkClientInstance = {
   close?(): Promise<void> | void;
 };
 
+/**
+ * Matches the real AssistantMessageEvent shape from @github/copilot-sdk:
+ *   { type: "assistant.message",
+ *     data: { messageId, content, toolRequests?, outputTokens?, requestId?, ... },
+ *     id, timestamp, parentId }
+ */
 export type SdkSession = {
   sendAndWait(
     options: { prompt: string },
     timeoutMs?: number,
-  ): Promise<{ content?: string; message?: { content?: string } } | undefined>;
+  ): Promise<
+    | {
+        type: string;
+        data: {
+          messageId?: string;
+          content: string;
+          toolRequests?: unknown[];
+          outputTokens?: number;
+        };
+        id?: string;
+        timestamp?: string;
+        parentId?: string | null;
+      }
+    | undefined
+  >;
   dispose?(): Promise<void> | void;
   close?(): Promise<void> | void;
 };
@@ -255,7 +275,8 @@ async function buildClient(options: SdkClientOptions): Promise<SdkClient> {
       });
       try {
         const result = await session.sendAndWait({ prompt }, timeoutMs);
-        const content = result?.content ?? result?.message?.content ?? "";
+        // AssistantMessageEvent shape: { type: "assistant.message", data: { content } }
+        const content = result?.data?.content ?? "";
         return { content };
       } finally {
         if (session.dispose) {

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -120,6 +120,7 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
 
 let cachedClient: SdkClient | undefined;
 let cachedOptionsFingerprint = "";
+let inflightInit: Promise<SdkClient> | undefined;
 
 function fingerprint(options: SdkClientOptions): string {
   return JSON.stringify({
@@ -131,17 +132,37 @@ function fingerprint(options: SdkClientOptions): string {
 /**
  * Returns the singleton SDK client, creating it on first use. A new client is
  * rebuilt when options change (rare; only `cliPath` is mutable today).
+ *
+ * Concurrent callers with the same options share a single in-flight init
+ * promise so only one CLI subprocess is ever spawned.
  */
 export async function getSdkClient(options: SdkClientOptions = {}): Promise<SdkClient> {
   const key = fingerprint(options);
   if (cachedClient && cachedOptionsFingerprint === key) {
     return cachedClient;
   }
+
+  // If another caller is already initializing with the same key, coalesce.
+  if (inflightInit && cachedOptionsFingerprint === key) {
+    return inflightInit;
+  }
+
+  // Options changed — tear down old client before rebuilding.
   if (cachedClient) {
     await cachedClient.close().catch(() => undefined);
     cachedClient = undefined;
   }
 
+  cachedOptionsFingerprint = key;
+  inflightInit = initClient(options, key);
+  try {
+    return await inflightInit;
+  } finally {
+    inflightInit = undefined;
+  }
+}
+
+async function initClient(options: SdkClientOptions, key: string): Promise<SdkClient> {
   const sdk = options.sdkFactory
     ? await options.sdkFactory()
     : ((await import("@github/copilot-sdk")) as unknown as SdkModule);
@@ -223,4 +244,5 @@ export async function getSdkClient(options: SdkClientOptions = {}): Promise<SdkC
 export function __resetSdkClientForTests(): void {
   cachedClient = undefined;
   cachedOptionsFingerprint = "";
+  inflightInit = undefined;
 }

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -55,6 +55,7 @@ export type SdkModule = {
 };
 
 export type SdkClientInstance = {
+  start(): Promise<void>;
   listModels(): Promise<Array<{ id: string; name?: string }>>;
   createSession(options: {
     model: string;
@@ -124,6 +125,10 @@ export async function getSdkClient(options: SdkClientOptions = {}): Promise<SdkC
     useStdio: true,
     telemetry: { enabled: false },
   });
+
+  // The SDK requires an explicit start() call to spawn the CLI subprocess and
+  // establish the JSON-RPC connection before any other method can be used.
+  await instance.start();
 
   const wrapper: SdkClient = {
     async listModels() {

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -24,6 +24,8 @@ export type RunPromptResult = {
 
 export type SdkClientOptions = {
   cliPath?: string;
+  /** Override the start() timeout (ms). Default: 15 000. */
+  startTimeoutMs?: number;
   /** Hook for tests to inject a fake SDK factory. */
   sdkFactory?: () => Promise<SdkModule>;
 };
@@ -94,11 +96,36 @@ export const denyAllPermissionHandler = (): PermissionResult => ({
   rules: [],
 });
 
+/** How long to wait for the SDK client to start (spawn CLI + JSON-RPC handshake). */
+const START_TIMEOUT_MS = 15_000;
+
+/** How long to wait for a listModels call to return. */
+const LIST_MODELS_TIMEOUT_MS = 10_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
 let cachedClient: SdkClient | undefined;
 let cachedOptionsFingerprint = "";
 
 function fingerprint(options: SdkClientOptions): string {
-  return JSON.stringify({ cliPath: options.cliPath ?? null });
+  return JSON.stringify({
+    cliPath: options.cliPath ?? null,
+    startTimeoutMs: options.startTimeoutMs ?? null,
+  });
 }
 
 /**
@@ -128,11 +155,19 @@ export async function getSdkClient(options: SdkClientOptions = {}): Promise<SdkC
 
   // The SDK requires an explicit start() call to spawn the CLI subprocess and
   // establish the JSON-RPC connection before any other method can be used.
-  await instance.start();
+  await withTimeout(
+    instance.start(),
+    options.startTimeoutMs ?? START_TIMEOUT_MS,
+    "CopilotClient.start()",
+  );
 
   const wrapper: SdkClient = {
     async listModels() {
-      const list = await instance.listModels();
+      const list = await withTimeout(
+        instance.listModels(),
+        LIST_MODELS_TIMEOUT_MS,
+        "CopilotClient.listModels()",
+      );
       return list.map((entry) => ({ id: entry.id, name: entry.name }));
     },
     async runPrompt({ model, prompt, timeoutMs }) {

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -4,8 +4,9 @@
  * Responsibilities:
  *   - Lazy-load the SDK (it's a runtime dep; may be absent in minimal installs)
  *   - Maintain one client per process lifetime
- *   - Keep the permission handler locked to "deny everything" so the Copilot
- *     CLI never executes tools on behalf of OpenClaw (that is OpenClaw's job)
+ *   - Support two permission modes:
+ *       deny-all: model acts as a pure LLM (no tool access)
+ *       approve-all: SDK's built-in tools (bash, grep, file ops) can execute
  *   - Provide `listModels` and `runPrompt` helpers the shim server uses
  *
  * The SDK is in public preview; every SDK call is wrapped so failures surface
@@ -16,6 +17,16 @@ export type RunPromptOptions = {
   model: string;
   prompt: string;
   timeoutMs?: number;
+  /**
+   * When true, the SDK session approves tool-execution permissions so the
+   * Copilot CLI's built-in tools (bash, file read/write, grep, etc.) can run.
+   * The SDK manages the full agentic tool loop internally — sendAndWait
+   * returns the final assistant message after all tool calls complete.
+   *
+   * When false (default), all permissions are denied and the model acts as a
+   * pure LLM with no tool access.
+   */
+  allowBuiltinTools?: boolean;
 };
 
 export type RunPromptResult = {
@@ -114,6 +125,15 @@ export type PermissionResult = {
 export const denyAllPermissionHandler = (): PermissionResult => ({
   kind: "denied-by-rules",
   rules: [],
+});
+
+/**
+ * Permission handler that approves every request so the Copilot CLI's
+ * built-in tools (bash, file read/write, grep, etc.) can execute.
+ * The SDK manages the full agentic tool loop internally.
+ */
+export const approveAllPermissionHandler = (): PermissionResult => ({
+  kind: "approved",
 });
 
 /** How long to wait for the SDK client to start (spawn CLI + JSON-RPC handshake). */
@@ -268,10 +288,12 @@ async function buildClient(options: SdkClientOptions): Promise<SdkClient> {
       );
       return list.map((entry) => ({ id: entry.id, name: entry.name }));
     },
-    async runPrompt({ model, prompt, timeoutMs }) {
+    async runPrompt({ model, prompt, timeoutMs, allowBuiltinTools }) {
       const session = await instance.createSession({
         model,
-        onPermissionRequest: denyAllPermissionHandler,
+        onPermissionRequest: allowBuiltinTools
+          ? approveAllPermissionHandler
+          : denyAllPermissionHandler,
       });
       try {
         const result = await session.sendAndWait({ prompt }, timeoutMs);

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -188,11 +188,18 @@ export async function getSdkClient(options: SdkClientOptions = {}): Promise<SdkC
       }
     },
     async close() {
-      if (instance.dispose) {
+      // The SDK exposes stop()/forceStop() to terminate the CLI subprocess.
+      // Fall back to dispose()/close() for compat with test mocks.
+      const inst = instance as Record<string, unknown>;
+      if (typeof inst.stop === "function") {
+        await Promise.resolve((inst.stop as () => unknown)()).catch(() => undefined);
+      } else if (instance.dispose) {
         await Promise.resolve(instance.dispose()).catch(() => undefined);
       } else if (instance.close) {
         await Promise.resolve(instance.close()).catch(() => undefined);
       }
+      cachedClient = undefined;
+      cachedOptionsFingerprint = "";
     },
   };
 

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -118,6 +118,9 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
   });
 }
 
+// Note: concurrent getSdkClient() calls with different option fingerprints can race.
+// This is acceptable for catalog-only use but would need per-fingerprint tracking
+// if used more broadly.
 let cachedClient: SdkClient | undefined;
 let cachedOptionsFingerprint = "";
 let inflightInit: Promise<SdkClient> | undefined;
@@ -162,7 +165,13 @@ export async function getSdkClient(options: SdkClientOptions = {}): Promise<SdkC
   }
 }
 
-async function initClient(options: SdkClientOptions, key: string): Promise<SdkClient> {
+/**
+ * Core init logic shared by the singleton (`getSdkClient`) and dedicated
+ * (`createDedicatedClient`) paths. Returns a raw `SdkClient` whose `close()`
+ * only tears down the underlying SDK instance — callers that need singleton
+ * cache management wrap it themselves.
+ */
+async function buildClient(options: SdkClientOptions): Promise<SdkClient> {
   const sdk = options.sdkFactory
     ? await options.sdkFactory()
     : ((await import("@github/copilot-sdk")) as unknown as SdkModule);
@@ -193,7 +202,7 @@ async function initClient(options: SdkClientOptions, key: string): Promise<SdkCl
     throw startErr;
   }
 
-  const wrapper: SdkClient = {
+  return {
     async listModels() {
       const list = await withTimeout(
         instance.listModels(),
@@ -230,6 +239,19 @@ async function initClient(options: SdkClientOptions, key: string): Promise<SdkCl
       } else if (instance.close) {
         await Promise.resolve(instance.close()).catch(() => undefined);
       }
+    },
+  };
+}
+
+async function initClient(options: SdkClientOptions, key: string): Promise<SdkClient> {
+  const inner = await buildClient(options);
+
+  // Wrap close() to also clear the singleton cache.
+  const wrapper: SdkClient = {
+    listModels: (...args) => inner.listModels(...args),
+    runPrompt: (...args) => inner.runPrompt(...args),
+    async close() {
+      await inner.close();
       cachedClient = undefined;
       cachedOptionsFingerprint = "";
     },
@@ -238,6 +260,18 @@ async function initClient(options: SdkClientOptions, key: string): Promise<SdkCl
   cachedClient = wrapper;
   cachedOptionsFingerprint = key;
   return wrapper;
+}
+
+/**
+ * Creates a fresh, non-singleton SDK client. Each call spawns a new CLI
+ * subprocess. The returned client's `close()` tears down only its own
+ * resources and does not affect the singleton cache used by `getSdkClient`.
+ *
+ * Use this when the caller needs a long-lived connection that must not be
+ * interrupted by catalog or other code that closes the singleton.
+ */
+export async function createDedicatedClient(options: SdkClientOptions = {}): Promise<SdkClient> {
+  return buildClient(options);
 }
 
 /** Test-only helper to reset the cached singleton between cases. */

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -166,6 +166,36 @@ export async function getSdkClient(options: SdkClientOptions = {}): Promise<SdkC
 }
 
 /**
+ * Unref the child process spawned by `@github/copilot-sdk` so it doesn't
+ * prevent Node from exiting in short-lived commands (e.g. `models list`).
+ * The field is private (`cliProcess`) so we access it via the runtime object.
+ */
+function unrefSdkChildProcess(instance: unknown): void {
+  try {
+    const inst = instance as Record<string, unknown>;
+    const cp = inst.cliProcess;
+    if (cp && typeof cp === "object") {
+      const proc = cp as Record<string, unknown>;
+      if (typeof proc.unref === "function") {
+        (proc.unref as () => void)();
+      }
+      // Also unref stdio streams — they can independently keep the loop alive.
+      for (const stream of [proc.stdin, proc.stdout, proc.stderr]) {
+        if (
+          stream &&
+          typeof stream === "object" &&
+          typeof (stream as Record<string, unknown>).unref === "function"
+        ) {
+          ((stream as Record<string, unknown>).unref as () => void)();
+        }
+      }
+    }
+  } catch {
+    // Best-effort; don't crash if the SDK internals change.
+  }
+}
+
+/**
  * Core init logic shared by the singleton (`getSdkClient`) and dedicated
  * (`createDedicatedClient`) paths. Returns a raw `SdkClient` whose `close()`
  * only tears down the underlying SDK instance — callers that need singleton
@@ -201,6 +231,13 @@ async function buildClient(options: SdkClientOptions): Promise<SdkClient> {
     }
     throw startErr;
   }
+
+  // The SDK's spawned CLI subprocess keeps the Node event loop alive,
+  // preventing short-lived commands (e.g. `models list`) from exiting.
+  // Unref the child process so it doesn't block process exit. The
+  // subprocess stays alive as long as we hold a reference and send RPCs;
+  // it's cleaned up by close()/stop() when the client is torn down.
+  unrefSdkChildProcess(instance);
 
   return {
     async listModels() {

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -1,0 +1,168 @@
+/**
+ * Singleton wrapper around `@github/copilot-sdk`'s CopilotClient.
+ *
+ * Responsibilities:
+ *   - Lazy-load the SDK (it's a runtime dep; may be absent in minimal installs)
+ *   - Maintain one client per process lifetime
+ *   - Keep the permission handler locked to "deny everything" so the Copilot
+ *     CLI never executes tools on behalf of OpenClaw (that is OpenClaw's job)
+ *   - Provide `listModels` and `runPrompt` helpers the shim server uses
+ *
+ * The SDK is in public preview; every SDK call is wrapped so failures surface
+ * as plain Error instances the shim can convert into HTTP 500 responses.
+ */
+
+export type RunPromptOptions = {
+  model: string;
+  prompt: string;
+  timeoutMs?: number;
+};
+
+export type RunPromptResult = {
+  content: string;
+};
+
+export type SdkClientOptions = {
+  cliPath?: string;
+  /** Hook for tests to inject a fake SDK factory. */
+  sdkFactory?: () => Promise<SdkModule>;
+};
+
+export type SdkModelInfo = {
+  id: string;
+  name?: string;
+};
+
+export type SdkClient = {
+  listModels(): Promise<SdkModelInfo[]>;
+  runPrompt(options: RunPromptOptions): Promise<RunPromptResult>;
+  close(): Promise<void>;
+};
+
+/**
+ * Minimal surface of `@github/copilot-sdk` that the wrapper depends on.
+ * Keeping it structural (no `import type` from the SDK) avoids a build-time
+ * dependency on the SDK's declaration files and keeps mocking trivial.
+ */
+export type SdkModule = {
+  CopilotClient: new (options?: {
+    cliPath?: string;
+    useLoggedInUser?: boolean;
+    useStdio?: boolean;
+    port?: number;
+    telemetry?: { enabled?: boolean };
+  }) => SdkClientInstance;
+};
+
+export type SdkClientInstance = {
+  listModels(): Promise<Array<{ id: string; name?: string }>>;
+  createSession(options: {
+    model: string;
+    onPermissionRequest: (request: unknown) => PermissionResult | Promise<PermissionResult>;
+  }): Promise<SdkSession>;
+  dispose?(): Promise<void> | void;
+  close?(): Promise<void> | void;
+};
+
+export type SdkSession = {
+  sendAndWait(
+    options: { prompt: string },
+    timeoutMs?: number,
+  ): Promise<{ content?: string; message?: { content?: string } } | undefined>;
+  dispose?(): Promise<void> | void;
+  close?(): Promise<void> | void;
+};
+
+export type PermissionResult = {
+  kind:
+    | "approved"
+    | "denied-by-rules"
+    | "denied-no-approval-rule-and-could-not-request-from-user"
+    | "denied-interactively-by-user"
+    | "denied-by-content-exclusion-policy";
+  rules?: unknown[];
+};
+
+/**
+ * Permission handler that denies every request, forcing the Copilot CLI to
+ * treat itself as a pure LLM. OpenClaw retains exclusive ownership of tool
+ * dispatch through its own runtime.
+ */
+export const denyAllPermissionHandler = (): PermissionResult => ({
+  kind: "denied-by-rules",
+  rules: [],
+});
+
+let cachedClient: SdkClient | undefined;
+let cachedOptionsFingerprint = "";
+
+function fingerprint(options: SdkClientOptions): string {
+  return JSON.stringify({ cliPath: options.cliPath ?? null });
+}
+
+/**
+ * Returns the singleton SDK client, creating it on first use. A new client is
+ * rebuilt when options change (rare; only `cliPath` is mutable today).
+ */
+export async function getSdkClient(options: SdkClientOptions = {}): Promise<SdkClient> {
+  const key = fingerprint(options);
+  if (cachedClient && cachedOptionsFingerprint === key) {
+    return cachedClient;
+  }
+  if (cachedClient) {
+    await cachedClient.close().catch(() => undefined);
+    cachedClient = undefined;
+  }
+
+  const sdk = options.sdkFactory
+    ? await options.sdkFactory()
+    : ((await import("@github/copilot-sdk")) as unknown as SdkModule);
+
+  const instance = new sdk.CopilotClient({
+    cliPath: options.cliPath,
+    useLoggedInUser: true,
+    useStdio: true,
+    telemetry: { enabled: false },
+  });
+
+  const wrapper: SdkClient = {
+    async listModels() {
+      const list = await instance.listModels();
+      return list.map((entry) => ({ id: entry.id, name: entry.name }));
+    },
+    async runPrompt({ model, prompt, timeoutMs }) {
+      const session = await instance.createSession({
+        model,
+        onPermissionRequest: denyAllPermissionHandler,
+      });
+      try {
+        const result = await session.sendAndWait({ prompt }, timeoutMs);
+        const content = result?.content ?? result?.message?.content ?? "";
+        return { content };
+      } finally {
+        if (session.dispose) {
+          await Promise.resolve(session.dispose()).catch(() => undefined);
+        } else if (session.close) {
+          await Promise.resolve(session.close()).catch(() => undefined);
+        }
+      }
+    },
+    async close() {
+      if (instance.dispose) {
+        await Promise.resolve(instance.dispose()).catch(() => undefined);
+      } else if (instance.close) {
+        await Promise.resolve(instance.close()).catch(() => undefined);
+      }
+    },
+  };
+
+  cachedClient = wrapper;
+  cachedOptionsFingerprint = key;
+  return wrapper;
+}
+
+/** Test-only helper to reset the cached singleton between cases. */
+export function __resetSdkClientForTests(): void {
+  cachedClient = undefined;
+  cachedOptionsFingerprint = "";
+}

--- a/extensions/copilot-sdk/sdk-client.ts
+++ b/extensions/copilot-sdk/sdk-client.ts
@@ -155,11 +155,22 @@ export async function getSdkClient(options: SdkClientOptions = {}): Promise<SdkC
 
   // The SDK requires an explicit start() call to spawn the CLI subprocess and
   // establish the JSON-RPC connection before any other method can be used.
-  await withTimeout(
-    instance.start(),
-    options.startTimeoutMs ?? START_TIMEOUT_MS,
-    "CopilotClient.start()",
-  );
+  try {
+    await withTimeout(
+      instance.start(),
+      options.startTimeoutMs ?? START_TIMEOUT_MS,
+      "CopilotClient.start()",
+    );
+  } catch (startErr) {
+    // Clean up the spawned subprocess so it doesn't leak on timeout/failure.
+    const inst = instance as Record<string, unknown>;
+    if (typeof inst.stop === "function") {
+      await Promise.resolve((inst.stop as () => unknown)()).catch(() => undefined);
+    } else if (typeof inst.dispose === "function") {
+      await Promise.resolve((inst.dispose as () => unknown)()).catch(() => undefined);
+    }
+    throw startErr;
+  }
 
   const wrapper: SdkClient = {
     async listModels() {

--- a/extensions/copilot-sdk/shared-types.ts
+++ b/extensions/copilot-sdk/shared-types.ts
@@ -1,0 +1,45 @@
+/**
+ * Narrow subset of the OpenClaw model definition shape we emit. Keeping this
+ * local and structural avoids dragging the full config type graph into the
+ * plugin package at build time; OpenClaw's runtime accepts any object that
+ * matches `ModelDefinitionConfig` structurally.
+ */
+export type ModelDefinitionConfig = {
+  id: string;
+  name: string;
+  api: "openai-completions";
+  reasoning: boolean;
+  input: Array<"text" | "image">;
+  cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  contextWindow: number;
+  maxTokens: number;
+};
+
+/**
+ * Subset of an OpenAI chat-completions request that the shim understands.
+ * Fields we don't use are intentionally optional `unknown` so new client
+ * options don't break parsing.
+ */
+export type OpenAiChatMessage = {
+  role: string;
+  content?: string | OpenAiContentPart[] | null;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: unknown;
+};
+
+export type OpenAiContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } }
+  | { type: string; [k: string]: unknown };
+
+export type OpenAiChatRequest = {
+  model: string;
+  messages: OpenAiChatMessage[];
+  stream?: boolean;
+  tools?: unknown[];
+  tool_choice?: unknown;
+  temperature?: number;
+  max_tokens?: number;
+  [k: string]: unknown;
+};

--- a/extensions/copilot-sdk/shared-types.ts
+++ b/extensions/copilot-sdk/shared-types.ts
@@ -13,6 +13,7 @@ export type ModelDefinitionConfig = {
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
   contextWindow: number;
   maxTokens: number;
+  compat?: { supportsTools?: boolean };
 };
 
 /**

--- a/extensions/copilot-sdk/shim-server.test.ts
+++ b/extensions/copilot-sdk/shim-server.test.ts
@@ -102,9 +102,9 @@ describe("copilot-sdk shim server", () => {
     expect(text.trim().endsWith("data: [DONE]")).toBe(true);
   });
 
-  it("rejects requests that declare tools with HTTP 400 by default", async () => {
+  it("rejects requests that declare tools with HTTP 400 when rejectToolRequests is true", async () => {
     const client = buildFakeClient();
-    const handle = await startShimServer({ client });
+    const handle = await startShimServer({ client, rejectToolRequests: true });
     handles.push(handle);
 
     const { status, body } = await fetchJson(`${handle.url}/chat/completions`, {
@@ -120,6 +120,51 @@ describe("copilot-sdk shim server", () => {
     expect(status).toBe(400);
     expect((body as { error: { type: string } }).error.type).toBe("tools_not_supported");
     expect(client.runPrompt).not.toHaveBeenCalled();
+  });
+
+  it("strips tools by default (rejectToolRequests defaults to false)", async () => {
+    const client = buildFakeClient();
+    const handle = await startShimServer({ client });
+    handles.push(handle);
+
+    const { status } = await fetchJson(`${handle.url}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{ type: "function", function: { name: "x", parameters: {} } }],
+      }),
+    });
+
+    expect(status).toBe(200);
+    expect(client.runPrompt).toHaveBeenCalledOnce();
+  });
+
+  it("logs warning when tools are stripped with rejectToolRequests=false", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const client = buildFakeClient();
+      const handle = await startShimServer({ client, rejectToolRequests: false });
+      handles.push(handle);
+
+      const { status } = await fetchJson(`${handle.url}/chat/completions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-5",
+          messages: [{ role: "user", content: "hi" }],
+          tools: [{ type: "function", function: { name: "x", parameters: {} } }],
+        }),
+      });
+
+      expect(status).toBe(200);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "copilot-sdk shim: stripping tools from request (not supported by Copilot CLI)",
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("silently drops tools when rejectToolRequests is false", async () => {

--- a/extensions/copilot-sdk/shim-server.test.ts
+++ b/extensions/copilot-sdk/shim-server.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SdkClient } from "./sdk-client.js";
+import { startShimServer } from "./shim-server.js";
+
+function buildFakeClient(overrides: Partial<SdkClient> = {}): SdkClient {
+  return {
+    listModels: vi.fn(async () => [{ id: "gpt-5", name: "GPT-5" }, { id: "claude-sonnet-4.5" }]),
+    runPrompt: vi.fn(async ({ prompt }) => ({ content: `echo:${prompt}` })),
+    close: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+async function fetchJson(
+  url: string,
+  init?: RequestInit,
+): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(url, init);
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : undefined };
+}
+
+describe("copilot-sdk shim server", () => {
+  const handles: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    while (handles.length) {
+      await handles
+        .pop()!
+        .close()
+        .catch(() => undefined);
+    }
+  });
+
+  it("binds to loopback on an ephemeral port and serves /v1/models", async () => {
+    const client = buildFakeClient();
+    const handle = await startShimServer({ client });
+    handles.push(handle);
+
+    expect(handle.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v1$/);
+
+    const { status, body } = await fetchJson(`${handle.url}/models`);
+    expect(status).toBe(200);
+    expect((body as { object: string }).object).toBe("list");
+    const data = (body as { data: Array<{ id: string; owned_by: string }> }).data;
+    expect(data.map((m) => m.id)).toEqual(["gpt-5", "claude-sonnet-4.5"]);
+    expect(data[0].owned_by).toBe("github-copilot");
+  });
+
+  it("returns an OpenAI-shaped completion for non-streaming requests", async () => {
+    const client = buildFakeClient();
+    const handle = await startShimServer({ client });
+    handles.push(handle);
+
+    const { status, body } = await fetchJson(`${handle.url}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5",
+        messages: [
+          { role: "system", content: "Be brief." },
+          { role: "user", content: "Hi" },
+        ],
+      }),
+    });
+
+    expect(status).toBe(200);
+    const completion = body as {
+      choices: Array<{ message: { content: string }; finish_reason: string }>;
+      model: string;
+    };
+    expect(completion.model).toBe("gpt-5");
+    expect(completion.choices[0].finish_reason).toBe("stop");
+    expect(completion.choices[0].message.content).toContain("echo:");
+    expect(completion.choices[0].message.content).toContain("[system]");
+    expect(completion.choices[0].message.content).toContain("[user]\nHi");
+    expect(client.runPrompt).toHaveBeenCalledOnce();
+  });
+
+  it("emits an SSE stream ending in [DONE] for stream:true", async () => {
+    const client = buildFakeClient({
+      runPrompt: vi.fn(async () => ({ content: "hello world" })),
+    });
+    const handle = await startShimServer({ client });
+    handles.push(handle);
+
+    const res = await fetch(`${handle.url}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "Say hi" }],
+        stream: true,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toContain("text/event-stream");
+    const text = await res.text();
+    expect(text).toContain("hello world");
+    expect(text).toContain('"finish_reason":"stop"');
+    expect(text.trim().endsWith("data: [DONE]")).toBe(true);
+  });
+
+  it("rejects requests that declare tools with HTTP 400 by default", async () => {
+    const client = buildFakeClient();
+    const handle = await startShimServer({ client });
+    handles.push(handle);
+
+    const { status, body } = await fetchJson(`${handle.url}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{ type: "function", function: { name: "x", parameters: {} } }],
+      }),
+    });
+
+    expect(status).toBe(400);
+    expect((body as { error: { type: string } }).error.type).toBe("tools_not_supported");
+    expect(client.runPrompt).not.toHaveBeenCalled();
+  });
+
+  it("silently drops tools when rejectToolRequests is false", async () => {
+    const client = buildFakeClient();
+    const handle = await startShimServer({ client, rejectToolRequests: false });
+    handles.push(handle);
+
+    const { status } = await fetchJson(`${handle.url}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{ type: "function", function: { name: "x", parameters: {} } }],
+      }),
+    });
+
+    expect(status).toBe(200);
+    expect(client.runPrompt).toHaveBeenCalledOnce();
+  });
+
+  it("returns 400 when body is missing required fields", async () => {
+    const client = buildFakeClient();
+    const handle = await startShimServer({ client });
+    handles.push(handle);
+
+    const { status, body } = await fetchJson(`${handle.url}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5" }),
+    });
+    expect(status).toBe(400);
+    expect((body as { error: { type: string } }).error.type).toBe("invalid_request");
+  });
+
+  it("returns 404 for unknown routes", async () => {
+    const client = buildFakeClient();
+    const handle = await startShimServer({ client });
+    handles.push(handle);
+
+    const { status } = await fetchJson(`${handle.url}/completions`);
+    expect(status).toBe(404);
+  });
+
+  it("converts SDK runPrompt errors into HTTP 500", async () => {
+    const client = buildFakeClient({
+      runPrompt: vi.fn(async () => {
+        throw new Error("sdk boom");
+      }),
+    });
+    const handle = await startShimServer({ client });
+    handles.push(handle);
+
+    const { status, body } = await fetchJson(`${handle.url}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(status).toBe(500);
+    expect((body as { error: { message: string } }).error.message).toBe("sdk boom");
+  });
+});

--- a/extensions/copilot-sdk/shim-server.test.ts
+++ b/extensions/copilot-sdk/shim-server.test.ts
@@ -184,4 +184,24 @@ describe("copilot-sdk shim server", () => {
     expect(status).toBe(500);
     expect((body as { error: { message: string } }).error.message).toBe("sdk boom");
   });
+
+  it("falls back to ephemeral port on EADDRINUSE", async () => {
+    const client = buildFakeClient();
+    // Occupy a fixed port
+    const blocker = await startShimServer({ client, port: 19876 });
+    handles.push(blocker);
+    expect(blocker.port).toBe(19876);
+
+    // Second server on the same fixed port should fall back to ephemeral
+    const fallback = await startShimServer({ client, port: 19876 });
+    handles.push(fallback);
+    expect(fallback.port).not.toBe(19876);
+    expect(fallback.port).toBeGreaterThan(0);
+
+    // Both servers should respond
+    const { status: s1 } = await fetchJson(`${blocker.url}/models`);
+    const { status: s2 } = await fetchJson(`${fallback.url}/models`);
+    expect(s1).toBe(200);
+    expect(s2).toBe(200);
+  });
 });

--- a/extensions/copilot-sdk/shim-server.test.ts
+++ b/extensions/copilot-sdk/shim-server.test.ts
@@ -249,4 +249,42 @@ describe("copilot-sdk shim server", () => {
     expect(s1).toBe(200);
     expect(s2).toBe(200);
   });
+
+  it("passes allowBuiltinTools through to runPrompt", async () => {
+    const client = buildFakeClient();
+    const handle = await startShimServer({ client, allowBuiltinTools: true });
+    handles.push(handle);
+
+    await fetchJson(`${handle.url}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(client.runPrompt).toHaveBeenCalledOnce();
+    const callArg = (client.runPrompt as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArg.allowBuiltinTools).toBe(true);
+  });
+
+  it("defaults allowBuiltinTools to false when not specified", async () => {
+    const client = buildFakeClient();
+    const handle = await startShimServer({ client });
+    handles.push(handle);
+
+    await fetchJson(`${handle.url}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(client.runPrompt).toHaveBeenCalledOnce();
+    const callArg = (client.runPrompt as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArg.allowBuiltinTools).toBe(false);
+  });
 });

--- a/extensions/copilot-sdk/shim-server.ts
+++ b/extensions/copilot-sdk/shim-server.ts
@@ -48,13 +48,17 @@ export async function startShimServer(options: ShimServerOptions): Promise<ShimS
     }
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(options.port ?? 0, "127.0.0.1", () => {
-      server.off("error", reject);
-      resolve();
-    });
-  });
+  const requestedPort = options.port ?? 0;
+  try {
+    await listenOn(server, requestedPort);
+  } catch (err) {
+    if (isAddrInUse(err) && requestedPort !== 0) {
+      // Stale shim from a previous process — fall back to an ephemeral port.
+      await listenOn(server, 0);
+    } else {
+      throw err;
+    }
+  }
 
   const address = server.address() as AddressInfo | null;
   if (!address || typeof address === "string") {
@@ -189,4 +193,18 @@ function toMessage(error: unknown): string {
     return error.message;
   }
   return String(error);
+}
+
+function listenOn(server: http.Server, port: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function isAddrInUse(err: unknown): boolean {
+  return err instanceof Error && "code" in err && (err as { code: string }).code === "EADDRINUSE";
 }

--- a/extensions/copilot-sdk/shim-server.ts
+++ b/extensions/copilot-sdk/shim-server.ts
@@ -134,11 +134,14 @@ async function handle(
       return;
     }
 
-    const reject = options.rejectToolRequests ?? true;
+    const reject = options.rejectToolRequests ?? false;
     if (reject && requestDeclaresTools(body)) {
       const err = new ToolsNotSupportedError();
       writeJson(res, 400, { error: { message: err.message, type: err.code } });
       return;
+    }
+    if (!reject && requestDeclaresTools(body)) {
+      console.warn("copilot-sdk shim: stripping tools from request (not supported by Copilot CLI)");
     }
 
     const prompt = openAiMessagesToPrompt(body.messages);

--- a/extensions/copilot-sdk/shim-server.ts
+++ b/extensions/copilot-sdk/shim-server.ts
@@ -12,6 +12,14 @@ import type { OpenAiChatRequest } from "./shared-types.js";
 
 const MAX_BODY_BYTES = 4 * 1024 * 1024;
 
+/** Thrown by request-parsing helpers so the top-level handler can return 400. */
+class ClientRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClientRequestError";
+  }
+}
+
 export type ShimServerOptions = {
   /** SDK client used to fulfill chat completions. Injected so tests can mock it. */
   client: SdkClient;
@@ -44,13 +52,12 @@ export async function startShimServer(options: ShimServerOptions): Promise<ShimS
     try {
       await handle(req, res, options);
     } catch (error) {
-      // Distinguish client errors (bad JSON, oversized body) from server errors.
       const msg = toMessage(error);
-      const isClientError =
-        msg.includes("JSON") || msg.includes("exceeds") || msg.includes("parse");
-      const status = isClientError ? 400 : 500;
-      const type = isClientError ? "invalid_request" : "internal_error";
-      writeJson(res, status, { error: { message: msg, type } });
+      if (error instanceof ClientRequestError) {
+        writeJson(res, 400, { error: { message: msg, type: "invalid_request" } });
+      } else {
+        writeJson(res, 500, { error: { message: msg, type: "internal_error" } });
+      }
     }
   });
 
@@ -166,16 +173,25 @@ async function readJsonBody<T>(req: http.IncomingMessage): Promise<T | undefined
   return new Promise<T | undefined>((resolve, reject) => {
     const chunks: Buffer[] = [];
     let size = 0;
+    let rejected = false;
     req.on("data", (chunk: Buffer) => {
+      if (rejected) {
+        return;
+      }
       size += chunk.length;
       if (size > MAX_BODY_BYTES) {
-        reject(new Error("Request body exceeds 4 MiB"));
-        req.destroy();
+        rejected = true;
+        reject(new ClientRequestError("Request body exceeds 4 MiB"));
+        // Don't destroy the socket — let the caller write the 400 response first.
+        req.resume();
         return;
       }
       chunks.push(chunk);
     });
     req.on("end", () => {
+      if (rejected) {
+        return;
+      }
       const raw = Buffer.concat(chunks).toString("utf8");
       if (!raw) {
         resolve(undefined);
@@ -184,7 +200,7 @@ async function readJsonBody<T>(req: http.IncomingMessage): Promise<T | undefined
       try {
         resolve(JSON.parse(raw) as T);
       } catch (error) {
-        reject(new Error(`Invalid JSON body: ${toMessage(error)}`));
+        reject(new ClientRequestError(`Invalid JSON body: ${toMessage(error)}`));
       }
     });
     req.on("error", reject);

--- a/extensions/copilot-sdk/shim-server.ts
+++ b/extensions/copilot-sdk/shim-server.ts
@@ -60,6 +60,12 @@ export async function startShimServer(options: ShimServerOptions): Promise<ShimS
     }
   }
 
+  // Allow the process to exit even while the shim is listening. The shim
+  // stays alive as long as the host (agent/gateway) keeps its own event loop
+  // running. For short-lived commands like `models list`, Node can exit
+  // immediately after the catalog completes.
+  server.unref();
+
   const address = server.address() as AddressInfo | null;
   if (!address || typeof address === "string") {
     throw new Error("copilot-sdk shim failed to bind a loopback port");

--- a/extensions/copilot-sdk/shim-server.ts
+++ b/extensions/copilot-sdk/shim-server.ts
@@ -30,6 +30,13 @@ export type ShimServerOptions = {
    * tools. When false, tools are silently dropped.
    */
   rejectToolRequests?: boolean;
+  /**
+   * When true, the SDK session approves tool-execution permissions so the
+   * Copilot CLI's built-in tools (bash, file read/write, grep, etc.) can run.
+   * The SDK handles the full agentic loop — sendAndWait returns the final
+   * assistant message after all tool calls complete.
+   */
+  allowBuiltinTools?: boolean;
 };
 
 export type ShimServerHandle = {
@@ -156,6 +163,7 @@ async function handle(
       model: body.model,
       prompt,
       timeoutMs: 120_000,
+      allowBuiltinTools: options.allowBuiltinTools ?? false,
     });
     if (body.stream) {
       writeSseHeaders(res);

--- a/extensions/copilot-sdk/shim-server.ts
+++ b/extensions/copilot-sdk/shim-server.ts
@@ -1,0 +1,192 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  buildChatCompletionResponse,
+  buildChatCompletionStreamChunks,
+  openAiMessagesToPrompt,
+  requestDeclaresTools,
+  ToolsNotSupportedError,
+} from "./message-translator.js";
+import type { SdkClient } from "./sdk-client.js";
+import type { OpenAiChatRequest } from "./shared-types.js";
+
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+export type ShimServerOptions = {
+  /** SDK client used to fulfill chat completions. Injected so tests can mock it. */
+  client: SdkClient;
+  /** Loopback port to bind (0 = ephemeral). */
+  port?: number;
+  /**
+   * When true (default), the shim returns HTTP 400 for requests that declare
+   * tools. When false, tools are silently dropped.
+   */
+  rejectToolRequests?: boolean;
+};
+
+export type ShimServerHandle = {
+  url: string;
+  port: number;
+  close(): Promise<void>;
+};
+
+/**
+ * Starts the OpenAI-compatible HTTP shim on 127.0.0.1. Routes:
+ *   GET  /v1/models                 -> proxies to SDK client.listModels
+ *   POST /v1/chat/completions       -> proxies to SDK client.runPrompt
+ * Anything else 404s so misconfigured callers fail fast.
+ *
+ * The server binds to the loopback interface only; it is never exposed on a
+ * non-loopback interface by design.
+ */
+export async function startShimServer(options: ShimServerOptions): Promise<ShimServerHandle> {
+  const server = http.createServer(async (req, res) => {
+    try {
+      await handle(req, res, options);
+    } catch (error) {
+      writeJson(res, 500, { error: { message: toMessage(error), type: "internal_error" } });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port ?? 0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo | null;
+  if (!address || typeof address === "string") {
+    throw new Error("copilot-sdk shim failed to bind a loopback port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/v1`,
+    port: address.port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+async function handle(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  options: ShimServerOptions,
+): Promise<void> {
+  const url = req.url ?? "";
+  const method = (req.method ?? "GET").toUpperCase();
+
+  if (method === "GET" && (url === "/v1/models" || url === "/v1/models/")) {
+    const models = await options.client.listModels();
+    writeJson(res, 200, {
+      object: "list",
+      data: models.map((model) => ({
+        id: model.id,
+        object: "model",
+        created: 0,
+        owned_by: "github-copilot",
+      })),
+    });
+    return;
+  }
+
+  if (method === "POST" && (url === "/v1/chat/completions" || url === "/v1/chat/completions/")) {
+    const body = await readJsonBody<OpenAiChatRequest>(req);
+    if (!body || typeof body !== "object") {
+      writeJson(res, 400, {
+        error: { message: "Request body must be a JSON object", type: "invalid_request" },
+      });
+      return;
+    }
+    if (!body.model || !Array.isArray(body.messages)) {
+      writeJson(res, 400, {
+        error: {
+          message: "Missing required fields `model` and `messages`",
+          type: "invalid_request",
+        },
+      });
+      return;
+    }
+
+    const reject = options.rejectToolRequests ?? true;
+    if (reject && requestDeclaresTools(body)) {
+      const err = new ToolsNotSupportedError();
+      writeJson(res, 400, { error: { message: err.message, type: err.code } });
+      return;
+    }
+
+    const prompt = openAiMessagesToPrompt(body.messages);
+    if (!prompt) {
+      writeJson(res, 400, {
+        error: { message: "No textual content found in `messages`", type: "invalid_request" },
+      });
+      return;
+    }
+
+    const { content } = await options.client.runPrompt({ model: body.model, prompt });
+    if (body.stream) {
+      writeSseHeaders(res);
+      for (const chunk of buildChatCompletionStreamChunks({ model: body.model, content })) {
+        res.write(chunk);
+      }
+      res.end();
+      return;
+    }
+    writeJson(res, 200, buildChatCompletionResponse({ model: body.model, content }));
+    return;
+  }
+
+  writeJson(res, 404, { error: { message: `No route for ${method} ${url}`, type: "not_found" } });
+}
+
+async function readJsonBody<T>(req: http.IncomingMessage): Promise<T | undefined> {
+  return new Promise<T | undefined>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error("Request body exceeds 4 MiB"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw) as T);
+      } catch (error) {
+        reject(new Error(`Invalid JSON body: ${toMessage(error)}`));
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function writeJson(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(body));
+}
+
+function writeSseHeaders(res: http.ServerResponse): void {
+  res.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  });
+}
+
+function toMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/extensions/copilot-sdk/shim-server.ts
+++ b/extensions/copilot-sdk/shim-server.ts
@@ -44,7 +44,13 @@ export async function startShimServer(options: ShimServerOptions): Promise<ShimS
     try {
       await handle(req, res, options);
     } catch (error) {
-      writeJson(res, 500, { error: { message: toMessage(error), type: "internal_error" } });
+      // Distinguish client errors (bad JSON, oversized body) from server errors.
+      const msg = toMessage(error);
+      const isClientError =
+        msg.includes("JSON") || msg.includes("exceeds") || msg.includes("parse");
+      const status = isClientError ? 400 : 500;
+      const type = isClientError ? "invalid_request" : "internal_error";
+      writeJson(res, status, { error: { message: msg, type } });
     }
   });
 
@@ -136,7 +142,11 @@ async function handle(
       return;
     }
 
-    const { content } = await options.client.runPrompt({ model: body.model, prompt });
+    const { content } = await options.client.runPrompt({
+      model: body.model,
+      prompt,
+      timeoutMs: 120_000,
+    });
     if (body.stream) {
       writeSseHeaders(res);
       for (const chunk of buildChatCompletionStreamChunks({ model: body.model, content })) {

--- a/extensions/copilot-sdk/tsconfig.json
+++ b/extensions/copilot-sdk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/copilot-sdk:
+    dependencies:
+      '@github/copilot-sdk':
+        specifier: 0.2.2
+        version: 0.2.2
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/deepgram:
     devDependencies:
       '@openclaw/plugin-sdk':
@@ -2115,6 +2125,50 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@github/copilot-darwin-arm64@1.0.32':
+    resolution: {integrity: sha512-RtGHpnrbP1eVtpzitLqC0jkBlo63PJiByv6W/NTtLw4ZAllumb5kMk8JaTtydKl9DCOHA0wfXbG5/JkGXuQ81g==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-darwin-x64@1.0.32':
+    resolution: {integrity: sha512-eyF6uy8gcZ4m/0UdM9UoykMDotZ8hZPJ1xIg0iHy4wrNtkYOaAspAoVpOkm50ODOQAHJ5PVV+9LuT6IoeL+wHQ==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-linux-arm64@1.0.32':
+    resolution: {integrity: sha512-acRAu5ehFPnw3hQSIxcmi7wzv8PAYd+nqdxZXizOi++en3QWgez7VEXiKLe9Ukf50iiGReg19yvWV4iDOGC0HQ==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-linux-x64@1.0.32':
+    resolution: {integrity: sha512-lw86YDwkTKwmeVpfnPErDe9DhemrOHN+l92xOU9wQSH5/d+HguXwRb3e4cQjlxsGLS+/fWRGtwf+u2fbQ37avw==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-sdk@0.2.2':
+    resolution: {integrity: sha512-VZCqS08YlUM90bUKJ7VLeIxgTTEHtfXBo84T1IUMNvXRREX2csjPH6Z+CPw3S2468RcCLvzBXcc9LtJJTLIWFw==}
+    engines: {node: '>=20.0.0'}
+
+  '@github/copilot-win32-arm64@1.0.32':
+    resolution: {integrity: sha512-+eZpuzgBbLHMIzltH541wfbbMy0HEdG91ISzRae3qPCssf3Ad85sat6k7FWTRBSZBFrN7z4yMQm5gROqDJYGSA==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot-win32-x64@1.0.32':
+    resolution: {integrity: sha512-R6SW1dsEVmPMhrN/WRTetS4gVxcuYcxi2zfDPOfcjW3W0iD0Vwpt3MlqwBaU2UL36j+rnTnmiOA+g82FIBCYVg==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot@1.0.32':
+    resolution: {integrity: sha512-ydEYAztJQa1sLQw+WPmnkkt3Sf/k2Smn/7szzYvt1feUOdNIak1gHpQhKcgPr2w252gjVLRWjOiynoeLVW0Fbw==}
+    hasBin: true
 
   '@google/genai@1.50.1':
     resolution: {integrity: sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==}
@@ -4126,12 +4180,12 @@ packages:
   '@telegraf/types@7.1.0':
     resolution: {integrity: sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==}
 
-  '@thi.ng/bitstream@2.4.46':
-    resolution: {integrity: sha512-p2cZshqkY/YX8EtNZEw29wbNF2vAJfi6A+yTkLUzERMpYIIdQz6bIt8rSJFyPqZcB5cI+tauXWwBXFbbsXuqKg==}
+  '@thi.ng/bitstream@2.4.45':
+    resolution: {integrity: sha512-LKOEJmmEvgUy1LKn79Hpc+EBMekGs5UOTqH3gcftl99w7fpzUAWg4gFmav34f/zw0SbjbnzO8EDmGUyyZW7dcA==}
     engines: {node: '>=18'}
 
-  '@thi.ng/errors@2.6.8':
-    resolution: {integrity: sha512-npKV69U8JYpMLZiqhUWf9dmd9Esjy36o7CxxGUgoLRS4ZmTLuIKqKfFnZuLrx6D5Mmb+D9ARCDR7qXO1QJV8DQ==}
+  '@thi.ng/errors@2.6.7':
+    resolution: {integrity: sha512-jFvECE7RPtB8P3BPL+XYOgGZqRheVtq32DAy3LJwbqgFP2v/lSyTwzvA47KsDKn1VDOGPGBhR5cM8eR7mnNbdQ==}
     engines: {node: '>=18'}
 
   '@tinyhttp/content-disposition@2.2.4':
@@ -7768,6 +7822,10 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  vscode-jsonrpc@8.2.1:
+    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
+    engines: {node: '>=14.0.0'}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -9364,6 +9422,39 @@ snapshots:
   '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
     optionalDependencies:
       '@noble/hashes': 2.0.1
+
+  '@github/copilot-darwin-arm64@1.0.32':
+    optional: true
+
+  '@github/copilot-darwin-x64@1.0.32':
+    optional: true
+
+  '@github/copilot-linux-arm64@1.0.32':
+    optional: true
+
+  '@github/copilot-linux-x64@1.0.32':
+    optional: true
+
+  '@github/copilot-sdk@0.2.2':
+    dependencies:
+      '@github/copilot': 1.0.32
+      vscode-jsonrpc: 8.2.1
+      zod: 4.3.6
+
+  '@github/copilot-win32-arm64@1.0.32':
+    optional: true
+
+  '@github/copilot-win32-x64@1.0.32':
+    optional: true
+
+  '@github/copilot@1.0.32':
+    optionalDependencies:
+      '@github/copilot-darwin-arm64': 1.0.32
+      '@github/copilot-darwin-x64': 1.0.32
+      '@github/copilot-linux-arm64': 1.0.32
+      '@github/copilot-linux-x64': 1.0.32
+      '@github/copilot-win32-arm64': 1.0.32
+      '@github/copilot-win32-x64': 1.0.32
 
   '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))':
     dependencies:
@@ -11405,12 +11496,12 @@ snapshots:
 
   '@telegraf/types@7.1.0': {}
 
-  '@thi.ng/bitstream@2.4.46':
+  '@thi.ng/bitstream@2.4.45':
     dependencies:
-      '@thi.ng/errors': 2.6.8
+      '@thi.ng/errors': 2.6.7
     optional: true
 
-  '@thi.ng/errors@2.6.8':
+  '@thi.ng/errors@2.6.7':
     optional: true
 
   '@tinyhttp/content-disposition@2.2.4': {}
@@ -14552,7 +14643,7 @@ snapshots:
 
   qoa-format@1.0.1:
     dependencies:
-      '@thi.ng/bitstream': 2.4.46
+      '@thi.ng/bitstream': 2.4.45
     optional: true
 
   qrcode-terminal@0.12.0: {}
@@ -15447,6 +15538,8 @@ snapshots:
       - msw
 
   void-elements@3.1.0: {}
+
+  vscode-jsonrpc@8.2.1: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/scripts/lib/bundled-runtime-sidecar-paths.json
+++ b/scripts/lib/bundled-runtime-sidecar-paths.json
@@ -3,6 +3,7 @@
   "dist/extensions/bluebubbles/runtime-api.js",
   "dist/extensions/browser/runtime-api.js",
   "dist/extensions/copilot-proxy/runtime-api.js",
+  "dist/extensions/copilot-sdk/runtime-api.js",
   "dist/extensions/diffs/runtime-api.js",
   "dist/extensions/discord/runtime-api.js",
   "dist/extensions/feishu/runtime-api.js",


### PR DESCRIPTION
## Summary

Adds `extensions/copilot-sdk/`, a bundled **opt-in** provider plugin that lets OpenClaw use a user's GitHub Copilot CLI subscription as the model backend — no API keys, no separate provider credentials. It spawns `@github/copilot` via `@github/copilot-sdk` and exposes a localhost OpenAI-compatible HTTP shim that OpenClaw's existing OpenAI-compatible provider path consumes.

This gives frontier-model access to users whose only LLM entitlement is their Copilot subscription.

## Why bundled (not third-party)

CONTRIBUTING.md notes most features should be third-party plugins. I'd like to flag this for maintainer judgment:

- **Precedent:** `copilot-proxy`, `lmstudio`, `ollama`, `google`, `openai` are all bundled provider plugins — this sits in the same category.
- **Surface is minimal and isolated:** one directory, `enabledByDefault: false`, manifest-driven, no core code touched outside a single sidecar-paths entry.
- **User value:** bundled = discoverable in `openclaw onboard` / `openclaw channels status` without a separate install step, which matters for the "I just want frontier models through my existing Copilot sub" use case.

Happy to convert to a third-party plugin using the public SDK if you'd prefer — the code is already structured against `openclaw/plugin-sdk/*` contracts, so the port is mechanical.

## What's in the diff

- `extensions/copilot-sdk/`
  - `index.ts` — plugin entrypoint, provider registration
  - `shim-server.ts` — localhost OpenAI-compatible HTTP shim
  - `sdk-client.ts` — `@github/copilot-sdk` wrapper
  - `message-translator.ts` — OpenAI ↔ Copilot message translation
  - `models.ts`, `shared-types.ts`, `runtime-api.ts`
  - `openclaw.plugin.json`, `package.json`, `tsconfig.json`, `README.md`
  - 4 `.test.ts` files — **33 unit tests**
- `scripts/lib/bundled-runtime-sidecar-paths.json` — adds `dist/extensions/copilot-sdk/runtime-api.js`

No changes to core, no changes to other plugins.

## Testing

- `pnpm test` — all 33 copilot-sdk tests pass; full suite green post-rebase
- `pnpm tsgo` — clean
- `pnpm check` — clean on changed files (pre-existing upstream lint errors in matrix/openai are unrelated and predate this branch)
- `pnpm build` — clean
- Bundled-plugin-metadata + extension-package-boundary contract tests — 23/23 pass
- Manual: CLI spawns `@github/copilot`, shim responds to OpenAI-format requests, translator round-trips messages

## Checklist (per CONTRIBUTING.md)

- [x] AI-assisted (Claude Opus 4.7 via Copilot CLI)
- [x] Fully tested (33/33 unit tests + full suite green post-rebase onto `origin/main`)
- [x] Author confirms understanding of the code
- [x] Rebased onto latest `origin/main` (no merge commit)
- [x] Bundled plugin follows existing provider-plugin contract (`copilot-proxy`, `lmstudio`, etc.)
- [x] `enabledByDefault: false` — zero impact on users who don't opt in

## Open questions for maintainers

1. Bundled vs. third-party — happy to convert if preferred.
2. Naming: `copilot-sdk` to distinguish from existing `copilot-proxy` (which talks to the legacy Copilot HTTP endpoint). Open to renaming.