### PR TITLE
fix(sessions-spawn): document runtime="acp" requirement on streamTo schema

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -367,6 +367,16 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
+  it('documents runtime="acp" requirement in streamTo schema description', () => {
+    const tool = createSessionsSpawnTool();
+    const schema = tool.parameters as {
+      properties?: { streamTo?: { description?: string } };
+    };
+    const description = schema.properties?.streamTo?.description ?? "";
+    expect(description).toMatch(/runtime="acp"/);
+    expect(description).toMatch(/subagent/);
+  });
+
   it('rejects streamTo when runtime is not "acp"', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -114,7 +114,10 @@ const SessionsSpawnToolSchema = Type.Object({
   mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
   sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
-  streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS),
+  streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS, {
+    description:
+      'Stream child output to the parent turn-by-turn. Requires runtime="acp"; omit for runtime="subagent" (subagents use push-based auto-announce instead).',
+  }),
   lightContext: Type.Optional(
     Type.Boolean({
       description:


### PR DESCRIPTION
## Summary

- **Problem:** `SessionsSpawnToolSchema.streamTo` was declared without a description, so models with `runtime="subagent"` routinely emit `streamTo: "parent"` on the first `sessions_spawn` attempt, get rejected server-side with `streamTo is only supported for runtime=acp`, then retry without it — paying ~2× tokens per delegation.
- **Why it matters:** This is a hot path for agents that delegate work to subagents. Sibling fields like `resumeSessionId` and `lightContext` both carry runtime hints in their descriptions; `streamTo` should too.
- **What changed:** Added a one-line description to the `streamTo` field in `SessionsSpawnToolSchema` explicitly stating the `runtime="acp"` requirement. Extended the existing schema test with an assertion on the rendered description.
- **What did NOT change:** Server-side validation, runtime dispatch, any caller. The rejection behavior is preserved; only the schema advertises the constraint up-front now.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69166
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** The schema advertised `streamTo` as a generic enum without the runtime constraint, so LLMs had no way to know it was ACP-only before issuing the call.
- **Missing detection / guardrail:** No schema-level check that every field conditionally-valid under a runtime has its constraint documented in `description`.
- **Contributing context:** Models typically read the schema once at the start of the session and retry with the correction in the next turn; that retry is what doubles the token cost for the delegation.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tools/sessions-spawn-tool.test.ts`
- Scenario the test should lock in: The schema for `streamTo` includes a description string mentioning both the enum and the `runtime="acp"` gate, so a future accidental removal of the hint fails the test.
- Why this is the smallest reliable guardrail: the whole user-visible signal is the schema description, and a string assertion pins it exactly.
- Existing test that already covers this: the same file already had coverage for the `streamTo` field's shape; this PR adds the description assertion.

## User-visible / Behavior Changes

- Tool consumers (LLM runtimes, doc generators) now see a description on `streamTo` clarifying the `runtime="acp"` constraint. No behavior change at the call site — invalid usage is still rejected the same way.

## Diagram

N/A — schema-level doc string change.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS 26.5 (also applies to Linux)
- Runtime/container: local
- Model/provider: any LLM using `sessions_spawn` with `runtime="subagent"`

### Steps

1. Prompt an agent to spawn a subagent with `runtime="subagent"`.
2. Observe the first call emits `streamTo: "parent"`.
3. Observe the server rejects, the agent retries.

### Expected

- Agent reads the schema once, sees the `runtime="acp"` constraint, never sends the invalid combination in the first place.

### Actual (before this PR)

- Agent has no way to know from the schema and learns by rejection, wasting tokens.

## Evidence

- [x] Failing test/log before + passing after — the new assertion in `sessions-spawn-tool.test.ts` fails on `main` and passes with this PR.

## Human Verification (required)

- Verified scenarios: inspected the schema, confirmed the description is rendered, cross-referenced sibling fields (`resumeSessionId`, `lightContext`) for consistency.
- Edge cases checked: none relevant — the change is a doc string.
- What I did not verify: did not run the full test suite locally; CI runs it.

## Review Conversations

- [x] I will reply to or resolve every bot review conversation I address in this PR.
- [x] I will leave unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- Risk: the description wording phrasing is subjective and maintainers may prefer different language.
  - Mitigation: happy to update to any preferred wording.
