### PR TITLE
Docker: add OPENCLAW_DOCKER_PLATFORM for cross-platform image builds

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -133,6 +133,7 @@ The setup script accepts these optional environment variables:
 | `OPENCLAW_HOME_VOLUME`         | Persist `/home/node` in a named Docker volume                    |
 | `OPENCLAW_SANDBOX`             | Opt in to sandbox bootstrap (`1`, `true`, `yes`, `on`)           |
 | `OPENCLAW_DOCKER_SOCKET`       | Override Docker socket path                                      |
+| `OPENCLAW_DOCKER_PLATFORM`     | Target platform for local image builds (e.g. `linux/amd64`)      |
 
 ### Health checks
 

--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -11,6 +11,7 @@ RAW_SANDBOX_SETTING="${OPENCLAW_SANDBOX:-}"
 SANDBOX_ENABLED=""
 DOCKER_SOCKET_PATH="${OPENCLAW_DOCKER_SOCKET:-}"
 TIMEZONE="${OPENCLAW_TZ:-}"
+DOCKER_PLATFORM="${OPENCLAW_DOCKER_PLATFORM:-}"
 
 fail() {
   echo "ERROR: $*" >&2
@@ -261,6 +262,15 @@ if [[ -n "$TIMEZONE" ]]; then
     fail "OPENCLAW_TZ must match a timezone in /usr/share/zoneinfo (e.g. Asia/Shanghai)."
   fi
 fi
+if [[ -n "$DOCKER_PLATFORM" ]]; then
+  if contains_disallowed_chars "$DOCKER_PLATFORM"; then
+    fail "OPENCLAW_DOCKER_PLATFORM contains unsupported control characters."
+  fi
+  # Accept Docker platform strings like linux/amd64, linux/arm64, linux/arm/v7.
+  if [[ ! "$DOCKER_PLATFORM" =~ ^[A-Za-z0-9][A-Za-z0-9/_.+\-]*$ ]]; then
+    fail "OPENCLAW_DOCKER_PLATFORM must be a Docker platform string (e.g. linux/amd64)."
+  fi
+fi
 
 mkdir -p "$OPENCLAW_CONFIG_DIR"
 mkdir -p "$OPENCLAW_WORKSPACE_DIR"
@@ -284,6 +294,7 @@ export OPENCLAW_ALLOW_INSECURE_PRIVATE_WS="${OPENCLAW_ALLOW_INSECURE_PRIVATE_WS:
 export OPENCLAW_SANDBOX="$SANDBOX_ENABLED"
 export OPENCLAW_DOCKER_SOCKET="$DOCKER_SOCKET_PATH"
 export OPENCLAW_TZ="$TIMEZONE"
+export OPENCLAW_DOCKER_PLATFORM="$DOCKER_PLATFORM"
 
 # Detect Docker socket GID for sandbox group_add.
 DOCKER_GID=""
@@ -469,11 +480,13 @@ upsert_env "$ENV_FILE" \
   DOCKER_GID \
   OPENCLAW_INSTALL_DOCKER_CLI \
   OPENCLAW_ALLOW_INSECURE_PRIVATE_WS \
-  OPENCLAW_TZ
+  OPENCLAW_TZ \
+  OPENCLAW_DOCKER_PLATFORM
 
 if [[ "$IMAGE_NAME" == "openclaw:local" ]]; then
   echo "==> Building Docker image: $IMAGE_NAME"
   run_docker_build \
+    ${OPENCLAW_DOCKER_PLATFORM:+--platform "$OPENCLAW_DOCKER_PLATFORM"} \
     --build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}" \
     --build-arg "OPENCLAW_EXTENSIONS=${OPENCLAW_EXTENSIONS}" \
     --build-arg "OPENCLAW_INSTALL_DOCKER_CLI=${OPENCLAW_INSTALL_DOCKER_CLI:-}" \
@@ -542,6 +555,7 @@ if [[ -n "$SANDBOX_ENABLED" ]]; then
   if [[ -f "$ROOT_DIR/Dockerfile.sandbox" ]]; then
     echo "Building sandbox image: openclaw-sandbox:bookworm-slim"
     run_docker_build \
+      ${OPENCLAW_DOCKER_PLATFORM:+--platform "$OPENCLAW_DOCKER_PLATFORM"} \
       -t "openclaw-sandbox:bookworm-slim" \
       -f "$ROOT_DIR/Dockerfile.sandbox" \
       "$ROOT_DIR"

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -301,6 +301,51 @@ describe("scripts/docker/setup.sh", () => {
     expect(envFile).toContain("OPENCLAW_TZ=Asia/Shanghai");
   });
 
