### PR TITLE
fix(ollama): fall back web search endpoints

### DIFF
--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -149,6 +149,125 @@ describe("ollama web search provider", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to the stable local Ollama web search endpoint after experimental 404", async () => {
+    const experimentalRelease = vi.fn(async () => {});
+    const stableRelease = vi.fn(async () => {});
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response("404 page not found", { status: 404 }),
+        release: experimentalRelease,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            results: [
+              {
+                title: "Stable",
+                url: "https://ollama.com/search",
+                content: "Stable endpoint result",
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: stableRelease,
+      });
+
+    const result = await runOllamaWebSearch({
+      config: createOllamaConfig(),
+      query: "ollama search",
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        url: "http://ollama.local:11434/api/experimental/web_search",
+      }),
+    );
+    expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        url: "http://ollama.local:11434/api/web_search",
+      }),
+    );
+    expect(result).toMatchObject({
+      count: 1,
+      results: [{ url: "https://ollama.com/search" }],
+    });
+    expect(experimentalRelease).toHaveBeenCalledTimes(1);
+    expect(stableRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the Ollama cloud endpoint when local web search endpoints 404 and an API key is available", async () => {
+    const original = process.env.OLLAMA_API_KEY;
+    const experimentalRelease = vi.fn(async () => {});
+    const stableRelease = vi.fn(async () => {});
+    const cloudRelease = vi.fn(async () => {});
+    try {
+      process.env.OLLAMA_API_KEY = "cloud-secret";
+      fetchWithSsrFGuardMock
+        .mockResolvedValueOnce({
+          response: new Response("404 page not found", { status: 404 }),
+          release: experimentalRelease,
+        })
+        .mockResolvedValueOnce({
+          response: new Response("404 page not found", { status: 404 }),
+          release: stableRelease,
+        })
+        .mockResolvedValueOnce({
+          response: new Response(
+            JSON.stringify({
+              results: [
+                {
+                  title: "Cloud",
+                  url: "https://ollama.com/cloud",
+                  content: "Cloud endpoint result",
+                },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+          release: cloudRelease,
+        });
+
+      const result = await runOllamaWebSearch({
+        config: createOllamaConfig({ apiKey: "OLLAMA_API_KEY" }),
+        query: "ollama cloud",
+      });
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          url: "https://ollama.com/api/web_search",
+          init: expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: "Bearer cloud-secret",
+            }),
+          }),
+        }),
+      );
+      expect(result).toMatchObject({
+        count: 1,
+        results: [{ url: "https://ollama.com/cloud" }],
+      });
+      expect(experimentalRelease).toHaveBeenCalledTimes(1);
+      expect(stableRelease).toHaveBeenCalledTimes(1);
+      expect(cloudRelease).toHaveBeenCalledTimes(1);
+    } finally {
+      if (original === undefined) {
+        delete process.env.OLLAMA_API_KEY;
+      } else {
+        process.env.OLLAMA_API_KEY = original;
+      }
+    }
+  });
+
   it("surfaces Ollama signin guidance for 401 responses", async () => {
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response("", { status: 401 }),

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -40,7 +40,8 @@ const OLLAMA_WEB_SEARCH_SCHEMA = Type.Object(
   { additionalProperties: false },
 );
 
-const OLLAMA_WEB_SEARCH_PATH = "/api/experimental/web_search";
+const OLLAMA_WEB_SEARCH_PATHS = ["/api/experimental/web_search", "/api/web_search"] as const;
+const OLLAMA_CLOUD_WEB_SEARCH_URL = "https://ollama.com/api/web_search";
 const DEFAULT_OLLAMA_WEB_SEARCH_COUNT = 5;
 const DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS = 15_000;
 const OLLAMA_WEB_SEARCH_SNIPPET_MAX_CHARS = 300;
@@ -85,6 +86,53 @@ function normalizeOllamaWebSearchResult(
   };
 }
 
+async function fetchOllamaWebSearch(params: {
+  baseUrl: string;
+  apiKey?: string;
+  headers: Record<string, string>;
+  body: string;
+}): Promise<{
+  response: Response;
+  release: () => Promise<void>;
+}> {
+  let last404Detail = "";
+  for (const path of OLLAMA_WEB_SEARCH_PATHS) {
+    const result = await fetchWithSsrFGuard({
+      url: `${params.baseUrl}${path}`,
+      init: {
+        method: "POST",
+        headers: params.headers,
+        body: params.body,
+        signal: AbortSignal.timeout(DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS),
+      },
+      policy: buildOllamaBaseUrlSsrFPolicy(params.baseUrl),
+      auditContext: "ollama-web-search.search",
+    });
+    if (result.response.status !== 404) {
+      return result;
+    }
+    const detail = await readResponseText(result.response, { maxBytes: 64_000 });
+    last404Detail = detail.text;
+    await result.release();
+  }
+
+  if (params.apiKey) {
+    return await fetchWithSsrFGuard({
+      url: OLLAMA_CLOUD_WEB_SEARCH_URL,
+      init: {
+        method: "POST",
+        headers: params.headers,
+        body: params.body,
+        signal: AbortSignal.timeout(DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS),
+      },
+      policy: buildOllamaBaseUrlSsrFPolicy(OLLAMA_CLOUD_WEB_SEARCH_URL),
+      auditContext: "ollama-web-search.search",
+    });
+  }
+
+  throw new Error(`Ollama web search failed (404): ${last404Detail}`.trim());
+}
+
 export async function runOllamaWebSearch(params: {
   config?: OpenClawConfig;
   query: string;
@@ -103,16 +151,11 @@ export async function runOllamaWebSearch(params: {
   if (apiKey) {
     headers.Authorization = `Bearer ${apiKey}`;
   }
-  const { response, release } = await fetchWithSsrFGuard({
-    url: `${baseUrl}${OLLAMA_WEB_SEARCH_PATH}`,
-    init: {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ query, max_results: count }),
-      signal: AbortSignal.timeout(DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS),
-    },
-    policy: buildOllamaBaseUrlSsrFPolicy(baseUrl),
-    auditContext: "ollama-web-search.search",
+  const { response, release } = await fetchOllamaWebSearch({
+    baseUrl,
+    apiKey,
+    headers,
+    body: JSON.stringify({ query, max_results: count }),
   });
 
   try {


### PR DESCRIPTION
## Summary
- try Ollama's existing experimental web_search endpoint first, then the stable local `/api/web_search` endpoint
- when both local endpoints return 404 and an Ollama API key is configured, retry via `https://ollama.com/api/web_search`
- add regression coverage for local fallback and cloud fallback behavior

Fixes #69132.

## Test plan
- `node scripts/run-vitest.mjs run extensions/ollama/src/web-search-provider.test.ts`
- `git diff --cached --check`

## Notes
The normal commit hook also ran the repo-wide `pnpm check` path but failed on an unrelated existing TypeScript error in `src/media-understanding/runner.proxy.test.ts` (`allowPrivateNetwork` missing on `MediaUnderstandingProviderRequestTransportOverrides`). The targeted Ollama test passed.