### PR TITLE
fix(tui): rearm streaming watchdog on tool events and reset state on reconnect

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -395,6 +395,10 @@ export function createEventHandlers(context: EventHandlerContext) {
       return;
     }
     if (evt.stream === "tool") {
+      // Rearm watchdog on tool events so long tool calls don't trigger a false idle.
+      if (isActiveRun) {
+        armStreamingWatchdog(evt.runId);
+      }
       const verbose = state.sessionInfo.verboseLevel ?? "off";
       const allowToolEvents = verbose !== "off";
       const allowToolOutput = verbose === "full";
@@ -476,5 +480,5 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearStreamingWatchdog();
   };
 
-  return { handleChatEvent, handleAgentEvent, handleBtwEvent, dispose };
+  return { handleChatEvent, handleAgentEvent, handleBtwEvent, clearStreamingWatchdog, dispose };
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -730,22 +730,23 @@ export async function runTui(opts: TuiOptions) {
     abortActive,
   } = sessionActions;
 
-  const { handleChatEvent, handleAgentEvent, handleBtwEvent } = createEventHandlers({
-    chatLog,
-    btw,
-    tui,
-    state,
-    setActivityStatus,
-    refreshSessionInfo,
-    loadHistory,
-    noteLocalRunId,
-    isLocalRunId,
-    forgetLocalRunId,
-    clearLocalRunIds,
-    isLocalBtwRunId,
-    forgetLocalBtwRunId,
-    clearLocalBtwRunIds,
-  });
+  const { handleChatEvent, handleAgentEvent, handleBtwEvent, clearStreamingWatchdog } =
+    createEventHandlers({
+      chatLog,
+      btw,
+      tui,
+      state,
+      setActivityStatus,
+      refreshSessionInfo,
+      loadHistory,
+      noteLocalRunId,
+      isLocalRunId,
+      forgetLocalRunId,
+      clearLocalRunIds,
+      isLocalBtwRunId,
+      forgetLocalBtwRunId,
+      clearLocalBtwRunIds,
+    });
 
   const requestExit = () => {
     if (exitRequested) {
@@ -888,6 +889,12 @@ export async function runTui(opts: TuiOptions) {
     pairingHintShown = false;
     const reconnected = wasDisconnected;
     wasDisconnected = false;
+    // On reconnect, clear stale run state so we don't stay stuck in 'streaming'.
+    if (reconnected) {
+      state.activeChatRunId = null;
+      clearStreamingWatchdog();
+      setActivityStatus("idle");
+    }
     setConnectionStatus("connected");
     void (async () => {
       await refreshAgents();


### PR DESCRIPTION
Fixes #69081

Two related bugs in the TUI's streaming-status handling:

**Bug 1 — False idle during tool calls:** The streaming watchdog only rearmed on chat `delta` events, not tool events. Long tool calls (>30s) without chat deltas triggered a false idle status. Fixed by rearming the watchdog in `handleAgentEvent` when a tool event arrives for the active run.

**Bug 2 — Stuck streaming after reconnect:** On WebSocket reconnect, `activeChatRunId` and watchdog state were not cleared, so if the `final` event was lost during disconnect, the TUI stayed in `streaming` forever. Fixed by clearing `activeChatRunId`, calling `clearStreamingWatchdog()`, and setting status to `idle` before `loadHistory()` on reconnect.

All 243 TUI tests pass.