### PR TITLE
fix(gateway): surface stream:"thinking" events in chat broadcasts

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1467,4 +1467,114 @@ describe("agent event handler", () => {
       "Disk usage crossed 95 percent on /data and needs cleanup now.",
     );
   });
+
+  // Regression for greptile P1 on PR #69277: a thinking-only delta must NOT
+  // append a `{type:"text", text:""}` block, otherwise the ACP translator
+  // converts it into a spurious empty `agent_message_chunk`.
+  it("emits a thinking-only chat delta with no empty text block", () => {
+    const { broadcast, nodeSendToSession, chatRunState, handler, nowSpy } = createHarness({
+      now: 1_000,
+    });
+    chatRunState.registry.add("run-thinking", {
+      sessionKey: "session-thinking",
+      clientRunId: "client-thinking",
+    });
+
+    handler({
+      runId: "run-thinking",
+      seq: 1,
+      stream: "thinking",
+      ts: Date.now(),
+      data: { text: "weighing options" },
+    });
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(1);
+    const payload = chatCalls[0]?.[1] as {
+      state?: string;
+      message?: {
+        content?: Array<{ type?: string; text?: string; thinking?: string }>;
+      };
+    };
+    expect(payload.state).toBe("delta");
+    expect(payload.message?.content).toEqual([{ type: "thinking", thinking: "weighing options" }]);
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy?.mockRestore();
+  });
+
+  // Regression for greptile outside-diff comment on PR #69277: a throttled
+  // thinking event must still be flushed via the pre-final delta path even
+  // when no assistant text has accumulated, so the client receives the
+  // latest reasoning slice as a delta rather than first seeing it in the
+  // final event.
+  it("flushes a pending thinking-only delta before the final event", () => {
+    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const { broadcast, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-thinking-flush", {
+      sessionKey: "session-thinking-flush",
+      clientRunId: "client-thinking-flush",
+    });
+
+    handler({
+      runId: "run-thinking-flush",
+      seq: 1,
+      stream: "thinking",
+      ts: 1_000,
+      data: { text: "first thought" },
+    });
+
+    dateSpy.mockReturnValue(1_050);
+    handler({
+      runId: "run-thinking-flush",
+      seq: 2,
+      stream: "thinking",
+      ts: 1_050,
+      data: { text: "first thought, then more" },
+    });
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
+
+    dateSpy.mockReturnValue(2_000);
+    emitLifecycleEnd(handler, "run-thinking-flush", 3);
+
+    // Cumulative broadcast calls: first delta (1_000) + pre-final flush (2_000)
+    // + final (2_000). Without the flush fix, the middle entry would be missing
+    // and the throttled second thinking slice would only surface in `final`.
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(3);
+
+    const firstDeltaPayload = chatCalls[0]?.[1] as {
+      state?: string;
+      message?: {
+        content?: Array<{ type?: string; text?: string; thinking?: string }>;
+      };
+    };
+    expect(firstDeltaPayload.state).toBe("delta");
+    expect(firstDeltaPayload.message?.content).toEqual([
+      { type: "thinking", thinking: "first thought" },
+    ]);
+
+    const flushPayload = chatCalls[1]?.[1] as {
+      state?: string;
+      message?: {
+        content?: Array<{ type?: string; text?: string; thinking?: string }>;
+      };
+    };
+    expect(flushPayload.state).toBe("delta");
+    expect(flushPayload.message?.content).toEqual([
+      { type: "thinking", thinking: "first thought, then more" },
+    ]);
+
+    const finalPayload = chatCalls[2]?.[1] as {
+      state?: string;
+      message?: {
+        content?: Array<{ type?: string; text?: string; thinking?: string }>;
+      };
+    };
+    expect(finalPayload.state).toBe("final");
+    expect(finalPayload.message?.content).toEqual([
+      { type: "thinking", thinking: "first thought, then more" },
+    ]);
+
+    dateSpy.mockRestore();
+  });
 });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -198,9 +198,16 @@ export type ChatRunState = {
   registry: ChatRunRegistry;
   rawBuffers: Map<string, string>;
   buffers: Map<string, string>;
+  /** Per-clientRunId reasoning text buffer (mirrors `buffers`/`rawBuffers`).
+   *  Populated from `stream: "thinking"` agent events so chat deltas can carry
+   *  a thinking block alongside the assistant text block. */
+  thinkingBuffers: Map<string, string>;
   deltaSentAt: Map<string, number>;
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
+  /** Length of thinking text at last broadcast — combined with deltaLastBroadcastLen
+   *  so thinking-only deltas still get flushed past the throttle. */
+  deltaLastBroadcastThinkingLen: Map<string, number>;
   abortedRuns: Map<string, number>;
   clear: () => void;
 };
