### PR TITLE
fix(agents): pass contextTokens to buildStatusText in session_status tool

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -26,6 +26,7 @@ const resolveEnvApiKeyMock = vi.hoisted(() =>
 const resolveUsableCustomProviderApiKeyMock = vi.hoisted(() =>
   vi.fn((_params?: { provider?: string }) => null as { apiKey: string; source: string } | null),
 );
+const buildStatusTextSpy = vi.hoisted(() => vi.fn());
 
 const createMockConfig = () => ({
   session: { mainKey: "main", scope: "per-sender" },
@@ -182,11 +183,13 @@ function createCommandsStatusRuntimeModuleMock() {
       statusChannel: string;
       provider?: string;
       model: string;
+      contextTokens?: number;
       primaryModelLabelOverride?: string;
       includeTranscriptUsage?: boolean;
       taskLineOverride?: string;
       resolveDefaultThinkingLevel?: () => unknown;
     }) => {
+      buildStatusTextSpy(params);
       resolveQueueSettingsMock({
         channel: params.statusChannel,
         sessionEntry: params.sessionEntry,
@@ -281,6 +284,7 @@ beforeAll(async () => {
 });
 
 function resetSessionStore(store: Record<string, SessionEntry>) {
+  buildStatusTextSpy.mockClear();
   buildStatusMessageMock.mockClear();
   resolveQueueSettingsMock.mockClear();
   resolveQueueSettingsMock.mockReturnValue({ mode: "interrupt" });
@@ -1481,5 +1485,25 @@ describe("session_status tool", () => {
     expect(saved.modelOverride).toBeUndefined();
     expect(saved.authProfileOverride).toBeUndefined();
     expect(saved.liveModelSwitchPending).toBe(true);
+  });
+
+  it("passes contextTokens from session entry to buildStatusText", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s-ctx",
+        updatedAt: 10,
+        contextTokens: 50000,
+      },
+    });
+
+    const tool = getSessionStatusTool();
+
+    await tool.execute("call-ctx-tokens", {});
+
+    expect(buildStatusTextSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextTokens: 50000,
+      }),
+    );
   });
 });

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -530,6 +530,7 @@ export function createSessionStatusTool(opts?: {
           "unknown",
         provider: providerForCard,
         model: defaultModelForCard,
+        contextTokens: resolved.entry?.contextTokens,
         resolvedThinkLevel: statusSessionEntry.thinkingLevel as ThinkLevel | undefined,
         resolvedFastMode: statusSessionEntry.fastMode,
         resolvedVerboseLevel: (statusSessionEntry.verboseLevel ?? "off") as VerboseLevel,


### PR DESCRIPTION
## Summary

- Problem: The `session_status` tool always reports `0/131k (0%)` context usage because the `buildStatusText()` call in `session-status-tool.ts` does not pass the `contextTokens` parameter from the session entry.
- Why it matters: Agents relying on `session_status` tool output get inaccurate context usage data, while the `/status` text command correctly shows the real value — an inconsistency that makes context-aware agent behavior unreliable.
- What changed: Added `contextTokens: resolved.entry?.contextTokens` to the `buildStatusText()` call in the session status tool, matching what the `/status` command already does.
- What did NOT change (scope boundary): No changes to `buildStatusText()` itself, the `/status` command path, or any session lifecycle logic.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #69151
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `session-status-tool.ts` calls `buildStatusText()` without the `contextTokens` parameter, so the function never injects `contextTokens` into the agent object passed to `buildStatusMessage()`.
- Missing detection / guardrail: No test asserting that `contextTokens` flows from the session entry into `buildStatusText`.
- Contributing context (if known): The session status tool was extracted into a separate runtime module in a prior refactor (#65807), and `contextTokens` was not carried over during that extraction.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/openclaw-tools.session-status.test.ts`
- Scenario the test should lock in: When a session entry has `contextTokens` set, `buildStatusText` must be called with that value.
- Why this is the smallest reliable guardrail: A unit test on the tool's execute path directly validates the parameter is forwarded without needing a full status rendering integration test.
- Existing test that already covers this (if any): None
- If no new test is added, why not: N/A (new test added)

## User-visible / Behavior Changes

`session_status` tool now reports accurate context token usage instead of always showing `0%`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel (if any): Any channel with agent tool access
- Relevant config (redacted): N/A

### Steps

1. Start a session with an agent that has `session_status` tool access
2. Have a multi-turn conversation
3. Run `session_status` from the agent

### Expected

- `session_status` reports actual context utilization matching `/status`

### Actual

- `session_status` reports `0/131k (0%)`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after

**Before (Red):**
```
expect(buildStatusTextSpy).toHaveBeenCalledWith(
  expect.objectContaining({ contextTokens: 50000 })
)
→ FAIL: contextTokens not present in call params
```

**After (Green):**
```
Tests  35 passed (35)
```

## Human Verification (required)

- Verified scenarios: Unit test confirms `contextTokens` from session entry is forwarded to `buildStatusText`
- Edge cases checked: When `contextTokens` is undefined on the session entry, the parameter is passed as `undefined` (same as before — `buildStatusText` already handles this with its `typeof contextTokens === "number"` guard)
- What you did **not** verify: Did not test with a live gateway session or verify the rendered status output end-to-end

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None