### PR TITLE
feat(gateway): add agent.identity.full method

### DIFF
--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -84,6 +84,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "tools.effective",
     "agents.list",
     "agent.identity.get",
+    "agent.identity.full",
     "skills.status",
     "skills.search",
     "skills.detail",

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -128,6 +128,7 @@ const BASE_METHODS = [
   "send",
   "agent",
   "agent.identity.get",
+  "agent.identity.full",
   "agent.wait",
   // WebChat WebSocket-native chat methods
   "chat.history",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -16,6 +16,7 @@ import { deviceHandlers } from "./server-methods/devices.js";
 import { doctorHandlers } from "./server-methods/doctor.js";
 import { execApprovalsHandlers } from "./server-methods/exec-approvals.js";
 import { healthHandlers } from "./server-methods/health.js";
+import { identityHandlers } from "./server-methods/identity.js";
 import { logsHandlers } from "./server-methods/logs.js";
 import { modelsAuthStatusHandlers } from "./server-methods/models-auth-status.js";
 import { modelsHandlers } from "./server-methods/models.js";
@@ -72,6 +73,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...logsHandlers,
   ...voicewakeHandlers,
   ...healthHandlers,
+  ...identityHandlers,
   ...channelsHandlers,
   ...chatHandlers,
   ...commandsHandlers,

--- a/src/gateway/server-methods/identity.test.ts
+++ b/src/gateway/server-methods/identity.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for agent.identity.full Gateway method.
+ *
+ * Uses a temporary workspace directory so the tests do not touch the
+ * real ~/.openclaw/workspace.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "fs";
+import * as path from "path";
+import * as os from "os";
+
+import { identityHandlers } from "./identity.js";
+
+// Minimal fakes for the GatewayRequestHandlerOptions shape that
+// identity.get actually uses. The real context has many more fields —
+// we only populate what the handler touches.
+function makeRespond() {
+  const calls: Array<{
+    ok: boolean;
+    payload?: unknown;
+    error?: unknown;
+    meta?: Record<string, unknown>;
+  }> = [];
+  const respond = (
+    ok: boolean,
+    payload?: unknown,
+    error?: unknown,
+    meta?: Record<string, unknown>,
+  ) => {
+    calls.push({ ok, payload, error, meta });
+  };
+  return { respond, calls };
+}
+
+async function runIdentityGet(workspacePath: string) {
+  const prev = process.env.OPENCLAW_WORKSPACE;
+  process.env.OPENCLAW_WORKSPACE = workspacePath;
+  try {
+    const { respond, calls } = makeRespond();
+    // Cast is fine — handler only uses `respond`
+    await identityHandlers["agent.identity.full"]!({
+      respond,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    return calls[0];
+  } finally {
+    if (prev === undefined) delete process.env.OPENCLAW_WORKSPACE;
+    else process.env.OPENCLAW_WORKSPACE = prev;
+  }
+}
+
+describe("agent.identity.full", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-identity-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns available=false when workspace does not exist", async () => {
+    const result = await runIdentityGet(path.join(tmpDir, "does-not-exist"));
+    expect(result.ok).toBe(true);
+    expect(result.payload).toMatchObject({
+      available: false,
+      reason: "no_workspace",
+    });
+  });
+
+  it("returns available=false when IDENTITY.md is missing", async () => {
+    const result = await runIdentityGet(tmpDir);
+    expect(result.ok).toBe(true);
+    expect(result.payload).toMatchObject({
+      available: false,
+      reason: "no_identity_md",
+    });
+  });
+
+  it("parses frontmatter and returns raw content when files exist", async () => {
+    const identityMd = [
+      "---",
+      'name: "Mr Claw"',
+      "did: did:claw:mrclaw",
+      "emoji: 🦀",
+      "creature: Crab",
+      'vibe: "Security-first engineer"',
+      "---",
+      "",
+      "# Mr Claw",
+      "",
+      "Body text.",
+    ].join("\n");
+    const soulMd = "# Soul\n\nI care about clear thinking.\n";
+
+    await fs.writeFile(path.join(tmpDir, "IDENTITY.md"), identityMd, "utf-8");
+    await fs.writeFile(path.join(tmpDir, "SOUL.md"), soulMd, "utf-8");
+
+    const result = await runIdentityGet(tmpDir);
+    expect(result.ok).toBe(true);
+
+    const payload = result.payload as {
+      available: boolean;
+      name?: string;
+      did?: string;
+      emoji?: string;
+      creature?: string;
+      vibe?: string;
+      identityRaw?: string;
+      soulRaw?: string;
+    };
+
+    expect(payload.available).toBe(true);
+    expect(payload.name).toBe("Mr Claw");
+    expect(payload.did).toBe("did:claw:mrclaw");
+    expect(payload.emoji).toBe("🦀");
+    expect(payload.creature).toBe("Crab");
+    expect(payload.vibe).toBe("Security-first engineer");
+    expect(payload.identityRaw).toContain("# Mr Claw");
+    expect(payload.soulRaw).toContain("I care about clear thinking");
+  });
+
+  it("handles missing SOUL.md gracefully", async () => {
+    const identityMd = [
+      "---",
+      "name: Solo",
+      "did: did:claw:solo",
+      "---",
+      "",
+      "# Solo",
+    ].join("\n");
+
+    await fs.writeFile(path.join(tmpDir, "IDENTITY.md"), identityMd, "utf-8");
+
+    const result = await runIdentityGet(tmpDir);
+    expect(result.ok).toBe(true);
+    const payload = result.payload as { available: boolean; soulRaw?: string };
+    expect(payload.available).toBe(true);
+    expect(payload.soulRaw).toBe("");
+  });
+
+  it("handles IDENTITY.md without frontmatter", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "IDENTITY.md"),
+      "# Just a title, no frontmatter\n",
+      "utf-8",
+    );
+    const result = await runIdentityGet(tmpDir);
+    expect(result.ok).toBe(true);
+    const payload = result.payload as {
+      available: boolean;
+      name?: string;
+      identityRaw?: string;
+    };
+    expect(payload.available).toBe(true);
+    expect(payload.name).toBeUndefined();
+    expect(payload.identityRaw).toContain("Just a title");
+  });
+});

