### PR TITLE
place permission under each branch of bot permissions for discord docs

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -63,7 +63,6 @@ You will need to create a new application with a bot, add the bot to your server
 
     A **Bot Permissions** section will appear below. Enable:
 
-
     **General Permissions**
       - View Channels
     **Text Permissions**
@@ -522,7 +521,7 @@ Use `bindings[].match.roles` to route Discord guild members to different agents 
     - scopes: `bot`, `applications.commands`
 
     Typical baseline permissions:
-    
+
     **General Permissions**
       - View Channels
     **Text Permissions**

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -63,12 +63,15 @@ You will need to create a new application with a bot, add the bot to your server
 
     A **Bot Permissions** section will appear below. Enable:
 
-    - View Channels
-    - Send Messages
-    - Read Message History
-    - Embed Links
-    - Attach Files
-    - Add Reactions (optional)
+
+    **General Permissions**
+      - View Channels
+    **Text Permissions**
+      - Send Messages
+      - Read Message History
+      - Embed Links
+      - Attach Files
+      - Add Reactions (optional)
 
     Copy the generated URL at the bottom, paste it into your browser, select your server, and click **Continue** to connect. You should now see your bot in the Discord server.
 
@@ -520,9 +523,9 @@ Use `bindings[].match.roles` to route Discord guild members to different agents 
 
     Typical baseline permissions:
     
-    [General Permissions]
+    **General Permissions**
       - View Channels
-    [Text Permissions]
+    **Text Permissions**
       - Send Messages
       - Read Message History
       - Embed Links

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -519,13 +519,15 @@ Use `bindings[].match.roles` to route Discord guild members to different agents 
     - scopes: `bot`, `applications.commands`
 
     Typical baseline permissions:
-
-    - View Channels
-    - Send Messages
-    - Read Message History
-    - Embed Links
-    - Attach Files
-    - Add Reactions (optional)
+    
+    [General Permissions]
+      - View Channels
+    [Text Permissions]
+      - Send Messages
+      - Read Message History
+      - Embed Links
+      - Attach Files
+      - Add Reactions (optional)
 
     Avoid `Administrator` unless explicitly needed.
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -61,7 +61,7 @@ You will need to create a new application with a bot, add the bot to your server
     - `bot`
     - `applications.commands`
 
-    A **Bot Permissions** section will appear below. Enable:
+    A **Bot Permissions** section will appear below. Enable at least:
 
     **General Permissions**
       - View Channels
@@ -72,6 +72,7 @@ You will need to create a new application with a bot, add the bot to your server
       - Attach Files
       - Add Reactions (optional)
 
+    This is the baseline set for normal text channels. If you plan to post in Discord threads, including forum or media channel workflows that create or continue a thread, also enable **Send Messages in Threads**.
     Copy the generated URL at the bottom, paste it into your browser, select your server, and click **Continue** to connect. You should now see your bot in the Discord server.
 
   </Step>
@@ -531,6 +532,7 @@ Use `bindings[].match.roles` to route Discord guild members to different agents 
       - Attach Files
       - Add Reactions (optional)
 
+    This is the baseline set for normal text channels. If you plan to post in Discord threads, including forum or media channel workflows that create or continue a thread, also enable **Send Messages in Threads**.
     Avoid `Administrator` unless explicitly needed.
 
   </Accordion>


### PR DESCRIPTION
## Summary

- **Problem:** The Discord bot permission list in `docs/channels/discord.md` was a flat list that didn't reflect how permissions are actually organized in the Discord bot invite flow UI.
- **Why it matters:** Users following the doc to configure bot permissions may be confused when the Discord UI groups permissions into categories (General, Text, etc.) but the doc showed them as a flat list.
- **What changed:** Regrouped the baseline permission list under `[General Permissions]` and `[Text Permissions]` labels matching Discord's UI layout.
- **What did NOT change:** No logic, code, config, or behavior changed — docs only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None — documentation wording only.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: N/A
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): N/A

### Steps

1. Open `docs/channels/discord.md` and navigate to the bot invite / permissions section.
2. Verify the permission list is now grouped under `[General Permissions]` and `[Text Permissions]` labels.

### Expected

- Permission labels are grouped to match Discord's UI permission categories.

### Actual

- Same as expected after this change.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

(Diff is the evidence — single-file doc restructure.)

## Human Verification (required)

- Verified scenarios: Confirmed the rendered markdown groups permissions correctly.
- Edge cases checked: N/A — no logic change.
- What you did **not** verify: Mintlify live render.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.
