### PR TITLE
fix: pass claude-cli prompt via stdin to avoid Windows ENAMETOOLONG (#69158)

### DIFF
--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -225,6 +225,7 @@ export async function executePreparedCliRun(
   const { argsPrompt, stdin } = resolvePromptInput({
     backend,
     prompt,
+    backendId: context.backendResolved.id,
   });
   const stdinPayload = stdin ?? "";
   const baseArgs = useResume ? (backend.resumeArgs ?? backend.args ?? []) : (backend.args ?? []);

--- a/src/agents/cli-runner/helpers.resolve-prompt-input.test.ts
+++ b/src/agents/cli-runner/helpers.resolve-prompt-input.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { CliBackendConfig } from "../../config/types.agent-defaults.js";
+import { resolvePromptInput } from "./helpers.js";
+
+function makeBackend(overrides: Partial<CliBackendConfig> = {}): CliBackendConfig {
+  return { command: "claude", ...overrides };
+}
+
+describe("resolvePromptInput", () => {
+  it("defaults to stdin for claude-cli backend", () => {
+    const result = resolvePromptInput({
+      backend: makeBackend(),
+      prompt: "hello world",
+      backendId: "claude-cli",
+    });
+    expect(result).toEqual({ stdin: "hello world" });
+  });
+
+  it("defaults to arg for non-claude-cli backends", () => {
+    const result = resolvePromptInput({
+      backend: makeBackend(),
+      prompt: "hello world",
+      backendId: "other-cli",
+    });
+    expect(result).toEqual({ argsPrompt: "hello world" });
+  });
+
+  it("defaults to arg when backendId is omitted", () => {
+    const result = resolvePromptInput({
+      backend: makeBackend(),
+      prompt: "hello world",
+    });
+    expect(result).toEqual({ argsPrompt: "hello world" });
+  });
+
+  it("respects explicit input=arg for claude-cli", () => {
+    const result = resolvePromptInput({
+      backend: makeBackend({ input: "arg" }),
+      prompt: "hello world",
+      backendId: "claude-cli",
+    });
+    expect(result).toEqual({ argsPrompt: "hello world" });
+  });
+
+  it("respects explicit input=stdin for non-claude-cli", () => {
+    const result = resolvePromptInput({
+      backend: makeBackend({ input: "stdin" }),
+      prompt: "hello world",
+      backendId: "other-cli",
+    });
+    expect(result).toEqual({ stdin: "hello world" });
+  });
+
+  it("falls back to stdin when prompt exceeds maxPromptArgChars", () => {
+    const result = resolvePromptInput({
+      backend: makeBackend({ maxPromptArgChars: 5 }),
+      prompt: "hello world",
+      backendId: "other-cli",
+    });
+    expect(result).toEqual({ stdin: "hello world" });
+  });
+
+  it("uses arg when prompt is within maxPromptArgChars", () => {
+    const result = resolvePromptInput({
+      backend: makeBackend({ maxPromptArgChars: 100 }),
+      prompt: "hello",
+      backendId: "other-cli",
+    });
+    expect(result).toEqual({ argsPrompt: "hello" });
+  });
+
+  it("handles long prompts for claude-cli via stdin (avoids ENAMETOOLONG)", () => {
+    const longPrompt = "x".repeat(10000);
+    const result = resolvePromptInput({
+      backend: makeBackend(),
+      prompt: longPrompt,
+      backendId: "claude-cli",
+    });
+    expect(result).toEqual({ stdin: longPrompt });
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -183,11 +183,16 @@ export function resolveSessionIdToSend(params: {
   return { sessionId: crypto.randomUUID(), isNew: true };
 }
 
-export function resolvePromptInput(params: { backend: CliBackendConfig; prompt: string }): {
+export function resolvePromptInput(params: {
+  backend: CliBackendConfig;
+  prompt: string;
+  backendId?: string;
+}): {
   argsPrompt?: string;
   stdin?: string;
 } {
-  const inputMode = params.backend.input ?? "arg";
+  const defaultMode = isClaudeCliProvider(params.backendId ?? "") ? "stdin" : "arg";
+  const inputMode = params.backend.input ?? defaultMode;
   if (inputMode === "stdin") {
     return { stdin: params.prompt };
   }


### PR DESCRIPTION
## Problem

On Windows, the claude-cli provider passes the user prompt as a shell argument with `shell: true`. Windows has an 8191-character command-line limit, causing `ENAMETOOLONG` errors for long prompts.

Fixes #69158

## Solution

- `resolvePromptInput()` now defaults to `stdin` input mode for `claude-cli` backends (other backends still default to `arg`)
- The prompt is written to the spawned process's stdin instead of being passed as a command-line argument
- Explicit `input` config still overrides the default in all cases
- `--system-prompt` and other flags remain as command-line arguments (they're short enough)

## Tests

Added 8 tests in `helpers.resolve-prompt-input.test.ts` covering:
- stdin default for claude-cli
- arg default for other backends
- explicit overrides
- `maxPromptArgChars` fallback
- long prompt handling