### PR TITLE
fix(agent): document that sessions_spawn streamTo is ACP-only

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -387,6 +387,19 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
+  it('documents that streamTo requires runtime="acp"', () => {
+    const tool = createSessionsSpawnTool();
+    const schema = tool.parameters as {
+      properties?: {
+        streamTo?: {
+          description?: string;
+        };
+      };
+    };
+
+    expect(schema.properties?.streamTo?.description).toContain('runtime="acp"');
+  });
+
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {
     const tool = createSessionsSpawnTool();
     const schema = tool.parameters as {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -114,7 +114,10 @@ const SessionsSpawnToolSchema = Type.Object({
   mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
   sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
-  streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS),
+  streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS, {
+    description:
+      'Stream child output to parent turn-by-turn. Requires runtime="acp"; omit for runtime="subagent".',
+  }),
   lightContext: Type.Optional(
     Type.Boolean({
       description:


### PR DESCRIPTION
## Summary
- document that `sessions_spawn.streamTo` requires `runtime="acp"`
- stop subagent callers from guessing `streamTo: "parent"` and paying for a guaranteed retry
- add a schema regression test for the runtime hint

## Testing
- `corepack pnpm exec vitest run src/agents/tools/sessions-spawn-tool.test.ts -t 'documents that streamTo requires runtime="acp"|rejects streamTo when runtime is not "acp"'`

Closes #69166