--- a/src/gateway/server-methods/identity.ts
+++ b/src/gateway/server-methods/identity.ts
@@ -1,0 +1,168 @@
+/**
+ * Gateway server method: agent.identity.full
+ *
+ * Returns the local OpenClaw agent's FULL identity (parsed frontmatter
+ * plus raw IDENTITY.md / SOUL.md content) so that external clients
+ * (e.g. agent-federation) do NOT need to read these files directly
+ * from the filesystem. Keeps the workspace as the single source of
+ * truth and lets OpenClaw mediate access.
+ *
+ * Compare with the existing `agent.identity.get` (in agent.ts) which
+ * returns only the UI-facing subset (name, avatar, emoji). This method
+ * exposes everything needed to build agent system prompts and perform
+ * DID-based peer identification.
+ *
+ * Registered under READ_SCOPE — any operator with read access can
+ * fetch agent identity.
+ */
+
+import { promises as fs } from "fs";
+import * as path from "path";
+import * as os from "os";
+
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import { formatError } from "../server-utils.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface IdentityPayload {
+  /** true if IDENTITY.md was found and parsed */
+  available: boolean;
+  /** Reason when available === false (e.g. "no_workspace", "no_identity_md") */
+  reason?: string;
+  /** Absolute path to the workspace we resolved (for debugging). */
+  workspacePath?: string;
+
+  // Parsed from YAML frontmatter of IDENTITY.md
+  name?: string;
+  did?: string;
+  emoji?: string;
+  creature?: string;
+  vibe?: string;
+
+  // Raw file contents for callers that want to re-parse (e.g. build
+  // system prompts that include SOUL).
+  identityRaw?: string;
+  soulRaw?: string;
+}
+
+// ─── Workspace resolution ─────────────────────────────────────────────────
+
+/**
+ * Resolve the OpenClaw workspace path.
+ * Priority: OPENCLAW_WORKSPACE env → ~/.openclaw/workspace
+ */
+function resolveWorkspacePath(): string {
+  const envPath = process.env.OPENCLAW_WORKSPACE;
+  if (envPath && envPath.length > 0) return envPath;
+  return path.join(os.homedir(), ".openclaw", "workspace");
+}
+
+// ─── YAML frontmatter parser ──────────────────────────────────────────────
+
+/**
+ * Very small YAML frontmatter parser.
+ *
+ * Accepts documents that begin with `---\n...\n---\n` and returns the
+ * parsed key-value pairs (string values only) plus the remaining body.
+ *
+ * Intentionally minimal — OpenClaw already has a richer YAML parser
+ * elsewhere but we avoid a new dependency in the Gateway path.
+ */
+function parseFrontmatter(raw: string): { meta: Record<string, string>; body: string } {
+  const meta: Record<string, string> = {};
+  if (!raw.startsWith("---")) return { meta, body: raw };
+
+  const end = raw.indexOf("\n---", 3);
+  if (end === -1) return { meta, body: raw };
+
+  const fm = raw.slice(3, end).trim();
+  const body = raw.slice(end + 4).replace(/^\n+/, "");
+
+  for (const line of fm.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) continue;
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    let value = trimmed.slice(colonIdx + 1).trim();
+
+    // Strip matching quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (key.length > 0) meta[key] = value;
+  }
+
+  return { meta, body };
+}
+
+// ─── Reader ────────────────────────────────────────────────────────────────
+
+async function readIdentity(workspacePath: string): Promise<IdentityPayload> {
+  try {
+    const stat = await fs.stat(workspacePath).catch(() => null);
+    if (!stat || !stat.isDirectory()) {
+      return { available: false, reason: "no_workspace", workspacePath };
+    }
+
+    const identityPath = path.join(workspacePath, "IDENTITY.md");
+    const soulPath = path.join(workspacePath, "SOUL.md");
+
+    let identityRaw: string;
+    try {
+      identityRaw = await fs.readFile(identityPath, "utf-8");
+    } catch {
+      return { available: false, reason: "no_identity_md", workspacePath };
+    }
+
+    let soulRaw = "";
+    try {
+      soulRaw = await fs.readFile(soulPath, "utf-8");
+    } catch {
+      // SOUL.md is optional
+      soulRaw = "";
+    }
+
+    const { meta } = parseFrontmatter(identityRaw);
+
+    return {
+      available: true,
+      workspacePath,
+      name: meta.name,
+      did: meta.did,
+      emoji: meta.emoji,
+      creature: meta.creature,
+      vibe: meta.vibe,
+      identityRaw,
+      soulRaw,
+    };
+  } catch (err) {
+    return {
+      available: false,
+      reason: `read_error: ${formatError(err)}`,
+      workspacePath,
+    };
+  }
+}
+
+// ─── Handler ───────────────────────────────────────────────────────────────
+
+export const identityHandlers: GatewayRequestHandlers = {
+  "agent.identity.full": async ({ respond }) => {
+    try {
+      const workspacePath = resolveWorkspacePath();
+      const payload = await readIdentity(workspacePath);
+      respond(true, payload, undefined);
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatError(err)));
+    }
+  },
+};


