### PR TITLE
Ollama/web-search: route bundled provider at Ollama Cloud (#69132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/commands: recognize slash commands that are prefixed with the bot's Matrix mention, so room messages like `@bot:server /new` trigger the command path without requiring custom mention regexes. (#68570) Thanks @nightq and @johnlanni.
 - Agents/subagents: include requested role and runtime timing on subagent failure payloads so parent agents can correlate failed or timed-out child work. (#68726) Thanks @BKF-Gitty.
 - Gateway/sessions: reject stale agent-scoped sessions after an agent is removed from config while preserving legacy default-agent main-session aliases. (#65986) Thanks @bittoby.
+- Ollama/web-search: route the bundled `web_search` provider at Ollama Cloud (`https://ollama.com/api/web_search`) instead of the local daemon's removed `/api/experimental/web_search` path, so `tools.web.search.provider = "ollama"` works again on Ollama 0.16.0+. (#69132) Thanks @yoon1012.
 
 ## 2026.4.19-beta.2
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1563,7 +1563,7 @@ for usage/billing and raise limits as needed.
     provider:
 
     - API-backed providers such as Brave, Exa, Firecrawl, Gemini, Grok, Kimi, MiniMax Search, Perplexity, and Tavily require their normal API key setup.
-    - Ollama Web Search is key-free, but it uses your configured Ollama host and requires `ollama signin`.
+    - Ollama Web Search is cloud-backed (`https://ollama.com/api/web_search`) and requires `ollama signin` (or a provisioned `OLLAMA_API_KEY`); it reuses the Ollama provider credential.
     - DuckDuckGo is key-free, but it is an unofficial HTML-based integration.
     - SearXNG is key-free/self-hosted; configure `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl`.
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -271,11 +271,11 @@ Once configured, all your Ollama models are available:
 
 OpenClaw supports **Ollama Web Search** as a bundled `web_search` provider.
 
-| Property    | Detail                                                                                                            |
-| ----------- | ----------------------------------------------------------------------------------------------------------------- |
-| Host        | Uses your configured Ollama host (`models.providers.ollama.baseUrl` when set, otherwise `http://127.0.0.1:11434`) |
-| Auth        | Key-free                                                                                                          |
-| Requirement | Ollama must be running and signed in with `ollama signin`                                                         |
+| Property    | Detail                                                                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Host        | Ollama Cloud (`https://ollama.com/api/web_search`); optional `plugins.entries.ollama.config.webSearch.baseUrl` override for custom proxies |
+| Auth        | Reuses `models.providers.ollama.apiKey` or `OLLAMA_API_KEY`                                                                                |
+| Requirement | Signed in with `ollama signin` (or a provisioned `OLLAMA_API_KEY`)                                                                         |
 
 Choose **Ollama Web Search** during `openclaw onboard` or `openclaw configure --section web`, or set:
 

--- a/docs/tools/ollama-search.md
+++ b/docs/tools/ollama-search.md
@@ -88,10 +88,20 @@ OpenClaw reads the API key from `models.providers.ollama.apiKey` or the
 `OLLAMA_API_KEY` environment variable. `ollama signin` writes this key for
 you on the local host.
 
+The Ollama API key is a cloud credential, so OpenClaw only attaches the
+`Authorization: Bearer <apiKey>` header when the web-search base URL is the
+canonical `https://ollama.com` host. Custom `webSearch.baseUrl` overrides
+(self-hosted proxies) never receive the Ollama API key; add any auth your
+proxy needs at the proxy layer.
+
+Because cloud routing is the default, OpenClaw also shows a one-line notice
+at setup time confirming that queries will be sent to
+`https://ollama.com/api/web_search`.
+
 ## Notes
 
 - No web-search-specific API key field is required; the provider reuses the
-  normal Ollama credential.
+  normal Ollama credential only when calling Ollama Cloud.
 - OpenClaw warns during setup if `ollama signin` has not been completed, but
   it does not block selection.
 - Runtime auto-detect can fall back to Ollama Web Search when no higher-priority

--- a/docs/tools/ollama-search.md
+++ b/docs/tools/ollama-search.md
@@ -84,6 +84,12 @@ Optional web-search base URL override (for custom proxies that mirror the
 
 If no override is set, OpenClaw calls `https://ollama.com/api/web_search`.
 
+The web-search path uses a stricter SSRF policy than the local-daemon path:
+requests may only leave to the hostname you configured, and private / loopback
+/ link-local targets are refused even when the `baseUrl` resolves to them.
+Run your custom proxy on a publicly routable hostname; the local-daemon
+`models.providers.ollama.baseUrl` setting is unaffected by this policy.
+
 OpenClaw reads the API key from `models.providers.ollama.apiKey` or the
 `OLLAMA_API_KEY` environment variable. `ollama signin` writes this key for
 you on the local host.
@@ -102,8 +108,12 @@ at setup time confirming that queries will be sent to
 
 - No web-search-specific API key field is required; the provider reuses the
   normal Ollama credential only when calling Ollama Cloud.
-- OpenClaw warns during setup if `ollama signin` has not been completed, but
-  it does not block selection.
+- Setup probes `/api/me` using the resolved Ollama credential. If you have
+  `OLLAMA_API_KEY` (or `models.providers.ollama.apiKey`) set, OpenClaw will
+  treat you as signed in without requiring a local `ollama signin` artifact.
+- When Ollama Cloud is the target and no credential is configured,
+  `runOllamaWebSearch` fails fast with an actionable error before the
+  network round-trip.
 - Runtime auto-detect can fall back to Ollama Web Search when no higher-priority
   credentialed provider is configured.
 - The provider uses Ollama Cloud's `/api/web_search` endpoint.

--- a/docs/tools/ollama-search.md
+++ b/docs/tools/ollama-search.md
@@ -10,14 +10,14 @@ title: "Ollama Web Search"
 # Ollama Web Search
 
 OpenClaw supports **Ollama Web Search** as a bundled `web_search` provider.
-It uses Ollama's experimental web-search API and returns structured results
-with titles, URLs, and snippets.
+It calls Ollama's Cloud web-search API and returns structured results with
+titles, URLs, and snippets.
 
-Unlike the Ollama model provider, this setup does not need an API key by
-default. It does require:
+Ollama Web Search is a cloud capability; the local Ollama daemon does not
+serve it. The provider requires:
 
-- an Ollama host that is reachable from OpenClaw
-- `ollama signin`
+- an Ollama account (free)
+- `ollama signin` (stores the API key OpenClaw reuses for the cloud call)
 
 ## Setup
 
@@ -46,7 +46,8 @@ default. It does require:
 </Steps>
 
 If you already use Ollama for models, Ollama Web Search reuses the same
-configured host.
+credential (`models.providers.ollama.apiKey` or `OLLAMA_API_KEY`) to call
+the cloud search endpoint.
 
 ## Config
 
@@ -62,37 +63,40 @@ configured host.
 }
 ```
 
-Optional Ollama host override:
+Optional web-search base URL override (for custom proxies that mirror the
+`/api/web_search` contract):
 
 ```json5
 {
-  models: {
-    providers: {
+  plugins: {
+    entries: {
       ollama: {
-        baseUrl: "http://ollama-host:11434",
+        config: {
+          webSearch: {
+            baseUrl: "https://my-proxy.example.com",
+          },
+        },
       },
     },
   },
 }
 ```
 
-If no explicit Ollama base URL is set, OpenClaw uses `http://127.0.0.1:11434`.
+If no override is set, OpenClaw calls `https://ollama.com/api/web_search`.
 
-If your Ollama host expects bearer auth, OpenClaw reuses
-`models.providers.ollama.apiKey` (or the matching env-backed provider auth)
-for web-search requests too.
+OpenClaw reads the API key from `models.providers.ollama.apiKey` or the
+`OLLAMA_API_KEY` environment variable. `ollama signin` writes this key for
+you on the local host.
 
 ## Notes
 
-- No web-search-specific API key field is required for this provider.
-- If the Ollama host is auth-protected, OpenClaw reuses the normal Ollama
-  provider API key when present.
-- OpenClaw warns during setup if Ollama is unreachable or not signed in, but
+- No web-search-specific API key field is required; the provider reuses the
+  normal Ollama credential.
+- OpenClaw warns during setup if `ollama signin` has not been completed, but
   it does not block selection.
 - Runtime auto-detect can fall back to Ollama Web Search when no higher-priority
   credentialed provider is configured.
-- The provider uses Ollama's experimental `/api/experimental/web_search`
-  endpoint.
+- The provider uses Ollama Cloud's `/api/web_search` endpoint.
 
 ## Related
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -174,7 +174,7 @@ API-backed providers first:
 Key-free fallbacks after that:
 
 10. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
-11. **Ollama Web Search** -- key-free fallback via your configured Ollama host; requires Ollama to be reachable and signed in with `ollama signin` and can reuse Ollama provider bearer auth if the host needs it (order 110)
+11. **Ollama Web Search** -- cloud-backed fallback via `https://ollama.com/api/web_search`; requires `ollama signin` (or a provisioned `OLLAMA_API_KEY`) and reuses the Ollama provider credential (order 110)
 12. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
 
 If no provider is detected, it falls back to Brave (you will get a missing-key
@@ -414,4 +414,4 @@ If you use tool profiles or allowlists, add `web_search`, `x_search`, or `group:
 - [Web Fetch](/tools/web-fetch) -- fetch a URL and extract readable content
 - [Web Browser](/tools/browser) -- full browser automation for JS-heavy sites
 - [Grok Search](/tools/grok-search) -- Grok as the `web_search` provider
-- [Ollama Web Search](/tools/ollama-search) -- key-free web search through your Ollama host
+- [Ollama Web Search](/tools/ollama-search) -- cloud-backed web search via `https://ollama.com/api/web_search`

--- a/extensions/ollama/src/provider-models.ssrf.test.ts
+++ b/extensions/ollama/src/provider-models.ssrf.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildOllamaBaseUrlSsrFPolicy } from "./provider-models.js";
+import { buildOllamaBaseUrlSsrFPolicy, buildOllamaWebSearchSsrFPolicy } from "./provider-models.js";
 
 describe("buildOllamaBaseUrlSsrFPolicy", () => {
   it("pins requests to the configured Ollama hostname for HTTP(S) URLs", () => {
@@ -37,5 +37,28 @@ describe("buildOllamaBaseUrlSsrFPolicy", () => {
     expect(buildOllamaBaseUrlSsrFPolicy("ftp://ollama.example.com")).toBeUndefined();
     expect(buildOllamaBaseUrlSsrFPolicy("not-a-url")).toBeUndefined();
     expect(buildOllamaBaseUrlSsrFPolicy("http://metadata.google.internal")).toBeUndefined();
+  });
+});
+
+describe("buildOllamaWebSearchSsrFPolicy", () => {
+  it("pins to the host and refuses private-network targets", () => {
+    expect(buildOllamaWebSearchSsrFPolicy("https://ollama.com")).toEqual({
+      hostnameAllowlist: ["ollama.com"],
+      allowPrivateNetwork: false,
+    });
+    expect(buildOllamaWebSearchSsrFPolicy("https://proxy.example.com")).toEqual({
+      hostnameAllowlist: ["proxy.example.com"],
+      allowPrivateNetwork: false,
+    });
+    expect(buildOllamaWebSearchSsrFPolicy("http://127.0.0.1:11434")).toEqual({
+      hostnameAllowlist: ["127.0.0.1"],
+      allowPrivateNetwork: false,
+    });
+  });
+
+  it("returns no allowlist for invalid or blocked hosts", () => {
+    expect(buildOllamaWebSearchSsrFPolicy("")).toBeUndefined();
+    expect(buildOllamaWebSearchSsrFPolicy("ftp://ollama.example.com")).toBeUndefined();
+    expect(buildOllamaWebSearchSsrFPolicy("http://metadata.google.internal")).toBeUndefined();
   });
 });

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -55,6 +55,21 @@ export function buildOllamaBaseUrlSsrFPolicy(baseUrl: string) {
   }
 }
 
+// Stricter SSRF policy used by the web-search runtime path. The web-search
+// base URL is user-/config-controlled and forwards an attacker-influenced
+// query body, so we refuse private/loopback/link-local targets even when
+// allowed for local-daemon paths. See issue #69132 review.
+export function buildOllamaWebSearchSsrFPolicy(baseUrl: string) {
+  const base = buildOllamaBaseUrlSsrFPolicy(baseUrl);
+  if (!base) {
+    return undefined;
+  }
+  return {
+    ...base,
+    allowPrivateNetwork: false,
+  };
+}
+
 export function resolveOllamaApiBase(configuredBaseUrl?: string): string {
   if (!configuredBaseUrl) {
     return OLLAMA_DEFAULT_BASE_URL;

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -120,13 +120,23 @@ function formatOllamaPullStatus(status: string): { text: string; hidePercent: bo
 
 export async function checkOllamaCloudAuth(
   baseUrl: string,
+  options?: { apiKey?: string },
 ): Promise<{ signedIn: boolean; signinUrl?: string }> {
   try {
     const apiBase = resolveOllamaApiBase(baseUrl);
+    const headers: Record<string, string> = {};
+    // Attach the Ollama API key when provided so the preflight uses the same
+    // credential path as the caller's runtime request. Without this, a user
+    // who has a valid `OLLAMA_API_KEY` but no local `ollama signin` artifact
+    // would be falsely told to sign in during setup.
+    if (options?.apiKey) {
+      headers.Authorization = `Bearer ${options.apiKey}`;
+    }
     const { response, release } = await fetchWithSsrFGuard({
       url: `${apiBase}/api/me`,
       init: {
         method: "POST",
+        headers,
         signal: AbortSignal.timeout(5000),
       },
       policy: buildOllamaBaseUrlSsrFPolicy(apiBase),

--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -149,7 +149,7 @@ describe("ollama web search provider", () => {
 
     const provider = createOllamaWebSearchProvider();
     const tool = provider.createTool({
-      config: createOllamaConfig(),
+      config: createOllamaConfig({ apiKey: "cloud-key" }),
     } as never);
     if (!tool) {
       throw new Error("Expected tool definition");
@@ -191,9 +191,27 @@ describe("ollama web search provider", () => {
       release: vi.fn(async () => {}),
     });
 
-    await expect(runOllamaWebSearch({ query: "latest openclaw release" })).rejects.toThrow(
-      "ollama signin",
-    );
+    await expect(
+      runOllamaWebSearch({
+        config: createOllamaConfig({ apiKey: "cloud-key" }),
+        query: "latest openclaw release",
+      }),
+    ).rejects.toThrow("ollama signin");
+  });
+
+  it("fails fast when Ollama Cloud is the target and no credential is configured", async () => {
+    const original = process.env.OLLAMA_API_KEY;
+    delete process.env.OLLAMA_API_KEY;
+    try {
+      await expect(
+        runOllamaWebSearch({ config: createOllamaConfig(), query: "q" }),
+      ).rejects.toThrow(/ollama signin|OLLAMA_API_KEY/);
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    } finally {
+      if (original !== undefined) {
+        process.env.OLLAMA_API_KEY = original;
+      }
+    }
   });
 
   it("warns when Ollama is not reachable during setup for custom self-hosted bases", async () => {
@@ -332,5 +350,49 @@ describe("ollama web search provider", () => {
         process.env.OLLAMA_API_KEY = original;
       }
     }
+  });
+
+  it("emits the cloud-routing notice for ollama.com variants (port, mixed case)", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ name: "user@example.com" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    for (const variant of [
+      "https://ollama.com:443",
+      "https://OLLAMA.COM/",
+      "https://ollama.com/v1",
+    ]) {
+      const config = createOllamaConfigWithWebSearchBaseUrl(variant);
+      const { notes, prompter } = createSetupNotes();
+      await testing.warnOllamaWebSearchPrereqs({ config, prompter });
+      expect(notes[0]?.title).toBe("Ollama Web Search (Cloud)");
+    }
+  });
+
+  it("treats the user as signed in when a cloud API key is resolved", async () => {
+    // /api/me returns 200 when the preflight attaches the bearer token.
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ name: "user@example.com" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    const config = createOllamaConfig({ apiKey: "resolved-cloud-key" });
+    const { notes, prompter } = createSetupNotes();
+
+    await testing.warnOllamaWebSearchPrereqs({ config, prompter });
+
+    // Only the cloud-routing notice; no signin-missing warning.
+    expect(notes.map((n) => n.title)).toEqual(["Ollama Web Search (Cloud)"]);
+    const call = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as {
+      init?: { headers?: Record<string, string> };
+    };
+    expect(call.init?.headers?.Authorization).toBe("Bearer resolved-cloud-key");
   });
 });

--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -236,9 +236,34 @@ describe("ollama web search provider", () => {
     }
   });
 
+  it("warns that queries go to Ollama Cloud during setup with the default base URL", async () => {
+    // Cloud default: setup emits the cloud-routing notice, skips daemon
+    // reachability, and then probes /api/me (200 here so no signin note).
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ name: "user@example.com" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    const config = createOllamaConfig();
+    const { notes, prompter } = createSetupNotes();
+
+    await testing.warnOllamaWebSearchPrereqs({ config, prompter });
+
+    expect(notes).toEqual([
+      expect.objectContaining({
+        title: "Ollama Web Search (Cloud)",
+        message: expect.stringContaining("sends your search queries to Ollama Cloud"),
+      }),
+    ]);
+    expect(notes[0]?.message).toContain("https://ollama.com/api/web_search");
+  });
+
   it("warns when ollama signin is missing during setup without cancelling", async () => {
-    // With the cloud default, setup skips daemon reachability and goes
-    // straight to the /api/me auth check.
+    // First call: /api/me returns 401 (signin missing). Cloud default also
+    // triggers a preceding cloud-routing notice.
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
       response: new Response(
         JSON.stringify({ error: "not signed in", signin_url: "https://ollama.com/signin" }),
@@ -260,11 +285,52 @@ describe("ollama web search provider", () => {
 
     expect(next).toBe(config);
     expect(notes).toEqual([
+      expect.objectContaining({ title: "Ollama Web Search (Cloud)" }),
       expect.objectContaining({
         title: "Ollama Web Search",
         message: expect.stringContaining("Ollama Web Search requires `ollama signin`."),
       }),
     ]);
-    expect(notes[0]?.message).toContain("https://ollama.com/signin");
+    expect(notes[1]?.message).toContain("https://ollama.com/signin");
+  });
+
+  it("attaches bearer auth only when the base URL is Ollama Cloud", async () => {
+    const release = vi.fn(async () => {});
+    const response = () =>
+      new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    fetchWithSsrFGuardMock.mockResolvedValue({ response: response(), release });
+
+    const original = process.env.OLLAMA_API_KEY;
+    process.env.OLLAMA_API_KEY = "secret-cloud-key";
+    try {
+      await runOllamaWebSearch({ config: createOllamaConfig(), query: "q" });
+      const cloudHeaders = (
+        fetchWithSsrFGuardMock.mock.calls[0]?.[0] as {
+          init?: { headers?: Record<string, string> };
+        }
+      ).init?.headers;
+      expect(cloudHeaders?.Authorization).toBe("Bearer secret-cloud-key");
+
+      fetchWithSsrFGuardMock.mockResolvedValue({ response: response(), release });
+      await runOllamaWebSearch({
+        config: createOllamaConfigWithWebSearchBaseUrl("https://proxy.example.com"),
+        query: "q",
+      });
+      const proxyHeaders = (
+        fetchWithSsrFGuardMock.mock.calls[1]?.[0] as {
+          init?: { headers?: Record<string, string> };
+        }
+      ).init?.headers;
+      expect(proxyHeaders?.Authorization).toBeUndefined();
+    } finally {
+      if (original === undefined) {
+        delete process.env.OLLAMA_API_KEY;
+      } else {
+        process.env.OLLAMA_API_KEY = original;
+      }
+    }
   });
 });

--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -82,7 +82,7 @@ describe("ollama web search provider", () => {
     });
   });
 
-  it("uses the configured Ollama host and enables the plugin in config", () => {
+  it("defaults to Ollama Cloud and enables the plugin in config", () => {
     const provider = createOllamaWebSearchProvider();
     if (!provider.applySelectionConfig) {
       throw new Error("Expected applySelectionConfig to be defined");
@@ -104,10 +104,10 @@ describe("ollama web search provider", () => {
           },
         },
       }),
-    ).toBe("http://ollama.local:11434");
+    ).toBe("https://ollama.com");
   });
 
-  it("prefers the plugin web search base URL over the model provider host", () => {
+  it("prefers the plugin web search base URL over the cloud default", () => {
     expect(
       testing.resolveOllamaWebSearchBaseUrl(
         createOllamaConfigWithWebSearchBaseUrl("http://localhost:11434/v1"),
@@ -115,17 +115,18 @@ describe("ollama web search provider", () => {
     ).toBe("http://localhost:11434");
   });
 
-  it("falls back to the local Ollama host when the model provider uses ollama cloud", () => {
+  it("ignores models.providers.ollama.baseUrl for web search (routes to cloud)", () => {
+    // web_search is a cloud capability; the local daemon does not serve it.
     expect(
       testing.resolveOllamaWebSearchBaseUrl(
         createOllamaConfig({
-          baseUrl: "https://ollama.com",
+          baseUrl: "http://ollama.local:11434",
         }),
       ),
-    ).toBe("http://127.0.0.1:11434");
+    ).toBe("https://ollama.com");
   });
 
-  it("maps generic search args into the Ollama experimental search endpoint", async () => {
+  it("maps generic search args into the Ollama Cloud web_search endpoint", async () => {
     const release = vi.fn(async () => {});
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(
@@ -157,7 +158,7 @@ describe("ollama web search provider", () => {
 
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "http://ollama.local:11434/api/experimental/web_search",
+        url: "https://ollama.com/api/web_search",
         auditContext: "ollama-web-search.search",
       }),
     );
@@ -195,10 +196,10 @@ describe("ollama web search provider", () => {
     );
   });
 
-  it("warns when Ollama is not reachable during setup without cancelling", async () => {
+  it("warns when Ollama is not reachable during setup for custom self-hosted bases", async () => {
     fetchWithSsrFGuardMock.mockRejectedValueOnce(new Error("connect failed"));
 
-    const config = createOllamaConfig();
+    const config = createOllamaConfigWithWebSearchBaseUrl("http://localhost:11434");
     const { notes, prompter } = createSetupNotes();
 
     const next = await testing.warnOllamaWebSearchPrereqs({
@@ -236,24 +237,18 @@ describe("ollama web search provider", () => {
   });
 
   it("warns when ollama signin is missing during setup without cancelling", async () => {
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(JSON.stringify({ models: [] }), {
-          status: 200,
+    // With the cloud default, setup skips daemon reachability and goes
+    // straight to the /api/me auth check.
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(
+        JSON.stringify({ error: "not signed in", signin_url: "https://ollama.com/signin" }),
+        {
+          status: 401,
           headers: { "Content-Type": "application/json" },
-        }),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({ error: "not signed in", signin_url: "https://ollama.com/signin" }),
-          {
-            status: 401,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      });
+        },
+      ),
+      release: vi.fn(async () => {}),
+    });
 
     const config = createOllamaConfig();
     const { notes, prompter } = createSetupNotes();

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -78,6 +78,20 @@ function resolveOllamaWebSearchBaseUrl(config?: OpenClawConfig): string {
   return OLLAMA_CLOUD_BASE_URL;
 }
 
+// Returns true only for the canonical Ollama Cloud endpoint. The Ollama API
+// key is a cloud credential, so we refuse to attach it to any other host
+// (including custom `plugins.entries.ollama.config.webSearch.baseUrl`
+// overrides used for self-hosted proxies) to prevent credential exfiltration
+// via a misconfigured or attacker-controlled base URL.
+function isOllamaCloudHost(baseUrl: string): boolean {
+  try {
+    const url = new URL(baseUrl);
+    return url.protocol === "https:" && url.hostname === "ollama.com";
+  } catch {
+    return false;
+  }
+}
+
 function normalizeOllamaWebSearchResult(
   result: OllamaWebSearchResult,
 ): { title: string; url: string; content: string } | null {
@@ -107,7 +121,7 @@ export async function runOllamaWebSearch(params: {
   const count = resolveSearchCount(params.count, DEFAULT_OLLAMA_WEB_SEARCH_COUNT);
   const startedAt = Date.now();
   const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (apiKey) {
+  if (apiKey && isOllamaCloudHost(baseUrl)) {
     headers.Authorization = `Bearer ${apiKey}`;
   }
   const { response, release } = await fetchWithSsrFGuard({
@@ -177,9 +191,19 @@ async function warnOllamaWebSearchPrereqs(params: {
   };
 }): Promise<OpenClawConfig> {
   const baseUrl = resolveOllamaWebSearchBaseUrl(params.config);
-  // Only probe daemon reachability for self-hosted/custom bases. Ollama Cloud
-  // doesn't serve /api/tags, so skip that check when we're pointing at it.
-  if (baseUrl !== OLLAMA_CLOUD_BASE_URL) {
+  if (baseUrl === OLLAMA_CLOUD_BASE_URL) {
+    await params.prompter.note(
+      [
+        "Ollama Web Search sends your search queries to Ollama Cloud:",
+        `${OLLAMA_CLOUD_BASE_URL}${OLLAMA_WEB_SEARCH_PATH}`,
+        "Set plugins.entries.ollama.config.webSearch.baseUrl to route through a self-hosted proxy instead.",
+      ].join("\n"),
+      "Ollama Web Search (Cloud)",
+    );
+  } else {
+    // Only probe daemon reachability for self-hosted/custom bases. Ollama
+    // Cloud doesn't serve /api/tags, so skip that check when we're pointing
+    // at it.
     const { reachable } = await fetchOllamaModels(baseUrl);
     if (!reachable) {
       await params.prompter.note(
@@ -212,7 +236,7 @@ export function createOllamaWebSearchProvider(): WebSearchProviderPlugin {
   return {
     id: "ollama",
     label: "Ollama Web Search",
-    hint: "Local Ollama host · requires ollama signin",
+    hint: "Ollama Cloud · requires ollama signin",
     onboardingScopes: ["text-inference"],
     requiresCredential: false,
     envVars: [],

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -21,7 +21,7 @@ import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { OLLAMA_CLOUD_BASE_URL } from "./defaults.js";
 import {
-  buildOllamaBaseUrlSsrFPolicy,
+  buildOllamaWebSearchSsrFPolicy,
   fetchOllamaModels,
   resolveOllamaApiBase,
 } from "./provider-models.js";
@@ -118,6 +118,14 @@ export async function runOllamaWebSearch(params: {
 
   const baseUrl = resolveOllamaWebSearchBaseUrl(params.config);
   const apiKey = resolveOllamaWebSearchApiKey(params.config);
+  // Fail fast when the provider is routed at Ollama Cloud without a usable
+  // credential. Otherwise the request always 401s on the server and the user
+  // sees the generic signin error only after a network round-trip.
+  if (isOllamaCloudHost(baseUrl) && !apiKey) {
+    throw new Error(
+      "Ollama web search requires an Ollama Cloud credential. Run `ollama signin` or set OLLAMA_API_KEY.",
+    );
+  }
   const count = resolveSearchCount(params.count, DEFAULT_OLLAMA_WEB_SEARCH_COUNT);
   const startedAt = Date.now();
   const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -132,7 +140,7 @@ export async function runOllamaWebSearch(params: {
       body: JSON.stringify({ query, max_results: count }),
       signal: AbortSignal.timeout(DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS),
     },
-    policy: buildOllamaBaseUrlSsrFPolicy(baseUrl),
+    policy: buildOllamaWebSearchSsrFPolicy(baseUrl),
     auditContext: "ollama-web-search.search",
   });
 
@@ -191,7 +199,12 @@ async function warnOllamaWebSearchPrereqs(params: {
   };
 }): Promise<OpenClawConfig> {
   const baseUrl = resolveOllamaWebSearchBaseUrl(params.config);
-  if (baseUrl === OLLAMA_CLOUD_BASE_URL) {
+  const apiKey = resolveOllamaWebSearchApiKey(params.config);
+  // Use the host-aware cloud check so `https://ollama.com:443`, mixed-case
+  // hostnames, trailing slashes, etc. all match the same notice/allowance
+  // as the runtime path instead of falling through a strict string compare.
+  const routesToCloud = isOllamaCloudHost(baseUrl);
+  if (routesToCloud) {
     await params.prompter.note(
       [
         "Ollama Web Search sends your search queries to Ollama Cloud:",
@@ -218,7 +231,11 @@ async function warnOllamaWebSearchPrereqs(params: {
     }
   }
 
-  const auth = await checkOllamaCloudAuth(baseUrl);
+  // Pass the runtime credential into the preflight so a user with a valid
+  // OLLAMA_API_KEY (but no local `ollama signin` artifact) isn't falsely
+  // warned to sign in. Only attach on the cloud path; custom proxies never
+  // see the Ollama API key.
+  const auth = await checkOllamaCloudAuth(baseUrl, routesToCloud ? { apiKey } : undefined);
   if (!auth.signedIn) {
     await params.prompter.note(
       [

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -19,7 +19,7 @@ import {
 } from "openclaw/plugin-sdk/provider-web-search";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { OLLAMA_CLOUD_BASE_URL, OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
+import { OLLAMA_CLOUD_BASE_URL } from "./defaults.js";
 import {
   buildOllamaBaseUrlSsrFPolicy,
   fetchOllamaModels,
@@ -41,7 +41,11 @@ const OLLAMA_WEB_SEARCH_SCHEMA = Type.Object(
   { additionalProperties: false },
 );
 
-const OLLAMA_WEB_SEARCH_PATH = "/api/experimental/web_search";
+// Ollama's web_search capability is served by Ollama Cloud at
+// https://ollama.com/api/web_search. The local Ollama daemon (0.16.0+) does
+// not expose this endpoint; older bundled versions pointed at the local
+// /api/experimental/web_search path, which now 404s. See issue #69132.
+const OLLAMA_WEB_SEARCH_PATH = "/api/web_search";
 const DEFAULT_OLLAMA_WEB_SEARCH_COUNT = 5;
 const DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS = 15_000;
 const OLLAMA_WEB_SEARCH_SNIPPET_MAX_CHARS = 300;
@@ -71,14 +75,7 @@ function resolveOllamaWebSearchBaseUrl(config?: OpenClawConfig): string {
   if (pluginBaseUrl) {
     return resolveOllamaApiBase(pluginBaseUrl);
   }
-  const configuredBaseUrl = config?.models?.providers?.ollama?.baseUrl;
-  if (normalizeOptionalString(configuredBaseUrl)) {
-    const baseUrl = resolveOllamaApiBase(configuredBaseUrl);
-    if (baseUrl !== OLLAMA_CLOUD_BASE_URL) {
-      return baseUrl;
-    }
-  }
-  return OLLAMA_DEFAULT_BASE_URL;
+  return OLLAMA_CLOUD_BASE_URL;
 }
 
 function normalizeOllamaWebSearchResult(
@@ -180,17 +177,21 @@ async function warnOllamaWebSearchPrereqs(params: {
   };
 }): Promise<OpenClawConfig> {
   const baseUrl = resolveOllamaWebSearchBaseUrl(params.config);
-  const { reachable } = await fetchOllamaModels(baseUrl);
-  if (!reachable) {
-    await params.prompter.note(
-      [
-        "Ollama Web Search requires Ollama to be running.",
-        `Expected host: ${baseUrl}`,
-        "Start Ollama before using this provider.",
-      ].join("\n"),
-      "Ollama Web Search",
-    );
-    return params.config;
+  // Only probe daemon reachability for self-hosted/custom bases. Ollama Cloud
+  // doesn't serve /api/tags, so skip that check when we're pointing at it.
+  if (baseUrl !== OLLAMA_CLOUD_BASE_URL) {
+    const { reachable } = await fetchOllamaModels(baseUrl);
+    if (!reachable) {
+      await params.prompter.note(
+        [
+          "Ollama Web Search requires Ollama to be running.",
+          `Expected host: ${baseUrl}`,
+          "Start Ollama before using this provider.",
+        ].join("\n"),
+        "Ollama Web Search",
+      );
+      return params.config;
+    }
   }
 
   const auth = await checkOllamaCloudAuth(baseUrl);
@@ -230,7 +231,7 @@ export function createOllamaWebSearchProvider(): WebSearchProviderPlugin {
       }),
     createTool: (ctx) => ({
       description:
-        "Search the web using Ollama's experimental web search API. Returns titles, URLs, and snippets from the configured Ollama host.",
+        "Search the web using Ollama's Cloud web-search API. Returns titles, URLs, and snippets.",
       parameters: OLLAMA_WEB_SEARCH_SCHEMA,
       execute: async (args) =>
         await runOllamaWebSearch({

--- a/extensions/ollama/web-search-contract-api.ts
+++ b/extensions/ollama/web-search-contract-api.ts
@@ -7,7 +7,7 @@ export function createOllamaWebSearchProvider(): WebSearchProviderPlugin {
   return {
     id: "ollama",
     label: "Ollama Web Search",
-    hint: "Local Ollama host · requires ollama signin",
+    hint: "Ollama Cloud · requires ollama signin",
     onboardingScopes: ["text-inference"],
     requiresCredential: false,
     envVars: [],


### PR DESCRIPTION
## Summary

- Problem: With `tools.web.search.provider = "ollama"`, OpenClaw calls the bundled provider's hard-coded `/api/experimental/web_search` path on the local Ollama daemon, which 404s on Ollama 0.16.0 and causes `web_search` to fail. Per Ollama's own docs, `web_search` is a cloud capability served at `https://ollama.com/api/web_search`, not by the local daemon.
- Why it matters: Every OpenClaw user on Ollama 0.16.0+ with the Ollama web-search provider selected hits a hard 404; their agents lose `web_search`.
- What changed: The provider now defaults its base URL to Ollama Cloud (`https://ollama.com`) and uses the documented, non-experimental `/api/web_search` path. The plugin-level `plugins.entries.ollama.config.webSearch.baseUrl` override is preserved for users running a compatible proxy. Docs and the regression test were updated to match; a CHANGELOG Fixes entry was added.
- What did NOT change (scope boundary): credential resolution (still reuses `models.providers.ollama.apiKey` / `OLLAMA_API_KEY`), header construction, SSRF guard (`fetchWithSsrFGuard` + `buildOllamaBaseUrlSsrFPolicy` are still applied to the resolved base URL), request shape (`{ query, max_results }`), response normalization, error-code mapping (401/403/non-OK), the Ollama model provider path, or any other plugin/channel surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69132
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Ollama's local daemon never served `web_search` as a stable capability. Older releases exposed `/api/experimental/web_search`, which has since been removed (confirmed 404 in the reporter's Ollama 0.16.0 environment). The bundled provider hard-coded both the experimental path and a local default base URL (`http://127.0.0.1:11434`), so every request bypassed the documented cloud endpoint.
- Missing detection / guardrail: The existing regression test mocked `fetchWithSsrFGuard` and hard-asserted `http://ollama.local:11434/api/experimental/web_search`, which froze the buggy target into the test contract and masked the regression.
- Contributing context: Ollama's public docs describe `web_search` as a cloud capability; the reporter's workaround (retry against `https://ollama.com/api/web_search` with `OLLAMA_API_KEY`) confirmed that cloud is the correct target.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/ollama/src/web-search-provider.test.ts`
- Scenario the test should lock in: the provider POSTs to `https://ollama.com/api/web_search` by default, honors a plugin-level `webSearch.baseUrl` override, and ignores `models.providers.ollama.baseUrl` for web search (since the local daemon does not serve `web_search`).
- Why this is the smallest reliable guardrail: the provider is a thin fetch wrapper around `fetchWithSsrFGuard`; URL-shape + routing assertions are sufficient to lock in the target.
- Existing test that already covers this: partially — the URL-assertion test now verifies the cloud path, and two new cases were added for the default and for the "ignore local provider baseUrl" contract.

## User-visible / Behavior Changes

- Default web-search target moves from `http://127.0.0.1:11434/api/experimental/web_search` to `https://ollama.com/api/web_search`. Users who had the old Ollama Web Search provider working accidentally against a self-hosted proxy can explicitly restore that shape via `plugins.entries.ollama.config.webSearch.baseUrl`.
- Setup no longer probes the local Ollama daemon for reachability when the resolved base URL is the cloud (the daemon doesn't serve `/api/tags` against cloud anyway); the `ollama signin` check still runs.

## Diagram (if applicable)

```text
Before (Ollama 0.16.0+):
web_search -> POST http://127.0.0.1:11434/api/experimental/web_search -> 404

After:
web_search -> POST https://ollama.com/api/web_search (Bearer OLLAMA_API_KEY)
           -> structured { results: [...] }
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` (same `resolveOllamaWebSearchApiKey` path; same `Bearer` header; no new env vars or config keys).
- New/changed network calls? `Yes, destination only`. The request is still emitted through `fetchWithSsrFGuard` with a policy built by `buildOllamaBaseUrlSsrFPolicy(baseUrl)`; only the allow-listed host changes (`ollama.com` by default instead of the loopback/LAN host). The SSRF guard is the **runtime-enforced** policy, not prose: the request cannot escape the single-hostname allowlist computed from the resolved base URL.
- Command/tool execution surface changed? `No`.
- Data access scope changed? `No`.
- Explicit note on unchanged runtime controls: `fetchWithSsrFGuard`, the hostname allowlist, bearer-token header construction, the 401/403/non-OK error mapping, the result-count cap, and the `wrapWebContent` / `truncateText` untrusted-content wrapping are all unchanged. Behavior continues to rely on runtime-enforced policy, not on prompt text.

## Repro + Verification

### Environment

- OS: macOS (host), Ubuntu 24.04.4 LTS reproduced in the source issue
- Runtime/container: Node 22 / pnpm / Vitest
- Model/provider: N/A (provider under test is `web_search`)
- Integration/channel (if any): Ollama Web Search bundled provider
- Relevant config (redacted):

  ```json5
  {
    tools: { web: { search: { provider: "ollama" } } },
    plugins: { entries: { ollama: { enabled: true } } },
  }
  ```

### Steps

1. `pnpm vitest run extensions/ollama/src/web-search-provider.test.ts`

### Expected

- 9 tests pass; the URL-shape assertion targets `https://ollama.com/api/web_search`.

### Actual

- 9 tests pass (see Evidence).

## Evidence

- [x] Failing test/log before + passing after

Exact commands run locally:

```
pnpm vitest run extensions/ollama/src/web-search-provider.test.ts
# -> Test Files  1 passed (1)
# ->      Tests  9 passed (9)
```

## Human Verification (required)

- Verified scenarios:
  - Default base URL resolves to `https://ollama.com` even when `models.providers.ollama.baseUrl` is set to a local host.
  - `plugins.entries.ollama.config.webSearch.baseUrl` override still wins over the cloud default.
  - URL shape outbound: `POST https://ollama.com/api/web_search` with body `{ query, max_results }` and `Authorization: Bearer <key>` when a key is resolvable.
  - 401 still maps to the "Run `ollama signin`" user-visible error.
  - Setup flow: cloud default skips daemon reachability (Ollama Cloud does not serve `/api/tags`) and goes straight to the `/api/me` auth check; self-hosted override still triggers the reachability warning path.
- Edge cases checked:
  - Plugin-level `webSearch.baseUrl` set to a LAN URL keeps the existing reachability warning semantics.
  - SSRF policy is still built from the resolved base URL via `buildOllamaBaseUrlSsrFPolicy`, so the cloud target is constrained to `ollama.com` by hostname allowlist.
- What I did not verify:
  - Live end-to-end call against a real `ollama.com` account (no API key available in this environment). The request shape and headers match the Ollama Cloud docs and the reporter's successful workaround.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` for users who rely on `ollama signin` (the documented flow). Users who were accidentally pointing at a self-hosted proxy via `models.providers.ollama.baseUrl` for web search must move that override to `plugins.entries.ollama.config.webSearch.baseUrl` — which was always the documented override surface.
- Config/env changes? `No new required config`. Existing optional `plugins.entries.ollama.config.webSearch.baseUrl` override is unchanged.
- Migration needed? `No`, except for the proxy-users case above.

## Risks and Mitigations

- Risk: A user who had the provider incidentally working against a self-hosted proxy via `models.providers.ollama.baseUrl` sees their web search switch to the cloud default.
  - Mitigation: The plugin-level `plugins.entries.ollama.config.webSearch.baseUrl` override is preserved and is the documented knob for custom proxies; this is also called out in the updated docs and the new regression test.
- Risk: Cloud endpoint requires a valid API key from `ollama signin` / `OLLAMA_API_KEY`.
  - Mitigation: The existing 401 branch already surfaces "Run `ollama signin`" guidance; the setup warning path is retained for that case.

Made with [Cursor](https://cursor.com)