### PR TITLE
Split gateway probe capability from reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles: prefer iMessage over SMS when both chats exist for the same handle, honor explicit `sms:` targets, and never silently downgrade iMessage-available recipients. (#61781) Thanks @rmartin.
 - Telegram/setup: require numeric `allowFrom` user IDs during setup instead of offering unsupported `@username` DM resolution, and point operators to `from.id`/`getUpdates` for discovery. (#69191) Thanks @obviyus.
 - GitHub Copilot/onboarding: default GitHub Copilot setup to `claude-opus-4.6` and keep the bundled default model list aligned, so new Copilot setups no longer start on the older `gpt-4o` default. (#69207) Thanks @obviyus.
+- Gateway/status: separate reachability, capability, and read-probe reporting so connect-only or scope-limited sessions no longer look fully healthy, and normalize SSH targets entered as `ssh user@host`. (#69215) Thanks @obviyus.
 
 ## 2026.4.19-beta.2
 

--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -25,7 +25,8 @@ openclaw channels status --probe
 Healthy baseline:
 
 - `Runtime: running`
-- `RPC probe: ok`
+- `Connectivity probe: ok`
+- `Capability: read-only`, `write-capable`, or `admin-capable`
 - Channel probe shows transport connected and, where supported, `works` or `audit ok`
 
 ## WhatsApp

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -106,7 +106,7 @@ Options:
 
 ### `gateway status`
 
-`gateway status` shows the Gateway service (launchd/systemd/schtasks) plus an optional RPC probe.
+`gateway status` shows the Gateway service (launchd/systemd/schtasks) plus an optional probe of connectivity/auth capability.
 
 ```bash
 openclaw gateway status
@@ -120,17 +120,18 @@ Options:
 - `--token <token>`: token auth for the probe.
 - `--password <password>`: password auth for the probe.
 - `--timeout <ms>`: probe timeout (default `10000`).
-- `--no-probe`: skip the RPC probe (service-only view).
+- `--no-probe`: skip the connectivity probe (service-only view).
 - `--deep`: scan system-level services too.
-- `--require-rpc`: exit non-zero when the RPC probe fails. Cannot be combined with `--no-probe`.
+- `--require-rpc`: upgrade the default connectivity probe to a read probe and exit non-zero when that read probe fails. Cannot be combined with `--no-probe`.
 
 Notes:
 
 - `gateway status` stays available for diagnostics even when the local CLI config is missing or invalid.
+- Default `gateway status` proves service state, WebSocket connect, and the auth capability visible at handshake time. It does not prove read/write/admin operations.
 - `gateway status` resolves configured auth SecretRefs for probe auth when possible.
 - If a required auth SecretRef is unresolved in this command path, `gateway status --json` reports `rpc.authWarning` when probe connectivity/auth fails; pass `--token`/`--password` explicitly or resolve the secret source first.
 - If the probe succeeds, unresolved auth-ref warnings are suppressed to avoid false positives.
-- Use `--require-rpc` in scripts and automation when a listening service is not enough and you need the Gateway RPC itself to be healthy.
+- Use `--require-rpc` in scripts and automation when a listening service is not enough and you need read-scope RPC calls to be healthy too.
 - `--deep` adds a best-effort scan for extra launchd/systemd/schtasks installs. When multiple gateway-like services are detected, human output prints cleanup hints and warns that most setups should run one gateway per machine.
 - Human output includes the resolved file log path plus the CLI-vs-service config paths/validity snapshot to help diagnose profile or state-dir drift.
 - On Linux systemd installs, service auth drift checks read both `Environment=` and `EnvironmentFile=` values from the unit (including `%h`, quoted paths, multiple files, and optional `-` files).
@@ -161,8 +162,9 @@ openclaw gateway probe --json
 Interpretation:
 
 - `Reachable: yes` means at least one target accepted a WebSocket connect.
-- `RPC: ok` means detail RPC calls (`health`/`status`/`system-presence`/`config.get`) also succeeded.
-- `RPC: limited - missing scope: operator.read` means connect succeeded but detail RPC is scope-limited. This is reported as **degraded** reachability, not full failure.
+- `Capability: read-only|write-capable|admin-capable|pairing-pending|connect-only` reports what the probe could prove about auth. It is separate from reachability.
+- `Read probe: ok` means read-scope detail RPC calls (`health`/`status`/`system-presence`/`config.get`) also succeeded.
+- `Read probe: limited - missing scope: operator.read` means connect succeeded but read-scope RPC is limited. This is reported as **degraded** reachability, not full failure.
 - Exit code is non-zero only when no probed target is reachable.
 
 JSON notes (`--json`):
@@ -170,6 +172,7 @@ JSON notes (`--json`):
 - Top level:
   - `ok`: at least one target is reachable.
   - `degraded`: at least one target had scope-limited detail RPC.
+  - `capability`: best capability seen across reachable targets (`read_only`, `write_capable`, `admin_capable`, `pairing_pending`, `connected_no_operator_scope`, or `unknown`).
   - `primaryTargetId`: best target to treat as the active winner in this order: explicit URL, SSH tunnel, configured remote, then local loopback.
   - `warnings[]`: best-effort warning records with `code`, `message`, and optional `targetIds`.
   - `network`: local loopback/tailnet URL hints derived from current config and host networking.
@@ -178,13 +181,17 @@ JSON notes (`--json`):
   - `ok`: reachability after connect + degraded classification.
   - `rpcOk`: full detail RPC success.
   - `scopeLimited`: detail RPC failed due to missing operator scope.
+- Per target (`targets[].auth`):
+  - `role`: auth role reported in `hello-ok` when available.
+  - `scopes`: granted scopes reported in `hello-ok` when available.
+  - `capability`: the surfaced auth capability classification for that target.
 
 Common warning codes:
 
 - `ssh_tunnel_failed`: SSH tunnel setup failed; the command fell back to direct probes.
 - `multiple_gateways`: more than one target was reachable; this is unusual unless you intentionally run isolated profiles, such as a rescue bot.
 - `auth_secretref_unresolved`: a configured auth SecretRef could not be resolved for a failed target.
-- `probe_scope_limited`: WebSocket connect succeeded, but detail RPC was limited by missing `operator.read`.
+- `probe_scope_limited`: WebSocket connect succeeded, but the read probe was limited by missing `operator.read`.
 
 #### Remote over SSH (Mac app parity)
 

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -47,7 +47,7 @@ openclaw status
 openclaw logs --follow
 ```
 
-Healthy baseline: `Runtime: running` and `RPC probe: ok`.
+Healthy baseline: `Runtime: running`, `Connectivity probe: ok`, and `Capability: ...` that matches what you expect. Use `openclaw gateway status --require-rpc` when you need read-scope RPC proof, not just reachability.
 
   </Step>
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -25,7 +25,7 @@ openclaw channels status --probe
 
 Expected healthy signals:
 
-- `openclaw gateway status` shows `Runtime: running` and `RPC probe: ok`.
+- `openclaw gateway status` shows `Runtime: running`, `Connectivity probe: ok`, and a `Capability: ...` line.
 - `openclaw doctor` reports no blocking config/service issues.
 - `openclaw channels status --probe` shows live per-account transport status and,
   where supported, probe/audit results such as `works` or `audit ok`.
@@ -281,7 +281,8 @@ Common signatures:
 
 - `SSH tunnel failed to start; falling back to direct probes.` → SSH setup failed, but the command still tried direct configured/loopback targets.
 - `multiple reachable gateways detected` → more than one target answered. Usually this means an intentional multi-gateway setup or stale/duplicate listeners.
-- `Probe diagnostics are limited by gateway scopes (missing operator.read)` → connect worked, but detail RPC is scope-limited; pair device identity or use credentials with `operator.read`.
+- `Read-probe diagnostics are limited by gateway scopes (missing operator.read)` → connect worked, but detail RPC is scope-limited; pair device identity or use credentials with `operator.read`.
+- `Capability: pairing-pending` or `gateway closed (1008): pairing required` → the gateway answered, but this client still needs pairing/approval before normal operator access.
 - unresolved `gateway.auth.*` / `gateway.remote.*` SecretRef warning text → auth material was unavailable in this command path for the failed target.
 
 Related:
@@ -471,7 +472,7 @@ What to check:
 Common signatures:
 
 - `refusing to bind gateway ... without auth` → non-loopback bind without a valid gateway auth path.
-- `RPC probe: failed` while runtime is running → gateway alive but inaccessible with current auth/url.
+- `Connectivity probe: failed` while runtime is running → gateway alive but inaccessible with current auth/url.
 
 ### 3) Pairing and device identity state changed
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2728,8 +2728,8 @@ Related: [/concepts/oauth](/concepts/oauth) (OAuth flows, token storage, multi-a
 
   </Accordion>
 
-  <Accordion title='Why does openclaw gateway status say "Runtime: running" but "RPC probe: failed"?'>
-    Because "running" is the **supervisor's** view (launchd/systemd/schtasks). The RPC probe is the CLI actually connecting to the gateway WebSocket and calling `status`.
+  <Accordion title='Why does openclaw gateway status say "Runtime: running" but "Connectivity probe: failed"?'>
+    Because "running" is the **supervisor's** view (launchd/systemd/schtasks). The connectivity probe is the CLI actually connecting to the gateway WebSocket.
 
     Use `openclaw gateway status` and trust these lines:
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -28,8 +28,8 @@ Good output in one line:
 
 - `openclaw status` → shows configured channels and no obvious auth errors.
 - `openclaw status --all` → full report is present and shareable.
-- `openclaw gateway probe` → expected gateway target is reachable (`Reachable: yes`). `RPC: limited - missing scope: operator.read` is degraded diagnostics, not a connect failure.
-- `openclaw gateway status` → `Runtime: running` and `RPC probe: ok`.
+- `openclaw gateway probe` → expected gateway target is reachable (`Reachable: yes`). `Capability: ...` tells you what auth level the probe could prove, and `Read probe: limited - missing scope: operator.read` is degraded diagnostics, not a connect failure.
+- `openclaw gateway status` → `Runtime: running`, `Connectivity probe: ok`, and a plausible `Capability: ...` line. Use `--require-rpc` if you need read-scope RPC proof too.
 - `openclaw doctor` → no blocking config/service errors.
 - `openclaw channels status --probe` → reachable gateway returns live per-account
   transport state plus probe/audit results such as `works` or `audit ok`; if the
@@ -117,7 +117,8 @@ flowchart TD
     Good output looks like:
 
     - `Runtime: running`
-    - `RPC probe: ok`
+    - `Connectivity probe: ok`
+    - `Capability: read-only`, `write-capable`, or `admin-capable`
     - Your channel shows transport connected and, where supported, `works` or `audit ok` in `channels status --probe`
     - Sender appears approved (or DM policy is open/allowlist)
 
@@ -147,7 +148,8 @@ flowchart TD
     Good output looks like:
 
     - `Dashboard: http://...` is shown in `openclaw gateway status`
-    - `RPC probe: ok`
+    - `Connectivity probe: ok`
+    - `Capability: read-only`, `write-capable`, or `admin-capable`
     - No auth loop in logs
 
     Common log signatures:
@@ -189,7 +191,8 @@ flowchart TD
 
     - `Service: ... (loaded)`
     - `Runtime: running`
-    - `RPC probe: ok`
+    - `Connectivity probe: ok`
+    - `Capability: read-only`, `write-capable`, or `admin-capable`
 
     Common log signatures:
 

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -19,7 +19,14 @@ vi.mock("../progress.js", () => ({
 describe("probeGatewayStatus", () => {
   it("uses lightweight token-only probing for daemon status", async () => {
     callGatewayMock.mockReset();
-    probeGatewayMock.mockResolvedValueOnce({ ok: true });
+    probeGatewayMock.mockResolvedValueOnce({
+      ok: true,
+      auth: {
+        role: "operator",
+        scopes: ["operator.write"],
+        capability: "write_capable",
+      },
+    });
 
     const result = await probeGatewayStatus({
       url: "ws://127.0.0.1:19191",
@@ -29,7 +36,16 @@ describe("probeGatewayStatus", () => {
       json: true,
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({
+      ok: true,
+      kind: "connect",
+      capability: "write_capable",
+      auth: {
+        role: "operator",
+        scopes: ["operator.write"],
+        capability: "write_capable",
+      },
+    });
     expect(callGatewayMock).not.toHaveBeenCalled();
     expect(probeGatewayMock).toHaveBeenCalledWith({
       url: "ws://127.0.0.1:19191",
@@ -58,7 +74,12 @@ describe("probeGatewayStatus", () => {
       configPath: "/tmp/openclaw-daemon/openclaw.json",
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({
+      ok: true,
+      kind: "read",
+      capability: "read_only",
+      auth: undefined,
+    });
     expect(probeGatewayMock).not.toHaveBeenCalled();
     expect(callGatewayMock).toHaveBeenCalledWith({
       url: "ws://127.0.0.1:19191",
@@ -78,6 +99,11 @@ describe("probeGatewayStatus", () => {
       ok: false,
       error: null,
       close: { code: 1008, reason: "pairing required" },
+      auth: {
+        role: null,
+        scopes: [],
+        capability: "pairing_pending",
+      },
     });
 
     const result = await probeGatewayStatus({
@@ -87,6 +113,13 @@ describe("probeGatewayStatus", () => {
 
     expect(result).toEqual({
       ok: false,
+      kind: "connect",
+      capability: "pairing_pending",
+      auth: {
+        role: null,
+        scopes: [],
+        capability: "pairing_pending",
+      },
       error: "gateway closed (1008): pairing required",
     });
   });
@@ -98,6 +131,11 @@ describe("probeGatewayStatus", () => {
       ok: false,
       error: "timeout",
       close: { code: 1008, reason: "pairing required" },
+      auth: {
+        role: null,
+        scopes: [],
+        capability: "pairing_pending",
+      },
     });
 
     const result = await probeGatewayStatus({
@@ -107,6 +145,13 @@ describe("probeGatewayStatus", () => {
 
     expect(result).toEqual({
       ok: false,
+      kind: "connect",
+      capability: "pairing_pending",
+      auth: {
+        role: null,
+        scopes: [],
+        capability: "pairing_pending",
+      },
       error: "gateway closed (1008): pairing required",
     });
   });
@@ -125,6 +170,7 @@ describe("probeGatewayStatus", () => {
 
     expect(result).toEqual({
       ok: false,
+      kind: "read",
       error: "missing scope: operator.admin",
     });
     expect(probeGatewayMock).not.toHaveBeenCalled();

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -63,6 +63,14 @@ describe("probeGatewayStatus", () => {
     callGatewayMock.mockReset();
     probeGatewayMock.mockReset();
     callGatewayMock.mockResolvedValueOnce({ status: "ok" });
+    probeGatewayMock.mockResolvedValueOnce({
+      ok: true,
+      auth: {
+        role: "operator",
+        scopes: ["operator.admin"],
+        capability: "admin_capable",
+      },
+    });
 
     const result = await probeGatewayStatus({
       url: "ws://127.0.0.1:19191",
@@ -77,10 +85,23 @@ describe("probeGatewayStatus", () => {
     expect(result).toEqual({
       ok: true,
       kind: "read",
-      capability: "read_only",
-      auth: undefined,
+      capability: "admin_capable",
+      auth: {
+        role: "operator",
+        scopes: ["operator.admin"],
+        capability: "admin_capable",
+      },
     });
-    expect(probeGatewayMock).not.toHaveBeenCalled();
+    expect(probeGatewayMock).toHaveBeenCalledWith({
+      url: "ws://127.0.0.1:19191",
+      auth: {
+        token: "temp-token",
+        password: undefined,
+      },
+      tlsFingerprint: "abc123",
+      timeoutMs: 5_000,
+      includeDetails: false,
+    });
     expect(callGatewayMock).toHaveBeenCalledWith({
       url: "ws://127.0.0.1:19191",
       token: "temp-token",
@@ -89,6 +110,38 @@ describe("probeGatewayStatus", () => {
       method: "status",
       timeoutMs: 5_000,
       configPath: "/tmp/openclaw-daemon/openclaw.json",
+    });
+  });
+
+  it("falls back to read-only when the status RPC succeeds but the auth probe is inconclusive", async () => {
+    callGatewayMock.mockReset();
+    probeGatewayMock.mockReset();
+    callGatewayMock.mockResolvedValueOnce({ status: "ok" });
+    probeGatewayMock.mockResolvedValueOnce({
+      ok: true,
+      auth: {
+        role: null,
+        scopes: [],
+        capability: "unknown",
+      },
+    });
+
+    const result = await probeGatewayStatus({
+      url: "ws://127.0.0.1:19191",
+      token: "temp-token",
+      timeoutMs: 5_000,
+      requireRpc: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      kind: "read",
+      capability: "read_only",
+      auth: {
+        role: null,
+        scopes: [],
+        capability: "unknown",
+      },
     });
   });
 

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -1,6 +1,8 @@
 import { formatErrorMessage } from "../../infra/errors.js";
 import { withProgress } from "../progress.js";
 
+type GatewayStatusProbeKind = "connect" | "read";
+
 function resolveProbeFailureMessage(result: {
   error?: string | null;
   close?: { code: number; reason: string } | null;
@@ -24,6 +26,7 @@ export async function probeGatewayStatus(opts: {
   requireRpc?: boolean;
   configPath?: string;
 }) {
+  const kind = (opts.requireRpc ? "read" : "connect") satisfies GatewayStatusProbeKind;
   try {
     const result = await withProgress(
       {
@@ -58,16 +61,26 @@ export async function probeGatewayStatus(opts: {
         });
       },
     );
+    const auth = "auth" in result ? result.auth : undefined;
     if (result.ok) {
-      return { ok: true } as const;
+      return {
+        ok: true,
+        kind,
+        capability: opts.requireRpc ? "read_only" : auth?.capability,
+        auth,
+      } as const;
     }
     return {
       ok: false,
+      kind,
+      capability: auth?.capability,
+      auth,
       error: resolveProbeFailureMessage(result),
     } as const;
   } catch (err) {
     return {
       ok: false,
+      kind,
       error: formatErrorMessage(err),
     } as const;
   }

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -46,7 +46,18 @@ export async function probeGatewayStatus(opts: {
             timeoutMs: opts.timeoutMs,
             ...(opts.configPath ? { configPath: opts.configPath } : {}),
           });
-          return { ok: true } as const;
+          const { probeGateway } = await import("../../gateway/probe.js");
+          const authProbe = await probeGateway({
+            url: opts.url,
+            auth: {
+              token: opts.token,
+              password: opts.password,
+            },
+            tlsFingerprint: opts.tlsFingerprint,
+            timeoutMs: opts.timeoutMs,
+            includeDetails: false,
+          }).catch(() => null);
+          return { ok: true as const, authProbe };
         }
         const { probeGateway } = await import("../../gateway/probe.js");
         return await probeGateway({
@@ -61,12 +72,20 @@ export async function probeGatewayStatus(opts: {
         });
       },
     );
-    const auth = "auth" in result ? result.auth : undefined;
+    const auth =
+      "auth" in result ? result.auth : "authProbe" in result ? result.authProbe?.auth : undefined;
     if (result.ok) {
       return {
         ok: true,
         kind,
-        capability: opts.requireRpc ? "read_only" : auth?.capability,
+        capability:
+          kind === "read"
+            ? auth?.capability && auth.capability !== "unknown"
+              ? auth.capability
+              : // The status RPC proves read access even when a follow-up hello probe
+                // cannot recover richer scope metadata.
+                "read_only"
+            : auth?.capability,
         auth,
       } as const;
     }

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -49,7 +49,9 @@ function resolveRpcOptions(cmdOpts: GatewayRpcOpts, command?: Command): GatewayR
 export function addGatewayServiceCommands(parent: Command, opts?: { statusDescription?: string }) {
   parent
     .command("status")
-    .description(opts?.statusDescription ?? "Show gateway service status + probe the Gateway")
+    .description(
+      opts?.statusDescription ?? "Show gateway service status + probe connectivity/capability",
+    )
     .option("--url <url>", "Gateway WebSocket URL (defaults to config/remote/local)")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")

--- a/src/cli/daemon-cli/register.ts
+++ b/src/cli/daemon-cli/register.ts
@@ -14,6 +14,6 @@ export function registerDaemonCli(program: Command) {
     );
 
   addGatewayServiceCommands(daemon, {
-    statusDescription: "Show service install status + probe the Gateway",
+    statusDescription: "Show service install status + probe connectivity/capability",
   });
 }

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -165,6 +165,13 @@ export type DaemonStatus = {
   lastError?: string;
   rpc?: {
     ok: boolean;
+    kind?: "connect" | "read";
+    capability?: string;
+    auth?: {
+      role?: string | null;
+      scopes?: string[];
+      capability?: string;
+    };
     error?: string;
     url?: string;
     authWarning?: string;

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -120,4 +120,36 @@ describe("printDaemonStatus", () => {
       expect.stringContaining(formatCliCommand("openclaw gateway restart")),
     );
   });
+
+  it("prints probe kind and capability separately", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        gateway: {
+          bindMode: "loopback",
+          bindHost: "127.0.0.1",
+          port: 18789,
+          portSource: "env/config",
+          probeUrl: "ws://127.0.0.1:18789",
+        },
+        rpc: {
+          ok: true,
+          kind: "connect",
+          capability: "write_capable",
+          url: "ws://127.0.0.1:18789",
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Connectivity probe: ok"));
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Capability: write-capable"));
+  });
 });

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -50,6 +50,17 @@ function sanitizeDaemonStatusForJson(status: DaemonStatus): DaemonStatus {
   };
 }
 
+function formatProbeKindLabel(kind?: "connect" | "read") {
+  return kind === "read" ? "Read probe:" : "Connectivity probe:";
+}
+
+function formatCapabilityLabel(capability?: string) {
+  if (!capability) {
+    return null;
+  }
+  return capability.replaceAll("_", "-");
+}
+
 export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean }) {
   if (opts.json) {
     const sanitized = sanitizeDaemonStatusForJson(status);
@@ -175,20 +186,25 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
     );
   }
   if (rpc) {
+    const probeLabel = formatProbeKindLabel(rpc.kind);
     if (rpc.ok) {
-      defaultRuntime.log(`${label("RPC probe:")} ${okText("ok")}`);
+      defaultRuntime.log(`${label(probeLabel)} ${okText("ok")}`);
     } else {
-      defaultRuntime.error(`${label("RPC probe:")} ${errorText("failed")}`);
+      defaultRuntime.error(`${label(probeLabel)} ${errorText("failed")}`);
       if (rpc.authWarning) {
-        defaultRuntime.error(`${label("RPC auth:")} ${warnText(rpc.authWarning)}`);
+        defaultRuntime.error(`${label("Probe auth:")} ${warnText(rpc.authWarning)}`);
       }
       if (rpc.url) {
-        defaultRuntime.error(`${label("RPC target:")} ${rpc.url}`);
+        defaultRuntime.error(`${label("Probe target:")} ${rpc.url}`);
       }
       const lines = (rpc.error ?? "unknown").split(/\r?\n/).filter(Boolean);
       for (const line of lines.slice(0, 12)) {
         defaultRuntime.error(`  ${errorText(line)}`);
       }
+    }
+    const capability = formatCapabilityLabel(rpc.capability);
+    if (capability) {
+      defaultRuntime.log(`${label("Capability:")} ${infoText(capability)}`);
     }
     spacer();
   }

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -144,7 +144,7 @@ export function registerGatewayCli(program: Command) {
         () =>
           `\n${theme.heading("Examples:")}\n${formatHelpExamples([
             ["openclaw gateway run", "Run the gateway in the foreground."],
-            ["openclaw gateway status", "Show service status and probe reachability."],
+            ["openclaw gateway status", "Show service status plus connectivity/capability."],
             ["openclaw gateway discover", "Find local and wide-area gateway beacons."],
             ["openclaw gateway call health", "Call a gateway RPC method directly."],
           ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/gateway", "docs.openclaw.ai/cli/gateway")}\n`,
@@ -156,7 +156,7 @@ export function registerGatewayCli(program: Command) {
   );
 
   addGatewayServiceCommands(gateway, {
-    statusDescription: "Show gateway service status + probe the Gateway",
+    statusDescription: "Show gateway service status + probe connectivity/capability",
   });
 
   gatewayCallOpts(
@@ -240,7 +240,9 @@ export function registerGatewayCli(program: Command) {
 
   gateway
     .command("probe")
-    .description("Show gateway reachability + discovery + health + status summary (local + remote)")
+    .description(
+      "Show gateway reachability, auth capability, and read-probe summary (local + remote)",
+    )
     .option("--url <url>", "Explicit Gateway WebSocket URL (still probes localhost)")
     .option("--ssh <target>", "SSH target for remote gateway tunnel (user@host or user@host:port)")
     .option("--ssh-identity <path>", "SSH identity file path")

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -55,6 +55,11 @@ const mocks = vi.hoisted(() => {
           connectLatencyMs: 12,
           error: null,
           close: null,
+          auth: {
+            role: "operator",
+            scopes: ["operator.read"],
+            capability: "read_only",
+          },
           health: { ok: true },
           status: {
             linkChannel: {
@@ -93,6 +98,11 @@ const mocks = vi.hoisted(() => {
         connectLatencyMs: 34,
         error: null,
         close: null,
+        auth: {
+          role: "operator",
+          scopes: ["operator.admin"],
+          capability: "admin_capable",
+        },
         health: { ok: true },
         status: {
           linkChannel: {
@@ -196,7 +206,8 @@ vi.mock("../infra/tls/gateway.js", () => ({
   loadGatewayTlsRuntime: mocks.loadGatewayTlsRuntime,
 }));
 
-vi.mock("../gateway/probe.js", () => ({
+vi.mock("../gateway/probe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../gateway/probe.js")>()),
   probeGateway: mocks.probeGateway,
 }));
 
@@ -346,6 +357,11 @@ describe("gateway-status command", () => {
       connectLatencyMs: 51,
       error: "missing scope: operator.read",
       close: null,
+      auth: {
+        role: "operator",
+        scopes: ["operator.write"],
+        capability: "write_capable",
+      },
       health: null,
       status: null,
       presence: null,
@@ -358,6 +374,7 @@ describe("gateway-status command", () => {
     const parsed = JSON.parse(runtimeLogs.join("\n")) as {
       ok?: boolean;
       degraded?: boolean;
+      capability?: string;
       warnings?: Array<{ code?: string; targetIds?: string[] }>;
       targets?: Array<{
         connect?: {
@@ -365,15 +382,20 @@ describe("gateway-status command", () => {
           rpcOk?: boolean;
           scopeLimited?: boolean;
         };
+        auth?: {
+          capability?: string;
+        };
       }>;
     };
     expect(parsed.ok).toBe(true);
     expect(parsed.degraded).toBe(true);
+    expect(parsed.capability).toBe("write_capable");
     expect(parsed.targets?.[0]?.connect).toMatchObject({
       ok: true,
       rpcOk: false,
       scopeLimited: true,
     });
+    expect(parsed.targets?.[0]?.auth?.capability).toBe("write_capable");
     const scopeLimitedWarning = parsed.warnings?.find(
       (warning) => warning.code === "probe_scope_limited",
     );
@@ -415,6 +437,11 @@ describe("gateway-status command", () => {
               connectLatencyMs: null,
               error: "connection refused",
               close: null,
+              auth: {
+                role: null,
+                scopes: [],
+                capability: "unknown",
+              },
               health: null,
               status: null,
               presence: null,
@@ -571,6 +598,11 @@ describe("gateway-status command", () => {
       connectLatencyMs: 20,
       error: null,
       close: null,
+      auth: {
+        role: "operator",
+        scopes: ["operator.read"],
+        capability: "read_only",
+      },
       health: { ok: true },
       status: {
         linkChannel: {

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAuthForTarget,
   resolveProbeBudgetMs,
   resolveTargets,
+  sanitizeSshTarget,
 } from "./helpers.js";
 import { createSecretRefGatewayConfig } from "./test-support.js";
 
@@ -367,5 +368,12 @@ describe("resolveProbeBudgetMs", () => {
         url: "wss://gateway.example/ws",
       }),
     ).toBe(2000);
+  });
+});
+
+describe("sanitizeSshTarget", () => {
+  it("strips a leading ssh command prefix", () => {
+    expect(sanitizeSshTarget("ssh me@studio")).toBe("me@studio");
+    expect(sanitizeSshTarget("  ssh me@studio:2222  ")).toBe("me@studio:2222");
   });
 });

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -230,6 +230,11 @@ describe("probe reachability classification", () => {
       connectLatencyMs: 51,
       error: "missing scope: operator.read",
       close: null,
+      auth: {
+        role: "operator",
+        scopes: ["operator.write"],
+        capability: "write_capable" as const,
+      },
       health: null,
       status: null,
       presence: null,
@@ -238,7 +243,8 @@ describe("probe reachability classification", () => {
 
     expect(isScopeLimitedProbeFailure(probe)).toBe(true);
     expect(isProbeReachable(probe)).toBe(true);
-    expect(renderProbeSummaryLine(probe, false)).toContain("RPC: limited");
+    expect(renderProbeSummaryLine(probe, false)).toContain("Capability: write-capable");
+    expect(renderProbeSummaryLine(probe, false)).toContain("Read probe: limited");
   });
 
   it("keeps non-scope RPC failures as unreachable", () => {
@@ -248,6 +254,11 @@ describe("probe reachability classification", () => {
       connectLatencyMs: 43,
       error: "unknown method: status",
       close: null,
+      auth: {
+        role: "operator",
+        scopes: [],
+        capability: "connected_no_operator_scope" as const,
+      },
       health: null,
       status: null,
       presence: null,
@@ -256,7 +267,8 @@ describe("probe reachability classification", () => {
 
     expect(isScopeLimitedProbeFailure(probe)).toBe(false);
     expect(isProbeReachable(probe)).toBe(false);
-    expect(renderProbeSummaryLine(probe, false)).toContain("RPC: failed");
+    expect(renderProbeSummaryLine(probe, false)).toContain("Capability: connect-only");
+    expect(renderProbeSummaryLine(probe, false)).toContain("Read probe: failed");
   });
 });
 describe("gateway-status local target scheme", () => {

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig, ConfigFileSnapshot } from "../../config/types.js";
 import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import { resolveGatewayProbeSurfaceAuth } from "../../gateway/auth-surface-resolution.js";
 import { isLoopbackHost } from "../../gateway/net.js";
-import type { GatewayProbeResult } from "../../gateway/probe.js";
+import { type GatewayProbeCapability, type GatewayProbeResult } from "../../gateway/probe.js";
 import { inspectBestEffortPrimaryTailnetIPv4 } from "../../infra/network-discovery-display.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { colorize, theme } from "../../terminal/theme.js";
@@ -280,22 +280,90 @@ export function isProbeReachable(probe: GatewayProbeResult): boolean {
   return probe.ok || isScopeLimitedProbeFailure(probe);
 }
 
+function getGatewayProbeCapability(probe: GatewayProbeResult): GatewayProbeCapability {
+  return probe.auth.capability;
+}
+
+export function summarizeGatewayProbeCapability(
+  probes: GatewayProbeResult[],
+): GatewayProbeCapability {
+  const priority: GatewayProbeCapability[] = [
+    "admin_capable",
+    "write_capable",
+    "read_only",
+    "connected_no_operator_scope",
+    "pairing_pending",
+    "unknown",
+  ];
+  for (const capability of priority) {
+    if (probes.some((probe) => getGatewayProbeCapability(probe) === capability)) {
+      return capability;
+    }
+  }
+  return "unknown";
+}
+
+function formatGatewayProbeCapabilityLabel(capability: GatewayProbeCapability) {
+  switch (capability) {
+    case "admin_capable":
+      return "Capability: admin-capable";
+    case "write_capable":
+      return "Capability: write-capable";
+    case "read_only":
+      return "Capability: read-only";
+    case "connected_no_operator_scope":
+      return "Capability: connect-only";
+    case "pairing_pending":
+      return "Capability: pairing pending";
+    default:
+      return "Capability: unknown";
+  }
+}
+
+function colorForGatewayProbeCapability(capability: GatewayProbeCapability) {
+  switch (capability) {
+    case "admin_capable":
+    case "write_capable":
+    case "read_only":
+      return theme.info;
+    case "connected_no_operator_scope":
+    case "pairing_pending":
+      return theme.warn;
+    default:
+      return theme.muted;
+  }
+}
+
+export function renderProbeCapabilityLine(probe: GatewayProbeResult, rich: boolean) {
+  const capability = getGatewayProbeCapability(probe);
+  return colorize(
+    rich,
+    colorForGatewayProbeCapability(capability),
+    formatGatewayProbeCapabilityLabel(capability),
+  );
+}
+
 export function renderProbeSummaryLine(probe: GatewayProbeResult, rich: boolean) {
+  const capability = renderProbeCapabilityLine(probe, rich);
   if (probe.ok) {
     const latency =
       typeof probe.connectLatencyMs === "number" ? `${probe.connectLatencyMs}ms` : "unknown";
-    return `${colorize(rich, theme.success, "Connect: ok")} (${latency}) · ${colorize(rich, theme.success, "RPC: ok")}`;
+    return `${colorize(rich, theme.success, "Connect: ok")} (${latency}) · ${capability} · ${colorize(rich, theme.success, "Read probe: ok")}`;
   }
 
   const detail = probe.error ? ` - ${probe.error}` : "";
   if (probe.connectLatencyMs != null) {
     const latency =
       typeof probe.connectLatencyMs === "number" ? `${probe.connectLatencyMs}ms` : "unknown";
-    const rpcStatus = isScopeLimitedProbeFailure(probe)
-      ? colorize(rich, theme.warn, "RPC: limited")
-      : colorize(rich, theme.error, "RPC: failed");
-    return `${colorize(rich, theme.success, "Connect: ok")} (${latency}) · ${rpcStatus}${detail}`;
+    const readStatus = isScopeLimitedProbeFailure(probe)
+      ? colorize(rich, theme.warn, "Read probe: limited")
+      : colorize(rich, theme.error, "Read probe: failed");
+    return `${colorize(rich, theme.success, "Connect: ok")} (${latency}) · ${capability} · ${readStatus}${detail}`;
   }
 
-  return `${colorize(rich, theme.error, "Connect: failed")}${detail}`;
+  if (getGatewayProbeCapability(probe) === "pairing_pending") {
+    return `${colorize(rich, theme.warn, "Connect: blocked")}${detail} · ${capability}`;
+  }
+
+  return `${colorize(rich, theme.error, "Connect: failed")}${detail} · ${capability}`;
 }

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -156,7 +156,7 @@ export function sanitizeSshTarget(value: unknown): string | null {
   if (!trimmed) {
     return null;
   }
-  return trimmed.replace(/^ssh\\s+/, "");
+  return trimmed.replace(/^ssh\s+/, "");
 }
 
 export async function resolveAuthForTarget(

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayProbeResult } from "../../gateway/probe.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { GatewayStatusProbedTarget } from "./probe-run.js";
+
+const writeRuntimeJson = vi.fn();
+
+vi.mock("../../runtime.js", () => ({
+  writeRuntimeJson: (...args: unknown[]) => writeRuntimeJson(...args),
+}));
+
+vi.mock("../../terminal/theme.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../terminal/theme.js")>("../../terminal/theme.js");
+  return {
+    ...actual,
+    colorize: (_rich: boolean, _theme: unknown, text: string) => text,
+  };
+});
+
+const { writeGatewayStatusJson, writeGatewayStatusText } = await import("./output.js");
+
+function createRuntimeCapture(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`__exit__:${code}`);
+    }),
+  } as unknown as RuntimeEnv;
+}
+
+function createProbe(
+  capability: GatewayProbeResult["auth"]["capability"],
+  params: {
+    ok: boolean;
+    connectLatencyMs: number | null;
+    error?: string | null;
+  },
+): GatewayProbeResult {
+  return {
+    ok: params.ok,
+    url: "ws://127.0.0.1:18789",
+    connectLatencyMs: params.connectLatencyMs,
+    error: params.error ?? null,
+    close: null,
+    auth: {
+      role: "operator",
+      scopes: capability === "admin_capable" ? ["operator.admin"] : ["operator.read"],
+      capability,
+    },
+    health: null,
+    status: null,
+    presence: null,
+    configSnapshot: null,
+  };
+}
+
+function createTarget(id: string, probe: GatewayProbeResult): GatewayStatusProbedTarget {
+  return {
+    target: {
+      id,
+      kind: "explicit",
+      url: probe.url,
+      active: true,
+    },
+    probe,
+    configSummary: null,
+    self: null,
+    authDiagnostics: [],
+  };
+}
+
+describe("gateway status output", () => {
+  beforeEach(() => {
+    writeRuntimeJson.mockReset();
+  });
+
+  it("derives summary capability from reachable probes only in json output", () => {
+    const runtime = createRuntimeCapture();
+    writeGatewayStatusJson({
+      runtime,
+      startedAt: Date.now() - 50,
+      overallTimeoutMs: 5_000,
+      discoveryTimeoutMs: 500,
+      network: {
+        localLoopbackUrl: "ws://127.0.0.1:18789",
+        localTailnetUrl: null,
+        tailnetIPv4: null,
+      },
+      discovery: [],
+      probed: [
+        createTarget(
+          "unreachable-admin",
+          createProbe("admin_capable", {
+            ok: false,
+            connectLatencyMs: 40,
+            error: "unknown method: status",
+          }),
+        ),
+        createTarget(
+          "reachable-read",
+          createProbe("read_only", {
+            ok: true,
+            connectLatencyMs: 20,
+          }),
+        ),
+      ],
+      warnings: [],
+      primaryTargetId: "reachable-read",
+    });
+
+    expect(writeRuntimeJson).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        ok: true,
+        capability: "read_only",
+      }),
+    );
+  });
+
+  it("derives summary capability from reachable probes only in text output", () => {
+    const runtime = createRuntimeCapture();
+    writeGatewayStatusText({
+      runtime,
+      rich: false,
+      overallTimeoutMs: 5_000,
+      discovery: [],
+      probed: [
+        createTarget(
+          "unreachable-admin",
+          createProbe("admin_capable", {
+            ok: false,
+            connectLatencyMs: 40,
+            error: "unknown method: status",
+          }),
+        ),
+        createTarget(
+          "reachable-read",
+          createProbe("read_only", {
+            ok: false,
+            connectLatencyMs: 20,
+            error: "missing scope: operator.read",
+          }),
+        ),
+      ],
+      warnings: [],
+    });
+
+    expect(runtime.log).toHaveBeenCalledWith("Capability: read-only");
+  });
+});

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -99,7 +99,7 @@ export function writeGatewayStatusJson(params: {
 }) {
   const reachable = params.probed.filter((entry) => isProbeReachable(entry.probe));
   const degraded = params.probed.some((entry) => isScopeLimitedProbeFailure(entry.probe));
-  const capability = summarizeGatewayProbeCapability(params.probed.map((entry) => entry.probe));
+  const capability = summarizeGatewayProbeCapability(reachable.map((entry) => entry.probe));
   writeRuntimeJson(params.runtime, {
     ok: reachable.length > 0,
     degraded,
@@ -153,7 +153,7 @@ export function writeGatewayStatusText(params: {
 }) {
   const reachable = params.probed.filter((entry) => isProbeReachable(entry.probe));
   const ok = reachable.length > 0;
-  const capability = summarizeGatewayProbeCapability(params.probed.map((entry) => entry.probe));
+  const capability = summarizeGatewayProbeCapability(reachable.map((entry) => entry.probe));
   params.runtime.log(colorize(params.rich, theme.heading, "Gateway Status"));
   params.runtime.log(
     ok

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -5,6 +5,7 @@ import { serializeGatewayDiscoveryBeacon } from "./discovery.js";
 import {
   isProbeReachable,
   isScopeLimitedProbeFailure,
+  summarizeGatewayProbeCapability,
   renderProbeSummaryLine,
   renderTargetHeader,
 } from "./helpers.js";
@@ -78,7 +79,7 @@ export function buildGatewayStatusWarnings(params: {
     warnings.push({
       code: "probe_scope_limited",
       message:
-        "Probe diagnostics are limited by gateway scopes (missing operator.read). Connection succeeded, but status details may be incomplete. Hint: pair device identity or use credentials with operator.read.",
+        "Read-probe diagnostics are limited by gateway scopes (missing operator.read). Connection succeeded, but read-only status calls are incomplete. Hint: pair device identity or use credentials with operator.read.",
       targetIds: [result.target.id],
     });
   }
@@ -98,9 +99,11 @@ export function writeGatewayStatusJson(params: {
 }) {
   const reachable = params.probed.filter((entry) => isProbeReachable(entry.probe));
   const degraded = params.probed.some((entry) => isScopeLimitedProbeFailure(entry.probe));
+  const capability = summarizeGatewayProbeCapability(params.probed.map((entry) => entry.probe));
   writeRuntimeJson(params.runtime, {
     ok: reachable.length > 0,
     degraded,
+    capability,
     ts: Date.now(),
     durationMs: Date.now() - params.startedAt,
     timeoutMs: params.overallTimeoutMs,
@@ -126,6 +129,7 @@ export function writeGatewayStatusJson(params: {
         error: entry.probe.error,
         close: entry.probe.close,
       },
+      auth: entry.probe.auth,
       self: entry.self,
       config: entry.configSummary,
       health: entry.probe.health,
@@ -149,11 +153,15 @@ export function writeGatewayStatusText(params: {
 }) {
   const reachable = params.probed.filter((entry) => isProbeReachable(entry.probe));
   const ok = reachable.length > 0;
+  const capability = summarizeGatewayProbeCapability(params.probed.map((entry) => entry.probe));
   params.runtime.log(colorize(params.rich, theme.heading, "Gateway Status"));
   params.runtime.log(
     ok
       ? `${colorize(params.rich, theme.success, "Reachable")}: yes`
       : `${colorize(params.rich, theme.error, "Reachable")}: no`,
+  );
+  params.runtime.log(
+    `${colorize(params.rich, theme.info, "Capability")}: ${capability.replaceAll("_", "-")}`,
   );
   params.runtime.log(
     colorize(params.rich, theme.muted, `Probe budget: ${params.overallTimeoutMs}ms`),

--- a/src/commands/status.scan-result.test.ts
+++ b/src/commands/status.scan-result.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildStatusScanResult } from "./status.scan-result.ts";
 import { buildColdStartStatusSummary } from "./status.scan.bootstrap-shared.ts";
+import type { GatewayProbeSnapshot } from "./status.scan.shared.ts";
 
 describe("buildStatusScanResult", () => {
   it("builds the full shared scan result shape", () => {
@@ -15,7 +16,17 @@ describe("buildStatusScanResult", () => {
       installKind: "package" as const,
       packageManager: "npm" as const,
     };
-    const gatewaySnapshot = {
+    const gatewaySnapshot: Pick<
+      GatewayProbeSnapshot,
+      | "gatewayConnection"
+      | "remoteUrlMissing"
+      | "gatewayMode"
+      | "gatewayProbeAuth"
+      | "gatewayProbeAuthWarning"
+      | "gatewayProbe"
+      | "gatewayReachable"
+      | "gatewaySelf"
+    > = {
       gatewayConnection: {
         url: "ws://127.0.0.1:18789",
         urlSource: "config" as const,
@@ -31,6 +42,11 @@ describe("buildStatusScanResult", () => {
         connectLatencyMs: 42,
         error: null,
         close: null,
+        auth: {
+          role: "operator",
+          scopes: ["operator.read"],
+          capability: "read_only",
+        },
         health: null,
         status: null,
         presence: null,

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -8,7 +8,7 @@ const gatewayClientState = vi.hoisted(() => ({
   helloAuth: {
     role: "operator",
     scopes: ["operator.read"],
-  },
+  } as { role?: string; scopes?: string[] } | undefined,
 }));
 
 const deviceIdentityState = vi.hoisted(() => ({
@@ -235,6 +235,40 @@ describe("probeGateway", () => {
     expect(result.auth).toMatchObject({
       scopes: ["operator.write"],
       capability: "write_capable",
+    });
+  });
+
+  it("keeps capability unknown when hello-ok omits auth metadata", async () => {
+    gatewayClientState.helloAuth = undefined;
+
+    const result = await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+      includeDetails: false,
+    });
+
+    expect(result.auth).toMatchObject({
+      role: null,
+      scopes: [],
+      capability: "unknown",
+    });
+  });
+
+  it("reports connect-only only when hello-ok explicitly includes empty auth metadata", async () => {
+    gatewayClientState.helloAuth = {};
+
+    const result = await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+      includeDetails: false,
+    });
+
+    expect(result.auth).toMatchObject({
+      role: null,
+      scopes: [],
+      capability: "connected_no_operator_scope",
     });
   });
 });

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -5,6 +5,10 @@ const gatewayClientState = vi.hoisted(() => ({
   requests: [] as string[],
   startMode: "hello" as "hello" | "close",
   close: { code: 1008, reason: "pairing required" },
+  helloAuth: {
+    role: "operator",
+    scopes: ["operator.read"],
+  },
 }));
 
 const deviceIdentityState = vi.hoisted(() => ({
@@ -33,7 +37,10 @@ class MockGatewayClient {
         }
         const onHelloOk = this.opts.onHelloOk;
         if (typeof onHelloOk === "function") {
-          await onHelloOk();
+          await onHelloOk({
+            type: "hello-ok",
+            auth: gatewayClientState.helloAuth,
+          });
         }
       })
       .catch(() => {});
@@ -70,6 +77,10 @@ describe("probeGateway", () => {
     deviceIdentityState.throwOnLoad = false;
     gatewayClientState.startMode = "hello";
     gatewayClientState.close = { code: 1008, reason: "pairing required" };
+    gatewayClientState.helloAuth = {
+      role: "operator",
+      scopes: ["operator.read"],
+    };
   });
 
   it("clamps probe timeout to timer-safe bounds", () => {
@@ -93,6 +104,11 @@ describe("probeGateway", () => {
       "config.get",
     ]);
     expect(result.ok).toBe(true);
+    expect(result.auth).toMatchObject({
+      role: "operator",
+      scopes: ["operator.read"],
+      capability: "read_only",
+    });
   });
 
   it("keeps device identity enabled for remote probes", async () => {
@@ -198,7 +214,27 @@ describe("probeGateway", () => {
       ok: false,
       error: "gateway closed (1008): pairing required",
       close: { code: 1008, reason: "pairing required" },
+      auth: { capability: "pairing_pending" },
     });
     expect(gatewayClientState.requests).toEqual([]);
+  });
+
+  it("reports write-capable auth when hello-ok scopes include operator.write", async () => {
+    gatewayClientState.helloAuth = {
+      role: "operator",
+      scopes: ["operator.write"],
+    };
+
+    const result = await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 1_000,
+      includeDetails: false,
+    });
+
+    expect(result.auth).toMatchObject({
+      scopes: ["operator.write"],
+      capability: "write_capable",
+    });
   });
 });

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -17,12 +17,27 @@ export type GatewayProbeClose = {
   hint?: string;
 };
 
+export type GatewayProbeCapability =
+  | "unknown"
+  | "pairing_pending"
+  | "connected_no_operator_scope"
+  | "read_only"
+  | "write_capable"
+  | "admin_capable";
+
+export type GatewayProbeAuthSummary = {
+  role: string | null;
+  scopes: string[];
+  capability: GatewayProbeCapability;
+};
+
 export type GatewayProbeResult = {
   ok: boolean;
   url: string;
   connectLatencyMs: number | null;
   error: string | null;
   close: GatewayProbeClose | null;
+  auth: GatewayProbeAuthSummary;
   health: unknown;
   status: unknown;
   presence: SystemPresence[] | null;
@@ -31,6 +46,10 @@ export type GatewayProbeResult = {
 
 export const MIN_PROBE_TIMEOUT_MS = 250;
 export const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const PAIRING_REQUIRED_PATTERN = /\bpairing required\b/i;
+const OPERATOR_READ_SCOPE = "operator.read";
+const OPERATOR_WRITE_SCOPE = "operator.write";
+const OPERATOR_ADMIN_SCOPE = "operator.admin";
 
 export function clampProbeTimeoutMs(timeoutMs: number): number {
   return Math.min(MAX_TIMER_DELAY_MS, Math.max(MIN_PROBE_TIMEOUT_MS, timeoutMs));
@@ -38,6 +57,69 @@ export function clampProbeTimeoutMs(timeoutMs: number): number {
 
 function formatProbeCloseError(close: GatewayProbeClose): string {
   return `gateway closed (${close.code}): ${close.reason}`;
+}
+
+function emptyProbeAuth(): GatewayProbeAuthSummary {
+  return {
+    role: null,
+    scopes: [],
+    capability: "unknown",
+  };
+}
+
+function resolveProbeAuthSummary(params: {
+  role?: string | null;
+  scopes?: string[];
+  error?: string | null;
+  close?: GatewayProbeClose | null;
+  verifiedRead?: boolean;
+  connectLatencyMs?: number | null;
+}): GatewayProbeAuthSummary {
+  const scopes = Array.isArray(params.scopes) ? params.scopes : [];
+  return {
+    role: params.role ?? null,
+    scopes,
+    capability: resolveGatewayProbeCapability({
+      auth: { scopes },
+      error: params.error,
+      close: params.close,
+      verifiedRead: params.verifiedRead,
+      connectLatencyMs: params.connectLatencyMs,
+    }),
+  };
+}
+
+export function isPairingPendingProbeFailure(params: {
+  error?: string | null;
+  close?: GatewayProbeClose | null;
+}): boolean {
+  return PAIRING_REQUIRED_PATTERN.test(params.close?.reason ?? params.error ?? "");
+}
+
+export function resolveGatewayProbeCapability(params: {
+  auth?: Pick<GatewayProbeAuthSummary, "scopes"> | null;
+  error?: string | null;
+  close?: GatewayProbeClose | null;
+  verifiedRead?: boolean;
+  connectLatencyMs?: number | null;
+}): GatewayProbeCapability {
+  if (isPairingPendingProbeFailure(params)) {
+    return "pairing_pending";
+  }
+  const scopes = Array.isArray(params.auth?.scopes) ? params.auth.scopes : [];
+  if (scopes.includes(OPERATOR_ADMIN_SCOPE)) {
+    return "admin_capable";
+  }
+  if (scopes.includes(OPERATOR_WRITE_SCOPE)) {
+    return "write_capable";
+  }
+  if (scopes.includes(OPERATOR_READ_SCOPE) || params.verifiedRead === true) {
+    return "read_only";
+  }
+  if (params.connectLatencyMs != null) {
+    return "connected_no_operator_scope";
+  }
+  return "unknown";
 }
 
 export async function probeGateway(opts: {
@@ -53,6 +135,7 @@ export async function probeGateway(opts: {
   let connectLatencyMs: number | null = null;
   let connectError: string | null = null;
   let close: GatewayProbeClose | null = null;
+  let auth = emptyProbeAuth();
 
   const detailLevel = opts.includeDetails === false ? "none" : (opts.detailLevel ?? "full");
 
@@ -100,6 +183,34 @@ export async function probeGateway(opts: {
       client.stop();
       resolve({ url: opts.url, ...result });
     };
+    const settleProbe = (params: {
+      ok: boolean;
+      error: string | null;
+      verifiedRead?: boolean;
+      health: unknown;
+      status: unknown;
+      presence: SystemPresence[] | null;
+      configSnapshot: unknown;
+    }) => {
+      settle({
+        ok: params.ok,
+        connectLatencyMs,
+        error: params.error,
+        close,
+        auth: resolveProbeAuthSummary({
+          role: auth.role,
+          scopes: auth.scopes,
+          error: params.error,
+          close,
+          verifiedRead: params.verifiedRead,
+          connectLatencyMs,
+        }),
+        health: params.health,
+        status: params.status,
+        presence: params.presence,
+        configSnapshot: params.configSnapshot,
+      });
+    };
 
     const client = new GatewayClient({
       url: opts.url,
@@ -118,11 +229,9 @@ export async function probeGateway(opts: {
       onClose: (code, reason) => {
         close = { code, reason };
         if (connectLatencyMs == null) {
-          settle({
+          settleProbe({
             ok: false,
-            connectLatencyMs,
             error: formatProbeCloseError(close),
-            close,
             health: null,
             status: null,
             presence: null,
@@ -130,14 +239,19 @@ export async function probeGateway(opts: {
           });
         }
       },
-      onHelloOk: async () => {
+      onHelloOk: async (hello) => {
         connectLatencyMs = Date.now() - startedAt;
+        auth = resolveProbeAuthSummary({
+          role: typeof hello?.auth?.role === "string" ? hello.auth.role : null,
+          scopes: Array.isArray(hello?.auth?.scopes)
+            ? hello.auth.scopes.filter((scope): scope is string => typeof scope === "string")
+            : [],
+        });
         if (detailLevel === "none") {
-          settle({
+          settleProbe({
             ok: true,
-            connectLatencyMs,
             error: null,
-            close,
+            verifiedRead: false,
             health: null,
             status: null,
             presence: null,
@@ -148,11 +262,9 @@ export async function probeGateway(opts: {
         // Once the gateway has accepted the session, a slow follow-up RPC should no longer
         // downgrade the probe to "unreachable". Give detail fetching its own budget.
         armProbeTimer(() => {
-          settle({
+          settleProbe({
             ok: false,
-            connectLatencyMs,
             error: "timeout",
-            close,
             health: null,
             status: null,
             presence: null,
@@ -162,11 +274,10 @@ export async function probeGateway(opts: {
         try {
           if (detailLevel === "presence") {
             const presence = await client.request("system-presence");
-            settle({
+            settleProbe({
               ok: true,
-              connectLatencyMs,
               error: null,
-              close,
+              verifiedRead: true,
               health: null,
               status: null,
               presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
@@ -180,22 +291,20 @@ export async function probeGateway(opts: {
             client.request("system-presence"),
             client.request("config.get", {}),
           ]);
-          settle({
+          settleProbe({
             ok: true,
-            connectLatencyMs,
             error: null,
-            close,
+            verifiedRead: true,
             health,
             status,
             presence: Array.isArray(presence) ? (presence as SystemPresence[]) : null,
             configSnapshot,
           });
         } catch (err) {
-          settle({
+          const error = formatErrorMessage(err);
+          settleProbe({
             ok: false,
-            connectLatencyMs,
-            error: formatErrorMessage(err),
-            close,
+            error,
             health: null,
             status: null,
             presence: null,
@@ -206,11 +315,10 @@ export async function probeGateway(opts: {
     });
 
     armProbeTimer(() => {
-      settle({
+      const error = connectError ? `connect failed: ${connectError}` : "timeout";
+      settleProbe({
         ok: false,
-        connectLatencyMs,
-        error: connectError ? `connect failed: ${connectError}` : "timeout",
-        close,
+        error,
         health: null,
         status: null,
         presence: null,

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -70,6 +70,7 @@ function emptyProbeAuth(): GatewayProbeAuthSummary {
 function resolveProbeAuthSummary(params: {
   role?: string | null;
   scopes?: string[];
+  authMetadataPresent?: boolean;
   error?: string | null;
   close?: GatewayProbeClose | null;
   verifiedRead?: boolean;
@@ -81,6 +82,7 @@ function resolveProbeAuthSummary(params: {
     scopes,
     capability: resolveGatewayProbeCapability({
       auth: { scopes },
+      authMetadataPresent: params.authMetadataPresent,
       error: params.error,
       close: params.close,
       verifiedRead: params.verifiedRead,
@@ -98,6 +100,7 @@ export function isPairingPendingProbeFailure(params: {
 
 export function resolveGatewayProbeCapability(params: {
   auth?: Pick<GatewayProbeAuthSummary, "scopes"> | null;
+  authMetadataPresent?: boolean;
   error?: string | null;
   close?: GatewayProbeClose | null;
   verifiedRead?: boolean;
@@ -116,7 +119,7 @@ export function resolveGatewayProbeCapability(params: {
   if (scopes.includes(OPERATOR_READ_SCOPE) || params.verifiedRead === true) {
     return "read_only";
   }
-  if (params.connectLatencyMs != null) {
+  if (params.connectLatencyMs != null && params.authMetadataPresent === true) {
     return "connected_no_operator_scope";
   }
   return "unknown";
@@ -136,6 +139,7 @@ export async function probeGateway(opts: {
   let connectError: string | null = null;
   let close: GatewayProbeClose | null = null;
   let auth = emptyProbeAuth();
+  let authMetadataPresent = false;
 
   const detailLevel = opts.includeDetails === false ? "none" : (opts.detailLevel ?? "full");
 
@@ -200,6 +204,7 @@ export async function probeGateway(opts: {
         auth: resolveProbeAuthSummary({
           role: auth.role,
           scopes: auth.scopes,
+          authMetadataPresent,
           error: params.error,
           close,
           verifiedRead: params.verifiedRead,
@@ -241,11 +246,13 @@ export async function probeGateway(opts: {
       },
       onHelloOk: async (hello) => {
         connectLatencyMs = Date.now() - startedAt;
+        authMetadataPresent = typeof hello?.auth === "object" && hello.auth !== null;
         auth = resolveProbeAuthSummary({
           role: typeof hello?.auth?.role === "string" ? hello.auth.role : null,
           scopes: Array.isArray(hello?.auth?.scopes)
             ? hello.auth.scopes.filter((scope): scope is string => typeof scope === "string")
             : [],
+          authMetadataPresent,
         });
         if (detailLevel === "none") {
           settleProbe({


### PR DESCRIPTION
## Summary
- split gateway probe output into separate reachability, capability, and read-probe signals
- rename default gateway status probe wording so connect-only success no longer implies full RPC/write health
- update troubleshooting/docs copy to match the new semantics

## Verification
- env OPENCLAW_LOCAL_CHECK=0 pnpm test src/gateway/probe.test.ts src/commands/gateway-status.test.ts src/commands/gateway-status/helpers.test.ts src/cli/daemon-cli/probe.test.ts src/cli/daemon-cli/status.print.test.ts
- env OPENCLAW_LOCAL_CHECK=0 pnpm tsgo:core
- env OPENCLAW_LOCAL_CHECK=0 pnpm build
- manual CLI smoke for gateway probe/status wording on local and isolated gateway targets