### PR TITLE
fix: stop gateway service before npm install to prevent file lock conflicts (fixes #66401)

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -76,6 +76,51 @@ import {
 } from "./shared.js";
 import { suppressDeprecations } from "./suppress-deprecations.js";
 
+// --- Helper Functions ---
+
+/**
+ * Stop the gateway service before running npm install.
+ * This prevents file lock conflicts where npm tries to overwrite files
+ * that are memory-mapped by the running Node.js process.
+ */
+async function stopGatewayServiceBeforeUpdate({
+  json,
+  _gatewayPort,
+}: {
+  json: boolean;
+  _gatewayPort: number;
+}): Promise<boolean> {
+  const service = resolveGatewayService();
+
+  try {
+    const loaded = await service.isLoaded({ env: process.env });
+    if (!loaded) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  if (!json) {
+    defaultRuntime.log(theme.heading("Stopping gateway service before update..."));
+  }
+
+  try {
+    await service.stop({ env: process.env, stdout: process.stdout });
+  } catch (err) {
+    if (!json) {
+      defaultRuntime.log(theme.warn(`Service stop failed: ${String(err)}`));
+      defaultRuntime.log(theme.muted("Continuing update — files may be locked."));
+    }
+    return false;
+  }
+
+  // Wait for the process to fully release file locks
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  return true;
+}
+
 const CLI_NAME = resolveCliName();
 const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
 const POST_CORE_UPDATE_ENV = "OPENCLAW_UPDATE_POST_CORE";
@@ -1052,6 +1097,18 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   const { progress, stop } = createUpdateProgress(showProgress);
   const startedAt = Date.now();
 
+  // Stop gateway service before npm install to prevent file lock conflicts
+  if (shouldRestart && updateInstallKind === "package") {
+    const gatewayPort = resolveGatewayPort(
+      configSnapshot.valid ? configSnapshot.config : undefined,
+      process.env,
+    );
+    await stopGatewayServiceBeforeUpdate({
+      json: Boolean(opts.json),
+      _gatewayPort: gatewayPort,
+    });
+  }
+
   const result =
     updateInstallKind === "package"
       ? await runPackageInstallUpdate({
@@ -1198,7 +1255,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
 
   let restartScriptPath: string | null = null;
   let refreshGatewayServiceEnv = false;
-  const gatewayPort = resolveGatewayPort(
+  const gatewayPortForRestart = resolveGatewayPort(
     postUpdateConfigSnapshot.valid ? postUpdateConfigSnapshot.config : undefined,
     process.env,
   );
@@ -1206,7 +1263,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     try {
       const loaded = await resolveGatewayService().isLoaded({ env: process.env });
       if (loaded) {
-        restartScriptPath = await prepareRestartScript(process.env, gatewayPort);
+        restartScriptPath = await prepareRestartScript(process.env, gatewayPortForRestart);
         refreshGatewayServiceEnv = true;
       }
     } catch {
@@ -1234,7 +1291,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       result,
       opts,
       refreshServiceEnv: refreshGatewayServiceEnv,
-      gatewayPort,
+      gatewayPort: gatewayPortForRestart,
       restartScriptPath,
       invocationCwd,
     });


### PR DESCRIPTION
## Problem

Running `openclaw update` while the gateway service is running causes three cascading failures (issue #66401):

1. **Gateway crash** — `npm install -g` overwrites JS files that are memory-mapped by the running Node.js process
2. **Feishu disconnection** — Config overwritten during update window
3. **100% Cron job loss** — SIGTERM interrupts `saveCronStore()` mid-write

## Solution

Stop the gateway service **before** running `npm install -g`.

## Changes

- **Added `stopGatewayServiceBeforeUpdate()`** in `src/cli/update-cli/update-command.ts`
  - Checks if gateway service is loaded (launchd/systemd/schtasks)
  - Sends stop signal via platform-specific service manager
  - Waits 2 seconds for file locks to release
  - Graceful fallback if stop fails
  - Only runs when `shouldRestart && updateInstallKind === "package"` (npm/pnpm/bun installs)

- **Refactored `gatewayPort` variable** to avoid duplicate declaration

## Why This Is Safe

| Scenario | Behavior |
|---|---|
| Service not loaded | No action taken |
| Service stop fails | Logs warning, continues |
| Platform unsupported | Returns `false`, no-op |
| `--no-restart` flag | Skipped entirely |
| Git-based install | Skipped (git flow) |

Fixes #66401