### PR TITLE
fix(voice-call): allow realtime short-circuit for outbound directions

### DIFF
--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -704,8 +704,18 @@ export class VoiceCallWebhookServer {
 
     const params = new URLSearchParams(ctx.rawBody);
     const direction = params.get("Direction");
-    const isInbound = !direction || direction === "inbound";
-    if (!isInbound) {
+    // Allow realtime short-circuit for inbound AND outbound (outbound-api /
+    // outbound-dial). The realtime handler's buildTwiMLPayload already
+    // supports both directions internally — it explicitly maps
+    // `rawDirection === "outbound-api"` to `token.direction = "outbound"`.
+    //
+    // Without this, outbound calls fall through to decideTwimlResponse,
+    // which on a realtime-only config (streaming.streamPath undefined →
+    // canStream === false) returns PAUSE_TWIML — caller hears any
+    // pre-stream <Say> followed by 30s of silence, then hangup.
+    const isSupportedDirection =
+      !direction || direction === "inbound" || direction.startsWith("outbound");
+    if (!isSupportedDirection) {
       return false;
     }
 


### PR DESCRIPTION
## Summary

- **Problem:** `shouldShortCircuitToRealtimeTwiml` in `extensions/voice-call/src/webhook.ts` gates the realtime TwiML path to only inbound directions. Outbound calls fall through to `decideTwimlResponse`, which on a realtime-only config (`streaming.streamPath` undefined → `canStream === false`) returns `PAUSE_TWIML`. Outbound conversation mode is unusable: caller hears any pre-stream `<Say>` then 30 seconds of silence before hangup.
- **Why it matters:** users following the docs to set up `realtime.enabled = true` (e.g. for OpenAI Realtime end-to-end) can place inbound calls but outbound is broken. Worse, `realtime.enabled` and `streaming.enabled` are mutually exclusive (the plugin rejects both true), so users can't work around this by also enabling streaming.
- **What changed:** loosen the gate to also accept directions starting with `"outbound"` (covers `outbound-api` and `outbound-dial`). The realtime handler's `buildTwiMLPayload` already supports outbound internally (`rawDirection === "outbound-api"` → `token.direction = "outbound"`). The gate was over-restrictive.
- **What did NOT change (scope boundary):** status callback / replay handling, terminal call status check, SpeechResult/Digits early-out behavior. Strictly additive: directions that previously short-circuited continue to do so; outbound directions now also short-circuit.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Related

- Refs #68713 — necessary but not sufficient on its own; also needs the `speakInitialMessage` race fix (`legonhilltech-jpg`'s workaround in that thread)
- Refs #36869, #48505 — same general bug complex

## Verification

End-to-end repro and fix verification on stock `openclaw 2026.4.15` with Twilio production number, OpenAI Realtime (`gpt-realtime-mini`), Cloudflare Tunnel webhook delivery. Combined with the #68713 workaround (skipping `maybeSpeakInitialMessageOnAnswered` when `this.config.realtime.enabled`), outbound conversation now connects, opens the realtime stream, and supports bidirectional voice end-to-end.

No unit test added — the existing webhook tests don't currently exercise the inbound vs outbound direction branching, and adding meaningful coverage would be a larger refactor of the test harness. Happy to follow up if maintainers want it.