### PR TITLE
Default GitHub Copilot onboarding to Claude Opus 4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles/reactions: fall back to `love` when an agent reacts with an emoji outside the iMessage tapback set (`love`/`like`/`dislike`/`laugh`/`emphasize`/`question`), so wider-vocabulary model reactions like `👀` still produce a visible tapback instead of failing the whole reaction request. Configured ack reactions still validate strictly via the new `normalizeBlueBubblesReactionInputStrict` path. (#64693) Thanks @zqchris.
 - BlueBubbles: prefer iMessage over SMS when both chats exist for the same handle, honor explicit `sms:` targets, and never silently downgrade iMessage-available recipients. (#61781) Thanks @rmartin.
 - Telegram/setup: require numeric `allowFrom` user IDs during setup instead of offering unsupported `@username` DM resolution, and point operators to `from.id`/`getUpdates` for discovery. (#69191) Thanks @obviyus.
+- GitHub Copilot/onboarding: default GitHub Copilot setup to `claude-opus-4.6` and keep the bundled default model list aligned, so new Copilot setups no longer start on the older `gpt-4o` default. (#69207) Thanks @obviyus.
 
 ## 2026.4.19-beta.2
 

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -69,7 +69,7 @@ export default definePluginEntry({
             credential,
           },
         ],
-        defaultModel: "github-copilot/gpt-4o",
+        defaultModel: "github-copilot/claude-opus-4.6",
       };
     }
 

--- a/extensions/github-copilot/models-defaults.ts
+++ b/extensions/github-copilot/models-defaults.ts
@@ -8,6 +8,7 @@ const DEFAULT_MAX_TOKENS = 8192;
 // We keep this list intentionally broad; if a model isn't available Copilot will
 // return an error and users can remove it from their config.
 const DEFAULT_MODEL_IDS = [
+  "claude-opus-4.6",
   "claude-sonnet-4.6",
   "claude-sonnet-4.5",
   "gpt-4o",

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -63,6 +63,10 @@ function requireResolvedModel(ctx: ProviderResolveDynamicModelContext) {
 
 describe("github-copilot model defaults", () => {
   describe("getDefaultCopilotModelIds", () => {
+    it("includes claude-opus-4.6", () => {
+      expect(getDefaultCopilotModelIds()).toContain("claude-opus-4.6");
+    });
+
     it("includes claude-sonnet-4.6", () => {
       expect(getDefaultCopilotModelIds()).toContain("claude-sonnet-4.6");
     });

--- a/test/helpers/plugins/provider-auth-contract.ts
+++ b/test/helpers/plugins/provider-auth-contract.ts
@@ -366,7 +366,7 @@ export function describeGithubCopilotProviderAuthContract() {
               },
             },
           ],
-          defaultModel: "github-copilot/gpt-4o",
+          defaultModel: "github-copilot/claude-opus-4.6",
         });
       } finally {
         if (previousIsTTYDescriptor) {


### PR DESCRIPTION
Switch the GitHub Copilot onboarding default from `gpt-4o` to `claude-opus-4.6` and keep the bundled default model list aligned with that choice.

Testing:
- pnpm test extensions/github-copilot/models.test.ts
- pnpm test src/plugins/contracts/provider-auth.contract.test.ts