### PR TITLE
fix: merge models on provider onboarding instead of replacing

### DIFF
--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -390,6 +390,8 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       fallbacks: ["claude-cli/claude-opus-4-6", "openai/gpt-5.2"],
     });
     expect(result.config.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+      "anthropic/claude-opus-4-6": { alias: "Opus" },
       "claude-cli/claude-sonnet-4-6": { alias: "Sonnet" },
       "claude-cli/claude-opus-4-6": { alias: "Opus" },
       "openai/gpt-5.2": {},

--- a/src/plugins/provider-auth-choice-helpers.test.ts
+++ b/src/plugins/provider-auth-choice-helpers.test.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { applyProviderAuthConfigPatch } from "./provider-auth-choice-helpers.js";
 
 describe("applyProviderAuthConfigPatch", () => {
-  it("replaces patched default model maps instead of recursively merging them", () => {
+  it("merges patched default model maps with existing models", () => {
     const base = {
       agents: {
         defaults: {
@@ -25,7 +25,6 @@ describe("applyProviderAuthConfigPatch", () => {
           models: {
             "claude-cli/claude-sonnet-4-6": { alias: "Sonnet" },
             "claude-cli/claude-opus-4-6": { alias: "Opus" },
-            "openai/gpt-5.2": {},
           },
         },
       },
@@ -33,8 +32,73 @@ describe("applyProviderAuthConfigPatch", () => {
 
     const next = applyProviderAuthConfigPatch(base, patch);
 
-    expect(next.agents?.defaults?.models).toEqual(patch.agents.defaults.models);
+    expect(next.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+      "anthropic/claude-opus-4-6": { alias: "Opus" },
+      "openai/gpt-5.2": {},
+      "claude-cli/claude-sonnet-4-6": { alias: "Sonnet" },
+      "claude-cli/claude-opus-4-6": { alias: "Opus" },
+    });
     expect(next.agents?.defaults?.model).toEqual(base.agents?.defaults?.model);
+  });
+
+  it("merges models from a second provider without losing the first provider's models", () => {
+    const afterFirstProvider = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+            "anthropic/claude-opus-4-6": { alias: "Opus" },
+          },
+        },
+      },
+    };
+    const secondProviderPatch = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.4": { alias: "GPT-5.4" },
+            "openai/gpt-5.2": {},
+          },
+        },
+      },
+    };
+
+    const next = applyProviderAuthConfigPatch(afterFirstProvider, secondProviderPatch);
+
+    expect(next.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+      "anthropic/claude-opus-4-6": { alias: "Opus" },
+      "openai/gpt-5.4": { alias: "GPT-5.4" },
+      "openai/gpt-5.2": {},
+    });
+  });
+
+  it("lets patch override existing model entry when keys collide", () => {
+    const base = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.2": { alias: "Old" },
+          },
+        },
+      },
+    };
+    const patch = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.2": { alias: "New" },
+          },
+        },
+      },
+    };
+
+    const next = applyProviderAuthConfigPatch(base, patch);
+
+    expect(next.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.2": { alias: "New" },
+    });
   });
 
   it("keeps normal recursive merges for unrelated provider auth patch fields", () => {

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -81,10 +81,12 @@ export function applyProviderAuthConfigPatch(cfg: OpenClawConfig, patch: unknown
       ...merged.agents,
       defaults: {
         ...merged.agents?.defaults,
-        // Provider auth migrations can intentionally replace the exact allowlist.
-        models: patchModels as NonNullable<
-          NonNullable<OpenClawConfig["agents"]>["defaults"]
-        >["models"],
+        // Merge new provider models with existing ones so multi-provider
+        // onboarding accumulates rather than replacing the allowlist.
+        models: {
+          ...merged.agents?.defaults?.models,
+          ...patchModels,
+        } as NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["models"],
       },
     },
   };


### PR DESCRIPTION
Fixes #69160

When onboarding a second provider, `applyProviderAuthConfigPatch` was replacing `agents.defaults.models` entirely with the new provider's models instead of merging them.

**Change:** In `src/plugins/provider-auth-choice-helpers.ts`, spread existing models before patch models so both providers' models are preserved. Duplicate model IDs take the newer value.

**Tests added:**
- Merges patched models with existing ones
- Second provider accumulates models from both providers
- Colliding model keys use the patch value