### PR TITLE
fix: add enabledByDefault to memory-core plugin manifest

### DIFF
--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "memory-core",
+  "enabledByDefault": true,
   "kind": "memory",
   "commandAliases": [
     {


### PR DESCRIPTION
## Summary

memory-core is a bundled plugin that provides core memory functionality (dreaming, memory recall, etc.), but its openclaw.plugin.json is missing the enabledByDefault: true field.

This causes openclaw doctor and openclaw update to fail with:

Bundled plugin public surface access blocked for memory-core via memory-core/runtime-api.js: bundled (disabled by default)

## Root Cause

In src/plugins/config-state.ts → resolvePluginActivationState, bundled plugins are only auto-enabled if they have enabledByDefault: true in their manifest. Other bundled plugins like arcee, huggingface, kilocode, litellm, and openrouter all have this field set — memory-core was simply missing it.

## Fix

Add enabledByDefault: true to extensions/memory-core/openclaw.plugin.json.

## Testing

- openclaw doctor passes with Errors: 0 after the fix
- All pre-commit checks pass (tsgo, lint, import-cycles, etc.)

## Checklist

- [x] Tests pass
- [x] openclaw doctor succeeds