### PR TITLE
test(agents,gateway): fix two main-baseline test breakages from #68726 and #65986

### DIFF
--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -563,7 +563,13 @@ describe("subagent registry steer restarts", () => {
     expect(mod.isSubagentSessionRunActive(childSessionKey)).toBe(false);
 
     const run = listMainRuns()[0];
-    expect(run?.outcome).toEqual({ status: "error", error: "manual kill" });
+    expect(run?.outcome).toEqual({
+      status: "error",
+      error: "manual kill",
+      startedAt: expect.any(Number),
+      endedAt: expect.any(Number),
+      elapsedMs: expect.any(Number),
+    });
     expect(run?.cleanupHandled).toBe(true);
     expect(typeof run?.cleanupCompletedAt).toBe("number");
     await flushAnnounce();

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -590,6 +590,9 @@ describe("gateway server sessions", () => {
 
   test("sessions.create can start the first agent turn from an initial task", async () => {
     await createSessionStoreDir();
+    // Register "ops" so the deleted-agent guard added in #65986 does not
+    // reject the auto-started chat.send triggered by `task:`.
+    testState.agentsConfig = { list: [{ id: "ops", default: true }] };
     const { ws } = await openClient();
 
     const created = await rpcReq<{


### PR DESCRIPTION
## Summary

Unblocks the two baseline failures currently red on main.

### 1. `checks-node-agentic-agents-plugins` — broken by #68726
File: `src/agents/subagent-registry.steer-restart.test.ts:566`

#68726 added `startedAt`/`endedAt`/`elapsedMs` to subagent run outcomes but missed updating this test's `toEqual`. Fixed by adding the timing fields using the same `expect.any(Number)` matcher already used a few lines below.

### 2. `checks-node-agentic-control-plane` — broken by #65986
File: `src/gateway/server.sessions.gateway-server-sessions-a.test.ts:591` ("sessions.create can start the first agent turn from an initial task")

#65986 added a deleted-agent guard to `chat.send`. This test calls `sessions.create` with `agentId: "ops"` and `task: "hello from create"` which auto-triggers `chat.send`, but the test never registered `ops` via `testState.agentsConfig`, so the new guard treated it as deleted and rejected the send. `runStarted` came back `false` instead of `true`.

Fixed by registering `ops` using the same `testState.agentsConfig = { list: [{ id: "ops", default: true }] }` pattern the file uses at lines 2129/2162/2211.

## Test plan

- [x] `pnpm test src/agents/subagent-registry.steer-restart.test.ts` — 15 passed
- [x] `pnpm test src/gateway/server.sessions.gateway-server-sessions-a.test.ts` — 51 passed
- [ ] CI `checks-node-agentic-agents-plugins` and `checks-node-agentic-control-plane` both green