### PR TITLE
fix(telegram): wire humanDelay into block-streaming dispatcher

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -4,6 +4,7 @@ import {
   logTypingFailure,
   removeAckReactionAfterReply,
 } from "openclaw/plugin-sdk/channel-feedback";
+import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
 import { resolveChannelStreamingBlockEnabled } from "openclaw/plugin-sdk/channel-streaming";
 import type {
@@ -687,6 +688,7 @@ export const dispatchTelegramMessage = async ({
         cfg,
         dispatcherOptions: {
           ...replyPipeline,
+          humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
           deliver: async (payload, info) => {
             if (isDispatchSuperseded()) {
               return;


### PR DESCRIPTION
## Summary

Telegram was the only channel not passing `humanDelay` config to the reply dispatcher, so `agents.defaults.humanDelay` (and per-agent overrides) had zero effect on Telegram block streaming. Messages would arrive back-to-back instead of with natural pacing.

Every other channel (Slack, Discord, Signal, iMessage, Matrix, Feishu, MS Teams, Mattermost, Tlon) already wires `resolveHumanDelayConfig()` into its dispatcher options — this just brings Telegram in line.

## Changes

- **extensions/telegram/src/bot-message-dispatch.ts**: Add `resolveHumanDelayConfig` import and pass `humanDelay` into `dispatcherOptions`

2 lines added, 0 removed.

Fixes #68945