@@ -209,16 +216,20 @@ export function createChatRunState(): ChatRunState {
   const registry = createChatRunRegistry();
   const rawBuffers = new Map<string, string>();
   const buffers = new Map<string, string>();
+  const thinkingBuffers = new Map<string, string>();
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
+  const deltaLastBroadcastThinkingLen = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
 
   const clear = () => {
     registry.clear();
     rawBuffers.clear();
     buffers.clear();
+    thinkingBuffers.clear();
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
+    deltaLastBroadcastThinkingLen.clear();
     abortedRuns.clear();
   };
 
@@ -226,8 +237,10 @@ export function createChatRunState(): ChatRunState {
     registry,
     rawBuffers,
     buffers,
+    thinkingBuffers,
     deltaSentAt,
     deltaLastBroadcastLen,
+    deltaLastBroadcastThinkingLen,
     abortedRuns,
     clear,
   };
@@ -489,8 +502,10 @@ export function createAgentEventHandler({
   const clearBufferedChatState = (clientRunId: string) => {
     chatRunState.rawBuffers.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
+    chatRunState.thinkingBuffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
+    chatRunState.deltaLastBroadcastThinkingLen.delete(clientRunId);
   };
 
   const clearPendingTerminalLifecycleError = (runId: string) => {
@@ -680,6 +695,39 @@ export function createAgentEventHandler({
     pendingTerminalLifecycleErrors.set(evt.runId, timer);
   };
 
+  /**
+   * Build the `message.content` array for a chat broadcast, merging the
+   * assistant text block with the current thinking buffer (if any). The
+   * thinking block uses the shape that `acp/translator.ts:handleDeltaEvent`
+   * already understands (`{type: "thinking", thinking: <text>}`), so ACP
+   * clients receive `agent_thought_chunk` updates without further changes.
+   */
+  const buildAssistantContent = (clientRunId: string, mergedText: string) => {
+    const thinkingText = chatRunState.thinkingBuffers.get(clientRunId) ?? "";
+    const blocks: Array<{ type: string; text?: string; thinking?: string }> = [];
+    if (thinkingText) {
+      blocks.push({ type: "thinking", thinking: thinkingText });
+    }
+    blocks.push({ type: "text", text: mergedText });
+    return blocks;
+  };
+
+  const accumulateThinking = (clientRunId: string, text: string, delta?: unknown) => {
+    const cleanedText = typeof text === "string" ? text : "";
+    const cleanedDelta = typeof delta === "string" ? delta : "";
+    const previous = chatRunState.thinkingBuffers.get(clientRunId) ?? "";
+    const merged = resolveMergedAssistantText({
+      previousText: previous,
+      nextText: cleanedText,
+      nextDelta: cleanedDelta,
+    });
+    if (!merged) {
+      return previous;
+    }
+    chatRunState.thinkingBuffers.set(clientRunId, merged);
+    return merged;
+  };
+
   const emitChatDelta = (
     sessionKey: string,
     clientRunId: string,
@@ -729,6 +777,8 @@ export function createAgentEventHandler({
     }
     chatRunState.deltaSentAt.set(clientRunId, now);
     chatRunState.deltaLastBroadcastLen.set(clientRunId, mergedText.length);
+    const thinkingText = chatRunState.thinkingBuffers.get(clientRunId) ?? "";
+    chatRunState.deltaLastBroadcastThinkingLen.set(clientRunId, thinkingText.length);
     const payload = {
       runId: clientRunId,
       sessionKey,
@@ -736,7 +786,56 @@ export function createAgentEventHandler({
       state: "delta" as const,
       message: {
         role: "assistant",
-        content: [{ type: "text", text: mergedText }],
+        content: buildAssistantContent(clientRunId, mergedText),
+        timestamp: now,
+      },
+    };
+    broadcast("chat", payload, { dropIfSlow: true });
+    nodeSendToSession(sessionKey, "chat", payload);
+  };
+
+  /**
+   * Broadcasts a chat delta whose `content` carries a thinking block (and the
+   * current assistant text, if any). Triggered by `stream: "thinking"` agent
+   * events so ACP/webchat clients can render reasoning live instead of waiting
+   * for the final result. Throttled with the same 150 ms window as text deltas.
+   */
+  const emitChatThinkingDelta = (
+    sessionKey: string,
+    clientRunId: string,
+    sourceRunId: string,
+    seq: number,
+    text: string,
+    delta?: unknown,
+  ) => {
+    if (shouldHideHeartbeatChatOutput(clientRunId, sourceRunId)) {
+      return;
+    }
+    const merged = accumulateThinking(clientRunId, text, delta);
+    if (!merged) {
+      return;
+    }
+    const lastThinkingLen = chatRunState.deltaLastBroadcastThinkingLen.get(clientRunId) ?? 0;
+    if (merged.length <= lastThinkingLen) {
+      return;
+    }
+    const now = Date.now();
+    const last = chatRunState.deltaSentAt.get(clientRunId) ?? 0;
+    if (now - last < 150) {
+      return;
+    }
+    chatRunState.deltaSentAt.set(clientRunId, now);
+    chatRunState.deltaLastBroadcastThinkingLen.set(clientRunId, merged.length);
+    const assistantText = chatRunState.buffers.get(clientRunId) ?? "";
+    chatRunState.deltaLastBroadcastLen.set(clientRunId, assistantText.length);
+    const payload = {
+      runId: clientRunId,
+      sessionKey,
+      seq,
+      state: "delta" as const,
+      message: {
+        role: "assistant",
+        content: buildAssistantContent(clientRunId, assistantText),
         timestamp: now,
       },
     };
@@ -781,7 +880,11 @@ export function createAgentEventHandler({
     }
 
     const lastBroadcastLen = chatRunState.deltaLastBroadcastLen.get(clientRunId) ?? 0;
-    if (text.length <= lastBroadcastLen) {
+    const thinkingText = chatRunState.thinkingBuffers.get(clientRunId) ?? "";
+    const lastThinkingLen = chatRunState.deltaLastBroadcastThinkingLen.get(clientRunId) ?? 0;
+    const textGrew = text.length > lastBroadcastLen;
+    const thinkingGrew = thinkingText.length > lastThinkingLen;
+    if (!textGrew && !thinkingGrew) {
       return;
     }
 
@@ -793,13 +896,14 @@ export function createAgentEventHandler({
       state: "delta" as const,
       message: {
         role: "assistant",
-        content: [{ type: "text", text }],
+        content: buildAssistantContent(clientRunId, text),
         timestamp: now,
       },
     };
     broadcast("chat", flushPayload, { dropIfSlow: true });
     nodeSendToSession(sessionKey, "chat", flushPayload);
     chatRunState.deltaLastBroadcastLen.set(clientRunId, text.length);
+    chatRunState.deltaLastBroadcastThinkingLen.set(clientRunId, thinkingText.length);
     chatRunState.deltaSentAt.set(clientRunId, now);
   };
 
@@ -819,25 +923,41 @@ export function createAgentEventHandler({
     // suppressed the most recent chunk, leaving the client with stale text.
     // Only flush if the buffer has grown since the last broadcast to avoid duplicates.
     flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, sourceRunId, seq);
+    const finalThinkingText = chatRunState.thinkingBuffers.get(clientRunId) ?? "";
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
+    chatRunState.deltaLastBroadcastThinkingLen.delete(clientRunId);
     chatRunState.rawBuffers.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
+    chatRunState.thinkingBuffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     if (jobState === "done") {
+      const hasVisibleText = Boolean(text) && !shouldSuppressSilent;
+      const hasThinking = finalThinkingText.length > 0;
+      let finalContent:
+        | Array<{ type: string; text?: string; thinking?: string }>
+        | undefined;
+      if (hasVisibleText || hasThinking) {
+        finalContent = [];
+        if (hasThinking) {
+          finalContent.push({ type: "thinking", thinking: finalThinkingText });
+        }
+        if (hasVisibleText) {
+          finalContent.push({ type: "text", text });
+        }
+      }
       const payload = {
         runId: clientRunId,
         sessionKey,
         seq,
         state: "final" as const,
         ...(stopReason && { stopReason }),
-        message:
-          text && !shouldSuppressSilent
-            ? {
-                role: "assistant",
-                content: [{ type: "text", text }],
-                timestamp: Date.now(),
-              }
-            : undefined,
+        message: finalContent
+          ? {
+              role: "assistant",
+              content: finalContent,
+              timestamp: Date.now(),
+            }
+          : undefined,
       };
       broadcast("chat", payload);
       nodeSendToSession(sessionKey, "chat", payload);
@@ -982,6 +1102,19 @@ export function createAgentEventHandler({
       }
       if (!isAborted && evt.stream === "assistant" && typeof evt.data?.text === "string") {
         emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text, evt.data.delta);
+      }
+      // Surface streamed reasoning as a thinking block on the chat broadcast so
+      // ACP clients (translator.ts → agent_thought_chunk) and webchat UI can
+      // render the agent's thought process live, not just after the run ends.
+      if (!isAborted && evt.stream === "thinking" && typeof evt.data?.text === "string") {
+        emitChatThinkingDelta(
+          sessionKey,
+          clientRunId,
+          evt.runId,
+          evt.seq,
+          evt.data.text,
+          evt.data.delta,
+        );
       }
     }
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -708,7 +708,14 @@ export function createAgentEventHandler({
     if (thinkingText) {
       blocks.push({ type: "thinking", thinking: thinkingText });
     }
-    blocks.push({ type: "text", text: mergedText });
+    // Guard against producing a spurious empty `{type:"text", text:""}` block
+    // for thinking-only deltas (before any assistant text has arrived). The
+    // ACP translator would otherwise convert that into an empty
+    // `agent_message_chunk`. `emitChatFinal` already uses an equivalent
+    // `if (hasVisibleText)` guard for the final payload.
+    if (mergedText) {
+      blocks.push({ type: "text", text: mergedText });
+    }
     return blocks;
   };
 
@@ -870,8 +877,13 @@ export function createAgentEventHandler({
       clientRunId,
       sourceRunId,
     );
+    // The text-based suppression flags only trigger when there IS assistant
+    // text to suppress; when text is empty (thinking-only run, or pre-text
+    // throttled tail) they are all false, so dropping the standalone `!text`
+    // bail allows reasoning-only flushes to reach the client. The
+    // `!textGrew && !thinkingGrew` check below still bails when there is
+    // genuinely nothing new to broadcast.
     if (
-      !text ||
       shouldSuppressSilent ||
       shouldSuppressSilentLeadFragment ||
       shouldSuppressHeartbeatStreaming
@@ -933,9 +945,7 @@ export function createAgentEventHandler({
     if (jobState === "done") {
       const hasVisibleText = Boolean(text) && !shouldSuppressSilent;
       const hasThinking = finalThinkingText.length > 0;
-      let finalContent:
-        | Array<{ type: string; text?: string; thinking?: string }>
-        | undefined;
+      let finalContent: Array<{ type: string; text?: string; thinking?: string }> | undefined;
       if (hasVisibleText || hasThinking) {
         finalContent = [];
         if (hasThinking) {


### PR DESCRIPTION
## Summary

- **Problem:** Reasoning emitted by the agent runtime via `emitAgentEvent({ stream: "thinking", ... })` (see `src/agents/pi-embedded-subscribe.ts:emitReasoningStream`) never reached chat broadcasts. `createAgentEventHandler` only forwarded `stream === "assistant"` into the chat pipeline, and even if a thinking event got through, `emitChatDelta` / `emitChatFinal` hardcoded `message.content = [{type: "text", text}]`, so any thinking block would have been silently dropped.
- **Why it matters:** ACP clients never receive `agent_thought_chunk` (the translator already converts `{type:"thinking", thinking}` content blocks into them — see `src/acp/translator.ts:handleDeltaEvent` ~L984). Webchat reasoning rendering was equally blank for live runs. The blocks ARE present via `session/load` replay, which masks the regression in casual testing.
- **What changed:** Add a per-`clientRunId` `thinkingBuffers` plus `deltaLastBroadcastThinkingLen` mirroring the existing `buffers` / `deltaLastBroadcastLen` pattern. Add `emitChatThinkingDelta` (same 150 ms throttle as text deltas). Update `flushBufferedChatDeltaIfNeeded` and `emitChatFinal` to flush/include the thinking buffer. New `buildAssistantContent(clientRunId, mergedText)` helper prepends a `{type: "thinking", thinking}` block when the thinking buffer has content, otherwise the broadcast payload is byte-identical to the old `[{type: "text", text}]` shape.
- **What did NOT change (scope boundary):** No protocol changes; ACP translator and webchat consumers already understand the thinking block shape. No behavior change when no `stream: "thinking"` events fire (e.g. `reasoning=off`).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Two-part: (1) the agent-event handler ignored `stream: "thinking"`; (2) the broadcast payload builders hardcoded a `text`-only content array, so even if a thinking event reached them it would have been dropped.
- **Missing detection / guardrail:** `src/gateway/server-chat.agent-events.test.ts` only fed `stream: "assistant"` events, so a thinking-only delta path was never exercised.
- **Contributing context:** The translator already supports the `{type:"thinking", thinking}` content shape on the ACP side, so the gap was purely on the broadcast-build side; the bug looked silent in `session/load` replays.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test:** Extend `src/gateway/server-chat.agent-events.test.ts` with a case that feeds a `stream: "thinking"` event and asserts the broadcast payload's `message.content` contains both a `thinking` and a `text` block (and that an assistant-only run still emits exactly `[{type:"text"}]`).
- **Scenario the test should lock in:** A live run where the agent emits reasoning before/alongside assistant text produces broadcast deltas that carry a `{type:"thinking", thinking}` block, throttled by the same 150 ms window as text deltas.
- **Why this is the smallest reliable guardrail:** It pins both the new code path (`emitChatThinkingDelta`) and the buffer-merging in `buildAssistantContent` without standing up a real agent runtime.

## User-visible / Behavior Changes

- ACP clients (Zed, claude-code, etc.) now receive `agent_thought_chunk` updates live during the prompt instead of only after `session/load`.
- Webchat / control UI surfaces that already render `{type:"thinking"}` blocks (matching `loadSession` replay) now light up live.
- When no thinking events fire, broadcast payloads are byte-identical to today's `[{type:"text", text}]` shape (verified by the existing test cases in `server-chat.agent-events.test.ts` continuing to pass unmodified).

## Diagram

```text
Before:
agent runtime --emit stream:"thinking"--> gateway agent-event handler --(only "assistant" forwarded)--> DROPPED
                                                                        ↓
                                                       chat broadcast: [{type:"text", text}]
                                                                        ↓
                                                     ACP/webchat: no live agent_thought_chunk

After:
agent runtime --emit stream:"thinking"--> emitChatThinkingDelta --(150ms throttle, accumulate buffer)--> broadcast
                                                                        ↓
                                                       chat broadcast: [{type:"thinking",...}, {type:"text", text}]
                                                                        ↓
                                                     ACP: agent_thought_chunk live  /  webchat: live thoughts
```

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** (reasoning text was already produced and persisted; this only restores live delivery to the same consumers that see it via session/load)

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime: Node 22, openclaw at `042c117`
- Model/provider: a model that emits reasoning streams (verified with `reasoning_level=stream` + `thought_level=high` set via `session/set_config_option`)
- Integration/channel: `openclaw acp` bridge consumed by an ACP client (also relevant to webchat)

### Steps

1. Build openclaw at `042c117` (no patch); start the ACP bridge with a model that supports reasoning streams.
2. Set `reasoning_level=stream` + `thought_level=high` via `session/set_config_option`.
3. Send a prompt likely to produce reasoning.
4. Observe `session/update` notifications.
5. Re-fetch the same session via `session/load` and compare.
6. Apply the patch, rebuild, repeat steps 3–4.

### Expected

- Live `session/update` notifications include `agent_thought_chunk` updates whenever the model produces reasoning, mirroring what `session/load` already shows.

### Actual (before patch)

- Only `agent_message_chunk` arrives live; `agent_thought_chunk` is absent live but present via `session/load` (proving the data exists, only delivery is broken).

### Actual (after patch)

- `agent_thought_chunk` updates stream live during the prompt (subject to the model actually producing reasoning).

## Evidence

- [x] Failing repro before + passing after (manual ACP probe against the bridge; live `agent_thought_chunk` updates appear only after the patch).

## Human Verification

- **Verified scenarios:** Live ACP run with reasoning enabled — confirmed `agent_thought_chunk` arrives live after the patch and does not arrive before. Confirmed assistant text deltas still arrive in the same throttle window.
- **Edge cases checked:** Run with no thinking events → broadcast payload byte-identical to old shape. Aborted run → buffers cleared correctly via `clearBufferedChatState`. Final flush includes the accumulated thinking text.
- **What I did not verify:** Webchat UI rendering side; high-volume reasoning streams under sustained throttle pressure; non-default `OPENCLAW_VITEST_POOL` configurations.

## Compatibility / Migration

- Backward compatible? **Yes** (no protocol or schema change; payloads unchanged when no thinking events fire)
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** Higher live broadcast volume on reasoning-heavy runs.
  - **Mitigation:** Reuses the existing 150 ms throttle window shared with text deltas; no new socket or broadcast plumbing.
- **Risk:** Consumers that only handled `[{type:"text"}]` content shapes might choke on a leading `thinking` block.
  - **Mitigation:** The `{type:"thinking", thinking}` shape is the same one already produced by `session/load`, so any consumer that handles loaded history already handles it; `loadSession` replay was the production reference for this shape.