### PR TITLE
fix(imessage): skip stale-socket health check for iMessage channel (#35072)

### DIFF
--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -190,6 +190,7 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
           cliPath: null,
           dbPath: null,
         }),
+        skipStaleSocketHealthCheck: true,
         collectStatusIssues: (accounts) => collectStatusIssuesFromLastError("imessage", accounts),
         buildChannelSummary: ({ snapshot }) =>
           buildPassiveProbedChannelStatusSummary(snapshot, {

--- a/src/plugin-sdk/status-helpers.ts
+++ b/src/plugin-sdk/status-helpers.ts
@@ -213,6 +213,7 @@ export function createComputedAccountStatusAdapter<
 ): ChannelStatusAdapter<ResolvedAccount, Probe, Audit> {
   return {
     defaultRuntime: options.defaultRuntime,
+    skipStaleSocketHealthCheck: options.skipStaleSocketHealthCheck,
     buildChannelSummary: options.buildChannelSummary,
     probeAccount: options.probeAccount,
     formatCapabilitiesProbe: options.formatCapabilitiesProbe,
@@ -255,6 +256,7 @@ export function createAsyncComputedAccountStatusAdapter<
 ): ChannelStatusAdapter<ResolvedAccount, Probe, Audit> {
   return {
     defaultRuntime: options.defaultRuntime,
+    skipStaleSocketHealthCheck: options.skipStaleSocketHealthCheck,
     buildChannelSummary: options.buildChannelSummary,
     probeAccount: options.probeAccount,
     formatCapabilitiesProbe: options.formatCapabilitiesProbe,


### PR DESCRIPTION
## Summary
The iMessage channel health monitor falsely detects idle iMessage channels as dead sockets, causing 59+ unnecessary provider restarts per 48 hours during normal idle periods.

## Root Cause
The channel health monitor uses a fixed 30-minute `staleEventThresholdMs` designed for WebSocket-based channels (Slack, Discord). iMessage uses local database polling (SQLite/AppleScript) — not a persistent WebSocket — so there is no socket that can go "half-dead". Long idle periods (hours) are normal for iMessage and do not indicate a connection failure.

## Changes
- `extensions/imessage/src/channel.ts`: Add `skipStaleSocketHealthCheck: true` to the iMessage status adapter, matching the existing Telegram pattern (which also opts out of stale socket checks for the same reason — Telegram uses HTTP long-polling, not a persistent WebSocket)

## Test
All 44 health monitor tests pass (`channel-health-monitor.test.ts`, `channel-health-policy.test.ts`).

Closes #35072