### PR TITLE
discord: split mixed replies on fenced code blocks

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1236,7 +1236,7 @@ High-signal Discord fields:
 - event queue: `eventQueue.listenerTimeout` (listener budget), `eventQueue.maxQueueSize`, `eventQueue.maxConcurrency`
 - inbound worker: `inboundWorker.runTimeoutMs`
 - reply/history: `replyToMode`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
-- delivery: `textChunkLimit`, `chunkMode`, `maxLinesPerMessage`
+- delivery: `textChunkLimit`, `chunkMode`, `maxLinesPerMessage`, `splitOnCodeBlocks`
 - streaming: `streaming` (legacy alias: `streamMode`), `draftChunk`, `blockStreaming`, `blockStreamingCoalesce`
 - media/retry: `mediaMaxMb`, `retry`
   - `mediaMaxMb` caps outbound Discord uploads (default: `100MB`)

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -281,6 +281,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       chunkMode: "length", // length | newline
       streaming: "off", // off | partial | block | progress (progress maps to partial on Discord)
       maxLinesPerMessage: 17,
+      splitOnCodeBlocks: false,
       ui: {
         components: {
           accentColor: "#5865F2",
@@ -334,6 +335,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - Bot-authored messages are ignored by default. `allowBots: true` enables them; use `allowBots: "mentions"` to only accept bot messages that mention the bot (own messages still filtered).
 - `channels.discord.guilds.<id>.ignoreOtherMentions` (and channel overrides) drops messages that mention another user or role but not the bot (excluding @everyone/@here).
 - `maxLinesPerMessage` (default 17) splits tall messages even when under 2000 chars.
+- `splitOnCodeBlocks` (default false) splits mixed prose + fenced code responses into distinct Discord messages before normal chunking. Handy when people want to copy code blocks cleanly on mobile.
 - `channels.discord.threadBindings` controls Discord thread-bound routing:
   - `enabled`: Discord override for thread-bound session features (`/focus`, `/unfocus`, `/agents`, `/session idle`, `/session max-age`, and bound delivery/routing)
   - `idleHours`: Discord override for inactivity auto-unfocus in hours (`0` disables)

--- a/extensions/discord/src/accounts.test.ts
+++ b/extensions/discord/src/accounts.test.ts
@@ -3,6 +3,7 @@ import {
   createDiscordActionGate,
   resolveDiscordAccount,
   resolveDiscordMaxLinesPerMessage,
+  resolveDiscordSplitOnCodeBlocks,
 } from "./accounts.js";
 
 describe("resolveDiscordAccount allowFrom precedence", () => {
@@ -159,5 +160,64 @@ describe("resolveDiscordMaxLinesPerMessage", () => {
     });
 
     expect(resolved).toBe(80);
+  });
+});
+
+describe("resolveDiscordSplitOnCodeBlocks", () => {
+  it("falls back to merged root discord splitOnCodeBlocks when runtime config omits it", () => {
+    const resolved = resolveDiscordSplitOnCodeBlocks({
+      cfg: {
+        channels: {
+          discord: {
+            splitOnCodeBlocks: true,
+            accounts: {
+              default: { token: "token-default" },
+            },
+          },
+        },
+      },
+      discordConfig: {},
+      accountId: "default",
+    });
+
+    expect(resolved).toBe(true);
+  });
+
+  it("prefers explicit runtime discord splitOnCodeBlocks over merged config", () => {
+    const resolved = resolveDiscordSplitOnCodeBlocks({
+      cfg: {
+        channels: {
+          discord: {
+            splitOnCodeBlocks: false,
+            accounts: {
+              default: { token: "token-default", splitOnCodeBlocks: false },
+            },
+          },
+        },
+      },
+      discordConfig: { splitOnCodeBlocks: true },
+      accountId: "default",
+    });
+
+    expect(resolved).toBe(true);
+  });
+
+  it("uses per-account discord splitOnCodeBlocks over the root value when runtime config omits it", () => {
+    const resolved = resolveDiscordSplitOnCodeBlocks({
+      cfg: {
+        channels: {
+          discord: {
+            splitOnCodeBlocks: false,
+            accounts: {
+              work: { token: "token-work", splitOnCodeBlocks: true },
+            },
+          },
+        },
+      },
+      discordConfig: {},
+      accountId: "work",
+    });
+
+    expect(resolved).toBe(true);
   });
 });

