### PR TITLE
fix: merge provider models instead of replacing on OAuth onboarding

### DIFF
--- a/extensions/openrouter/onboard.test.ts
+++ b/extensions/openrouter/onboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   expectProviderOnboardAllowlistAlias,
   expectProviderOnboardPrimaryAndFallbacks,
@@ -23,5 +23,13 @@ describe("openrouter onboard", () => {
       applyConfig: applyOpenrouterConfig,
       modelRef: OPENROUTER_DEFAULT_MODEL_REF,
     });
+  });
+
+  it("sets provider config with correct baseUrl", () => {
+    const cfg = applyOpenrouterConfig({});
+    expect(cfg.models?.providers?.openrouter?.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(cfg.models?.providers?.openrouter?.api).toBe("openai-completions");
+    expect(cfg.models?.providers?.openrouter?.models).toBeDefined();
+    expect(cfg.models?.providers?.openrouter?.models?.length).toBeGreaterThan(0);
   });
 });

--- a/extensions/openrouter/onboard.ts
+++ b/extensions/openrouter/onboard.ts
@@ -1,7 +1,9 @@
 import {
   applyAgentDefaultModelPrimary,
+  applyProviderConfigWithDefaultModelsPreset,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
+import { buildOpenrouterProvider, OPENROUTER_BASE_URL } from "./provider-catalog.js";
 
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
 
@@ -25,8 +27,13 @@ export function applyOpenrouterProviderConfig(cfg: OpenClawConfig): OpenClawConf
 }
 
 export function applyOpenrouterConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return applyAgentDefaultModelPrimary(
-    applyOpenrouterProviderConfig(cfg),
-    OPENROUTER_DEFAULT_MODEL_REF,
-  );
+  const provider = buildOpenrouterProvider();
+  const next = applyProviderConfigWithDefaultModelsPreset(cfg, {
+    providerId: "openrouter",
+    api: "openai-completions",
+    baseUrl: OPENROUTER_BASE_URL,
+    defaultModels: provider.models,
+    aliases: [{ modelRef: OPENROUTER_DEFAULT_MODEL_REF, alias: "OpenRouter" }],
+  });
+  return applyAgentDefaultModelPrimary(next, OPENROUTER_DEFAULT_MODEL_REF);
 }

--- a/src/plugins/provider-auth-choice-helpers.test.ts
+++ b/src/plugins/provider-auth-choice-helpers.test.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { applyProviderAuthConfigPatch } from "./provider-auth-choice-helpers.js";
 
 describe("applyProviderAuthConfigPatch", () => {
-  it("replaces patched default model maps instead of recursively merging them", () => {
+  it("merges patched default model maps with existing models", () => {
     const base = {
       agents: {
         defaults: {
@@ -23,9 +23,8 @@ describe("applyProviderAuthConfigPatch", () => {
       agents: {
         defaults: {
           models: {
-            "claude-cli/claude-sonnet-4-6": { alias: "Sonnet" },
-            "claude-cli/claude-opus-4-6": { alias: "Opus" },
-            "openai/gpt-5.2": {},
+            "google-gemini/gemini-2.5-pro": { alias: "Gemini Pro" },
+            "openai/gpt-5.2": { alias: "GPT-5.2 Updated" },
           },
         },
       },
@@ -33,7 +32,13 @@ describe("applyProviderAuthConfigPatch", () => {
 
     const next = applyProviderAuthConfigPatch(base, patch);
 
-    expect(next.agents?.defaults?.models).toEqual(patch.agents.defaults.models);
+    // Should merge models, not replace
+    expect(next.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+      "anthropic/claude-opus-4-6": { alias: "Opus" },
+      "openai/gpt-5.2": { alias: "GPT-5.2 Updated" },
+      "google-gemini/gemini-2.5-pro": { alias: "Gemini Pro" },
+    });
     expect(next.agents?.defaults?.model).toEqual(base.agents?.defaults?.model);
   });
 

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -81,10 +81,12 @@ export function applyProviderAuthConfigPatch(cfg: OpenClawConfig, patch: unknown
       ...merged.agents,
       defaults: {
         ...merged.agents?.defaults,
-        // Provider auth migrations can intentionally replace the exact allowlist.
-        models: patchModels as NonNullable<
-          NonNullable<OpenClawConfig["agents"]>["defaults"]
-        >["models"],
+        // Merge models to allow multiple providers to be onboarded
+        // without overwriting each other's models.
+        models: {
+          ...merged.agents?.defaults?.models,
+          ...patchModels,
+        } as NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["models"],
       },
     },
   };


### PR DESCRIPTION
## Summary
Fixes the bug where onboarding multiple providers overwrites  instead of merging them, ensuring users can onboard multiple providers without losing previously configured models.

## Root Cause
 was replacing the entire  object with the new provider's models. When a user onboarded a second provider, the first provider's models were lost because the patch only contained the new provider's models.

## Fix
Changed  to merge the new provider's models with existing models using the spread operator:


This allows multiple providers to be onboarded without overwriting each other's models.

## Test Plan
- [x] Updated unit test in  to verify merging behavior
- [x] Test passes: 
> openclaw@2026.4.19-beta.2 test /Volumes/PS3000/GitHub/openclaw
> node scripts/test-projects.mjs -- src/plugins/provider-auth-choice-helpers.test.ts


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.4 [39m[90m/Volumes/PS3000/GitHub/openclaw[39m

 [32m✓[39m [30m[45m unit-fast [49m[39m src/plugins/provider-auth-choice-helpers.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 2[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m   Start at [22m 11:25:20
[2m   Duration [22m 194ms[2m (transform 75ms, setup 0ms, import 127ms, tests 2ms, environment 0ms)[22m

## Changes
- Modified  to merge models instead of replacing
- Updated  to reflect new expected behavior

Closes openclaw#69160