### PR TITLE
feat(github-copilot): add missing Copilot models to defaults

### DIFF
--- a/extensions/github-copilot/models-defaults.ts
+++ b/extensions/github-copilot/models-defaults.ts
@@ -8,9 +8,13 @@ const DEFAULT_MAX_TOKENS = 8192;
 // We keep this list intentionally broad; if a model isn't available Copilot will
 // return an error and users can remove it from their config.
 const DEFAULT_MODEL_IDS = [
+  "claude-opus-4.7",
   "claude-opus-4.6",
+  "claude-opus-4.5",
   "claude-sonnet-4.6",
   "claude-sonnet-4.5",
+  "claude-haiku-4.5",
+  "gemini-2.5-pro",
   "gpt-4o",
   "gpt-4.1",
   "gpt-4.1-mini",


### PR DESCRIPTION
## Summary

Add commonly available Copilot models that were missing from `DEFAULT_MODEL_IDS`:

- `claude-opus-4.7`
- `claude-opus-4.5`
- `claude-haiku-4.5`
- `gemini-2.5-pro`

These models are available on Copilot plans (confirmed via OpenCode's model list) but couldn't be selected in OpenClaw because they weren't in the default list.

The existing comment already says *"We keep this list intentionally broad"* — this PR follows that philosophy.

## Changes

Single file: `extensions/github-copilot/models-defaults.ts` — added 4 model IDs to the array.

Closes #69241