### PR TITLE
Surface pending scope upgrades in gateway auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/status: separate reachability, capability, and read-probe reporting so connect-only or scope-limited sessions no longer look fully healthy, and normalize SSH targets entered as `ssh user@host`. (#69215) Thanks @obviyus.
 - Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
+- Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
 
 ## 2026.4.19-beta.2
 

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -320,4 +320,21 @@ describe("createNodesTool screen_record duration guardrails", () => {
       }),
     ).rejects.toThrow('invokeCommand "system.run" is reserved for shell execution');
   });
+
+  it("keeps invoke pairing guidance for scope upgrade rejections", async () => {
+    gatewayMocks.callGatewayTool.mockRejectedValueOnce(
+      new Error("scope upgrade pending approval (requestId: req-123)"),
+    );
+    const tool = createNodesTool();
+
+    await expect(
+      tool.execute("call-1", {
+        action: "invoke",
+        node: "macbook",
+        invokeCommand: "device.status",
+      }),
+    ).rejects.toThrow(
+      "pairing required before node invoke. Approve pairing request req-123 and retry.",
+    );
+  });
 });

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -2,9 +2,9 @@ import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { OperatorScope } from "../../gateway/method-scopes.js";
+import { readConnectPairingRequiredMessage } from "../../gateway/protocol/connect-error-details.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveNodePairApprovalScopes } from "../../infra/node-pairing-authz.js";
-import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { resolveImageSanitizationLimits } from "../image-sanitization.js";
@@ -72,20 +72,6 @@ async function resolveNodePairApproveScopes(
     }
   }
   return resolveApproveScopes(match?.commands);
-}
-
-function isPairingRequiredMessage(message: string): boolean {
-  const lower = normalizeLowercaseStringOrEmpty(message);
-  return lower.includes("pairing required") || lower.includes("not_paired");
-}
-
-function extractPairingRequestId(message: string): string | null {
-  const match = message.match(/\(requestId:\s*([^)]+)\)/i);
-  if (!match) {
-    return null;
-  }
-  const value = (match[1] ?? "").trim();
-  return value.length > 0 ? value : null;
 }
 
 // Flattened schema: runtime validates per-action requirements.
@@ -307,8 +293,9 @@ export function createNodesTool(options?: {
             : "default";
         const agentLabel = agentId ?? "unknown";
         let message = formatErrorMessage(err);
-        if (action === "invoke" && isPairingRequiredMessage(message)) {
-          const requestId = extractPairingRequestId(message);
+        const pairing = action === "invoke" ? readConnectPairingRequiredMessage(message) : null;
+        if (pairing) {
+          const requestId = pairing.requestId ?? null;
           const approveHint = requestId
             ? `Approve pairing request ${requestId} and retry.`
             : "Approve the pending pairing request and retry.";

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -223,8 +223,9 @@ describe("probeGatewayStatus", () => {
       timeoutMs: 5_000,
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       ok: false,
+      kind: "connect",
       error: "scope upgrade pending approval (requestId: req-123)",
     });
   });

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -209,6 +209,26 @@ describe("probeGatewayStatus", () => {
     });
   });
 
