### PR TITLE
fix(plugins): preserve memory capability across snapshot plugin loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/memory: preserve the active memory capability when read-only snapshot plugin loads run, so status and provider discovery paths no longer wipe memory public artifacts. (#69219) Thanks @zeroaltitude.
 - fix(security): block MINIMAX_API_HOST workspace env injection and remove env-driven URL routing [AI-assisted]. (#67300) Thanks @pgondhi987.
 - Cron/delivery: treat explicit `delivery.mode: "none"` runs as not requested even if the runner reports `delivered: false`, so no-delivery cron jobs no longer persist false delivery failures or errors. (#69285) Thanks @matsuri1987.
 - Plugins/install: repair active and default-enabled bundled plugin runtime dependencies before import in packaged installs, so bundled Discord, WhatsApp, Slack, Telegram, and provider plugins work without putting their dependency trees in core.

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2527,6 +2527,87 @@ module.exports = { id: "throws-after-import", register() {} };`,
     );
   });
 
+  it("preserves previously registered memory capability across activate:false snapshot loads", async () => {
+    useNoBundledPlugins();
+    const workspaceDir = makeTempDir();
+    const absolutePath = path.join(workspaceDir, "MEMORY.md");
+    fs.writeFileSync(absolutePath, "# Memory\n");
+    const memoryPlugin = writePlugin({
+      id: "capability-survives-memory",
+      filename: "capability-survives-memory.cjs",
+      body: `module.exports = {
+        id: "capability-survives-memory",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCapability({
+            publicArtifacts: {
+              async listArtifacts() {
+                return [{
+                  kind: "memory-root",
+                  workspaceDir: ${JSON.stringify(workspaceDir)},
+                  relativePath: "MEMORY.md",
+                  absolutePath: ${JSON.stringify(absolutePath)},
+                  agentIds: ["main"],
+                  contentType: "markdown",
+                }];
+              },
+            },
+          });
+        },
+      };`,
+    });
+    const sidecarPlugin = writePlugin({
+      id: "capability-survives-sidecar",
+      filename: "capability-survives-sidecar.cjs",
+      body: `module.exports = {
+        id: "capability-survives-sidecar",
+        register() {},
+      };`,
+    });
+
+    const activateConfig = {
+      plugins: {
+        load: { paths: [memoryPlugin.file, sidecarPlugin.file] },
+        allow: ["capability-survives-memory", "capability-survives-sidecar"],
+        slots: { memory: "capability-survives-memory" },
+      },
+    };
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: memoryPlugin.dir,
+      config: activateConfig,
+    });
+
+    const expectedArtifacts = [
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+        absolutePath,
+        agentIds: ["main"],
+        contentType: "markdown" as const,
+      },
+    ];
+
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual(
+      expectedArtifacts,
+    );
+
+    // Simulate what resolvePluginWebSearchProviders and similar read-only paths do:
+    // load plugins again with activate:false. Each per-plugin snapshot/rollback must
+    // preserve the previously registered memory capability.
+    loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      workspaceDir: memoryPlugin.dir,
+      config: activateConfig,
+    });
+
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual(
+      expectedArtifacts,
+    );
+  });
+
   it("throws when activate:false is used without cache:false", () => {
     expect(() => loadOpenClawPlugins({ activate: false })).toThrow(
       "activate:false requires cache:false",

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2253,6 +2253,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousAgentHarnesses = listRegisteredAgentHarnesses();
       const previousCompactionProviders = listRegisteredCompactionProviders();
       const previousDetachedTaskRuntimeRegistration = getDetachedTaskLifecycleRuntimeRegistration();
+      const previousMemoryCapability = getMemoryCapabilityRegistration();
       const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
       const previousMemoryFlushPlanResolver = getMemoryFlushPlanResolver();
       const previousMemoryPromptBuilder = getMemoryPromptSectionBuilder();
@@ -2269,6 +2270,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           restoreDetachedTaskLifecycleRuntimeRegistration(previousDetachedTaskRuntimeRegistration);
           restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
           restoreMemoryPluginState({
+            capability: previousMemoryCapability,
             corpusSupplements: previousMemoryCorpusSupplements,
             promptBuilder: previousMemoryPromptBuilder,
             promptSupplements: previousMemoryPromptSupplements,
@@ -2286,6 +2288,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         restoreDetachedTaskLifecycleRuntimeRegistration(previousDetachedTaskRuntimeRegistration);
         restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
         restoreMemoryPluginState({
+          capability: previousMemoryCapability,
           corpusSupplements: previousMemoryCorpusSupplements,
           promptBuilder: previousMemoryPromptBuilder,
           promptSupplements: previousMemoryPromptSupplements,


### PR DESCRIPTION
## Problem

The plugin loader's per-plugin snapshot/rollback dance captures several `previousMemory*` values to restore after a non-activating load — but **`previousMemoryCapability` was missing**. Both restore sites (the `if (!shouldActivate)` branch post-register, and the register-`catch` branch) called `restoreMemoryPluginState({...})` without a `capability` field.

Because `restoreMemoryPluginState` treats the field as authoritative (`state.capability ? {...} : void 0`), **omitting the field was effectively a wipe**.

## Symptom

Any non-activating load — for example `resolvePluginWebSearchProviders` calling `loadOpenClawPlugins({ activate: false })` — iterates every plugin, re-registers, then restores to the pre-snapshot state without `capability`. This clears whatever capability the memory plugin had registered on the live load.

In practice: `listActiveMemoryPublicArtifacts` returns `[]` and `wiki.bridge.import` returns 0 artifacts after the first non-activating load, even though memory plugins appear `loaded` and their `register()` runs correctly.

## Fix

- Capture `previousMemoryCapability = getMemoryCapabilityRegistration()` alongside the other per-plugin snapshots
- Include `capability: previousMemoryCapability` in both `restoreMemoryPluginState` call sites

The cached-load site (around line 1453 in current main) already did this correctly — it's the two per-plugin sites inside the iteration that were the outliers.

## Testing

Added `preserves previously registered memory capability across activate:false snapshot loads` in `src/plugins/loader.test.ts`:

- Registers a memory-kind plugin that sets a `publicArtifacts` capability
- Asserts `listActiveMemoryPublicArtifacts` returns the artifact
- Triggers a second `loadOpenClawPlugins({ activate: false })` (same shape as the real secondary loaders)
- Asserts the capability still returns the artifact

Red-green verified locally: without the fix the second `listActiveMemoryPublicArtifacts` returns `[]`; with the fix it returns the expected artifact. All 94 tests in `loader.test.ts` pass.

## Discovery context

Found while debugging `wiki.bridge.import` returning 0 artifacts with `memory-core` installed and the `vaultMode: "bridge"` config. The misleading clue: `getMemoryCapabilityRegistration()` immediately after `registerMemoryCapability()` always returned the right value, because the wipe happened on a later iteration of the rollback loop (including repeated calls from `resolvePluginWebSearchProviders`).