### PR TITLE
fix(spawn): propagate parent deliveryContext to sessions_spawn children

### DIFF
--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -63,6 +63,7 @@ import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
 import {
   deliveryContextFromSession,
   formatConversationTarget,
+  mergeDeliveryContext,
   normalizeDeliveryContext,
   resolveConversationDeliveryTarget,
 } from "../utils/delivery-context.js";
@@ -675,6 +676,30 @@ function resolveAcpSpawnRequesterState(params: {
       : params.ctx.agentThreadId != null;
   const requesterAgentId = requesterParsedSession?.agentId;
 
+  // Backfill missing ctx delivery fields from the parent session's stored
+  // deliveryContext so sessions_spawn children inherit the originating thread
+  // when the tool-wiring layer did not populate ctx.agent{To,ThreadId}.
+  let parentDelivery: ReturnType<typeof deliveryContextFromSession> = undefined;
+  if (params.parentSessionKey && requesterAgentId) {
+    try {
+      const parentStorePath = resolveStorePath(params.cfg.session?.store, {
+        agentId: requesterAgentId,
+      });
+      const parentStore = loadSessionStore(parentStorePath);
+      parentDelivery = deliveryContextFromSession(parentStore[params.parentSessionKey]);
+    } catch {
+      parentDelivery = undefined;
+    }
+  }
+  const ctxDeliveryHint = normalizeDeliveryContext({
+    channel: params.ctx.agentChannel,
+    to: params.ctx.agentTo,
+    accountId: params.ctx.agentAccountId,
+    threadId: params.ctx.agentThreadId,
+  });
+  const effectiveDelivery =
+    mergeDeliveryContext(ctxDeliveryHint, parentDelivery) ?? ctxDeliveryHint;
+
   return {
     parentSessionKey: params.parentSessionKey,
     isSubagentSession,
@@ -696,10 +721,10 @@ function resolveAcpSpawnRequesterState(params: {
       cfg: params.cfg,
       targetAgentId: params.targetAgentId,
       requesterAgentId: normalizeAgentId(requesterAgentId),
-      requesterChannel: params.ctx.agentChannel,
-      requesterAccountId: params.ctx.agentAccountId,
-      requesterTo: params.ctx.agentTo,
-      requesterThreadId: params.ctx.agentThreadId,
+      requesterChannel: effectiveDelivery?.channel ?? params.ctx.agentChannel,
+      requesterAccountId: effectiveDelivery?.accountId ?? params.ctx.agentAccountId,
+      requesterTo: effectiveDelivery?.to ?? params.ctx.agentTo,
+      requesterThreadId: effectiveDelivery?.threadId ?? params.ctx.agentThreadId,
       requesterGroupSpace: params.ctx.agentGroupSpace,
       requesterMemberRoleIds: params.ctx.agentMemberRoleIds,
     }),
@@ -1065,12 +1090,22 @@ export async function spawnAcpDirect(
   let sessionCreated = false;
   let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
   try {
+    const initialChildDelivery = requesterState.origin;
     await callGateway({
       method: "sessions.patch",
       params: {
         key: sessionKey,
         spawnedBy: requesterInternalKey,
         ...(params.label ? { label: params.label } : {}),
+        ...(initialChildDelivery
+          ? {
+              deliveryContext: initialChildDelivery,
+              lastChannel: initialChildDelivery.channel,
+              lastTo: initialChildDelivery.to,
+              lastAccountId: initialChildDelivery.accountId,
+              lastThreadId: initialChildDelivery.threadId,
+            }
+          : {}),
       },
       timeoutMs: 10_000,
     });

--- a/src/agents/subagent-spawn.parent-context-backfill.test.ts
+++ b/src/agents/subagent-spawn.parent-context-backfill.test.ts
@@ -1,0 +1,231 @@
+import os from "node:os";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSubagentSpawnTestConfig,
+  loadSubagentSpawnModuleForTest,
+} from "./subagent-spawn.test-helpers.js";
+
+// Covers the gap that mofolo's #64864 hook cannot fill on its own: when the
+// tool-wiring layer (pi-tools / tool-resolution) doesn't populate
+// ctx.agent{To,ThreadId} on the spawn call (e.g. router-style top-level-agent
+// flows where the current invocation isn't a fresh inbound), the spawned child
+// must still inherit the parent session's stored deliveryContext so outbound
+// replies route back to the originating thread.
+
+const hoisted = vi.hoisted(() => ({
+  callGatewayMock: vi.fn(),
+  updateSessionStoreMock: vi.fn(),
+  configOverride: {} as Record<string, unknown>,
+  parentEntry: undefined as Record<string, unknown> | undefined,
+}));
+
+let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
+let resetSubagentRegistryForTests: typeof import("./subagent-registry.js").resetSubagentRegistryForTests;
+
+function configWithMain() {
+  return createSubagentSpawnTestConfig(os.tmpdir(), {
+    agents: {
+      defaults: { workspace: os.tmpdir() },
+      list: [{ id: "main", workspace: "/tmp/workspace-main" }],
+    },
+  });
+}
+
+function captureSessionsPatchForChild(childKeyPattern: RegExp) {
+  const patches: Array<Record<string, unknown>> = [];
+  hoisted.callGatewayMock.mockImplementation(
+    async (request: { method?: string; params?: unknown }) => {
+      if (request.method === "agent") {
+        return { runId: "run-1" };
+      }
+      if (request.method === "sessions.patch") {
+        const params = request.params as { key?: string } & Record<string, unknown>;
+        if (typeof params?.key === "string" && childKeyPattern.test(params.key)) {
+          patches.push(params);
+        }
+        return { ok: true };
+      }
+      if (request.method?.startsWith("sessions.")) {
+        return { ok: true };
+      }
+      return { ok: true };
+    },
+  );
+  return patches;
+}
+
+describe("spawnSubagentDirect parent-context backfill", () => {
+  beforeAll(async () => {
+    ({ spawnSubagentDirect, resetSubagentRegistryForTests } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: hoisted.callGatewayMock,
+      loadConfig: () => hoisted.configOverride,
+      updateSessionStoreMock: hoisted.updateSessionStoreMock,
+      resolveAgentConfig: () => undefined,
+      resolveSubagentSpawnModelSelection: () => "openai-codex/gpt-5.4",
+      resolveSandboxRuntimeStatus: () => ({ sandboxed: false }),
+      sessionStorePath: "/tmp/subagent-spawn-backfill.json",
+      resetModules: false,
+      parentSessionEntry: undefined,
+    }));
+  });
+
+  beforeEach(() => {
+    resetSubagentRegistryForTests();
+    hoisted.callGatewayMock.mockReset();
+    hoisted.updateSessionStoreMock.mockReset();
+    hoisted.configOverride = configWithMain();
+    hoisted.parentEntry = undefined;
+
+    hoisted.updateSessionStoreMock.mockImplementation(
+      async (
+        _storePath: string,
+        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
+      ) => {
+        const store: Record<string, Record<string, unknown>> = {};
+        await mutator(store);
+        return store;
+      },
+    );
+  });
+
+  it("inherits parent deliveryContext when ctx.agent{To,ThreadId} are absent", async () => {
+    // Reload the module with a parent entry that mimics a Slack thread session.
+    ({ spawnSubagentDirect, resetSubagentRegistryForTests } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: hoisted.callGatewayMock,
+      loadConfig: () => hoisted.configOverride,
+      updateSessionStoreMock: hoisted.updateSessionStoreMock,
+      resolveAgentConfig: () => undefined,
+      resolveSubagentSpawnModelSelection: () => "openai-codex/gpt-5.4",
+      resolveSandboxRuntimeStatus: () => ({ sandboxed: false }),
+      sessionStorePath: "/tmp/subagent-spawn-backfill.json",
+      resetModules: true,
+      parentSessionEntry: {
+        deliveryContext: {
+          channel: "slack",
+          to: "channel:C0ACJ9D6E4W",
+          threadId: "1775970111.589749",
+        },
+      },
+    }));
+
+    const patches = captureSessionsPatchForChild(/^agent:main:subagent:/);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "do thing",
+        runTimeoutSeconds: 1,
+        cleanup: "keep",
+      },
+      {
+        agentSessionKey: "main",
+        // Intentionally omit agentTo / agentThreadId — this is the failure mode.
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+
+    const initialPatch = patches[0];
+    expect(initialPatch).toBeDefined();
+    expect(initialPatch).toMatchObject({
+      deliveryContext: {
+        channel: "slack",
+        to: "channel:C0ACJ9D6E4W",
+        threadId: "1775970111.589749",
+      },
+      lastChannel: "slack",
+      lastTo: "channel:C0ACJ9D6E4W",
+      lastThreadId: "1775970111.589749",
+    });
+  });
+
+  it("does not cross channels when ctx and parent disagree", async () => {
+    ({ spawnSubagentDirect, resetSubagentRegistryForTests } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: hoisted.callGatewayMock,
+      loadConfig: () => hoisted.configOverride,
+      updateSessionStoreMock: hoisted.updateSessionStoreMock,
+      resolveAgentConfig: () => undefined,
+      resolveSubagentSpawnModelSelection: () => "openai-codex/gpt-5.4",
+      resolveSandboxRuntimeStatus: () => ({ sandboxed: false }),
+      sessionStorePath: "/tmp/subagent-spawn-backfill.json",
+      resetModules: true,
+      parentSessionEntry: {
+        deliveryContext: {
+          channel: "slack",
+          to: "channel:C0ACJ9D6E4W",
+          threadId: "1775970111.589749",
+        },
+      },
+    }));
+
+    const patches = captureSessionsPatchForChild(/^agent:main:subagent:/);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "do thing",
+        runTimeoutSeconds: 1,
+        cleanup: "keep",
+      },
+      {
+        agentSessionKey: "main",
+        agentChannel: "discord",
+        // No discord to/threadId — and parent's slack to/threadId must NOT leak.
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+
+    const initialPatch = patches[0];
+    expect(initialPatch).toBeDefined();
+    // mergeDeliveryContext's channelsConflict guard drops the parent's
+    // route fields when channels disagree.
+    expect(initialPatch?.deliveryContext).toMatchObject({ channel: "discord" });
+    expect((initialPatch?.deliveryContext as Record<string, unknown>)?.to).toBeUndefined();
+    expect((initialPatch?.deliveryContext as Record<string, unknown>)?.threadId).toBeUndefined();
+  });
+
+  it("ctx values win over parent deliveryContext when both are present", async () => {
+    ({ spawnSubagentDirect, resetSubagentRegistryForTests } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: hoisted.callGatewayMock,
+      loadConfig: () => hoisted.configOverride,
+      updateSessionStoreMock: hoisted.updateSessionStoreMock,
+      resolveAgentConfig: () => undefined,
+      resolveSubagentSpawnModelSelection: () => "openai-codex/gpt-5.4",
+      resolveSandboxRuntimeStatus: () => ({ sandboxed: false }),
+      sessionStorePath: "/tmp/subagent-spawn-backfill.json",
+      resetModules: true,
+      parentSessionEntry: {
+        deliveryContext: {
+          channel: "slack",
+          to: "channel:STALE",
+          threadId: "1700000000.000000",
+        },
+      },
+    }));
+
+    const patches = captureSessionsPatchForChild(/^agent:main:subagent:/);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "do thing",
+        runTimeoutSeconds: 1,
+        cleanup: "keep",
+      },
+      {
+        agentSessionKey: "main",
+        agentChannel: "slack",
+        agentTo: "channel:CURRENT",
+        agentThreadId: "1776000000.111111",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+
+    const initialPatch = patches[0];
+    expect(initialPatch).toBeDefined();
+    expect(initialPatch?.deliveryContext).toMatchObject({
+      channel: "slack",
+      to: "channel:CURRENT",
+      threadId: "1776000000.111111",
+    });
+  });
+});