--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -34,7 +34,7 @@ export function mergeDiscordAccountConfig(
   accountId: string,
 ): DiscordAccountConfig {
   return resolveMergedAccountConfig<DiscordAccountConfig>({
-    channelConfig: cfg.channels?.discord as DiscordAccountConfig | undefined,
+    channelConfig: cfg.channels?.discord,
     accounts: cfg.channels?.discord?.accounts as
       | Record<string, Partial<DiscordAccountConfig>>
       | undefined,
@@ -89,6 +89,20 @@ export function resolveDiscordMaxLinesPerMessage(params: {
     cfg: params.cfg,
     accountId: params.accountId,
   }).config.maxLinesPerMessage;
+}
+
+export function resolveDiscordSplitOnCodeBlocks(params: {
+  cfg: OpenClawConfig;
+  discordConfig?: DiscordAccountConfig | null;
+  accountId?: string | null;
+}): boolean | undefined {
+  if (typeof params.discordConfig?.splitOnCodeBlocks === "boolean") {
+    return params.discordConfig.splitOnCodeBlocks;
+  }
+  return resolveDiscordAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  }).config.splitOnCodeBlocks;
 }
 
 export function listEnabledDiscordAccounts(cfg: OpenClawConfig): ResolvedDiscordAccount[] {

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -1,6 +1,10 @@
 import { countLines, hasBalancedFences } from "openclaw/plugin-sdk/testing";
 import { describe, expect, it } from "vitest";
-import { chunkDiscordText, chunkDiscordTextWithMode } from "./chunk.js";
+import {
+  chunkDiscordText,
+  chunkDiscordTextWithMode,
+  splitDiscordTextOnCodeBlocks,
+} from "./chunk.js";
 
 describe("chunkDiscordText", () => {
   it("splits tall messages even when under 2000 chars", () => {
@@ -129,5 +133,35 @@ describe("chunkDiscordText", () => {
     const second = chunks[1];
     expect(second.startsWith("_")).toBe(true);
     expect(second).toContain("  11. indented line");
+  });
+
+  it("splits mixed prose and fenced code into distinct groups when enabled", () => {
+    const text = "Intro\n\n```ts\nconst x = 1;\n```\n\nOutro";
+
+    expect(splitDiscordTextOnCodeBlocks(text)).toEqual([
+      "Intro\n\n",
+      "```ts\nconst x = 1;\n```\n\n",
+      "Outro",
+    ]);
+  });
+
+  it("keeps whitespace between adjacent code blocks attached to a neighbor", () => {
+    const text = "```ts\nconst a = 1;\n```\n\n```ts\nconst b = 2;\n```";
+
+    const groups = splitDiscordTextOnCodeBlocks(text);
+    expect(groups).toEqual(["```ts\nconst a = 1;\n```\n\n", "```ts\nconst b = 2;\n```"]);
+    expect(groups.join("")).toBe(text);
+  });
+
+  it("emits separate Discord chunks around fenced code when enabled", () => {
+    const text = "Intro\n\n```ts\nconst x = 1;\n```\n\nOutro";
+
+    const chunks = chunkDiscordTextWithMode(text, {
+      maxChars: 2000,
+      maxLines: 50,
+      splitOnCodeBlocks: true,
+    });
+
+    expect(chunks).toEqual(["Intro\n\n", "```ts\nconst x = 1;\n```\n\n", "Outro"]);
   });
 });

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -153,6 +153,14 @@ describe("chunkDiscordText", () => {
     expect(groups.join("")).toBe(text);
   });
 
+  it("does not treat closing fences with trailing text as a real close", () => {
+    const text = "```ts\nconst a = 1;\n```not-close\nconst b = 2;\n```\nAfter";
+
+    const groups = splitDiscordTextOnCodeBlocks(text);
+    expect(groups).toEqual(["```ts\nconst a = 1;\n```not-close\nconst b = 2;\n```\n", "After"]);
+    expect(groups.join("")).toBe(text);
+  });
+
   it("emits separate Discord chunks around fenced code when enabled", () => {
     const text = "Intro\n\n```ts\nconst x = 1;\n```\n\nOutro";
 

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -161,6 +161,15 @@ describe("chunkDiscordText", () => {
     expect(groups.join("")).toBe(text);
   });
 
+  it("rejects invalid backtick fences when splitting code blocks", () => {
+    const text = "Intro\n\n```js`\nthis is not actually a valid code fence opener\nOutro";
+
+    // Invalid opener (backticks in info string) should be treated as prose,
+    // otherwise we'd incorrectly group the remainder as code.
+    const groups = splitDiscordTextOnCodeBlocks(text);
+    expect(groups).toEqual([text]);
+  });
+
   it("emits separate Discord chunks around fenced code when enabled", () => {
     const text = "Intro\n\n```ts\nconst x = 1;\n```\n\nOutro";
 

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -24,6 +24,14 @@ type OpenFence = {
   openLine: string;
 };
 
+type FenceLine = {
+  indent: string;
+  markerChar: string;
+  markerLen: number;
+  trailing: string;
+  openLine: string;
+};
+
 const DEFAULT_MAX_CHARS = 2000;
 const DEFAULT_MAX_LINES = 17;
 const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
@@ -35,17 +43,19 @@ function countLines(text: string) {
   return text.split("\n").length;
 }
 
-function parseFenceLine(line: string): OpenFence | null {
+function parseFenceLine(line: string): FenceLine | null {
   const match = line.match(FENCE_RE);
   if (!match) {
     return null;
   }
   const indent = match[1] ?? "";
   const marker = match[2] ?? "";
+  const trailing = match[3] ?? "";
   return {
     indent,
     markerChar: marker[0] ?? "`",
     markerLen: marker.length,
+    trailing,
     openLine: line,
   };
 }
@@ -137,6 +147,24 @@ function mergeWhitespaceOnlySegments(segments: string[]): string[] {
   return merged.filter(Boolean);
 }
 
+function moveLeadingNewlinesToPreviousSegment(segments: string[]): string[] {
+  const moved = [...segments];
+  for (let i = 1; i < moved.length; i++) {
+    const segment = moved[i];
+    if (!segment) {
+      continue;
+    }
+    const leadingNewlineMatch = segment.match(/^\n+/);
+    if (!leadingNewlineMatch || !leadingNewlineMatch[0]) {
+      continue;
+    }
+    const leadingNewlines = leadingNewlineMatch[0];
+    moved[i - 1] += leadingNewlines;
+    moved[i] = segment.slice(leadingNewlines.length);
+  }
+  return moved.filter(Boolean);
+}
+
 export function splitDiscordTextOnCodeBlocks(text: string): string[] {
   const body = text ?? "";
   if (!body) {
@@ -175,7 +203,8 @@ export function splitDiscordTextOnCodeBlocks(text: string): string[] {
       openFence &&
       fenceInfo &&
       openFence.markerChar === fenceInfo.markerChar &&
-      fenceInfo.markerLen >= openFence.markerLen
+      fenceInfo.markerLen >= openFence.markerLen &&
+      fenceInfo.trailing.trim().length === 0
     ) {
       flush();
       openFence = null;
@@ -184,7 +213,8 @@ export function splitDiscordTextOnCodeBlocks(text: string): string[] {
 
   flush();
   const merged = mergeWhitespaceOnlySegments(segments);
-  return merged.length > 0 ? merged : [body];
+  const normalized = moveLeadingNewlinesToPreviousSegment(merged);
+  return normalized.length > 0 ? normalized : [body];
 }
 
 /**
@@ -237,7 +267,8 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
         nextOpenFence = fenceInfo;
       } else if (
         openFence.markerChar === fenceInfo.markerChar &&
-        fenceInfo.markerLen >= openFence.markerLen
+        fenceInfo.markerLen >= openFence.markerLen &&
+        fenceInfo.trailing.trim().length === 0
       ) {
         nextOpenFence = null;
       }

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -64,6 +64,15 @@ function closeFenceLine(openFence: OpenFence) {
   return `${openFence.indent}${openFence.markerChar.repeat(openFence.markerLen)}`;
 }
 
+function isValidFenceOpener(fenceInfo: FenceLine): boolean {
+  // CommonMark: for backtick fences, the info string (everything after the opening backticks)
+  // must not contain any backtick characters.
+  if (fenceInfo.markerChar !== "`") {
+    return true;
+  }
+  return !fenceInfo.trailing.includes("`");
+}
+
 function closeFenceIfNeeded(text: string, openFence: OpenFence | null) {
   if (!openFence) {
     return text;
@@ -190,7 +199,7 @@ export function splitDiscordTextOnCodeBlocks(text: string): string[] {
 
   for (const line of lines) {
     const fenceInfo = parseFenceLine(trimTrailingNewline(line));
-    if (!openFence && fenceInfo) {
+    if (!openFence && fenceInfo && isValidFenceOpener(fenceInfo)) {
       flush();
       current = line;
       openFence = fenceInfo;
@@ -264,7 +273,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     let nextOpenFence: OpenFence | null = openFence;
     if (fenceInfo) {
       if (!openFence) {
-        nextOpenFence = fenceInfo;
+        nextOpenFence = isValidFenceOpener(fenceInfo) ? fenceInfo : null;
       } else if (
         openFence.markerChar === fenceInfo.markerChar &&
         fenceInfo.markerLen >= openFence.markerLen &&

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -10,6 +10,11 @@ export type ChunkDiscordTextOpts = {
    * by lines keeps long multi-paragraph replies readable.
    */
   maxLines?: number;
+  /**
+   * If true, split mixed prose + fenced code responses into distinct message
+   * groups before normal Discord chunking runs.
+   */
+  splitOnCodeBlocks?: boolean;
 };
 
 type OpenFence = {
@@ -99,6 +104,87 @@ function splitLongLine(
     out.push(remaining);
   }
   return out;
+}
+
+function splitLinesPreserveNewlines(text: string): string[] {
+  const matches = text.match(/[^\n]*\n|[^\n]+$/g);
+  return matches ?? [];
+}
+
+function trimTrailingNewline(line: string): string {
+  return line.endsWith("\n") ? line.slice(0, -1) : line;
+}
+
+function mergeWhitespaceOnlySegments(segments: string[]): string[] {
+  const merged = [...segments];
+  for (let i = 0; i < merged.length; i++) {
+    const segment = merged[i];
+    if (!segment || segment.trim().length > 0) {
+      continue;
+    }
+    const prevIndex = i - 1;
+    const nextIndex = i + 1;
+    if (prevIndex >= 0 && merged[prevIndex]) {
+      merged[prevIndex] += segment;
+      merged[i] = "";
+      continue;
+    }
+    if (nextIndex < merged.length && merged[nextIndex]) {
+      merged[nextIndex] = `${segment}${merged[nextIndex]}`;
+      merged[i] = "";
+    }
+  }
+  return merged.filter(Boolean);
+}
+
+export function splitDiscordTextOnCodeBlocks(text: string): string[] {
+  const body = text ?? "";
+  if (!body) {
+    return [];
+  }
+
+  const lines = splitLinesPreserveNewlines(body);
+  if (lines.length === 0) {
+    return [body];
+  }
+
+  const segments: string[] = [];
+  let current = "";
+  let openFence: OpenFence | null = null;
+
+  const flush = () => {
+    if (!current) {
+      return;
+    }
+    segments.push(current);
+    current = "";
+  };
+
+  for (const line of lines) {
+    const fenceInfo = parseFenceLine(trimTrailingNewline(line));
+    if (!openFence && fenceInfo) {
+      flush();
+      current = line;
+      openFence = fenceInfo;
+      continue;
+    }
+
+    current += line;
+
+    if (
+      openFence &&
+      fenceInfo &&
+      openFence.markerChar === fenceInfo.markerChar &&
+      fenceInfo.markerLen >= openFence.markerLen
+    ) {
+      flush();
+      openFence = null;
+    }
+  }
+
+  flush();
+  const merged = mergeWhitespaceOnlySegments(segments);
+  return merged.length > 0 ? merged : [body];
 }
 
 /**
@@ -212,6 +298,25 @@ export function chunkDiscordTextWithMode(
   text: string,
   opts: ChunkDiscordTextOpts & { chunkMode?: ChunkMode },
 ): string[] {
+  if (opts.splitOnCodeBlocks) {
+    const groups = splitDiscordTextOnCodeBlocks(text);
+    const chunks: string[] = [];
+    for (const group of groups) {
+      const nested = chunkDiscordTextWithMode(group, {
+        ...opts,
+        splitOnCodeBlocks: false,
+      });
+      if (!nested.length) {
+        if (group.trim()) {
+          chunks.push(group);
+        }
+        continue;
+      }
+      chunks.push(...nested);
+    }
+    return chunks;
+  }
+
   const chunkMode = opts.chunkMode ?? "length";
   if (chunkMode !== "newline") {
     return chunkDiscordText(text, opts);

--- a/extensions/discord/src/config-ui-hints.ts
+++ b/extensions/discord/src/config-ui-hints.ts
@@ -81,6 +81,10 @@ export const discordChannelConfigUiHints = {
     label: "Discord Max Lines Per Message",
     help: "Soft max line count per Discord message (default: 17).",
   },
+  splitOnCodeBlocks: {
+    label: "Discord Split On Code Blocks",
+    help: "Split mixed prose + fenced code responses into distinct Discord messages before normal chunking runs (default: false).",
+  },
   "inboundWorker.runTimeoutMs": {
     label: "Discord Inbound Worker Timeout (ms)",
     help: "Optional queued Discord inbound worker timeout in ms. This is separate from Carbon listener timeouts; defaults to 1800000 and can be disabled with 0. Set per account via channels.discord.accounts.<id>.inboundWorker.runTimeoutMs.",

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -29,7 +29,7 @@ import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime
 import { createNonExitingRuntime, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import { logDebug, logError } from "openclaw/plugin-sdk/text-runtime";
-import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
+import { resolveDiscordMaxLinesPerMessage, resolveDiscordSplitOnCodeBlocks } from "../accounts.js";
 import { createDiscordRestClient } from "../client.js";
 import {
   parseDiscordComponentCustomIdForCarbon,
@@ -561,6 +561,11 @@ async function dispatchDiscordComponentEvent(params: {
           replyToMode,
           textLimit,
           maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({
+            cfg: ctx.cfg,
+            discordConfig: ctx.discordConfig,
+            accountId,
+          }),
+          splitOnCodeBlocks: resolveDiscordSplitOnCodeBlocks({
             cfg: ctx.cfg,
             discordConfig: ctx.discordConfig,
             accountId,

--- a/extensions/discord/src/monitor/inbound-worker.ts
+++ b/extensions/discord/src/monitor/inbound-worker.ts
@@ -167,6 +167,7 @@ async function sendDiscordInboundWorkerTimeoutReply(params: {
       runtime: params.runtime,
       textLimit: params.job.payload.textLimit,
       maxLinesPerMessage: params.job.payload.discordConfig?.maxLinesPerMessage,
+      splitOnCodeBlocks: params.job.payload.discordConfig?.splitOnCodeBlocks,
       replyToId: deliveryPlan.replyReference.use(),
       replyToMode: params.job.payload.replyToMode,
       sessionKey:

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -43,7 +43,7 @@ import {
   stripReasoningTagsFromText,
   truncateUtf16Safe,
 } from "openclaw/plugin-sdk/text-runtime";
-import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
+import { resolveDiscordMaxLinesPerMessage, resolveDiscordSplitOnCodeBlocks } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { createDiscordRestClient } from "../client.js";
 import { resolveDiscordConversationIdentity } from "../conversation-identity.js";
@@ -568,6 +568,11 @@ export async function processDiscordMessage(
     accountId,
   });
   const chunkMode = resolveChunkMode(cfg, "discord", accountId);
+  const splitOnCodeBlocks = resolveDiscordSplitOnCodeBlocks({
+    cfg,
+    discordConfig,
+    accountId,
+  });
 
   // --- Discord draft stream (edit-based preview streaming) ---
   const discordStreamMode = resolveDiscordPreviewStreamMode(discordConfig);
@@ -615,6 +620,7 @@ export async function processDiscordMessage(
       maxChars: draftMaxChars,
       maxLines: maxLinesPerMessage,
       chunkMode,
+      splitOnCodeBlocks,
     });
     if (!chunks.length && formatted) {
       chunks.push(formatted);
@@ -840,6 +846,7 @@ export async function processDiscordMessage(
           replyToMode,
           textLimit,
           maxLinesPerMessage,
+          splitOnCodeBlocks,
           tableMode,
           chunkMode,
           sessionKey: ctxPayload.SessionKey,

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -53,7 +53,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/text-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
-import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
+import { resolveDiscordMaxLinesPerMessage, resolveDiscordSplitOnCodeBlocks } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import {
   normalizeDiscordAllowList,
@@ -1098,6 +1098,7 @@ async function dispatchDiscordCommandInteraction(params: {
         fallbackLimit: 2000,
       }),
       maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
+      splitOnCodeBlocks: resolveDiscordSplitOnCodeBlocks({ cfg, discordConfig, accountId }),
       preferFollowUp,
       chunkMode: resolveChunkMode(cfg, "discord", accountId),
     });
@@ -1167,6 +1168,7 @@ async function dispatchDiscordCommandInteraction(params: {
           fallbackLimit: 2000,
         }),
         maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
+        splitOnCodeBlocks: resolveDiscordSplitOnCodeBlocks({ cfg, discordConfig, accountId }),
         preferFollowUp,
         chunkMode: resolveChunkMode(cfg, "discord", accountId),
       });
@@ -1232,6 +1234,7 @@ async function dispatchDiscordCommandInteraction(params: {
               fallbackLimit: 2000,
             }),
             maxLinesPerMessage: resolveDiscordMaxLinesPerMessage({ cfg, discordConfig, accountId }),
+            splitOnCodeBlocks: resolveDiscordSplitOnCodeBlocks({ cfg, discordConfig, accountId }),
             preferFollowUp: preferFollowUp || didReply,
             chunkMode: resolveChunkMode(cfg, "discord", accountId),
           });
@@ -1313,10 +1316,19 @@ async function deliverDiscordInteractionReply(params: {
   mediaLocalRoots?: readonly string[];
   textLimit: number;
   maxLinesPerMessage?: number;
+  splitOnCodeBlocks?: boolean;
   preferFollowUp: boolean;
   chunkMode: "length" | "newline";
 }) {
-  const { interaction, payload, textLimit, maxLinesPerMessage, preferFollowUp, chunkMode } = params;
+  const {
+    interaction,
+    payload,
+    textLimit,
+    maxLinesPerMessage,
+    splitOnCodeBlocks,
+    preferFollowUp,
+    chunkMode,
+  } = params;
   const reply = resolveSendableOutboundReplyParts(payload);
   const discordData = payload.channelData?.discord as
     | { components?: TopLevelComponents[] }
@@ -1380,6 +1392,7 @@ async function deliverDiscordInteractionReply(params: {
         maxChars: textLimit,
         maxLines: maxLinesPerMessage,
         chunkMode,
+        splitOnCodeBlocks,
       }),
     );
     const caption = chunks[0] ?? "";
@@ -1404,6 +1417,7 @@ async function deliverDiscordInteractionReply(params: {
             maxChars: textLimit,
             maxLines: maxLinesPerMessage,
             chunkMode,
+            splitOnCodeBlocks,
           }),
         )
       : [];

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -421,7 +421,7 @@ describe("deliverDiscordReply", () => {
     expect(sendDiscordTextMock.mock.calls[1]?.[1]).toBe("789");
   });
 
-  it("passes maxLinesPerMessage and chunkMode through the fast path", async () => {
+  it("passes maxLinesPerMessage, chunkMode, and splitOnCodeBlocks through the fast path", async () => {
     const fakeRest = {} as import("@buape/carbon").RequestClient;
 
     await deliverDiscordReply({
@@ -434,15 +434,18 @@ describe("deliverDiscordReply", () => {
       textLimit: 2000,
       maxLinesPerMessage: 120,
       chunkMode: "newline",
+      splitOnCodeBlocks: true,
     });
 
     expect(sendMessageDiscordMock).not.toHaveBeenCalled();
     expect(sendDiscordTextMock).toHaveBeenCalledTimes(1);
     const firstSendDiscordTextCall = sendDiscordTextMock.mock.calls[0];
-    const [, , , , , maxLinesPerMessageArg, , , chunkModeArg] = firstSendDiscordTextCall ?? [];
+    const [, , , , , maxLinesPerMessageArg, , , chunkModeArg, splitOnCodeBlocksArg] =
+      firstSendDiscordTextCall ?? [];
 
     expect(maxLinesPerMessageArg).toBe(120);
     expect(chunkModeArg).toBe("newline");
+    expect(splitOnCodeBlocksArg).toBe(true);
   });
 
   it("falls back to sendMessageDiscord when rest is not provided", async () => {

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -152,6 +152,7 @@ async function sendDiscordPayloadText(params: {
   accountId?: string;
   textLimit?: number;
   maxLinesPerMessage?: number;
+  splitOnCodeBlocks?: boolean;
   binding?: DiscordThreadBindingLookupRecord;
   chunkMode?: ChunkMode;
   username?: string;
@@ -169,6 +170,7 @@ async function sendDiscordPayloadText(params: {
       maxChars: chunkLimit,
       maxLines: params.maxLinesPerMessage,
       chunkMode: mode,
+      splitOnCodeBlocks: params.splitOnCodeBlocks,
     }),
   );
   for (const chunk of chunks) {
@@ -183,6 +185,7 @@ async function sendDiscordPayloadText(params: {
       rest: params.rest,
       accountId: params.accountId,
       maxLinesPerMessage: params.maxLinesPerMessage,
+      splitOnCodeBlocks: params.splitOnCodeBlocks,
       replyTo: params.resolveReplyTo(),
       binding: params.binding,
       chunkMode: params.chunkMode,
@@ -282,6 +285,7 @@ async function sendDiscordChunkWithFallback(params: {
   token: string;
   accountId?: string;
   maxLinesPerMessage?: number;
+  splitOnCodeBlocks?: boolean;
   rest?: RequestClient;
   replyTo?: string;
   binding?: DiscordThreadBindingLookupRecord;
@@ -334,6 +338,7 @@ async function sendDiscordChunkWithFallback(params: {
           undefined,
           undefined,
           params.chunkMode,
+          params.splitOnCodeBlocks,
         ),
       params.retryConfig,
     );
@@ -362,6 +367,7 @@ export async function deliverDiscordReply(params: {
   runtime: RuntimeEnv;
   textLimit: number;
   maxLinesPerMessage?: number;
+  splitOnCodeBlocks?: boolean;
   replyToId?: string;
   replyToMode?: ReplyToMode;
   tableMode?: MarkdownTableMode;
@@ -399,6 +405,7 @@ export async function deliverDiscordReply(params: {
   const channelId = resolveTargetChannelId(params.target);
   const account = resolveDiscordAccount({ cfg: params.cfg, accountId: params.accountId });
   const retryConfig = resolveDeliveryRetryConfig(account.config.retry);
+  const splitOnCodeBlocks = params.splitOnCodeBlocks ?? account.config.splitOnCodeBlocks;
   const request: RetryRunner | undefined = channelId
     ? createDiscordRetryRunner({ configRetry: account.config.retry })
     : undefined;
@@ -426,6 +433,7 @@ export async function deliverDiscordReply(params: {
         accountId: params.accountId,
         textLimit: params.textLimit,
         maxLinesPerMessage: params.maxLinesPerMessage,
+        splitOnCodeBlocks,
         resolveReplyTo: resolvePayloadReplyTo,
         binding,
         chunkMode: params.chunkMode,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -81,6 +81,7 @@ async function sendDiscordThreadTextChunks(params: {
   request: DiscordClientRequest;
   maxLinesPerMessage?: number;
   chunkMode: ReturnType<typeof resolveChunkMode>;
+  splitOnCodeBlocks?: boolean;
   silent?: boolean;
 }): Promise<void> {
   for (const chunk of params.chunks) {
@@ -94,6 +95,7 @@ async function sendDiscordThreadTextChunks(params: {
       undefined,
       undefined,
       params.chunkMode,
+      params.splitOnCodeBlocks,
       params.silent,
     );
   }
@@ -151,6 +153,7 @@ export async function sendMessageDiscord(
     accountId: accountInfo.accountId,
   });
   const chunkMode = resolveChunkMode(cfg, "discord", accountInfo.accountId);
+  const splitOnCodeBlocks = accountInfo.config.splitOnCodeBlocks;
   const mediaMaxBytes =
     typeof accountInfo.config.mediaMaxMb === "number"
       ? accountInfo.config.mediaMaxMb * 1024 * 1024
@@ -171,6 +174,7 @@ export async function sendMessageDiscord(
     const chunks = buildDiscordTextChunks(textWithMentions, {
       maxLinesPerMessage: accountInfo.config.maxLinesPerMessage,
       chunkMode,
+      splitOnCodeBlocks,
     });
     const starterContent = chunks[0]?.trim() ? chunks[0] : threadName;
     const starterComponents = resolveDiscordSendComponents({
@@ -230,6 +234,7 @@ export async function sendMessageDiscord(
           undefined,
           undefined,
           chunkMode,
+          splitOnCodeBlocks,
           opts.silent,
         );
         await sendDiscordThreadTextChunks({
@@ -239,6 +244,7 @@ export async function sendMessageDiscord(
           request,
           maxLinesPerMessage: accountInfo.config.maxLinesPerMessage,
           chunkMode,
+          splitOnCodeBlocks,
           silent: opts.silent,
         });
       } else {
@@ -249,6 +255,7 @@ export async function sendMessageDiscord(
           request,
           maxLinesPerMessage: accountInfo.config.maxLinesPerMessage,
           chunkMode,
+          splitOnCodeBlocks,
           silent: opts.silent,
         });
       }
@@ -293,6 +300,7 @@ export async function sendMessageDiscord(
         opts.components,
         opts.embeds,
         chunkMode,
+        splitOnCodeBlocks,
         opts.silent,
       );
     } else {
@@ -306,6 +314,7 @@ export async function sendMessageDiscord(
         opts.components,
         opts.embeds,
         chunkMode,
+        splitOnCodeBlocks,
         opts.silent,
       );
     }

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -207,7 +207,12 @@ export const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
 
 export function buildDiscordTextChunks(
   text: string,
-  opts: { maxLinesPerMessage?: number; chunkMode?: ChunkMode; maxChars?: number } = {},
+  opts: {
+    maxLinesPerMessage?: number;
+    chunkMode?: ChunkMode;
+    maxChars?: number;
+    splitOnCodeBlocks?: boolean;
+  } = {},
 ): string[] {
   if (!text) {
     return [];
@@ -216,6 +221,7 @@ export function buildDiscordTextChunks(
     maxChars: opts.maxChars ?? DISCORD_TEXT_LIMIT,
     maxLines: opts.maxLinesPerMessage,
     chunkMode: opts.chunkMode,
+    splitOnCodeBlocks: opts.splitOnCodeBlocks,
   });
   return resolveTextChunksWithFallback(text, chunks);
 }
@@ -305,6 +311,7 @@ async function sendDiscordText(
   components?: DiscordSendComponents,
   embeds?: DiscordSendEmbeds,
   chunkMode?: ChunkMode,
+  splitOnCodeBlocks?: boolean,
   silent?: boolean,
 ) {
   if (!text.trim()) {
@@ -312,7 +319,11 @@ async function sendDiscordText(
   }
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
   const flags = silent ? SUPPRESS_NOTIFICATIONS_FLAG : undefined;
-  const chunks = buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode });
+  const chunks = buildDiscordTextChunks(text, {
+    maxLinesPerMessage,
+    chunkMode,
+    splitOnCodeBlocks,
+  });
   const sendChunk = async (chunk: string, isFirst: boolean) => {
     const chunkComponents = resolveDiscordSendComponents({
       components,
@@ -366,6 +377,7 @@ async function sendDiscordMedia(
   components?: DiscordSendComponents,
   embeds?: DiscordSendEmbeds,
   chunkMode?: ChunkMode,
+  splitOnCodeBlocks?: boolean,
   silent?: boolean,
 ) {
   const media = await loadWebMedia(
@@ -378,7 +390,9 @@ async function sendDiscordMedia(
     media.fileName ||
     (media.contentType ? `upload${extensionForMime(media.contentType) ?? ""}` : "") ||
     "upload";
-  const chunks = text ? buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode }) : [];
+  const chunks = text
+    ? buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode, splitOnCodeBlocks })
+    : [];
   const caption = chunks[0] ?? "";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
   const flags = silent ? SUPPRESS_NOTIFICATIONS_FLAG : undefined;
@@ -425,6 +439,7 @@ async function sendDiscordMedia(
       undefined,
       undefined,
       chunkMode,
+      splitOnCodeBlocks,
       silent,
     );
   }

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -912,6 +912,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           exclusiveMinimum: 0,
           maximum: 9007199254740991,
         },
+        splitOnCodeBlocks: {
+          type: "boolean",
+        },
         mediaMaxMb: {
           type: "number",
           exclusiveMinimum: 0,
@@ -2076,6 +2079,9 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                 exclusiveMinimum: 0,
                 maximum: 9007199254740991,
               },
+              splitOnCodeBlocks: {
+                type: "boolean",
+              },
               mediaMaxMb: {
                 type: "number",
                 exclusiveMinimum: 0,
@@ -3060,6 +3066,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
       maxLinesPerMessage: {
         label: "Discord Max Lines Per Message",
         help: "Soft max line count per Discord message (default: 17).",
+      },
+      splitOnCodeBlocks: {
+        label: "Discord Split On Code Blocks",
+        help: "Split mixed prose + fenced code responses into distinct Discord messages before normal chunking runs (default: false).",
       },
       "inboundWorker.runTimeoutMs": {
         label: "Discord Inbound Worker Timeout (ms)",

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -260,6 +260,11 @@ export type DiscordAccountConfig = {
    * keeps replies readable in-channel. Default: 17.
    */
   maxLinesPerMessage?: number;
+  /**
+   * Split mixed prose + fenced code responses into distinct outbound Discord
+   * messages before normal chunking runs. Default: false.
+   */
+  splitOnCodeBlocks?: boolean;
   mediaMaxMb?: number;
   historyLimit?: number;
   /** Max DM turns to keep as history context. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -529,6 +529,7 @@ export const DiscordAccountSchema = z
     textChunkLimit: z.number().int().positive().optional(),
     streaming: ChannelPreviewStreamingConfigSchema.optional(),
     maxLinesPerMessage: z.number().int().positive().optional(),
+    splitOnCodeBlocks: z.boolean().optional(),
     mediaMaxMb: z.number().positive().optional(),
     retry: RetryConfigSchema,
     actions: z


### PR DESCRIPTION
## Summary
- add Discord config `splitOnCodeBlocks` (default off)
- split mixed prose + fenced code into distinct messages before normal chunking
- propagate option through shared outbound send path and monitor fast-path/native command paths
- update docs, schema/config metadata, and tests

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/discord/src/chunk.test.ts extensions/discord/src/accounts.test.ts extensions/discord/src/monitor/reply-delivery.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts`
- pre-commit `pnpm check` gate passed during commit
