### PR TITLE
fix(anthropic): Opus 4.7 thinking.type leak + assistant-prefill short-circuit

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -65,6 +65,7 @@ export {
 export { pickFallbackThinkingLevel } from "./pi-embedded-helpers/thinking.js";
 
 export {
+  dropAllTrailingNonUserTurns,
   dropTrailingEmptyAssistantTurns,
   mergeConsecutiveUserTurns,
   messagesEndWithUserTurn,

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -65,7 +65,9 @@ export {
 export { pickFallbackThinkingLevel } from "./pi-embedded-helpers/thinking.js";
 
 export {
+  dropTrailingEmptyAssistantTurns,
   mergeConsecutiveUserTurns,
+  messagesEndWithUserTurn,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "./pi-embedded-helpers/turns.js";

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -68,6 +68,7 @@ export {
   dropTrailingEmptyAssistantTurns,
   mergeConsecutiveUserTurns,
   messagesEndWithUserTurn,
+  shouldShortCircuitForMissingUserTail,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "./pi-embedded-helpers/turns.js";

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  dropAllTrailingNonUserTurns,
   dropTrailingEmptyAssistantTurns,
   mergeConsecutiveUserTurns,
   messagesEndWithUserTurn,
@@ -805,6 +806,152 @@ describe("dropTrailingEmptyAssistantTurns", () => {
       { role: "user", content: [{ type: "text", text: "Retry" }] },
     ]);
     expect(dropTrailingEmptyAssistantTurns(msgs)).toBe(msgs);
+  });
+
+  it("leaves gateway error-surface assistant messages intact (first-pass gap)", () => {
+    // Regression guard: gateway-surfaced errors (billing errors, prefill
+    // rejections, etc.) are injected as real-content assistant turns. They
+    // are NOT empty or thinking-only, so dropTrailingEmptyAssistantTurns
+    // must not remove them. The runner-level safety net is responsible for
+    // stripping them before the Anthropic request goes out.
+    const billingMsgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "API provider returned a billing error: please update payment info.",
+          },
+        ],
+      },
+    ]);
+    expect(dropTrailingEmptyAssistantTurns(billingMsgs)).toBe(billingMsgs);
+
+    const prefillRejectionMsgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "LLM request rejected: This model does not support assistant message prefill.",
+          },
+        ],
+      },
+    ]);
+    expect(dropTrailingEmptyAssistantTurns(prefillRejectionMsgs)).toBe(prefillRejectionMsgs);
+  });
+});
+
+describe("dropAllTrailingNonUserTurns", () => {
+  it("returns the input unchanged when the tail is already user-like", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+      { role: "user", content: [{ type: "text", text: "More" }] },
+    ]);
+    expect(dropAllTrailingNonUserTurns(msgs)).toBe(msgs);
+  });
+
+  it("drops a trailing assistant turn that carries real gateway error text", () => {
+    // The exact case that slipped past dropTrailingEmptyAssistantTurns and
+    // kept firing the old warn-only guard: a surfaced error shows up as a
+    // non-empty assistant tail, so the runner must strip it before sending
+    // to Anthropic.
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "API provider returned a billing error: please update payment info.",
+          },
+        ],
+      },
+    ]);
+    const result = dropAllTrailingNonUserTurns(msgs);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+    expect(messagesEndWithUserTurn(result)).toBe(true);
+  });
+
+  it("drops multiple consecutive non-user trailing turns including real text", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "Reply 1" }] },
+      { role: "assistant", content: [{ type: "text", text: "Reply 2 (prefill error)" }] },
+    ]);
+    const result = dropAllTrailingNonUserTurns(msgs);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+  });
+
+  it("returns an empty array when every message is non-user", () => {
+    const msgs = asMessages([
+      { role: "assistant", content: [{ type: "text", text: "stray reply" }] },
+      { role: "assistant", content: [{ type: "text", text: "another stray" }] },
+    ]);
+    const result = dropAllTrailingNonUserTurns(msgs);
+    expect(result).toHaveLength(0);
+  });
+
+  it("preserves user-like tails of tool-result and tool roles", () => {
+    const toolResultTail = asMessages([
+      { role: "user", content: [{ type: "text", text: "use tool" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "tool-1", name: "t", arguments: {} }],
+      },
+      { role: "toolResult", toolUseId: "tool-1", content: [{ type: "text", text: "ok" }] },
+    ]);
+    expect(dropAllTrailingNonUserTurns(toolResultTail)).toBe(toolResultTail);
+
+    const toolTail = asMessages([
+      { role: "user", content: [{ type: "text", text: "use tool" }] },
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "tool-2", name: "t", arguments: {} }],
+      },
+      { role: "tool", toolCallId: "tool-2", content: [{ type: "text", text: "ok" }] },
+    ]);
+    expect(dropAllTrailingNonUserTurns(toolTail)).toBe(toolTail);
+  });
+
+  it("only touches trailing turns; non-user turns in the middle stay intact", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "mid reply" }] },
+      { role: "user", content: [{ type: "text", text: "ok" }] },
+      { role: "assistant", content: [{ type: "text", text: "billing error text" }] },
+    ]);
+    const result = dropAllTrailingNonUserTurns(msgs);
+    expect(result).toHaveLength(3);
+    expect(result[0].role).toBe("user");
+    expect(result[1].role).toBe("assistant");
+    expect((result[1] as { content?: unknown[] }).content).toEqual([
+      { type: "text", text: "mid reply" },
+    ]);
+    expect(result[2].role).toBe("user");
+    expect(messagesEndWithUserTurn(result)).toBe(true);
+  });
+
+  it("returns the input unchanged for an empty array", () => {
+    const msgs = asMessages([]);
+    expect(dropAllTrailingNonUserTurns(msgs)).toBe(msgs);
+  });
+
+  it("is idempotent across repeated passes", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "error" }] },
+    ]);
+    const once = dropAllTrailingNonUserTurns(msgs);
+    const twice = dropAllTrailingNonUserTurns(once);
+    expect(twice).toBe(once);
+    expect(once).toHaveLength(1);
   });
 });
 

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -1,7 +1,9 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  dropTrailingEmptyAssistantTurns,
   mergeConsecutiveUserTurns,
