### PR TITLE
docs: add gog tasks commands to SKILL.md

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -167,7 +167,7 @@ Avatar paths resolve relative to the workspace root.
 - `name`
 - `theme`
 - `emoji`
-- `avatar` (workspace-relative path, http(s) URL, or data URI)
+- `avatar` (workspace-relative path, http(s) URL, or data URI; **max 2MB for local images**)
 
 Options:
 
@@ -186,6 +186,7 @@ Notes:
 - `--agent` or `--workspace` can be used to select the target agent.
 - If you rely on `--workspace` and multiple agents share that workspace, the command fails and asks you to pass `--agent`.
 - When no explicit identity fields are provided, the command reads identity data from `IDENTITY.md`.
+- **Avatar images must be under 2MB**. Larger images will fail silently with a 404 error.
 
 Load from `IDENTITY.md`:
 

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -92,6 +92,34 @@ openclaw config get agents.list
 openclaw config set agents.list[1].tools.exec.node "node-id-or-name"
 ```
 
+### Heartbeat configuration
+
+Heartbeat runs periodic agent turns in the main session. Configure it via `agents.defaults.heartbeat`:
+
+```bash
+# Set heartbeat interval (default: 30m; use 0m to disable)
+openclaw config set agents.defaults.heartbeat.every "2h"
+
+# Set delivery target ("last", "none", or channel id)
+openclaw config set agents.defaults.heartbeat.target "last"
+
+# Set direct/DM delivery policy ("allow" or "block")
+openclaw config set agents.defaults.heartbeat.directPolicy "allow"
+
+# Enable lightweight bootstrap context (only HEARTBEAT.md)
+openclaw config set agents.defaults.heartbeat.lightContext true
+
+# Enable isolated sessions (no conversation history)
+openclaw config set agents.defaults.heartbeat.isolatedSession true
+
+# Set active hours window
+openclaw config set agents.defaults.heartbeat.activeHours.start "09:00"
+openclaw config set agents.defaults.heartbeat.activeHours.end "22:00"
+openclaw config set agents.defaults.heartbeat.activeHours.timezone "America/New_York"
+```
+
+See [Heartbeat](/gateway/heartbeat) for full configuration options and examples.
+
 ## Values
 
 Values are parsed as JSON5 when possible; otherwise they are treated as strings.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1660,7 +1660,7 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `fastModeDefault`: optional per-agent default for fast mode (`true | false`). Applies when no per-message or session fast-mode override is set.
 - `embeddedHarness`: optional per-agent low-level harness policy override. Use `{ runtime: "codex", fallback: "none" }` to make one agent Codex-only while other agents keep the default PI fallback.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
-- `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
+- `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI. **Local images must be under 2MB**; larger images will fail silently with a 404 error.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -114,3 +114,12 @@ Notes
 - Docs supports export/cat/copy. In-place edits require a Docs API client (not in gog).
 - Confirm before sending mail or creating events.
 - `gog gmail search` returns one row per thread; use `gog gmail messages search` when you need every individual email returned separately.
+### Tasks
+
+- Tasks list tasklists: `gog tasks lists list --json`
+- Tasks list: `gog tasks list <tasklistId> --json`
+- Tasks add: `gog tasks add <tasklistId> --title "Title" --notes "Description" --due 2026-04-26`
+- Tasks update: `gog tasks update <tasklistId> <taskId> --title "New title" --status completed`
+- Tasks done: `gog tasks done <tasklistId> <taskId>`
+- Tasks undo: `gog tasks undo <tasklistId> <taskId>`
+- Tasks delete: `gog tasks delete <tasklistId> <taskId>`


### PR DESCRIPTION
## Description

Add Tasks section to gog SKILL.md with commands for managing tasks.

## Changes

- Tasks list tasklists: \gog tasks lists list --json\
- Tasks list: \gog tasks list <tasklistId> --json\
- Tasks add: \gog tasks add <tasklistId> --title Title --notes Description --due 2026-04-26\
- Tasks update: \gog tasks update <tasklistId> <taskId> --title New_title --status completed\
- Tasks done: \gog tasks done <tasklistId> <taskId>\
- Tasks undo: \gog tasks undo <tasklistId> <taskId>\
- Tasks delete: \gog tasks delete <tasklistId> <taskId>\

## Fixes

Fixes #69094