### PR TITLE
fix(security): trust manifest registry in phantom plugin audit

### DIFF
--- a/src/security/audit-plugins-trust.test.ts
+++ b/src/security/audit-plugins-trust.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { createPathResolutionEnv, withEnvAsync } from "../test-utils/env.js";
 import { collectPluginsTrustFindings } from "./audit-plugins-trust.js";
@@ -30,8 +30,14 @@ const readInstalledPackageVersionMock = vi.hoisted(() =>
   }),
 );
 
+const loadPluginManifestRegistryMock = vi.hoisted(() => vi.fn());
+
 vi.mock("../infra/package-update-utils.js", () => ({
   readInstalledPackageVersion: readInstalledPackageVersionMock,
+}));
+
+vi.mock("../plugins/manifest-registry.js", () => ({
+  loadPluginManifestRegistry: (...args: unknown[]) => loadPluginManifestRegistryMock(...args),
 }));
 
 vi.mock("../plugins/config-state.js", () => ({
@@ -105,6 +111,14 @@ describe("security audit install metadata findings", () => {
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-security-install-"));
     sharedInstallMetadataStateDir = path.join(fixtureRoot, "shared-install-metadata-state");
     await fs.mkdir(sharedInstallMetadataStateDir, { recursive: true });
+  });
+
+  beforeEach(() => {
+    loadPluginManifestRegistryMock.mockReset();
+    loadPluginManifestRegistryMock.mockReturnValue({
+      plugins: [{ id: "discord" }, { id: "bundled-provider-plugin" }],
+      diagnostics: [],
+    });
   });
 
   afterAll(async () => {
@@ -253,6 +267,23 @@ describe("security audit install metadata findings", () => {
     );
     expect(
       bundledFindings.find((finding) => finding.checkId === "plugins.allow_phantom_entries"),
+    ).toBeUndefined();
+
+    const bundledProviderStateDir = await makeTmpDir("phantom-bundled-provider-excluded");
+    await fs.mkdir(path.join(bundledProviderStateDir, "extensions", "some-installed-plugin"), {
+      recursive: true,
+    });
+
+    const bundledProviderFindings = await runInstallMetadataAudit(
+      {
+        plugins: { allow: ["bundled-provider-plugin", "some-installed-plugin"] },
+      },
+      bundledProviderStateDir,
+    );
+    expect(
+      bundledProviderFindings.find(
+        (finding) => finding.checkId === "plugins.allow_phantom_entries",
+      ),
     ).toBeUndefined();
 
     const reportedStateDir = await makeTmpDir("phantom-reported");

--- a/src/security/audit-plugins-trust.ts
+++ b/src/security/audit-plugins-trust.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import { inspectReadOnlyChannelAccount } from "../channels/read-only-account-inspect.js";
 import { resolveNativeSkillsEnabled } from "../config/commands.js";
@@ -7,6 +8,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
 import { readInstalledPackageVersion } from "../infra/package-update-utils.js";
 import { normalizePluginId, normalizePluginsConfig } from "../plugins/config-state.js";
+import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import type { SecurityAuditFinding } from "./audit.types.js";
 
@@ -280,26 +282,33 @@ export async function collectPluginsTrustFindings(params: {
     const allowConfigured = Array.isArray(allow) && allow.length > 0;
 
     if (allowConfigured) {
+      const workspaceDir =
+        resolveAgentWorkspaceDir(params.cfg, resolveDefaultAgentId(params.cfg)) ?? undefined;
       const installedPluginIds = new Set(pluginDirs.map((dir) => path.basename(dir).toLowerCase()));
-      const bundledPluginIds = new Set(listChannelPlugins().map((p) => p.id.toLowerCase()));
+      const knownPluginIds = new Set(
+        loadPluginManifestRegistry({
+          config: params.cfg,
+          workspaceDir,
+        }).plugins.map((plugin) => plugin.id.toLowerCase()),
+      );
       const phantomEntries = allow.filter((entry) => {
         if (typeof entry !== "string" || entry === "group:plugins") {
           return false;
         }
         const lower = entry.toLowerCase();
-        if (installedPluginIds.has(lower) || bundledPluginIds.has(lower)) {
+        if (installedPluginIds.has(lower) || knownPluginIds.has(lower)) {
           return false;
         }
         const canonicalId = normalizeOptionalLowercaseString(normalizePluginId(entry)) ?? "";
-        return !canonicalId || !bundledPluginIds.has(canonicalId);
+        return !canonicalId || !knownPluginIds.has(canonicalId);
       });
       if (phantomEntries.length > 0) {
         findings.push({
           checkId: "plugins.allow_phantom_entries",
           severity: "warn",
-          title: "plugins.allow contains entries with no matching installed plugin",
+          title: "plugins.allow contains entries with no matching known plugin",
           detail:
-            `The following plugins.allow entries do not correspond to any installed plugin: ${phantomEntries.join(", ")}.\n` +
+            `The following plugins.allow entries do not correspond to any known plugin: ${phantomEntries.join(", ")}.\n` +
             "Phantom entries could be exploited by registering a new plugin with an allowlisted ID.",
           remediation:
             "Remove unused entries from plugins.allow, or verify the expected plugins are installed.",


### PR DESCRIPTION
## Summary
- use the full plugin manifest registry when checking `plugins.allow` for phantom entries
- stop treating bundled non-channel plugins like `openai`, `google`, and `acpx` as phantom allowlist IDs
- add regression coverage for bundled non-channel plugin IDs in the security audit tests

## Root cause
The phantom allowlist audit trusted installed extension directories plus bundled channel plugins only. Config validation and doctor already trust the full plugin manifest registry, so bundled non-channel plugins could still trigger false-positive warnings.

On current `main`, the active audit logic lives in `src/security/audit-plugins-trust.ts`.

## Testing
- `pnpm test -- src/security/audit-plugins-trust.test.ts`
- `pnpm test -- src/security/dangerous-config-flags.test.ts`
- repo commit hook (`pnpm check:changed` chain) during commit
