### PR TITLE
fix(tasks): add tolerance for startedAt before createdAt in task audit

### DIFF
--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -99,4 +99,50 @@ describe("task-registry audit", () => {
 
     expect(findings.map((finding) => finding.code)).toEqual(["lost"]);
   });
+
+  it("does not flag startedAt slightly before createdAt (in-flight registration)", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const createdAt = now - 60_000;
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "inflight",
+          status: "succeeded",
+          // startedAt captured 500ms before the task record was created —
+          // this is the normal in-flight registration pattern.
+          createdAt,
+          startedAt: createdAt - 500,
+          endedAt: createdAt + 5_000,
+          cleanupAfter: createdAt + 3_600_000,
+        }),
+      ],
+    });
+
+    expect(findings.map((f) => f.code)).toEqual([]);
+  });
+
+  it("flags startedAt far before createdAt as genuinely inconsistent", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const createdAt = now - 60_000;
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "corrupt",
+          status: "succeeded",
+          // startedAt 2 minutes before createdAt — well beyond the 30s
+          // tolerance, indicating genuinely corrupt data.
+          createdAt,
+          startedAt: createdAt - 120_000,
+          endedAt: createdAt + 5_000,
+          cleanupAfter: createdAt + 3_600_000,
+        }),
+      ],
+    });
+
+    expect(findings.map((f) => [f.code, f.task.taskId])).toEqual([
+      ["inconsistent_timestamps", "corrupt"],
+    ]);
+  });
 });

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -45,8 +45,22 @@ function taskReferenceAt(task: TaskRecord): number {
   return task.lastEventAt ?? task.startedAt ?? task.createdAt;
 }
 
+/**
+ * Tasks frequently start before their registry record is created (in-flight
+ * registration). `startedAt` is captured at tool-call start, while `createdAt`
+ * is set inside `createTaskRecord` which runs later. A small negative delta
+ * (startedAt < createdAt) is therefore architecturally expected and should not
+ * produce a warning. Only flag genuinely corrupt data where the gap exceeds a
+ * generous tolerance window.
+ */
+const STARTED_BEFORE_CREATED_TOLERANCE_MS = 30_000;
+
 function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
-  if (task.startedAt && task.startedAt < task.createdAt) {
+  if (
+    task.startedAt &&
+    task.startedAt < task.createdAt &&
+    task.createdAt - task.startedAt > STARTED_BEFORE_CREATED_TOLERANCE_MS
+  ) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",


### PR DESCRIPTION
## Summary

`openclaw tasks audit` reports false-positive `inconsistent_timestamps` warnings on the majority of tasks (both succeeded and failed), making the audit output noisy and hiding real issues.

## Root Cause

Tasks frequently start before their registry record is created. The `startedAt` timestamp is captured at tool-call initiation time (e.g. `Date.now()` in `pi-embedded-subscribe.handlers.tools.ts:579`), while `createdAt` is set inside `createTaskRecord()` which runs later. This means `startedAt < createdAt` is architecturally expected for any in-flight registration.

The audit was checking `startedAt < createdAt` with zero tolerance, flagging every task where even 1ms of processing occurred between start and registration.

## Fix

Add a 30-second tolerance window to the `findTimestampInconsistency` check. Only flag when `createdAt - startedAt > 30s`, which catches genuinely corrupt data while allowing normal tool-call-to-registration latency.

## Changes

- `src/tasks/task-registry.audit.ts`: Add `STARTED_BEFORE_CREATED_TOLERANCE_MS` (30s) constant and gate the check on the gap exceeding this tolerance
- `src/tasks/task-registry.audit.test.ts`: Add two tests:
  - In-flight registration (500ms gap) does NOT produce a warning
  - Genuinely corrupt data (120s gap) still produces a warning

## Testing

All 5 audit tests pass (3 existing + 2 new).

Fixes #69229