### PR TITLE
fix(cron): preserve cron lane for top-level dispatch, only remap to nested for inner ops

### DIFF
--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -45,7 +45,7 @@ export async function compactEmbeddedPiSession(
     return harnessResult;
   }
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
-  const globalLane = resolveGlobalLane(params.lane);
+  const globalLane = resolveGlobalLane(params.lane, { inner: true });
   const enqueueGlobal =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
   return enqueueCommandInLane(sessionLane, () =>

--- a/src/agents/pi-embedded-runner/lanes.test.ts
+++ b/src/agents/pi-embedded-runner/lanes.test.ts
@@ -10,12 +10,20 @@ describe("resolveGlobalLane", () => {
     }
   });
 
-  it("maps cron lane to nested lane to prevent deadlocks", () => {
-    // When cron jobs trigger nested agent runs, the outer execution holds
-    // the cron lane slot. Inner work must use a separate lane to avoid
-    // deadlock. See: https://github.com/openclaw/openclaw/issues/44805
+  it("preserves cron lane for top-level dispatch (honours maxConcurrentRuns)", () => {
+    // Top-level cron runs must stay on the cron lane so that
+    // cron.maxConcurrentRuns is respected. See: #66828
     for (const lane of ["cron", "  cron  "]) {
-      expect(resolveGlobalLane(lane)).toBe(CommandLane.Nested);
+      expect(resolveGlobalLane(lane)).toBe(CommandLane.Cron);
+    }
+  });
+
+  it("maps cron lane to nested for inner operations to prevent deadlocks", () => {
+    // When cron jobs trigger nested agent runs (compaction, followup), the
+    // outer execution holds the cron lane slot. Inner work must use a
+    // separate lane to avoid deadlock. See: #44805
+    for (const lane of ["cron", "  cron  "]) {
+      expect(resolveGlobalLane(lane, { inner: true })).toBe(CommandLane.Nested);
     }
   });
 

--- a/src/agents/pi-embedded-runner/lanes.ts
+++ b/src/agents/pi-embedded-runner/lanes.ts
@@ -5,10 +5,12 @@ export function resolveSessionLane(key: string) {
   return cleaned.startsWith("session:") ? cleaned : `session:${cleaned}`;
 }
 
-export function resolveGlobalLane(lane?: string) {
+export function resolveGlobalLane(lane?: string, { inner }: { inner?: boolean } = {}) {
   const cleaned = lane?.trim();
-  // Cron jobs hold the cron lane slot; inner operations must use nested to avoid deadlock.
-  if (cleaned === CommandLane.Cron) {
+  // Only remap cron→nested for inner operations (compaction, followup) to avoid
+  // deadlock with the cron lane slot. The top-level cron dispatch must stay on
+  // CommandLane.Cron so that cron.maxConcurrentRuns is honoured.
+  if (inner && cleaned === CommandLane.Cron) {
     return CommandLane.Nested;
   }
   return cleaned ? cleaned : CommandLane.Main;


### PR DESCRIPTION
## Summary

\esolveGlobalLane\ unconditionally remapped \CommandLane.Cron\ to \CommandLane.Nested\, which funnelled **all** cron work into a serial bottleneck (\
ested\ defaults to \maxConcurrent: 1\) and effectively ignored \cron.maxConcurrentRuns\.

## Changes

- Add an \{ inner }\ option to \esolveGlobalLane()\ so only inner operations (compaction, followup) get remapped to \Nested\ to avoid deadlock
- Top-level cron dispatch now stays on \CommandLane.Cron\, honoring the configured concurrency
- Updated \compact.queued.ts\ to pass \{ inner: true }\ since it's an inner operation
- Updated tests to cover both behaviors

## Affected files

- \src/agents/pi-embedded-runner/lanes.ts\
- \src/agents/pi-embedded-runner/compact.queued.ts\
- \src/agents/pi-embedded-runner/lanes.test.ts\

Fixes #66828 (Bug A: Cron lane remapped to Nested)