### PR TITLE
fix(tasks): allow timestamp jitter tolerance in audit inconsistency check

### DIFF
--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -83,6 +83,82 @@ describe("task-registry audit", () => {
     });
   });
 
+  it("does not flag startedAt equal to createdAt as inconsistent", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const base = Date.parse("2026-03-30T00:00:00.000Z");
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "same-ts",
+          status: "succeeded",
+          createdAt: base,
+          startedAt: base,
+          endedAt: base + 5000,
+          cleanupAfter: now + 60_000,
+        }),
+      ],
+    });
+    expect(findings.map((f) => f.code)).toEqual([]);
+  });
+
+  it("does not flag startedAt slightly before createdAt within jitter tolerance", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const base = Date.parse("2026-03-30T00:00:00.000Z");
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "slight-jitter",
+          status: "succeeded",
+          createdAt: base + 500,
+          startedAt: base,
+          endedAt: base + 5000,
+          cleanupAfter: now + 60_000,
+        }),
+      ],
+    });
+    expect(findings.map((f) => f.code)).toEqual([]);
+  });
+
+  it("flags startedAt significantly before createdAt as inconsistent", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const base = Date.parse("2026-03-30T00:00:00.000Z");
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "big-gap",
+          status: "succeeded",
+          createdAt: base + 2000,
+          startedAt: base,
+          endedAt: base + 5000,
+          cleanupAfter: now + 60_000,
+        }),
+      ],
+    });
+    expect(findings.map((f) => f.code)).toEqual(["inconsistent_timestamps"]);
+  });
+
+  it("does not flag endedAt slightly before startedAt within jitter tolerance", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const base = Date.parse("2026-03-30T00:00:00.000Z");
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "end-jitter",
+          status: "failed",
+          createdAt: base,
+          startedAt: base + 500,
+          endedAt: base + 100,
+          cleanupAfter: now + 60_000,
+        }),
+      ],
+    });
+    expect(findings.map((f) => f.code)).toEqual([]);
+  });
+
   it("does not double-report lost tasks as missing cleanup", () => {
     const now = Date.parse("2026-03-30T01:00:00.000Z");
     const findings = listTaskAuditFindings({

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -45,8 +45,12 @@ function taskReferenceAt(task: TaskRecord): number {
   return task.lastEventAt ?? task.startedAt ?? task.createdAt;
 }
 
+// Timestamps are set via separate Date.now() calls that may have sub-ms jitter
+// or land in slightly different order, so allow a small tolerance before flagging.
+const TIMESTAMP_JITTER_MS = 1000;
+
 function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
-  if (task.startedAt && task.startedAt < task.createdAt) {
+  if (task.startedAt && task.createdAt - task.startedAt > TIMESTAMP_JITTER_MS) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",
@@ -54,7 +58,7 @@ function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
       detail: "startedAt is earlier than createdAt",
     });
   }
-  if (task.endedAt && task.startedAt && task.endedAt < task.startedAt) {
+  if (task.endedAt && task.startedAt && task.startedAt - task.endedAt > TIMESTAMP_JITTER_MS) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",


### PR DESCRIPTION
Fixes #69229

## Problem
`openclaw tasks audit` reports false-positive `inconsistent_timestamps` warnings when `startedAt` is slightly earlier than `createdAt` due to sub-millisecond clock jitter between separate `Date.now()` calls.

## Fix
Added a 1-second tolerance (`TIMESTAMP_JITTER_MS = 1000`) to `findTimestampInconsistency()` in `task-registry.audit.ts`. Instead of strict `startedAt < createdAt`, it now checks `createdAt - startedAt > 1000`, so minor clock resolution differences no longer trigger warnings.

## Tests
Added 4 new test cases covering equal timestamps, within-tolerance jitter, beyond-tolerance (still warns), and endedAt jitter.