### PR TITLE
fix(agents): exclude volatile inbound metadata from CLI session reuse hash (#68471)

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { __testing as cliBackendsTesting } from "../cli-backends.js";
+import { hashCliSessionText } from "../cli-session.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../music-generation-task-status.js";
 import { buildActiveVideoGenerationTaskPromptContextForSession } from "../video-generation-task-status.js";
 import {
@@ -52,11 +53,15 @@ const mockBuildActiveMusicGenerationTaskPromptContextForSession = vi.mocked(
   buildActiveMusicGenerationTaskPromptContextForSession,
 );
 
-function createCliBackendConfig(params: { systemPromptOverride?: string } = {}): OpenClawConfig {
+function createCliBackendConfig(
+  params: { systemPromptOverride?: string | null } = {},
+): OpenClawConfig {
   return {
     agents: {
       defaults: {
-        systemPromptOverride: params.systemPromptOverride ?? "test system prompt",
+        ...(params.systemPromptOverride !== null
+          ? { systemPromptOverride: params.systemPromptOverride ?? "test system prompt" }
+          : {}),
         cliBackends: {
           "test-cli": {
             command: "test-cli",
@@ -308,7 +313,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         model: "test-model",
         timeoutMs: 1_000,
         runId: "run-test-legacy-merge",
-        config: createCliBackendConfig(),
+        config: createCliBackendConfig({ systemPromptOverride: null }),
       });
 
       expect(context.params.prompt).toBe("prompt prepend\n\nlegacy prepend\n\nlatest ask");
@@ -350,6 +355,63 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.systemPrompt).toBe("base extra system");
       expect(context.systemPrompt).not.toContain("hook exploded");
       expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses explicit static prompt text for CLI session reuse hashing", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-static-prompt",
+        extraSystemPrompt: "## Inbound Context\nchannel=telegram",
+        extraSystemPromptStatic: "",
+        cliSessionBinding: {
+          sessionId: "cli-session",
+        },
+        config: createCliBackendConfig({ systemPromptOverride: null }),
+      });
+
+      expect(context.systemPrompt).toContain("## Inbound Context\nchannel=telegram");
+      expect(context.extraSystemPromptHash).toBeUndefined();
+      expect(context.reusableCliSession).toEqual({ sessionId: "cli-session" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores volatile prompt text when static prompt text matches", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const staticPrompt = "## Direct Context\nYou are in a Telegram direct conversation.";
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-volatile-prompt",
+        extraSystemPrompt: `## Inbound Context\nchannel=heartbeat\n\n${staticPrompt}`,
+        extraSystemPromptStatic: staticPrompt,
+        cliSessionBinding: {
+          sessionId: "cli-session",
+          extraSystemPromptHash: hashCliSessionText(staticPrompt),
+        },
+        config: createCliBackendConfig(),
+      });
+
+      expect(context.extraSystemPromptHash).toBe(hashCliSessionText(staticPrompt));
+      expect(context.reusableCliSession).toEqual({ sessionId: "cli-session" });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- **Problem:** The built-in heartbeat mechanism triggers a full CLI session reset every 30 minutes because `extraSystemPromptHash` includes the volatile inbound-meta envelope. A user message via Feishu/Telegram produces one inbound payload; a heartbeat fires with a different one. Hashes differ → `resolveCliSessionReuse` returns `invalidatedReason: "system-prompt"` → conversation context is destroyed.
- **Why it matters:** Affects every CLI-backed agent (claude-cli, openai-codex, google-gemini-cli). Users lose conversation context at least every 30 minutes, and more often when heartbeats interleave with user messages. The current workaround (disable heartbeat entirely, set all cron jobs to `sessionTarget: "isolated"`) sacrifices all proactive/periodic behavior in the main session.
- **What changed:** Split the `extraSystemPrompt` injected at run time from the hash input used for session reuse. Structural parts that *should* bust the session (group config, group intro, group system prompt, exec elevation) stay in the hash. The inbound-meta envelope is still injected into the prompt so the model sees it, but is excluded from the hash.
- **What did NOT change (scope boundary):** Embedded Pi runtime (Anthropic / OpenAI native) does not use `extraSystemPromptHash` for reuse; that path is untouched. Callers that do not pass `extraSystemPromptHashInput` get the legacy hash-over-full-prompt behavior.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #68471
- Earlier attempt at the same root cause: #68490 (closed voluntarily by @kagura-agent to reduce their PR queue)
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `src/agents/cli-runner/prepare.ts:80-81` hashed the entire `extraSystemPrompt` string. `src/auto-reply/reply/get-reply-run.ts:294-305` prepends `buildInboundMetaSystemPrompt(...)` (channel, provider, surface, account_id, chat_type) to the structural parts before passing them in. Those inbound fields flip between channel-bound runs and heartbeat/cron triggers, so the same session produces two different hashes → `invalidatedReason: "system-prompt"` on every transition.
- **Missing detection / guardrail:** `buildInboundMetaSystemPrompt` already excludes per-turn identifiers (chat_id, message_id, timestamp) from the system-role block for prompt-cache stability — but not from the CLI session reuse key. There was no test that locked in the hash-stable contract across trigger flips.
- **Contributing context:** `buildInboundMetaSystemPrompt` comment at `inbound-meta.ts:118-125` documents the intent to keep system metadata stable for cache safety. That reasoning applies equally to the CLI session reuse hash; the fix aligns the hash scope with that existing contract.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test or file:** `src/agents/cli-session.test.ts`
- **Scenario the test should lock in:** When callers split the stable structural subset from the volatile inbound envelope, `hashCliSessionText(stable)` stays identical across trigger flips even though the full injected prompt differs. Sanity-asserts that the legacy full-prompt hash *does* diverge between channel-message and heartbeat envelopes, so the fix is needed.
- **Why this is the smallest reliable guardrail:** The bug is entirely about which text is fed into the hash. A unit test against `hashCliSessionText` + `resolveCliSessionReuse` locks the contract without needing a full CLI backend / heartbeat integration.

## User-visible / Behavior Changes

CLI-backed sessions (claude-cli, openai-codex, google-gemini-cli) no longer reset when the same session is visited by both channel messages and heartbeat/cron triggers. Structural changes (group config, exec elevation) still invalidate the session as before.

## Diagram

```text
Before:
user-message (channel=feishu) → hash(full prompt including inbound envelope)
                              = H1
heartbeat (channel=undefined) → hash(full prompt including inbound envelope)
                              = H2 (≠ H1) → cli session reset "system-prompt"

After:
user-message → extraSystemPrompt = inboundMetaPrompt + stableParts
             → extraSystemPromptHashInput = stableParts
             → hash = H(stableParts)
heartbeat    → extraSystemPrompt = inboundMetaPrompt' + stableParts
             → extraSystemPromptHashInput = stableParts
             → hash = H(stableParts)  ← same → session reused
```

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11 (reporter), reproducible on any platform
- Runtime/container: OpenClaw 2026.4.15 gateway
- Model/provider: claude-cli via OAuth (also reproduces on openai-codex, google-gemini-cli)
- Integration/channel: Feishu (also reproduces on other channels)
- Relevant config: default heartbeat `every: "30m"`

### Steps

1. Configure a Feishu (or any messaging channel) + heartbeat at default `every: "30m"`
2. Send a message, receive a reply (CLI session established)
3. Wait for heartbeat to fire
4. Observe: `[agent] cli session reset: provider=claude-cli reason=system-prompt`
5. Next user message loses all prior context

### Expected

Heartbeat fires without resetting the CLI session; prior conversation context preserved.

### Actual (before fix)

`cli session reset: reason=system-prompt` on every transition between user-message and heartbeat.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Reporter's trace from the linked issue shows the exact reset pattern. Added regression test in `src/agents/cli-session.test.ts` asserts hash stability across trigger flips; sanity-asserts that the legacy full-prompt hash diverges, locking in the fix.

## Human Verification

- **Verified scenarios:**
  - `pnpm tsgo` clean on the changed files
  - `pnpm test src/agents/cli-session.test.ts` — 8 tests pass (includes the new regression)
  - `pnpm test src/auto-reply/reply/session.test.ts` — 65 tests pass (covers the get-reply-run assembly surface)
  - `pnpm oxlint` clean on all 6 changed files
- **Edge cases checked:**
  - Legacy callers that don't pass `extraSystemPromptHashInput` still get the previous full-prompt hash behavior (backward compatible).
  - Embedded Pi path is not touched (only the CLI path uses `extraSystemPromptHash`).
  - Exec elevation and group config changes still trigger session invalidation (they remain in the hashed stable subset).
- **What I did NOT verify:**
  - Live heartbeat reproduction on a running Feishu/claude-cli stack. The unit-level assertions and the traced code path are sufficient evidence that the reported symptom is gone.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

The new field `extraSystemPromptHashInput` is optional in `RunCliAgentParams`. Callers that do not split fall back to hashing the full `extraSystemPrompt` (previous behavior).

## Risks and Mitigations

- Risk: The inbound-meta envelope is no longer part of the reuse key, so a session that was bound to one channel could theoretically be reused under a different channel.
  - Mitigation: In practice the CLI session is already scoped by `sessionKey` (agent + channel + account composition), which is upstream of this hash. The inbound-meta prompt is still *injected* on every run so the model always sees the current channel/account context. The hash change only affects whether the CLI subprocess is reset, not whether the correct context reaches the model.