### PR TITLE
fix: merge models from multiple providers instead of replacing

### DIFF
--- a/src/plugins/provider-auth-choice-helpers.test.ts
+++ b/src/plugins/provider-auth-choice-helpers.test.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { applyProviderAuthConfigPatch } from "./provider-auth-choice-helpers.js";
 
 describe("applyProviderAuthConfigPatch", () => {
-  it("replaces patched default model maps instead of recursively merging them", () => {
+  it("merges patched default model maps instead of replacing them", () => {
     const base = {
       agents: {
         defaults: {
@@ -33,7 +33,14 @@ describe("applyProviderAuthConfigPatch", () => {
 
     const next = applyProviderAuthConfigPatch(base, patch);
 
-    expect(next.agents?.defaults?.models).toEqual(patch.agents.defaults.models);
+    // Should merge, not replace - both providers' models should be present
+    expect(next.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+      "anthropic/claude-opus-4-6": { alias: "Opus" },
+      "openai/gpt-5.2": {},
+      "claude-cli/claude-sonnet-4-6": { alias: "Sonnet" },
+      "claude-cli/claude-opus-4-6": { alias: "Opus" },
+    });
     expect(next.agents?.defaults?.model).toEqual(base.agents?.defaults?.model);
   });
 

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -81,10 +81,12 @@ export function applyProviderAuthConfigPatch(cfg: OpenClawConfig, patch: unknown
       ...merged.agents,
       defaults: {
         ...merged.agents?.defaults,
-        // Provider auth migrations can intentionally replace the exact allowlist.
-        models: patchModels as NonNullable<
-          NonNullable<OpenClawConfig["agents"]>["defaults"]
-        >["models"],
+        // Merge models instead of replacing to preserve multi-provider setups.
+        // Provider auth migrations can still override specific model entries.
+        models: {
+          ...merged.agents?.defaults?.models,
+          ...patchModels,
+        } as NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["models"],
       },
     },
   };


### PR DESCRIPTION
## Summary

Fixes #69160

When onboarding multiple providers sequentially, the second provider's  was replacing  entirely instead of merging with models from the first provider.

## Root Cause

In , the  field was being set directly to , which overwrote any existing models from previously onboarded providers.

## Fix

Changed the logic to merge existing models with new patch models using spread operator:



This preserves models from all onboarded providers while still allowing new models to be added.

## Test Plan

- [x] Updated unit test to verify merging behavior instead of replacement
- [x] Test confirms both original and new provider models are preserved

## Changes

- : Merge models instead of replacing
- : Update test expectations