### PR TITLE
fix(exec): fallback to /bin/sh when SHELL is non-functional (e.g. /usr/bin/false)

### DIFF
--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
-import { getShellConfig, resolvePowerShellPath, resolveShellFromPath } from "./shell-utils.js";
+import {
+  getShellConfig,
+  isNonFunctionalShell,
+  resolvePowerShellPath,
+  resolveShellFromPath,
+} from "./shell-utils.js";
 
 const isWin = process.platform === "win32";
 
@@ -72,7 +77,43 @@ describe("getShellConfig", () => {
     delete process.env.SHELL;
     process.env.PATH = "";
     const { shell } = getShellConfig();
-    expect(shell).toBe("sh");
+    expect(shell).toBe("/bin/sh");
+  });
+
+  it("falls back to /bin/sh when SHELL is /usr/bin/false", () => {
+    process.env.SHELL = "/usr/bin/false";
+    process.env.PATH = "";
+    const { shell } = getShellConfig();
+    expect(shell).toBe("/bin/sh");
+  });
+
+  it("falls back to /bin/sh when SHELL is /sbin/nologin", () => {
+    process.env.SHELL = "/sbin/nologin";
+    process.env.PATH = "";
+    const { shell } = getShellConfig();
+    expect(shell).toBe("/bin/sh");
+  });
+});
+
+describe("isNonFunctionalShell", () => {
+  it("detects /usr/bin/false", () => {
+    expect(isNonFunctionalShell("/usr/bin/false")).toBe(true);
+  });
+
+  it("detects /sbin/nologin", () => {
+    expect(isNonFunctionalShell("/sbin/nologin")).toBe(true);
+  });
+
+  it("detects /bin/true", () => {
+    expect(isNonFunctionalShell("/bin/true")).toBe(true);
+  });
+
+  it("accepts /bin/bash", () => {
+    expect(isNonFunctionalShell("/bin/bash")).toBe(false);
+  });
+
+  it("accepts /bin/zsh", () => {
+    expect(isNonFunctionalShell("/bin/zsh")).toBe(false);
   });
 });
 

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -38,6 +38,14 @@ export function resolvePowerShellPath(): string {
   return "powershell.exe";
 }
 
+// Shells that immediately exit without running commands (service users, nologin).
+const NON_FUNCTIONAL_SHELLS = new Set(["false", "nologin", "true", "shutdown", "halt"]);
+
+export function isNonFunctionalShell(shellPath: string): boolean {
+  const name = path.basename(shellPath.trim());
+  return NON_FUNCTIONAL_SHELLS.has(name);
+}
+
 export function getShellConfig(): { shell: string; args: string[] } {
   if (process.platform === "win32") {
     // Use PowerShell instead of cmd.exe on Windows.
@@ -53,8 +61,14 @@ export function getShellConfig(): { shell: string; args: string[] } {
 
   const envShell = process.env.SHELL?.trim();
   const shellName = envShell ? path.basename(envShell) : "";
+
+  // Non-functional shells (e.g. /usr/bin/false, /sbin/nologin) exit immediately
+  // without running commands. Fall back to /bin/sh for service users.
+  const effectiveShell = envShell && !isNonFunctionalShell(envShell) ? envShell : "";
+  const effectiveName = effectiveShell ? shellName : "";
+
   // Fish rejects common bashisms used by tools, so prefer bash when detected.
-  if (shellName === "fish") {
+  if (effectiveName === "fish") {
     const bash = resolveShellFromPath("bash");
     if (bash) {
       return { shell: bash, args: ["-c"] };
@@ -64,7 +78,7 @@ export function getShellConfig(): { shell: string; args: string[] } {
       return { shell: sh, args: ["-c"] };
     }
   }
-  const shell = envShell && envShell.length > 0 ? envShell : "sh";
+  const shell = effectiveShell && effectiveShell.length > 0 ? effectiveShell : "/bin/sh";
   return { shell, args: ["-c"] };
 }
 


### PR DESCRIPTION
Fixes #69077

When OpenClaw runs as a macOS LaunchDaemon under a service user whose login shell is `/usr/bin/false`, `process.env.SHELL` inherits that value. Node's `child_process` then uses it as the shell for exec commands, which immediately exits 1 without running anything.

**Changes:**
- Added `isNonFunctionalShell()` utility that detects known non-functional shells (`false`, `nologin`, `true`, `shutdown`, `halt`)
- Updated `getShellConfig()` to skip non-functional shells and fall back to `/bin/sh`
- Also normalized the unset-SHELL fallback from `"sh"` to `"/bin/sh"` for consistency
- Added tests for both the detection function and the fallback behavior