### PR TITLE
Explain pairing scope upgrades during reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - GitHub Copilot/onboarding: default GitHub Copilot setup to `claude-opus-4.6` and keep the bundled default model list aligned, so new Copilot setups no longer start on the older `gpt-4o` default. (#69207) Thanks @obviyus.
 - Gateway/status: separate reachability, capability, and read-probe reporting so connect-only or scope-limited sessions no longer look fully healthy, and normalize SSH targets entered as `ssh user@host`. (#69215) Thanks @obviyus.
 - Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
+- Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 
 ## 2026.4.19-beta.2
 

--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -100,6 +100,12 @@ If the same device retries with different auth details (for example different
 role/scopes/public key), the previous pending request is superseded and a new
 `requestId` is created.
 
+Important: an already paired device does not get broader access silently. If it
+reconnects asking for more scopes or a broader role, OpenClaw keeps the
+existing approval as-is and creates a fresh pending upgrade request. Use
+`openclaw devices list` to compare the currently approved access with the newly
+requested access before you approve.
+
 ### Node pairing state storage
 
 Stored under `~/.openclaw/devices/`:

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -21,8 +21,9 @@ openclaw devices list
 openclaw devices list --json
 ```
 
-Pending request output includes the requested role and scopes so approvals can
-be reviewed before you approve.
+Pending request output shows the requested access next to the device's current
+approved access when the device is already paired. This makes scope/role
+upgrades explicit instead of looking like the pairing was lost.
 
 ### `openclaw devices remove <deviceId>`
 
@@ -58,6 +59,12 @@ Note: if a device retries pairing with changed auth details (role/scopes/public
 key), OpenClaw supersedes the previous pending entry and issues a new
 `requestId`. Run `openclaw devices list` right before approval to use the
 current ID.
+
+If the device is already paired and asks for broader scopes or a broader role,
+OpenClaw keeps the existing approval in place and creates a new pending upgrade
+request. Review the `Requested` vs `Approved` columns in `openclaw devices list`
+or use `openclaw devices approve --latest` to preview the exact upgrade before
+approving it.
 
 ```
 openclaw devices approve

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -58,6 +58,11 @@ If the browser retries pairing with changed auth details (role/scopes/public
 key), the previous pending request is superseded and a new `requestId` is
 created. Re-run `openclaw devices list` before approval.
 
+If the browser is already paired and you change it from read access to
+write/admin access, this is treated as an approval upgrade, not a silent
+reconnect. OpenClaw keeps the old approval active, blocks the broader reconnect,
+and asks you to approve the new scope set explicitly.
+
 Once approved, the device is remembered and won't require re-approval unless
 you revoke it with `openclaw devices revoke --device <id> --role <role>`. See
 [Devices CLI](/cli/devices) for token rotation and revocation.

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -97,6 +97,14 @@ describe("devices cli approve", () => {
           ts: 1000,
         },
       ],
+      paired: [
+        {
+          deviceId: "device-9",
+          displayName: "Device Nine",
+          roles: ["operator"],
+          scopes: ["operator.read"],
+        },
+      ],
     });
 
     await runDevicesApprove([]);