+  it("passes --platform to docker build when OPENCLAW_DOCKER_PLATFORM is set", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    await writeFile(join(activeSandbox.rootDir, "Dockerfile.sandbox"), "FROM scratch\n");
+    await resetDockerLog(activeSandbox);
+
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_DOCKER_PLATFORM: "linux/arm64",
+      OPENCLAW_SANDBOX: "1",
+    });
+
+    expect(result.status).toBe(0);
+    const envFile = await readFile(join(activeSandbox.rootDir, ".env"), "utf8");
+    expect(envFile).toContain("OPENCLAW_DOCKER_PLATFORM=linux/arm64");
+    const buildLines = (await readDockerLogLines(activeSandbox)).filter((line) =>
+      line.startsWith("build "),
+    );
+    expect(buildLines.length).toBeGreaterThanOrEqual(2);
+    expect(buildLines.every((line) => line.includes("--platform linux/arm64"))).toBe(true);
+  });
+
+  it("omits --platform from docker build when OPENCLAW_DOCKER_PLATFORM is unset", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    await resetDockerLog(activeSandbox);
+
+    const result = runDockerSetup(activeSandbox);
+
+    expect(result.status).toBe(0);
+    const buildLines = (await readDockerLogLines(activeSandbox)).filter((line) =>
+      line.startsWith("build "),
+    );
+    expect(buildLines.length).toBeGreaterThanOrEqual(1);
+    expect(buildLines.every((line) => !line.includes("--platform"))).toBe(true);
+  });
+
+  it("rejects invalid OPENCLAW_DOCKER_PLATFORM values", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_DOCKER_PLATFORM: "linux amd64",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("OPENCLAW_DOCKER_PLATFORM must be a Docker platform string");
+  });
+
   it("precreates agent data dirs to avoid EACCES in container", async () => {
     const activeSandbox = requireSandbox(sandbox);
     const configDir = join(activeSandbox.rootDir, "config-agent-dirs");


### PR DESCRIPTION
## Summary

- Problem: The Docker setup script builds `openclaw:local` (and the sandbox image) only for the host's native platform. Cross-building a Linux image from macOS for an airgapped Linux host isn't possible without editing the script.
- Why it matters: Operators preparing images on one OS for deployment on another (e.g. building on macOS/arm64 to deploy on a linux/amd64 airgapped host) need `docker build --platform <target>` support.
- What changed: New optional env var `OPENCLAW_DOCKER_PLATFORM`. When set, it is forwarded as `--platform <value>` to both the main image build and the sandbox image build. When unset (default), nothing changes — local platform is used.
- What did NOT change (scope boundary): No changes to Dockerfiles, compose files, runtime behavior, pull paths, sandbox semantics, or podman script.

## Change Type

- [x] Feature
- [x] Docs

## Scope

- [x] CI/CD / infra

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause

N/A

## Implementation

- `scripts/docker/setup.sh`:
  - Read `OPENCLAW_DOCKER_PLATFORM` alongside the other `OPENCLAW_*` env vars (empty default).
  - Validate: rejects control chars and anything outside `^[A-Za-z0-9][A-Za-z0-9/_.+\-]*$`, matching the style of the existing `OPENCLAW_TZ` validation.
  - Exported and persisted to `.env` via the existing `upsert_env` call so reruns stay deterministic.
  - Used in both `run_docker_build` calls via `\${OPENCLAW_DOCKER_PLATFORM:+--platform "\$OPENCLAW_DOCKER_PLATFORM"}` — the flag only appears when the value is non-empty.
- `docs/install/docker.md`: one-line table entry in the env-var reference.

## Testing

`src/docker-setup.e2e.test.ts` gets three new cases:
- passes `--platform <value>` to both main + sandbox builds and persists to `.env` when set
- omits `--platform` entirely when unset
- rejects invalid values (e.g. `"linux amd64"`)

Local verification:
- `pnpm test src/docker-setup.e2e.test.ts` — 24/24 pass
- `pnpm check` — tsgo (core, core:test, extensions, extensions:test), oxlint, webhook/auth lints, import-cycles, madge — all green
- `pnpm format:check` — clean
- `bash -n scripts/docker/setup.sh` — OK

## Example

```bash
# build a linux/amd64 openclaw image from macOS for an airgapped host
OPENCLAW_DOCKER_PLATFORM=linux/amd64 ./scripts/docker/setup.sh
```

Default behavior unchanged when the var is unset.