--- a/src/agents/subagent-spawn.runtime.ts
+++ b/src/agents/subagent-spawn.runtime.ts
@@ -5,12 +5,14 @@ export { mergeSessionEntry, updateSessionStore } from "../config/sessions.js";
 export { callGateway } from "../gateway/call.js";
 export { ADMIN_SCOPE, isAdminOnlyMethod } from "../gateway/method-scopes.js";
 export {
+  loadSessionEntry,
   pruneLegacyStoreKeys,
   resolveGatewaySessionStoreTarget,
 } from "../gateway/session-utils.js";
 export { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 export { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 export {
+  deliveryContextFromSession,
   mergeDeliveryContext,
   normalizeDeliveryContext,
 } from "../utils/delivery-context.shared.js";

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -59,7 +59,15 @@ export function setupAcceptedSubagentGatewayMock(callGatewayMock: MockImplementa
 }
 
 export function identityDeliveryContext(value: unknown) {
-  return value;
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).filter(
+    ([, v]) => v !== undefined && v !== null && v !== "",
+  );
+  return entries.length === 0
+    ? undefined
+    : (Object.fromEntries(entries) as Record<string, unknown>);
 }
 
 export function createDefaultSessionHelperMocks() {
@@ -144,6 +152,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
   workspaceDir?: string;
   sessionStorePath?: string;
   resetModules?: boolean;
+  parentSessionEntry?: Record<string, unknown>;
 }): Promise<SubagentSpawnModuleForTest> {
   if (params.resetModules ?? true) {
     vi.resetModules();
@@ -193,10 +202,22 @@ export async function loadSubagentSpawnModuleForTest(params: {
     mergeDeliveryContext: (
       primary?: Record<string, unknown>,
       fallback?: Record<string, unknown>,
-    ) => ({
-      ...fallback,
-      ...primary,
-    }),
+    ) => {
+      const p = identityDeliveryContext(primary);
+      const f = identityDeliveryContext(fallback);
+      const primaryChannel = typeof p?.channel === "string" ? p.channel : undefined;
+      const fallbackChannel = typeof f?.channel === "string" ? f.channel : undefined;
+      const channelsConflict =
+        primaryChannel && fallbackChannel && primaryChannel !== fallbackChannel;
+      const merged: Record<string, unknown> = {
+        ...(channelsConflict ? {} : f),
+        ...p,
+      };
+      if (!channelsConflict && f) {
+        merged.channel = primaryChannel ?? fallbackChannel;
+      }
+      return identityDeliveryContext(merged);
+    },
     resolveGatewaySessionStoreTarget: (targetParams: { key: string }) => ({
       agentId: "main",
       storePath: params.sessionStorePath ?? "/tmp/subagent-spawn-model-session.json",
@@ -204,6 +225,9 @@ export async function loadSubagentSpawnModuleForTest(params: {
       storeKeys: [targetParams.key],
     }),
     normalizeDeliveryContext: identityDeliveryContext,
+    deliveryContextFromSession: (entry?: Record<string, unknown>) =>
+      entry?.deliveryContext as Record<string, unknown> | undefined,
+    loadSessionEntry: (_key: string) => ({ entry: params.parentSessionEntry }),
     resolveAgentConfig: params.resolveAgentConfig ?? (() => undefined),
     resolveAgentWorkspaceDir:
       params.resolveAgentWorkspaceDir ?? (() => params.workspaceDir ?? os.tmpdir()),

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -39,9 +39,11 @@ import {
   DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
   buildSubagentSystemPrompt,
   callGateway,
+  deliveryContextFromSession,
   emitSessionLifecycleEvent,
   getGlobalHookRunner,
   loadConfig,
+  loadSessionEntry,
   mergeSessionEntry,
   mergeDeliveryContext,
   normalizeDeliveryContext,
@@ -460,14 +462,40 @@ export async function spawnSubagentDirect(
     };
   }
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
+  // Backfill missing delivery routing fields from the parent session's stored
+  // deliveryContext. The tool-wiring layer (pi-tools / tool-resolution) sources
+  // ctx.agent{Channel,To,ThreadId,AccountId} from the current invocation's
+  // request, which can be empty for top-level-agent runs not driven by a direct
+  // inbound (e.g. a router awakened by an internal trigger). Without backfill
+  // the spawned child loses thread context and replies leak to the channel
+  // root. mergeDeliveryContext owns the channel-mismatch guard so we never
+  // cross to/threadId between unrelated channels.
+  const ctxDeliveryHint = normalizeDeliveryContext({
+    channel: ctx.agentChannel,
+    to: ctx.agentTo,
+    accountId: ctx.agentAccountId,
+    threadId: ctx.agentThreadId,
+  });
+  // Best-effort parent lookup; defensive against test harnesses or future
+  // callers that don't provide a writable session store.
+  let parentDelivery: DeliveryContext | undefined;
+  if (requesterInternalKey && typeof loadSessionEntry === "function") {
+    try {
+      parentDelivery = deliveryContextFromSession(loadSessionEntry(requesterInternalKey).entry);
+    } catch {
+      parentDelivery = undefined;
+    }
+  }
+  const effectiveRequesterDelivery =
+    mergeDeliveryContext(ctxDeliveryHint, parentDelivery) ?? ctxDeliveryHint;
   const requesterOrigin = resolveRequesterOriginForChild({
     cfg,
     targetAgentId,
     requesterAgentId,
-    requesterChannel: ctx.agentChannel,
-    requesterAccountId: ctx.agentAccountId,
-    requesterTo: ctx.agentTo,
-    requesterThreadId: ctx.agentThreadId,
+    requesterChannel: effectiveRequesterDelivery?.channel ?? ctx.agentChannel,
+    requesterAccountId: effectiveRequesterDelivery?.accountId ?? ctx.agentAccountId,
+    requesterTo: effectiveRequesterDelivery?.to ?? ctx.agentTo,
+    requesterThreadId: effectiveRequesterDelivery?.threadId ?? ctx.agentThreadId,
     requesterGroupSpace: ctx.agentGroupSpace,
     requesterMemberRoleIds: ctx.agentMemberRoleIds,
   });
@@ -549,11 +577,25 @@ export async function spawnSubagentDirect(
     }
   };
 
+  // Persist the resolved parent-origin delivery context onto the child entry so
+  // outbound replies (announce / session-mode follow-ups) have a route even
+  // before any inbound message seeds it via gateway.agent. Defense-in-depth:
+  // the gateway-side seeding at server-methods/agent.ts only seeds from the
+  // request's own to/threadId, which can be empty when the child first speaks.
   const initialChildSessionPatch: Record<string, unknown> = {
     spawnDepth: childDepth,
     subagentRole: childCapabilities.role === "main" ? null : childCapabilities.role,
     subagentControlScope: childCapabilities.controlScope,
     ...plan.initialSessionPatch,
+    ...(requesterOrigin
+      ? {
+          deliveryContext: requesterOrigin,
+          lastChannel: requesterOrigin.channel,
+          lastTo: requesterOrigin.to,
+          lastAccountId: requesterOrigin.accountId,
+          lastThreadId: requesterOrigin.threadId,
+        }
+      : {}),
   };
 
   const initialPatchError = await patchChildSession(initialChildSessionPatch);
@@ -623,6 +665,35 @@ export async function spawnSubagentDirect(
     hasBoundThreadDeliveryOrigin = hasRoutableDeliveryOrigin(bindResult.deliveryOrigin);
     childSessionOrigin =
       mergeDeliveryContext(bindResult.deliveryOrigin, requesterOrigin) ?? childSessionOrigin;
+    // The thread binding may have introduced a binding-owned override (e.g. a
+    // different thread targeted by the binding manager). Persist the merged
+    // origin so subsequent outbound resolution honors the binding decision
+    // rather than the pre-binding initial patch.
+    if (childSessionOrigin && childSessionOrigin !== requesterOrigin) {
+      const followupPatchError = await patchChildSession({
+        deliveryContext: childSessionOrigin,
+        lastChannel: childSessionOrigin.channel,
+        lastTo: childSessionOrigin.to,
+        lastAccountId: childSessionOrigin.accountId,
+        lastThreadId: childSessionOrigin.threadId,
+      });
+      if (followupPatchError) {
+        try {
+          await callSubagentGateway({
+            method: "sessions.delete",
+            params: { key: childSessionKey, emitLifecycleHooks: false },
+            timeoutMs: 10_000,
+          });
+        } catch {
+          // Best-effort cleanup only.
+        }
+        return {
+          status: "error",
+          error: followupPatchError,
+          childSessionKey,
+        };
+      }
+    }
   }
   const mountPathHint = sanitizeMountPathHint(params.attachMountPath);
 


### PR DESCRIPTION
## Summary

When a router agent calls `sessions_spawn` to delegate to a top-level worker agent (configured in `openclaw.json` `agents.list`), the spawned worker's session is created with `deliveryContext: {"channel":"slack"}` only — no `to`, no `threadId`. When the worker completes and posts its reply, the channel outbound adapter has no `thread_ts`, so replies land in the channel root instead of the originating thread. Reproduces on v2026.4.15.

Channel-agnostic — same failure mode for Discord, Mattermost, Telegram, Matrix.

## Why this isn't already fixed by #64864

mofolo's #64864 added a stateless `subagent_delivery_target` hook that reads `origin.threadId`. That works for in-session `Task`-style subagents whose `subagent_spawning` hook fires. For `sessions_spawn` → top-level agent with `thread=false`, that hook never runs (`subagent-spawn.ts:591` gates it on `requestThreadBinding`), so #64864 has nothing to read. The two fixes are complementary — this PR covers the `sessions_spawn` path.

## Root cause

Two-step gap:

1. `tool-resolution.ts` / `pi-tools.ts` constructs `createOpenClawTools({agentTo, agentThreadId, ...})` from `options.messageTo / messageThreadId`. For top-level agent runs not driven by a direct inbound, those can be undefined — even though the parent session's *stored* `deliveryContext` has the correct values.
2. `subagent-spawn.ts` called `resolveRequesterOriginForChild` with the empty ctx fields, yielding `requesterOrigin = {channel}` only. Gateway `agent` call passed `to: undefined, threadId: undefined`. The seeding block at `gateway/server-methods/agent.ts` (which already comments on this exact symptom) can only seed from `request.*`, which is also empty. Child entry persisted as `{channel:"slack"}`.

## Fix (defense in depth)

**Part A — Backfill ctx from parent session entry before origin resolution.** In `spawnSubagentDirect` and `resolveAcpSpawnRequesterState`, look up the parent session entry and fall back to its stored `deliveryContext` for any field the tool-wiring layer didn't populate. Guards:

- ctx values always win (current request beats stored state).
- `mergeDeliveryContext`'s existing `channelsConflict` guard prevents adopting the parent's `to`/`threadId` across channels.
- Only delivery fields are backfilled — `groupSpace` / `memberRoleIds` are untouched.
- Cross-agent `accountId` resolution still owned by `resolveFirstBoundAccountId` inside the resolver.

**Part B — Persist `deliveryContext` explicitly on the child session entry.** The initial `sessions.patch` that creates the child now includes the resolved `requesterOrigin` as `deliveryContext` + `last*` fields, so outbound resolution stays correct even if future refactors bypass the gateway-side seeding block.

## Test plan

- [x] New test file `src/agents/subagent-spawn.parent-context-backfill.test.ts` (3 cases):
  - Empty ctx + parent has delivery → backfill populates child's patch with parent's `to/threadId`.
  - Channel mismatch between ctx and parent → route fields are NOT crossed (only channel persists).
  - Both present → ctx wins over parent.
- [x] All existing `subagent-spawn.*` tests pass (29 tests across 5 files).
- [x] All existing `acp-spawn.*` tests pass (49 tests).
- [x] `pnpm check` (tsgo core/core-test/extensions/extensions-test, oxlint 11800 files, webhook/auth lints, import-cycle checks) — all green.
- [ ] Manual verification on live Slack deployment: router → `sessions_spawn` → worker reply lands in the originating thread.

## Risk callouts

- **Cross-channel:** `mergeDeliveryContext`'s `channelsConflict` guard drops parent `to/threadId` when channels differ.
- **Cross-agent accountId:** resolver owns the final decision; backfill only seeds the fallback.
- **Stale parent deliveryContext:** ctx-wins-via-`??` means current-request values always beat stored state; backfill only fires when ctx is genuinely empty.
- **Thread-bound spawn:** the initial patch uses `requesterOrigin`; thread-binding paths continue to overwrite via existing `childSessionOrigin` machinery.

## Files touched

- `src/agents/subagent-spawn.ts` — Part A backfill, Part B initial patch.
- `src/agents/subagent-spawn.runtime.ts` — re-export `loadSessionEntry`, `deliveryContextFromSession`.
- `src/agents/acp-spawn.ts` — Part A + Part B mirror.
- `src/agents/subagent-spawn.test-helpers.ts` — tighten delivery-context mocks to match production normalization semantics.
- `src/agents/subagent-spawn.parent-context-backfill.test.ts` — new test coverage.