@@ -108,6 +116,8 @@ describe("devices cli approve", () => {
     const logOutput = runtime.log.mock.calls.map((c) => readRuntimeCallText(c)).join("\n");
     expect(logOutput).toContain("req-abc");
     expect(logOutput).toContain("Device Nine");
+    expect(logOutput).toContain("Approved: roles: operator; scopes: operator.read");
+    expect(logOutput).toContain("Requested scopes exceed the current approval");
     expect(runtime.error).toHaveBeenCalledWith(
       expect.stringContaining("openclaw devices approve req-abc"),
     );
@@ -115,6 +125,36 @@ describe("devices cli approve", () => {
     expect(callGateway).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: "device.pair.approve" }),
     );
+  });
+
+  it("sanitizes preview ip output for implicit approval", async () => {
+    callGateway.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-abc",
+          deviceId: "device-9",
+          displayName: "Device Nine",
+          role: "operator",
+          scopes: ["operator.admin"],
+          remoteIp: "10.0.0.9\rspoof",
+          ts: 1000,
+        },
+      ],
+      paired: [
+        {
+          deviceId: "device-9",
+          displayName: "Device Nine",
+          roles: ["operator"],
+          scopes: ["operator.read"],
+        },
+      ],
+    });
+
+    await runDevicesApprove([]);
+
+    const logOutput = runtime.log.mock.calls.map((c) => readRuntimeCallText(c)).join("\n");
+    expect(logOutput).not.toContain("\r");
+    expect(logOutput).toContain("IP:     10.0.0.9spoof");
   });
 
   it.each([
@@ -208,6 +248,7 @@ describe("devices cli approve", () => {
   it("returns JSON for implicit approval preview in JSON mode", async () => {
     callGateway.mockResolvedValueOnce({
       pending: [{ requestId: "req-json", deviceId: "device-json", ts: 1000 }],
+      paired: [],
     });
 
     await runDevicesApprove(["--latest", "--json", "--url", "ws://gateway.example:18789"]);
@@ -216,6 +257,11 @@ describe("devices cli approve", () => {
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.writeJson).toHaveBeenCalledWith({
       selected: { requestId: "req-json", deviceId: "device-json", ts: 1000 },
+      approvalState: {
+        kind: "new-pairing",
+        requested: { roles: [], scopes: [] },
+        approved: null,
+      },
       approveCommand: "openclaw devices approve req-json --url ws://gateway.example:18789 --json",
       requiresAuthFlags: {
         token: false,
@@ -404,7 +450,7 @@ describe("devices cli local fallback", () => {
 });
 
 describe("devices cli list", () => {
-  it("renders pending scopes when present", async () => {
+  it("renders requested versus approved access for pending upgrades", async () => {
     callGateway.mockResolvedValueOnce({
       pending: [
         {
@@ -416,14 +462,119 @@ describe("devices cli list", () => {
           ts: 1,
         },
       ],
-      paired: [],
+      paired: [
+        {
+          deviceId: "device-1",
+          displayName: "Device One",
+          roles: ["operator"],
+          scopes: ["operator.read"],
+        },
+      ],
     });
 
     await runDevicesCommand(["list"]);
 
     const output = runtime.log.mock.calls.map((entry) => readRuntimeCallText(entry)).join("\n");
-    expect(output).toContain("Scopes");
-    expect(output).toContain("operator.admin, operator.read");
+    expect(output).toContain("Requested");
+    expect(output).toContain("Approved");
+    expect(output).toContain("operator.write");
+    expect(output).toContain("operator.read");
+    expect(output).toContain("scope upgrade");
+  });
+
+  it("normalizes pending device ids before matching paired approvals", async () => {
+    callGateway.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-1",
+          deviceId: " device-1 ",
+          displayName: "Device One",
+          role: "operator",
+          scopes: ["operator.admin"],
+          ts: 1,
+        },
+      ],
+      paired: [
+        {
+          deviceId: "device-1",
+          displayName: "Device One",
+          roles: ["operator"],
+          scopes: ["operator.read"],
+        },
+      ],
+    });
+
+    await runDevicesCommand(["list"]);
+
+    const output = runtime.log.mock.calls.map((entry) => readRuntimeCallText(entry)).join("\n");
+    expect(output).toContain("scope upgrade");
+    expect(output).toContain("operator.read");
+  });
+
+  it("does not show upgrade context for key-mismatched pending requests", async () => {
+    callGateway.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-1",
+          deviceId: "device-1",
+          publicKey: "new-key",
+          displayName: "Device One",
+          role: "operator",
+          scopes: ["operator.admin"],
+          ts: 1,
+        },
+      ],
+      paired: [
+        {
+          deviceId: "device-1",
+          publicKey: "old-key",
+          displayName: "Device One",
+          roles: ["operator"],
+          scopes: ["operator.read"],
+        },
+      ],
+    });
+
+    await runDevicesCommand(["list"]);
+
+    const output = runtime.log.mock.calls.map((entry) => readRuntimeCallText(entry)).join("\n");
+    expect(output).toContain("new pairing");
+    expect(output).not.toContain("scope upgrade");
+    expect(output).not.toContain("roles: operator; scopes: operator.read");
+  });
+
+  it("sanitizes device-controlled terminal output", async () => {
+    callGateway.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-1",
+          deviceId: "device-1",
+          displayName: "Bad\u001b[2J\nName",
+          role: "operator",
+          scopes: ["operator.admin"],
+          remoteIp: "10.0.0.9\rspoof",
+          ts: 1,
+        },
+      ],
+      paired: [
+        {
+          deviceId: "device-1",
+          displayName: "Pair\u001b]8;;https://evil.example\u001b\\ed",
+          roles: ["operator"],
+          scopes: ["operator.read"],
+          remoteIp: "10.0.0.1\u007f",
+        },
+      ],
+    });
+
+    await runDevicesCommand(["list"]);
+
+    const output = runtime.log.mock.calls.map((entry) => readRuntimeCallText(entry)).join("\n");
+    expect(output).not.toContain("\u001b");
+    expect(output).not.toContain("\r");
+    expect(output).toContain("BadName");
+    expect(output).toContain("spoof");
+    expect(output).toContain("Paired");
   });
 });
 

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -12,10 +12,16 @@ import {
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { defaultRuntime } from "../runtime.js";
 import {
+  resolvePendingDeviceApprovalState,
+  type DevicePairingAccessSummary,
+  type PendingDeviceApprovalKind,
+} from "../shared/device-pairing-access.js";
+import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
 } from "../shared/string-coerce.js";
+import { sanitizeForLog } from "../terminal/ansi.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { withProgress } from "./progress.js";
@@ -43,6 +49,7 @@ type DeviceTokenSummary = {
 type PendingDevice = {
   requestId: string;
   deviceId: string;
+  publicKey?: string;
   displayName?: string;
   role?: string;
   roles?: string[];
@@ -54,6 +61,7 @@ type PendingDevice = {
 
 type PairedDevice = {
   deviceId: string;
+  publicKey?: string;
   displayName?: string;
   roles?: string[];
   scopes?: string[];
@@ -212,37 +220,77 @@ function formatTokenSummary(tokens: DeviceTokenSummary[] | undefined) {
     return "none";
   }
   const parts = tokens
-    .map((t) => `${t.role}${t.revokedAtMs ? " (revoked)" : ""}`)
+    .map((t) => `${sanitizeForLog(t.role)}${t.revokedAtMs ? " (revoked)" : ""}`)
     .toSorted((a, b) => a.localeCompare(b));
   return parts.join(", ");
 }
 
-function formatPendingRoles(request: PendingDevice): string {
-  const role = normalizeOptionalString(request.role) ?? "";
-  if (role) {
-    return role;
-  }
-  const roles = Array.isArray(request.roles)
-    ? request.roles.map((item) => item.trim()).filter((item) => item.length > 0)
-    : [];
-  if (roles.length === 0) {
-    return "";
-  }
-  return roles.join(", ");
-}
-
-function formatPendingScopes(request: PendingDevice): string {
-  const scopes = Array.isArray(request.scopes)
-    ? request.scopes.map((item) => item.trim()).filter((item) => item.length > 0)
-    : [];
-  if (scopes.length === 0) {
-    return "";
-  }
-  return scopes.join(", ");
-}
-
 function formatPendingDeviceIdentity(request: PendingDevice): string {
-  return normalizeOptionalString(request.displayName) ?? request.deviceId;
+  const displayName = normalizeOptionalString(request.displayName);
+  if (displayName) {
+    return sanitizeForLog(displayName);
+  }
+  return sanitizeForLog(normalizeOptionalString(request.deviceId) ?? "");
+}
+
+function formatAccessSummary(access: DevicePairingAccessSummary | null): string {
+  if (!access) {
+    return "none";
+  }
+  const roles =
+    access.roles.length > 0 ? access.roles.map((role) => sanitizeForLog(role)).join(", ") : "none";
+  const scopes =
+    access.scopes.length > 0
+      ? access.scopes.map((scope) => sanitizeForLog(scope)).join(", ")
+      : "none";
+  return `roles: ${roles}; scopes: ${scopes}`;
+}
+
+function formatPendingApprovalKind(kind: PendingDeviceApprovalKind): string {
+  switch (kind) {
+    case "new-pairing":
+      return "new pairing";
+    case "role-upgrade":
+      return "role upgrade";
+    case "scope-upgrade":
+      return "scope upgrade";
+    case "re-approval":
+      return "re-approval";
+  }
+  const exhaustiveKind: never = kind;
+  void exhaustiveKind;
+  throw new Error("unsupported pending approval kind");
+}
+
+function indexPairedDevices(paired: PairedDevice[] | undefined): Map<string, PairedDevice> {
+  const out = new Map<string, PairedDevice>();
+  for (const device of paired ?? []) {
+    const deviceId = normalizeOptionalString(device.deviceId);
+    if (deviceId) {
+      out.set(deviceId, device);
+    }
+  }
+  return out;
+}
+
+function lookupPairedDevice(
+  pairedByDeviceId: ReadonlyMap<string, PairedDevice>,
+  request: Pick<PendingDevice, "deviceId" | "publicKey">,
+): PairedDevice | undefined {
+  const normalizedDeviceId = normalizeOptionalString(request.deviceId);
+  if (!normalizedDeviceId) {
+    return undefined;
+  }
+  const paired = pairedByDeviceId.get(normalizedDeviceId);
+  if (!paired) {
+    return undefined;
+  }
+  const requestPublicKey = normalizeOptionalString(request.publicKey);
+  const pairedPublicKey = normalizeOptionalString(paired.publicKey);
+  if (requestPublicKey && pairedPublicKey && requestPublicKey !== pairedPublicKey) {
+    return undefined;
+  }
+  return paired;
 }
 
 function quoteCliArg(value: string): string {
@@ -304,6 +352,7 @@ export function registerDevicesCli(program: Command) {
       .description("List pending and paired devices")
       .action(async (opts: DevicesRpcOpts) => {
         const list = await listPairingWithFallback(opts);
+        const pairedByDeviceId = indexPairedDevices(list.paired);
         if (opts.json) {
           defaultRuntime.writeJson(list);
           return;
@@ -319,21 +368,29 @@ export function registerDevicesCli(program: Command) {
               columns: [
                 { key: "Request", header: "Request", minWidth: 10 },
                 { key: "Device", header: "Device", minWidth: 16, flex: true },
-                { key: "Role", header: "Role", minWidth: 8 },
-                { key: "Scopes", header: "Scopes", minWidth: 14, flex: true },
-                { key: "IP", header: "IP", minWidth: 12 },
+                { key: "Requested", header: "Requested", minWidth: 20, flex: true },
+                { key: "Approved", header: "Approved", minWidth: 20, flex: true },
                 { key: "Age", header: "Age", minWidth: 8 },
-                { key: "Flags", header: "Flags", minWidth: 8 },
+                { key: "Status", header: "Status", minWidth: 12 },
               ],
-              rows: list.pending.map((req) => ({
-                Request: req.requestId,
-                Device: req.displayName || req.deviceId,
-                Role: formatPendingRoles(req),
-                Scopes: formatPendingScopes(req),
-                IP: req.remoteIp ?? "",
-                Age: typeof req.ts === "number" ? formatTimeAgo(Date.now() - req.ts) : "",
-                Flags: req.isRepair ? "repair" : "",
-              })),
+              rows: list.pending.map((req) => {
+                const approval = resolvePendingDeviceApprovalState(
+                  req,
+                  lookupPairedDevice(pairedByDeviceId, req),
+                );
+                const statusParts = [formatPendingApprovalKind(approval.kind)];
+                if (req.isRepair) {
+                  statusParts.push("repair");
+                }
+                return {
+                  Request: req.requestId,
+                  Device: `${formatPendingDeviceIdentity(req)}${req.remoteIp ? ` · ${sanitizeForLog(req.remoteIp)}` : ""}`,
+                  Requested: formatAccessSummary(approval.requested),
+                  Approved: formatAccessSummary(approval.approved),
+                  Age: typeof req.ts === "number" ? formatTimeAgo(Date.now() - req.ts) : "",
+                  Status: statusParts.join(", "),
+                };
+              }),
             }).trimEnd(),
           );
         }
@@ -353,11 +410,15 @@ export function registerDevicesCli(program: Command) {
                 { key: "IP", header: "IP", minWidth: 12 },
               ],
               rows: list.paired.map((device) => ({
-                Device: device.displayName || device.deviceId,
-                Roles: device.roles?.length ? device.roles.join(", ") : "",
-                Scopes: device.scopes?.length ? device.scopes.join(", ") : "",
+                Device: sanitizeForLog(device.displayName || device.deviceId),
+                Roles: device.roles?.length
+                  ? device.roles.map((role) => sanitizeForLog(role)).join(", ")
+                  : "",
+                Scopes: device.scopes?.length
+                  ? device.scopes.map((scope) => sanitizeForLog(scope)).join(", ")
+                  : "",
                 Tokens: formatTokenSummary(device.tokens),
-                IP: device.remoteIp ?? "",
+                IP: device.remoteIp ? sanitizeForLog(device.remoteIp) : "",
               })),
             }).trimEnd(),
           );
@@ -449,13 +510,13 @@ export function registerDevicesCli(program: Command) {
       .argument("[requestId]", "Pending request id")
       .option("--latest", "Show the most recent pending request to approve explicitly", false)
       .action(async (requestId: string | undefined, opts: DevicesRpcOpts) => {
+        let pairingList: DevicePairingList | null = null;
         let resolvedRequestId = requestId?.trim();
         const usingImplicitSelection = !resolvedRequestId || Boolean(opts.latest);
         let selectedRequest: PendingDevice | null = null;
         if (usingImplicitSelection) {
-          selectedRequest = selectLatestPendingRequest(
-            (await listPairingWithFallback(opts)).pending,
-          );
+          pairingList = await listPairingWithFallback(opts);
+          selectedRequest = selectLatestPendingRequest(pairingList.pending);
           resolvedRequestId = selectedRequest?.requestId?.trim();
         }
         if (!resolvedRequestId) {
@@ -467,11 +528,20 @@ export function registerDevicesCli(program: Command) {
           // Keep implicit selection preview-only. A second command with the exact
           // requestId binds the approval to the request the operator inspected.
           const req = selectedRequest!;
+          const approval = resolvePendingDeviceApprovalState(
+            req,
+            lookupPairedDevice(indexPairedDevices(pairingList?.paired), req),
+          );
           const approveCommand = buildExplicitApproveCommand(opts, req.requestId);
           const authReminder = formatAuthFlagReminder(opts);
           if (opts.json) {
             defaultRuntime.writeJson({
               selected: req,
+              approvalState: {
+                kind: approval.kind,
+                requested: approval.requested,
+                approved: approval.approved,
+              },
               approveCommand,
               requiresAuthFlags: {
                 token: Boolean(normalizeOptionalString(opts.token)),
@@ -485,16 +555,32 @@ export function registerDevicesCli(program: Command) {
             `${theme.warn("Selected pending device request")} ${theme.command(req.requestId)}`,
           );
           defaultRuntime.log(`  Device: ${formatPendingDeviceIdentity(req)}`);
-          const role = formatPendingRoles(req);
-          if (role) {
-            defaultRuntime.log(`  Role:   ${role}`);
-          }
-          const scopes = formatPendingScopes(req);
-          if (scopes) {
-            defaultRuntime.log(`  Scopes: ${scopes}`);
+          defaultRuntime.log(`  Requested: ${formatAccessSummary(approval.requested)}`);
+          if (approval.approved) {
+            defaultRuntime.log(`  Approved: ${formatAccessSummary(approval.approved)}`);
           }
           if (req.remoteIp) {
-            defaultRuntime.log(`  IP:     ${req.remoteIp}`);
+            defaultRuntime.log(`  IP:     ${sanitizeForLog(req.remoteIp)}`);
+          }
+          switch (approval.kind) {
+            case "scope-upgrade":
+              defaultRuntime.log(
+                "  Note:   Already paired. Requested scopes exceed the current approval, so reconnect stays blocked until you approve this upgrade.",
+              );
+              break;
+            case "role-upgrade":
+              defaultRuntime.log(
+                "  Note:   Already paired. Requested role exceeds the current approval, so reconnect stays blocked until you approve this upgrade.",
+              );
+              break;
+            case "re-approval":
+              defaultRuntime.log(
+                "  Note:   Already paired. Approval-bound device details changed, so OpenClaw created a fresh request instead of silently reusing the old approval.",
+              );
+              break;
+            case "new-pairing":
+              defaultRuntime.log("  Note:   First-time device pairing request.");
+              break;
           }
           defaultRuntime.error(`Approve this exact request with: ${approveCommand}`);
           if (authReminder) {

--- a/src/gateway/protocol/connect-error-details.ts
+++ b/src/gateway/protocol/connect-error-details.ts
@@ -59,6 +59,11 @@ export type PairingConnectErrorDetails = {
   reason?: ConnectPairingRequiredReason;
   requestId?: string;
   remediationHint?: string;
+  deviceId?: string;
+  requestedRole?: string;
+  requestedScopes?: string[];
+  approvedRoles?: string[];
+  approvedScopes?: string[];
 };
 
 const CONNECT_RECOVERY_NEXT_STEP_VALUES: ReadonlySet<ConnectRecoveryNextStep> = new Set([
@@ -209,6 +214,16 @@ export function normalizePairingConnectRequestId(value: unknown): string | undef
   return normalized && PAIRING_CONNECT_REQUEST_ID_PATTERN.test(normalized) ? normalized : undefined;
 }
 
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized = value
+    .map((item) => normalizeOptionalString(item))
+    .filter((item): item is string => Boolean(item));
+  return normalized.length > 0 ? normalized : [];
+}
+
 export function describePairingConnectRequirement(
   reason: ConnectPairingRequiredReason | undefined,
 ): string {
@@ -245,16 +260,31 @@ export function buildPairingConnectErrorDetails(params: {
   reason: ConnectPairingRequiredReason | undefined;
   requestId?: string;
   remediationHint?: string;
+  deviceId?: string;
+  requestedRole?: string;
+  requestedScopes?: string[];
+  approvedRoles?: string[];
+  approvedScopes?: string[];
 }): PairingConnectErrorDetails {
   const requestId = normalizePairingConnectRequestId(params.requestId);
   const remediationHint =
     normalizeOptionalString(params.remediationHint) ??
     buildPairingConnectRemediationHint(params.reason);
+  const deviceId = normalizeOptionalString(params.deviceId);
+  const requestedRole = normalizeOptionalString(params.requestedRole);
+  const requestedScopes = normalizeStringArray(params.requestedScopes);
+  const approvedRoles = normalizeStringArray(params.approvedRoles);
+  const approvedScopes = normalizeStringArray(params.approvedScopes);
   return {
     code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
     ...(params.reason ? { reason: params.reason } : {}),
     ...(requestId ? { requestId } : {}),
     ...(remediationHint ? { remediationHint } : {}),
+    ...(deviceId ? { deviceId } : {}),
+    ...(requestedRole ? { requestedRole } : {}),
+    ...(requestedScopes ? { requestedScopes } : {}),
+    ...(approvedRoles ? { approvedRoles } : {}),
+    ...(approvedScopes ? { approvedScopes } : {}),
   };
 }
 
@@ -273,19 +303,37 @@ export function readPairingConnectErrorDetails(
   if (readConnectErrorDetailCode(details) !== ConnectErrorDetailCodes.PAIRING_REQUIRED) {
     return null;
   }
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return null;
+  }
   const raw = details as {
     reason?: unknown;
     requestId?: unknown;
     remediationHint?: unknown;
+    deviceId?: unknown;
+    requestedRole?: unknown;
+    requestedScopes?: unknown;
+    approvedRoles?: unknown;
+    approvedScopes?: unknown;
   };
   const reason = normalizePairingConnectReason(raw.reason);
   const requestId = normalizePairingConnectRequestId(raw.requestId);
   const remediationHint =
     normalizeOptionalString(raw.remediationHint) ?? buildPairingConnectRemediationHint(reason);
+  const deviceId = normalizeOptionalString(raw.deviceId);
+  const requestedRole = normalizeOptionalString(raw.requestedRole);
+  const requestedScopes = normalizeStringArray(raw.requestedScopes);
+  const approvedRoles = normalizeStringArray(raw.approvedRoles);
+  const approvedScopes = normalizeStringArray(raw.approvedScopes);
   return {
     code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
     ...(reason ? { reason } : {}),
     ...(requestId ? { requestId } : {}),
     ...(remediationHint ? { remediationHint } : {}),
+    ...(deviceId ? { deviceId } : {}),
+    ...(requestedRole ? { requestedRole } : {}),
+    ...(requestedScopes ? { requestedScopes } : {}),
+    ...(approvedRoles ? { approvedRoles } : {}),
+    ...(approvedScopes ? { approvedScopes } : {}),
   };
 }

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -14,6 +14,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
   onceMessage,
+  openTailscaleWs,
   openWs,
   originForPort,
   readConnectChallengeNonce,
@@ -199,6 +200,16 @@ export function registerControlUiAndPairingSuite(): void {
     const legacy = getRequiredPairedMetadata(paired, deviceId);
     delete legacy.roles;
     delete legacy.scopes;
+    await writeJsonAtomic(pairedPath, paired);
+  };
+
+  const overwritePairedPublicKey = async (deviceId: string, publicKey: string) => {
+    const { resolvePairingPaths, readJsonFile } = await import("../infra/pairing-files.js");
+    const { writeJsonAtomic } = await import("../infra/json-files.js");
+    const { pairedPath } = resolvePairingPaths(undefined, "devices");
+    const paired = (await readJsonFile<Record<string, Record<string, unknown>>>(pairedPath)) ?? {};
+    const metadata = getRequiredPairedMetadata(paired, deviceId);
+    metadata.publicKey = publicKey;
     await writeJsonAtomic(pairedPath, paired);
   };
 
@@ -740,6 +751,93 @@ export function registerControlUiAndPairingSuite(): void {
     restoreGatewayToken(prevToken);
   });
 
+  test("does not expose approved access when a paired device id reconnects with a different key", async () => {
+    const { identity, identityPath } = await seedApprovedOperatorReadPairing({
+      identityPrefix: "openclaw-device-key-mismatch-",
+      clientId: TEST_OPERATOR_CLIENT.id,
+      clientMode: TEST_OPERATOR_CLIENT.mode,
+      displayName: "remote-key-mismatch",
+      platform: TEST_OPERATOR_CLIENT.platform,
+    });
+    await overwritePairedPublicKey(identity.deviceId, "mismatched-public-key");
+
+    const { server, port, prevToken } = await startControlUiServer("secret");
+    const ws2 = await openTailscaleWs(port);
+    try {
+      const nonce2 = await readConnectChallengeNonce(ws2);
+      const mismatched = await connectReq(ws2, {
+        token: "secret",
+        scopes: ["operator.admin"],
+        client: { ...TEST_OPERATOR_CLIENT },
+        device: await buildSignedDeviceForIdentity({
+          identityPath,
+          client: TEST_OPERATOR_CLIENT,
+          scopes: ["operator.admin"],
+          nonce: nonce2,
+        }),
+      });
+      expect(mismatched.ok).toBe(false);
+      expect(mismatched.error?.message ?? "").toContain("pairing required");
+      expect(
+        (
+          mismatched.error?.details as
+            | {
+                reason?: string;
+                requestedRole?: string;
+                requestedScopes?: string[];
+                approvedRoles?: string[];
+                approvedScopes?: string[];
+              }
+            | undefined
+        )?.reason,
+      ).toBe("not-paired");
+      expect(
+        (
+          mismatched.error?.details as
+            | {
+                requestedRole?: string;
+                requestedScopes?: string[];
+              }
+            | undefined
+        )?.requestedRole,
+      ).toBe("operator");
+      expect(
+        (
+          mismatched.error?.details as
+            | {
+                requestedRole?: string;
+                requestedScopes?: string[];
+              }
+            | undefined
+        )?.requestedScopes,
+      ).toEqual(["operator.admin"]);
+      expect(
+        (
+          mismatched.error?.details as
+            | {
+                approvedRoles?: string[];
+                approvedScopes?: string[];
+              }
+            | undefined
+        )?.approvedRoles,
+      ).toBeUndefined();
+      expect(
+        (
+          mismatched.error?.details as
+            | {
+                approvedRoles?: string[];
+                approvedScopes?: string[];
+              }
+            | undefined
+        )?.approvedScopes,
+      ).toBeUndefined();
+    } finally {
+      ws2.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("auto-approves fresh node bootstrap pairing from qr setup code", async () => {
     const { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } =
       await import("../infra/device-bootstrap.js");
@@ -1025,6 +1123,26 @@ export function registerControlUiAndPairingSuite(): void {
       expect(
         (upgrade.error?.details as { code?: string; reason?: string } | undefined)?.reason,
       ).toBe("role-upgrade");
+      expect(
+        (
+          upgrade.error?.details as
+            | {
+                requestedRole?: string;
+                approvedRoles?: string[];
+              }
+            | undefined
+        )?.requestedRole,
+      ).toBe("node");
+      expect(
+        (
+          upgrade.error?.details as
+            | {
+                requestedRole?: string;
+                approvedRoles?: string[];
+              }
+            | undefined
+        )?.approvedRoles,
+      ).toEqual(["operator"]);
 
       const pending = (await listDevicePairing()).pending.filter(
         (entry) => entry.deviceId === identity.deviceId,
@@ -1285,6 +1403,54 @@ export function registerControlUiAndPairingSuite(): void {
       });
       expect(upgraded.ok).toBe(false);
       expect(upgraded.error?.message ?? "").toContain("pairing required");
+      expect(
+        (
+          upgraded.error?.details as
+            | {
+                reason?: string;
+                requestedRole?: string;
+                requestedScopes?: string[];
+                approvedScopes?: string[];
+              }
+            | undefined
+        )?.reason,
+      ).toBe("scope-upgrade");
+      expect(
+        (
+          upgraded.error?.details as
+            | {
+                reason?: string;
+                requestedRole?: string;
+                requestedScopes?: string[];
+                approvedScopes?: string[];
+              }
+            | undefined
+        )?.requestedRole,
+      ).toBe("operator");
+      expect(
+        (
+          upgraded.error?.details as
+            | {
+                reason?: string;
+                requestedRole?: string;
+                requestedScopes?: string[];
+                approvedScopes?: string[];
+              }
+            | undefined
+        )?.requestedScopes,
+      ).toEqual(["operator.admin"]);
+      expect(
+        (
+          upgraded.error?.details as
+            | {
+                reason?: string;
+                requestedRole?: string;
+                requestedScopes?: string[];
+                approvedScopes?: string[];
+              }
+            | undefined
+        )?.approvedScopes,
+      ).toEqual(["operator.read"]);
       wsUpgrade.close();
 
       const pendingUpgrade = (await listDevicePairing()).pending.find(

--- a/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
+++ b/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
@@ -37,13 +37,68 @@ async function expectRejectedScopeUpgradeAttempt({
         requestId?: unknown;
         reason?: unknown;
         remediationHint?: unknown;
+        requestedRole?: unknown;
+        requestedScopes?: unknown;
+        approvedScopes?: unknown;
       }
     ).requestId,
   ).toBe(pending.pending[0]?.requestId);
-  expect(((attempt.error?.details ?? {}) as { reason?: unknown }).reason).toBe("scope-upgrade");
-  expect(((attempt.error?.details ?? {}) as { remediationHint?: unknown }).remediationHint).toBe(
-    "Review the requested scopes, then approve the pending upgrade.",
-  );
+  expect(
+    (
+      (attempt.error?.details ?? {}) as {
+        requestId?: unknown;
+        reason?: unknown;
+        requestedRole?: unknown;
+        requestedScopes?: unknown;
+        approvedScopes?: unknown;
+      }
+    ).reason,
+  ).toBe("scope-upgrade");
+  expect(
+    (
+      (attempt.error?.details ?? {}) as {
+        requestId?: unknown;
+        reason?: unknown;
+        requestedRole?: unknown;
+        requestedScopes?: unknown;
+        approvedScopes?: unknown;
+      }
+    ).requestedRole,
+  ).toBe("operator");
+  expect(
+    (
+      (attempt.error?.details ?? {}) as {
+        requestId?: unknown;
+        reason?: unknown;
+        requestedRole?: unknown;
+        requestedScopes?: unknown;
+        approvedScopes?: unknown;
+      }
+    ).requestedScopes,
+  ).toEqual(["operator.admin"]);
+  expect(
+    (
+      (attempt.error?.details ?? {}) as {
+        requestId?: unknown;
+        reason?: unknown;
+        requestedRole?: unknown;
+        requestedScopes?: unknown;
+        approvedScopes?: unknown;
+      }
+    ).approvedScopes,
+  ).toEqual(["operator.read"]);
+  expect(
+    (
+      (attempt.error?.details ?? {}) as {
+        requestId?: unknown;
+        reason?: unknown;
+        remediationHint?: unknown;
+        requestedRole?: unknown;
+        requestedScopes?: unknown;
+        approvedScopes?: unknown;
+      }
+    ).remediationHint,
+  ).toBe("Review the requested scopes, then approve the pending upgrade.");
 
   const requested = (await requestedEvent) as {
     payload?: { requestId?: string; deviceId?: string; scopes?: string[] };

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -19,6 +19,7 @@ import {
   ensureDeviceToken,
   getPairedDevice,
   hasEffectivePairedDeviceRole,
+  listApprovedPairedDeviceRoles,
   listDevicePairing,
   listEffectivePairedDeviceRoles,
   requestDevicePairing,
@@ -1006,9 +1007,25 @@ export function attachGatewayWsMessageHandler(params: {
                 (approved?.status === "approved" || resolvedByConcurrentApproval)
               )
             ) {
+              const exposeApprovedAccess = existingPairedDevice?.publicKey === devicePublicKey;
+              const approvedRoles = exposeApprovedAccess
+                ? listApprovedPairedDeviceRoles(existingPairedDevice)
+                : [];
+              const approvedScopes = exposeApprovedAccess
+                ? Array.isArray(existingPairedDevice.approvedScopes)
+                  ? existingPairedDevice.approvedScopes
+                  : Array.isArray(existingPairedDevice.scopes)
+                    ? existingPairedDevice.scopes
+                    : []
+                : [];
               const pairingErrorDetails = buildPairingConnectErrorDetails({
                 reason,
                 requestId: recoveryRequestId,
+                deviceId: device.id,
+                requestedRole: role,
+                requestedScopes: scopes,
+                ...(approvedRoles.length > 0 ? { approvedRoles } : {}),
+                ...(approvedScopes.length > 0 ? { approvedScopes } : {}),
               });
               const pairingErrorMessage = buildPairingConnectErrorMessage(reason);
               setHandshakeState("failed");

--- a/src/shared/device-pairing-access.test.ts
+++ b/src/shared/device-pairing-access.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { resolvePendingDeviceApprovalState } from "./device-pairing-access.js";
+
+describe("resolvePendingDeviceApprovalState", () => {
+  it("treats legacy singular approved role fields as approved access", () => {
+    expect(
+      resolvePendingDeviceApprovalState(
+        {
+          role: "operator",
+          scopes: ["operator.read"],
+        },
+        {
+          role: "operator",
+          scopes: ["operator.read"],
+        },
+      ),
+    ).toEqual({
+      kind: "re-approval",
+      requested: {
+        roles: ["operator"],
+        scopes: ["operator.read"],
+      },
+      approved: {
+        roles: ["operator"],
+        scopes: ["operator.read"],
+      },
+    });
+  });
+
+  it("treats revoked approved-role tokens as a role upgrade", () => {
+    expect(
+      resolvePendingDeviceApprovalState(
+        {
+          role: "operator",
+          scopes: ["operator.read"],
+        },
+        {
+          role: "operator",
+          scopes: ["operator.read"],
+          tokens: {
+            operator: {
+              role: "operator",
+              revokedAtMs: Date.now(),
+            },
+          },
+        },
+      ),
+    ).toEqual({
+      kind: "role-upgrade",
+      requested: {
+        roles: ["operator"],
+        scopes: ["operator.read"],
+      },
+      approved: {
+        roles: [],
+        scopes: ["operator.read"],
+      },
+    });
+  });
+});

--- a/src/shared/device-pairing-access.ts
+++ b/src/shared/device-pairing-access.ts
@@ -1,0 +1,114 @@
+import { normalizeDeviceAuthScopes } from "./device-auth.js";
+
+export type DevicePairingAccessSummary = {
+  roles: string[];
+  scopes: string[];
+};
+
+export type PendingDeviceApprovalKind =
+  | "new-pairing"
+  | "role-upgrade"
+  | "scope-upgrade"
+  | "re-approval";
+
+export type PendingDeviceApprovalState = {
+  kind: PendingDeviceApprovalKind;
+  requested: DevicePairingAccessSummary;
+  approved: DevicePairingAccessSummary | null;
+};
+
+type PendingLike = {
+  role?: string;
+  roles?: string[];
+  scopes?: string[];
+};
+
+type PairedLike = {
+  role?: string;
+  roles?: string[];
+  scopes?: string[];
+  tokens?:
+    | Array<{
+        role?: string;
+        revokedAtMs?: number | null;
+      }>
+    | Record<
+        string,
+        {
+          role?: string;
+          revokedAtMs?: number | null;
+        }
+      >;
+};
+
+function normalizeRoleList(...items: Array<string | string[] | undefined>): string[] {
+  const roles = new Set<string>();
+  for (const item of items) {
+    if (!item) {
+      continue;
+    }
+    if (Array.isArray(item)) {
+      for (const role of item) {
+        const trimmed = role.trim();
+        if (trimmed) {
+          roles.add(trimmed);
+        }
+      }
+      continue;
+    }
+    const trimmed = item.trim();
+    if (trimmed) {
+      roles.add(trimmed);
+    }
+  }
+  return [...roles].toSorted();
+}
+
+function includesAll(allowed: readonly string[], requested: readonly string[]): boolean {
+  const allowedSet = new Set(allowed);
+  return requested.every((value) => allowedSet.has(value));
+}
+
+export function summarizePendingDeviceAccess(request: PendingLike): DevicePairingAccessSummary {
+  return {
+    roles: normalizeRoleList(request.roles, request.role),
+    scopes: normalizeDeviceAuthScopes(request.scopes),
+  };
+}
+
+export function summarizeApprovedDeviceAccess(device: PairedLike): DevicePairingAccessSummary {
+  const approvedRoles = normalizeRoleList(device.roles, device.role);
+  const tokenList = Array.isArray(device.tokens)
+    ? device.tokens
+    : device.tokens
+      ? Object.values(device.tokens)
+      : undefined;
+  const activeTokenRoles =
+    tokenList === undefined
+      ? approvedRoles
+      : normalizeRoleList(
+          tokenList.filter((token) => !token.revokedAtMs).flatMap((token) => token.role ?? []),
+        ).filter((role) => approvedRoles.includes(role));
+  return {
+    roles: activeTokenRoles,
+    scopes: normalizeDeviceAuthScopes(device.scopes),
+  };
+}
+
+export function resolvePendingDeviceApprovalState(
+  request: PendingLike,
+  paired?: PairedLike,
+): PendingDeviceApprovalState {
+  const requested = summarizePendingDeviceAccess(request);
+  const approved = paired ? summarizeApprovedDeviceAccess(paired) : null;
+  if (!approved) {
+    return { kind: "new-pairing", requested, approved: null };
+  }
+  if (!includesAll(approved.roles, requested.roles)) {
+    return { kind: "role-upgrade", requested, approved };
+  }
+  if (!includesAll(approved.scopes, requested.scopes)) {
+    return { kind: "scope-upgrade", requested, approved };
+  }
+  return { kind: "re-approval", requested, approved };
+}

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -2,6 +2,7 @@ import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
 } from "../../../src/gateway/events.js";
+import { ConnectErrorDetailCodes } from "../../../src/gateway/protocol/connect-error-details.js";
 import {
   CHAT_SESSIONS_ACTIVE_MINUTES,
   clearPendingQueueItemsForRun,
@@ -307,7 +308,9 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       if (code !== 1012) {
         if (error?.message) {
           host.lastError =
-            host.lastErrorCode && isGenericBrowserFetchFailure(error.message)
+            host.lastErrorCode &&
+            (host.lastErrorCode === ConnectErrorDetailCodes.PAIRING_REQUIRED ||
+              isGenericBrowserFetchFailure(error.message))
               ? formatConnectError({
                   message: error.message,
                   details: error.details,

--- a/ui/src/ui/connect-error.test.ts
+++ b/ui/src/ui/connect-error.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../src/gateway/protocol/connect-error-details.js";
+import { formatConnectError } from "./connect-error.ts";
+
+describe("formatConnectError", () => {
+  it("explains scope upgrades that require approval", () => {
+    expect(
+      formatConnectError({
+        message: "pairing required",
+        details: {
+          code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+          reason: "scope-upgrade",
+          approvedScopes: ["operator.read"],
+          requestedScopes: ["operator.admin", "operator.read"],
+        },
+      }),
+    ).toBe(
+      "device scope upgrade requires approval (approved: operator.read; requested: operator.admin, operator.read)",
+    );
+  });
+
+  it("explains role upgrades that require approval", () => {
+    expect(
+      formatConnectError({
+        message: "pairing required",
+        details: {
+          code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+          reason: "role-upgrade",
+          approvedRoles: ["operator"],
+          requestedRole: "node",
+        },
+      }),
+    ).toBe("device role upgrade requires approval (approved: operator; requested: node)");
+  });
+});

--- a/ui/src/ui/connect-error.ts
+++ b/ui/src/ui/connect-error.ts
@@ -1,5 +1,4 @@
 import {
-  buildPairingConnectErrorMessage,
   ConnectErrorDetailCodes,
   readPairingConnectErrorDetails,
 } from "../../../src/gateway/protocol/connect-error-details.js";
@@ -32,8 +31,23 @@ function formatErrorFromMessageAndDetails(error: ErrorWithMessageAndDetails): st
       return "gateway auth failed";
     case ConnectErrorDetailCodes.AUTH_RATE_LIMITED:
       return "too many failed authentication attempts";
-    case ConnectErrorDetailCodes.PAIRING_REQUIRED:
-      return `gateway ${buildPairingConnectErrorMessage(readPairingConnectErrorDetails(error.details)?.reason)}`;
+    case ConnectErrorDetailCodes.PAIRING_REQUIRED: {
+      const pairing = readPairingConnectErrorDetails(error.details);
+      const approvedRoles = pairing?.approvedRoles?.join(", ") || "none";
+      const requestedRole = pairing?.requestedRole || "none";
+      const approvedScopes = pairing?.approvedScopes?.join(", ") || "none";
+      const requestedScopes = pairing?.requestedScopes?.join(", ") || "none";
+      switch (pairing?.reason) {
+        case "scope-upgrade":
+          return `device scope upgrade requires approval (approved: ${approvedScopes}; requested: ${requestedScopes})`;
+        case "role-upgrade":
+          return `device role upgrade requires approval (approved: ${approvedRoles}; requested: ${requestedRole})`;
+        case "metadata-upgrade":
+          return "device reconnect details changed and require approval";
+        default:
+          return "gateway pairing required";
+      }
+    }
     case ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED:
       return "device identity required (use HTTPS/localhost or allow insecure auth explicitly)";
     case ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED:

--- a/ui/src/ui/controllers/devices.ts
+++ b/ui/src/ui/controllers/devices.ts
@@ -14,6 +14,7 @@ export type DeviceTokenSummary = {
 export type PendingDevice = {
   requestId: string;
   deviceId: string;
+  publicKey?: string;
   displayName?: string;
   role?: string;
   roles?: string[];
@@ -25,6 +26,7 @@ export type PendingDevice = {
 
 export type PairedDevice = {
   deviceId: string;
+  publicKey?: string;
   displayName?: string;
   roles?: string[];
   scopes?: string[];
@@ -61,7 +63,7 @@ export async function loadDevices(state: DevicesState, opts?: { quiet?: boolean 
   try {
     const res = await state.client.request<{
       pending?: Array<PendingDevice>;
-      paired?: Array<PendingDevice>;
+      paired?: Array<PairedDevice>;
     }>("device.pair.list", {});
     state.devicesList = {
       pending: Array.isArray(res?.pending) ? res.pending : [],

--- a/ui/src/ui/views/nodes.devices.test.ts
+++ b/ui/src/ui/views/nodes.devices.test.ts
@@ -47,7 +47,7 @@ function baseProps(overrides: Partial<NodesProps> = {}): NodesProps {
 }
 
 describe("nodes devices pending rendering", () => {
-  it("shows pending role and scopes from effective pending auth", () => {
+  it("shows requested and approved access for a scope upgrade", () => {
     const container = document.createElement("div");
     render(
       renderNodes(
@@ -63,7 +63,14 @@ describe("nodes devices pending rendering", () => {
                 ts: Date.now(),
               },
             ],
-            paired: [],
+            paired: [
+              {
+                deviceId: "device-1",
+                displayName: "Device One",
+                roles: ["operator"],
+                scopes: ["operator.read"],
+              },
+            ],
           },
         }),
       ),
@@ -71,8 +78,83 @@ describe("nodes devices pending rendering", () => {
     );
 
     const text = container.textContent ?? "";
-    expect(text).toContain("role: operator");
-    expect(text).toContain("scopes: operator.admin, operator.read");
+    expect(text).toContain("scope upgrade requires approval");
+    expect(text).toContain("requested: roles: operator");
+    expect(text).toContain("approved now: roles: operator");
+    expect(text).toContain("operator.admin, operator.read");
+  });
+
+  it("normalizes pending device ids before matching paired access", () => {
+    const container = document.createElement("div");
+    render(
+      renderNodes(
+        baseProps({
+          devicesList: {
+            pending: [
+              {
+                requestId: "req-1",
+                deviceId: " device-1 ",
+                displayName: "Device One",
+                role: "operator",
+                scopes: ["operator.admin", "operator.read"],
+                ts: Date.now(),
+              },
+            ],
+            paired: [
+              {
+                deviceId: "device-1",
+                displayName: "Device One",
+                roles: ["operator"],
+                scopes: ["operator.read"],
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("scope upgrade requires approval");
+    expect(text).toContain("approved now: roles: operator");
+  });
+
+  it("does not show upgrade context for key-mismatched pending requests", () => {
+    const container = document.createElement("div");
+    render(
+      renderNodes(
+        baseProps({
+          devicesList: {
+            pending: [
+              {
+                requestId: "req-1",
+                deviceId: "device-1",
+                publicKey: "new-key",
+                displayName: "Device One",
+                role: "operator",
+                scopes: ["operator.admin"],
+                ts: Date.now(),
+              },
+            ],
+            paired: [
+              {
+                deviceId: "device-1",
+                publicKey: "old-key",
+                displayName: "Device One",
+                roles: ["operator"],
+                scopes: ["operator.read"],
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("new device pairing request");
+    expect(text).not.toContain("scope upgrade requires approval");
+    expect(text).not.toContain("approved now:");
   });
 
   it("falls back to roles when role is absent", () => {
@@ -98,7 +180,7 @@ describe("nodes devices pending rendering", () => {
     );
 
     const text = container.textContent ?? "";
-    expect(text).toContain("role: node, operator");
+    expect(text).toContain("requested: roles: node, operator");
     expect(text).toContain("scopes: operator.read");
   });
 });

--- a/ui/src/ui/views/nodes.ts
+++ b/ui/src/ui/views/nodes.ts
@@ -1,4 +1,9 @@
 import { html, nothing } from "lit";
+import {
+  resolvePendingDeviceApprovalState,
+  type DevicePairingAccessSummary,
+  type PendingDeviceApprovalKind,
+} from "../../../../src/shared/device-pairing-access.js";
 import { t } from "../../i18n/index.ts";
 import type { DeviceTokenSummary, PairedDevice, PendingDevice } from "../controllers/devices.ts";
 import { formatRelativeTimestamp, formatList } from "../format.ts";
@@ -36,6 +41,11 @@ function renderDevices(props: NodesProps) {
   const list = props.devicesList ?? { pending: [], paired: [] };
   const pending = Array.isArray(list.pending) ? list.pending : [];
   const paired = Array.isArray(list.paired) ? list.paired : [];
+  const pairedByDeviceId = new Map(
+    paired
+      .map((device) => [normalizeOptionalString(device.deviceId), device] as const)
+      .filter((entry): entry is [string, PairedDevice] => Boolean(entry[0])),
+  );
   return html`
     <section class="card">
       <div class="row" style="justify-content: space-between;">
@@ -54,7 +64,9 @@ function renderDevices(props: NodesProps) {
         ${pending.length > 0
           ? html`
               <div class="muted" style="margin-bottom: 8px;">Pending</div>
-              ${pending.map((req) => renderPendingDevice(req, props))}
+              ${pending.map((req) =>
+                renderPendingDevice(req, props, lookupPairedDevice(pairedByDeviceId, req)),
+              )}
             `
           : nothing}
         ${paired.length > 0
@@ -71,11 +83,53 @@ function renderDevices(props: NodesProps) {
   `;
 }
 
-function renderPendingDevice(req: PendingDevice, props: NodesProps) {
+function lookupPairedDevice(
+  pairedByDeviceId: ReadonlyMap<string, PairedDevice>,
+  request: Pick<PendingDevice, "deviceId" | "publicKey">,
+): PairedDevice | undefined {
+  const deviceId = normalizeOptionalString(request.deviceId);
+  if (!deviceId) {
+    return undefined;
+  }
+  const paired = pairedByDeviceId.get(deviceId);
+  if (!paired) {
+    return undefined;
+  }
+  const requestPublicKey = normalizeOptionalString(request.publicKey);
+  const pairedPublicKey = normalizeOptionalString(paired.publicKey);
+  if (requestPublicKey && pairedPublicKey && requestPublicKey !== pairedPublicKey) {
+    return undefined;
+  }
+  return paired;
+}
+
+function formatAccessSummary(access: DevicePairingAccessSummary | null): string {
+  if (!access) {
+    return "none";
+  }
+  return `roles: ${formatList(access.roles)} · scopes: ${formatList(access.scopes)}`;
+}
+
+function renderPendingApprovalNote(kind: PendingDeviceApprovalKind) {
+  switch (kind) {
+    case "scope-upgrade":
+      return "scope upgrade requires approval";
+    case "role-upgrade":
+      return "role upgrade requires approval";
+    case "re-approval":
+      return "reconnect details changed; approval required";
+    case "new-pairing":
+      return "new device pairing request";
+  }
+  const exhaustiveKind: never = kind;
+  void exhaustiveKind;
+  throw new Error("unsupported pending approval kind");
+}
+
+function renderPendingDevice(req: PendingDevice, props: NodesProps, paired?: PairedDevice) {
   const name = normalizeOptionalString(req.displayName) || req.deviceId;
   const age = typeof req.ts === "number" ? formatRelativeTimestamp(req.ts) : t("common.na");
-  const roleValue = normalizeOptionalString(req.role) || formatList(req.roles);
-  const scopesValue = formatList(req.scopes);
+  const approval = resolvePendingDeviceApprovalState(req, paired);
   const repair = req.isRepair ? " · repair" : "";
   const ip = req.remoteIp ? ` · ${req.remoteIp}` : "";
   return html`
@@ -84,8 +138,18 @@ function renderPendingDevice(req: PendingDevice, props: NodesProps) {
         <div class="list-title">${name}</div>
         <div class="list-sub">${req.deviceId}${ip}</div>
         <div class="muted" style="margin-top: 6px;">
-          role: ${roleValue} · scopes: ${scopesValue} · requested ${age}${repair}
+          ${renderPendingApprovalNote(approval.kind)} · requested ${age}${repair}
         </div>
+        <div class="muted" style="margin-top: 6px;">
+          requested: ${formatAccessSummary(approval.requested)}
+        </div>
+        ${approval.approved
+          ? html`
+              <div class="muted" style="margin-top: 6px;">
+                approved now: ${formatAccessSummary(approval.approved)}
+              </div>
+            `
+          : nothing}
       </div>
       <div class="list-meta">
         <div class="row" style="justify-content: flex-end; gap: 8px; flex-wrap: wrap;">

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -86,6 +86,11 @@ export function renderOverview(props: OverviewProps) {
       <div class="muted" style="margin-top: 8px">
         ${t("overview.pairing.hint")}
         <div style="margin-top: 6px">
+          If the device was already paired, this usually means it asked for more access than you
+          previously approved. OpenClaw keeps the old approval and creates a new pending upgrade
+          request instead of widening scopes silently.
+        </div>
+        <div style="margin-top: 6px">
           <span class="mono">openclaw devices list</span><br />
           <span class="mono">openclaw devices approve &lt;requestId&gt;</span>
         </div>
@@ -260,11 +265,9 @@ export function renderOverview(props: OverviewProps) {
                       type="button"
                       class="btn btn--icon ${props.showGatewayToken ? "active" : ""}"
                       style="flex-shrink: 0; width: 36px; height: 36px; box-sizing: border-box;"
-                      title=${
-                        props.showGatewayToken
-                          ? t("overview.access.hideToken")
-                          : t("overview.access.showToken")
-                      }
+                      title=${props.showGatewayToken
+                        ? t("overview.access.hideToken")
+                        : t("overview.access.showToken")}
                       aria-label=${t("overview.access.toggleTokenVisibility")}
                       aria-pressed=${props.showGatewayToken}
                       @click=${props.onToggleGatewayTokenVisibility}
@@ -291,11 +294,9 @@ export function renderOverview(props: OverviewProps) {
                       type="button"
                       class="btn btn--icon ${props.showGatewayPassword ? "active" : ""}"
                       style="flex-shrink: 0; width: 36px; height: 36px; box-sizing: border-box;"
-                      title=${
-                        props.showGatewayPassword
-                          ? t("overview.access.hidePassword")
-                          : t("overview.access.showPassword")
-                      }
+                      title=${props.showGatewayPassword
+                        ? t("overview.access.hidePassword")
+                        : t("overview.access.showPassword")}
                       aria-label=${t("overview.access.togglePasswordVisibility")}
                       aria-pressed=${props.showGatewayPassword}
                       @click=${props.onToggleGatewayPasswordVisibility}


### PR DESCRIPTION
This keeps approval-required scope and role upgrades, but makes that model explicit instead of looking like a broken pairing.

- include requested vs approved access on pairing-required upgrade errors
- show the same upgrade state in `openclaw devices` and the Control UI
- document the upgrade flow for paired devices

Verification:
- `pnpm test src/cli/devices-cli.test.ts src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts src/gateway/server.auth.control-ui.suite.ts ui/src/ui/views/nodes.devices.test.ts ui/src/ui/connect-error.test.ts ui/src/ui/views/overview.node.test.ts`
- manual repro: seed a read-only Control UI pairing, reconnect with broader scopes, confirm the UI shows the upgrade message, approve it, then confirm reconnect succeeds
