### PR TITLE
fix: OpenRouter setup writes correct baseUrl

### DIFF
--- a/extensions/openrouter/onboard.test.ts
+++ b/extensions/openrouter/onboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   expectProviderOnboardAllowlistAlias,
   expectProviderOnboardPrimaryAndFallbacks,
@@ -23,5 +23,13 @@ describe("openrouter onboard", () => {
       applyConfig: applyOpenrouterConfig,
       modelRef: OPENROUTER_DEFAULT_MODEL_REF,
     });
+  });
+
+  it("sets provider config with correct baseUrl", () => {
+    const cfg = applyOpenrouterConfig({});
+    expect(cfg.models?.providers?.openrouter?.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(cfg.models?.providers?.openrouter?.api).toBe("openai-completions");
+    expect(cfg.models?.providers?.openrouter?.models).toBeDefined();
+    expect(cfg.models?.providers?.openrouter?.models?.length).toBeGreaterThan(0);
   });
 });

--- a/extensions/openrouter/onboard.ts
+++ b/extensions/openrouter/onboard.ts
@@ -1,7 +1,9 @@
 import {
   applyAgentDefaultModelPrimary,
+  applyProviderConfigWithDefaultModelsPreset,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
+import { buildOpenrouterProvider, OPENROUTER_BASE_URL } from "./provider-catalog.js";
 
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
 
@@ -25,8 +27,13 @@ export function applyOpenrouterProviderConfig(cfg: OpenClawConfig): OpenClawConf
 }
 
 export function applyOpenrouterConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return applyAgentDefaultModelPrimary(
-    applyOpenrouterProviderConfig(cfg),
-    OPENROUTER_DEFAULT_MODEL_REF,
-  );
+  const provider = buildOpenrouterProvider();
+  const next = applyProviderConfigWithDefaultModelsPreset(cfg, {
+    providerId: "openrouter",
+    api: "openai-completions",
+    baseUrl: OPENROUTER_BASE_URL,
+    defaultModels: provider.models,
+    aliases: [{ modelRef: OPENROUTER_DEFAULT_MODEL_REF, alias: "OpenRouter" }],
+  });
+  return applyAgentDefaultModelPrimary(next, OPENROUTER_DEFAULT_MODEL_REF);
 }


### PR DESCRIPTION
## Summary
Fixes the OpenRouter setup wizard writing the wrong baseUrl. The setup now correctly writes `https://openrouter.ai/api/v1` instead of leaving the provider config incomplete.

## Root Cause
The `applyOpenrouterConfig` function in `onboard.ts` only set the default model via `applyAgentDefaultModelPrimary` and `applyOpenrouterProviderConfig`, but did not set the provider configuration with the baseUrl. This caused the setup to write an incomplete provider configuration.

## Fix
Updated `applyOpenrouterConfig` to use `applyProviderConfigWithDefaultModelsPreset` which:
1. Sets the provider config with the correct `OPENROUTER_BASE_URL` (`https://openrouter.ai/api/v1`)
2. Includes the default models from `buildOpenrouterProvider()`
3. Sets up the model aliases correctly

## Test Plan
- [x] Added regression test verifying provider config is set with correct baseUrl
- [x] Existing unit tests pass
- [x] Verified the fix writes the correct baseUrl to the provider config

Closes openclaw#69104