### PR TITLE
fix(slack): enforce maxRequestConcurrency=1 to preserve message ordering

### DIFF
--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -91,6 +91,7 @@ export function resolveSlackWriteClientOptions(options: WebClientOptions = {}): 
     ...options,
     agent: options.agent ?? resolveSlackProxyAgent(),
     retryConfig: options.retryConfig ?? SLACK_WRITE_RETRY_OPTIONS,
+    maxRequestConcurrency: options.maxRequestConcurrency ?? 1,
   };
 }
 


### PR DESCRIPTION
Closes #69101

The Slack WebClient defaults to maxRequestConcurrency: 100, which allows later chat.postMessage requests to complete before earlier ones when sent in rapid succession. This causes messages to arrive out of order on Slack clients. Setting maxRequestConcurrency to 1 on the write client ensures sequential delivery while still respecting the existing retryConfig.