+  it("keeps actionable probe errors when the close reason stays generic", async () => {
+    callGatewayMock.mockReset();
+    probeGatewayMock.mockReset();
+    probeGatewayMock.mockResolvedValueOnce({
+      ok: false,
+      error: "scope upgrade pending approval (requestId: req-123)",
+      close: { code: 1008, reason: "pairing required" },
+    });
+
+    const result = await probeGatewayStatus({
+      url: "ws://127.0.0.1:19191",
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "scope upgrade pending approval (requestId: req-123)",
+    });
+  });
+
   it("surfaces status RPC errors when requireRpc is enabled", async () => {
     callGatewayMock.mockReset();
     probeGatewayMock.mockReset();

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -439,6 +439,22 @@ describe("devices cli local fallback", () => {
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
   });
 
+  it("falls back to local pairing list when gateway returns a scope upgrade message on loopback", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("scope upgrade pending approval (requestId: req-123)"),
+    );
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-1", deviceId: "device-1", publicKey: "pk", ts: 1 }],
+      paired: [],
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesCommand(["list"]);
+
+    expect(listDevicePairing).toHaveBeenCalledTimes(1);
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
+  });
+
   it("does not use local fallback when an explicit --url is provided", async () => {
     callGateway.mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
 

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
+import { readConnectPairingRequiredMessage } from "../gateway/protocol/connect-error-details.js";
 import {
   approveDevicePairing,
   formatDevicePairingForbiddenMessage,
@@ -120,7 +121,7 @@ function normalizeErrorMessage(error: unknown): string {
 
 function shouldUseLocalPairingFallback(opts: DevicesRpcOpts, error: unknown): boolean {
   const message = normalizeLowercaseStringOrEmpty(normalizeErrorMessage(error));
-  if (!message.includes("pairing required")) {
+  if (!readConnectPairingRequiredMessage(message)) {
     return false;
   }
   if (typeof opts.url === "string" && opts.url.trim().length > 0) {

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -158,6 +158,29 @@ describe("logs cli", () => {
     expect(stderrWrites.join("")).toContain("reading local log file instead");
   });
 
+  it("falls back to the local log file on loopback scope-upgrade errors", async () => {
+    callGatewayFromCli.mockRejectedValueOnce(
+      new Error("scope upgrade pending approval (requestId: req-123)"),
+    );
+    readConfiguredLogTail.mockResolvedValueOnce({
+      file: "/tmp/openclaw.log",
+      cursor: 5,
+      size: 5,
+      lines: ["local fallback line"],
+      truncated: false,
+      reset: false,
+    });
+
+    const stdoutWrites = captureStdoutWrites();
+    const stderrWrites = captureStderrWrites();
+
+    await runLogsCli(["logs"]);
+
+    expect(readConfiguredLogTail).toHaveBeenCalledTimes(1);
+    expect(stdoutWrites.join("")).toContain("local fallback line");
+    expect(stderrWrites.join("")).toContain("reading local log file instead");
+  });
+
   describe("formatLogTimestamp", () => {
     it("formats UTC timestamp in plain mode by default", () => {
       const result = formatLogTimestamp("2025-01-01T12:00:00.000Z");

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -2,6 +2,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import type { Command } from "commander";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { isLoopbackHost } from "../gateway/net.js";
+import { readConnectPairingRequiredMessage } from "../gateway/protocol/connect-error-details.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { readConfiguredLogTail } from "../logging/log-tail.js";
 import { parseLogLine } from "../logging/parse-log-line.js";
@@ -96,7 +97,7 @@ function normalizeErrorMessage(error: unknown): string {
 
 function shouldUseLocalLogsFallback(opts: LogsCliOptions, error: unknown): boolean {
   const message = normalizeLowercaseStringOrEmpty(normalizeErrorMessage(error));
-  if (!message.includes("pairing required")) {
+  if (!readConnectPairingRequiredMessage(message)) {
     return false;
   }
   if (typeof opts.url === "string" && opts.url.trim().length > 0) {

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,6 +1,7 @@
 import { withProgress } from "../cli/progress.js";
 import {
   normalizePairingConnectRequestId,
+  readConnectPairingRequiredMessage,
   readPairingConnectErrorDetails,
   type ConnectPairingRequiredReason,
 } from "../gateway/protocol/connect-error-details.js";
@@ -84,15 +85,15 @@ export function resolvePairingRecoveryContext(params: {
   const source = [params.error, params.closeReason]
     .filter((part) => typeof part === "string" && part.trim().length > 0)
     .join(" ");
-  if (!source || !/pairing required/i.test(source)) {
+  const pairing = readConnectPairingRequiredMessage(source);
+  if (!pairing) {
     return null;
   }
-  const requestIdMatch = source.match(/requestId:\s*([^\s)]+)/i);
-  const requestId =
-    requestIdMatch && requestIdMatch[1]
-      ? (normalizePairingConnectRequestId(requestIdMatch[1]) ?? null)
-      : null;
-  return { requestId: requestId || null, reason: null, remediationHint: null };
+  return {
+    requestId: normalizePairingConnectRequestId(pairing.requestId) ?? null,
+    reason: pairing.reason ?? null,
+    remediationHint: null,
+  };
 }
 
 export async function statusCommand(

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1270,28 +1270,28 @@ describe("statusCommand", () => {
   it("prints safe gateway pairing recovery guidance", async () => {
     expect(
       resolvePairingRecoveryContext({
-        error: "connect failed: pairing required (requestId: req-123)",
-        closeReason: "pairing required (requestId: req-123)",
+        error: "scope upgrade pending approval (requestId: req-123)",
+        closeReason: "pairing required",
       }),
-    ).toEqual({ requestId: "req-123", reason: null, remediationHint: null });
+    ).toEqual({ requestId: "req-123", reason: "scope-upgrade", remediationHint: null });
     expect(
       resolvePairingRecoveryContext({
         error: "connect failed: pairing required",
         closeReason: "connect failed",
       }),
-    ).toEqual({ requestId: null, reason: null, remediationHint: null });
+    ).toEqual({ requestId: null, reason: "not-paired", remediationHint: null });
     expect(
       resolvePairingRecoveryContext({
         error: "connect failed: pairing required (requestId: req-123;rm -rf /)",
         closeReason: "pairing required (requestId: req-123;rm -rf /)",
       }),
-    ).toEqual({ requestId: null, reason: null, remediationHint: null });
+    ).toEqual({ requestId: null, reason: "not-paired", remediationHint: null });
     expect(
       resolvePairingRecoveryContext({
         error: "connect failed: pairing required",
         closeReason: "pairing required (requestId: req-close-456)",
       }),
-    ).toEqual({ requestId: "req-close-456", reason: null, remediationHint: null });
+    ).toEqual({ requestId: "req-close-456", reason: "not-paired", remediationHint: null });
     expect(
       resolvePairingRecoveryContext({
         details: {
@@ -1326,8 +1326,7 @@ describe("statusCommand", () => {
       channels: { whatsapp: { allowFrom: ["*"] } },
     });
     mockProbeGatewayResult({
-      error:
-        "connect failed: pairing required: device is asking for more scopes than currently approved",
+      error: "scope upgrade pending approval (requestId: req-123)",
       connectErrorDetails: {
         code: "PAIRING_REQUIRED",
         reason: "scope-upgrade",
@@ -1336,8 +1335,7 @@ describe("statusCommand", () => {
       },
       close: {
         code: 1008,
-        reason:
-          "pairing required: device is asking for more scopes than currently approved (requestId: req-123)",
+        reason: "pairing required",
       },
     });
     const joined = await runStatusAndGetJoinedLogs();

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -30,6 +30,7 @@ import { resolveConnectChallengeTimeoutMs } from "./handshake-timeouts.js";
 import { isLoopbackHost, isSecureWebSocketUrl } from "./net.js";
 import {
   ConnectErrorDetailCodes,
+  formatConnectErrorMessage,
   readConnectErrorDetailCode,
   readConnectErrorRecoveryAdvice,
   type ConnectErrorRecoveryAdvice,
@@ -88,7 +89,7 @@ export class GatewayClientRequestError extends Error {
   readonly retryAfterMs?: number;
 
   constructor(error: GatewayClientErrorShape) {
-    super(error.message ?? "gateway request failed");
+    super(formatConnectErrorMessage({ message: error.message, details: error.details }));
     this.name = "GatewayClientRequestError";
     this.gatewayCode = error.code ?? "UNAVAILABLE";
     this.details = error.details;

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -3,18 +3,33 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const gatewayClientState = vi.hoisted(() => ({
   options: null as Record<string, unknown> | null,
   requests: [] as string[],
-  startMode: "hello" as "hello" | "close",
+  startMode: "hello" as "hello" | "close" | "connect-error-close",
   close: { code: 1008, reason: "pairing required" },
   helloAuth: {
     role: "operator",
     scopes: ["operator.read"],
   } as { role?: string; scopes?: string[] } | undefined,
+  connectError: "scope upgrade pending approval (requestId: req-123)",
+  connectErrorDetails: {
+    code: "PAIRING_REQUIRED",
+    reason: "scope-upgrade",
+    requestId: "req-123",
+  } as Record<string, unknown> | null,
 }));
 
 const deviceIdentityState = vi.hoisted(() => ({
   value: { id: "test-device-identity" } as Record<string, unknown>,
   throwOnLoad: false,
 }));
+
+class MockGatewayClientRequestError extends Error {
+  readonly details?: unknown;
+
+  constructor(error: { message?: string; details?: unknown }) {
+    super(error.message ?? "gateway request failed");
+    this.details = error.details;
+  }
+}
 
 class MockGatewayClient {
   private readonly opts: Record<string, unknown>;
@@ -29,6 +44,22 @@ class MockGatewayClient {
     void Promise.resolve()
       .then(async () => {
         if (gatewayClientState.startMode === "close") {
+          const onClose = this.opts.onClose;
+          if (typeof onClose === "function") {
+            onClose(gatewayClientState.close.code, gatewayClientState.close.reason);
+          }
+          return;
+        }
+        if (gatewayClientState.startMode === "connect-error-close") {
+          const onConnectError = this.opts.onConnectError;
+          if (typeof onConnectError === "function") {
+            onConnectError(
+              new MockGatewayClientRequestError({
+                message: gatewayClientState.connectError,
+                details: gatewayClientState.connectErrorDetails,
+              }),
+            );
+          }
           const onClose = this.opts.onClose;
           if (typeof onClose === "function") {
             onClose(gatewayClientState.close.code, gatewayClientState.close.reason);
@@ -59,6 +90,7 @@ class MockGatewayClient {
 
 vi.mock("./client.js", () => ({
   GatewayClient: MockGatewayClient,
+  GatewayClientRequestError: MockGatewayClientRequestError,
 }));
 
 vi.mock("../infra/device-identity.js", () => ({
@@ -80,6 +112,12 @@ describe("probeGateway", () => {
     gatewayClientState.helloAuth = {
       role: "operator",
       scopes: ["operator.read"],
+    };
+    gatewayClientState.connectError = "scope upgrade pending approval (requestId: req-123)";
+    gatewayClientState.connectErrorDetails = {
+      code: "PAIRING_REQUIRED",
+      reason: "scope-upgrade",
+      requestId: "req-123",
     };
   });
 
@@ -269,6 +307,23 @@ describe("probeGateway", () => {
       role: null,
       scopes: [],
       capability: "connected_no_operator_scope",
+    });
+  });
+
+  it("prefers the structured connect error over the generic close reason", async () => {
+    gatewayClientState.startMode = "connect-error-close";
+
+    const result = await probeGateway({
+      url: "ws://127.0.0.1:18789",
+      auth: { token: "secret" },
+      timeoutMs: 5_000,
+      includeDetails: false,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "scope upgrade pending approval (requestId: req-123)",
+      close: { code: 1008, reason: "pairing required" },
     });
   });
 });

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -251,7 +251,7 @@ export async function probeGateway(opts: {
         if (connectLatencyMs == null) {
           settleProbe({
             ok: false,
-            error: formatProbeCloseError(close),
+            error: connectError || formatProbeCloseError(close),
             health: null,
             status: null,
             presence: null,

--- a/src/gateway/protocol/connect-error-details.test.ts
+++ b/src/gateway/protocol/connect-error-details.test.ts
@@ -5,9 +5,13 @@ import {
   buildPairingConnectErrorMessage,
   ConnectPairingRequiredReasons,
   describePairingConnectRequirement,
+  formatConnectErrorMessage,
+  formatConnectPairingRequiredMessage,
   normalizePairingConnectRequestId,
   readConnectErrorDetailCode,
   readConnectErrorRecoveryAdvice,
+  readConnectPairingRequiredDetails,
+  readConnectPairingRequiredMessage,
   readPairingConnectErrorDetails,
 } from "./connect-error-details.js";
 
@@ -112,5 +116,58 @@ describe("pairing connect details", () => {
       reason: "scope-upgrade",
       remediationHint: "Review the requested scopes, then approve the pending upgrade.",
     });
+  });
+
+  it("reads pairing details as compact connect details", () => {
+    expect(
+      readConnectPairingRequiredDetails({
+        code: "PAIRING_REQUIRED",
+        requestId: "req-123",
+        reason: "scope-upgrade",
+        remediationHint: "Review the requested scopes, then approve the pending upgrade.",
+      }),
+    ).toEqual({
+      requestId: "req-123",
+      reason: "scope-upgrade",
+    });
+  });
+
+  it("formats upgrade rejections with the request id", () => {
+    expect(
+      formatConnectPairingRequiredMessage({
+        code: "PAIRING_REQUIRED",
+        requestId: "req-123",
+        reason: "scope-upgrade",
+      }),
+    ).toBe("scope upgrade pending approval (requestId: req-123)");
+  });
+
+  it("parses surfaced pairing-required messages", () => {
+    expect(
+      readConnectPairingRequiredMessage("scope upgrade pending approval (requestId: req-123)"),
+    ).toEqual({
+      requestId: "req-123",
+      reason: "scope-upgrade",
+    });
+    expect(
+      readConnectPairingRequiredMessage(
+        "scope upgrade pending approval (requestId: req-123;rm -rf /)",
+      ),
+    ).toEqual({
+      reason: "scope-upgrade",
+    });
+  });
+
+  it("prefers pairing detail formatting over the generic message", () => {
+    expect(
+      formatConnectErrorMessage({
+        message: "pairing required",
+        details: {
+          code: "PAIRING_REQUIRED",
+          requestId: "req-123",
+          reason: "scope-upgrade",
+        },
+      }),
+    ).toBe("scope upgrade pending approval (requestId: req-123)");
   });
 });

--- a/src/gateway/protocol/connect-error-details.ts
+++ b/src/gateway/protocol/connect-error-details.ts
@@ -66,6 +66,11 @@ export type PairingConnectErrorDetails = {
   approvedScopes?: string[];
 };
 
+export type ConnectPairingRequiredDetails = Pick<
+  PairingConnectErrorDetails,
+  "reason" | "requestId"
+>;
+
 const CONNECT_RECOVERY_NEXT_STEP_VALUES: ReadonlySet<ConnectRecoveryNextStep> = new Set([
   "retry_with_device_token",
   "update_auth_configuration",
@@ -112,6 +117,15 @@ const PAIRING_CONNECT_REASON_METADATA: Readonly<
     remediationHint: "Review the refreshed device details, then approve the pending request.",
     recoveryTitle: "Gateway device refresh approval required.",
   },
+};
+
+const CONNECT_PAIRING_REQUIRED_MESSAGE_BY_REASON: Readonly<
+  Record<ConnectPairingRequiredReason, string>
+> = {
+  "not-paired": "device pairing required",
+  "role-upgrade": "role upgrade pending approval",
+  "scope-upgrade": "scope upgrade pending approval",
+  "metadata-upgrade": "device metadata change pending approval",
 };
 
 export function resolveAuthConnectErrorDetailCode(
@@ -336,4 +350,65 @@ export function readPairingConnectErrorDetails(
     ...(approvedRoles ? { approvedRoles } : {}),
     ...(approvedScopes ? { approvedScopes } : {}),
   };
+}
+
+export function readConnectPairingRequiredDetails(
+  details: unknown,
+): ConnectPairingRequiredDetails | null {
+  const pairing = readPairingConnectErrorDetails(details);
+  if (!pairing) {
+    return null;
+  }
+  return {
+    ...(pairing.requestId ? { requestId: pairing.requestId } : {}),
+    ...(pairing.reason ? { reason: pairing.reason } : {}),
+  };
+}
+
+export function readConnectPairingRequiredMessage(
+  message: string | null | undefined,
+): ConnectPairingRequiredDetails | null {
+  const normalizedMessage = normalizeOptionalString(message);
+  if (!normalizedMessage) {
+    return null;
+  }
+  const normalized = normalizedMessage.trim().toLowerCase();
+  let reason: ConnectPairingRequiredReason | undefined;
+  for (const [candidate, prefix] of Object.entries(
+    CONNECT_PAIRING_REQUIRED_MESSAGE_BY_REASON,
+  ) as Array<[ConnectPairingRequiredReason, string]>) {
+    if (normalized.includes(prefix)) {
+      reason = candidate;
+      break;
+    }
+  }
+  if (!reason && normalized.includes("pairing required")) {
+    reason = ConnectPairingRequiredReasons.NOT_PAIRED;
+  }
+  if (!reason) {
+    return null;
+  }
+  const requestId = normalizePairingConnectRequestId(
+    normalizedMessage.match(/\(requestId:\s*([^\s)]+)\)/i)?.[1],
+  );
+  return {
+    ...(requestId ? { requestId } : {}),
+    reason,
+  };
+}
+
+export function formatConnectPairingRequiredMessage(details: unknown): string {
+  const pairing = readPairingConnectErrorDetails(details);
+  const base =
+    CONNECT_PAIRING_REQUIRED_MESSAGE_BY_REASON[
+      pairing?.reason ?? ConnectPairingRequiredReasons.NOT_PAIRED
+    ];
+  return pairing?.requestId ? `${base} (requestId: ${pairing.requestId})` : base;
+}
+
+export function formatConnectErrorMessage(params: { message?: string; details?: unknown }): string {
+  if (readConnectErrorDetailCode(params.details) === ConnectErrorDetailCodes.PAIRING_REQUIRED) {
+    return formatConnectPairingRequiredMessage(params.details);
+  }
+  return normalizeOptionalString(params.message) ?? "gateway request failed";
 }

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -519,7 +519,7 @@ describe("gateway node command allowlist", () => {
           displayName: "node-platform-pin",
           deviceIdentity,
         }),
-      ).rejects.toThrow(/pairing required/i);
+      ).rejects.toThrow(/device metadata change pending approval/i);
     } finally {
       await iosClient?.stopAndWait();
     }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:29:53.282Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:51.356Z",
   "locale": "de",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:29:56.350Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:51.716Z",
   "locale": "es",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:30:04.864Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:52.788Z",
   "locale": "fr",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:30:14.879Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:53.864Z",
   "locale": "id",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:29:59.242Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:52.074Z",
   "locale": "ja-JP",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:30:01.914Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:52.433Z",
   "locale": "ko",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:30:17.790Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:54.274Z",
   "locale": "pl",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:29:49.118Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:50.998Z",
   "locale": "pt-BR",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:30:07.502Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:53.144Z",
   "locale": "tr",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:30:10.188Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:53.508Z",
   "locale": "uk",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:29:46.215Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:50.281Z",
   "locale": "zh-CN",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,18 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-20T06:29:48.803Z",
+  "fallbackKeys": [
+    "overview.pairing.metadataUpgradeSummary",
+    "overview.pairing.metadataUpgradeTitle",
+    "overview.pairing.roleUpgradeSummary",
+    "overview.pairing.roleUpgradeTitle",
+    "overview.pairing.scopeUpgradeSummary",
+    "overview.pairing.scopeUpgradeTitle"
+  ],
+  "generatedAt": "2026-04-20T07:50:50.642Z",
   "locale": "zh-TW",
   "model": "gpt-5.4",
   "provider": "openai",
-  "sourceHash": "c7e1febc5a5715b59bbda5d9ea08187c13267c82c1fcfe3996a469205539eba0",
-  "totalKeys": 727,
+  "sourceHash": "3ca70e4eba34c7843d6a23944d24fdcf565b45d2b83e4fc371b9763235d25d3c",
+  "totalKeys": 733,
   "translatedKeys": 727,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -247,6 +247,15 @@ export const de: TranslationMap = {
     },
     pairing: {
       hint: "Dieses Gerät benötigt eine Pairing-Freigabe vom Gateway-Host.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "Auf dem Mobilgerät? Kopieren Sie die vollständige URL (einschließlich #token=...) von openclaw dashboard --no-open auf Ihrem Desktop.",
       docsTitle: "Gerätekopplungs-Dokumentation (öffnet sich in neuem Tab)",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -239,6 +239,15 @@ export const en: TranslationMap = {
     },
     pairing: {
       hint: "This device needs pairing approval from the gateway host.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "On mobile? Copy the full URL (including #token=...) from openclaw dashboard --no-open on your desktop.",
       docsTitle: "Device pairing docs (opens in new tab)",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -243,6 +243,15 @@ export const es: TranslationMap = {
     },
     pairing: {
       hint: "Este dispositivo necesita aprobación de emparejamiento del host de la puerta de enlace.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "¿En el móvil? Copia la URL completa (incluyendo #token=...) desde openclaw dashboard --no-open en tu escritorio.",
       docsTitle: "Documentación de emparejamiento de dispositivos (se abre en una pestaña nueva)",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -245,6 +245,15 @@ export const fr: TranslationMap = {
     },
     pairing: {
       hint: "Cet appareil nécessite une approbation d’appairage de l’hôte Gateway.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "Sur mobile ? Copiez l’URL complète (y compris #token=...) depuis openclaw dashboard --no-open sur votre ordinateur.",
       docsTitle: "Documentation sur l’appairage des appareils (s’ouvre dans un nouvel onglet)",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -243,6 +243,15 @@ export const id: TranslationMap = {
     },
     pairing: {
       hint: "Perangkat ini memerlukan persetujuan pairing dari host gateway.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "Di seluler? Salin URL lengkap (termasuk #token=...) dari openclaw dashboard --no-open di desktop Anda.",
       docsTitle: "Dokumentasi pemasangan perangkat (dibuka di tab baru)",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -247,6 +247,15 @@ export const ja_JP: TranslationMap = {
     },
     pairing: {
       hint: "このデバイスは Gateway ホストからのペアリング承認が必要です。",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "モバイルを使用していますか？ デスクトップで openclaw dashboard --no-open から完全な URL（#token=... を含む）をコピーしてください。",
       docsTitle: "デバイスのペアリングに関するドキュメント（新しいタブで開きます）",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -242,6 +242,15 @@ export const ko: TranslationMap = {
     },
     pairing: {
       hint: "이 디바이스는 gateway host의 페어링 승인이 필요합니다.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "모바일에서 사용 중이신가요? 데스크톱에서 openclaw dashboard --no-open으로 전체 URL(#token=... 포함)을 복사하세요.",
       docsTitle: "기기 페어링 문서(새 탭에서 열림)",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -244,6 +244,15 @@ export const pl: TranslationMap = {
     },
     pairing: {
       hint: "To urządzenie wymaga zatwierdzenia parowania przez host Gateway.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "Na urządzeniu mobilnym? Skopiuj pełny URL (w tym #token=...) z openclaw dashboard --no-open na komputerze.",
       docsTitle: "Dokumentacja parowania urządzeń (otwiera się w nowej karcie)",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -243,6 +243,15 @@ export const pt_BR: TranslationMap = {
     },
     pairing: {
       hint: "Este dispositivo precisa de aprovação de pareamento do host do gateway.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "No celular? Copie a URL completa (incluindo #token=...) executando openclaw dashboard --no-open no desktop.",
       docsTitle: "Documentação de pareamento de dispositivo (abre em nova aba)",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -246,6 +246,15 @@ export const tr: TranslationMap = {
     },
     pairing: {
       hint: "Bu cihazın Gateway ana bilgisayarından eşleştirme onayı alması gerekiyor.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "Mobilde misiniz? Masaüstünüzde openclaw dashboard --no-open komutundan tam URL'yi (#token=... dahil) kopyalayın.",
       docsTitle: "Cihaz eşleştirme belgeleri (yeni sekmede açılır)",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -245,6 +245,15 @@ export const uk: TranslationMap = {
     },
     pairing: {
       hint: "Цей пристрій потребує схвалення спарювання від хоста шлюзу.",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "На мобільному? Скопіюйте повний URL (включно з #token=...) з openclaw dashboard --no-open на вашому комп’ютері.",
       docsTitle: "Документація щодо сполучення пристроїв (відкривається в новій вкладці)",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -239,6 +239,15 @@ export const zh_CN: TranslationMap = {
     },
     pairing: {
       hint: "此设备需要网关主机的配对批准。",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "在手机上？从桌面运行 openclaw dashboard --no-open 复制完整 URL（包括 #token=...）。",
       docsTitle: "设备配对文档（在新标签页中打开）",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -239,6 +239,15 @@ export const zh_TW: TranslationMap = {
     },
     pairing: {
       hint: "此裝置需要閘道主機的配對批准。",
+      scopeUpgradeTitle: "Scope upgrade pending approval.",
+      scopeUpgradeSummary:
+        "This device is already paired, but the requested wider scope is waiting for approval.",
+      roleUpgradeTitle: "Role upgrade pending approval.",
+      roleUpgradeSummary:
+        "This device is already paired, but the requested role change is waiting for approval.",
+      metadataUpgradeTitle: "Device metadata change pending approval.",
+      metadataUpgradeSummary:
+        "This device is already paired, but the metadata change is waiting for approval.",
       mobileHint:
         "在手機上？從桌面執行 openclaw dashboard --no-open 複製完整 URL（包括 #token=...）。",
       docsTitle: "裝置配對文件（在新分頁中開啟）",

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -433,6 +433,31 @@ describe("connectGateway", () => {
     expect(host.lastErrorCode).toBe("AUTH_TOKEN_MISMATCH");
   });
 
+  it("surfaces scope-upgrade approval details instead of a dead pairing error", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitClose({
+      code: 4008,
+      reason: "connect failed",
+      error: {
+        code: "NOT_PAIRED",
+        message: "scope upgrade pending approval (requestId: req-123)",
+        details: {
+          code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+          reason: "scope-upgrade",
+          requestId: "req-123",
+        },
+      },
+    });
+
+    expect(host.lastErrorCode).toBe(ConnectErrorDetailCodes.PAIRING_REQUIRED);
+    expect(host.lastError).toBe("scope upgrade pending approval (requestId: req-123)");
+  });
+
   it("surfaces shutdown restart reasons before the socket closes", () => {
     const host = createHost();
 

--- a/ui/src/ui/connect-error.ts
+++ b/ui/src/ui/connect-error.ts
@@ -1,6 +1,6 @@
 import {
   ConnectErrorDetailCodes,
-  readPairingConnectErrorDetails,
+  formatConnectPairingRequiredMessage,
 } from "../../../src/gateway/protocol/connect-error-details.js";
 import { resolveGatewayErrorDetailCode } from "./gateway.ts";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
@@ -31,23 +31,8 @@ function formatErrorFromMessageAndDetails(error: ErrorWithMessageAndDetails): st
       return "gateway auth failed";
     case ConnectErrorDetailCodes.AUTH_RATE_LIMITED:
       return "too many failed authentication attempts";
-    case ConnectErrorDetailCodes.PAIRING_REQUIRED: {
-      const pairing = readPairingConnectErrorDetails(error.details);
-      const approvedRoles = pairing?.approvedRoles?.join(", ") || "none";
-      const requestedRole = pairing?.requestedRole || "none";
-      const approvedScopes = pairing?.approvedScopes?.join(", ") || "none";
-      const requestedScopes = pairing?.requestedScopes?.join(", ") || "none";
-      switch (pairing?.reason) {
-        case "scope-upgrade":
-          return `device scope upgrade requires approval (approved: ${approvedScopes}; requested: ${requestedScopes})`;
-        case "role-upgrade":
-          return `device role upgrade requires approval (approved: ${approvedRoles}; requested: ${requestedRole})`;
-        case "metadata-upgrade":
-          return "device reconnect details changed and require approval";
-        default:
-          return "gateway pairing required";
-      }
-    }
+    case ConnectErrorDetailCodes.PAIRING_REQUIRED:
+      return formatConnectPairingRequiredMessage(error.details);
     case ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED:
       return "device identity required (use HTTPS/localhost or allow insecure auth explicitly)";
     case ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED:

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../src/gateway/protocol/client-info.js";
 import {
   ConnectErrorDetailCodes,
+  formatConnectErrorMessage,
   readConnectErrorRecoveryAdvice,
   readConnectErrorDetailCode,
 } from "../../../src/gateway/protocol/connect-error-details.js";
@@ -51,7 +52,7 @@ export class GatewayRequestError extends Error {
   readonly retryAfterMs?: number;
 
   constructor(error: GatewayErrorInfo) {
-    super(error.message);
+    super(formatConnectErrorMessage({ message: error.message, details: error.details }));
     this.name = "GatewayRequestError";
     this.gatewayCode = error.code;
     this.details = error.details;

--- a/ui/src/ui/views/overview-hints.ts
+++ b/ui/src/ui/views/overview-hints.ts
@@ -1,4 +1,7 @@
-import { ConnectErrorDetailCodes } from "../../../../src/gateway/protocol/connect-error-details.js";
+import {
+  ConnectErrorDetailCodes,
+  readConnectPairingRequiredMessage,
+} from "../../../../src/gateway/protocol/connect-error-details.js";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 
 const AUTH_REQUIRED_CODES = new Set<string>([
@@ -29,19 +32,51 @@ const INSECURE_CONTEXT_CODES = new Set<string>([
 
 type AuthHintKind = "required" | "failed";
 
+export type PairingHint =
+  | {
+      kind: "pairing-required";
+      requestId: string | null;
+    }
+  | {
+      kind: "scope-upgrade-pending" | "role-upgrade-pending" | "metadata-upgrade-pending";
+      requestId: string | null;
+    };
+
+export function resolvePairingHint(
+  connected: boolean,
+  lastError: string | null,
+  lastErrorCode?: string | null,
+): PairingHint | null {
+  if (connected || !lastError) {
+    return null;
+  }
+  const pairing = readConnectPairingRequiredMessage(lastError);
+  if (pairing) {
+    return {
+      kind:
+        pairing.reason === "scope-upgrade"
+          ? "scope-upgrade-pending"
+          : pairing.reason === "role-upgrade"
+            ? "role-upgrade-pending"
+            : pairing.reason === "metadata-upgrade"
+              ? "metadata-upgrade-pending"
+              : "pairing-required",
+      requestId: pairing.requestId ?? null,
+    };
+  }
+  if (lastErrorCode === ConnectErrorDetailCodes.PAIRING_REQUIRED) {
+    return { kind: "pairing-required", requestId: null };
+  }
+  return null;
+}
+
 /** Whether the overview should show device-pairing guidance for this error. */
 export function shouldShowPairingHint(
   connected: boolean,
   lastError: string | null,
   lastErrorCode?: string | null,
 ): boolean {
-  if (connected || !lastError) {
-    return false;
-  }
-  if (lastErrorCode === ConnectErrorDetailCodes.PAIRING_REQUIRED) {
-    return true;
-  }
-  return normalizeLowercaseStringOrEmpty(lastError).includes("pairing required");
+  return resolvePairingHint(connected, lastError, lastErrorCode) !== null;
 }
 
 /**

--- a/ui/src/ui/views/overview.node.test.ts
+++ b/ui/src/ui/views/overview.node.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../../src/gateway/protocol/connect-error-details.js";
-import { resolveAuthHintKind, shouldShowPairingHint } from "./overview-hints.ts";
+import {
+  resolveAuthHintKind,
+  resolvePairingHint,
+  shouldShowPairingHint,
+} from "./overview-hints.ts";
 
 describe("shouldShowPairingHint", () => {
   it("returns true for 'pairing required' close reason", () => {
@@ -35,6 +39,21 @@ describe("shouldShowPairingHint", () => {
         ConnectErrorDetailCodes.PAIRING_REQUIRED,
       ),
     ).toBe(true);
+  });
+});
+
+describe("resolvePairingHint", () => {
+  it("detects scope-upgrade pending approval and keeps the request id", () => {
+    expect(
+      resolvePairingHint(
+        false,
+        "scope upgrade pending approval (requestId: req-123)",
+        ConnectErrorDetailCodes.PAIRING_REQUIRED,
+      ),
+    ).toEqual({
+      kind: "scope-upgrade-pending",
+      requestId: "req-123",
+    });
   });
 });
 

--- a/ui/src/ui/views/overview.render.test.ts
+++ b/ui/src/ui/views/overview.render.test.ts
@@ -108,4 +108,19 @@ describe("overview view rendering", () => {
     );
     expect(container.textContent).toContain("openclaw devices approve req-123");
   });
+
+  it("does not suggest preview-only latest approval when the request id is absent", async () => {
+    const container = document.createElement("div");
+    const props = createOverviewProps({
+      lastError: "scope upgrade pending approval",
+      lastErrorCode: "PAIRING_REQUIRED",
+    });
+
+    render(renderOverview(props), container);
+    await Promise.resolve();
+
+    expect(container.textContent).toContain("Scope upgrade pending approval.");
+    expect(container.textContent).toContain("openclaw devices list");
+    expect(container.textContent).not.toContain("openclaw devices approve --latest");
+  });
 });

--- a/ui/src/ui/views/overview.render.test.ts
+++ b/ui/src/ui/views/overview.render.test.ts
@@ -91,4 +91,21 @@ describe("overview view rendering", () => {
 
     await i18n.setLocale("en");
   });
+
+  it("renders a dedicated scope-upgrade approval hint with the exact approve command", async () => {
+    const container = document.createElement("div");
+    const props = createOverviewProps({
+      lastError: "scope upgrade pending approval (requestId: req-123)",
+      lastErrorCode: "PAIRING_REQUIRED",
+    });
+
+    render(renderOverview(props), container);
+    await Promise.resolve();
+
+    expect(container.textContent).toContain("Scope upgrade pending approval.");
+    expect(container.textContent).toContain(
+      "This device is already paired, but the requested wider scope is waiting for approval.",
+    );
+    expect(container.textContent).toContain("openclaw devices approve req-123");
+  });
 });

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -67,27 +67,25 @@ export type OverviewProps = {
 const PAIRING_HINT_COPY: Record<
   PairingHint["kind"],
   {
-    title: string;
-    summary: string | null;
+    titleKey: string | null;
+    summaryKey: string | null;
   }
 > = {
   "pairing-required": {
-    title: "",
-    summary: null,
+    titleKey: null,
+    summaryKey: null,
   },
   "scope-upgrade-pending": {
-    title: "Scope upgrade pending approval.",
-    summary:
-      "This device is already paired, but the requested wider scope is waiting for approval.",
+    titleKey: "overview.pairing.scopeUpgradeTitle",
+    summaryKey: "overview.pairing.scopeUpgradeSummary",
   },
   "role-upgrade-pending": {
-    title: "Role upgrade pending approval.",
-    summary:
-      "This device is already paired, but the requested role change is waiting for approval.",
+    titleKey: "overview.pairing.roleUpgradeTitle",
+    summaryKey: "overview.pairing.roleUpgradeSummary",
   },
   "metadata-upgrade-pending": {
-    title: "Device metadata change pending approval.",
-    summary: "This device is already paired, but the metadata change is waiting for approval.",
+    titleKey: "overview.pairing.metadataUpgradeTitle",
+    summaryKey: "overview.pairing.metadataUpgradeSummary",
   },
 };
 
@@ -112,14 +110,16 @@ export function renderOverview(props: OverviewProps) {
       return null;
     }
     const copy = PAIRING_HINT_COPY[pairingState.kind];
-    const title = copy.title || t("overview.pairing.hint");
+    const title = copy.titleKey ? t(copy.titleKey) : t("overview.pairing.hint");
     const approveCommand = pairingState.requestId
       ? `openclaw devices approve ${pairingState.requestId}`
       : "openclaw devices approve --latest";
     return html`
       <div class="muted" style="margin-top: 8px">
         ${title}
-        ${copy.summary ? html`<div style="margin-top: 6px">${copy.summary}</div>` : nothing}
+        ${copy.summaryKey
+          ? html`<div style="margin-top: 6px">${t(copy.summaryKey)}</div>`
+          : nothing}
         <div style="margin-top: 6px">
           <span class="mono">${approveCommand}</span><br />
           <span class="mono">openclaw devices list</span>

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -111,9 +111,6 @@ export function renderOverview(props: OverviewProps) {
     }
     const copy = PAIRING_HINT_COPY[pairingState.kind];
     const title = copy.titleKey ? t(copy.titleKey) : t("overview.pairing.hint");
-    const approveCommand = pairingState.requestId
-      ? `openclaw devices approve ${pairingState.requestId}`
-      : "openclaw devices approve --latest";
     return html`
       <div class="muted" style="margin-top: 8px">
         ${title}
@@ -121,7 +118,10 @@ export function renderOverview(props: OverviewProps) {
           ? html`<div style="margin-top: 6px">${t(copy.summaryKey)}</div>`
           : nothing}
         <div style="margin-top: 6px">
-          <span class="mono">${approveCommand}</span><br />
+          ${pairingState.requestId
+            ? html`<span class="mono">openclaw devices approve ${pairingState.requestId}</span
+                ><br />`
+            : nothing}
           <span class="mono">openclaw devices list</span>
         </div>
         <div style="margin-top: 6px; font-size: 12px;">${t("overview.pairing.mobileHint")}</div>

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -22,8 +22,9 @@ import { renderOverviewCards } from "./overview-cards.ts";
 import { renderOverviewEventLog } from "./overview-event-log.ts";
 import {
   resolveAuthHintKind,
+  type PairingHint,
+  resolvePairingHint,
   shouldShowInsecureContextHint,
-  shouldShowPairingHint,
 } from "./overview-hints.ts";
 import { renderOverviewLogTail } from "./overview-log-tail.ts";
 
@@ -63,6 +64,33 @@ export type OverviewProps = {
   onRefreshLogs: () => void;
 };
 
+const PAIRING_HINT_COPY: Record<
+  PairingHint["kind"],
+  {
+    title: string;
+    summary: string | null;
+  }
+> = {
+  "pairing-required": {
+    title: "",
+    summary: null,
+  },
+  "scope-upgrade-pending": {
+    title: "Scope upgrade pending approval.",
+    summary:
+      "This device is already paired, but the requested wider scope is waiting for approval.",
+  },
+  "role-upgrade-pending": {
+    title: "Role upgrade pending approval.",
+    summary:
+      "This device is already paired, but the requested role change is waiting for approval.",
+  },
+  "metadata-upgrade-pending": {
+    title: "Device metadata change pending approval.",
+    summary: "This device is already paired, but the metadata change is waiting for approval.",
+  },
+};
+
 export function renderOverview(props: OverviewProps) {
   const snapshot = props.hello?.snapshot as
     | {
@@ -79,20 +107,22 @@ export function renderOverview(props: OverviewProps) {
   const isTrustedProxy = authMode === "trusted-proxy";
 
   const pairingHint = (() => {
-    if (!shouldShowPairingHint(props.connected, props.lastError, props.lastErrorCode)) {
+    const pairingState = resolvePairingHint(props.connected, props.lastError, props.lastErrorCode);
+    if (!pairingState) {
       return null;
     }
+    const copy = PAIRING_HINT_COPY[pairingState.kind];
+    const title = copy.title || t("overview.pairing.hint");
+    const approveCommand = pairingState.requestId
+      ? `openclaw devices approve ${pairingState.requestId}`
+      : "openclaw devices approve --latest";
     return html`
       <div class="muted" style="margin-top: 8px">
-        ${t("overview.pairing.hint")}
+        ${title}
+        ${copy.summary ? html`<div style="margin-top: 6px">${copy.summary}</div>` : nothing}
         <div style="margin-top: 6px">
-          If the device was already paired, this usually means it asked for more access than you
-          previously approved. OpenClaw keeps the old approval and creates a new pending upgrade
-          request instead of widening scopes silently.
-        </div>
-        <div style="margin-top: 6px">
-          <span class="mono">openclaw devices list</span><br />
-          <span class="mono">openclaw devices approve &lt;requestId&gt;</span>
+          <span class="mono">${approveCommand}</span><br />
+          <span class="mono">openclaw devices list</span>
         </div>
         <div style="margin-top: 6px; font-size: 12px;">${t("overview.pairing.mobileHint")}</div>
         <div style="margin-top: 6px">


### PR DESCRIPTION
## Summary
When a paired read-only device reconnects asking for wider operator scopes, surface the real approval state instead of a generic pairing/auth failure.

## Changes
- format pairing rejection details into actionable scope/role/metadata upgrade messages
- surface those messages in CLI/status/probe flows and show a dedicated pending-approval state in Control UI

## Verification
- OPENCLAW_LOCAL_CHECK=0 pnpm test src/gateway/protocol/connect-error-details.test.ts src/gateway/probe.test.ts src/cli/daemon-cli/probe.test.ts src/commands/status.test.ts src/commands/status.command-sections.test.ts ui/src/ui/views/overview.node.test.ts ui/src/ui/views/overview.render.test.ts ui/src/ui/app-gateway.node.test.ts src/gateway/server.auth.control-ui.suite.ts
- pnpm build
- manual repro against a throwaway local gateway + live Control UI session