### PR TITLE
fix(telegram): wire humanDelay into block-streaming dispatcher

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -13,6 +13,7 @@ import type {
 } from "openclaw/plugin-sdk/config-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-history";
+import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { isAbortRequestText, type ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -687,6 +688,7 @@ export const dispatchTelegramMessage = async ({
         cfg,
         dispatcherOptions: {
           ...replyPipeline,
+          humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
           deliver: async (payload, info) => {
             if (isDispatchSuperseded()) {
               return;


### PR DESCRIPTION
## Problem

**#68945** — `agents.defaults.humanDelay` has no effect on Telegram. Messages are sent immediately regardless of the configured delay, while all other channels respect it.

## Root Cause

`dispatchTelegramMessage()` passes `dispatcherOptions` to `dispatchReplyWithBufferedBlockDispatcher()` but never includes `humanDelay`. Every other channel (Slack, Discord, Signal, iMessage, Matrix, Feishu, MS Teams, Mattermost, Tlon) already wires this:

```js
humanDelay: resolveHumanDelayConfig(cfg, route.agentId)
```

Telegram is the **only** channel missing this.

## Fix
2 lines: add import + pass `humanDelay` in dispatcher options.

## Changed
- `extensions/telegram/src/bot-message-dispatch.ts`