### PR TITLE
fix(acp): return SESSION_BUSY error when concurrent calls hit active session

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -702,6 +702,19 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
+
+    // Check if there's already an active turn for this session
+    // If so, throw SESSION_BUSY error so callers can distinguish
+    // "session busy, retry" from "real crash/timeout"
+    const actorKey = normalizeActorKey(sessionKey);
+    const activeTurn = this.activeTurnBySession.get(actorKey);
+    if (activeTurn) {
+      throw new AcpRuntimeError(
+        "SESSION_BUSY",
+        `Session ${sessionKey} is busy processing another turn.`,
+      );
+    }
+
     await this.withSessionActor(
       sessionKey,
       async () => {


### PR DESCRIPTION
When multiple concurrent openclaw agent --session-id calls target the same session while a turn is in progress, callers could be silently dropped.

This fix checks for an active turn before entering the actor queue and throws an AcpRuntimeError with code SESSION_BUSY to allow callers to distinguish session busy from real crash/timeout.

Fixes #69112