### PR DESCRIPTION
## Summary

Adds a new Gateway RPC method `agent.identity.full` that exposes the local OpenClaw agent's full identity (parsed frontmatter plus raw IDENTITY.md + SOUL.md content) to authenticated Gateway clients.

**Why:** Downstream tools that need the agent identity — such as [agent-federation](https://github.com/stiva79-19/Agent-Federation), a Hyperswarm-based P2P federation layer — currently read `~/.openclaw/workspace/IDENTITY.md` and `SOUL.md` directly from the filesystem. That makes the workspace a de-facto shared public surface and prevents OpenClaw from mediating access in the future (consent prompts, scoped tokens, audit logging).

With `agent.identity.full`, external clients go through the Gateway and OpenClaw becomes the single gatekeeper. This is the first step of a broader migration documented in agent-federation's `docs/openclaw-pr-draft/README.md`.

## Why a new method vs. extending `agent.identity.get`

The existing `agent.identity.get` (in `agent.ts`) returns the UI-facing subset — `agentId`, `name`, `avatar`, `emoji`. That surface is intentionally minimal for UI clients.

External federation clients need more: the raw `IDENTITY.md` body (for system prompts), `SOUL.md` (personality), and additional frontmatter fields like `did`, `creature`, `vibe`. Keeping the UI-facing surface narrow while offering a separate `full` method avoids accidentally leaking prompt-building content to UI callers and lets each concern evolve independently.

## Contract

- **Method:** `agent.identity.full`
- **Params:** none
- **Scope:** `READ_SCOPE` (registered in `method-scopes.ts`)
- **Success payload:**
  ```ts
  {
    available: true;
    workspacePath: string;
    name?: string;
    did?: string;
    emoji?: string;
    creature?: string;
    vibe?: string;
    identityRaw: string;  // full IDENTITY.md
    soulRaw: string;      // full SOUL.md, "" if missing
  }
  ```
- **Graceful failure:** `{ available: false, reason: "no_workspace" | "no_identity_md" | ... }` — not treated as an RPC error so clients can degrade cleanly.

## Implementation notes

- Workspace path resolution: `OPENCLAW_WORKSPACE` env → `~/.openclaw/workspace`.
- Minimal built-in YAML frontmatter parser to avoid introducing a new dependency in the Gateway hot path.
- `SOUL.md` is optional; missing file returns `soulRaw: ""` rather than erroring.
- Handler follows the same shape as `healthHandlers` / `cronHandlers`.

## Files changed

New:
- `src/gateway/server-methods/identity.ts` — handler + YAML frontmatter parser + workspace resolver.
- `src/gateway/server-methods/identity.test.ts` — 5 unit tests.

Registry:
- `src/gateway/server-methods.ts` — import + spread `identityHandlers` alongside other core handlers.
- `src/gateway/server-methods-list.ts` — add `"agent.identity.full"` to `BASE_METHODS`.
- `src/gateway/method-scopes.ts` — add `"agent.identity.full"` to the `READ_SCOPE` group.

## Test plan

- [x] Unit tests cover: missing workspace, missing IDENTITY.md, full happy path with frontmatter + SOUL, missing SOUL, IDENTITY.md without frontmatter.
- [ ] Manual: `openclaw gateway call agent.identity.full --json`
- [ ] Manual: `openclaw gateway call agent.identity.full --json` with `OPENCLAW_WORKSPACE=/tmp/empty` returns `available: false`

> Local-dev note: tests were not runnable in the contributor's environment because `openclaw`'s Vitest config hit a `tinypool` `minThreads/maxThreads` conflict under Node 22.22 + vitest 1.6.1 via the nested `agent-federation/node_modules/vitest` resolution chain. The test file follows the same structure as other gateway method tests; CI should exercise it cleanly.

## Follow-ups (not in this PR)

- `llm.chat` method with streaming events so LLM API keys stay behind the Gateway (Phase 1b) — this will let agent-federation stop reading `~/.openclaw/credentials/` entirely.
- `auth.grant` method wrapping `exec.approval.*` for per-session scoped tokens (Phase 2) — consent-based access for external federation clients.