+  messagesEndWithUserTurn,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "./pi-embedded-helpers.js";
@@ -671,6 +673,60 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     expect(assistantContent).toEqual([{ type: "text", text: "[tool calls omitted]" }]);
   });
 
+  it("drops trailing empty assistant turn left behind by tool_use stripping", () => {
+    // Regression: aborted assistant whose only content was a dangling tool_use
+    // gets emptied by stripDanglingAnthropicToolUses. If that empty turn is
+    // the tail, Anthropic rejects the request because the conversation does
+    // not end with a user turn.
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Use tool" }] },
+      {
+        role: "assistant",
+        stopReason: "aborted",
+        content: [{ type: "toolCall", id: "tool-1", name: "test", arguments: {} }],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "Use tool" }],
+    });
+  });
+
+  it("drops trailing assistant turn with only thinking blocks (no outbound text)", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "planning...", thinkingSignature: "sig" }],
+        stopReason: "aborted",
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+  });
+
+  it("preserves trailing assistant turns that still carry real text content", () => {
+    // Guard must not discard legitimate prior assistant output. If a caller
+    // ever ships this transcript to Anthropic, the stream wrapper / runner
+    // guard is responsible for logging — validateAnthropicTurns should not
+    // silently erase the assistant reply.
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hello!" }] },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toEqual(msgs);
+  });
+
   it("is replay-safe across repeated validation passes", () => {
     const msgs = makeDualToolAnthropicTurns([
       {
@@ -699,5 +755,103 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     expect(() => validateAnthropicTurns(msgs)).not.toThrow();
     const result = validateAnthropicTurns(msgs);
     expect(result).toHaveLength(3);
+  });
+});
+
+describe("dropTrailingEmptyAssistantTurns", () => {
+  it("returns the input unchanged when the tail is already user-like", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+      { role: "user", content: [{ type: "text", text: "More" }] },
+    ]);
+    expect(dropTrailingEmptyAssistantTurns(msgs)).toBe(msgs);
+  });
+
+  it("drops a single trailing assistant turn with empty content array", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [], stopReason: "aborted" },
+    ]);
+    const result = dropTrailingEmptyAssistantTurns(msgs);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+  });
+
+  it("drops multiple consecutive empty trailing assistant turns", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [], stopReason: "error" },
+      { role: "assistant", content: [{ type: "text", text: "   " }], stopReason: "aborted" },
+    ]);
+    const result = dropTrailingEmptyAssistantTurns(msgs);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+  });
+
+  it("keeps a non-empty trailing assistant (guard is for empty tails only)", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "Real reply" }] },
+    ]);
+    expect(dropTrailingEmptyAssistantTurns(msgs)).toBe(msgs);
+  });
+
+  it("does not disturb empty assistant turns in the middle of the transcript", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [], stopReason: "aborted" },
+      { role: "user", content: [{ type: "text", text: "Retry" }] },
+    ]);
+    expect(dropTrailingEmptyAssistantTurns(msgs)).toBe(msgs);
+  });
+});
+
+describe("messagesEndWithUserTurn", () => {
+  it("returns true for user, toolResult, and tool tails", () => {
+    expect(messagesEndWithUserTurn(asMessages([{ role: "user", content: "x" }]))).toBe(true);
+    expect(
+      messagesEndWithUserTurn(asMessages([{ role: "toolResult", toolUseId: "t", content: [] }])),
+    ).toBe(true);
+    expect(
+      messagesEndWithUserTurn(asMessages([{ role: "tool", toolCallId: "t", content: [] }])),
+    ).toBe(true);
+  });
+
+  it("returns false when trailing role is assistant", () => {
+    expect(
+      messagesEndWithUserTurn(
+        asMessages([
+          { role: "user", content: "x" },
+          { role: "assistant", content: [{ type: "text", text: "y" }] },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for an empty list", () => {
+    expect(messagesEndWithUserTurn([])).toBe(false);
+  });
+});
+
+describe("heartbeat contamination regression (validateAnthropicTurns)", () => {
+  // Reproduces the case where filterHeartbeatPairs removed the trailing
+  // (user heartbeat, assistant HEARTBEAT_OK) pair but the subsequent tool_use
+  // stripping emptied the prior aborted assistant, leaving nothing sendable
+  // after the initial user turn.
+  it("emits a transcript ending on a user turn after aborted empty assistant at tail", () => {
+    const msgs = asMessages([
+      { role: "user", content: [{ type: "text", text: "Original question" }] },
+      {
+        role: "assistant",
+        stopReason: "aborted",
+        content: [{ type: "toolUse", id: "tool-dangling", name: "exec", arguments: {} }],
+      },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(1);
+    expect(messagesEndWithUserTurn(result)).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -919,6 +919,41 @@ describe("shouldShortCircuitForMissingUserTail", () => {
       }),
     ).toBe(false);
   });
+
+  it("does not short-circuit when the assistant tail is an empty/aborted stub", () => {
+    // Regression: a previous attempt can leave an empty or aborted assistant
+    // turn in `activeSession.messages` before `dropTrailingEmptyAssistantTurns`
+    // has a chance to strip it. The guard must not treat that stale tail as a
+    // reason to skip the provider call — the downstream pipeline removes it.
+    const emptyAbortedTail = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      { role: "assistant", content: [], stopReason: "aborted" },
+    ]);
+    expect(
+      shouldShortCircuitForMissingUserTail({
+        validateAnthropicTurns: true,
+        messages: emptyAbortedTail,
+        promptText: "",
+        hasImages: false,
+      }),
+    ).toBe(false);
+
+    const thinkingOnlyTail = asMessages([
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "internal" }],
+      },
+    ]);
+    expect(
+      shouldShortCircuitForMissingUserTail({
+        validateAnthropicTurns: true,
+        messages: thinkingOnlyTail,
+        promptText: "",
+        hasImages: false,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("heartbeat contamination regression (validateAnthropicTurns)", () => {

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -4,6 +4,7 @@ import {
   dropTrailingEmptyAssistantTurns,
   mergeConsecutiveUserTurns,
   messagesEndWithUserTurn,
+  shouldShortCircuitForMissingUserTail,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "./pi-embedded-helpers.js";
@@ -831,6 +832,92 @@ describe("messagesEndWithUserTurn", () => {
 
   it("returns false for an empty list", () => {
     expect(messagesEndWithUserTurn([])).toBe(false);
+  });
+});
+
+describe("shouldShortCircuitForMissingUserTail", () => {
+  const assistantTail = asMessages([
+    { role: "user", content: "x" },
+    { role: "assistant", content: [{ type: "text", text: "complete reply" }] },
+  ]);
+  const userTail = asMessages([
+    { role: "user", content: "x" },
+    { role: "assistant", content: [{ type: "text", text: "y" }] },
+    { role: "user", content: "follow-up" },
+  ]);
+
+  it("short-circuits when transcript tail is assistant and prompt is empty without images", () => {
+    expect(
+      shouldShortCircuitForMissingUserTail({
+        validateAnthropicTurns: true,
+        messages: assistantTail,
+        promptText: "",
+        hasImages: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShortCircuitForMissingUserTail({
+        validateAnthropicTurns: true,
+        messages: assistantTail,
+        promptText: "   \n\t",
+        hasImages: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not short-circuit when a fresh user prompt will be appended", () => {
+    expect(
+      shouldShortCircuitForMissingUserTail({
+        validateAnthropicTurns: true,
+        messages: assistantTail,
+        promptText: "hello",
+        hasImages: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not short-circuit when an image will be appended", () => {
+    expect(
+      shouldShortCircuitForMissingUserTail({
+        validateAnthropicTurns: true,
+        messages: assistantTail,
+        promptText: "",
+        hasImages: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not short-circuit when transcript already ends with a user-like turn", () => {
+    expect(
+      shouldShortCircuitForMissingUserTail({
+        validateAnthropicTurns: true,
+        messages: userTail,
+        promptText: "",
+        hasImages: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not short-circuit when Anthropic turn validation is disabled", () => {
+    expect(
+      shouldShortCircuitForMissingUserTail({
+        validateAnthropicTurns: false,
+        messages: assistantTail,
+        promptText: "",
+        hasImages: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not short-circuit on an empty transcript", () => {
+    expect(
+      shouldShortCircuitForMissingUserTail({
+        validateAnthropicTurns: true,
+        messages: [],
+        promptText: "",
+        hasImages: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -122,6 +122,40 @@ export function messagesEndWithUserTurn(messages: AgentMessage[]): boolean {
   return role === "user" || role === "toolResult" || role === "tool";
 }
 
+function isUserLikeTurn(message: AgentMessage | undefined): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const role = (message as { role?: unknown }).role;
+  return role === "user" || role === "toolResult" || role === "tool";
+}
+
+/**
+ * Drops every trailing non-user turn until the transcript ends with a
+ * user-like turn (`user`, `toolResult`, or `tool`). This is the safety net
+ * for cases where a trailing assistant turn carries real but unsendable
+ * content — for example, gateway-surfaced error text like
+ * "API provider returned a billing error" or "LLM request rejected: this
+ * model does not support assistant message prefill". These turns are not
+ * empty or thinking-only, so `dropTrailingEmptyAssistantTurns` correctly
+ * leaves them alone; the runner-level guard uses this helper as a final
+ * pass immediately before sending the transcript to Anthropic so the
+ * provider call cannot land on a `role: assistant` tail.
+ *
+ * Non-trailing assistant turns are never touched; real assistant replies
+ * in the middle of the transcript remain intact.
+ */
+export function dropAllTrailingNonUserTurns(messages: AgentMessage[]): AgentMessage[] {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return messages;
+  }
+  let end = messages.length;
+  while (end > 0 && !isUserLikeTurn(messages[end - 1])) {
+    end -= 1;
+  }
+  return end === messages.length ? messages : messages.slice(0, end);
+}
+
 /**
  * Decides whether to short-circuit an Anthropic request because the request
  * would otherwise end on an `assistant` turn (which Anthropic rejects with

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -148,7 +148,22 @@ export function shouldShortCircuitForMissingUserTail(params: {
   if (promptHasContent || params.hasImages) {
     return false;
   }
-  return !messagesEndWithUserTurn(params.messages);
+  if (messagesEndWithUserTurn(params.messages)) {
+    return false;
+  }
+  // Only short-circuit when the trailing assistant turn carries real content.
+  // Empty or aborted trailing assistants are removed by
+  // `dropTrailingEmptyAssistantTurns` before the request is sent, so treating
+  // them as a short-circuit trigger would be a false positive when a previous
+  // attempt left a stale empty/aborted assistant in the session buffer.
+  const last = params.messages[params.messages.length - 1];
+  if (!last || typeof last !== "object") {
+    return false;
+  }
+  if ((last as { role?: unknown }).role !== "assistant") {
+    return false;
+  }
+  return !isEffectivelyEmptyAssistantContent(last);
 }
 
 function extractToolResultMatchIds(record: Record<string, unknown>): Set<string> {

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -65,11 +65,9 @@ function isUnsendableTrailingAssistant(message: AgentMessage): boolean {
     return true;
   }
   // Aborted/errored assistant turns without useful content cannot be the final
-  // message in an Anthropic request — they either fail the empty-content check
-  // or leave the transcript ending on an assistant role. Drop them even if
-  // they carry thinking-only blocks, since those would produce an empty
-  // outbound message anyway.
-  return isAbortedAssistantTurn(message) && isEffectivelyEmptyAssistantContent(message);
+  // message in an Anthropic request — isEffectivelyEmptyAssistantContent above
+  // already handles the thinking-only / empty-content cases.
+  return false;
 }
 
 /**

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -28,6 +28,102 @@ function isAbortedAssistantTurn(message: AgentMessage): boolean {
   return stopReason === "aborted" || stopReason === "error";
 }
 
+function isEffectivelyEmptyAssistantContent(message: AgentMessage): boolean {
+  const content = (message as { content?: unknown }).content;
+  if (content == null) {
+    return true;
+  }
+  if (!Array.isArray(content)) {
+    return typeof content === "string" && content.trim().length === 0;
+  }
+  if (content.length === 0) {
+    return true;
+  }
+  return content.every((block) => {
+    if (!block || typeof block !== "object") {
+      return true;
+    }
+    const rec = block as { type?: unknown; text?: unknown };
+    if (isThinkingLikeBlock(block)) {
+      return true;
+    }
+    if (rec.type === "text") {
+      return typeof rec.text !== "string" || rec.text.trim().length === 0;
+    }
+    return false;
+  });
+}
+
+function isUnsendableTrailingAssistant(message: AgentMessage): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  if ((message as { role?: unknown }).role !== "assistant") {
+    return false;
+  }
+  if (isEffectivelyEmptyAssistantContent(message)) {
+    return true;
+  }
+  // Aborted/errored assistant turns without useful content cannot be the final
+  // message in an Anthropic request — they either fail the empty-content check
+  // or leave the transcript ending on an assistant role. Drop them even if
+  // they carry thinking-only blocks, since those would produce an empty
+  // outbound message anyway.
+  return isAbortedAssistantTurn(message) && isEffectivelyEmptyAssistantContent(message);
+}
+
+/**
+ * Drops trailing assistant turns that would make an Anthropic request invalid.
+ *
+ * The Anthropic Messages API requires the conversation to end with a user
+ * turn and rejects assistant turns with empty content. Several pipeline
+ * steps can produce such trailing turns:
+ *   - `stripDanglingAnthropicToolUses` empties aborted tool-only assistant
+ *     messages when their tool_use blocks cannot be matched.
+ *   - `filterHeartbeatPairs` removes `(user heartbeat, assistant HEARTBEAT_OK)`
+ *     pairs, which can expose a prior assistant turn at the tail if no real
+ *     user turn followed.
+ *   - `limitHistoryTurns` can leave the tail unchanged (it slices from the
+ *     oldest retained user turn) but subsequent tool pairing repair can
+ *     reshape trailing blocks.
+ *
+ * This helper removes only unambiguously unsendable trailing assistant turns
+ * (empty or aborted-with-no-content); it never drops an assistant turn that
+ * still carries real model output.
+ *
+ * Maintainer note: this is a good upstream PR candidate for anyone else
+ * using the pi-agent-core replay pipeline with Anthropic — the trailing
+ * empty/aborted assistant case is not handled by `validateAnthropicTurns`
+ * alone, and surfaces as opaque 400 errors from Opus 4.6/4.7.
+ */
+export function dropTrailingEmptyAssistantTurns(messages: AgentMessage[]): AgentMessage[] {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return messages;
+  }
+  let end = messages.length;
+  while (end > 0 && isUnsendableTrailingAssistant(messages[end - 1])) {
+    end -= 1;
+  }
+  return end === messages.length ? messages : messages.slice(0, end);
+}
+
+/**
+ * Returns true when the last message in the list is a user-like turn
+ * (`user`, `toolResult`, or `tool` role), which Anthropic accepts as the
+ * terminal message of a request.
+ */
+export function messagesEndWithUserTurn(messages: AgentMessage[]): boolean {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return false;
+  }
+  const last = messages[messages.length - 1];
+  if (!last || typeof last !== "object") {
+    return false;
+  }
+  const role = (last as { role?: unknown }).role;
+  return role === "user" || role === "toolResult" || role === "tool";
+}
+
 function extractToolResultMatchIds(record: Record<string, unknown>): Set<string> {
   const ids = new Set<string>();
   for (const value of [
@@ -363,17 +459,26 @@ export function mergeConsecutiveUserTurns(
 
 /**
  * Validates and fixes conversation turn sequences for Anthropic API.
- * Anthropic requires strict alternating user→assistant pattern.
- * Merges consecutive user messages together.
- * Also strips dangling tool_use blocks that lack corresponding tool_result blocks.
+ * Anthropic requires strict alternating user→assistant pattern and the
+ * conversation must end with a user-role turn. This helper:
+ *   1. Strips dangling tool_use blocks that lack matching tool_result blocks
+ *      (which can leave aborted assistant turns with empty content).
+ *   2. Merges consecutive user messages together.
+ *   3. Drops trailing empty/aborted assistant turns exposed by step 1 so the
+ *      transcript still ends on a valid user-like turn.
  */
 export function validateAnthropicTurns(messages: AgentMessage[]): AgentMessage[] {
   // First, strip dangling tool-call blocks from assistant messages.
   const stripped = stripDanglingAnthropicToolUses(messages);
 
-  return validateTurnsWithConsecutiveMerge({
+  const merged = validateTurnsWithConsecutiveMerge({
     messages: stripped,
     role: "user",
     merge: mergeConsecutiveUserTurns,
   });
+
+  // After stripping tool_use blocks, a trailing assistant turn can end up
+  // with empty content (e.g. aborted/errored retries). Those are not a
+  // valid terminal message for Anthropic, so drop them here too.
+  return dropTrailingEmptyAssistantTurns(merged);
 }

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -124,6 +124,35 @@ export function messagesEndWithUserTurn(messages: AgentMessage[]): boolean {
   return role === "user" || role === "toolResult" || role === "tool";
 }
 
+/**
+ * Decides whether to short-circuit an Anthropic request because the request
+ * would otherwise end on an `assistant` turn (which Anthropic rejects with
+ * "This model does not support assistant message prefill"). The session
+ * wrapper only appends a new user turn when the caller passes a non-empty
+ * prompt or images, so when neither is available and the transcript still
+ * ends with a non-empty assistant turn, we skip the provider call instead
+ * of letting the API reject it.
+ */
+export function shouldShortCircuitForMissingUserTail(params: {
+  validateAnthropicTurns: boolean;
+  messages: AgentMessage[];
+  promptText: string;
+  hasImages: boolean;
+}): boolean {
+  if (!params.validateAnthropicTurns) {
+    return false;
+  }
+  if (!Array.isArray(params.messages) || params.messages.length === 0) {
+    return false;
+  }
+  const promptHasContent =
+    typeof params.promptText === "string" && params.promptText.trim().length > 0;
+  if (promptHasContent || params.hasImages) {
+    return false;
+  }
+  return !messagesEndWithUserTurn(params.messages);
+}
+
 function extractToolResultMatchIds(record: Record<string, unknown>): Set<string> {
   const ids = new Set<string>();
   for (const value of [

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -426,16 +426,16 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     expect(streamFn).not.toBe(streamSimple);
   });
 
-  it("keeps explicit custom currentStreamFn values unchanged", () => {
+  it("keeps explicit custom currentStreamFn values unchanged for apis without a boundary-aware transport", () => {
     const currentStreamFn = vi.fn();
     const streamFn = resolveEmbeddedAgentStreamFn({
       currentStreamFn: currentStreamFn as never,
       shouldUseWebSocketTransport: false,
       sessionId: "session-1",
       model: {
-        api: "openai-responses",
-        provider: "openai",
-        id: "gpt-5.4",
+        api: "mistral-conversations",
+        provider: "mistral",
+        id: "mistral-large",
       } as never,
     });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1557,9 +1557,10 @@ export async function runEmbeddedAttempt(
           );
         }
         cacheTrace?.recordStage("session:limited", { messages: limited });
-        if (limited.length > 0 || skipPromptSubmission) {
-          activeSession.agent.state.messages = limited;
-        }
+        // Always write back: an empty result from dropTrailingEmptyAssistantTurns
+        // must still replace the stale tail so the deferred prune and
+        // shouldShortCircuitForMissingUserTail see the cleaned state.
+        activeSession.agent.state.messages = limited;
 
         if (params.contextEngine) {
           try {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -73,6 +73,7 @@ import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
+  dropAllTrailingNonUserTurns,
   dropTrailingEmptyAssistantTurns,
   isCloudCodeAssistFormatError,
   messagesEndWithUserTurn,
@@ -82,11 +83,11 @@ import {
   shouldShortCircuitForMissingUserTail,
 } from "../../pi-embedded-helpers.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
+import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import {
   applyPiAutoCompactionGuard,
   applyPiCompactionSettingsFromConfig,
 } from "../../pi-settings.js";
-import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import {
   createClientToolNameConflictError,
   findClientToolNameConflicts,
@@ -1464,6 +1465,7 @@ export async function runEmbeddedAttempt(
         );
       }
 
+      let skipPromptSubmission = false;
       try {
         const prior = await sanitizeSessionHistory({
           messages: activeSession.messages,
@@ -1520,7 +1522,7 @@ export async function runEmbeddedAttempt(
         // trailing assistants before handing the transcript off to the
         // provider. See `validateAnthropicTurns` for the initial pass and
         // `dropTrailingEmptyAssistantTurns` for the helper semantics.
-        const limited = transcriptPolicy.validateAnthropicTurns
+        let limited = transcriptPolicy.validateAnthropicTurns
           ? dropTrailingEmptyAssistantTurns(paired)
           : paired;
         if (
@@ -1528,20 +1530,53 @@ export async function runEmbeddedAttempt(
           limited.length > 0 &&
           !messagesEndWithUserTurn(limited)
         ) {
-          // Upstream should always leave a user-like tail before we send to
-          // Anthropic. Log loudly so the underlying bug (e.g. a heartbeat ack
-          // becoming the only tail, or a missing current user prompt) is
-          // visible. We intentionally do not mutate the history further: the
-          // provider call will surface the misuse instead of silently sending
-          // a degraded transcript.
-          log.warn(
-            `anthropic transcript guard: messages do not end with a user turn (len=${limited.length}, trailingRole=${String(
-              (limited[limited.length - 1] as { role?: unknown })?.role,
-            )}). This usually means heartbeat filtering or post-truncation repair ran without a fresh user prompt at the tail.`,
-          );
+          // The transcript ends on a non-user turn. This is expected in two
+          // very different situations:
+          //
+          // A) Normal follow-up — the user just typed a new message.
+          //    `session.prompt()` will append it as a user turn *after* this
+          //    sanitisation phase, so the trailing assistant is the previous
+          //    reply and should be kept (removing it would lose conversational
+          //    context and may collapse consecutive user turns).
+          //
+          // B) No fresh input — a heartbeat, cron, or retry where the caller
+          //    provides no new prompt and no images. `session.prompt()` will
+          //    NOT append a user turn, so the request would reach Anthropic
+          //    ending on an assistant turn and be rejected with HTTP 400
+          //    ("This model does not support assistant message prefill").
+          //    Gateway-injected error surfaces ("API provider returned a
+          //    billing error…", "LLM request rejected…") survive the empty/
+          //    thinking-only strip in `dropTrailingEmptyAssistantTurns` because
+          //    they carry real content, poisoning every subsequent attempt.
+          //
+          // Only strip trailing non-user turns in case (B) — when there is no
+          // fresh user prompt or image about to be appended.
+          const promptHasContent =
+            typeof params.prompt === "string" && params.prompt.trim().length > 0;
+          const hasImages = Array.isArray(params.images) && params.images.length > 0;
+
+          if (!promptHasContent && !hasImages) {
+            const trailingRole = String((limited[limited.length - 1] as { role?: unknown })?.role);
+            log.warn(
+              `anthropic transcript guard: messages do not end with a user turn and no fresh user input is available (len=${limited.length}, trailingRole=${trailingRole}). Dropping trailing non-user turns to keep the request sendable.`,
+            );
+            limited = dropAllTrailingNonUserTurns(limited);
+            if (limited.length === 0) {
+              log.warn(
+                `anthropic transcript guard: transcript emptied after dropping trailing non-user turns; skipping provider call. runId=${params.runId} sessionId=${params.sessionId}`,
+              );
+              skipPromptSubmission = true;
+            }
+          } else {
+            // Case (A): fresh input will be appended — leave the history
+            // intact. Log at debug level for diagnostics only.
+            log.debug(
+              `anthropic transcript guard: trailing non-user turn detected but fresh user input is available; leaving history intact (len=${limited.length}).`,
+            );
+          }
         }
         cacheTrace?.recordStage("session:limited", { messages: limited });
-        if (limited.length > 0) {
+        if (limited.length > 0 || skipPromptSubmission) {
           activeSession.agent.state.messages = limited;
         }
 
@@ -1841,7 +1876,6 @@ export async function runEmbeddedAttempt(
       let promptError: unknown = null;
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
       let promptErrorSource: "prompt" | "compaction" | "precheck" | null = null;
-      let skipPromptSubmission = false;
       try {
         const promptStartedAt = Date.now();
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1466,6 +1466,7 @@ export async function runEmbeddedAttempt(
       }
 
       let skipPromptSubmission = false;
+      let needsTrailingTurnPrune = false;
       try {
         const prior = await sanitizeSessionHistory({
           messages: activeSession.messages,
@@ -1536,44 +1537,24 @@ export async function runEmbeddedAttempt(
           // A) Normal follow-up — the user just typed a new message.
           //    `session.prompt()` will append it as a user turn *after* this
           //    sanitisation phase, so the trailing assistant is the previous
-          //    reply and should be kept (removing it would lose conversational
-          //    context and may collapse consecutive user turns).
+          //    reply and should be kept.
           //
           // B) No fresh input — a heartbeat, cron, or retry where the caller
           //    provides no new prompt and no images. `session.prompt()` will
           //    NOT append a user turn, so the request would reach Anthropic
-          //    ending on an assistant turn and be rejected with HTTP 400
-          //    ("This model does not support assistant message prefill").
-          //    Gateway-injected error surfaces ("API provider returned a
-          //    billing error…", "LLM request rejected…") survive the empty/
-          //    thinking-only strip in `dropTrailingEmptyAssistantTurns` because
-          //    they carry real content, poisoning every subsequent attempt.
+          //    ending on an assistant turn and be rejected with HTTP 400.
           //
-          // Only strip trailing non-user turns in case (B) — when there is no
-          // fresh user prompt or image about to be appended.
-          const promptHasContent =
-            typeof params.prompt === "string" && params.prompt.trim().length > 0;
-          const hasImages = Array.isArray(params.images) && params.images.length > 0;
-
-          if (!promptHasContent && !hasImages) {
-            const trailingRole = String((limited[limited.length - 1] as { role?: unknown })?.role);
-            log.warn(
-              `anthropic transcript guard: messages do not end with a user turn and no fresh user input is available (len=${limited.length}, trailingRole=${trailingRole}). Dropping trailing non-user turns to keep the request sendable.`,
-            );
-            limited = dropAllTrailingNonUserTurns(limited);
-            if (limited.length === 0) {
-              log.warn(
-                `anthropic transcript guard: transcript emptied after dropping trailing non-user turns; skipping provider call. runId=${params.runId} sessionId=${params.sessionId}`,
-              );
-              skipPromptSubmission = true;
-            }
-          } else {
-            // Case (A): fresh input will be appended — leave the history
-            // intact. Log at debug level for diagnostics only.
-            log.debug(
-              `anthropic transcript guard: trailing non-user turn detected but fresh user input is available; leaving history intact (len=${limited.length}).`,
-            );
-          }
+          // The raw `params.prompt` is not sufficient to tell these apart:
+          // bootstrap warnings, routing prefixes, and `before_prompt_build`
+          // hooks can still inject content that becomes a user turn even when
+          // `params.prompt` is empty. Defer the aggressive prune until after
+          // `effectivePrompt` is finalised so the decision sees the real
+          // outbound prompt, not just the caller input.
+          needsTrailingTurnPrune = true;
+          const trailingRole = String((limited[limited.length - 1] as { role?: unknown })?.role);
+          log.warn(
+            `anthropic transcript guard: messages do not end with a user turn (len=${limited.length}, trailingRole=${trailingRole}); deferring prune decision until effective prompt is finalized.`,
+          );
         }
         cacheTrace?.recordStage("session:limited", { messages: limited });
         if (limited.length > 0 || skipPromptSubmission) {
@@ -1939,6 +1920,41 @@ export async function runEmbeddedAttempt(
             systemPromptText = prependedOrAppendedSystemPrompt;
             log.debug(
               `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
+            );
+          }
+        }
+
+        // Deferred Anthropic-tail prune: the pre-flight guard flagged a
+        // trailing non-user turn but could not safely decide whether to strip
+        // it using `params.prompt` alone. Now that `effectivePrompt` has been
+        // finalised (bootstrap warning, routing prefix, and
+        // `before_prompt_build` hook context all applied), re-evaluate. Strip
+        // the tail only when no user turn will be appended downstream — i.e.
+        // the outbound prompt is empty/whitespace and no images are queued.
+        if (needsTrailingTurnPrune) {
+          const promptHasContent =
+            typeof effectivePrompt === "string" && effectivePrompt.trim().length > 0;
+          const hasImages = Array.isArray(params.images) && params.images.length > 0;
+          if (!promptHasContent && !hasImages) {
+            const stateMessages = activeSession.agent.state.messages;
+            const trailingRole =
+              stateMessages.length > 0
+                ? String((stateMessages[stateMessages.length - 1] as { role?: unknown })?.role)
+                : "none";
+            log.warn(
+              `anthropic transcript guard: effective prompt empty and no images after hooks (len=${stateMessages.length}, trailingRole=${trailingRole}); dropping trailing non-user turns to keep the request sendable.`,
+            );
+            const prunedMessages = dropAllTrailingNonUserTurns(stateMessages);
+            activeSession.agent.state.messages = prunedMessages;
+            if (prunedMessages.length === 0) {
+              log.warn(
+                `anthropic transcript guard: transcript emptied after dropping trailing non-user turns; skipping provider call. runId=${params.runId} sessionId=${params.sessionId}`,
+              );
+              skipPromptSubmission = true;
+            }
+          } else {
+            log.debug(
+              `anthropic transcript guard: trailing non-user turn detected but fresh user input is available after hooks; leaving history intact.`,
             );
           }
         }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2200,9 +2200,10 @@ export async function runEmbeddedAttempt(
             // transcript still ends on a non-empty assistant turn AND there is
             // no fresh user input, the outbound request would end on
             // `role: assistant`, which Anthropic rejects as an "assistant
-            // message prefill". Empty/aborted trailing assistants were already
-            // dropped by `dropTrailingEmptyAssistantTurns`, so anything still
-            // present is a fully-formed reply we should not re-submit.
+            // message prefill". `shouldShortCircuitForMissingUserTail` only
+            // fires on non-empty assistant tails; stale empty/aborted tails
+            // from a previous attempt are left for `dropTrailingEmptyAssistantTurns`
+            // to strip downstream and do not trigger a false-positive skip.
             log.warn(
               `anthropic transcript guard: skipping provider call because ` +
                 `the transcript already ends on a non-empty assistant turn ` +

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -79,6 +79,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
+  shouldShortCircuitForMissingUserTail,
 } from "../../pi-embedded-helpers.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import {
@@ -2181,6 +2182,33 @@ export async function runEmbeddedAttempt(
                 `reserveTokens=${reserveTokens} ` +
                 `effectiveReserveTokens=${preemptiveCompaction.effectiveReserveTokens} ` +
                 `sessionFile=${params.sessionFile}`,
+            );
+            skipPromptSubmission = true;
+          }
+
+          if (
+            !skipPromptSubmission &&
+            shouldShortCircuitForMissingUserTail({
+              validateAnthropicTurns: transcriptPolicy.validateAnthropicTurns,
+              messages: activeSession.messages,
+              promptText: effectivePrompt,
+              hasImages: imageResult.images.length > 0,
+            })
+          ) {
+            // pi-coding-agent's session.prompt() only appends a new user turn
+            // when the caller passes a non-empty prompt or images. If the
+            // transcript still ends on a non-empty assistant turn AND there is
+            // no fresh user input, the outbound request would end on
+            // `role: assistant`, which Anthropic rejects as an "assistant
+            // message prefill". Empty/aborted trailing assistants were already
+            // dropped by `dropTrailingEmptyAssistantTurns`, so anything still
+            // present is a fully-formed reply we should not re-submit.
+            log.warn(
+              `anthropic transcript guard: skipping provider call because ` +
+                `the transcript already ends on a non-empty assistant turn ` +
+                `and no fresh user prompt or image is available. ` +
+                `runId=${params.runId} sessionId=${params.sessionId} ` +
+                `messages=${activeSession.messages.length}`,
             );
             skipPromptSubmission = true;
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -73,7 +73,9 @@ import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
+  dropTrailingEmptyAssistantTurns,
   isCloudCodeAssistFormatError,
+  messagesEndWithUserTurn,
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
@@ -1505,11 +1507,38 @@ export async function runEmbeddedAttempt(
         // Re-run tool_use/tool_result pairing repair after truncation, since
         // limitHistoryTurns can orphan tool_result blocks by removing the
         // assistant message that contained the matching tool_use.
-        const limited = transcriptPolicy.repairToolUseResultPairing
+        const paired = transcriptPolicy.repairToolUseResultPairing
           ? sanitizeToolUseResultPairing(truncated, {
               erroredAssistantResultPolicy: "drop",
             })
           : truncated;
+        // Final Anthropic-tail guard: post-processing (heartbeat pair removal,
+        // history truncation, tool_use/tool_result repair) can expose an empty
+        // or aborted trailing assistant turn, which Anthropic rejects because
+        // the conversation no longer ends on a user-role turn. Strip any such
+        // trailing assistants before handing the transcript off to the
+        // provider. See `validateAnthropicTurns` for the initial pass and
+        // `dropTrailingEmptyAssistantTurns` for the helper semantics.
+        const limited = transcriptPolicy.validateAnthropicTurns
+          ? dropTrailingEmptyAssistantTurns(paired)
+          : paired;
+        if (
+          transcriptPolicy.validateAnthropicTurns &&
+          limited.length > 0 &&
+          !messagesEndWithUserTurn(limited)
+        ) {
+          // Upstream should always leave a user-like tail before we send to
+          // Anthropic. Log loudly so the underlying bug (e.g. a heartbeat ack
+          // becoming the only tail, or a missing current user prompt) is
+          // visible. We intentionally do not mutate the history further: the
+          // provider call will surface the misuse instead of silently sending
+          // a degraded transcript.
+          log.warn(
+            `anthropic transcript guard: messages do not end with a user turn (len=${limited.length}, trailingRole=${String(
+              (limited[limited.length - 1] as { role?: unknown })?.role,
+            )}). This usually means heartbeat filtering or post-truncation repair ran without a fresh user prompt at the tail.`,
+          );
+        }
         cacheTrace?.recordStage("session:limited", { messages: limited });
         if (limited.length > 0) {
           activeSession.agent.state.messages = limited;

--- a/src/agents/pi-embedded-runner/stream-resolution.test.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.test.ts
@@ -50,15 +50,29 @@ describe("describeEmbeddedAgentStreamStrategy", () => {
     ).toBe("boundary-aware:openai-codex-responses");
   });
 
-  it("keeps custom session streams labeled as custom", () => {
+  it("prefers boundary-aware transport even when a session wrapper hides streamSimple", () => {
     expect(
       describeEmbeddedAgentStreamStrategy({
         currentStreamFn: vi.fn() as never,
         shouldUseWebSocketTransport: false,
         model: {
-          api: "openai-responses",
-          provider: "openai",
-          id: "gpt-5.4",
+          api: "anthropic-messages",
+          provider: "anthropic",
+          id: "claude-opus-4-7",
+        } as never,
+      }),
+    ).toBe("boundary-aware:anthropic-messages");
+  });
+
+  it("falls back to session-custom for apis without a boundary-aware transport", () => {
+    expect(
+      describeEmbeddedAgentStreamStrategy({
+        currentStreamFn: vi.fn() as never,
+        shouldUseWebSocketTransport: false,
+        model: {
+          api: "mistral-conversations",
+          provider: "mistral",
+          id: "mistral-large",
         } as never,
       }),
     ).toBe("session-custom");
@@ -109,6 +123,57 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     });
 
     expect(streamFn).not.toBe(streamSimple);
+  });
+
+  it("routes Anthropic sessions through boundary-aware transport even when pi-coding-agent wraps streamSimple", () => {
+    const sessionWrapper = vi.fn();
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: sessionWrapper as never,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-opus-4-7",
+      } as never,
+    });
+
+    expect(streamFn).not.toBe(sessionWrapper);
+    expect(streamFn).not.toBe(streamSimple);
+  });
+
+  it("injects the resolved api key into the boundary-aware Anthropic transport", async () => {
+    const sessionWrapper = vi.fn();
+    const captured: { apiKey?: string } = {};
+    const fakeBoundaryAwareStream = vi.fn(async (_m, _ctx, opts) => {
+      captured.apiKey = (opts as { apiKey?: string } | undefined)?.apiKey;
+      return opts;
+    });
+    const provider = await import("../provider-transport-stream.js");
+    const spy = vi
+      .spyOn(provider, "createBoundaryAwareStreamFnForModel")
+      .mockReturnValue(fakeBoundaryAwareStream as never);
+    try {
+      const streamFn = resolveEmbeddedAgentStreamFn({
+        currentStreamFn: sessionWrapper as never,
+        shouldUseWebSocketTransport: false,
+        sessionId: "session-1",
+        model: {
+          api: "anthropic-messages",
+          provider: "anthropic",
+          id: "claude-opus-4-7",
+        } as never,
+        resolvedApiKey: "resolved-key",
+      });
+
+      await streamFn({ provider: "anthropic", id: "claude-opus-4-7" } as never, {} as never, {
+        apiKey: "stale",
+      });
+      expect(captured.apiKey).toBe("resolved-key");
+      expect(fakeBoundaryAwareStream).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("injects the resolved run api key into provider-owned stream functions", async () => {

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -3,7 +3,10 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import { createAnthropicVertexStreamFnForModel } from "../anthropic-vertex-stream.js";
 import { createOpenAIWebSocketStreamFn } from "../openai-ws-stream.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
-import { createBoundaryAwareStreamFnForModel } from "../provider-transport-stream.js";
+import {
+  createBoundaryAwareStreamFnForModel,
+  isTransportAwareApiSupported,
+} from "../provider-transport-stream.js";
 import { stripSystemPromptCacheBoundary } from "../system-prompt-cache-boundary.js";
 import type { EmbeddedRunAttemptParams } from "./run/types.js";
 
@@ -41,10 +44,14 @@ export function describeEmbeddedAgentStreamStrategy(params: {
   if (params.model.provider === "anthropic-vertex") {
     return "anthropic-vertex";
   }
+  if (
+    isTransportAwareApiSupported(params.model.api) &&
+    createBoundaryAwareStreamFnForModel(params.model)
+  ) {
+    return `boundary-aware:${params.model.api}`;
+  }
   if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
-    return createBoundaryAwareStreamFnForModel(params.model)
-      ? `boundary-aware:${params.model.api}`
-      : "stream-simple";
+    return "stream-simple";
   }
   return "session-custom";
 }
@@ -117,11 +124,29 @@ export function resolveEmbeddedAgentStreamFn(params: {
     return createAnthropicVertexStreamFnForModel(params.model);
   }
 
-  if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
-    const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
-    if (boundaryAwareStreamFn) {
-      return boundaryAwareStreamFn;
+  // Prefer the boundary-aware transport for supported APIs regardless of what
+  // pi-coding-agent has wrapped `streamSimple` with. The session's default
+  // wrapper injects apiKey + headers and then calls pi-ai's streamSimple,
+  // which still carries vendor-specific compat gaps (e.g. Anthropic adaptive
+  // thinking for Opus 4.7). The OpenClaw transport implements those contracts
+  // correctly, so we route to it and re-apply apiKey injection here.
+  const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
+  if (boundaryAwareStreamFn) {
+    if (params.authStorage || params.resolvedApiKey) {
+      const { authStorage, model, resolvedApiKey } = params;
+      return async (m, context, options) => {
+        const apiKey = await resolveEmbeddedAgentApiKey({
+          provider: model.provider,
+          resolvedApiKey,
+          authStorage,
+        });
+        return boundaryAwareStreamFn(m, context, {
+          ...options,
+          apiKey: apiKey ?? options?.apiKey,
+        });
+      };
     }
+    return boundaryAwareStreamFn;
   }
 
   return currentStreamFn;


### PR DESCRIPTION
## Summary

Two related bugs that made Anthropic sessions (specifically Claude Opus 4.7 with adaptive thinking) unusable when the pi-coding-agent wrapper was active.

### Bug 1 — `thinking.type.enabled` rejected by Opus 4.7

**Symptom:** API rejects requests with malformed `thinking` field when `supportsAdaptiveThinking(claude-opus-4-7) === true`.

**Root cause:** pi-coding-agent's `streamSimple` wrapper bypassed OpenClaw's boundary-aware Anthropic transport and fell back to pi-ai's `streamSimpleAnthropic`, which emits a legacy `thinking.type` shape incompatible with Claude 4.7's adaptive thinking API.

**Fix:** `stream-resolution.ts` now routes all supported Anthropic APIs through the OpenClaw transport unconditionally (commit `4a11d2b165`).

### Bug 2 — "assistant message prefill" error

**Symptom:** Provider call fails with "assistant message prefill" when a session's transcript tail is an assistant turn and there's no fresh user input.

**Root cause:** An empty-prompt path could reach `activeSession.prompt()` when the transcript ended on an assistant turn (e.g. after a heartbeat or system event without a user follow-up). The existing guard only warned; it didn't mutate the request or skip it.

**Fix:** New `shouldShortCircuitForMissingUserTail()` helper; sets `skipPromptSubmission = true` when no fresh user input is available (commit `0eaee207e8`).

## Verification

- ✅ 11 stream-resolution tests pass
- ✅ 49 validate-turns tests pass
- ✅ `pnpm tsgo` clean
- ✅ `pnpm build` clean
- ✅ Bundled dist contains changes
- ✅ Gateway restarted against these commits; session previously hitting both bugs is now stable

## Notes

- Built on top of existing local patch `a1e7bcb0e6` ("drop trailing empty/aborted assistant turns before Anthropic send") — that patch prevents malformed transcripts from going out; these two fixes prevent the upstream conditions that produce them in the first place.
- Tested against real Opus 4.7 API traffic in a long-running orchestrator session.
