### PR TITLE
fix(memory): preserve pre-increment compaction count in memoryFlushCompactionCount (#12590)

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -192,7 +192,11 @@ describe("runMemoryFlushIfNeeded", () => {
     };
     expect(persisted.main.sessionId).toBe("session-rotated");
     expect(persisted.main.compactionCount).toBe(2);
-    expect(persisted.main.memoryFlushCompactionCount).toBe(2);
+    // memoryFlushCompactionCount records the pre-increment count at which the
+    // flush was initiated, not the post-increment count. This ensures
+    // hasAlreadyFlushedForCurrentCompaction does not falsely skip the next
+    // cycle's flush (see #12590).
+    expect(persisted.main.memoryFlushCompactionCount).toBe(1);
     expect(persisted.main.memoryFlushAt).toBe(1_700_000_000_000);
   });
 

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -823,9 +823,14 @@ export async function runMemoryFlushIfNeeded(params: {
           });
         }
       }
-      if (typeof nextCount === "number") {
-        memoryFlushCompactionCount = nextCount;
-      }
+      // NOTE: Do NOT update memoryFlushCompactionCount to nextCount here.
+      // memoryFlushCompactionCount records the compaction count at the time the
+      // flush was initiated (pre-increment). If we overwrite it with the
+      // post-increment value, hasAlreadyFlushedForCurrentCompaction will
+      // compare equal on the next cycle and incorrectly skip the flush,
+      // causing memoryFlush to fire on every other auto-compaction cycle
+      // instead of every cycle. See #12590.
+      void nextCount;
     }
     if (params.storePath && params.sessionKey) {
       try {


### PR DESCRIPTION
## Summary
`memoryFlush` only fires on every other auto-compaction cycle instead of every cycle. The dedup logic falsely skips the flush because `memoryFlushCompactionCount` is set to the post-increment compaction count.

## Root Cause
In `runMemoryFlushIfNeeded` (`src/auto-reply/reply/agent-runner-memory.ts`), when compaction completes during a flush, `incrementCompactionCount` bumps `compactionCount` from N to N+1, and then `memoryFlushCompactionCount` is overwritten to N+1 (the new count). On the next cycle, `hasAlreadyFlushedForCurrentCompaction` compares `memoryFlushCompactionCount === compactionCount` → `N+1 === N+1` → true → flush is incorrectly skipped.

## Changes
- `src/auto-reply/reply/agent-runner-memory.ts`: Stop overwriting `memoryFlushCompactionCount` with the post-increment count. Keep it at the pre-increment value so the dedup check correctly detects a new compaction cycle.
- `src/auto-reply/reply/agent-runner-memory.test.ts`: Update test expectation to match the corrected pre-increment behavior.

## Test
```
pnpm test src/auto-reply/reply/agent-runner-memory.test.ts
pnpm test src/auto-reply/reply/agent-runner-memory.dedup.test.ts
pnpm test src/auto-reply/reply/reply-state.test.ts
```
All 50 tests pass (3 + 15 + 32).

Closes #12590