### PR TITLE
fix(acp): declare TOOL_EVENTS capability so live tool calls reach ACP clients

### DIFF
--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -5,7 +5,11 @@ import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
 import { loadConfig } from "../config/config.js";
 import { resolveGatewayClientBootstrap } from "../gateway/client-bootstrap.js";
 import { GatewayClient } from "../gateway/client.js";
-import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
+import {
+  GATEWAY_CLIENT_CAPS,
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../gateway/protocol/client-info.js";
 import { isMainModule } from "../infra/is-main.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { readSecretFromFile } from "./secret-file.js";
@@ -60,6 +64,12 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     clientDisplayName: "ACP",
     clientVersion: "acp",
     mode: GATEWAY_CLIENT_MODES.CLI,
+    // Without TOOL_EVENTS the gateway never registers this connection as a
+    // toolEventRecipient, so `tool` stream events are dropped before they
+    // reach `AcpGatewayAgent.handleAgentEvent`. The agent already filters
+    // for `stream === "tool"` (see translator.ts), so it's a no-op when the
+    // events do arrive — we only need to opt in to the firehose.
+    caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
     onEvent: (evt) => {
       void agent?.handleGatewayEvent(evt);
     },


### PR DESCRIPTION
## Summary

- **Problem:** The `openclaw acp` bridge constructs its `GatewayClient` without a `caps` array. The gateway uses `caps` to decide which event firehoses to forward — specifically `wantsToolEvents` (see `src/gateway/server-methods/chat.ts`, the `client?.connect?.caps` check that gates `toolEventRecipient` registration). With `caps: []` the bridge is never registered, so `stream === "tool"` events from the agent never reach `AcpGatewayAgent.handleAgentEvent` (which already filters for that exact stream — `src/acp/translator.ts:845` `if (stream !== "tool") return;`).
- **Why it matters:** ACP clients (Zed, claude-code, third-party ACP front-ends) never see `session/update` notifications with `sessionUpdate: "tool_call"` or `tool_call_update` while a prompt is live. They DO see them in `session/load` replay, which masks the bug in casual testing.
- **What changed:** Declare `caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS]` when the ACP bridge connects to the gateway. One-line behavior change plus the import.
- **What did NOT change (scope boundary):** No protocol changes, no translator changes, no event semantics changes — the agent already emits the events and the translator already handles them. This patch only opts the bridge into the existing firehose.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `serveAcpGateway` constructed `GatewayClient` with no `caps`, so `wantsToolEvents` resolved to `false` and the gateway never added the bridge to `toolEventRecipients`. `stream: "tool"` events were dropped before reaching the ACP translator.
- **Missing detection / guardrail:** No coverage that asserts a live ACP `prompt` produces `tool_call` / `tool_call_update` ACP updates (only `session/load` replay was effectively exercised).
- **Contributing context:** The bug is silent because `session/load` history correctly contains tool-call entries — only live runs are affected.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Seam / integration test
- **Target test:** A new test alongside `src/acp/server.test.ts` (or `src/gateway/server-methods/chat.test.ts`) that wires an `AcpGatewayAgent` against a fake gateway, dispatches a `stream: "tool"` agent event, and asserts a `session/update` with `sessionUpdate: "tool_call"` is delivered.
- **Scenario the test should lock in:** ACP bridge declares TOOL_EVENTS → gateway registers it as a `toolEventRecipient` → live `tool` stream events flow through translator → ACP client receives `tool_call` updates.
- **Why this is the smallest reliable guardrail:** It exercises the exact wiring that broke (`caps → registration → forward → translate`) without standing up a real model run.

## User-visible / Behavior Changes

ACP clients now receive live `session/update` notifications for `tool_call` and `tool_call_update` during a running prompt (matching the existing `session/load` replay behavior). Behavior for non-ACP clients is unchanged.

## Diagram

```text
Before:
agent --emit stream:"tool"--> gateway --(bridge has no TOOL_EVENTS cap)--> DROPPED
                                                                          ↓
                                                             ACP client sees nothing live

After:
agent --emit stream:"tool"--> gateway --(bridge registered as toolEventRecipient)
       --> AcpGatewayAgent.handleAgentEvent --> translator --> session/update {tool_call*}
                                                                          ↓
                                                             ACP client renders live tool calls
```

## Security Impact

- New permissions/capabilities? **No** (declares an existing capability flag for the same process)
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No** (events were already produced; only their delivery to the local ACP bridge is restored)
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime: Node 22, openclaw at `042c117`
- Model/provider: any provider that triggers a tool call (verified with a Bash-using prompt)
- Integration/channel: `openclaw acp` bridge consumed by an ACP client

### Steps

1. Build openclaw at `042c117` (no patch) and start the ACP bridge.
2. Send a prompt that forces a tool call (e.g. "run `ls /tmp`").
3. Observe ACP `session/update` notifications.
4. Apply the patch, rebuild, repeat.

### Expected

- `session/update` notifications include `sessionUpdate: "tool_call"` and `tool_call_update` during the live prompt.

### Actual (before patch)

- Only `agent_message_chunk` and `session_info_update` arrive live; `tool_call*` updates appear only via `session/load`.

### Actual (after patch)

- `tool_call` and `tool_call_update` updates stream live during the prompt.

## Evidence

- [x] Failing repro before + passing after (manual ACP probe against the bridge; logs show `tool_call` updates only with `caps: ["tool-events"]` declared).

## Human Verification

- **Verified scenarios:** Live ACP `prompt` against the bridge with a Bash tool call; confirmed `tool_call` / `tool_call_update` updates arrive live after the patch and don't arrive without it.
- **Edge cases checked:** Non-tool-using prompts still behave identically; `session/load` replay unchanged.
- **What I did not verify:** Multi-tool concurrency stress; cross-version ACP client compatibility beyond a single client.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** Slightly higher event volume on the bridge connection now that `tool` events are forwarded.
  - **Mitigation:** This matches every other client that already declares `TOOL_EVENTS`; no new event types are introduced.