### PR TITLE
fix(telegram): disable HTTP/2 for all Telegram polling dispatchers

### DIFF
--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -265,14 +265,22 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
   mode: TelegramDispatcherMode;
   effectivePolicy: PinnedDispatcherPolicy;
 } {
+  // Telegram polling uses long-lived connections. Undici 8 enables HTTP/2 ALPN
+  // by default which causes stalls on Windows (IPv6 + H2 multiplexing issues).
+  // Force HTTP/1.1 for all Telegram dispatchers to match the core fetch-guard
+  // approach. See: https://github.com/openclaw/openclaw/issues/66885
   if (policy.mode === "explicit-proxy") {
     const requestTlsOptions = withPinnedLookup(policy.proxyTls, policy.pinnedHostname);
     const proxyOptions = requestTlsOptions
       ? ({
           uri: policy.proxyUrl,
+          allowH2: false,
           requestTls: requestTlsOptions,
         } satisfies ConstructorParameters<typeof ProxyAgent>[0])
-      : policy.proxyUrl;
+      : ({
+          uri: typeof policy.proxyUrl === "string" ? policy.proxyUrl : policy.proxyUrl!,
+          allowH2: false,
+        } satisfies ConstructorParameters<typeof ProxyAgent>[0]);
     try {
       return {
         dispatcher: new ProxyAgent(proxyOptions),
@@ -291,10 +299,11 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
     const proxyOptions =
       connectOptions || proxyTlsOptions
         ? ({
+            allowH2: false,
             ...(connectOptions ? { connect: connectOptions } : {}),
             ...(proxyTlsOptions ? { proxyTls: proxyTlsOptions } : {}),
           } satisfies ConstructorParameters<typeof EnvHttpProxyAgent>[0])
-        : undefined;
+        : ({ allowH2: false } satisfies ConstructorParameters<typeof EnvHttpProxyAgent>[0]);
     try {
       return {
         dispatcher: new EnvHttpProxyAgent(proxyOptions),
@@ -312,8 +321,8 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
       return {
         dispatcher: new Agent(
           directPolicy.connect
-            ? ({ connect: directPolicy.connect } satisfies ConstructorParameters<typeof Agent>[0])
-            : undefined,
+            ? ({ allowH2: false, connect: directPolicy.connect } satisfies ConstructorParameters<typeof Agent>[0])
+            : ({ allowH2: false } satisfies ConstructorParameters<typeof Agent>[0]),
         ),
         mode: "direct",
         effectivePolicy: directPolicy,
@@ -326,9 +335,10 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
     dispatcher: new Agent(
       connectOptions
         ? ({
+            allowH2: false,
             connect: connectOptions,
           } satisfies ConstructorParameters<typeof Agent>[0])
-        : undefined,
+        : ({ allowH2: false } satisfies ConstructorParameters<typeof Agent>[0]),
     ),
     mode: "direct",
     effectivePolicy: policy,


### PR DESCRIPTION
## Summary

Undici 8 enables HTTP/2 ALPN by default, causing Telegram long-polling connections to stall on Windows (IPv6 + H2 multiplexing issues).

The core fetch-guard (\src/infra/net/undici-runtime.ts\) already applies \llowH2: false\ for guarded paths, but the Telegram extension creates its own \Agent\/\ProxyAgent\/\EnvHttpProxyAgent\ instances directly from undici without this flag.

## Changes

- Apply \llowH2: false\ to all dispatcher constructors in \xtensions/telegram/src/fetch.ts\
- Matches the approach used in \src/infra/net/undici-runtime.ts\ (\HTTP1_ONLY_DISPATCHER_OPTIONS\)

## Affected files

- \xtensions/telegram/src/fetch.ts\

Fixes #66885